### PR TITLE
Apply the Spall Liner factor to non-penetrating HE

### DIFF
--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -10864,7 +10864,10 @@ class BattleRuntime(object):
             record, critical_target, shot, trace_start, trace_end,
             collisions, result,
             historic=isinstance(collision_pose, dict))
-        damage = combat_rules.damage(shot, result, armor)
+        damage = combat_rules.damage(
+            shot, result, armor,
+            spall_coefficient=tank_collision.descriptor_spall_coefficient(
+                getattr(critical_target, 'typeDescriptor', None)))
         hull_damage = damage
         legacy_shell = combat_rules.legacy_shot(shot).get('shell') or {}
         attacker_id = int(getattr(
@@ -10957,7 +10960,9 @@ class BattleRuntime(object):
                 nominal = combat_rules.he_hull_armor(
                     target.typeDescriptor)
             damage = combat_rules.he_splash_damage(
-                shot, nominal, distance / radius)
+                shot, nominal, distance / radius,
+                spall_coefficient=tank_collision.descriptor_spall_coefficient(
+                    target.typeDescriptor))
             if damage <= 0:
                 continue
             hull_damage = damage
@@ -18173,7 +18178,9 @@ class BattleRuntime(object):
                 collisions = ()
                 nominal = combat_rules.he_hull_armor(target.typeDescriptor)
             damage = combat_rules.he_splash_damage(
-                shot, nominal, distance / radius)
+                shot, nominal, distance / radius,
+                spall_coefficient=tank_collision.descriptor_spall_coefficient(
+                    target.typeDescriptor))
             if damage <= 0:
                 continue
             hull_damage = damage
@@ -18310,7 +18317,10 @@ class BattleRuntime(object):
         # result, and HE still detonates on the part it reached.
         result = 1 if contact is None else contact['result']
         armor = combat_rules.he_nominal_armor(collisions, target_descriptor)
-        return combat_rules.damage(shot, result, armor), result
+        return combat_rules.damage(
+            shot, result, armor,
+            spall_coefficient=tank_collision.descriptor_spall_coefficient(
+                target_descriptor)), result
 
     def _defer_avatar_leave(self):
         """Finish the native leaveArena stack before retiring its Avatar."""

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/combat_rules.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/combat_rules.py
@@ -308,9 +308,21 @@ def _offh_he_factors(shot):
 	return damage_factor, absorption_factor, edge_factor
 
 
