### PR TITLE
Remove the unreachable terminal damage-panel push

### DIFF
--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/critical_damage.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/critical_damage.py
@@ -308,10 +308,10 @@ def _offh_extinguish(target_mock, is_player_target, reason):
 		LOG_DEBUG('fuel tank restore after fire failed:', str(_fx))
 
 
-def _offh_knock_out_everything(mock, is_player):
-	'''A destroyed tank has everything destroyed: every module at 0 HP and every
-	crewman down. Used for drowning AND for an ordinary kill - previously only
-	drowning called it, so a normal death left most module icons untouched.'''
+def _offh_knock_out_everything(mock):
+	'''Put every module at 0 HP and every crewman down for a terminal state.
+
+	The stock #1513 death path owns the terminal damage-panel presentation.'''
 	try:
 		if getattr(mock, 'devices_hp', None) is None:
 			mock.devices_hp = {}
@@ -347,57 +347,7 @@ def _offh_knock_out_everything(mock, is_player):
 		_refresh_mobility_flags(mock)
 	except Exception:
 		pass
-	LOG_DEBUG('KNOCKOUT called: is_player=%s devices=%d crew=%d' % (is_player, len(_OFFH_DEATH_DEVICES), len(_roster)))
-	if not is_player:
-		return
-	try:
-		import BigWorld
-		from gui import WindowsManager as _wmko
-		_p = BigWorld.player()
-		_bw = getattr(_wmko.g_windowsManager, 'battleWindow', None)
-		_dp = getattr(_bw, 'damagePanel', None) if _bw is not None else None
-		_ui = [_module_ui_name(_n) for _n in _OFFH_DEATH_DEVICES] + list(_roster)
-		LOG_DEBUG('KNOCKOUT: is_player=%s panel=%s names=%s' % (is_player, _dp is not None, _ui))
-		for _n in _ui:
-			try: _p.guiSessionProvider.invalidateVehicleState(2, _p.playerVehicleID, _n, 'destroyed')
-			except Exception: pass
-			if _dp is not None:
-				try: _dp.updateState(_n, 'destroyed')
-				except Exception: pass
-		# Retail greys the panel and deactivates the crew from DamagePanel._updateOther
-		# the moment the vehicle reads dead. That tick needs a real BigWorld entity, so
-		# offline it never runs and the crew icons stayed lit on a destroyed tank.
-		if _dp is not None:
-			try: _dp.onVehicleDestroyed()
-			except Exception: pass
-			try: _dp.onCrewDeactivated()
-			except Exception: pass
-		# onVehicleDestroyed greys the WHOLE panel out, wiping the red module icons we
-		# just set, and it can also fire again later. Push them again on the next
-		# frames so the destroyed state is what stays visible.
-		def _reassert(_names=list(_ui), _panel=_dp, _hp=_offh_hp_display(mock)):
-			if _panel is None:
-				return
-			for _m in _names:
-				try: _panel.updateState(_m, 'destroyed')
-				except Exception: pass
-			# A drowned tank keeps its last HP; anything else is already 0 here.
-			try: _panel.updateHealth(_hp)
-			except Exception: pass
-		try:
-			import BigWorld as _bwr
-			# Spread over the whole post-mortem: WG's DamagePanel._updateSelf ticks every
-			# 30 ms and calls onVehicleDestroyed() the moment the vehicle reads as dead,
-			# which greys the panel. Re-push past that point so the red module icons are
-			# what remains on screen.
-			_bwr.callback(0.1, _reassert)
-			_bwr.callback(0.5, _reassert)
-			_bwr.callback(1.5, _reassert)
-			_bwr.callback(3.0, _reassert)
-		except Exception:
-			pass
-	except Exception:
-		pass
+	LOG_DEBUG('KNOCKOUT called: devices=%d crew=%d' % (len(_OFFH_DEATH_DEVICES), len(_roster)))
 
 
 def _offh_module_test_mode():
