### PR TITLE
Restore a minimal teammate following limit

### DIFF
--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/ai/adapter.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/ai/adapter.py
@@ -134,7 +134,6 @@ class BotAdapter(object):
                 bot_id, position, float(state.get('yaw', 0.0)),
                 float(state.get('speed', 0.0)), float(state.get('dt', 0.0)),
                 target, state.get('neighbours', ()), direction_clear,
-                velocity=state.get('velocity'),
                 half_length=float(state.get('half_length', 3.5)),
                 half_width=float(state.get('half_width', 1.7)),
                 movement_intent=movement_intent,

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/ai/driver.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/ai/driver.py
@@ -311,17 +311,6 @@ class LocalDriver(object):
 		except Exception:
 			return False
 
-	def _velocity(self, value):
-		if value is None:
-			return (0.0, 0.0)
-		try:
-			return (float(value[0]), float(value[2]))
-		except Exception:
-			try:
-				return (float(value[0]), float(value[1]))
-			except Exception:
-				return (0.0, 0.0)
-
 	def _obb_overlap(self, first, first_yaw, first_length, first_width,
 				 second, second_yaw, second_length, second_width):
 		"""2D rectangle SAT, using yaw convention atan2(x, z)."""
@@ -345,67 +334,8 @@ class LocalDriver(object):
 				return False
 		return True
 
-	def _prediction_clear(self, position, candidate_yaw, speed, velocity,
-				neighbours, half_length, half_width):
-		"""Reject a locally clear ray if its next 1.2s overlaps another OBB."""
-		own_speed = max(0.0, abs(float(speed)))
-		# At walking pace there is not enough velocity for an OBB extrapolation
-		# to be useful.  In a dense line-up it instead predicts every neighbour's
-		# acceleration against a nearly stationary hull and vetoes all exits.
-		# Separation steering and the physical tank resolver remain active; resume
-		# predictive collision avoidance once the bot has actually got moving.
-		if own_speed < 1.25:
-			return True
-		desired_vx = math.sin(candidate_yaw) * own_speed
-		desired_vz = math.cos(candidate_yaw) * own_speed
-		actual_vx, actual_vz = self._velocity(velocity)
-		# Tanks cannot instantaneously rotate their velocity vector.  Blend the
-		# observed velocity into the short prediction whenever the caller has it.
-		if abs(actual_vx) + abs(actual_vz) > 0.05:
-			own_vx = actual_vx * 0.45 + desired_vx * 0.55
-			own_vz = actual_vz * 0.45 + desired_vz * 0.55
-		else:
-			own_vx = desired_vx
-			own_vz = desired_vz
-		for neighbour in neighbours or ():
-			other = self._neighbour_position(neighbour)
-			if other is None:
-				continue
-			try:
-				if abs(float(other[1]) - float(position[1])) > 5.0:
-					continue
-			except Exception:
-				pass
-			other_yaw = 0.0
-			other_velocity = None
-			other_length = half_length
-			other_width = half_width
-			if isinstance(neighbour, dict):
-				other_yaw = float(neighbour.get('yaw', 0.0) or 0.0)
-				other_velocity = neighbour.get('velocity') or neighbour.get('vel')
-				other_length = float(neighbour.get('half_length', half_length) or half_length)
-				other_width = float(neighbour.get('half_width', half_width) or half_width)
-			other_vx, other_vz = self._velocity(other_velocity)
-			# Spawn formations can place two hull boxes slightly inside each other.
-			# Treating that existing overlap as a future collision rejects every
-			# steering candidate, so all bots stop and enter the recovery turn loop.
-			# Separation steering already handles this case; predictive vetoes resume
-			# as soon as the hulls have moved apart.
-			if self._obb_overlap(position, candidate_yaw, half_length, half_width,
-					other, other_yaw, other_length, other_width):
-				continue
-			for horizon in (0.35, 0.75, 1.20):
-				own = (float(position[0]) + own_vx * horizon, 0.0,
-				       float(position[2]) + own_vz * horizon)
-				predicted = (float(other[0]) + other_vx * horizon, 0.0,
-				             float(other[2]) + other_vz * horizon)
-				if self._obb_overlap(own, candidate_yaw, half_length, half_width,
-						predicted, other_yaw, other_length, other_width):
-					return False
-		return True
-
-	def _choose_yaw(self, state, desired_yaw, current_yaw, position, speed,
-			velocity, neighbours, direction_clear, half_length, half_width):
+	def _choose_yaw(self, state, desired_yaw, current_yaw, position,
+			neighbours, direction_clear, half_length, half_width):
 		separation = self._separation_yaw(
 			position, current_yaw, neighbours, half_length, half_width)
 		candidates = []
@@ -432,7 +362,7 @@ class LocalDriver(object):
 		return None
 
 	def drive(self, bot_id, position, yaw, speed, dt, target, neighbours,
-			direction_clear, velocity=None, half_length=3.5, half_width=1.7,
+			direction_clear, half_length=3.5, half_width=1.7,
 			movement_intent=True, stopping_distance=None,
 			stop_at_target=True, decision_horizon=0.0):
 		"""Return ``throttle``, ``turn``, ``target_yaw`` and ``recovery_mode``.
@@ -564,7 +494,7 @@ class LocalDriver(object):
 			chosen_yaw = old_yaw
 		if chosen_yaw is None:
 			chosen_yaw = self._choose_yaw(
-				state, desired_yaw, yaw, position, speed, velocity, neighbours,
+				state, desired_yaw, yaw, position, neighbours,
 				direction_clear, own_half_length, own_half_width)
 			state['plan_age'] = 0.0
 		if chosen_yaw is None:

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -116,11 +116,16 @@ MOTION_PROBE_FORWARD_BUDGET = 3.5
 # A validated baked edge needs enough native lookahead to react, not a ray past
 # its next turn. Expand from one grid cell to a 1.5-second horizon with speed.
 BAKED_MOTION_LOOKAHEAD_SECONDS = 1.5
-# Friendly following uses the same one-second time gap that the former hard
-# cutoff attempted to enforce.  Keep its standstill gap separate from hull
-# extents: ``clearance`` below is already measured edge-to-edge.
+# Friendly following ramps throttle over a one-second time gap and settles one
+# standstill gap behind the hull ahead.  ``clearance`` is edge-to-edge, so this
+# gap stays separate from hull extents.
 TRAFFIC_HEADWAY_SECONDS = 1.0
 TRAFFIC_STANDSTILL_CLEARANCE = 1.5
+# A queue that never moves is released at a crawl: the follower may work
+# past the hull ahead, but never at approach speed.
+TRAFFIC_RELEASE_THROTTLE = 0.35
+# Below this the column counts as stalled rather than following.
+TRAFFIC_PROGRESS_SPEED = 1.0
 # Match the copied longitudinal integrator's parked-speed boundary when
 # integrating the remaining coast distance.  A parked hull still keeps its
 # physical yaw for same-lane versus crossing classification.
@@ -1894,6 +1899,7 @@ class BotRuntime(object):
         self._decision_cache = {}
         self._motion_probe_cache = {}
         self._traffic_stopping_cache = {}
+        self._traffic_leases = {}
         self._slope_pose_cursor = 0
         self._flip_diary = {}
         self.debug_logging = False
@@ -2308,6 +2314,7 @@ class BotRuntime(object):
         self._spotting_profiles.pop(('bot', bot_id), None)
         self._motion_probe_cache.pop(bot_id, None)
         self._traffic_stopping_cache.pop(bot_id, None)
+        self._traffic_leases.pop(bot_id, None)
         self._cancel_artillery_intent(bot_id)
         if state is not None:
             half_length, half_width = _hull_dimensions(descriptor)
@@ -2605,6 +2612,7 @@ class BotRuntime(object):
             self._decision_cache = {}
             self._motion_probe_cache = {}
             self._traffic_stopping_cache = {}
+            self._traffic_leases = {}
             self._slope_pose_cursor = 0
             self._world_receipt_waiting = []
             self._world_receipt_frame = None
@@ -2648,6 +2656,7 @@ class BotRuntime(object):
             self._decision_cache = {}
             self._motion_probe_cache = {}
             self._traffic_stopping_cache = {}
+            self._traffic_leases = {}
             self._world_receipt_waiting = []
             self._world_receipt_frame = None
             self._prewarm_receipt_cursor = 0
@@ -5310,44 +5319,25 @@ class BotRuntime(object):
         return entry
 
     @staticmethod
-    def _traffic_throttle(source, command, neighbours, physics_params=None,
-                          stopping_distance_resolver=None):
-        """Return ``(throttle, waiting)`` for nearby friendly traffic.
+    def _traffic_blocker(source, neighbours):
+        """Return ``(id, clearance, crossing)`` for the teammate ahead.
 
-        Same-lane followers always respect the vehicle ahead. At a crossing or
-        merge, the lower bot id has deterministic right of way; every bot yields
-        to a human.  A following vehicle uses a continuous time-gap controller
-        translated through its copied drivetrain.  The former absolute-speed
-        cutoff alternated full throttle and coast braking whenever a dense
-        spawn row crossed ``clearance == speed`` even if both tanks had the
-        same velocity.
+        Only the nearest friendly hull inside this bot's own travel corridor
+        which is stopped or no faster counts.  ``crossing`` reports a hull
+        which does not travel along that corridor.
         """
