### PR TITLE
Decouple A* search throughput from worker frame rate

### DIFF
--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
@@ -30,7 +30,12 @@ HARD_CONTACT_EDGE_PENALTY = 240.0
 
 SEARCH_EXPANSIONS_PER_SECOND = 960.0
 MAX_SEARCH_EXPANSIONS_PER_FRAME = 96
-MAX_SEARCH_CREDIT = float(MAX_SEARCH_EXPANSIONS_PER_FRAME)
+SEARCH_CATCH_UP_FRAMES = 4
+# One catch-up frame may spend four nominal frames of credit, so the rate holds
+# down to 4 Hz render callbacks and one stall cannot spend an unbounded backlog.
+MAX_SEARCH_EXPANSIONS_PER_CATCH_UP_FRAME = (
+	MAX_SEARCH_EXPANSIONS_PER_FRAME * SEARCH_CATCH_UP_FRAMES)
+MAX_SEARCH_CREDIT = float(MAX_SEARCH_EXPANSIONS_PER_CATCH_UP_FRAME)
 
 
 def _distance_2d(first, second):
@@ -1110,21 +1115,27 @@ class TerrainNavigator(object):
 				self.searches.pop(key, None)
 				self.search_times.pop(key, None)
 
+	def _accrue_search_credit(self, elapsed):
+		"""Earn elapsed credit and size this frame's expansion ceiling from it."""
+		self.search_credit = min(
+			MAX_SEARCH_CREDIT,
+			self.search_credit +
+			max(0.0, float(elapsed)) * SEARCH_EXPANSIONS_PER_SECOND)
+		self.search_frame_budget = min(
+			MAX_SEARCH_EXPANSIONS_PER_CATCH_UP_FRAME,
+			max(MAX_SEARCH_EXPANSIONS_PER_FRAME, int(self.search_credit)))
+
 	def begin_frame(self, elapsed):
 		"""Accrue deterministic A* work once for one render callback.
 
-		Search progress is paid with simulation elapsed rather than CPU wall time.
-		A long callback can therefore earn work without forcing the complete debt
-		into that same render frame.  Unspent credit is retained up to one bounded
-		frame, and the rotating queue below preserves fairness between jobs.
+		Search progress is paid with simulation elapsed rather than CPU wall time,
+		so a given elapsed interval buys the same expansions at any frame rate.
+		Credit is retained across frames up to a bounded catch-up reserve, and the
+		rotating queue below preserves fairness between jobs.
 		"""
-		elapsed = max(0.0, float(elapsed))
 		self.search_frame_serial += 1
-		self.search_frame_budget = MAX_SEARCH_EXPANSIONS_PER_FRAME
 		self.search_frame_open = True
-		self.search_credit = min(
-			MAX_SEARCH_CREDIT,
-			self.search_credit + elapsed * SEARCH_EXPANSIONS_PER_SECOND)
+		self._accrue_search_credit(elapsed)
 
 	def end_frame(self):
 		"""Close an explicit render-frame work budget."""
@@ -1143,10 +1154,7 @@ class TerrainNavigator(object):
 		           max(0.0, now - self.search_auto_time))
 		self.search_auto_time = now
 		self.search_frame_serial += 1
