### PR TITLE
Make controlled shallow-water recovery coherent

### DIFF
--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/ai/driver.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/ai/driver.py
@@ -11,6 +11,8 @@ import math
 
 WAYPOINT_ARRIVAL_RADIUS = 1.5
 TRAFFIC_WAIT_LEASE_SECONDS = 1.5
+# First avoidance branch of the steering fan.
+FIRST_CANDIDATE_OFFSET = 0.42
 # Fifteen-degree circular buckets centre both the +/-pi seam and cardinal yaws.
 FAILED_YAW_BUCKET_COUNT = 24
 
@@ -120,7 +122,8 @@ class LocalDriver(object):
 	treated as blocked.
 	"""
 	_CANDIDATE_OFFSETS = (
-		0.0, 0.42, -0.42, 0.78, -0.78, 1.18, -1.18, 1.55, -1.55)
+		0.0, FIRST_CANDIDATE_OFFSET, -FIRST_CANDIDATE_OFFSET,
+		0.78, -0.78, 1.18, -1.18, 1.55, -1.55)
 	gun_yaw_limits = staticmethod(gun_yaw_limits)
 	combat_hull_aim = staticmethod(combat_hull_aim)
 	gun_aligned = staticmethod(gun_aligned)

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
@@ -11,7 +11,8 @@ probes so it can be tested outside the legacy client.
 import heapq
 import math
 
-from gui.mods.offline_lan_0922.ai.driver import WAYPOINT_ARRIVAL_RADIUS
+from gui.mods.offline_lan_0922.ai.driver import (
+	FIRST_CANDIDATE_OFFSET, WAYPOINT_ARRIVAL_RADIUS)
 
 
 SQRT_TWO = math.sqrt(2.0)
@@ -23,10 +24,12 @@ BAKED_SHALLOW_WATER_PENALTY = 4.0
 BAKED_EDGE_CLEARANCE_WEIGHT = 0.20
 BAKED_FORMAT_NAME = 'offline-lan-0922-navgraph'
 BAKED_FORMAT_VERSION = 2
-HARD_CONTACT_REPLAN_SECONDS = 1.0
-HARD_CONTACT_REPLAN_VERDICTS = 4
-HARD_CONTACT_EDGE_TTL = 12.0
-HARD_CONTACT_EDGE_PENALTY = 240.0
+BLOCKED_STEP_REPLAN_SECONDS = 1.0
+BLOCKED_STEP_REPLAN_VERDICTS = 4
+BLOCKED_STEP_EDGE_TTL = 12.0
+BLOCKED_STEP_EDGE_PENALTY = 240.0
+# A controlled ford admits LocalDriver's first avoidance branch, and no wider.
+CONTROLLED_SHALLOW_YAW_WINDOW = FIRST_CANDIDATE_OFFSET + 0.03
 
 SEARCH_EXPANSIONS_PER_SECOND = 960.0
 MAX_SEARCH_EXPANSIONS_PER_FRAME = 96
@@ -256,19 +259,6 @@ class TerrainGrid(object):
 					cache.popitem()
 				except Exception:
 					break
-
-	def remember_failed_segment(self, start, end, now, ttl=18.0, penalty=240.0):
-		"""Penalize the first coarse edge of a route that made no progress."""
-		key = self._edge_cells_for_segment(start, end)
-		if key is None:
-			return
-		self._failed_edges[key] = (float(now) + max(1.0, float(ttl)),
-		                           max(0.0, float(penalty)))
-		if len(self._failed_edges) > 512:
-			alive = [(edge, value) for edge, value in self._failed_edges.items()
-			         if value[0] > float(now)]
-			alive.sort(key=lambda item: item[1][0], reverse=True)
-			self._failed_edges = dict(alive[:384])
 
 	def _failed_edge_penalty(self, first_cell, second_cell, now):
 		key = tuple(sorted((first_cell, second_cell)))
@@ -927,8 +917,8 @@ class TerrainNavigator(object):
 				'tick_age_ms': int(max(0.0, float(now) - self.search_now) * 1000.0)
 					if now is not None else 0,
 			},
-			'hard_contact_replans': sum(
-				int(state.get('hard_contact_replans', 0))
+			'blocked_step_replans': sum(
+				int(state.get('blocked_step_replans', 0))
 				for state in self.bot_states.values()),
 		}
 
@@ -941,7 +931,16 @@ class TerrainNavigator(object):
 		as steering intent for LocalDriver. The caller still probes every candidate
 		vehicle-width corridor and can only throttle into one that is locally safe.
 		"""