-        throttle = max(-1.0, min(1.0, _number(command.get('throttle'))))
-        if throttle <= 0.01:
-            return throttle, False
         position = _position(source)
-        source_team = int(_number(source.get('team')))
-        if source_team not in (1, 2):
-            return throttle, False
         yaw = _number(source.get('yaw'))
+        sine, cosine = math.sin(yaw), math.cos(yaw)
+        team = int(_number(source.get('team')))
         own_speed = abs(_number(source.get('speed')))
         own_length = max(0.5, _number(source.get('half_length'), 3.5))
         own_width = max(0.3, _number(source.get('half_width'), 1.7))
-        if physics_params is None:
-            physics_params = vehicle_physics.derive_params({})
-        slope_pitch = _number(source.get('last_drive_pitch'))
-        steering = abs(_number(command.get('turn'))) > 0.01
-        stopping_clearance = None
-        scan_clearance = None
-        sine, cosine = math.sin(yaw), math.cos(yaw)
-        target_yaw = _number(command.get('target_yaw'), yaw)
-        target_sine = math.sin(target_yaw)
-        target_cosine = math.cos(target_yaw)
         nearest = None
         for raw in neighbours or ():
             if not isinstance(raw, dict):
                 continue
-            if int(_number(raw.get('team'))) != source_team:
+            if int(_number(raw.get('team'))) != team:
                 continue
             other = raw.get('position') or raw.get('pos')
             if other is None:
@@ -5359,141 +5349,90 @@ class BotRuntime(object):
                     continue
             except (TypeError, ValueError, IndexError):
                 continue
-            forward = dx * sine + dz * cosine
-            lateral = abs(dx * cosine - dz * sine)
-            corridor_yaw = yaw
-            if abs(_angle_delta(target_yaw, yaw)) > 0.20:
-                target_forward = dx * target_sine + dz * target_cosine
-                target_lateral = abs(
-                    dx * target_cosine - dz * target_sine)
-                if (target_forward > 0.0 and
-                        target_lateral < lateral):
-                    forward = target_forward
-                    lateral = target_lateral
-                    corridor_yaw = target_yaw
-            if forward <= 0.0:
+            if dx * sine + dz * cosine <= 0.0:
                 continue
-            other_length = max(
-                0.5, _number(raw.get('half_length'), 3.5))
-            other_width = max(
-                0.3, _number(raw.get('half_width'), 1.7))
+            other_length = max(0.5, _number(raw.get('half_length'), 3.5))
+            other_width = max(0.3, _number(raw.get('half_width'), 1.7))
             # The sum of both OBB circumradii is a strict separating bound.
-            # Outside it, no forward translation along this corridor can make
-            # the hulls overlap, so the four-axis continuous SAT is needless.
+            # Outside it no forward travel can make the hulls meet, so the
+            # four-axis continuous SAT below is needless.
             if BotRuntime._traffic_lateral_separated(
-                    lateral, own_width, own_length,
+                    abs(dx * cosine - dz * sine), own_width, own_length,
                     other_width, other_length):
                 continue
-            other_velocity = raw.get('velocity') or raw.get('vel')
+            velocity = raw.get('velocity') or raw.get('vel')
             try:
-                other_vx = float(other_velocity[0])
-                other_vz = float(other_velocity[2])
+                leader_speed = (float(velocity[0]) * sine +
+                                float(velocity[2]) * cosine)
             except (TypeError, ValueError, IndexError):
-                other_vx = 0.0
-                other_vz = 0.0
-            other_yaw = _number(raw.get('yaw'), corridor_yaw)
-            # Velocity has no direction once a teammate is parked.  Its hull
-            # yaw still tells us whether it occupies this lane longitudinally
-            # or crosses it, and therefore whether deterministic right of way
-            # can break a spawn-grid deadlock.  The physical near-field gate
-            # below still makes both ids brake inside the copied stopping
-            # distance.
-            same_direction = abs(
-                _angle_delta(other_yaw, corridor_yaw)) < 0.65
-            clearance = BotRuntime._traffic_obb_clearance(
-                dx, dz, corridor_yaw, yaw, own_width, own_length,
-                other_yaw, other_width, other_length)
-            if stopping_clearance is None:
-                stopping_distance = (
-                    stopping_distance_resolver(
-                        source, command, physics_params)
-                    if callable(stopping_distance_resolver) else
-                    BotRuntime._traffic_stopping_distance(
-                        own_speed, physics_params, slope_pitch, steering))
-                stopping_clearance = (
-                    TRAFFIC_STANDSTILL_CLEARANCE + stopping_distance)
-                scan_clearance = max(
-                    9.0, TRAFFIC_STANDSTILL_CLEARANCE +
-                    own_speed * TRAFFIC_HEADWAY_SECONDS,
-                    stopping_clearance)
-            if clearance > scan_clearance:
+                leader_speed = 0.0
+            if leader_speed >= own_speed + TRAFFIC_DIRECTION_SPEED_EPSILON:
                 continue
-            if (not same_direction and raw.get('id') is not None and
-                    source.get('id') is not None):
+            other_yaw = _number(raw.get('yaw'), yaw)
+            clearance = BotRuntime._traffic_obb_clearance(
+                dx, dz, yaw, yaw, own_width, own_length,
+                other_yaw, other_width, other_length)
+            if math.isinf(clearance):
+                continue
+            if nearest is None or clearance < nearest[1]:
                 try:
                     other_id = int(raw.get('id'))
-                    if (other_id < HUMAN_TARGET_ID_BASE and
-                            other_id > int(source.get('id')) and
-                            clearance > stopping_clearance):
-                        continue
                 except (TypeError, ValueError):