-		self.search_frame_budget = MAX_SEARCH_EXPANSIONS_PER_FRAME
-		self.search_credit = min(
-			MAX_SEARCH_CREDIT,
-			self.search_credit + elapsed * SEARCH_EXPANSIONS_PER_SECOND)
+		self._accrue_search_credit(elapsed)
 
 	def _advance_searches(self, now):
 		"""Give every pending A* task a deterministic fair frame share.

--- a/0.9.22/tests/test_port_0922_ai.py
+++ b/0.9.22/tests/test_port_0922_ai.py
@@ -20,8 +20,9 @@ from gui.mods.offline_lan_0922.ai.planner import (
     BattleDirector, build_vehicle_profile,
 )
 from gui.mods.offline_lan_0922.ai.navigation import (
-    BAKED_SHALLOW_WATER, MAX_SEARCH_EXPANSIONS_PER_FRAME,
-    SEARCH_EXPANSIONS_PER_SECOND, TerrainGrid, TerrainNavigator,
+    BAKED_SHALLOW_WATER, MAX_SEARCH_EXPANSIONS_PER_CATCH_UP_FRAME,
+    MAX_SEARCH_EXPANSIONS_PER_FRAME, SEARCH_EXPANSIONS_PER_SECOND,
+    TerrainGrid, TerrainNavigator,
 )
 from gui.mods.offline_lan_0922 import prebaked_navigation
 from lan_battle_server import MAP_POOL
@@ -47,6 +48,17 @@ class _StrictNoLegacyStuff(object):
     __contains__ = _forbidden
     __iter__ = _forbidden
     __len__ = _forbidden
+
+
+class _PendingSearch(object):
+    """A* job double that counts expansions and never completes."""
+    def __init__(self):
+        self.done = False
+        self.last_frame = None
+        self.steps = 0
+
+    def step(self, count):
+        self.steps += int(count)
 
 
 class BotAiPortTests(unittest.TestCase):
@@ -721,21 +733,17 @@ class BotAiPortTests(unittest.TestCase):
             ('prune', 2.1), ('trim', None),
         ], calls)
 
-    def test_astar_work_uses_elapsed_credit_with_a_hard_frame_cap(self):
-        class PendingSearch(object):
-            def __init__(self):
-                self.done = False
-                self.last_frame = None
-                self.steps = 0
-
-            def step(self, count):
-                self.steps += int(count)
-
+    @staticmethod
+    def _pending_search_navigator(count):
         navigator = TerrainNavigator(lambda *unused: 0.0)
-        searches = [PendingSearch() for unused in range(4)]
+        searches = [_PendingSearch() for unused in range(count)]
         navigator.searches = dict(
             (('job', index), search)
             for index, search in enumerate(searches))
+        return navigator, searches
+
+    def test_astar_work_uses_elapsed_credit_with_a_hard_frame_cap(self):
+        navigator, searches = self._pending_search_navigator(4)
 
         navigator.begin_frame(0.05)
         navigator.tick(1.0)
@@ -752,11 +760,87 @@ class BotAiPortTests(unittest.TestCase):
         navigator.end_frame()
 
         self.assertEqual(
-            earned + MAX_SEARCH_EXPANSIONS_PER_FRAME,
+            earned + MAX_SEARCH_EXPANSIONS_PER_CATCH_UP_FRAME,
             sum(search.steps for search in searches))
         self.assertLessEqual(
             max(search.steps for search in searches) -
             min(search.steps for search in searches), 1)
+
+    def _drive_search_frames(self, frame_interval, seconds, job_count=8):
+        """Return total and peak-frame expansions for one simulated frame rate."""
+        navigator, searches = self._pending_search_navigator(job_count)
+        frames = int(round(float(seconds) / float(frame_interval)))
+        now = 0.0
+        peak = 0
+        for unused in range(frames):
+            before = sum(search.steps for search in searches)
+            now += frame_interval
+            navigator.begin_frame(frame_interval)
+            navigator.tick(now)
+            navigator.end_frame()
+            peak = max(peak, sum(search.steps for search in searches) - before)
+        spread = (max(search.steps for search in searches) -
+                  min(search.steps for search in searches))
+        return sum(search.steps for search in searches), peak, spread
+
+    def test_astar_throughput_is_independent_of_render_frame_rate(self):
+        seconds = 2.4
+        results = dict(
+            (fps, self._drive_search_frames(1.0 / fps, seconds))
+            for fps in (5, 10, 30, 60))
+        expected = int(seconds * SEARCH_EXPANSIONS_PER_SECOND)
+
+        for fps, (total, peak, spread) in sorted(results.items()):
+            self.assertEqual(expected, total, 'throughput differs at %d fps' % fps)
+            self.assertLessEqual(
+                peak, MAX_SEARCH_EXPANSIONS_PER_CATCH_UP_FRAME)
+            self.assertLessEqual(spread, 1)
+
+        self.assertEqual(
+            MAX_SEARCH_EXPANSIONS_PER_FRAME, results[10][1])
+        self.assertEqual(
+            MAX_SEARCH_EXPANSIONS_PER_FRAME * 2, results[5][1])
+        self.assertEqual(
+            int(SEARCH_EXPANSIONS_PER_SECOND / 60.0), results[60][1])
+
+    def test_astar_catch_up_after_a_stall_stays_bounded(self):
+        navigator, searches = self._pending_search_navigator(8)
+
+        navigator.begin_frame(5.0)
+        navigator.tick(5.0)
+        navigator.end_frame()
+
+        self.assertEqual(
+            MAX_SEARCH_EXPANSIONS_PER_CATCH_UP_FRAME,
+            sum(search.steps for search in searches))
+        self.assertEqual(0.0, navigator.search_credit)
+
+        navigator.begin_frame(0.1)
+        navigator.tick(5.1)
+        navigator.end_frame()
+
+        self.assertEqual(
+            MAX_SEARCH_EXPANSIONS_PER_CATCH_UP_FRAME +
+            MAX_SEARCH_EXPANSIONS_PER_FRAME,
+            sum(search.steps for search in searches))
+
+    def test_astar_frame_share_starves_no_pending_search(self):
+        navigator, searches = self._pending_search_navigator(29)
+
+        now = 0.0
+        for unused in range(20):
+            now += 0.2
+            navigator.begin_frame(0.2)
+            navigator.tick(now)
+            navigator.end_frame()
+
+        self.assertEqual(
+            int(4.0 * SEARCH_EXPANSIONS_PER_SECOND),
+            sum(search.steps for search in searches))
+        self.assertLessEqual(
+            max(search.steps for search in searches) -
+            min(search.steps for search in searches), 1)
+        self.assertTrue(all(search.steps > 0 for search in searches))
 
     def test_empty_failed_edge_table_skips_route_segment_scans(self):
         grid = TerrainGrid(lambda *unused: 0.0)


### PR DESCRIPTION
## Problem

A* search throughput was linearly bound to the hidden worker's render frame rate, so a slow worker left bots waiting in `nav_wait` instead of leaving spawn.

`MAX_SEARCH_CREDIT` was equal to `MAX_SEARCH_EXPANSIONS_PER_FRAME`, so credit earned from elapsed time could not survive into the next frame. Usable expansions per second were therefore `min(96 * FPS, 960)`: constant at and above 10 FPS, but decaying linearly below it. At 5 FPS the room got half its nominal search rate.

While a search is pending a bot follows its last proven edge or stops in `nav_wait`. That is the feedback loop described under "Performance investigations" in `0.9.22/CLAUDE.md`: a low frame rate slows searches, stopped bots make traffic worse, and the frame rate does not recover.

## Change

Let credit accumulate across frames up to a bounded catch-up reserve, and size each frame's ceiling from the credit actually banked.

- `SEARCH_CATCH_UP_FRAMES = 4` gives `MAX_SEARCH_CREDIT = 384`, which is 0.4 s of nominal work. The nominal 960/s rate now holds down to 2.5 FPS instead of 10 FPS.
- A catch-up frame may spend up to `MAX_SEARCH_EXPANSIONS_PER_CATCH_UP_FRAME`, so one long stall cannot dump an unbounded backlog into a single frame. After a 5 s gap the next frame does exactly 384 expansions, not 4800.
- The per-frame floor stays at the previous 96.
- `begin_frame` and `_begin_automatic_frame` had duplicated the accrual arithmetic. Both now call `_accrue_search_credit`, so the two paths cannot drift.

The rotating queue, `search_next_key` cross-frame resumption, per-search `search_max_expansions`, and credit consumption in `_advance_searches` are untouched. Routes, driving parameters and hazard classification are out of scope.

Measured with 8 pending searches over 2.4 simulated seconds: 5/10/30/60 FPS now all perform 2304 expansions, with per-frame peaks of 192/96/32/16. Before the change 5 FPS managed 1152.

## Tests

- `test_astar_throughput_is_independent_of_render_frame_rate`: equal elapsed time at 5, 10, 30 and 60 FPS yields exactly equal totals, and pins the expected per-frame peak at each rate.
- `test_astar_catch_up_after_a_stall_stays_bounded`: a 5 s gap spends exactly one catch-up frame and then returns to the nominal budget.
- `test_astar_frame_share_starves_no_pending_search`: with 29 pending searches no job is starved and the spread stays within one expansion.
- The existing hard-frame-cap test was updated to the new ceiling.

Commands run:

- `python -m unittest discover -s 0.9.22/tests -p "test_port_0922_ai.py"`: 58 tests, OK
- `python -m unittest discover -s 0.9.22/tests -p "test_port_0922_navigation*.py"`: 53 tests, OK
- `python -m unittest discover -s 0.9.22/tests -p "test_port_0922_bot_runtime.py"`: 312 tests, OK
- `python -m unittest discover -s 0.9.22/tests -p "test_*.py"`: 2854 tests, OK
- CPython 2.7.18 source compile of the client tree: 88 files passed

## What this does not prove

Pure-data tests prove the budget arithmetic only. Whether the hidden worker actually leaves spawn at a low frame rate, and whether a 384-expansion catch-up frame is itself visible as a hitch, needs frame pacing and `PERF` stage timing on the exact Windows client. The 4-frame reserve is derived from the nominal 960/s rate against a 10 Hz frame, not calibrated against captured low-frame-rate traces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)