-		state.pop('controlled_shallow_target', None)
+		# A fallback replaces the route decision, not the ford the planner already
+		# selected. Drop that ford only once it stops being a reachable safe edge.
+		ford = state.get('controlled_shallow_target')
+		if ford is not None and (
+				_distance_2d(current, ford) <= WAYPOINT_ARRIVAL_RADIUS or
+				self._bot_edges_penalized(bot_id, current, ford, now) or
+				self.grid.segment_has_baked_hazard(
+					current, ford, BAKED_FATAL_HAZARDS) or
+				not self.grid.segment_clear(current, ford)):
+			state.pop('controlled_shallow_target', None)
 		if allow_safe_local:
 			fallback = self.grid.safe_local_target(
 				current, goal, now, avoid_points,
@@ -1008,8 +1007,15 @@ class TerrainNavigator(object):
 			self.bot_failed_edges.pop(int(bot_id), None)
 		return result or None
 
-	def report_hard_contact(self, bot_id, current, target, now):
-		"""Escalate repeated completed contact into a bot-local route replan."""
+	def _bot_edges_penalized(self, bot_id, start, end, now):
+		"""True when this bot's own escalation covers any edge of the segment."""
+		penalties = self._active_bot_edge_penalties(bot_id, now)
+		return bool(penalties and any(
+			edge in penalties
+			for edge in self.grid._edge_keys_for_segment(start, end)))
+
+	def report_blocked_step(self, bot_id, current, target, now):
+		"""Escalate a repeated contact or planner veto into a bot-local replan."""
 		bot_id = int(bot_id)
 		state = self.bot_states.get(bot_id)
 		if state is None or target is None:
@@ -1024,34 +1030,34 @@ class TerrainNavigator(object):
 		if key is None:
 			return False
 		now = float(now)
-		if now < float(state.get('hard_contact_escalated_until', 0.0)):
+		if now < float(state.get('blocked_step_escalated_until', 0.0)):
 			return False
-		tracker = state.get('hard_contact_tracker')
-		same_contact = bool(
+		tracker = state.get('blocked_step_tracker')
+		same_edge = bool(
 			isinstance(tracker, dict) and tracker.get('key') == key and
 			now - float(tracker.get('last_at', now)) <= 0.5 and
 			_distance_2d(current, tracker.get('origin', current)) <=
 			max(1.5, self.grid.cell_size * 0.5))
-		if same_contact:
+		if same_edge:
 			tracker['count'] = int(tracker.get('count', 0)) + 1
 			tracker['last_at'] = now
 		else:
 			tracker = {
 				'key': key, 'count': 1, 'first_at': now,
 				'last_at': now, 'origin': tuple(current)}
-			state['hard_contact_tracker'] = tracker
-		if (int(tracker['count']) < HARD_CONTACT_REPLAN_VERDICTS or
-				now - float(tracker['first_at']) < HARD_CONTACT_REPLAN_SECONDS):
+			state['blocked_step_tracker'] = tracker
+		if (int(tracker['count']) < BLOCKED_STEP_REPLAN_VERDICTS or
+				now - float(tracker['first_at']) < BLOCKED_STEP_REPLAN_SECONDS):
 			return False
 		failed = self.bot_failed_edges.setdefault(bot_id, {})
 		failed[key] = (
-			now + HARD_CONTACT_EDGE_TTL, HARD_CONTACT_EDGE_PENALTY)
+			now + BLOCKED_STEP_EDGE_TTL, BLOCKED_STEP_EDGE_PENALTY)
 		state['replan_generation'] = int(
 			state.get('replan_generation', 0)) + 1
-		state['hard_contact_replans'] = int(
-			state.get('hard_contact_replans', 0)) + 1
-		state['hard_contact_escalated_until'] = now + 2.0
-		state['hard_contact_tracker'] = None
+		state['blocked_step_replans'] = int(
+			state.get('blocked_step_replans', 0)) + 1
+		state['blocked_step_escalated_until'] = now + 2.0
+		state['blocked_step_tracker'] = None
 		state['path_key'] = None
 		state['index'] = 0
 		state['recovery_start'] = tuple(current)
@@ -1346,9 +1352,9 @@ class TerrainNavigator(object):
 			         'planned_at': 0.0, 'navigation_status': 'pending',
 			         'target_is_terminal': False,
 			         'replan_generation': 0, 'replan_active': False,
-			         'hard_contact_replans': 0,
-			         'hard_contact_tracker': None,
-			         'hard_contact_escalated_until': 0.0}
+			         'blocked_step_replans': 0,
+			         'blocked_step_tracker': None,
+			         'blocked_step_escalated_until': 0.0}
 			self.bot_states[bot_id] = state
 		path_identity = tuple(path_key)
 		planned_goal = state.get('planned_goal')