-                    pass
-            corridor_sine = math.sin(corridor_yaw)
-            corridor_cosine = math.cos(corridor_yaw)
-            other_forward = max(
-                0.0, other_vx * corridor_sine +
-                other_vz * corridor_cosine)
-            candidate = (clearance, other_forward, same_direction)
-            if nearest is None or candidate[0] < nearest[0]:
-                nearest = candidate
-        if nearest is None:
+                    other_id = -1
+                nearest = (other_id, clearance,
+                           abs(_angle_delta(other_yaw, yaw)) >= 0.65)
+        return nearest
+
+    def _traffic_follow_throttle(self, source, command, neighbours,
+                                 physics_params, step):
+        """Return ``(throttle, waiting)`` behind a slower teammate.
+
+        The limit holds while the teammate occupies the corridor. ``waiting``
+        suppresses stuck recovery only while the follower is stalled behind it.
+        After ``TRAFFIC_WAIT_LEASE_SECONDS`` of that, the follower is released
+        to a crawl so a dead column cannot hold it in place.
+        """
+        throttle = max(-1.0, min(1.0, _number(command.get('throttle'))))
+        bot_id = int(_number(source.get('id')))
+        blocker = None
+        if (throttle > 0.01 and physics_params is not None and
+                int(_number(source.get('team'))) in (1, 2)):
+            blocker = self._traffic_blocker(source, neighbours)
+        if blocker is None:
+            self._traffic_leases.pop(bot_id, None)
             return throttle, False
-        clearance, leader_speed, same_direction = nearest
-        if not same_direction:
-            # A crossing or head-on merge is a discrete right-of-way event,
-            # not longitudinal following.  Preserve the established yield
-            # gate; the continuous controller below applies only to vehicles
-            # travelling along the same corridor.
-            safe_clearance = max(
-                stopping_clearance,
-                TRAFFIC_STANDSTILL_CLEARANCE +
-                own_speed * TRAFFIC_HEADWAY_SECONDS)
-            if clearance <= safe_clearance:
-                return (0.0,
-                        own_speed > TRAFFIC_DIRECTION_SPEED_EPSILON)
-            if own_speed > leader_speed + 0.5:
-                limited = min(throttle, max(0.0, min(
-                    1.0, (clearance - safe_clearance) / 4.0)))
-                return (limited, bool(
-                    limited <= 0.01 and
-                    own_speed > TRAFFIC_DIRECTION_SPEED_EPSILON))
+        own_speed = abs(_number(source.get('speed')))
+        reserve = (TRAFFIC_STANDSTILL_CLEARANCE +
+                   self._cached_traffic_stopping_distance(
+                       source, command, physics_params))
+        # A crossing hull is a right-of-way event: the lower bot id keeps the
+        # lane and every bot yields to a human, but only while the copied coast
+        # distance still fits in front of that hull.
+        if (blocker[2] and blocker[1] > reserve and
+                bot_id < blocker[0] < HUMAN_TARGET_ID_BASE):
+            self._traffic_leases.pop(bot_id, None)
             return throttle, False
-        if clearance <= TRAFFIC_STANDSTILL_CLEARANCE:
-            return (0.0,
-                    own_speed > TRAFFIC_DIRECTION_SPEED_EPSILON)
-        try:
-            mass = max(1.0, float(physics_params['mass']))
-            drive_accel = vehicle_physics.engine_force(
-                physics_params, own_speed, 1.0, slope_pitch) / mass
-            rolling_accel = vehicle_physics.rolling_resist_force(
-                physics_params, 0, steering) / mass
-            gravity_accel = vehicle_physics.GRAVITY * math.sin(slope_pitch)
-        except (KeyError, TypeError, ValueError, OverflowError):
+        band = max(1.0, own_speed * TRAFFIC_HEADWAY_SECONDS)
+        limited = min(throttle, max(0.0, min(
+            1.0, (blocker[1] - reserve) / band)))
+        lease = self._traffic_leases.get(bot_id)
+        if lease is None or lease[0] != blocker[0]:
+            lease = [blocker[0], 0.0, False]
+            self._traffic_leases[bot_id] = lease
+        if limited >= throttle - 0.000001:
+            lease[1] = 0.0
+            lease[2] = False
             return throttle, False
-        if drive_accel <= 0.000001:
-            return throttle, False
-        desired_clearance = max(
-            stopping_clearance,
-            TRAFFIC_STANDSTILL_CLEARANCE +
-            own_speed * TRAFFIC_HEADWAY_SECONDS)
-        # Standard constant-time-headway feedback: close the spacing error in
-        # one headway while also matching the leader's forward velocity.  The
-        # result is an acceleration, not a hand-tuned throttle blend.
-        desired_accel = (
-            (clearance - desired_clearance) /
-            (TRAFFIC_HEADWAY_SECONDS * TRAFFIC_HEADWAY_SECONDS) +
-            (leader_speed - own_speed) / TRAFFIC_HEADWAY_SECONDS)
-        required = ((desired_accel - gravity_accel + rolling_accel) /
-                    drive_accel)
-        limited = min(throttle, max(0.0, min(1.0, required)))
-        # ``waiting`` suppresses route-stuck recovery only while a moving hull
-        # is actually coasting to a traffic stop.  A partial drive command is
-        # still progress, and a parked crossing must enter the existing
-        # recovery path so two stopped neighbours cannot reset one another's
-        # stuck clock forever.
-        return (limited, bool(
-            limited <= 0.01 and
-            own_speed > TRAFFIC_DIRECTION_SPEED_EPSILON))
+        progressing = own_speed >= TRAFFIC_PROGRESS_SPEED
+        if not lease[2]:
+            lease[1] = 0.0 if progressing else lease[1] + max(
+                0.0, _number(step))
+            lease[2] = lease[1] >= ai_driver.TRAFFIC_WAIT_LEASE_SECONDS
+        # A released column stays released against the same hull, so the
+        # follower crawls steadily instead of cycling through the lease.
+        if lease[2]:
+            return max(limited, min(throttle, TRAFFIC_RELEASE_THROTTLE)), False
+        return limited, not progressing
 
     def _player_vehicle_profile(self, raw):
         vehicle_name = raw.get('vehicle')
@@ -7741,10 +7680,9 @@ class BotRuntime(object):
         shot_lane_budget = [MAX_SHOT_LANE_PAIRS_PER_FRAME]
         shot_lanes_ready = True
         neighbours = list(neighbours or []) + self._player_neighbours(players)
-        # Native terrain and visibility probes run on BigWorld's render thread.
-        # Build the local-overlap view lazily, only when a staggered decision is
-        # due. It steers apart hulls which already touch; it never predicts
-        # traffic or changes their strategic terrain path.
+        # One local-overlap view per authority tick. It steers apart hulls which
+        # already touch and feeds the friendly following limit; it never changes
+        # a strategic terrain path.
         traffic_bodies = None
         traffic_index = None
         observation_entries = {}
@@ -7801,6 +7739,11 @@ class BotRuntime(object):
             tick_poses[state['id']] = position
             tick_safe[state['id']] = prebaked_navigation.pose_is_safe(
                 self.baked_graph, position, shoulder_cells=0)
