### PR TITLE
Keep Python bots moving at low worker frame rates

### DIFF
--- a/0.9.22/server/lan_battle_server.py
+++ b/0.9.22/server/lan_battle_server.py
@@ -5134,6 +5134,7 @@ class BattleState:
             source_time_us = None
             source_batch_horizon_us = None
             source_clock_rebase = False
+            same_source_batch = False
             if "sample_time_us" in message:
                 try:
                     source_time_us = _exact_int(
@@ -5161,6 +5162,10 @@ class BattleState:
                         "horizon_us=%s previous=%s" % (
                             source_batch_horizon_us,
                             self.bot_source_batch_horizon_us))
+                same_source_batch = bool(
+                    self.bot_source_batch_horizon_us is not None and
+                    source_batch_horizon_us ==
+                    self.bot_source_batch_horizon_us)
                 if (self.bot_source_time_us is not None and
                         source_time_us <= self.bot_source_time_us):
                     return self._set_protocol_reject(
@@ -5181,9 +5186,10 @@ class BattleState:
                     receipt_elapsed_us = max(
                         0, received_raw_motion_time_us -
                         self.bot_source_receipt_time_us)
-                    if source_delta_us > (
-                            receipt_elapsed_us +
-                            MAX_BOT_SAMPLE_LEAD_US):
+                    if (not same_source_batch and
+                            source_delta_us > (
+                                receipt_elapsed_us +
+                                MAX_BOT_SAMPLE_LEAD_US)):
                         # A complete, valid publication may re-anchor the
                         # trusted source clock after a render stall or a
                         # coalesced outbound backlog.  Defer that rebase until
@@ -5195,6 +5201,11 @@ class BattleState:
                             received_motion_time_us,
                             self.bot_state_time_us + 1)
                     else:
+                        # One slow worker callback can publish ordered physical
+                        # checkpoints which share its final source horizon.
+                        # Their near-identical receipt times do not make the
+                        # later checkpoint a source-clock jump; preserving the
+                        # source delta also preserves every admitted shot edge.
                         next_bot_state_time_us = (
                             self.bot_state_time_us + source_delta_us)
             elif "source_batch_horizon_us" in message:

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -39,11 +39,11 @@ OBSERVATION_SECONDS = 0.40
 # while burst edges below retain their exact due timestamps.
 PUBLICATION_SECONDS = 1.0 / 30.0
 WORKER_CONTROL_SECONDS = 0.10
-# Run at most one full-roster step in a render callback. A late callback
-# consumes its actual elapsed interval in that one step instead of queuing
-# another complete planner/probe pass or leaking permanent simulation debt.
-# The mature variable-step seam already bounds copied physics at 200 ms; keep
-# the worker inside that reviewed limit and carry only larger one-off stalls.
+# Keep copied physics inside the mature 200 ms variable-step bound. A slow
+# render callback may need several such slices, but only its first slice may
+# refresh planner control work. Later slices keep applying the last valid
+# command and acquire a new physical corridor only after ongoing motion has
+# consumed or rotated beyond the previous proof.
 MAX_CONTROL_ELAPSED_SECONDS = 0.20
 LOCAL_ACTION_SECONDS = 0.10
 TACTICAL_REFRESH_SECONDS = 1.0
@@ -1824,6 +1824,11 @@ class BotRuntime(object):
         self._fixed_control = control_seconds is not None
         self._control_seconds = max(
             0.001, _number(control_seconds, PUBLICATION_SECONDS))
+        # Direct _update_once callers retain the mature full-control behavior.
+        # update() temporarily clears this flag only for physical catch-up
+        # slices inside the same render callback.
+        self._refresh_control_this_step = True
+        self._publish_control_this_step = True
         self._water_depth_probe = (
             water_depth_probe if callable(water_depth_probe) else
             (lambda unused_position: -1.0))
@@ -4519,9 +4524,23 @@ class BotRuntime(object):
                 now >= cached.get('deadline', 0.0)):
             return False
         lookahead = 20.0 if abs(_number(speed)) > 5.0 else 15.0
+        forward_budget = MOTION_PROBE_FORWARD_BUDGET
+        if ignore_deadline:
+            # A catch-up slice keeps exactly the sampled heading. Its complete
+            # dual-height, three-lane corridor may therefore be consumed up to
+            # the actual probed distance instead of paying the ordinary 3.5 m
+            # re-planning budget repeatedly in one render callback.
+            probed_distance = cached.get('probe_distance')
+            if probed_distance is not None:
+                current_reach = max(
+                    0.4, abs(_number(speed)) * max(
+                        0.0, min(MAX_CONTROL_ELAPSED_SECONDS, _number(dt))) +
+                    0.2)
+                forward_budget = max(
+                    0.0, _number(probed_distance) - current_reach)
         heading_drift = lookahead * abs(math.sin(angle))
         reusable = bool(
-            -0.1 <= forward <= MOTION_PROBE_FORWARD_BUDGET and
+            -0.1 <= forward <= forward_budget and
             lateral + heading_drift <= MOTION_PROBE_LATERAL_BUDGET)
         if not reusable:
             return False
@@ -6852,7 +6871,8 @@ class BotRuntime(object):
         cached = self._ballistic_solution_cache.get(bot_id)
         fresh = bool(
             force or cached is None or cached[0] != signature or
-            _number(now) + 1.0e-9 >= cached[1])
+            (self._refresh_control_this_step and
+             _number(now) + 1.0e-9 >= cached[1]))
         if fresh:
             solution = self._ballistic_solution(
                 state, target, descriptor, shell_index, now)
@@ -7792,14 +7812,14 @@ class BotRuntime(object):
         return result
 
     def update(self, dt, now, players=None, neighbours=None):
-        """Advance Bot control without multiplying full-roster slow work.
+        """Advance Bot motion in real time with one control refresh per frame.
 