@@ -1546,11 +1552,10 @@ class TerrainNavigator(object):
 		return bool(state is not None and state.get('target_is_terminal'))
 
 	def controlled_shallow_step(self, bot_id, current, sample_yaw,
-			maximum_yaw_error=0.20):
-		"""Admit only the A*-selected heading into a passable shallow cell."""
+			maximum_yaw_error=CONTROLLED_SHALLOW_YAW_WINDOW):
+		"""Admit only headings toward the A*-selected ford into a shallow cell."""
 		state = self.bot_states.get(int(bot_id))
-		if (state is None or
-				self.fallback_modes.get(int(bot_id)) not in (None, 'pending')):
+		if state is None:
 			return False
 		target = state.get('controlled_shallow_target')
 		if target is None:

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -8319,6 +8319,15 @@ class BotRuntime(object):
                 remember = getattr(driver, 'remember_failure', None)
                 if callable(remember) and not probe_deferred:
                     remember(state['id'], travel_yaw)
+                report_blocked = getattr(
+                    self.navigator, 'report_blocked_step', None)
+                # A hull contact escalates from its realised status below.
+                if (callable(report_blocked) and not probe_deferred and
+                        not (isinstance(motion_probe, dict) and
+                             motion_probe.get('collision', False)) and
+                        command.get('move_position') is not None):
+                    report_blocked(state['id'], position,
+                                   command.get('move_position'), now)
             steer_dir = 0
             if abs(turn) > 0.01:
                 # LocalDriver already inverts reverse recovery steering for the