+            if traffic_bodies is None:
+                traffic_bodies, traffic_index = self._traffic_snapshot(
+                    neighbours)
+            bot_neighbours = self._neighbours_for(
+                state, neighbours, traffic_index, traffic_bodies)
             server_order = self._server_orders.get(state['id'])
             decide_with_order = getattr(self.adapter, 'decide_with_order', None)
             cache_key = (('server', self._server_order_tokens.get(
@@ -7867,9 +7810,6 @@ class BotRuntime(object):
             else:
                 contacts, targets = self._contacts_for(
                     state, players, now, team_visibility, visibility_tick)
-                if traffic_bodies is None:
-                    traffic_bodies, traffic_index = self._traffic_snapshot(
-                        neighbours)
                 decision_step = step
                 if decision_cache is not None:
                     decision_step = max(
@@ -7897,13 +7837,7 @@ class BotRuntime(object):
                     'health': state['health'],
                     'max_health': state['max_health'],
                     'contacts': contacts,
-                    'neighbours': self._neighbours_for(
-                        state, neighbours, traffic_index, traffic_bodies),
-                    'velocity': (
-                        math.sin(_number(state.get('yaw'))) *
-                        _number(state.get('speed')), 0.0,
-                        math.cos(_number(state.get('yaw'))) *
-                        _number(state.get('speed'))),
+                    'neighbours': bot_neighbours,
                     'half_length': _number(state.get('half_length'), 3.5),
                     'half_width': _number(state.get('half_width'), 1.7),
                     'stopping_distance': stopping_distance,
@@ -7945,13 +7879,18 @@ class BotRuntime(object):
                     DECISION_TIER_FACTOR[self._detail_tier(state)],
                     3, decision_cache is None)
                 raw_command = dict(command)
-            # Hull contact is already solved simultaneously after every Bot's
-            # copied step. Friendly ramming no longer deals damage, so a second
-            # predictive headway controller only makes slow vehicles coast and
-            # accelerate in visible pulses. Preserve the planner's last valid
-            # command until terrain/world collision gives a completed veto.
-            command['throttle'] = max(
-                -1.0, min(1.0, _number(command.get('throttle'))))
+            # Hull contact stays owned by the simultaneous tank solver. This is
+            # only a following speed limit, so a queued Bot settles behind a
+            # slower teammate instead of pushing it and reversing away again.
+            command['throttle'], traffic_waiting = (
+                self._traffic_follow_throttle(
+                    state, command, bot_neighbours,
+                    self._physics_params.get(state['id']), step))
+            if traffic_waiting and decision_due:
+                driver = getattr(self.adapter, 'driver', None)
+                wait = getattr(driver, 'wait_for_traffic', None)
+                if callable(wait):
+                    wait(state['id'])
             if decision_due:
                 self._decision_cache[state['id']] = (
                     cache_key, decision_deadline, _number(now), raw_command,

--- a/0.9.22/tests/test_port_0922_ai.py
+++ b/0.9.22/tests/test_port_0922_ai.py
@@ -946,7 +946,6 @@ class BotAiPortTests(unittest.TestCase):
             133, (0.0, 0.0, 0.0), 0.0, 8.0, 0.1,
             (0.0, 0.0, 50.0), (neighbour,),
             lambda unused_yaw: True,
-            velocity=(0.0, 0.0, 8.0),
             half_length=3.5, half_width=1.7)
 
         self.assertEqual('drive', order['recovery_mode'])

--- a/0.9.22/tests/test_port_0922_bot_runtime.py
+++ b/0.9.22/tests/test_port_0922_bot_runtime.py
@@ -3535,17 +3535,18 @@ class BotRuntimeTests(unittest.TestCase):
             'velocity': (0.0, 0.0, 8.0),
             'half_length': 3.5, 'half_width': 1.7,
         }
+        runtime = self.module.BotRuntime(1)
+        params = self.module.vehicle_physics.derive_params({})
         original = self.module.BotRuntime._traffic_stopping_distance
         self.module.BotRuntime._traffic_stopping_distance = staticmethod(
             lambda *unused: (_ for _ in ()).throw(
                 AssertionError('unused coast integral ran')))
         try:
-            self.assertEqual((1.0, False), self.module.BotRuntime.
-                             _traffic_throttle(source, {
-                                 'throttle': 1.0,
-                                 'target_yaw': 0.0,
-                                 'turn': 0.0,
-                             }, [behind]))
+            self.assertEqual(
+                (1.0, False),
+                runtime._traffic_follow_throttle(
+                    source, {'throttle': 1.0, 'turn': 0.0}, [behind],
+                    params, 0.04))
         finally:
             self.module.BotRuntime._traffic_stopping_distance = staticmethod(
                 original)
@@ -3606,69 +3607,7 @@ class BotRuntimeTests(unittest.TestCase):
                                              other_yaw, other_width,
                                              other_length))
 
-    def test_friendly_crossing_traffic_brakes_both_inside_safe_clearance(self):
-        lower = {
-            'id': 21, 'team': 2,
-            'x': 0.0, 'y': 0.0, 'z': 0.0,
-            'yaw': 0.0, 'speed': 5.0,
-            'half_length': 3.5, 'half_width': 1.7,
-        }
-        higher = {
-            'id': 23, 'team': 2,
-            'x': 0.0, 'y': 0.0, 'z': 8.0,
-            'yaw': math.pi, 'speed': 5.0,
-            'half_length': 3.5, 'half_width': 1.7,
-        }
-        lower_command = {'throttle': 1.0, 'target_yaw': 0.0}
-        higher_command = {'throttle': 1.0, 'target_yaw': math.pi}
-
-        traffic_throttle = self.module.BotRuntime._traffic_throttle
-        lower_throttle, lower_waiting = traffic_throttle(
-            lower, lower_command, [dict(
-                higher, position=(higher['x'], higher['y'], higher['z']),
-                velocity=(0.0, 0.0, -5.0))])
-        higher_throttle, higher_waiting = traffic_throttle(
-            higher, higher_command, [dict(
-                lower, position=(lower['x'], lower['y'], lower['z']),
-                velocity=(0.0, 0.0, 5.0))])
-
-        self.assertEqual((0.0, True),
-                         (lower_throttle, lower_waiting))
-        self.assertEqual((0.0, True),
-                         (higher_throttle, higher_waiting))
-
-    def test_friendly_crossing_traffic_keeps_right_of_way_at_safe_distance(self):
-        lower = {
-            'id': 21, 'team': 2,
-            'x': 0.0, 'y': 0.0, 'z': 0.0,
-            'yaw': 0.0, 'speed': 5.0,
-            'half_length': 3.5, 'half_width': 1.7,
-        }
-        higher = {
-            'id': 23, 'team': 2,
-            'x': 0.0, 'y': 0.0, 'z': 15.0,
-            'yaw': math.pi, 'speed': 5.0,
-            'half_length': 3.5, 'half_width': 1.7,
-        }
-        lower_command = {'throttle': 1.0, 'target_yaw': 0.0}
-        higher_command = {'throttle': 1.0, 'target_yaw': math.pi}
-
-        traffic_throttle = self.module.BotRuntime._traffic_throttle
-        lower_throttle, lower_waiting = traffic_throttle(
-            lower, lower_command, [dict(
-                higher, position=(higher['x'], higher['y'], higher['z']),
-                velocity=(0.0, 0.0, -5.0))])
-        higher_throttle, higher_waiting = traffic_throttle(
-            higher, higher_command, [dict(
-                lower, position=(lower['x'], lower['y'], lower['z']),
-                velocity=(0.0, 0.0, 5.0))])
-
-        self.assertEqual((1.0, False),
-                         (lower_throttle, lower_waiting))
-        self.assertLess(higher_throttle, 1.0)
-        self.assertFalse(higher_waiting)
-
-    def test_crossing_nearfield_uses_copied_stopping_distance(self):
+    def test_traffic_stopping_distance_matches_the_copied_coast_law(self):
         vehicle_physics = self.module.vehicle_physics
         params = vehicle_physics.derive_params(_combat_descriptor())
         speed = 13.0