-def _offh_he_damage(shot, base_damage, armor_nominal, dist_frac=0.0):
+def _offh_he_spall(spall_coefficient):
+	'''Target Spall Liner multiplier on the armour absorption term.'''
+	try:
+		value = float(spall_coefficient)
+	except (TypeError, ValueError, OverflowError):
+		return 1.0
+	if value != value or abs(value) == float('inf') or value < 1.0:
+		return 1.0
+	return value
+
+
+def _offh_he_damage(shot, base_damage, armor_nominal, dist_frac=0.0,
+                    spall_coefficient=1.0):
 	'''Damage an HE burst does to a hull it did NOT get through.
-	
+
 	dist_frac is 0.0 for the vehicle actually struck and rises to 1.0 at the edge
 	of explosionRadius for everything else caught in the blast. Returns 0 when the
 	plate eats the whole thing - the normal outcome against heavy armour, and the
@@ -324,7 +336,8 @@ def _offh_he_damage(shot, base_damage, armor_nominal, dist_frac=0.0):
 	blast_factor = damage_factor + (
 		edge_factor - damage_factor) * distance_fraction
 	d = (float(base_damage) * blast_factor -
-	     absorption_factor * float(armor_nominal or 0.0))
+	     absorption_factor * float(armor_nominal or 0.0) *
+	     _offh_he_spall(spall_coefficient))
 	return int(d) if d > 0.0 else 0
 
 
@@ -566,7 +579,8 @@ def he_nominal_armor(collisions, descriptor=None):
         collision_layers(collisions), descriptor)
 
 
-def damage(shot, result, nominal_armor, random_uniform=None):
+def damage(shot, result, nominal_armor, random_uniform=None,
+           spall_coefficient=1.0):
     """Apply the legacy direct-damage formula to the resolved vehicle hit."""
     converted = legacy_shot(shot)
     shell = converted.get('shell') or {}
@@ -583,7 +597,8 @@ def damage(shot, result, nominal_armor, random_uniform=None):
     if int(result) == 2:
         return rolled
     if _offh_is_he(converted):
-        return _offh_he_damage(converted, rolled, nominal_armor, 0.0)
+        return _offh_he_damage(
+            converted, rolled, nominal_armor, 0.0, spall_coefficient)
     return 0
 
 
@@ -604,7 +619,7 @@ def he_factors(shot):
 
 
 def he_splash_damage(shot, nominal_armor, distance_fraction,
-                     random_uniform=None):
+                     random_uniform=None, spall_coefficient=1.0):
     converted = legacy_shot(shot)
     shell = converted.get('shell') or {}
     raw = shell.get('damage')
@@ -618,7 +633,8 @@ def he_splash_damage(shot, nominal_armor, distance_fraction,
     uniform = random_uniform or random.uniform
     rolled = uniform(average * 0.75, average * 1.25)
     return _offh_he_damage(
-        converted, rolled, nominal_armor, distance_fraction)
+        converted, rolled, nominal_armor, distance_fraction,
+        spall_coefficient)
 
 
 def apply_he_tuning(overrides):

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/tank_collision.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/tank_collision.py
@@ -260,6 +260,22 @@ def _axes(yaw):
     return ((cosine, -sine), (sine, cosine))
 
 
+def descriptor_spall_coefficient(type_descriptor):
+    """Return ``miscAttrs.antifragmentationLiningFactor``, or 1.0 without one.
+
+    1.0 is the descriptor's own no-liner value, so an absent field leaves the
+    armour absorption term unchanged rather than inventing a reduction.
+    """
+    misc = _value(type_descriptor, 'miscAttrs', {}) or {}
+    try:
+        spall = float(_value(misc, 'antifragmentationLiningFactor', 1.0))
+    except (TypeError, ValueError):
+        return 1.0
+    if spall < 1.0 or not _finite(spall):
+        return 1.0
+    return spall
+
+
 def descriptor_ram_profile(type_descriptor, ramming_bonus=0.0):
     """Return source-backed non-contact ram inputs from one descriptor.
 

--- a/0.9.22/tests/test_port_0922_combat_rules.py
+++ b/0.9.22/tests/test_port_0922_combat_rules.py
@@ -10,6 +10,7 @@ CLIENT_SCRIPTS = ROOT / '0.9.22' / 'src' / 'res' / 'scripts' / 'client'
 sys.path.insert(0, str(CLIENT_SCRIPTS))
 
 from gui.mods.offline_lan_0922 import combat_rules
+from gui.mods.offline_lan_0922 import tank_collision
 
 
 def _shot(kind='ARMOR_PIERCING', caliber=90.0,
@@ -789,6 +790,50 @@ class CombatRulesTests(unittest.TestCase):
         self.assertEqual(200, center)
         self.assertEqual(65, middle)
         self.assertEqual(60, edge)
+
+    def test_spall_liner_scales_the_he_armour_absorption_term(self):
+        shot = _shot(
+            kind='HIGH_EXPLOSIVE', damage=400.0, explosion_radius=10.0)
+        uniform = lambda low, high: (low + high) * 0.5
+
+        bare = combat_rules.he_splash_damage(
+            shot, 50.0, 0.0, random_uniform=uniform)
+        lined = combat_rules.he_splash_damage(
+            shot, 50.0, 0.0, random_uniform=uniform, spall_coefficient=1.5)
+        direct_bare = combat_rules.damage(
+            shot, 1, 50.0, random_uniform=uniform)
+        direct_lined = combat_rules.damage(
+            shot, 1, 50.0, random_uniform=uniform, spall_coefficient=1.5)
+
+        # 400 * 0.5 - 1.3 * 50 * spall
+        self.assertEqual(135, bare)
+        self.assertEqual(102, lined)
+        self.assertEqual(135, direct_bare)
+        self.assertEqual(102, direct_lined)
+
+    def test_he_absorption_ignores_an_absent_or_invalid_spall_factor(self):
+        shot = _shot(
+            kind='HIGH_EXPLOSIVE', damage=400.0, explosion_radius=10.0)
+        uniform = lambda low, high: (low + high) * 0.5
+        baseline = combat_rules.he_splash_damage(
+            shot, 50.0, 0.0, random_uniform=uniform)
+
+        for value in (None, 'x', float('nan'), float('inf'), 0.0, -2.0, 0.5):
+            self.assertEqual(baseline, combat_rules.he_splash_damage(
+                shot, 50.0, 0.0, random_uniform=uniform,
+                spall_coefficient=value), value)
+
+    def test_spall_coefficient_reads_the_1513_descriptor_default(self):
+        self.assertEqual(1.0, tank_collision.descriptor_spall_coefficient(
+            types.SimpleNamespace(miscAttrs={})))
+        self.assertEqual(1.0, tank_collision.descriptor_spall_coefficient(None))
+        self.assertEqual(1.5, tank_collision.descriptor_spall_coefficient(
+            types.SimpleNamespace(
+                miscAttrs={'antifragmentationLiningFactor': 1.5})))
+        # A liner never reduces absorption below the no-liner value.
+        self.assertEqual(1.0, tank_collision.descriptor_spall_coefficient(
+            types.SimpleNamespace(
+                miscAttrs={'antifragmentationLiningFactor': 0.4})))
 
     def test_native_1513_shell_type_overrides_all_he_factors(self):
         shell_type = types.SimpleNamespace(


### PR DESCRIPTION
## Problem

The non-penetrating HE formula subtracts `absorption factor * nominal armour` from the blast damage. Retail scales that armour term by the target's `miscAttrs.antifragmentationLiningFactor`, so a mounted Spall Liner absorbs more of the burst.

The ram path in this repository already does exactly that, and cites the 9.22-era formula it comes from (`tank_collision.py:40-60`, wiki revision 270080):

```
damage = HE damage factor * share * potential
         - HE absorption factor * nominal armour * spall coefficient
```

The direct HE and splash paths used the same formula without the trailing coefficient. A vehicle with a Spall Liner therefore took full HE damage, and the liner only worked against ramming.

## Change

- `tank_collision.descriptor_spall_coefficient` reads the factor beside the existing `descriptor_ram_profile`, keeping one owner for the field.
- `combat_rules.damage` and `combat_rules.he_splash_damage` take an optional `spall_coefficient` and apply it to the absorption term.
- The four `battle_runtime` call sites pass the target descriptor's factor.

The reader returns the descriptor's own 1.0 no-liner value when the field is absent or unusable. 1.0 is the identity for this term, so a missing field reproduces today's numbers exactly. It deliberately does not raise the way `descriptor_ram_profile` does, because these call sites sit inside projectile resolution and a descriptor problem must not turn a shot into a failed battle.

Effect on a 400-damage HE shell against 50 mm nominal armour: 135 damage without a liner, 102 with a 1.5 factor.

## Tests

- `test_spall_liner_scales_the_he_armour_absorption_term`: covers both the direct and splash entry points against the hand-computed values.
- `test_he_absorption_ignores_an_absent_or_invalid_spall_factor`: `None`, a string, NaN, infinity, zero, a negative value and a below-1.0 value all reproduce the no-liner result.
- `test_spall_coefficient_reads_the_1513_descriptor_default`: descriptor reads, the absent-field default, and the clamp.

Commands run:

- `python -m unittest discover -s 0.9.22/tests -p "test_port_0922_combat_rules.py"`: 54 tests, OK
- `python -m unittest discover -s 0.9.22/tests -p "test_*.py"`: 2854 tests, OK
- CPython 2.7.18 source compile of the client tree: 88 files passed
- `git diff --check`: clean

## What this does not prove

The formula shape follows the repository's own ram derivation and the era wiki revision it cites. Whether the resulting HE feel against lined heavy vehicles matches retail can only be settled by play on the exact Windows client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)