@@ -8466,7 +8475,7 @@ class BotRuntime(object):
                             state, position, state['yaw'], speed,
                             descriptor, step, now)
                     report_contact = getattr(
-                        self.navigator, 'report_hard_contact', None)
+                        self.navigator, 'report_blocked_step', None)
                     if (callable(report_contact) and
                             command.get('move_position') is not None):
                         report_contact(

--- a/0.9.22/tests/test_port_0922_ai.py
+++ b/0.9.22/tests/test_port_0922_ai.py
@@ -20,7 +20,8 @@ from gui.mods.offline_lan_0922.ai.planner import (
     BattleDirector, build_vehicle_profile,
 )
 from gui.mods.offline_lan_0922.ai.navigation import (
-    BAKED_SHALLOW_WATER, MAX_SEARCH_EXPANSIONS_PER_FRAME,
+    BAKED_FATAL_HAZARDS, BAKED_SHALLOW_WATER,
+    MAX_SEARCH_EXPANSIONS_PER_FRAME,
     SEARCH_EXPANSIONS_PER_SECOND, TerrainGrid, TerrainNavigator,
 )
 from gui.mods.offline_lan_0922 import prebaked_navigation
@@ -686,7 +687,7 @@ class BotAiPortTests(unittest.TestCase):
         self.assertTrue(navigator.controlled_shallow_step(
             7, current, math.pi * 0.5))
         self.assertFalse(navigator.controlled_shallow_step(
-            7, current, math.pi * 0.5 + 0.42))
+            7, current, math.pi * 0.5 + 0.78))
 
         retained = navigator.next_target(
             7, current, goal, ('route', 1, 'only-ford'), 1.2)
@@ -694,6 +695,180 @@ class BotAiPortTests(unittest.TestCase):
         self.assertNotIn(7, navigator.fallback_modes)
         self.assertTrue(navigator.controlled_shallow_step(
             7, current, math.pi * 0.5))