@@ -3683,65 +3622,83 @@ class BotRuntimeTests(unittest.TestCase):
             simulated += max(0.0, current) * self.module.PUBLICATION_SECONDS
         self.assertAlmostEqual(simulated, stopping, places=9)
 
+    def test_stopped_teammate_ahead_settles_the_follower_behind_it(self):
+        runtime = self.module.BotRuntime(1)
+        params = self.module.vehicle_physics.derive_params({})
         source = {
+            'id': 10, 'team': 1,
+            'x': 0.0, 'y': 0.0, 'z': 0.0,
+            'yaw': 0.0, 'speed': 0.0,
+            'half_length': 3.5, 'half_width': 1.7,
+            'last_drive_pitch': 0.0,
+        }
+        command = {'throttle': 1.0, 'turn': 0.0}
+
+        def teammate(clearance):
+            return {
+                'id': 12, 'team': 1,
+                'position': (0.0, 0.0, 7.0 + clearance), 'yaw': 0.0,
+                'velocity': (0.0, 0.0, 0.0),
+                'half_length': 3.5, 'half_width': 1.7,
+            }
+
+        self.assertEqual(
+            (0.0, True),
+            runtime._traffic_follow_throttle(
+                source, command,
+                [teammate(self.module.TRAFFIC_STANDSTILL_CLEARANCE - 0.01)],
+                params, 0.04))
+        self.assertEqual(
+            (1.0, False),
+            runtime._traffic_follow_throttle(
+                source, command,
+                [teammate(self.module.TRAFFIC_STANDSTILL_CLEARANCE + 1.01)],
+                params, 0.04))
+
+    def test_crossing_teammates_break_the_tie_by_bot_id(self):
+        runtime = self.module.BotRuntime(1)
+        params = self.module.vehicle_physics.derive_params({})
+        speed = 5.0
+        gap = (7.0 + 2.0 + self.module.TRAFFIC_STANDSTILL_CLEARANCE +
+               self.module.BotRuntime._traffic_stopping_distance(
+                   speed, params))
+        lower = {
             'id': 21, 'team': 2,
             'x': 0.0, 'y': 0.0, 'z': 0.0,
             'yaw': 0.0, 'speed': speed,
             'half_length': 3.5, 'half_width': 1.7,
             'last_drive_pitch': 0.0,
         }