@@ -798,9 +748,7 @@ def _dev_critical_set(mock):
 def _module_ui_name(name):
 	'''Damage-panel device name = extra name minus 'Health'; tracks keep their side.
 
-	The battle scope defines its own and publishes it over this one. This module-level
-	copy exists because _offh_knock_out_everything is module-level too: without it the
-	name lookup raised NameError and took the whole panel block down with it.'''
+	The battle scope defines its own and publishes it over this one.'''
 	return name[:-6] if name.endswith('Health') else name
 
 
@@ -1664,7 +1612,7 @@ def apply_drowning(vehicle):
 	if vehicle is None:
 		return None
 	before = _state(vehicle)
-	_offh_knock_out_everything(vehicle, False)
+	_offh_knock_out_everything(vehicle)
 	after = _state(vehicle)
 	return _payload(
 		before, after, getattr(vehicle, 'typeDescriptor', None), 'drowning')
@@ -1684,7 +1632,7 @@ def apply_death(vehicle, cause='shot'):
     before = _state(vehicle)
     if bool(getattr(vehicle, 'is_on_fire', False)):
         _offh_extinguish(vehicle, False, cause)
-    _offh_knock_out_everything(vehicle, False)
+    _offh_knock_out_everything(vehicle)
     after = _state(vehicle)
     return _payload(
         before, after, getattr(vehicle, 'typeDescriptor', None), cause)

--- a/0.9.22/tests/test_port_0922_critical_damage.py
+++ b/0.9.22/tests/test_port_0922_critical_damage.py
@@ -1129,6 +1129,34 @@ class CriticalDamageTests(unittest.TestCase):
             {'kind': 'fire', 'state': False, 'cause': 'fire'},
             payload['events'])
 
+    def test_terminal_state_schedules_no_delayed_native_callback(self):
+        scheduled = []
+        self.bigworld.callback = lambda delay, function: scheduled.append(
+            (delay, function))
+        self.bigworld.cancelCallback = lambda handle: scheduled.clear()
+        panel = mock.Mock()
+        windows_manager = types.ModuleType('gui.WindowsManager')
+        windows_manager.g_windowsManager = types.SimpleNamespace(
+            battleWindow=types.SimpleNamespace(damagePanel=panel))
+
+        for cause, terminal in (
+                ('drowning', critical_damage.apply_drowning),
+                ('shot', lambda vehicle: critical_damage.apply_death(
+                    vehicle, 'shot'))):
+            vehicle = types.SimpleNamespace(
+                typeDescriptor=_descriptor(), health=0, id=999,
+                devices_hp={}, _destroyed_devices=set(), _crew_ko=set(),
+                is_on_fire=False)
+            with mock.patch.dict(sys.modules, {
+                    'BigWorld': self.bigworld, 'Math': self.math,
+                    'gui.WindowsManager': windows_manager}):
+                terminal(vehicle)
+            self.assertEqual([], scheduled, cause)
+            self.assertEqual([], panel.method_calls, cause)
+            self.assertEqual(
+                set(critical_damage._OFFH_DEATH_DEVICES),
+                vehicle._destroyed_devices, cause)
+
     def test_destroyed_track_repairs_to_descriptor_regen_cap(self):
         vehicle = types.SimpleNamespace(
             typeDescriptor=_descriptor(), health=500,


### PR DESCRIPTION
## Problem

`critical_damage._offh_knock_out_everything` carried a player-only block that pushed terminal module and crew state into the damage panel, then re-pushed it from four `BigWorld.callback` timers at 0.1 s, 0.5 s, 1.5 s and 3.0 s.

Those timers captured the `damagePanel` view object in default arguments and checked neither the battle generation nor whether the view was still alive. A player who left the battle inside that three-second window would have handed a stale native pointer to Scaleform. Commit afb0299 already produced a dump proving that a native conversion over a cleared display-object pointer faults, and `except Exception` does not catch a native access violation.

## Reachability

The block never ran in this port, for two independent reasons:

1. Both call sites pass `is_player=False` (`apply_drowning` and `apply_death`), and nothing else calls the function. `battle_runtime` deliberately leaves terminal panel state to the stock #1513 death path, which is why the argument is pinned.
2. The port never carried `_offh_hp_display` over from 0.8.2. Evaluating the `_reassert` default arguments would have raised `NameError` before any timer could be armed, and the enclosing `except Exception: pass` would have swallowed it.

In 0.8.2 the same function is called with `True` and `_offh_hp_display` exists, so this is legacy code that the 0.9.22 port copied without its dependency.

## Change

Delete the dead block and the parameter that selected it. The authority state work is unchanged: module HP, the destroyed set, crew knockout and the mobility flags all behave exactly as before.

`_module_ui_name` keeps its remaining caller in the repair path; its docstring no longer claims it exists for the removed block.

## Tests

New `test_terminal_state_schedules_no_delayed_native_callback` pins the contract for both `apply_drowning` and `apply_death`: a terminal state schedules no delayed native callback and touches no damage panel, while still producing the full destroyed set.

Verified the test fails when the pattern is reintroduced.

- `python -m unittest discover -s 0.9.22/tests -p "test_port_0922_critical_damage.py"`: 55 tests, OK
- `python -m unittest discover -s 0.9.22/tests -p "test_*.py"`: 2852 tests, OK
- CPython 2.7.18 source compile of the changed client file: passed

## What this does not prove

This removes a latent trap rather than a reproduced crash. Because the block could never arm a timer, it is not the cause of any existing crash report, and the remaining crash candidates are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)