+
+    def _planned_ford(self, bot_id=7):
+        """Return a navigator whose only route crosses one shallow cell."""
+        graph = self._baked_graph(3, 1)
+        graph['hazards'] = [0, BAKED_SHALLOW_WATER, 0]
+        navigator = TerrainNavigator(lambda *unused: None, baked_graph=graph)
+        current = (10.0, 0.0, 20.0)
+        goal = (18.0, 0.0, 20.0)
+        route_key = ('route', 1, 'only-ford')
+        navigator.next_target(bot_id, current, goal, route_key, 1.0)
+        self.assertEqual((14.0, 0.0, 20.0), navigator.next_target(
+            bot_id, current, goal, route_key, 1.1))
+        return navigator, current, goal
+
+    def test_fallback_bot_still_follows_the_planner_selected_ford(self):
+        for mode, local in (('safe_local', (10.0, 0.0, 22.0)),
+                            ('reactive', None)):
+            navigator, current, goal = self._planned_ford()
+            navigator._path = lambda *unused: (('search-result',), ())
+            navigator.grid.safe_local_target = (
+                lambda *unused, **kwargs: local)
+
+            navigator.next_target(
+                7, current, goal, ('route', 1, 'only-ford'), 1.2)
+
+            self.assertEqual(mode, navigator.fallback_modes[7])
+            self.assertTrue(navigator.controlled_shallow_step(
+                7, current, math.pi * 0.5))
+
+    def test_first_steering_candidate_offset_may_enter_the_planned_ford(self):
+        navigator, current, unused_goal = self._planned_ford()
+        offsets = sorted(set(abs(value)
+                             for value in LocalDriver._CANDIDATE_OFFSETS))
+        bearing = math.pi * 0.5
+
+        self.assertEqual(0.0, offsets[0])
+        for sign in (1.0, -1.0):
+            self.assertTrue(navigator.controlled_shallow_step(
+                7, current, bearing + sign * offsets[1]))
+            self.assertFalse(navigator.controlled_shallow_step(
+                7, current, bearing + sign * offsets[2]))
+
+    def test_fallback_drops_a_ford_target_behind_deep_water(self):
+        graph = self._baked_graph(3, 1, blocked=((1, 0),))
+        graph['hazards'] = [0, 1, 0]
+        navigator = TerrainNavigator(lambda *unused: None, baked_graph=graph)
+        current = (10.0, 0.0, 20.0)
+        goal = (18.0, 0.0, 20.0)
+        state = {'controlled_shallow_target': goal}
+        navigator.bot_states[7] = state
+
+        navigator._fallback_target(7, current, goal, 1.0, None, state, False)
+
+        self.assertTrue(navigator.grid.segment_has_baked_hazard(
+            current, goal, BAKED_FATAL_HAZARDS))
+        self.assertNotIn('controlled_shallow_target', state)
+        self.assertFalse(navigator.controlled_shallow_step(
+            7, current, math.pi * 0.5))
+
+    def test_fallback_drops_a_ford_this_bot_escalated_away_from(self):
+        graph = self._baked_graph(3, 1)
+        navigator = TerrainNavigator(lambda *unused: None, baked_graph=graph)
+        current = (10.0, 0.0, 20.0)
+        ford = (18.0, 0.0, 20.0)
+        state = {'controlled_shallow_target': ford}
+        navigator.bot_states[7] = state
+        navigator.bot_states[8] = {'controlled_shallow_target': ford}
+
+        navigator._fallback_target(7, current, ford, 1.0, None, state, False)
+        self.assertEqual(ford, state['controlled_shallow_target'])
+
+        edge = navigator.grid._edge_cells_for_segment(current, ford)
+        navigator.bot_failed_edges[7] = {edge: (60.0, 240.0)}
+        navigator._fallback_target(7, current, ford, 1.0, None, state, False)
+
+        self.assertIsNone(state.get('controlled_shallow_target'))
+        # The peer never escalated, so its own ford survives.
+        peer = navigator.bot_states[8]
+        navigator._fallback_target(8, current, ford, 1.0, None, peer, False)
+        self.assertEqual(ford, peer['controlled_shallow_target'])
+        self.assertFalse(navigator.grid._failed_edges)
+
+    def test_blocked_step_escalation_reroutes_only_the_reporting_bot(self):
+        graph = self._baked_graph(5, 3, blocked=((2, 1),))
+        navigator = TerrainNavigator(lambda *unused: None, baked_graph=graph)
+        current = (10.0, 0.0, 24.0)
+        goal = (26.0, 0.0, 24.0)
+        route_key = ('route', 1, 'veto-detour')
+        now = 1.0
+        for unused_step in range(12):
+            now += 0.02
+            vetoed = navigator.next_target(11, current, goal, route_key, now)
+            peer = navigator.next_target(12, current, goal, route_key, now)
+
+        for offset in (0.0, 0.34, 0.68, 1.02):
+            navigator.report_blocked_step(11, current, vetoed, now + offset)
+        now += 1.02
+        replanned = current
+        for unused_step in range(30):
+            now += 0.02
+            replanned = navigator.next_target(11, current, goal, route_key, now)
+
+        self.assertEqual(vetoed, peer)
+        self.assertNotEqual(vetoed, replanned)
+        self.assertEqual(peer, navigator.next_target(
+            12, current, goal, route_key, now + 0.02))
+        self.assertFalse(navigator.grid._failed_edges)
+        self.assertNotIn(12, navigator.bot_failed_edges)
+        self.assertEqual(
+            1, navigator.bot_states[11]['blocked_step_replans'])
+        self.assertEqual(0, navigator.bot_states[12].get(
+            'blocked_step_replans', 0))
+
+    def test_shore_ford_episode_crosses_instead_of_oscillating(self):
+        open_cells = set(((0, 2), (1, 2), (2, 2), (3, 2)))
+        for x in range(4, 7):
+            for z in range(5):
+                open_cells.add((x, z))
+        graph = self._baked_graph(7, 5, blocked=tuple(
+            (x, z) for z in range(5) for x in range(7)
+            if (x, z) not in open_cells))
+        graph['hazards'][2 * 7 + 3] = BAKED_SHALLOW_WATER
+        navigator = TerrainNavigator(lambda *unused: None, baked_graph=graph)
+        grid = navigator.grid
+        driver = LocalDriver()
+        goal = (34.0, 0.0, 28.0)
+        route_key = ('route', 1, 'shore-ford')
+        position = [10.0, 0.0, 28.0]
+        yaw = [0.0]
+        planned = navigator._path
+
+        def shore_search(path_key, start, target, now, avoid_points):
+            # A search near the shore fails after A* has selected the ford.
+            if position[0] >= 17.0:
+                return (('shore-search-failed',), ())
+            return planned(path_key, start, target, now, avoid_points)
+
+        def direction_clear(sample_yaw):
+            # Same one-cell corridor rule as the runtime planner gate.
+            end = (position[0] + math.sin(sample_yaw) * grid.cell_size,
+                   position[1],
+                   position[2] + math.cos(sample_yaw) * grid.cell_size)
+            mask = BAKED_FATAL_HAZARDS
+            if not navigator.controlled_shallow_step(
+                    9, tuple(position), sample_yaw):
+                mask |= BAKED_SHALLOW_WATER
+            return (not grid.segment_has_baked_hazard(
+                        tuple(position), end, mask) and
+                    grid.segment_clear(tuple(position), end))
+
+        navigator._path = shore_search
+        now = 1.0
+        near_bank_fallbacks = set()
+        for unused_step in range(200):
+            target = navigator.next_target(
+                9, tuple(position), goal, route_key, now)
+            mode = navigator.fallback_modes.get(9)
+            if position[0] < 22.0 and mode in ('safe_local', 'reactive'):
+                near_bank_fallbacks.add(mode)
+            command = driver.drive(
+                9, tuple(position), yaw[0], 0.0, 0.1, target, (),
+                direction_clear)
+            yaw[0] = float(command['target_yaw'])
+            throttle = float(command['throttle'])
+            travel = yaw[0] if throttle >= 0.0 else yaw[0] + math.pi
+            if abs(throttle) > 0.0 and direction_clear(travel):
+                position[0] += math.sin(travel) * 4.0 * abs(throttle) * 0.1
+                position[2] += math.cos(travel) * 4.0 * abs(throttle) * 0.1
+            now += 0.1
+
+        self.assertTrue(near_bank_fallbacks)
+        self.assertGreater(position[0], 30.0)
+        self.assertFalse(grid.point_has_baked_hazard(
+            tuple(position), BAKED_FATAL_HAZARDS | BAKED_SHALLOW_WATER))
 
     def test_prebaked_segment_rejects_destination_beyond_map_bounds(self):
         graph = self._baked_graph(3, 1)