-        command = {'throttle': 1.0, 'target_yaw': 0.0, 'turn': 0.0}
-        edge_threshold = (
-            self.module.TRAFFIC_STANDSTILL_CLEARANCE + stopping)
-
-        def crossing(clearance):
-            return {
-                'id': 23, 'team': 2,
-                'position': (0.0, 0.0, 7.0 + clearance),
-                'yaw': math.pi, 'velocity': (0.0, 0.0, -speed),
-                'half_length': 3.5, 'half_width': 1.7,
-            }
-
-        self.assertEqual((0.0, True), self.module.BotRuntime.
-                         _traffic_throttle(
-                             source, command,
-                             [crossing(edge_threshold - 0.01)], params))
-        self.assertEqual((1.0, False), self.module.BotRuntime.
-                         _traffic_throttle(
-                             source, command,
-                             [crossing(edge_threshold + 0.01)], params))
-
-    def test_stopped_crossing_keeps_hull_yaw_and_nearfield_gate(self):
-        source = {
-            'id': 10, 'team': 1,
-            'x': 0.0, 'y': 0.0, 'z': 0.0,
-            'yaw': 0.0, 'speed': 0.0,
+        higher = {
+            'id': 23, 'team': 2,
+            'x': 0.0, 'y': 0.0, 'z': gap,
+            'yaw': math.pi, 'speed': speed,
             'half_length': 3.5, 'half_width': 1.7,
+            'last_drive_pitch': 0.0,
         }
-        command = {
-            'throttle': 1.0, 'target_yaw': 0.0, 'turn': 0.0,
-        }
+        command = {'throttle': 1.0, 'turn': 0.0}
 
-        def stopped_crossing(clearance):
-            # Perpendicular projected forward support is its half-width.
-            return {
-                'id': 12, 'team': 1,
-                'position': (0.0, 0.0, 3.5 + 1.7 + clearance),
-                'yaw': math.pi * 0.5,
-                'velocity': (0.0, 0.0, 0.0),
-                'half_length': 3.5, 'half_width': 1.7,
-            }
+        self.assertEqual(
+            (1.0, False),
+            runtime._traffic_follow_throttle(
+                lower, command,
+                [dict(higher, position=(0.0, 0.0, gap),
+                      velocity=(0.0, 0.0, -speed))], params, 0.04))
+        higher_throttle, higher_waiting = runtime._traffic_follow_throttle(
+            higher, command,
+            [dict(lower, position=(0.0, 0.0, 0.0),
+                  velocity=(0.0, 0.0, speed))], params, 0.04)
+        self.assertLess(higher_throttle, 1.0)
+        self.assertFalse(higher_waiting)
 
-        self.assertEqual((0.0, False), self.module.BotRuntime.
-                         _traffic_throttle(source, command, [
-                             stopped_crossing(
-                                 self.module.
-                                 TRAFFIC_STANDSTILL_CLEARANCE - 0.01)]))
-        self.assertEqual((1.0, False), self.module.BotRuntime.
-                         _traffic_throttle(source, command, [
-                             stopped_crossing(
-                                 self.module.
-                                 TRAFFIC_STANDSTILL_CLEARANCE + 0.01)]))
+        # The same crossing against a human keeps no right of way at all.
+        human_throttle, human_waiting = runtime._traffic_follow_throttle(
+            lower, command,
+            [dict(higher, id=self.module.HUMAN_TARGET_ID_BASE + 1,
+                  position=(0.0, 0.0, gap),
+                  velocity=(0.0, 0.0, -speed))], params, 0.04)
+        self.assertLess(human_throttle, 1.0)
+        self.assertFalse(human_waiting)
 
     def test_rotated_obb_corners_that_miss_the_corridor_do_not_block(self):
         source = {
@@ -3751,7 +3708,7 @@ class BotRuntimeTests(unittest.TestCase):
             'half_length': 3.5, 'half_width': 1.7,
         }
         other = {
-            'id': 15, 'team': 1,
+            'id': 5, 'team': 1,
             'position': (5.3, 0.0, 6.0),
             'yaw': math.pi * 0.5,
             'velocity': (0.0, 0.0, 0.0),
@@ -3762,84 +3719,75 @@ class BotRuntimeTests(unittest.TestCase):
                          _traffic_obb_clearance(
                              5.3, 6.0, 0.0, 0.0, 1.7, 3.5,
                              math.pi * 0.5, 1.7, 3.5))
-        self.assertEqual((1.0, False), self.module.BotRuntime.
-                         _traffic_throttle(source, {
-                             'throttle': 1.0,
-                             'target_yaw': 0.0,
-                             'turn': 0.0,
-                         }, [other]))
+        self.assertIsNone(
+            self.module.BotRuntime._traffic_blocker(source, [other]))
 
-    def test_lower_id_fast_bot_brakes_for_rotated_stopped_teammate(self):
-        source = {
-            'id': 23, 'team': 2,
-            'x': 0.0, 'y': 0.0, 'z': 0.0,
-            'yaw': 0.641, 'speed': 13.163,
-            'half_length': 3.5, 'half_width': 1.7,
-        }
-        forward = 11.0
-        other = {
-            'id': 30, 'team': 2,
-            'position': (
-                math.sin(source['yaw']) * forward, 0.0,
-                math.cos(source['yaw']) * forward),
-            'yaw': 2.582,
-            'velocity': (-0.0010, 0.0, 0.0016),
-            'half_length': 3.5, 'half_width': 1.7,
-        }
-
-        self.assertEqual((0.0, True), self.module.BotRuntime.
-                         _traffic_throttle(source, {
-                             'throttle': 1.0,
-                             'target_yaw': source['yaw'],
-                         }, [other]))
-
-    def test_rotated_stopped_teammate_uses_projected_hull_width(self):
+    def test_rotated_stopped_teammate_blocks_by_projected_hull_width(self):
+        runtime = self.module.BotRuntime(1)
+        params = self.module.vehicle_physics.derive_params({})
         source = {
             'id': 19, 'team': 2,
             'x': 0.0, 'y': 0.0, 'z': 0.0,
             'yaw': 0.0, 'speed': 8.59,
             'half_length': 3.5, 'half_width': 1.7,
+            'last_drive_pitch': 0.0,
         }
         other = {
             'id': 30, 'team': 2,
-            # The centre is outside the parallel-width corridor.  Its long
-            # hull is nearly perpendicular, however, and occupies that lane
-            # inside the follower's copied stopping clearance.
+            # The centre is outside the parallel-width corridor.  Its long hull
+            # is nearly perpendicular and still occupies the lane ahead.
             'position': (4.5, 0.0, 9.0),
             'yaw': math.pi * 0.5,
             'velocity': (0.0, 0.0, 0.0),
             'half_length': 5.0, 'half_width': 1.5,
         }
 
-        self.assertEqual((0.0, True), self.module.BotRuntime.
-                         _traffic_throttle(source, {
-                             'throttle': 1.0, 'target_yaw': 0.0,
-                         }, [other]))
+        blocker = self.module.BotRuntime._traffic_blocker(source, [other])
+        self.assertEqual(30, blocker[0])
+        self.assertEqual(
+            (0.0, False),
+            runtime._traffic_follow_throttle(
+                source, {'throttle': 1.0, 'turn': 0.0}, [other], params, 0.04))
 
-    def test_high_speed_headway_is_not_clipped_at_nine_metres(self):
+    def test_traffic_yield_is_friendly_only(self):
         source = {
-            'id': 23, 'team': 2,
+            'id': 21, 'team': 2,
             'x': 0.0, 'y': 0.0, 'z': 0.0,
-            'yaw': 0.0, 'speed': 13.163,
+            'yaw': 0.0, 'speed': 5.0,
             'half_length': 3.5, 'half_width': 1.7,
         }
-        # Twelve metres edge-to-edge is outside the former fixed 9 m scan,
-        # but inside the established standstill gap + one-second headway.
-        other = {
-            'id': 30, 'team': 2,
-            'position': (0.0, 0.0, 19.0), 'yaw': 0.0,
+        traffic = {
+            'position': (0.0, 0.0, 8.0), 'yaw': 0.0,
             'velocity': (0.0, 0.0, 0.0),
             'half_length': 3.5, 'half_width': 1.7,
         }
 
-        self.assertEqual((0.0, True), self.module.BotRuntime.
-                         _traffic_throttle(source, {
-                             'throttle': 1.0, 'target_yaw': 0.0,
-                         }, [other]))
+        blocker = self.module.BotRuntime._traffic_blocker
+        self.assertIsNone(blocker(source, [dict(traffic, id=22, team=1)]))
+        self.assertEqual(
+            22, blocker(source, [dict(traffic, id=22, team=2)])[0])
 
-    def test_malinovka_fast_follower_stops_before_rotated_teammate(self):
+    def test_a_teammate_pulling_away_is_never_a_blocker(self):
+        source = {
+            'id': 21, 'team': 2,
+            'x': 0.0, 'y': 0.0, 'z': 0.0,
+            'yaw': 0.0, 'speed': 5.0,
+            'half_length': 3.5, 'half_width': 1.7,
+        }
+        ahead = {
+            'id': 22, 'team': 2,
+            'position': (0.0, 0.0, 8.0), 'yaw': 0.0,
+            'velocity': (0.0, 0.0, 9.0),
+            'half_length': 3.5, 'half_width': 1.7,
+        }
+
+        self.assertIsNone(
+            self.module.BotRuntime._traffic_blocker(source, [ahead]))
+
+    def test_fast_follower_settles_behind_a_stopped_teammate(self):
         vehicle_physics = self.module.vehicle_physics
         params = vehicle_physics.derive_params({})
+        runtime = self.module.BotRuntime(1)
         yaw = 0.641
         source = {
             'id': 23, 'team': 2,
@@ -3858,25 +3806,141 @@ class BotRuntimeTests(unittest.TestCase):
             'velocity': (-0.0010, 0.0, 0.0016),
             'half_length': 3.5, 'half_width': 1.7,
         }
-        command = {'throttle': 1.0, 'target_yaw': yaw, 'turn': 0.0}
-        minimum_clearance = leader_forward - 7.0
+        command = {'throttle': 1.0, 'turn': 0.0}
+        leased_clearance = leader_forward - 7.0
+        leased_speed = None
+        released_throttle = []
 
-        # Twenty-four seconds is long enough to prove this converges to the
-        # stopped queue instead of merely delaying the same collision.
         for unused_frame in range(600):
-            throttle, unused_waiting = self.module.BotRuntime.\
-                _traffic_throttle(source, command, [other], params)
+            throttle, waiting = runtime._traffic_follow_throttle(
+                source, command, [other], params, 0.04)
             source['speed'] = vehicle_physics.longitudinal_step(
                 params, source['speed'], throttle, False, 0.0, 0.04)
             source['x'] += math.sin(yaw) * source['speed'] * 0.04
             source['z'] += math.cos(yaw) * source['speed'] * 0.04
             travelled = (source['x'] * math.sin(yaw) +
                          source['z'] * math.cos(yaw))
-            minimum_clearance = min(
-                minimum_clearance, leader_forward - travelled - 7.0)
+            clearance = leader_forward - travelled - 7.0
+            if waiting:
+                leased_speed = source['speed']
+                leased_clearance = min(leased_clearance, clearance)
+            elif leased_speed is not None and clearance > 0.0:
+                released_throttle.append(throttle)
 
-        self.assertGreater(minimum_clearance, 0.0)
-        self.assertAlmostEqual(0.0, source['speed'], delta=0.05)
+        # The follower brakes to a standstill behind the hull ahead instead of
+        # arriving at approach speed.
+        self.assertGreater(leased_clearance, 0.0)
+        self.assertIsNotNone(leased_speed)
+        self.assertLess(leased_speed, 1.0)
+        # A column that never moves releases to a crawl, never to full drive.
+        self.assertTrue(released_throttle)
+        self.assertLessEqual(
+            max(released_throttle), self.module.TRAFFIC_RELEASE_THROTTLE)
+
+    def test_traffic_lease_expires_and_stays_released_while_parked(self):
+        runtime = self.module.BotRuntime(1)
+        params = self.module.vehicle_physics.derive_params({})
+        source = {
+            'id': 10, 'team': 1,
+            'x': 0.0, 'y': 0.0, 'z': 0.0,
+            'yaw': 0.0, 'speed': 0.0,
+            'half_length': 3.5, 'half_width': 1.7,
+            'last_drive_pitch': 0.0,
+        }
+        parked = {
+            'id': 12, 'team': 1,
+            'position': (0.0, 0.0, 7.5), 'yaw': 0.0,
+            'velocity': (0.0, 0.0, 0.0),
+            'half_length': 3.5, 'half_width': 1.7,
+        }
+        command = {'throttle': 1.0, 'turn': 0.0}
+        results = [runtime._traffic_follow_throttle(
+            source, command, [parked], params, 0.04) for unused in range(200)]
+        held = [index for index, result in enumerate(results) if result[1]]
+
+        # The limit holds the follower at a standstill while the lease runs,
+        # then releases it to a crawl rather than to full drive.
+        self.assertEqual([0.0] * len(held), [results[i][0] for i in held])
+        self.assertEqual(list(range(len(held))), held)
+        self.assertAlmostEqual(
+            self.module.ai_driver.TRAFFIC_WAIT_LEASE_SECONDS,
+            len(held) * 0.04, delta=0.04)
+        self.assertEqual(
+            [(self.module.TRAFFIC_RELEASE_THROTTLE, False)] * (200 - len(held)),
+            results[len(held):])
+
+    def test_traffic_lease_releases_when_the_teammate_moves_away(self):
+        runtime = self.module.BotRuntime(1)
+        params = self.module.vehicle_physics.derive_params({})
+        source = {
+            'id': 10, 'team': 1,
+            'x': 0.0, 'y': 0.0, 'z': 0.0,
+            'yaw': 0.0, 'speed': 0.0,
+            'half_length': 3.5, 'half_width': 1.7,
+            'last_drive_pitch': 0.0,
+        }
+        leader = {
+            'id': 12, 'team': 1,
+            'position': (0.0, 0.0, 7.5), 'yaw': 0.0,
+            'velocity': (0.0, 0.0, 0.0),
+            'half_length': 3.5, 'half_width': 1.7,
+        }
+        command = {'throttle': 1.0, 'turn': 0.0}
+
+        self.assertEqual((0.0, True), runtime._traffic_follow_throttle(
+            source, command, [leader], params, 0.04))
+        leader['position'] = (0.0, 0.0, 20.0)
+        leader['velocity'] = (0.0, 0.0, 6.0)
+
+        self.assertEqual((1.0, False), runtime._traffic_follow_throttle(
+            source, command, [leader], params, 0.04))
+        self.assertEqual({}, runtime._traffic_leases)
+
+    def test_two_facing_bots_never_both_yield_forever(self):
+        runtime = self.module.BotRuntime(1)
+        params = self.module.vehicle_physics.derive_params({})
+        command = {'throttle': 1.0, 'turn': 0.0}
+        lower = {
+            'id': 21, 'team': 2,
+            'x': 0.0, 'y': 0.0, 'z': 0.0,
+            'yaw': 0.0, 'speed': 0.0,
+            'half_length': 3.5, 'half_width': 1.7,
+            'last_drive_pitch': 0.0,
+        }
+        higher = {
+            'id': 23, 'team': 2,
+            'x': 0.0, 'y': 0.0, 'z': 12.0,
+            'yaw': math.pi, 'speed': 0.0,
+            'half_length': 3.5, 'half_width': 1.7,
+            'last_drive_pitch': 0.0,
+        }
+        stalled = 0
+        waits = []
+
+        for unused_frame in range(200):
+            lower_throttle, lower_waiting = runtime._traffic_follow_throttle(
+                lower, command, [dict(
+                    higher, position=(higher['x'], 0.0, higher['z']),
+                    velocity=(0.0, 0.0, 0.0))], params, 0.04)
+            higher_throttle, higher_waiting = runtime._traffic_follow_throttle(
+                higher, command, [dict(
+                    lower, position=(lower['x'], 0.0, lower['z']),
+                    velocity=(0.0, 0.0, 0.0))], params, 0.04)
+            if lower_throttle <= 0.01 and higher_throttle <= 0.01:
+                stalled += 1
+            waits.append((lower_waiting, higher_waiting))
+            lower['z'] += lower_throttle * 0.04
+            higher['z'] -= higher_throttle * 0.04
+
+        # Deterministic right of way keeps the pair asymmetric: the lower id
+        # takes more of the closing distance than the hull it meets.
+        self.assertGreater(lower['z'], 1.0)
+        self.assertGreater(lower['z'], 12.0 - higher['z'])
+        # Neither bot is suppressed forever, so a close standoff still reaches
+        # the ordinary stuck recovery instead of holding both in place.
+        self.assertFalse(waits[-1][0])
+        self.assertFalse(waits[-1][1])
+        self.assertGreater(stalled, 0)
 
     def test_opening_queue_runtime_never_reaches_stopped_teammate(self):
         yaw = 0.641
@@ -3953,17 +4017,30 @@ class BotRuntimeTests(unittest.TestCase):
             'half_length': 3.5, 'half_width': 1.7,
         }
 
-        traffic_throttle = self.module.BotRuntime._traffic_throttle
-        self.assertEqual((1.0, False), traffic_throttle(
-            source, command, [dict(traffic, id=22, team=1)]))
-        self.assertEqual((0.0, True), traffic_throttle(
+        runtime = self.module.BotRuntime(1)
+        params = self.module.vehicle_physics.derive_params({})
+
+        # An enemy hull is never traffic.
+        self.assertEqual((1.0, False), runtime._traffic_follow_throttle(
+            source, command, [dict(traffic, id=22, team=1)], params, 0.04))
+        # A friendly human ahead is yielded to like any other teammate.
+        self.assertEqual((0.0, False), runtime._traffic_follow_throttle(
             source, command, [dict(
                 traffic, id=self.module.HUMAN_TARGET_ID_BASE + 1,
-                team=2)]))
+                team=2)], params, 0.04))
+        # Right of way never lets a bot claim a lane against a human, even
+        # when its own id is the lower one.
+        crossing = dict(
+            traffic, id=self.module.HUMAN_TARGET_ID_BASE + 1, team=2,
+            yaw=math.pi * 0.5, position=(0.0, 0.0, 12.0))
+        throttle, unused_waiting = runtime._traffic_follow_throttle(
+            source, command, [crossing], params, 0.04)
+        self.assertLess(throttle, 1.0)
 
     def test_dense_spawn_following_has_no_full_coast_speed_pulse(self):
         vehicle_physics = self.module.vehicle_physics
         params = vehicle_physics.derive_params({})