-        Fixed-control workers run at most once per render callback. That step
-        consumes the accumulated elapsed interval up to the reviewed 200 ms
-        physics bound, so a sustained 5-10 FPS worker keeps moving in real
-        time instead of adding 100 ms of permanent debt every frame. An armed
-        burst may shorten the step at its next physical round; the remainder
-        stays queued so no one-shot edge or frozen launch pose is skipped.
+        Fixed-control workers consume every elapsed second in bounded physical
+        slices. The first slice may think and observe; later slices keep its
+        command until the next render callback. Physical corridor proofs may
+        still follow an ongoing turn, without re-entering the planner. Burst
+        edges can shorten any slice, so accepted rounds and their frozen launch
+        poses are never skipped when a callback is late.
         """
         if (not self.is_authority() or self.adapter is None or
                 self.finished):
@@ -7838,17 +7858,24 @@ class BotRuntime(object):
                             min(elapsed, 0.2))
                         elapsed = max(0.0, elapsed - frame_step)
                         step_now = now - elapsed
-                        outgoing.extend(self._update_once(
-                            frame_step, step_now, players, neighbours))
+                        outgoing.extend(self._run_update_once(
+                            frame_step, step_now, players, neighbours, True,
+                            True))
                 else:
-                    frame_step = min(
-                        self._accumulator, MAX_CONTROL_ELAPSED_SECONDS)
-                    frame_step = self._bounded_burst_step(frame_step)
-                    self._accumulator = max(
-                        0.0, self._accumulator - frame_step)
-                    step_now = now - self._accumulator
-                    outgoing.extend(self._update_once(
-                        frame_step, step_now, players, neighbours))
+                    elapsed = self._accumulator
+                    self._accumulator = 0.0
+                    refresh_control = True
+                    while elapsed > 1e-12:
+                        frame_step = self._bounded_burst_step(
+                            min(elapsed, MAX_CONTROL_ELAPSED_SECONDS))
+                        elapsed = max(0.0, elapsed - frame_step)
+                        step_now = now - elapsed
+                        publish_step = bool(
+                            refresh_control or elapsed <= 1e-12)
+                        outgoing.extend(self._run_update_once(
+                            frame_step, step_now, players, neighbours,
+                            refresh_control, publish_step))
+                        refresh_control = False
             finally:
                 if receipt_frame_open:
                     self._finish_world_receipt_frame()
@@ -7865,9 +7892,25 @@ class BotRuntime(object):
             message['source_batch_horizon_us'] = source_batch_horizon_us
         return outgoing
 
+    def _run_update_once(self, frame_step, now, players, neighbours,
+                         refresh_control, publish_step=True):
+        """Expose one per-callback control-refresh flag without changing seams."""
+        previous = (
+            self._refresh_control_this_step,
+            self._publish_control_this_step)
+        self._refresh_control_this_step = bool(refresh_control)
+        self._publish_control_this_step = bool(publish_step)
+        try:
+            return self._update_once(
+                frame_step, now, players, neighbours)
+        finally:
+            (self._refresh_control_this_step,
+             self._publish_control_this_step) = previous
+
     def _update_once(self, frame_step, now, players=None, neighbours=None):
         """Advance one stable authority substep and preserve its events."""
-        publish = True
+        publish = bool(self._publish_control_this_step)
+        refresh_control = bool(self._refresh_control_this_step)
         step_duration_us = max(
             1, int(round(float(frame_step) * 1000000.0)))
         step_start_time_us = self._sample_time_us
@@ -7888,18 +7931,19 @@ class BotRuntime(object):
         # Spotting is latency-sensitive presentation state. Full-roster firing
         # lanes and cover fans only guide the one-hertz server planner, so they
         # run on independent clocks and can never delay this observation.
-        observation_due = now >= self._next_observation
+        observation_due = refresh_control and now >= self._next_observation
         collect_observation = publish and observation_due
         shot_lane_refresh_time = self._next_shot_lane_refresh
         shot_lane_refresh_due = now >= shot_lane_refresh_time
         refresh_shot_lanes = (
+            refresh_control and
             not self._cover_queue and
             (shot_lane_refresh_due or
              (shot_lane_refresh_time > 0.0 and
               now + SHOT_LANE_REFRESH_SECONDS + 1e-9 >=
               shot_lane_refresh_time)))
         collect_cover_jobs = bool(
-            publish and not self._cover_queue and
+            refresh_control and publish and not self._cover_queue and
             now >= self._next_cover_refresh)
         shot_lane_budget = [MAX_SHOT_LANE_PAIRS_PER_FRAME]
         shot_lanes_ready = True
@@ -7970,10 +8014,13 @@ class BotRuntime(object):
                               state['id'], 0))
                          if server_order is not None else ('local',))
             decision_cache = self._decision_cache.get(state['id'])
-            decision_due = not (
-                decision_cache is not None and
-                decision_cache[0] == cache_key and
-                _number(now) < decision_cache[1])
+            decision_cache_valid = bool(
+                decision_cache is not None and len(decision_cache) >= 6 and
+                decision_cache[0] == cache_key)
+            decision_due = bool(
+                refresh_control and
+                (not decision_cache_valid or
+                 _number(now) >= decision_cache[1]))
             decision_deadline = None
             raw_command = None
             planner_probe_samples = {}
@@ -8020,13 +8067,30 @@ class BotRuntime(object):
                     return True
                 return self._probe_is_clear(sample)
 
-            if not decision_due:
-                if len(decision_cache) < 6:
-                    raise RuntimeError(
-                        'cached bot perception is unavailable')
+            if decision_cache_valid and not decision_due:
                 command = dict(decision_cache[3])
                 contacts = decision_cache[4]
                 targets = decision_cache[5]
+            elif not refresh_control:
+                # A completed physical veto may invalidate the command chosen
+                # by the first slice. Do not run the planner again in the same
+                # render callback and do not keep driving into proved danger.
+                position_hold = _position(state)
+                command = {
+                    'bot_id': int(state['id']), 'target_id': None,
+                    'aim_position': position_hold,
+                    'face_position': position_hold,
+                    'move_position': position_hold,
+                    'fire_range': 0.0, 'combat_mode': 'physical_hold',
+                    'fire_allowed': False,
+                    'shell_index': int(state.get('shell_index', 0)),
+                    'throttle': 0.0, 'turn': 0.0,
+                    'target_yaw': _number(state.get('yaw')),
+                    'recovery_mode': 'physical_hold',
+                    'movement_intent': False,
+                }
+                contacts = ()
+                targets = {}
             else:
                 contacts, targets = self._contacts_for(
                     state, players, now, team_visibility, visibility_tick)
@@ -8346,11 +8410,38 @@ class BotRuntime(object):
                 abs(_number(state.get('speed'))) <= 0.02 and
                 state.get('grounded_once', False) and
                 not state.get('airborne', False))
-            if not ((not decision_due or self._motion_probe_covers_distance(
+            motion_probe_reusable = bool(
+                (not decision_due or self._motion_probe_covers_distance(
                     cached_motion_probe, maximum_probe_distance)) and
-                    self._motion_probe_reusable(
-                        cached_motion_probe, position, travel_yaw,
-                        state.get('speed', 0.0), now, settled_motion, step)):
+                self._motion_probe_reusable(
+                    cached_motion_probe, position, travel_yaw,
+                    state.get('speed', 0.0), now, settled_motion, step,
+                    ignore_deadline=not refresh_control))
+            cached_motion_result = (
+                (cached_motion_probe or {}).get('result') or {})
+            catchup_motion_reprobe = bool(
+                not refresh_control and not motion_probe_reusable and
+                isinstance(cached_motion_probe, dict) and
+                isinstance(cached_motion_result, dict) and
+                self._probe_is_clear(cached_motion_result) and
+                (abs(throttle) > 0.01 or
+                 abs(_number(state.get('speed'))) > 0.0001 or
+                 abs(turn) > 0.01 or
+                 abs(_number(self._turn_speeds.get(
+                     state['id'], 0.0))) > 0.01))
+            catchup_motion_hold = bool(
+                not refresh_control and not motion_probe_reusable and
+                not catchup_motion_reprobe)
+            if catchup_motion_hold:
+                # With no prior clear physical proof, this callback may not
+                # turn a missing/deferred/blocked sample into motion. A valid
+                # command which merely consumed or turned beyond its old clear
+                # corridor re-probes below without re-entering the planner.
+                motion_probe = None
+                throttle = 0.0
+                turn = 0.0
+                state['speed'] = 0.0
+            elif not motion_probe_reusable:
                 # Planner ranking is intentionally unable to satisfy this
                 # gate.  Every newly selected travel corridor receives its own
                 # complete native generic probe before an exact receipt can be
@@ -8441,6 +8532,10 @@ class BotRuntime(object):
                         'position': position,
                         'yaw': travel_yaw,
                         'maximum_distance': maximum_probe_distance,
+                        'probe_distance': min(
+                            20.0 if abs(_number(
+                                state.get('speed'))) > 5.0 else 15.0,
+                            _number(maximum_probe_distance, float('inf'))),
                         'deadline': (
                             _number(now)
                             if receipt_pending
@@ -8469,7 +8564,8 @@ class BotRuntime(object):
                 motion_probe.get('collision', False) and
                 not motion_probe.get('water', False) and
                 abs(_number(motion_probe.get('slope', 0.0))) <= 0.55)
-            path_clear = (True if (probe_deferred or motion_probe is None or
+            path_clear = (True if (catchup_motion_hold or probe_deferred or
+                                   motion_probe is None or
                                    exact_motion_owns_collision or
                                    (abs(throttle) <= 0.01 and
                                     abs(_number(state.get('speed'))) <=
@@ -8854,7 +8950,7 @@ class BotRuntime(object):
                 self._cover_queue.append((
                     ready_at, bot_id, source, target, route,
                     tuple(ally_positions.get(source.get('team'), ()))))
-        if self._cover_queue:
+        if refresh_control and self._cover_queue:
             ready_at, bot_id, source, target, route, allies = \
                 self._cover_queue[0]
             if now + 1e-9 >= ready_at:
@@ -8878,8 +8974,16 @@ class BotRuntime(object):
                         'target_kind': target.get('kind', 'human'),
                         'candidates': list(candidates),
                     })
+        pending_ram_count = len(self._pending_ram_reports)
         self._pending_ram_reports.extend(
             self._resolve_tank_contacts(players, now, frame_step))
+        if (not publish and
+                len(self._pending_ram_reports) > pending_ram_count):
+            # A ram report is a one-shot state barrier. Publish the contact
+            # pose from this exact physical slice before the event; waiting for
+            # the callback's final pose can move both hulls beyond the server's
+            # bounded proximity validation and silently discard a real hit.
+            publish = True
         for bot_id, locked_pose in siege_locked_poses.items():
             state = self.states.get(bot_id)
             if state is None:
@@ -8906,7 +9010,7 @@ class BotRuntime(object):
                         attempted_yaw)
                 slope_candidates.append(state)
         self._alive_bot_ticks += len(slope_candidates)
-        if slope_candidates:
+        if refresh_control and slope_candidates:
             start = self._slope_pose_cursor % len(slope_candidates)
             visited = 0
             sampled = 0
@@ -8922,6 +9026,7 @@ class BotRuntime(object):
             if publish:
                 self._mark_combat_publication(state)
         if not publish:
+            self._sample_time_us = step_end_time_us
             return []
         wire_states = []
         launches = [dict(launch) for launch in self._pending_launches]

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -4531,13 +4531,15 @@ class BotRuntime(object):
             # the actual probed distance instead of paying the ordinary 3.5 m
             # re-planning budget repeatedly in one render callback.
             probed_distance = cached.get('probe_distance')
-            if probed_distance is not None:
+            probe_leading = cached.get('probe_leading')
+            if probed_distance is not None and probe_leading is not None:
                 current_reach = max(
                     0.4, abs(_number(speed)) * max(
                         0.0, min(MAX_CONTROL_ELAPSED_SECONDS, _number(dt))) +
                     0.2)
                 forward_budget = max(
-                    0.0, _number(probed_distance) - current_reach)
+                    0.0, _number(probed_distance) -
+                    max(0.5, _number(probe_leading)) - current_reach)
         heading_drift = lookahead * abs(math.sin(angle))
         reusable = bool(
             -0.1 <= forward <= forward_budget and
@@ -8536,6 +8538,11 @@ class BotRuntime(object):
                             20.0 if abs(_number(
                                 state.get('speed'))) > 5.0 else 15.0,
                             _number(maximum_probe_distance, float('inf'))),
+                        # The generic rays begin at the hull origin. Reserve
+                        # its admitted collision half-length before catch-up
+                        # slices consume the remainder of that clear corridor.
+                        'probe_leading': max(
+                            0.5, _number(state.get('half_length'), 3.5)),
                         'deadline': (
                             _number(now)
                             if receipt_pending

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
@@ -3426,6 +3426,13 @@ class LANClient(object):
                         # A different canonical Bot checkpoint is a state
                         # edge.  Never move a later state back across it.
                         break
+                    if (isinstance(queued, dict) and
+                            queued.get('type') == 'bot_ram'):
+                        # The server validates this one-shot contact against
+                        # the immediately preceding authority pose. A newer
+                        # checkpoint may not replace that state from across
+                        # the event even when its continuous key is equal.
+                        break
             previous = (self._outbound_queue[replacement_index]
                         if replacement_index is not None else None)
             replacement_bytes = (

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
@@ -3427,7 +3427,7 @@ class LANClient(object):
                         # edge.  Never move a later state back across it.
                         break
                     if (isinstance(queued, dict) and
-                            queued.get('type') == 'bot_ram'):
+                            queued.get('type') == 'bot_ram_report'):
                         # The server validates this one-shot contact against
                         # the immediately preceding authority pose. A newer
                         # checkpoint may not replace that state from across

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/snapshot_sync.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/snapshot_sync.py
@@ -6,7 +6,7 @@ import math
 
 
 PREDICTION_SECONDS = 0.05
-# BotRuntime admits at most one 0.2-second authority integration step after a
+# BotRuntime keeps every copied-physics slice at or below 0.2 seconds after a
 # delayed callback. Keep the derived diagnostic velocity on that same span;
 # timed presentation below interpolates confirmed samples and does not use it.
 MAX_TIMED_PREDICTION_SECONDS = 0.2
@@ -332,6 +332,31 @@ class SnapshotSync(object):
             return True
         return False
 
+    @staticmethod
+    def _start_live_timeline(record, time_us, local_time):
+        """Re-anchor one confirmed countdown pose at the live phase edge."""
+        pose = record.get('target') or record.get('current')
+        if pose is None:
+            return False
+        pose = dict(pose)
+        record['target'] = pose
+        record['target_time'] = float(local_time)
+        record['target_sample_time_us'] = int(time_us)
+        record['motion_anchor_time_us'] = int(time_us)
+        record['motion_anchor_local_time'] = float(local_time)
+        record['snapshot_interval_us'] = None
+        record['interpolation_delay_us'] = None
+        record['presentation_delay_us'] = None
+        record['timed_warmup_intervals'] = 0
+        record['timed_warmup_active'] = True
+        record['timed_samples'] = [{
+            'time_us': int(time_us), 'pose': dict(pose)}]
+        record['presentation_time_us'] = int(time_us)
+        record['timed_teleport'] = False
+        record['target_age'] = 0.0
+        record['timed_prediction'] = True
+        return True
+
     def _upsert(self, kind, state, now, output, update_remote_pose=True,
                 sample_time_us=None, sample_age=0.0, motion_time_us=None,
                 motion_anchor_local_time=None,
@@ -494,11 +519,14 @@ class SnapshotSync(object):
         timing = message.get('timing')
         timing_phase = (timing.get('phase')
                         if isinstance(timing, dict) else None)
-        if (timing_phase == 'battle' and
-                self._last_timing_phase in ('loading', 'prebattle')):
+        entered_battle = bool(
+            timing_phase == 'battle' and
+            self._last_timing_phase in ('loading', 'prebattle'))
+        if entered_battle:
             # The phase transition and the first live bot revision need not be
-            # published by the same server snapshot. Keep the reset armed
-            # until an advanced timed bot sample can actually consume it.
+            # published by the same server snapshot. The unchanged phase-edge
+            # pose below can establish the live anchor; otherwise keep the
+            # reset armed until an advanced timed sample can consume it.
             self._live_timeline_reset_pending = True
         live_timeline_started = bool(
             self._live_timeline_reset_pending and timed_bot_poses and
@@ -514,6 +542,22 @@ class SnapshotSync(object):
         dispatch_delay = max(
             0.0, _number(message.get('_client_dispatch_delay'), 0.0))
         motion_anchor_local_time = now - dispatch_delay
+        if (entered_battle and timed_bot_poses and not update_bot_poses):
+            # The server may publish the phase edge before the first live Bot
+            # revision. The unchanged canonical pose proves that the hull held
+            # through this motion time, so make it the confirmed live anchor.
+            # The next slow-worker sample can then form a real interpolation
+            # segment instead of being mistaken for a countdown-spanning stale
+            # anchor and snapping directly to its final pose.
+            anchored = False
+            for key, record in self._entities.items():
+                if record.get('kind') != 'bot' or record.get('dead'):
+                    continue
+                anchored = self._start_live_timeline(
+                    record, motion_time_us, motion_anchor_local_time) or anchored
+            if anchored:
+                self._live_timeline_reset_pending = False
+                live_timeline_started = False
         output = []
         seen = set()
         for kind, field in (('player', 'players'), ('bot', 'bots')):

--- a/0.9.22/tests/test_port_0922_authority_worker_client.py
+++ b/0.9.22/tests/test_port_0922_authority_worker_client.py
@@ -451,6 +451,40 @@ class AuthorityWorkerClientTests(unittest.TestCase):
             if isinstance(item[1], lan_client_module._PreencodedOutbound)]
         self.assertEqual(9.0, wires[-1]['bots'][0]['x'])
 
+    def test_worker_ram_event_preserves_its_preceding_pose_barrier(self):
+        client = self._active_client()
+        contact = _projected_bot_state()
+        contact['x'] = 5.0
+        later = json.loads(json.dumps(contact))
+        later['x'] = 20.0
+
+        self.assertTrue(client.send_projected_bot_state(
+            [contact], sample_time_us=400000,
+            source_batch_horizon_us=1000000))
+        self.assertTrue(client._send({
+            'type': 'bot_ram', 'bot_id': 11,
+            'target_kind': 'bot', 'target_id': 12,
+            'ram_seq': 1, 'damage_to_bot': 1,
+            'damage_to_target': 1,
+        }))
+        self.assertTrue(client.send_projected_bot_state(
+            [later], sample_time_us=1000000,
+            source_batch_horizon_us=1000000))
+
+        self.assertEqual([
+            'bot_state', 'bot_ram', 'bot_state',
+        ], [
+            (json.loads(item[1].payload.decode('utf-8'))['type']
+             if isinstance(item[1], lan_client_module._PreencodedOutbound)
+             else item[1]['type'])
+            for item in client._outbound_queue])
+        states = [
+            json.loads(item[1].payload.decode('utf-8'))
+            for item in client._outbound_queue
+            if isinstance(item[1], lan_client_module._PreencodedOutbound)]
+        self.assertEqual([5.0, 20.0], [
+            state['bots'][0]['x'] for state in states])
+
     def test_worker_never_coalesces_damage_or_combat_sequence_edges(self):
         client = self._active_client()
         first = _projected_bot_state()

--- a/0.9.22/tests/test_port_0922_authority_worker_client.py
+++ b/0.9.22/tests/test_port_0922_authority_worker_client.py
@@ -461,18 +461,14 @@ class AuthorityWorkerClientTests(unittest.TestCase):
         self.assertTrue(client.send_projected_bot_state(
             [contact], sample_time_us=400000,
             source_batch_horizon_us=1000000))
-        self.assertTrue(client._send({
-            'type': 'bot_ram', 'bot_id': 11,
-            'target_kind': 'bot', 'target_id': 12,
-            'ram_seq': 1, 'damage_to_bot': 1,
-            'damage_to_target': 1,
-        }))
+        self.assertTrue(client.send_bot_ram(
+            11, 'bot', 12, 1, 1, 1))
         self.assertTrue(client.send_projected_bot_state(
             [later], sample_time_us=1000000,
             source_batch_horizon_us=1000000))
 
         self.assertEqual([
-            'bot_state', 'bot_ram', 'bot_state',
+            'bot_state', 'bot_ram_report', 'bot_state',
         ], [
             (json.loads(item[1].payload.decode('utf-8'))['type']
              if isinstance(item[1], lan_client_module._PreencodedOutbound)

--- a/0.9.22/tests/test_port_0922_battle_runtime.py
+++ b/0.9.22/tests/test_port_0922_battle_runtime.py
@@ -14114,6 +14114,52 @@ class BattleRuntimeContractTests(unittest.TestCase):
         world_probe.assert_not_called()
         battle._destructibles._catalog_motion_blocked.assert_not_called()
 
+    def test_bot_pending_generic_corridor_recasts_before_hull_leaves_proof(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        bots = bot_runtime.BotRuntime(1)
+        bots.states = {11: {
+            'movement_dir': 1, 'rotation_dir': 0,
+            'airborne': False,
+        }}
+        bots._motion_probe_cache[11] = {
+            'result': {
+                'clear': True, 'collision': False, 'slope': 0.0,
+                '_world_receipt_pending': True,
+            },
+            'position': (0.0, 0.0, 0.0),
+            'yaw': 0.0,
+            'probe_distance': 15.0,
+            'probe_leading': 3.5,
+            'deadline': 0.0,
+        }
+        battle._bots = bots
+        battle._destructibles = mock.Mock()
+        battle._destructibles._catalog_hull_contact.return_value = False
+        battle._destructibles._catalog_motion_blocked.return_value = {
+            'status': 'clear', 'token': None,
+            'accepted_now': False, 'used_kinetic_speed': False,
+        }
+
+        with mock.patch(
+                'gui.mods.offline_lan_0922.battle_runtime.'
+                'world_collision.check_horizontal_collision',
+                return_value='clear') as world_probe:
+            inside = battle._resolve_bot_motion(
+                11, (0.0, 0.0, 11.0), 0.0, 4.0,
+                _Descriptor(), 0.04, 10.0)
+            self.assertEqual('clear', inside)
+            world_probe.assert_not_called()
+
+            outside = battle._resolve_bot_motion(
+                11, (0.0, 0.0, 11.2), 0.0, 4.0,
+                _Descriptor(), 0.04, 10.0)
+
+        self.assertEqual('clear', outside)
+        world_probe.assert_called_once()
+        battle._destructibles._catalog_motion_blocked.assert_called_once()
+
     def test_bot_reverse_receipt_uses_travel_yaw_and_actual_dt(self):
         runtime = _runtime()
         battle = BattleRuntime(runtime)

--- a/0.9.22/tests/test_port_0922_bot_runtime.py
+++ b/0.9.22/tests/test_port_0922_bot_runtime.py
@@ -4952,6 +4952,9 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertGreater(state['speed'], 0.0)
         self.assertEqual(2000000, runtime._sample_time_us)
         self.assertAlmostEqual(0.0, runtime._accumulator)
+        self.assertEqual(
+            state['half_length'],
+            runtime._motion_probe_cache[11]['probe_leading'])
 
     def test_authority_publication_and_server_ack_remain_live_for_two_minutes(self):
         command = {
@@ -5575,6 +5578,43 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertTrue(covers({'maximum_distance': 6.0}, 4.0))
         self.assertTrue(covers({}, 6.0))
         self.assertFalse(covers({'maximum_distance': 4.0}, None))
+
+    def test_pending_generic_corridor_reserves_the_hull_leading_edge(self):
+        runtime = self.module.BotRuntime(1)
+
+        def install(yaw):
+            runtime._motion_probe_cache[11] = {
+                'result': {
+                    'clear': True, 'collision': False, 'slope': 0.0,
+                    '_world_receipt_pending': True,
+                },
+                'position': (0.0, 0.0, 0.0),
+                'yaw': yaw,
+                'probe_distance': 15.0,
+                'probe_leading': 3.5,
+                'deadline': 0.0,
+            }
+
+        install(0.0)
+        self.assertTrue(runtime.motion_world_corridor_reusable(
+            11, (0.0, 0.0, 11.0), 0.0, 4.0,
+            now=10.0, dt=0.04))
+        self.assertFalse(runtime.motion_world_corridor_reusable(
+            11, (0.0, 0.0, 11.2), 0.0, 4.0,
+            now=10.0, dt=0.04))
+
+        install(math.pi)
+        self.assertTrue(runtime.motion_world_corridor_reusable(
+            11, (0.0, 0.0, -11.0), math.pi, -4.0,
+            now=10.0, dt=0.04))
+        self.assertFalse(runtime.motion_world_corridor_reusable(
+            11, (0.0, 0.0, -11.2), math.pi, -4.0,
+            now=10.0, dt=0.04))
+
+        runtime._motion_probe_cache[11].pop('probe_leading')
+        self.assertFalse(runtime.motion_world_corridor_reusable(
+            11, (0.0, 0.0, -3.6), math.pi, -4.0,
+            now=10.0, dt=0.04))
 
     def test_typed_world_receipt_contains_only_the_actual_motion_step(self):
         runtime = self.module.BotRuntime(1)

--- a/0.9.22/tests/test_port_0922_bot_runtime.py
+++ b/0.9.22/tests/test_port_0922_bot_runtime.py
@@ -4540,10 +4540,11 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertEqual([{'type': 'ram_damage', 'event': 'once'}], events)
         self.assertEqual(0.0, self.runtime._accumulator)
 
-    def test_worker_stall_runs_one_roster_step_per_callback(self):
+    def test_worker_stall_refreshes_control_once_and_consumes_all_elapsed(self):
+        adapter = _Adapter()
         runtime = self.module.BotRuntime(
             1, descriptor_resolver=lambda unused: _combat_descriptor(),
-            adapter_factory=lambda *args: _Adapter(*args),
+            adapter_factory=lambda *unused: adapter,
             direction_probe=lambda *unused: {'clear': True, 'slope': .2},
             ground_probe=lambda *unused: 0.0,
             physics_ground_probe=lambda *unused: 0.0,
@@ -4553,32 +4554,80 @@ class BotRuntimeTests(unittest.TestCase):
         runtime._pending_ram_reports = [{
             'type': 'ram_damage', 'event': 'once'}]
         runtime._world_receipt_waiting = [(11, True)]
+        steps = []
+        original_update_once = runtime._update_once
+
+        def counted_update_once(*args):
+            steps.append((
+                args[0],
+                getattr(runtime, '_refresh_control_this_step', True)))
+            return original_update_once(*args)
+
+        runtime._update_once = counted_update_once
 
         self.assertEqual([], runtime.update(0.01, 9.01))
         self.assertEqual([(11, True)], runtime._world_receipt_waiting)
 
-        first = runtime.update(0.99, 10.0)
-        states = [message for message in first
+        outgoing = runtime.update(0.99, 10.0)
+        states = [message for message in outgoing
                   if message.get('type') == 'bot_state']
-        events = [message for message in first
+        events = [message for message in outgoing
                   if message.get('type') == 'ram_damage']
 
-        self.assertEqual([200000], [
-            message['sample_time_us'] for message in states])
-        self.assertEqual([{'type': 'ram_damage', 'event': 'once'}], events)
-        self.assertAlmostEqual(0.8, runtime._accumulator)
-
-        drained = []
-        for unused in range(4):
-            drained.extend(runtime.update(0.0, 10.0))
-        all_messages = first + drained
+        self.assertEqual(1000000, states[-1]['sample_time_us'])
         self.assertEqual(
-            [index * 200000 for index in range(1, 6)],
-            [message['sample_time_us'] for message in all_messages
-             if message.get('type') == 'bot_state'])
-        self.assertEqual(1, sum(
-            message.get('type') == 'ram_damage'
-            for message in all_messages))
+            [1000000] * len(states),
+            [message['source_batch_horizon_us'] for message in states])
+        self.assertEqual([{'type': 'ram_damage', 'event': 'once'}], events)
+        self.assertAlmostEqual(1.0, sum(step for step, unused in steps))
+        self.assertTrue(all(
+            step <= self.module.MAX_CONTROL_ELAPSED_SECONDS + 1.0e-9
+            for step, unused in steps))
+        self.assertEqual(
+            [True] + [False] * (len(steps) - 1),
+            [refresh for unused, refresh in steps])
+        self.assertEqual(1, len(adapter.calls))
+        self.assertEqual(1000000, runtime._sample_time_us)
+        self.assertAlmostEqual(0.0, runtime._accumulator)
+
+    def test_worker_intermediate_ram_report_forces_state_barrier(self):
+        runtime = self.module.BotRuntime(
+            1, descriptor_resolver=lambda unused: _combat_descriptor(),
+            adapter_factory=lambda *unused: _FixedAdapter(
+                self._stationary_command()),
+            direction_probe=lambda *unused: {'clear': True, 'slope': 0.0},
+            ground_probe=lambda *unused: 0.0,
+            physics_ground_probe=lambda *unused: 0.0,
+            spawn_resolver=_spawn_resolver, baked_graph=_graph(),
+            control_seconds=self.module.WORKER_CONTROL_SECONDS)
+        runtime.battle_start(self.start)
+        contact_slices = []
+
+        def contact(unused_players, unused_now, step):
+            contact_slices.append(step)
+            if len(contact_slices) == 3:
+                return [{
+                    'type': 'bot_ram', 'bot_id': 11,
+                    'target_kind': 'bot', 'target_id': 12,
+                    'ram_seq': 1, 'damage_to_bot': 1,
+                    'damage_to_target': 1,
+                }]
+            return []
+
+        runtime._resolve_tank_contacts = contact
+        outgoing = runtime.update(1.0, 1.0)
+        event_index = next(
+            index for index, message in enumerate(outgoing)
+            if message.get('type') == 'bot_ram')
+
+        self.assertEqual(5, len(contact_slices))
+        self.assertEqual('bot_state', outgoing[event_index - 1]['type'])
+        self.assertEqual(
+            600000, outgoing[event_index - 1]['sample_time_us'])
+        self.assertEqual([200000, 600000, 1000000], [
+            message['sample_time_us'] for message in outgoing
+            if message.get('type') == 'bot_state'])
+        self.assertEqual(1000000, runtime._sample_time_us)
         self.assertAlmostEqual(0.0, runtime._accumulator)
 
     def test_worker_sustained_five_fps_consumes_elapsed_without_debt(self):
@@ -4613,42 +4662,71 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertEqual([0.12, 0.10], steps)
         self.assertAlmostEqual(0.0, runtime._accumulator)
 
-    def test_worker_gap_debt_is_stable_at_five_fps_and_then_recovers(self):
-        runtime = self.module.BotRuntime(
-            1, control_seconds=self.module.WORKER_CONTROL_SECONDS)
-        runtime.authority_id = 1
-        runtime.adapter = object()
-        steps = []
-        runtime._update_once = lambda step, *unused: steps.append(step) or []
+    def test_worker_fixed_control_tracks_wall_time_from_five_to_one_fps(self):
+        wall_seconds = 2
+        for fps in (5, 4, 2, 1):
+            with self.subTest(fps=fps):
+                runtime = self.module.BotRuntime(
+                    1, control_seconds=self.module.WORKER_CONTROL_SECONDS)
+                runtime.authority_id = 1
+                runtime.adapter = object()
+                callback_calls = []
+                current_callback = [None]
 
-        runtime.update(0.3, 1.0)
+                def simulate(step, unused_now, unused_players,
+                             unused_neighbours):
+                    callback_calls[current_callback[0]].append((
+                        step,
+                        getattr(runtime, '_refresh_control_this_step', True)))
+                    duration_us = max(
+                        1, int(round(float(step) * 1000000.0)))
+                    runtime._sample_time_us += duration_us
+                    return []
 
-        self.assertEqual([self.module.MAX_CONTROL_ELAPSED_SECONDS], steps)
-        self.assertAlmostEqual(0.1, runtime._accumulator)
+                runtime._update_once = simulate
+                frame_seconds = 1.0 / float(fps)
+                frame_count = wall_seconds * fps
+                accumulator_us = []
+                for frame in range(frame_count):
+                    current_callback[0] = frame
+                    callback_calls.append([])
+                    runtime.update(
+                        frame_seconds, (frame + 1) * frame_seconds)
+                    accumulator_us.append(int(round(
+                        runtime._accumulator * 1000000.0)))
 
-        # At the exact 200 ms physics bound, one callback cannot consume old
-        # debt without either exceeding that bound or running the full roster
-        # twice. The lag stays constant instead of growing.
-        for frame in range(3):
-            before = len(steps)
-            runtime.update(0.2, 1.2 + frame * 0.2)
-            self.assertEqual(before + 1, len(steps))
-            self.assertAlmostEqual(0.1, runtime._accumulator)
-
-        # The measured bad session still delivered 8.85 callbacks per second.
-        # That leaves enough room under the 200 ms step bound to retire the
-        # carried interval without a second roster pass in either callback.
-        observed_slow_frame = 1.0 / 8.85
-        runtime.update(observed_slow_frame, 1.8)
-        self.assertAlmostEqual(
-            0.1 + observed_slow_frame -
-            self.module.MAX_CONTROL_ELAPSED_SECONDS,
-            runtime._accumulator)
-        runtime.update(observed_slow_frame, 1.8 + observed_slow_frame)
-        self.assertAlmostEqual(0.0, runtime._accumulator)
-        self.assertTrue(all(
-            step <= self.module.MAX_CONTROL_ELAPSED_SECONDS + 1.0e-9
-            for step in steps))
+                callback_elapsed_us = [
+                    int(round(sum(step for step, unused in calls) *
+                              1000000.0))
+                    for calls in callback_calls]
+                refresh_counts = [sum(
+                    1 for unused, refresh in calls if refresh)
+                    for calls in callback_calls]
+                max_step_us = max(
+                    int(round(step * 1000000.0))
+                    for calls in callback_calls for step, unused in calls)
+                self.assertEqual({
+                    'accumulator_us': [0] * frame_count,
+                    'sample_time_us': wall_seconds * 1000000,
+                    'callback_elapsed_us': [
+                        int(round(frame_seconds * 1000000.0))
+                    ] * frame_count,
+                    'refresh_counts': [1] * frame_count,
+                    'refresh_ordered': True,
+                    'step_bound_held': True,
+                }, {
+                    'accumulator_us': accumulator_us,
+                    'sample_time_us': runtime._sample_time_us,
+                    'callback_elapsed_us': callback_elapsed_us,
+                    'refresh_counts': refresh_counts,
+                    'refresh_ordered': all(
+                        calls and calls[0][1] and
+                        not any(refresh for unused, refresh in calls[1:])
+                        for calls in callback_calls),
+                    'step_bound_held': max_step_us <= int(round(
+                        self.module.MAX_CONTROL_ELAPSED_SECONDS *
+                        1000000.0)),
+                })
 
     def test_worker_low_fps_reuses_valid_drive_and_moves_continuously(self):
         command = self._stationary_command()
@@ -4693,6 +4771,187 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertEqual(1000000, runtime._sample_time_us)
         self.assertAlmostEqual(0.0, runtime._accumulator)
         self.assertEqual(1, len(adapter.calls))
+
+    def test_worker_one_hz_holds_one_drive_plan_through_bounded_slices(self):
+        command = self._stationary_command()
+        command.update({
+            'throttle': 1.0, 'combat_mode': 'route',
+            'move_position': (0.0, 0.0, 100.0),
+            'recovery_mode': 'drive', 'movement_intent': True,
+        })
+        adapter = _FixedAdapter(command)
+        direction_calls = []
+        runtime = self.module.BotRuntime(
+            1, descriptor_resolver=lambda unused: _combat_descriptor(),
+            adapter_factory=lambda *unused, **kwargs: adapter,
+            direction_probe=lambda *unused: direction_calls.append(1) or {
+                'clear': True, 'collision': False, 'slope': 0.0},
+            ground_probe=lambda *unused: 0.0,
+            physics_ground_probe=lambda *unused: 0.0,
+            spawn_resolver=_spawn_resolver, baked_graph=_graph(),
+            control_seconds=self.module.WORKER_CONTROL_SECONDS)
+        runtime.battle_start(self.start)
+        runtime.navigator = None
+        state = runtime.states[11]
+        state.update(x=0.0, y=0.0, z=0.0, yaw=0.0, speed=4.0,
+                     grounded_once=True)
+        original_pose_safe = self.module.prebaked_navigation.pose_is_safe
+        self.module.prebaked_navigation.pose_is_safe = (
+            lambda *unused, **unused_kwargs: True)
+        try:
+            outgoing = runtime.update(1.0, 1.0)
+        finally:
+            self.module.prebaked_navigation.pose_is_safe = original_pose_safe
+
+        states = [message for message in outgoing
+                  if message.get('type') == 'bot_state']
+        self.assertGreater(state['z'], 4.0)
+        self.assertEqual(1, state['movement_dir'])
+        self.assertEqual(1, len(adapter.calls))
+        self.assertEqual(2, len(direction_calls))
+        self.assertEqual(1000000, runtime._sample_time_us)
+        self.assertAlmostEqual(0.0, runtime._accumulator)
+        self.assertEqual([200000, 1000000], [
+            message['sample_time_us'] for message in states])
+        self.assertEqual([1000000, 1000000], [
+            message['source_batch_horizon_us'] for message in states])
+
+    def test_worker_one_hz_full_roster_refreshes_planning_once(self):
+        command = self._stationary_command()
+        command.update({
+            'throttle': 1.0, 'combat_mode': 'route',
+            'move_position': (0.0, 0.0, 200.0),
+            'recovery_mode': 'drive', 'movement_intent': True,
+        })
+        roster = [
+            {'id': 11 + index,
+             'team': 1 if index < 14 else 2,
+             'slot': index if index < 14 else index - 14,
+             'name': 'Slow-worker-%02d' % index}
+            for index in range(29)
+        ]
+        adapter = _FixedAdapter(command)
+        direction_calls = []
+        runtime = self.module.BotRuntime(
+            1, descriptor_resolver=lambda unused: _combat_descriptor(),
+            adapter_factory=lambda *unused, **kwargs: adapter,
+            direction_probe=lambda *unused: direction_calls.append(1) or {
+                'clear': True, 'collision': False, 'slope': 0.0},
+            ground_probe=lambda *unused: 0.0,
+            physics_ground_probe=lambda *unused: 0.0,
+            spawn_resolver=_spawn_resolver, baked_graph=_graph(),
+            control_seconds=self.module.WORKER_CONTROL_SECONDS)
+        runtime.battle_start(dict(self.start, bots=roster))
+        runtime.navigator = None
+        for index, state in enumerate(runtime._ordered_states()):
+            state.update(
+                x=float(index * 20), y=0.0, z=0.0, yaw=0.0,
+                speed=4.0, grounded_once=True)
+        original_pose_safe = self.module.prebaked_navigation.pose_is_safe
+        self.module.prebaked_navigation.pose_is_safe = (
+            lambda *unused, **unused_kwargs: True)
+        try:
+            outgoing = runtime.update(1.0, 1.0)
+        finally:
+            self.module.prebaked_navigation.pose_is_safe = original_pose_safe
+
+        states = [message for message in outgoing
+                  if message.get('type') == 'bot_state']
+        self.assertEqual(29, len(adapter.calls))
+        self.assertEqual(58, len(direction_calls))
+        self.assertTrue(all(
+            state['z'] > 4.0 and state['movement_dir'] == 1
+            for state in runtime.states.values()))
+        self.assertEqual([200000, 1000000], [
+            message['sample_time_us'] for message in states])
+        self.assertEqual(1000000, runtime._sample_time_us)
+        self.assertAlmostEqual(0.0, runtime._accumulator)
+
+    def test_worker_four_fps_keeps_turning_drive_active_between_plans(self):
+        command = self._stationary_command()
+        command.update({
+            'target_yaw': math.pi / 2.0,
+            'throttle': 1.0, 'turn': 1.0, 'combat_mode': 'route',
+            'move_position': (100.0, 0.0, 100.0),
+            'recovery_mode': 'drive', 'movement_intent': True,
+        })
+        adapter = _FixedAdapter(command)
+        direction_calls = []
+        runtime = self.module.BotRuntime(
+            1, descriptor_resolver=lambda unused: _combat_descriptor(),
+            adapter_factory=lambda *unused, **kwargs: adapter,
+            direction_probe=lambda *unused: direction_calls.append(1) or {
+                'clear': True, 'collision': False, 'slope': 0.0},
+            ground_probe=lambda *unused: 0.0,
+            physics_ground_probe=lambda *unused: 0.0,
+            spawn_resolver=_spawn_resolver, baked_graph=_graph(),
+            control_seconds=self.module.WORKER_CONTROL_SECONDS)
+        runtime.battle_start(self.start)
+        runtime.navigator = None
+        state = runtime.states[11]
+        state.update(x=0.0, y=0.0, z=0.0, yaw=0.0, speed=4.0,
+                     grounded_once=True)
+        original_pose_safe = self.module.prebaked_navigation.pose_is_safe
+        self.module.prebaked_navigation.pose_is_safe = (
+            lambda *unused, **unused_kwargs: True)
+        try:
+            samples = []
+            for frame in range(4):
+                runtime.update(0.25, (frame + 1) * 0.25)
+                samples.append((
+                    state['x'], state['z'], state['yaw'], state['speed'],
+                    state['movement_dir']))
+        finally:
+            self.module.prebaked_navigation.pose_is_safe = original_pose_safe
+
+        self.assertEqual(4, len(adapter.calls))
+        self.assertTrue(all(
+            speed > 0.0 and movement_dir == 1
+            for unused_x, unused_z, unused_yaw, speed, movement_dir in samples))
+        self.assertTrue(all(
+            later[0] > earlier[0] and later[1] > earlier[1] and
+            later[2] > earlier[2]
+            for earlier, later in zip(samples, samples[1:])))
+        self.assertEqual(12, len(direction_calls))
+        self.assertEqual(1000000, runtime._sample_time_us)
+        self.assertAlmostEqual(0.0, runtime._accumulator)
+
+    def test_worker_catchup_reprobes_exhausted_corridor_without_replanning(self):
+        command = self._stationary_command()
+        command.update({
+            'throttle': 1.0, 'combat_mode': 'route',
+            'move_position': (0.0, 0.0, 100.0),
+            'recovery_mode': 'drive', 'movement_intent': True,
+        })
+        direction_calls = []
+        runtime = self.module.BotRuntime(
+            1, descriptor_resolver=lambda unused: _combat_descriptor(),
+            adapter_factory=lambda *unused, **kwargs: _FixedAdapter(command),
+            direction_probe=lambda *unused: direction_calls.append(1) or {
+                'clear': True, 'collision': False, 'slope': 0.0},
+            ground_probe=lambda *unused: 0.0,
+            physics_ground_probe=lambda *unused: 0.0,
+            spawn_resolver=_spawn_resolver, baked_graph=_graph(),
+            control_seconds=self.module.WORKER_CONTROL_SECONDS)
+        runtime.battle_start(self.start)
+        runtime.navigator = None
+        state = runtime.states[11]
+        state.update(x=0.0, y=0.0, z=0.0, yaw=0.0, speed=35.0,
+                     grounded_once=True)
+        original_pose_safe = self.module.prebaked_navigation.pose_is_safe
+        self.module.prebaked_navigation.pose_is_safe = (
+            lambda *unused, **unused_kwargs: True)
+        try:
+            runtime.update(2.0, 2.0)
+        finally:
+            self.module.prebaked_navigation.pose_is_safe = original_pose_safe
+
+        self.assertEqual(3, len(direction_calls))
+        self.assertGreater(state['z'], 20.0)
+        self.assertEqual(1, state['movement_dir'])
+        self.assertGreater(state['speed'], 0.0)
+        self.assertEqual(2000000, runtime._sample_time_us)
+        self.assertAlmostEqual(0.0, runtime._accumulator)
 
     def test_authority_publication_and_server_ack_remain_live_for_two_minutes(self):
         command = {
@@ -7309,91 +7568,133 @@ class BotRuntimeTests(unittest.TestCase):
                 self.assertTrue(all(
                     step <= 0.100000001 for step in substeps))
 
-    def test_worker_burst_edges_stay_exact_and_debt_recovers_at_slow_fps(self):
+    def test_worker_slow_fps_catchup_preserves_every_burst_edge(self):
         count = 11
-        descriptor = _combat_descriptor(
-            reload_time=4.0, clip=(count + 1, 2.0),
-            dispersion=0.01, max_ammo=count + 2)
-        descriptor.gun.burst = (count, 0.1)
-        descriptor.gun.shotDispersionFactors = {
-            'afterShot': 4.0, 'afterShotInBurst': 1.0,
-            'turretRotation': 0.0,
-        }
-        runtime = self.module.BotRuntime(
-            1, friendly_lane_probe=lambda *unused: True,
-            direct_launch_origin_probe=lambda source, *unused: (
-                source['x'], source['y'] + 1.0, source['z']),
-            control_seconds=self.module.WORKER_CONTROL_SECONDS)
-        runtime.round_id = 5
-        runtime.authority_id = 1
-        runtime.adapter = object()
-        runtime._descriptors[11] = descriptor
-        state = {
-            'id': 11, 'alive': True, 'health': 1000,
-            'fire_seq': 0, 'x': 0.0, 'y': 0.0, 'z': 0.0,
-            'yaw': 0.0, 'pitch': 0.0, 'roll': 0.0,
-            'aim_yaw': 0.0, 'turret_yaw': 0.0,
-            'gun_pitch': -0.01, 'critical': {}, 'profile': {},
-        }
-        target = {
-            'id': 2, 'network_id': 2, 'kind': 'human',
-            'alive': True, 'position': (0.0, 1.0, 100.0),
-        }
-        solution = {'flight_time': 0.5}
-        gun_state = self.module._BotGunState(descriptor)
-        gun_state.elapsed = 10.0
-        ammo_state = self.module._BotAmmoState(descriptor, {}, state)
-        runtime._gun_states[11] = gun_state
-        runtime._ammo_states[11] = ammo_state
-        preview = runtime._direct_launch_preview(
-            state, descriptor, ammo_state.loaded, gun_state, solution)
-        self.assertTrue(runtime._fire(
-            state, gun_state, 1.0, descriptor,
-            ammo_state=ammo_state, launch_preview=preview,
-            launch_time_us=0))
+        for fps in (5, 4, 2, 1):
+            with self.subTest(fps=fps):
+                descriptor = _combat_descriptor(
+                    reload_time=4.0, clip=(count + 1, 2.0),
+                    dispersion=0.01, max_ammo=count + 2)
+                descriptor.gun.burst = (count, 0.1)
+                descriptor.gun.shotDispersionFactors = {
+                    'afterShot': 4.0, 'afterShotInBurst': 1.0,
+                    'turretRotation': 0.0,
+                }
+                runtime = self.module.BotRuntime(
+                    1, friendly_lane_probe=lambda *unused: True,
+                    direct_launch_origin_probe=lambda source, *unused: (
+                        source['x'], source['y'] + 1.0, source['z']),
+                    control_seconds=self.module.WORKER_CONTROL_SECONDS)
+                runtime.round_id = 5
+                runtime.authority_id = 1
+                runtime.adapter = object()
+                runtime._descriptors[11] = descriptor
+                state = {
+                    'id': 11, 'alive': True, 'health': 1000,
+                    'fire_seq': 0, 'x': 0.0, 'y': 0.0, 'z': 0.0,
+                    'yaw': 0.0, 'pitch': 0.0, 'roll': 0.0,
+                    'aim_yaw': 0.0, 'turret_yaw': 0.0,
+                    'gun_pitch': -0.01, 'critical': {}, 'profile': {},
+                }
+                target = {
+                    'id': 2, 'network_id': 2, 'kind': 'human',
+                    'alive': True, 'position': (0.0, 1.0, 100.0),
+                }
+                solution = {'flight_time': 0.5}
+                gun_state = self.module._BotGunState(descriptor)
+                gun_state.elapsed = 10.0
+                ammo_state = self.module._BotAmmoState(
+                    descriptor, {}, state)
+                runtime._gun_states[11] = gun_state
+                runtime._ammo_states[11] = ammo_state
+                preview = runtime._direct_launch_preview(
+                    state, descriptor, ammo_state.loaded, gun_state,
+                    solution)
+                self.assertTrue(runtime._fire(
+                    state, gun_state, 1.0, descriptor,
+                    ammo_state=ammo_state, launch_preview=preview,
+                    launch_time_us=0))
 
-        substeps = []
+                callback_calls = []
+                current_callback = [None]
 
-        def simulate(step, unused_now, unused_players, unused_neighbours):
-            start_us = runtime._sample_time_us
-            duration_us = max(1, int(round(step * 1000000.0)))
-            end_us = start_us + duration_us
-            state['z'] += 10.0 * step
-            substeps.append(step)
-            runtime._advance_active_burst(
-                state, gun_state, ammo_state, 1.0, descriptor,
-                target, solution, step, set(), start_us, end_us)
-            runtime._sample_time_us = end_us
-            return []
+                def simulate(step, unused_now, unused_players,
+                             unused_neighbours):
+                    start_us = runtime._sample_time_us
+                    duration_us = max(
+                        1, int(round(step * 1000000.0)))
+                    end_us = start_us + duration_us
+                    state['z'] += 10.0 * step
+                    callback_calls[current_callback[0]].append((
+                        step,
+                        getattr(runtime, '_refresh_control_this_step', True)))
+                    runtime._advance_active_burst(
+                        state, gun_state, ammo_state, 1.0, descriptor,
+                        target, solution, step, set(), start_us, end_us)
+                    runtime._sample_time_us = end_us
+                    return []
 
-        runtime._update_once = simulate
-        runtime.update(1.0, 1.0)
-        self.assertEqual(2, len(runtime._pending_launches))
-        self.assertAlmostEqual(0.9, runtime._accumulator)
+                runtime._update_once = simulate
+                frame_seconds = 1.0 / float(fps)
+                accumulator_us = []
+                for frame in range(fps):
+                    current_callback[0] = frame
+                    callback_calls.append([])
+                    runtime.update(
+                        frame_seconds, (frame + 1) * frame_seconds)
+                    accumulator_us.append(int(round(
+                        runtime._accumulator * 1000000.0)))
 
-        observed_slow_frame = 1.0 / 8.85
-        callbacks = 0
-        while ((runtime._burst_states[11].active or
-                runtime._accumulator > 1.0e-9) and callbacks < 64):
-            before = len(substeps)
-            callbacks += 1
-            runtime.update(
-                observed_slow_frame,
-                1.0 + callbacks * observed_slow_frame)
-            self.assertLessEqual(len(substeps) - before, 1)
-
-        self.assertEqual(count, len(runtime._pending_launches))
-        self.assertEqual(
-            [index * 100000 for index in range(count)],
-            [launch['launch_time_us']
-             for launch in runtime._pending_launches])
-        self.assertEqual(
-            [round(float(index), 6) for index in range(count)],
-            [round(launch['shot_origin'][2], 6)
-             for launch in runtime._pending_launches])
-        self.assertEqual([0.1] * 10, substeps[:10])
-        self.assertLess(callbacks, 64)
-        self.assertAlmostEqual(0.0, runtime._accumulator)
+                launches = runtime._pending_launches
+                callback_elapsed_us = [
+                    int(round(sum(step for step, unused in calls) *
+                              1000000.0))
+                    for calls in callback_calls]
+                refresh_counts = [sum(
+                    1 for unused, refresh in calls if refresh)
+                    for calls in callback_calls]
+                all_steps = [
+                    step for calls in callback_calls
+                    for step, unused in calls]
+                self.assertEqual({
+                    'accumulator_us': [0] * fps,
+                    'sample_time_us': 1000000,
+                    'callback_elapsed_us': [
+                        int(round(frame_seconds * 1000000.0))
+                    ] * fps,
+                    'refresh_counts': [1] * fps,
+                    'refresh_ordered': True,
+                    'step_bound_held': True,
+                    'burst_active': False,
+                    'launch_time_us': [
+                        index * 100000 for index in range(count)],
+                    'shot_origin_z': [
+                        float(index) for index in range(count)],
+                    'launch_pose_z': [
+                        float(index) for index in range(count)],
+                }, {
+                    'accumulator_us': accumulator_us,
+                    'sample_time_us': runtime._sample_time_us,
+                    'callback_elapsed_us': callback_elapsed_us,
+                    'refresh_counts': refresh_counts,
+                    'refresh_ordered': all(
+                        calls and calls[0][1] and
+                        not any(refresh for unused, refresh in calls[1:])
+                        for calls in callback_calls),
+                    'step_bound_held': bool(all_steps) and all(
+                        step <= (self.module.MAX_CONTROL_ELAPSED_SECONDS +
+                                 1.0e-9)
+                        for step in all_steps),
+                    'burst_active': runtime._burst_states[11].active,
+                    'launch_time_us': [
+                        launch['launch_time_us'] for launch in launches],
+                    'shot_origin_z': [
+                        round(launch['shot_origin'][2], 6)
+                        for launch in launches],
+                    'launch_pose_z': [
+                        round(launch['launch_pose'][2], 6)
+                        for launch in launches],
+                })
 
     def test_siege_transition_edge_locks_pose_in_its_starting_tick(self):
         self.runtime.battle_start(self.start)

--- a/0.9.22/tests/test_port_0922_server_combat_lineage.py
+++ b/0.9.22/tests/test_port_0922_server_combat_lineage.py
@@ -205,6 +205,83 @@ class ServerCombatLineageIntegrationTests(unittest.TestCase):
             'round_id': server.round_id, 'bots': manifest['bots']}))
         return runtime, server, roster
 
+    def test_same_source_batch_horizon_preserves_slow_callback_burst_edges(
+            self):
+        unused_runtime, server, unused_roster = self._runtime_and_server()
+        shooter = server.bot_states[11]
+        shooter.update({
+            'clip': 3, 'clip_size': 3,
+            'reload_time': 0.0, 'reload_duration': 0.5,
+            'ammo_remaining': [45], 'ammo_reload_pending': False,
+        })
+
+        def publication(fire_seq, ammo, clip, burst_active, next_index,
+                        time_left):
+            rows = []
+            for bot_id in sorted(server.bot_states):
+                row = dict(server.bot_states[bot_id])
+                row['ammo_remaining'] = list(
+                    row.get('ammo_remaining') or [])
+                row['equipment_states'] = list(
+                    row.get('equipment_states') or [])
+                row['combat_seq'] = int(row.get('combat_ack_seq', 0))
+                rows.append(row)
+            shot = next(row for row in rows if row['id'] == 11)
+            shot.update({
+                'fire_seq': fire_seq,
+                'ammo_remaining': [ammo],
+                'ammo_reload_pending': True,
+                'clip': clip, 'clip_size': 3,
+                'reload_time': 0.5, 'reload_duration': 0.5,
+                'burst_active': burst_active,
+                'burst_group_seq': 1, 'burst_count': 3,
+                'burst_next_index': next_index,
+                'burst_interval': 0.1,
+                'burst_time_left': time_left,
+                'burst_shell_index': 0,
+            })
+            return rows
+
+        # One slow worker callback can expose its first physical edge before
+        # the callback's final source horizon. The later publication belongs
+        # to the same callback even though almost no server wall time elapsed.
+        self.assertTrue(server.update_bot_states(1, {
+            'round_id': server.round_id,
+            'bots': publication(1, 44, 2, True, 1, 0.1),
+            'sample_time_us': 200000,
+            'source_batch_horizon_us': 1000000,
+        }), server.last_bot_state_reject)
+        first_mapped_time_us = server.bot_state_time_us
+
+        self.assertTrue(server.update_bot_states(1, {
+            'round_id': server.round_id,
+            'bots': publication(3, 42, 0, False, 3, 0.0),
+            'sample_time_us': 1000000,
+            'source_batch_horizon_us': 1000000,
+        }), server.last_bot_state_reject)
+
+        launches = sorted(server.bot_pending_projectile_launches)
+        metadata = server.bot_pending_projectile_metadata
+        self.assertEqual({
+            'launches': [(11, 1), (11, 2), (11, 3)],
+            'burst_indexes': [0, 1, 2],
+            'sample_windows': [
+                (0, 200000),
+                (200000, 1000000),
+                (200000, 1000000),
+            ],
+            'mapped_time_delta_us': 800000,
+        }, {
+            'launches': launches,
+            'burst_indexes': [
+                metadata[key]['burst_index'] for key in launches],
+            'sample_windows': [(
+                metadata[key]['sample_start_us'],
+                metadata[key]['sample_end_us']) for key in launches],
+            'mapped_time_delta_us': (
+                server.bot_state_time_us - first_mapped_time_us),
+        })
+
     def test_29_bot_fire_hits_survive_external_combat_rebases(self):
         runtime, server, roster = self._runtime_and_server()
         # This historical stress test invokes legacy reports directly.  Keep

--- a/0.9.22/tests/test_port_0922_snapshot_sync.py
+++ b/0.9.22/tests/test_port_0922_snapshot_sync.py
@@ -719,7 +719,7 @@ class SnapshotSyncTests(unittest.TestCase):
         self.assertGreaterEqual(presented['pose']['x'], 0.12)
         self.assertLessEqual(presented['pose']['x'], 0.32)
 
-    def test_first_live_reset_waits_for_an_advanced_bot_revision(self):
+    def test_battle_phase_anchors_unchanged_pose_before_first_live_revision(self):
         clock = [0.0]
         sync = self.module.SnapshotSync(1, clock=lambda: clock[0])
 
@@ -738,8 +738,9 @@ class SnapshotSyncTests(unittest.TestCase):
             'bots': [bot(0.0)],
         })
         # The server can enter battle before the worker publishes its first
-        # live revision. This repeated pose must not consume the timeline
-        # reset intended for the following advanced sample.
+        # live revision. This repeated pose is a confirmed live-time anchor,
+        # so a slow first revision forms an interpolation segment rather than
+        # snapping after the countdown-sized gap.
         clock[0] = 15.0
         sync.snapshot({
             'round_id': 1, 'server_tick': 450,
@@ -748,7 +749,11 @@ class SnapshotSyncTests(unittest.TestCase):
             'timing': {'phase': 'battle'},
             'bots': [bot(0.0)],
         })
-        self.assertTrue(sync._live_timeline_reset_pending)
+        self.assertFalse(sync._live_timeline_reset_pending)
+        record = sync._entities['bot:7']
+        self.assertEqual([15000000], [
+            sample['time_us'] for sample in record['timed_samples']])
+        self.assertEqual(15000000, record['presentation_time_us'])
 
         clock[0] = 15.04
         events = sync.snapshot({
@@ -761,11 +766,12 @@ class SnapshotSyncTests(unittest.TestCase):
 
         update = [event for event in events
                   if event.get('entity') == 'bot:7'][-1]
-        self.assertTrue(update['snap'])
-        self.assertAlmostEqual(0.12, update['pose']['x'])
+        self.assertFalse(update['snap'])
+        self.assertIsNone(update['pose'])
         record = sync._entities['bot:7']
-        self.assertEqual(1, len(record['timed_samples']))
-        self.assertEqual(15040000, record['presentation_time_us'])
+        self.assertEqual([15000000, 15040000], [
+            sample['time_us'] for sample in record['timed_samples']])
+        self.assertEqual(15000000, record['presentation_time_us'])
         self.assertFalse(sync._live_timeline_reset_pending)
 
     def test_first_live_reset_discards_all_prebattle_pose_history(self):


### PR DESCRIPTION
## Summary

- consume all hidden-worker elapsed time in bounded physics slices while refreshing Bot planning once per render callback
- keep straight and turning commands active between plans, with contained physical corridor re-probes and safe holds when proof is missing or blocked
- preserve ram and burst state barriers across one slow source batch
- anchor the first live timed pose so slow-worker updates interpolate instead of snapping after countdown

## Validation

- PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s 0.9.22/tests (2900 tests passed)
- Python 2.7 compile of all 88 client Python files
- Python 3 compile of the changed LAN server module
- git diff --check

## Native boundary

Static and contract tests prove the Python scheduling, message ordering, and compatibility shape. Exact #1513 Windows-client acceptance is still required to prove BigWorld native-query performance and gameplay feel at very low hidden-worker frame rates.