@@ -778,7 +953,7 @@ class BotAiPortTests(unittest.TestCase):
         self.assertTrue(grid.path_has_penalty((
             (0.0, 0.0, 0.0), (4.0, 0.0, 0.0)), 1.0))
 
-    def test_repeated_hard_contact_replans_only_the_blocked_bot(self):
+    def test_repeated_blocked_step_replans_only_the_blocked_bot(self):
         graph = self._baked_graph(5, 3)
         navigator = TerrainNavigator(
             lambda *unused: None, baked_graph=graph)
@@ -787,7 +962,7 @@ class BotAiPortTests(unittest.TestCase):
         route_key = ('route', 1, 'contact-detour')
         navigator.next_target(11, current, goal, route_key, 1.0)
 
-        escalated = [navigator.report_hard_contact(
+        escalated = [navigator.report_blocked_step(
             11, current, goal, now) for now in (1.0, 1.34, 1.68, 2.02)]
 
         self.assertEqual([False, False, False, True], escalated)
@@ -798,7 +973,7 @@ class BotAiPortTests(unittest.TestCase):
         navigator.next_target(11, current, goal, route_key, 2.04)
         active_key = navigator.bot_states[11]['path_key']
         self.assertEqual('recovery', active_key[0][0])
-        self.assertEqual(1, navigator.bot_states[11]['hard_contact_replans'])
+        self.assertEqual(1, navigator.bot_states[11]['blocked_step_replans'])
 
     def test_superseded_route_join_search_is_cancelled_for_its_bot(self):
         navigator = TerrainNavigator(lambda *unused: 0.0)

--- a/0.9.22/tests/test_port_0922_bot_runtime.py
+++ b/0.9.22/tests/test_port_0922_bot_runtime.py
@@ -1458,6 +1458,62 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertTrue(runtime._planner_corridor_clear(
             (0.0, 0.0, 0.0), 0.0, 0.0, allow_shallow=True))
 
+    def test_controlled_shallow_step_cannot_admit_a_fatal_baked_hazard(self):
+        class Grid(object):
+            prebaked = True
+            cell_size = 4.0
+
+            def near_baked_navigation(self, unused_position, unused_radius):
+                return True
+
+            def segment_has_baked_hazard(
+                    self, unused_start, unused_end, hazard_mask):
+                return bool(hazard_mask & self_module.BAKED_FATAL_HAZARDS)
+
+            def segment_clear(self, unused_start, unused_end):
+                raise AssertionError('fatal hazard should decide first')
+
+        self_module = self.module
+        runtime = self.module.BotRuntime(1)
+        runtime.navigator = types.SimpleNamespace(grid=Grid())
+        runtime.baked_graph = {'bake': {
+            'vehicle_half_width': 2.15,
+            'edge_clearance_radii': (3.0,),
+        }}
+
+        self.assertFalse(runtime._planner_corridor_clear(
+            (0.0, 0.0, 0.0), 0.0, 0.0, allow_shallow=True))
+
+    def test_repeated_water_veto_reports_a_blocked_step_for_that_bot(self):
+        aim = (0.0, 0.0, 200.0)
+        command = self._stationary_command()
+        command.update({
+            'throttle': 1.0, 'combat_mode': 'route',
+            'aim_position': aim, 'face_position': aim, 'move_position': aim,
+            'recovery_mode': 'drive', 'movement_intent': True,
+        })
+        runtime = self.module.BotRuntime(
+            1, descriptor_resolver=lambda unused: _combat_descriptor(),
+            adapter_factory=lambda *unused, **kwargs: _FixedAdapter(command),
+            direction_probe=lambda *unused: {
+                'clear': False, 'collision': False, 'water': True,
+                'slope': 0.0},
+            ground_probe=lambda *unused: 0.0,
+            physics_ground_probe=lambda *unused: 0.0,
+            spawn_resolver=_spawn_resolver, baked_graph=_graph())
+        runtime.battle_start(self.start)
+        reports = []
+        runtime.navigator.report_blocked_step = (
+            lambda *args: reports.append(args))
+        state = runtime.states[11]
+        state.update(x=0.0, y=0.0, z=0.0, yaw=0.0, speed=4.0,
+                     grounded_once=True)
+
+        runtime.update(.04, 1.0)
+
+        self.assertEqual([(11, (0.0, 0.0, 0.0), aim, 1.0)], reports)
+        self.assertEqual((0.0, 0.0), (state['x'], state['z']))
+
     def test_post_turn_travel_yaw_cannot_enter_unplanned_shallow(self):
         graph = _graph()
         graph['hazards'] = (0, self.module.BAKED_SHALLOW_WATER, 0)
@@ -3031,7 +3087,7 @@ class BotRuntimeTests(unittest.TestCase):
             spawn_resolver=_spawn_resolver, baked_graph=_graph())
         runtime.battle_start(self.start)
         contact_reports = []
-        runtime.navigator.report_hard_contact = (
+        runtime.navigator.report_blocked_step = (
             lambda *args: contact_reports.append(args))
         state = runtime.states[11]
         state.update(x=0.0, y=0.0, z=0.0, yaw=attempted_yaw,


### PR DESCRIPTION
## Problem

Bots reaching a shore ford could stall there for the rest of the battle: approach, get vetoed, back off, re-approach, repeat. Shallow-water policy disagreed between the layers, and a water veto had no escalation path. `0.9.22/CLAUDE.md` requires hazard policy to be identical across A*, direct shortcuts, smoothing, local recovery and the runtime probe.

## Three disagreements, three changes

**A fallback state forbade the ford outright.** `controlled_shallow_step` returned False whenever the bot held any fallback mode, while A* treats shallow water as high-cost passable and had already routed through the ford. Searches near water fail often, so the bot entered `safe_local` or `reactive` and could then never take the crossing its own route had selected; `_planner_corridor_clear` rejected every candidate toward it as `BAKED_SHALLOW_WATER`.

The fallback now keeps the planner's ford and drops it only once it stops being a reachable safe edge: on arrival, on a fatal baked hazard, when the segment stops being clear, or when this bot's own escalation covers it.

**The alignment window was narrower than the driver's first steering branch.** `controlled_shallow_step` admitted headings within 0.20 rad of the ford bearing, but `LocalDriver` candidate offsets start at 0.42 rad. Every avoidance-offset candidate therefore lost `allow_shallow` and was masked out; with the straight-ahead direction separately blocked the whole fan emptied, `_choose_yaw` returned None and the bot dropped into blocked/recovery.

The window is now derived from `FIRST_CANDIDATE_OFFSET`, which `LocalDriver._CANDIDATE_OFFSETS` also uses, so the two cannot drift apart. Wider offsets stay rejected.

**A repeated veto had no escalation.** The motion gate only recorded a 5 s yaw failure and zeroed the throttle. `report_hard_contact` already turned repeated blocked steps into a bot-scoped failed edge and a replan, but only a realised hull contact reached it, so A* kept returning the identical route and the bot retried the same approach forever.

It is renamed `report_blocked_step` and the planner-veto path now reports too, excluding budget-deferred probes (a deferred probe is not evidence about the terrain) and contacts that already escalate from their own realised status.

## Escalation is bot-scoped

`TerrainGrid.remember_failed_segment` is removed. It was the only writer of the shared failed-edge table, had no caller anywhere in `0.9.22/src` or `0.9.22/tests`, and shared grid state is the wrong owner for one bot's local decision.

That exposed an incoherence worth flagging: the ford-retention check first consulted `grid.segment_penalty`, which can never be non-zero now that the shared table has no writer. It consults this bot's own escalated edges instead, so an escalation actually retires the ford it escalated away from. A regression test covers exactly this, and fails if the check reverts to the shared table.

Deep water stays rejected in every path, and no shared navgraph or grid state is mutated.

## Tests

- A bot in `safe_local` or `reactive` fallback still follows the planner-selected ford.
- A candidate at the driver's first steering offset may enter the planned ford; the next offset out may not.
- The fallback drops a ford behind deep water, and drops one this bot escalated away from while a peer keeps its own.
- Repeated blocked steps replan only the reporting bot, leaving `grid._failed_edges` empty and the peer's routing untouched.
- A shore-ford episode crosses instead of oscillating.

Commands run:

- `python -m unittest discover -s 0.9.22/tests -p "test_port_0922_ai.py"`: 61 tests, OK
- `python -m unittest discover -s 0.9.22/tests -p "test_*.py"`: 2859 tests, OK
- CPython 2.7.18 source compile of the client tree: 88 files passed
- `git diff --check`: clean

## Merge order

Verified by trial merge against `origin/main`:

- This branch + #5 (teammate traffic): merges clean.
- This branch + #3 (A* credit): **one conflict**, in the `ai.navigation` import list of `0.9.22/tests/test_port_0922_ai.py`. Both branches added a constant to the same import. Resolve by taking the union of the two lists; the `ai/navigation.py` source itself merges clean. With the union applied, `test_port_0922_ai.py` passes 64 tests.
- #3 + #5: merges clean.

## What this does not prove

Pure-data tests prove the gates agree and that escalation is bot-local. Whether bots actually cross the fords on the maps where Peng saw them stall needs the exact Windows client. Publishing `fallback_diagnostics`, which is implemented but has no caller, would make that observable in a single session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