+        runtime = self.module.BotRuntime(1)
         source = {
             'id': 21, 'team': 2,
             'x': 0.0, 'y': 0.0, 'z': 0.0,
@@ -3989,14 +4066,14 @@ class BotRuntimeTests(unittest.TestCase):
             if frame % 3 == 0:
                 source['z'] = follower_z
                 source['speed'] = follower_speed
-                throttle, unused_waiting = self.module.BotRuntime.\
-                    _traffic_throttle(source, command, [{
+                throttle, unused_waiting = runtime._traffic_follow_throttle(
+                    source, command, [{
                         'id': 22, 'team': 2,
                         'position': (0.0, 0.0, leader_z),
                         'yaw': 0.0,
                         'velocity': (0.0, 0.0, leader_speed),
                         'half_length': 3.5, 'half_width': 1.7,
-                    }], params)
+                    }], params, 0.12)
             previous_speed = follower_speed
             leader_speed = vehicle_physics.longitudinal_step(
                 params, leader_speed, 0.7, False, 0.0, frame_step)
@@ -4008,7 +4085,11 @@ class BotRuntimeTests(unittest.TestCase):
             speed_steps.append(follower_speed - previous_speed)
             clearances.append(clearance)
 
-        self.assertGreater(min(clearances), 4.0)
+        # The queue closes while both hulls accelerate, then recovers. It stays
+        # clear of the standstill gap throughout.
+        self.assertGreater(
+            min(clearances), self.module.TRAFFIC_STANDSTILL_CLEARANCE * 2.0)
+        self.assertGreater(clearances[-1], 4.0)
         self.assertGreater(min(throttle_samples), 0.1)
         self.assertGreater(min(speed_steps), -0.05)
         self.assertAlmostEqual(leader_speed, follower_speed, delta=0.05)
@@ -12954,7 +13035,7 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertEqual(0.0, state['yaw'])
         self.assertEqual(0, state['rotation_dir'])
 
-    def test_driver_receives_native_collision_dimensions_and_velocity(self):
+    def test_driver_receives_native_collision_dimensions(self):
         descriptor = _combat_descriptor()
         descriptor.chassis.hitTester = _HitTester1513(
             (-2.1, -1.0, -4.2), (2.3, 1.0, 3.8))
@@ -12969,10 +13050,7 @@ class BotRuntimeTests(unittest.TestCase):
         decision = self.adapters[0].calls[0][0]
         self.assertEqual(4.2, decision['half_length'])
         self.assertEqual(2.3, decision['half_width'])
-        expected_velocity = (
-            math.sin(self.runtime.states[11]['yaw']) * 6.0, 0.0,
-            math.cos(self.runtime.states[11]['yaw']) * 6.0)
-        self.assertEqual(expected_velocity, decision['velocity'])
+        self.assertNotIn('velocity', decision)
         neighbour = decision['neighbours'][0]
         self.assertEqual(4.2, neighbour['half_length'])
         self.assertEqual(2.3, neighbour['half_width'])

--- a/0.9.22/tests/test_port_0922_fjord_departure.py
+++ b/0.9.22/tests/test_port_0922_fjord_departure.py
@@ -218,17 +218,17 @@ class SpawnDepartureTests(unittest.TestCase):
                     return order
 
                 runtime.adapter.driver.drive = drive
-                original_traffic = runtime._traffic_throttle
+                original_traffic = runtime._traffic_follow_throttle
 
-                def traffic_throttle(
-                        source, command, neighbours, physics_params=None):
+                def traffic_follow_throttle(
+                        source, command, neighbours, physics_params, step):
                     throttle, waiting = original_traffic(
-                        source, command, neighbours, physics_params)
+                        source, command, neighbours, physics_params, step)
                     monitor.record(
                         'traffic', int(source['id']), waiting, now[0])
                     return throttle, waiting
 
-                runtime._traffic_throttle = traffic_throttle
+                runtime._traffic_follow_throttle = traffic_follow_throttle
 
                 for frame in range(1, fps * 30 + 1):
                     now[0] = frame / float(fps)


### PR DESCRIPTION
## Problem

A bot following a stopped teammate drove into it at approach speed. The contact solver separated the pair, displacement went to zero, the stuck timer misfired at its 1.8-2.2 s threshold, the bot reversed for ~1 s, then drove in again. That loop is the visible "bots interfere with each other" symptom.

All teammate traffic control had been deleted earlier. `BotRuntime._traffic_throttle`, `LocalDriver.wait_for_traffic` and `LocalDriver._prediction_clear` had no production caller left, so nothing slowed a follower and nothing told the driver that queueing is not the same as being stuck. Tank-to-tank contact never sets `motion_status == 'hard'`, so `report_hard_contact` never fired for a blocking teammate either.

## Change

`_traffic_blocker` returns the nearest friendly hull inside the bot's own travel corridor that is stopped or no faster, plus whether it crosses that corridor. It reuses the existing circumradius separating bound before the four-axis SAT, so the scan stays cheap enough for a per-control-step call.

`_traffic_follow_throttle` ramps the throttle down across a headway band so the follower settles behind that hull instead of pushing it, and reports `waiting` while it is stalled there. `waiting` drives `wait_for_traffic`, which clears the driver's stuck and recovery timers, so a queue no longer reads as being stuck.

A crossing hull keeps the established right of way: the lower bot id holds the lane, and every bot yields to a human.

## The lease is the interesting part

Three behaviours were tried, and only the third satisfies both requirements.

| After the lease expires | Result |
| --- | --- |
| Release to full throttle | Restores the ram: the follower accelerates into the stationary hull from 1.4 m away |
| Keep the limit | Strands bots at spawn. `test_port_0922_fjord_departure` caught two bots that moved 5.8 m and 8.6 m in 30 s, and a 6.7 s continuous traffic wait against its 5 s guard |
| Release to a crawl, latched | Follower works past the hull at `TRAFFIC_RELEASE_THROTTLE` while `waiting` clears, so ordinary stuck recovery reroutes it |

The lease also had to be keyed on progress rather than on a near-zero speed. Keying it on `TRAFFIC_DIRECTION_SPEED_EPSILON` let an inching bot reset the lease every step, so `waiting` never cleared and the departure guard failed. It now accumulates whenever the follower is below `TRAFFIC_PROGRESS_SPEED`, and the release latches against the same hull so the bot crawls steadily instead of cycling between crawling and stopping.

Measured against a stationary leader 30 m ahead at 13 m/s: throttle ramps from 1.0 to 0 between t=1.1 s and t=2.2 s, the follower settles 1.36 m behind, and at t=4.3 s the lease releases it to a 0.35 crawl with `waiting` cleared.

## Removed

`_prediction_clear`, `_velocity`, the `velocity` argument to `drive`/`_choose_yaw`, and the `velocity` decision field. The deleted predictive controller was their only reader.

## Tests

New: follower settles without ramming and releases only to a crawl; the lease expires and stays released against a parked hull; two facing bots break the tie by id and neither is suppressed forever; a queued bot does not enter reverse recovery.

Ported to the new API rather than deleted: friendly-only yielding with human priority, the dense-spawn no-throttle-pulse episode, the rotated-hull corridor test, the crossing tie-break, and the Fjord/Airfield spawn departure instrumentation.

Several assertions changed meaning because `waiting` now means "stalled behind traffic" rather than "limited": a bot still moving at 5 m/s while being limited reports `waiting=False`, since its stuck timer cannot misfire. Two episode tests also stopped asserting on final positions, because `_traffic_follow_throttle` alone has no contact solver and lets hulls pass through each other in a unit harness.

- `python -m unittest discover -s 0.9.22/tests -p "test_*.py"`: 2853 tests, OK
- CPython 2.7.18 source compile of the client tree: 88 files passed
- `git diff --check`: clean

## What this does not prove

Pure-data tests prove the throttle law and the lease. Whether the queue feels right, and whether the crawl hand-off to stuck recovery resolves a real spawn column, needs the exact Windows client. `TRAFFIC_RELEASE_THROTTLE` and `TRAFFIC_PROGRESS_SPEED` are design choices, not calibrated values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)