### PR TITLE
Reduce Python hidden-worker render-thread workload

### DIFF
--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/authority_worker.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/authority_worker.py
@@ -51,6 +51,78 @@ _COALESCIBLE_BOT_STATE_FIELDS = frozenset((
     'combat_fire_elapsed', 'combat_fire_timer'))
 _COALESCIBLE_EQUIPMENT_FIELDS = frozenset((
     'cooldownTimeLeft', 'autoPendingElapsed', 'aiPendingElapsed'))
+_VISIBILITY_DIAGNOSTIC_COUNTERS = (
+    'visibility_admitted', 'visibility_completed', 'visibility_deferred',
+    'visibility_selected_services', 'visibility_fire_services',
+    'visibility_new_services', 'visibility_ordinary_services')
+_SHOT_LANE_DIAGNOSTIC_COUNTERS = (
+    'shot_lane_completed_pairs',
+    'shot_lane_budget_deferred_attempts')
+
+
+def _windows_process_counters():
+    """Read cheap process counters on the exact Windows worker, fail-soft."""
+    if not sys.platform.startswith('win'):
+        return None
+    try:
+        import ctypes
+
+        class _FileTime(ctypes.Structure):
+            _fields_ = [
+                ('low', ctypes.c_ulong),
+                ('high', ctypes.c_ulong),
+            ]
+
+        class _ProcessMemoryCounters(ctypes.Structure):
+            _fields_ = [
+                ('cb', ctypes.c_ulong),
+                ('page_fault_count', ctypes.c_ulong),
+                ('peak_working_set_size', ctypes.c_size_t),
+                ('working_set_size', ctypes.c_size_t),
+                ('quota_peak_paged_pool_usage', ctypes.c_size_t),
+                ('quota_paged_pool_usage', ctypes.c_size_t),
+                ('quota_peak_non_paged_pool_usage', ctypes.c_size_t),
+                ('quota_non_paged_pool_usage', ctypes.c_size_t),
+                ('pagefile_usage', ctypes.c_size_t),
+                ('peak_pagefile_usage', ctypes.c_size_t),
+            ]
+
+        kernel = ctypes.windll.kernel32
+        process = kernel.GetCurrentProcess()
+        creation = _FileTime()
+        exit_time = _FileTime()
+        kernel_time = _FileTime()
+        user_time = _FileTime()
+        if not kernel.GetProcessTimes(
+                process, ctypes.byref(creation), ctypes.byref(exit_time),
+                ctypes.byref(kernel_time), ctypes.byref(user_time)):
+            return None
+        memory = _ProcessMemoryCounters()
+        memory.cb = ctypes.sizeof(memory)
+        if not ctypes.windll.psapi.GetProcessMemoryInfo(
+                process, ctypes.byref(memory), memory.cb):
+            return None
+
+        def filetime_seconds(value):
+            ticks = (int(value.high) << 32) | int(value.low)
+            return ticks / 10000000.0
+
+        processors = None
+        try:
+            processors = max(
+                1, int(os.environ.get('NUMBER_OF_PROCESSORS')))
+        except (TypeError, ValueError, OverflowError):
+            processors = None
+        return {
+            'cpu_seconds': (
+                filetime_seconds(kernel_time) +
+                filetime_seconds(user_time)),
+            'working_set_bytes': int(memory.working_set_size),
+            'logical_processors': processors,
+        }
+    except Exception:
+        # Performance evidence can be absent; it cannot alter worker life.
+        return None
 
 
 def _immutable_outbound_key(value):
@@ -671,6 +743,8 @@ class WorkerSession(object):
         self._probe_round_id = None
         self._probe_time = None
         self._probe_sample = None
+        self._process_sample_time = None
+        self._process_cpu_seconds = None
 
     def _ensure_runtime_boundaries(self):
         if self._bigworld is None:
@@ -1132,6 +1206,7 @@ class WorkerSession(object):
                 None if self.client is None else
                 self.client.bot_authority_id),
             'world_draw_enabled': draw_enabled,
+            'process_performance': self._process_performance(now),
             'runtime': self._runtime_status(now),
         }
         try:
@@ -1143,12 +1218,94 @@ class WorkerSession(object):
             return False
         return True
 
+    def _process_performance(self, now):
+        """Sample Windows CPU/working set only at the two-second status rate."""
+        counters = _windows_process_counters()
+        if not isinstance(counters, dict):
+            return {
+                'available': False,
+                'source': 'windows_process_api',
+                'cpu_core_percent': None,
+                'cpu_machine_percent': None,
+                'working_set_bytes': None,
+                'logical_processors': None,
+                'gpu_measured': False,
+            }
+        try:
+            cpu_seconds = float(counters['cpu_seconds'])
+            working_set = max(0, int(counters['working_set_bytes']))
+            processors = counters.get('logical_processors')
+            processors = (None if processors is None else
+                          max(1, int(processors)))
+        except (KeyError, TypeError, ValueError, OverflowError):
+            return {
+                'available': False,
+                'source': 'windows_process_api',
+                'cpu_core_percent': None,
+                'cpu_machine_percent': None,
+                'working_set_bytes': None,
+                'logical_processors': None,
+                'gpu_measured': False,
+            }
+        core_percent = None
+        if (self._process_sample_time is not None and
+                self._process_cpu_seconds is not None and
+                float(now) > self._process_sample_time and
+                cpu_seconds >= self._process_cpu_seconds):
+            core_percent = (100.0 *
+                            (cpu_seconds - self._process_cpu_seconds) /
+                            (float(now) - self._process_sample_time))
+        self._process_sample_time = float(now)
+        self._process_cpu_seconds = cpu_seconds
+        return {
+            'available': True,
+            'source': 'windows_process_api',
+            # This may exceed 100% when several worker threads are busy.
+            'cpu_core_percent': core_percent,
+            'cpu_machine_percent': (
+                None if core_percent is None or processors is None else
+                core_percent / processors),
+            'working_set_bytes': working_set,
+            'logical_processors': processors,
+            # #1513 exposes no reliable per-process GPU counter to Python.
+            'gpu_measured': False,
+        }
+
     @staticmethod
     def _counter_delta(current, previous, name):
         try:
             return max(0, int(current.get(name)) - int(previous.get(name)))
         except (AttributeError, TypeError, ValueError, OverflowError):
             return None
+
+    @staticmethod
+    def _mapping_delta(current, previous, name, integer=False):
+        try:
+            current_values = current.get(name) or {}
+            previous_values = previous.get(name) or {}
+        except AttributeError:
+            return None
+        if (not isinstance(current_values, dict) or
+                not isinstance(previous_values, dict)):
+            return None
+        result = {}
+        for key in set(current_values).union(previous_values):
+            try:
+                value = (float(current_values.get(key, 0.0)) -
+                         float(previous_values.get(key, 0.0)))
+            except (TypeError, ValueError, OverflowError):
+                continue
+            if value < 0.0 or math.isnan(value) or math.isinf(value):
+                continue
+            result[str(key)] = int(value) if integer else value
+        return result
+
+    @staticmethod
+    def _mapping_rates(values, seconds, scale=1.0):
+        if not isinstance(values, dict) or not seconds:
+            return None
+        return dict((name, float(value) * float(scale) / float(seconds))
+                    for name, value in values.items())
 
     def _reset_probe_window(self):
         self._probe_runtime = None
@@ -1174,20 +1331,76 @@ class WorkerSession(object):
             previous is not None and previous_time is not None and
             now > previous_time)
         window_seconds = None
-        callback_delta = publication_delta = None
+        callback_delta = render_delta = publication_delta = None
         revision_delta = send_failed_delta = None
+        probe_deltas = probe_rates = None
+        timed_probe_seconds = timed_probe_ms = None
+        presentation_delta = presentation_rates = None
+        catchup_delta = debt_callback_delta = None
+        astar_exhausted_delta = astar_completed_delta = None
+        astar_failed_delta = None
+        visibility_delta = visibility_hz = None
+        shot_lane_delta = shot_lane_hz = None
         if same_window:
             window_seconds = float(now - previous_time)
             callback_delta = self._counter_delta(
                 sample, previous, 'authority_callbacks')
+            render_delta = self._counter_delta(
+                sample, previous, 'frame_callbacks')
             publication_delta = self._counter_delta(
                 sample, previous, 'bot_state_enqueued')
             revision_delta = self._counter_delta(
                 sample, previous, 'bot_state_revision')
             send_failed_delta = self._counter_delta(
                 sample, previous, 'bot_state_send_failed')
+            probe_deltas = self._mapping_delta(
+                sample, previous, 'bot_probes', integer=True)
+            probe_rates = self._mapping_rates(
+                probe_deltas, window_seconds)
+            timed_probe_seconds = self._mapping_delta(
+                sample, previous, 'bot_probe_seconds')
+            timed_probe_ms = self._mapping_rates(
+                timed_probe_seconds, 1.0, scale=1000.0)
+            presentation_delta = self._mapping_delta(
+                sample, previous, 'presentation', integer=True)
+            presentation_rates = self._mapping_rates(
+                presentation_delta, window_seconds)
+            current_control = sample.get('control') or {}
+            previous_control = previous.get('control') or {}
+            catchup_delta = self._counter_delta(
+                current_control, previous_control, 'catchup_callbacks')
+            debt_callback_delta = self._counter_delta(
+                current_control, previous_control, 'debt_callbacks')
+            astar_exhausted_delta = self._counter_delta(
+                current_control, previous_control,
+                'astar_budget_exhausted_callbacks')
+            astar_completed_delta = self._counter_delta(
+                current_control, previous_control, 'astar_completed')
+            astar_failed_delta = self._counter_delta(
+                current_control, previous_control, 'astar_failed')
+            current_diagnostics = sample.get('bot_diagnostics') or {}
+            previous_diagnostics = previous.get('bot_diagnostics') or {}
+            visibility_delta = {}
+            for name in _VISIBILITY_DIAGNOSTIC_COUNTERS:
+                delta = self._counter_delta(
+                    current_diagnostics, previous_diagnostics, name)
+                if delta is not None:
+                    visibility_delta[name] = delta
+            visibility_hz = self._mapping_rates(
+                visibility_delta, window_seconds)
+            shot_lane_delta = {}
+            for name in _SHOT_LANE_DIAGNOSTIC_COUNTERS:
+                delta = self._counter_delta(
+                    current_diagnostics, previous_diagnostics, name)
+                if delta is not None:
+                    shot_lane_delta[name] = delta
+            shot_lane_hz = self._mapping_rates(
+                shot_lane_delta, window_seconds)
         sample.update({
             'window_seconds': window_seconds,
+            'render_callback_hz': (
+                None if render_delta is None else
+                render_delta / window_seconds),
             'callback_hz': (
                 None if callback_delta is None else
                 callback_delta / window_seconds),
@@ -1196,6 +1409,20 @@ class WorkerSession(object):
                 publication_delta / window_seconds),
             'revision_delta': revision_delta,
             'send_failed_delta': send_failed_delta,
+            'logical_probe_delta': probe_deltas,
+            'logical_probe_hz': probe_rates,
+            'timed_probe_ms_delta': timed_probe_ms,
+            'presentation_delta': presentation_delta,
+            'presentation_hz': presentation_rates,
+            'catchup_delta': catchup_delta,
+            'debt_callback_delta': debt_callback_delta,
+            'astar_budget_exhausted_delta': astar_exhausted_delta,
+            'astar_completed_delta': astar_completed_delta,
+            'astar_failed_delta': astar_failed_delta,
+            'visibility_counter_delta': visibility_delta,
+            'visibility_counter_hz': visibility_hz,
+            'shot_lane_counter_delta': shot_lane_delta,
+            'shot_lane_counter_hz': shot_lane_hz,
         })
         self._probe_runtime = runtime
         self._probe_round_id = self._active_round_id

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -11813,19 +11813,33 @@ class BattleRuntime(object):
         except (AttributeError, TypeError, ValueError, OverflowError):
             sample_time_after = sample_time_before = 0
         advanced = max(0, sample_time_after - sample_time_before)
+        try:
+            control_steps = max(0, int(getattr(
+                self._bots, '_last_update_control_steps')))
+        except (AttributeError, TypeError, ValueError, OverflowError):
+            control_steps = 1 if advanced > 0 else 0
+        try:
+            max_control_step = max(0.0, float(getattr(
+                self._bots, '_last_update_max_control_step')))
+        except (AttributeError, TypeError, ValueError, OverflowError):
+            max_control_step = advanced / 1000000.0
+        if math.isnan(max_control_step) or math.isinf(max_control_step):
+            max_control_step = advanced / 1000000.0
         debt = max(0.0, _number(getattr(
             self._bots, '_accumulator', 0.0)))
         self._worker_probe_control_debt = debt
         self._worker_probe_max_control_debt = max(
             self._worker_probe_max_control_debt, debt)
         if advanced > 0:
-            step = advanced / 1000000.0
-            self._worker_probe_control_steps += 1
+            if control_steps <= 0:
+                control_steps = 1
+            self._worker_probe_control_steps += control_steps
             self._worker_probe_max_control_step = max(
-                self._worker_probe_max_control_step, step)
+                self._worker_probe_max_control_step, max_control_step)
             control_seconds = max(0.0, _number(getattr(
                 self._bots, '_control_seconds', 0.0)))
-            if step > control_seconds + 1.0e-9:
+            if (control_steps > 1 or
+                    advanced / 1000000.0 > control_seconds + 1.0e-9):
                 self._worker_probe_catchup_callbacks += 1
             if debt + 1.0e-9 >= control_seconds > 0.0:
                 self._worker_probe_control_debt_callbacks += 1

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -60,9 +60,8 @@ from gui.mods.offline_lan_0922 import (
 # and makes copied local physics, authority bots and remote interpolation step
 # even while the renderer itself reports a healthy frame rate.
 FRAME_SECONDS = 0.0
-# Runtime profiling is observational. The same process-time clock separately
-# gates whether a hidden-worker callback may run its second fixed catch-up
-# step; it never becomes simulation time or changes retained elapsed debt.
+# Runtime profiling is observational. Its process-time clock never becomes
+# simulation time and never feeds the fixed-control or A* schedulers.
 PERFORMANCE_DIAGNOSTICS = True
 WORKER_NATIVE_PROBE_SECONDS = 5.0
 # Keep enough timing evidence for user-submitted logs without displacing
@@ -71,6 +70,21 @@ WORKER_NATIVE_PROBE_SECONDS = 5.0
 DIAGNOSTIC_INITIAL_WINDOW_SECONDS = 5.0
 DIAGNOSTIC_WINDOW_SECONDS = 30.0
 DIAGNOSTIC_TOP_FRAMES = 3
+# A normal 30-second window at 60-120 FPS fits entirely. Pathological high
+# frame rates retain only the latest bounded sample set while exact maxima and
+# threshold counts still cover the complete window.
+DIAGNOSTIC_PERCENTILE_SAMPLES = 4096
+_WORKER_DIAGNOSTIC_FIELDS = (
+    'alive_bot_ticks', 'visibility_queue_depth',
+    'visibility_queue_max_depth', 'visibility_oldest_stale_age_ms',
+    'visibility_oldest_stale_max_age_ms', 'visibility_admitted',
+    'visibility_completed', 'visibility_deferred',
+    'visibility_selected_services', 'visibility_fire_services',
+    'visibility_new_services', 'visibility_ordinary_services',
+    'shot_lane_pending_pairs', 'shot_lane_pending_max_pairs',
+    'shot_lane_oldest_due_age_ms', 'shot_lane_oldest_due_max_age_ms',
+    'shot_lane_completed_pairs',
+    'shot_lane_budget_deferred_attempts')
 AMMO_SECONDS = 0.10
 NETWORK_INPUT_SECONDS = 1.0 / 30.0
 RPM_PRESENTATION_SECONDS = 0.10
@@ -365,7 +379,7 @@ def _is_port_object(value):
 
 
 _FRAME_STAGE_NAMES = (
-    'house', 'sync', 'critical', 'drown', 'transition', 'local',
+    'house', 'sync', 'critical', 'drown', 'prewarm', 'transition', 'local',
     'outline', 'bots_update', 'bot_present', 'bot_events', 'spot', 'lock',
     'schedule', 'diag_emit')
 _PROJECTILE_METRIC_NAMES = (
@@ -393,6 +407,7 @@ class _FrameDiagnostics(object):
         self._frame_id = 0
         self._window_id = 0
         self._window_seconds = self._initial_window_seconds
+        self._last_snapshot = {}
         self._reset_window()
 
     def _reset_window(self):
@@ -406,10 +421,18 @@ class _FrameDiagnostics(object):
         self._exec_max = 0.0
         self._outside_sum = 0.0
         self._outside_max = 0.0
+        self._gap_samples = collections.deque(
+            maxlen=DIAGNOSTIC_PERCENTILE_SAMPLES)
+        self._exec_samples = collections.deque(
+            maxlen=DIAGNOSTIC_PERCENTILE_SAMPLES)
+        self._outside_samples = collections.deque(
+            maxlen=DIAGNOSTIC_PERCENTILE_SAMPLES)
+        self._distribution_samples = 0
         self._offframe_sum = 0.0
         self._offframe_max = 0.0
         self._load_busiest = ()
         self._collections = {}
+        self._worker_runtime = {}
         self._stage_sums = dict((name, 0.0)
                                 for name in _FRAME_STAGE_NAMES)
         self._stage_maxima = dict((name, 0.0)
@@ -490,6 +513,10 @@ class _FrameDiagnostics(object):
         self._exec_max = max(self._exec_max, execution)
         self._outside_sum += outside
         self._outside_max = max(self._outside_max, outside)
+        self._gap_samples.append(gap)
+        self._exec_samples.append(execution)
+        self._outside_samples.append(outside)
+        self._distribution_samples += 1
         offframe = row.get('offframe', 0.0)
         self._offframe_sum += offframe
         self._offframe_max = max(self._offframe_max, offframe)
@@ -558,24 +585,122 @@ class _FrameDiagnostics(object):
         self._load_busiest = tuple(report.get('busiest') or ())
         return True
 
+    def note_worker_runtime(self, report):
+        """Record one low-frequency fixed-control/presentation snapshot."""
+        if not self.enabled or not isinstance(report, dict):
+            return False
+        self._worker_runtime = dict(report)
+        return True
+
     @staticmethod
     def _milliseconds(value):
         return max(0.0, float(value)) * 1000.0
+
+    @staticmethod
+    def _percentile(sorted_values, fraction):
+        if not sorted_values:
+            return 0.0
+        if len(sorted_values) == 1:
+            return float(sorted_values[0])
+        rank = max(0.0, min(1.0, float(fraction))) * (
+            len(sorted_values) - 1)
+        lower = int(math.floor(rank))
+        upper = int(math.ceil(rank))
+        if lower == upper:
+            return float(sorted_values[lower])
+        weight = rank - lower
+        return (float(sorted_values[lower]) * (1.0 - weight) +
+                float(sorted_values[upper]) * weight)
+
+    def _distribution(self, samples, exact_maximum):
+        values = sorted(samples)
+        return {
+            'p50': self._milliseconds(self._percentile(values, 0.50)),
+            'p95': self._milliseconds(self._percentile(values, 0.95)),
+            'p99': self._milliseconds(self._percentile(values, 0.99)),
+            'max': self._milliseconds(exact_maximum),
+        }
+
+    def snapshot(self):
+        """Return the most recently completed bounded performance window."""
+        return dict(self._last_snapshot)
 
     def _format(self):
         samples = max(1, self._samples)
         elapsed = max(1e-9, self._window_elapsed)
         context = self._last_context
         self._window_id += 1
+        gap_distribution = self._distribution(
+            self._gap_samples, self._gap_max)
+        exec_distribution = self._distribution(
+            self._exec_samples, self._exec_max)
+        outside_distribution = self._distribution(
+            self._outside_samples, self._outside_max)
+        stage_snapshot = {}
+        for name in _FRAME_STAGE_NAMES:
+            stage_snapshot[name] = {
+                'avg_ms': self._milliseconds(
+                    self._stage_sums[name] / samples),
+                'max_ms': self._milliseconds(self._stage_maxima[name]),
+            }
+        probe_snapshot = {}
+        for name in PROBE_KINDS:
+            probe_snapshot[name] = {
+                'logical_count': self._probe_sums[name],
+                'logical_hz': self._probe_sums[name] / elapsed,
+                'logical_per_frame_avg': (
+                    float(self._probe_sums[name]) / samples),
+                'logical_per_frame_max': self._probe_maxima[name],
+                'timed_ms_total': self._milliseconds(
+                    self._probe_duration_sums[name]),
+                'timed_ms_per_second': self._milliseconds(
+                    self._probe_duration_sums[name] / elapsed),
+                'timed_ms_per_frame_avg': self._milliseconds(
+                    self._probe_duration_sums[name] / samples),
+                'timed_ms_per_frame_max': self._milliseconds(
+                    self._probe_duration_maxima[name]),
+            }
+        self._last_snapshot = {
+            'schema': 1,
+            'window': self._window_id,
+            'round': context.get('round', '-'),
+            'map': context.get('map', '-'),
+            'phase': context.get('phase', '-'),
+            'role': context.get('role', '-'),
+            'probe_timing': context.get('probe_timing', 'off'),
+            'samples': self._samples,
+            'seconds': self._window_elapsed,
+            'render_callback_fps': self._samples / elapsed,
+            'distribution_samples': len(self._gap_samples),
+            'distribution_dropped': max(
+                0, self._distribution_samples - len(self._gap_samples)),
+            'frame_interval_ms': gap_distribution,
+            'python_callback_ms': exec_distribution,
+            'outside_callback_ms': outside_distribution,
+            'python_stages_ms': stage_snapshot,
+            # One logical probe can contain several native calls. The current
+            # Python boundary cannot truthfully derive raw call/primitives.
+            'raw_native_calls_measured': False,
+            'logical_native_probes': probe_snapshot,
+            'worker_runtime': dict(self._worker_runtime),
+            'over_50_67_100': (
+                self._over_50, self._over_67, self._over_100),
+            'simulation_caps': self._sim_caps,
+            'clock_regressions': self._clock_regressions,
+        }
         prefix = '[Offline LAN 0.9.22] PERF '
         lines = [
             (prefix +
-             'summary v=2 window=%d round=%s map=%s phase=%s role=%s '
+             'summary v=3 window=%d round=%s map=%s phase=%s role=%s '
              'probe_timing=%s '
              'samples=%d seconds=%.3f fps=%.2f authority_frames=%d '
              'gap_ms_avg_max=%.3f/%.3f raw_dt_ms_avg_max=%.3f/%.3f '
              'exec_ms_avg_max=%.3f/%.3f offframe_ms_avg_max=%.3f/%.3f '
              'outside_ms_avg_max=%.3f/%.3f '
+             'gap_ms_p50_p95_p99_max=%.3f/%.3f/%.3f/%.3f '
+             'python_ms_p50_p95_p99_max=%.3f/%.3f/%.3f/%.3f '
+             'outside_ms_p50_p95_p99_max=%.3f/%.3f/%.3f/%.3f '
+             'distribution_kept_dropped=%d/%d '
              'over_50_67_100=%d/%d/%d sim_caps=%d clock_regress=%d\n') % (
                  self._window_id, context.get('round', '-'),
                  context.get('map', '-'), context.get('phase', '-'),
@@ -592,6 +717,17 @@ class _FrameDiagnostics(object):
                  self._milliseconds(self._offframe_max),
                  self._milliseconds(self._outside_sum / samples),
                  self._milliseconds(self._outside_max),
+                 gap_distribution['p50'], gap_distribution['p95'],
+                 gap_distribution['p99'], gap_distribution['max'],
+                 exec_distribution['p50'], exec_distribution['p95'],
+                 exec_distribution['p99'], exec_distribution['max'],
+                 outside_distribution['p50'],
+                 outside_distribution['p95'],
+                 outside_distribution['p99'],
+                 outside_distribution['max'],
+                 len(self._gap_samples), max(
+                     0, self._distribution_samples -
+                     len(self._gap_samples)),
                  self._over_50, self._over_67, self._over_100,
                  self._sim_caps, self._clock_regressions),
         ]
@@ -603,6 +739,49 @@ class _FrameDiagnostics(object):
             ' '.join('%s=%d' % (name, self._collections[name])
                      for name in sorted(self._collections)) or 'none') +
             '\n')
+        control = self._worker_runtime.get('control') or {}
+        presentation = self._worker_runtime.get('presentation') or {}
+        bot_diagnostics = self._worker_runtime.get('bot_diagnostics') or {}
+        lines.append(
+            (prefix +
+             'worker control_steps=%s catchup=%s debt_callbacks=%s '
+             'control_debt_ms=%s max_control_step_ms=%s '
+             'astar_pending=%s astar_credit=%s astar_budget_remaining=%s '
+             'astar_budget_exhausted=%s astar_completed=%s astar_failed=%s '
+             'visibility_queue_depth_max=%s/%s '
+             'visibility_oldest_ms_max=%s/%s '
+             'shot_lane_pending_max=%s/%s '
+             'shot_lane_oldest_due_ms_max=%s/%s '
+             'shot_lane_completed_deferred=%s/%s '
+             'pose_writes_skips=%s/%s aim_writes_skips=%s/%s\n') % (
+                 control.get('control_steps'),
+                 control.get('catchup_callbacks'),
+                 control.get('debt_callbacks'),
+                 control.get('control_debt_ms'),
+                 control.get('max_control_step_ms'),
+                 control.get('astar_pending'),
+                 control.get('astar_credit'),
+                 control.get('astar_budget_remaining'),
+                 control.get('astar_budget_exhausted_callbacks'),
+                 control.get('astar_completed'),
+                 control.get('astar_failed'),
+                 bot_diagnostics.get('visibility_queue_depth'),
+                 bot_diagnostics.get('visibility_queue_max_depth'),
+                 bot_diagnostics.get('visibility_oldest_stale_age_ms'),
+                 bot_diagnostics.get(
+                     'visibility_oldest_stale_max_age_ms'),
+                 bot_diagnostics.get('shot_lane_pending_pairs'),
+                 bot_diagnostics.get('shot_lane_pending_max_pairs'),
+                 bot_diagnostics.get('shot_lane_oldest_due_age_ms'),
+                 bot_diagnostics.get(
+                     'shot_lane_oldest_due_max_age_ms'),
+                 bot_diagnostics.get('shot_lane_completed_pairs'),
+                 bot_diagnostics.get(
+                     'shot_lane_budget_deferred_attempts'),
+                 presentation.get('pose_writes'),
+                 presentation.get('pose_skips'),
+                 presentation.get('aim_writes'),
+                 presentation.get('aim_skips')))
         stage_values = []
         for name in _FRAME_STAGE_NAMES:
             stage_values.append('%s=%.3f/%.3f' % (
@@ -616,8 +795,15 @@ class _FrameDiagnostics(object):
             probe_values.append('%s=%.2f/%d' % (
                 name, float(self._probe_sums[name]) / samples,
                 self._probe_maxima[name]))
-        lines.append(prefix + 'probes_avg_max ' +
+        lines.append(prefix + 'logical_probes_avg_max ' +
                      ' '.join(probe_values) + '\n')
+        probe_rate_values = []
+        for name in PROBE_KINDS:
+            probe_rate_values.append('%s=%.2f/%d' % (
+                name, self._probe_sums[name] / elapsed,
+                self._probe_sums[name]))
+        lines.append(prefix + 'logical_probes_hz_total ' +
+                     ' '.join(probe_rate_values) + '\n')
         probe_duration_values = []
         for name in PROBE_KINDS:
             probe_duration_values.append('%s=%.3f/%.3f' % (
@@ -625,8 +811,17 @@ class _FrameDiagnostics(object):
                 self._milliseconds(
                     self._probe_duration_sums[name] / samples),
                 self._milliseconds(self._probe_duration_maxima[name])))
-        lines.append(prefix + 'probe_ms_avg_max ' +
+        lines.append(prefix + 'logical_probe_ms_avg_max ' +
                      ' '.join(probe_duration_values) + '\n')
+        probe_duration_rate_values = []
+        for name in PROBE_KINDS:
+            probe_duration_rate_values.append('%s=%.3f/%.3f' % (
+                name,
+                self._milliseconds(
+                    self._probe_duration_sums[name] / elapsed),
+                self._milliseconds(self._probe_duration_sums[name])))
+        lines.append(prefix + 'logical_probe_ms_per_s_total ' +
+                     ' '.join(probe_duration_rate_values) + '\n')
         lines.append(
             (prefix +
              'projectile_avg_max active=%.2f/%.0f chords=%.2f/%.0f '
@@ -664,7 +859,8 @@ class _FrameDiagnostics(object):
                  'pose_step_m=%.4f speed_mps=%.3f camera_mps=%.3f '
                  'airborne=%d grind=%d bots=%d outgoing=%d '
                  'transition=%d prev_emit=%d '
-                 'projectile=%s stages_ms=%s probes=%s probe_ms=%s\n') % (
+                 'projectile=%s stages_ms=%s logical_probes=%s '
+                 'logical_probe_ms=%s\n') % (
                      rank, row['cause'], row['next'],
                      self._milliseconds(row['wall_gap']),
                      row['raw_dt'] * 1000.0,
@@ -1230,6 +1426,18 @@ class BattleRuntime(object):
         self._worker_probe_bot_send_failed = 0
         self._worker_probe_bot_count = 0
         self._worker_probe_simulation_caps = 0
+        self._worker_probe_control_steps = 0
+        self._worker_probe_catchup_callbacks = 0
+        self._worker_probe_control_debt_callbacks = 0
+        self._worker_probe_max_control_step = 0.0
+        self._worker_probe_control_debt = 0.0
+        self._worker_probe_max_control_debt = 0.0
+        self._worker_probe_astar_budget_exhausted = 0
+        self._worker_probe_astar_max_pending = 0
+        self._authority_pose_writes = 0
+        self._authority_pose_skips = 0
+        self._authority_aim_writes = 0
+        self._authority_aim_skips = 0
         self._frame_diagnostics = (
             _FrameDiagnostics(
                 initial_window_seconds=DIAGNOSTIC_INITIAL_WINDOW_SECONDS)
@@ -1474,6 +1682,18 @@ class BattleRuntime(object):
         self._worker_probe_bot_send_failed = 0
         self._worker_probe_bot_count = 0
         self._worker_probe_simulation_caps = 0
+        self._worker_probe_control_steps = 0
+        self._worker_probe_catchup_callbacks = 0
+        self._worker_probe_control_debt_callbacks = 0
+        self._worker_probe_max_control_step = 0.0
+        self._worker_probe_control_debt = 0.0
+        self._worker_probe_max_control_debt = 0.0
+        self._worker_probe_astar_budget_exhausted = 0
+        self._worker_probe_astar_max_pending = 0
+        self._authority_pose_writes = 0
+        self._authority_pose_skips = 0
+        self._authority_aim_writes = 0
+        self._authority_aim_skips = 0
         self._next_bot_manifest_retry = 0.0
         self._bot_manifest_retry_deadline = 0.0
         self._bot_manifest_retry_identity = None
@@ -11582,6 +11802,99 @@ class BattleRuntime(object):
             result['camouflage_id'] = camouflage_id
         return result
 
+    def _record_worker_control_diagnostics(self, sample_time_before):
+        """Observe fixed-control and A* debt without feeding either scheduler."""
+        if not self._worker_mode or self._bots is None:
+            return False
+        try:
+            sample_time_after = int(getattr(
+                self._bots, '_sample_time_us'))
+            sample_time_before = int(sample_time_before)
+        except (AttributeError, TypeError, ValueError, OverflowError):
+            sample_time_after = sample_time_before = 0
+        advanced = max(0, sample_time_after - sample_time_before)
+        debt = max(0.0, _number(getattr(
+            self._bots, '_accumulator', 0.0)))
+        self._worker_probe_control_debt = debt
+        self._worker_probe_max_control_debt = max(
+            self._worker_probe_max_control_debt, debt)
+        if advanced > 0:
+            step = advanced / 1000000.0
+            self._worker_probe_control_steps += 1
+            self._worker_probe_max_control_step = max(
+                self._worker_probe_max_control_step, step)
+            control_seconds = max(0.0, _number(getattr(
+                self._bots, '_control_seconds', 0.0)))
+            if step > control_seconds + 1.0e-9:
+                self._worker_probe_catchup_callbacks += 1
+            if debt + 1.0e-9 >= control_seconds > 0.0:
+                self._worker_probe_control_debt_callbacks += 1
+        navigator = getattr(self._bots, 'navigator', None)
+        searches = getattr(navigator, 'searches', None)
+        pending = len(searches) if isinstance(searches, dict) else 0
+        self._worker_probe_astar_max_pending = max(
+            self._worker_probe_astar_max_pending, pending)
+        if advanced > 0 and pending > 0:
+            try:
+                remaining = int(getattr(
+                    navigator, 'search_frame_budget'))
+            except (AttributeError, TypeError, ValueError, OverflowError):
+                remaining = None
+            if remaining is not None and remaining <= 0:
+                self._worker_probe_astar_budget_exhausted += 1
+        return advanced > 0
+
+    def _worker_diagnostic_totals(self):
+        """Project only bounded non-negative Bot diagnostic integers."""
+        provider = getattr(self._bots, 'diagnostic_totals', None)
+        try:
+            raw = provider() if callable(provider) else {}
+        except Exception:
+            raw = {}
+        result = {}
+        if isinstance(raw, dict):
+            for name in _WORKER_DIAGNOSTIC_FIELDS:
+                value = raw.get(name)
+                if (isinstance(value, bool) or
+                        not isinstance(value, _INTEGER_TYPES) or value < 0):
+                    continue
+                result[name] = int(value)
+        return result
+
+    def _worker_control_snapshot(self):
+        bots = self._bots
+        navigator = getattr(bots, 'navigator', None)
+        searches = getattr(navigator, 'searches', None)
+        pending = len(searches) if isinstance(searches, dict) else None
+
+        def finite_attribute(owner, name):
+            if owner is None or not hasattr(owner, name):
+                return None
+            value = _number(getattr(owner, name), float('nan'))
+            return value if not math.isnan(value) and not math.isinf(
+                value) else None
+
+        return {
+            'control_steps': self._worker_probe_control_steps,
+            'catchup_callbacks': self._worker_probe_catchup_callbacks,
+            'debt_callbacks': self._worker_probe_control_debt_callbacks,
+            'max_control_step_ms': (
+                self._worker_probe_max_control_step * 1000.0),
+            'control_debt_ms': self._worker_probe_control_debt * 1000.0,
+            'max_control_debt_ms': (
+                self._worker_probe_max_control_debt * 1000.0),
+            'astar_pending': pending,
+            'astar_credit': finite_attribute(navigator, 'search_credit'),
+            'astar_budget_remaining': finite_attribute(
+                navigator, 'search_frame_budget'),
+            'astar_completed': finite_attribute(
+                navigator, 'search_completed'),
+            'astar_failed': finite_attribute(navigator, 'search_failed'),
+            'astar_budget_exhausted_callbacks': (
+                self._worker_probe_astar_budget_exhausted),
+            'astar_max_pending': self._worker_probe_astar_max_pending,
+        }
+
     def _authority_worker_probe_sample(self):
         totals = None
         provider = getattr(self._bots, 'probe_totals', None)
@@ -11599,15 +11912,42 @@ class BattleRuntime(object):
                     probes[name] = int(totals[index])
                 except (TypeError, ValueError, OverflowError):
                     continue
-        diagnostic_totals = {}
-        diagnostic_provider = getattr(
-            self._bots, 'diagnostic_totals', None)
-        if callable(diagnostic_provider):
+        duration_totals = None
+        duration_provider = getattr(
+            self._bots, 'probe_duration_totals', None)
+        if callable(duration_provider):
             try:
-                diagnostic_totals = diagnostic_provider()
+                duration_totals = duration_provider()
             except Exception:
-                diagnostic_totals = {}
+                duration_totals = None
+        probe_seconds = {}
+        if isinstance(duration_totals, (list, tuple)):
+            for index, name in enumerate(PROBE_KINDS):
+                if index >= len(duration_totals):
+                    break
+                try:
+                    value = float(duration_totals[index])
+                    if value >= 0.0 and not math.isnan(value) and not math.isinf(
+                            value):
+                        probe_seconds[name] = value
+                except (TypeError, ValueError, OverflowError):
+                    continue
+        probe_timing = 'off'
+        timing_provider = getattr(self._bots, 'probe_timing_state', None)
+        if callable(timing_provider):
+            try:
+                probe_timing = str(timing_provider())
+            except Exception:
+                probe_timing = 'failed'
+        diagnostic_totals = self._worker_diagnostic_totals()
         snapshot = self._last_snapshot or {}
+        frame_performance = {}
+        frame_provider = getattr(self._frame_diagnostics, 'snapshot', None)
+        if callable(frame_provider):
+            try:
+                frame_performance = frame_provider()
+            except Exception:
+                frame_performance = {}
         return {
             'round_finished': self._battle_result is not None,
             'frame_callbacks': self._worker_frame_callbacks,
@@ -11617,9 +11957,20 @@ class BattleRuntime(object):
             'bot_state_send_failed': self._worker_probe_bot_send_failed,
             'bot_state_revision': snapshot.get('bot_state_revision'),
             'bot_probes': probes,
+            'bot_probe_seconds': probe_seconds,
+            'probe_timing': probe_timing,
             'bot_count': self._worker_probe_bot_count,
             'simulation_caps': self._worker_probe_simulation_caps,
             'alive_bot_ticks': diagnostic_totals.get('alive_bot_ticks'),
+            'bot_diagnostics': diagnostic_totals,
+            'control': self._worker_control_snapshot(),
+            'presentation': {
+                'pose_writes': self._authority_pose_writes,
+                'pose_skips': self._authority_pose_skips,
+                'aim_writes': self._authority_aim_writes,
+                'aim_skips': self._authority_aim_skips,
+            },
+            'frame_performance': frame_performance,
         }
 
     def authority_worker_ready_for_draw_off(self):
@@ -11946,8 +12297,13 @@ class BattleRuntime(object):
                     # and make worker authority behave unlike player authority.
                     set_camera(
                         None if self._worker_mode else self._local_position)
+                control_sample_before = getattr(
+                    self._bots, '_sample_time_us', None)
                 outgoing_messages = self._bots.update(
                     rule_dt, now, players=players)
+                if self._worker_mode:
+                    self._record_worker_control_diagnostics(
+                        control_sample_before)
                 after_probes = None
                 after_probe_durations = None
                 if profiling and callable(probe_totals):
@@ -11994,10 +12350,10 @@ class BattleRuntime(object):
                     raise RuntimeError(
                         'authority bot presentation boundary is unavailable')
                 # Pull the accepted authority pose on every render callback,
-                # while the complete simulation and LAN bot_state cadence are
-                # capped together at 30 Hz.  RemoteVehicle's MatrixAnimation
-                # interpolates between changed poses; unchanged pulls are a
-                # cheap no-op and do not require render-frame bot physics.
+                # while BotRuntime advances only when its production fixed-
+                # control scheduler consumes elapsed time. RemoteVehicle's
+                # MatrixAnimation interpolates between changed poses; exact
+                # duplicate render pulls do not require native rewrites.
                 states = presentation_states(now)
                 bot_count = len(states)
                 self._apply_authority_bot_poses(states)
@@ -12092,6 +12448,23 @@ class BattleRuntime(object):
                     diagnostics.note_collections(self._collection_counts())
                 except Exception:
                     pass
+                note_worker_runtime = getattr(
+                    diagnostics, 'note_worker_runtime', None)
+                if self._worker_mode and callable(note_worker_runtime):
+                    try:
+                        note_worker_runtime({
+                            'control': self._worker_control_snapshot(),
+                            'bot_diagnostics': (
+                                self._worker_diagnostic_totals()),
+                            'presentation': {
+                                'pose_writes': self._authority_pose_writes,
+                                'pose_skips': self._authority_pose_skips,
+                                'aim_writes': self._authority_aim_writes,
+                                'aim_skips': self._authority_aim_skips,
+                            },
+                        })
+                    except Exception:
+                        pass
             diagnostics.finish(
                 frame_id, entry_wall, tick_dt, dt, stages, probes, {
                     'round': (self._start_message or {}).get('round_id', '-'),
@@ -14988,16 +15361,48 @@ class BattleRuntime(object):
         self._bot_yaw_rates[key] = turned / elapsed
         return elapsed * POSE_RELAX_STRETCH
 
+    def _authority_presentation_lifecycle(self, record, bot_id):
+        """Fence unchanged-pose caches to one live actor/entity generation."""
+        lifecycle = (
+            int(self._generation), int(bot_id),
+            int(record.get('engine_id', 0)), id(record))
+        if record.get('_authority_presentation_lifecycle') != lifecycle:
+            record['_authority_presentation_lifecycle'] = lifecycle
+            record.pop('_authority_pose_signature', None)
+            record.pop('_authority_aim_signature', None)
+            self._bot_pose_times.pop(bot_id, None)
+            self._bot_yaw_rates.pop(bot_id, None)
+        return lifecycle
+
+    @staticmethod
+    def _clear_authority_presentation_signatures(record):
+        if isinstance(record, dict):
+            record.pop('_authority_presentation_lifecycle', None)
+            record.pop('_authority_pose_signature', None)
+            record.pop('_authority_aim_signature', None)
+
     def _apply_authority_bot_poses(self, states):
         """Present copied 0.8.2 bot poses through the remote filter."""
         applied = False
         now = self._clock()
+        try:
+            control_pose_epoch = int(getattr(
+                self._bots, '_sample_time_us'))
+        except (AttributeError, TypeError, ValueError, OverflowError):
+            control_pose_epoch = None
         for state in states:
             if not isinstance(state, dict) or state.get('id') is None:
                 continue
             record = self._records.get('bot:%s' % state['id'])
-            if record is None or not record.get('ready'):
+            if record is None:
                 continue
+            if not record.get('ready'):
+                self._clear_authority_presentation_signatures(record)
+                continue
+            bot_id = int(state['id'])
+            engine_id = int(record['engine_id'])
+            lifecycle = self._authority_presentation_lifecycle(
+                record, bot_id)
             x = _number(state.get('x'))
             y = _number(state.get('y'))
             z = _number(state.get('z'))
@@ -15006,7 +15411,10 @@ class BattleRuntime(object):
             yaw = _number(state.get('yaw'))
             if (self._worker_mode and self._destructibles is not None and
                     self._bot_destructible_scan_due(state, now)):
-                entity = self._server_entity(record['engine_id'])
+                entity = self._server_entity(engine_id)
+                if entity is None:
+                    raise RuntimeError(
+                        'authority bot presentation entity is unavailable')
                 descriptor = getattr(entity, 'typeDescriptor', None)
                 if descriptor is None:
                     raise RuntimeError(
@@ -15016,14 +15424,61 @@ class BattleRuntime(object):
                     _number(state.get('speed')), descriptor)
             rotation = _engine_rotation(
                 yaw, _number(state.get('pitch')), _number(state.get('roll')))
-            self._binding.set_vehicle_pose(
-                record['engine_id'], position, rotation,
-                relax_time=self._bot_pose_relax(
-                    state, (tuple(position), rotation), now), now=now)
-            self._binding.update_vehicle_aim(
-                record['engine_id'], yaw,
-                _number(state.get('aim_yaw', yaw)),
-                _number(state.get('gun_pitch')))
+            relax_time = self._bot_pose_relax(
+                state, (tuple(position), rotation), now)
+            speed = _number(state.get('speed'))
+            motion_alive = (
+                bool(state.get('alive', True)) and
+                _number(state.get('health', 1), 1.0) > 0.0)
+            motion_active = motion_alive and (
+                speed != 0.0 or
+                any(_number(state.get(name)) != 0.0 for name in (
+                    'movement_dir', 'rotation_dir', 'vertical_speed',
+                    'slide_speed', 'push_x', 'push_z', 'air_lateral_x',
+                    'air_lateral_z')) or
+                bool(state.get('airborne', False)))
+            pose_signature = (
+                lifecycle, x, y, z, rotation,
+                # NativeRemoteVehicle derives its motion overlay from pose
+                # deltas. An exact speed edge with an unchanged final pose
+                # must still settle or resume that overlay once. While any
+                # canonical motion remains active, replay one identical pose
+                # per control epoch so a physically blocked Bot publishes
+                # zero native velocity instead of retaining its prior delta.
+                speed,
+                control_pose_epoch if motion_active else None,
+                motion_alive,
+                int(state.get('siege_state', 0) or 0))
+            if record.get('_authority_pose_signature') == pose_signature:
+                self._authority_pose_skips += 1
+            else:
+                self._binding.set_vehicle_pose(
+                    engine_id, position, rotation,
+                    relax_time=relax_time, now=now)
+                if not motion_active:
+                    # Remote presentation derives velocity from successive pose
+                    # writes.  A stop sample can also advance to its final pose,
+                    # so clear that derived delta now without re-keying the hull
+                    # animation or waiting for a duplicate render callback.
+                    self._binding.settle_vehicle_motion(engine_id, now=now)
+                record['_authority_pose_signature'] = pose_signature
+                self._authority_pose_writes += 1
+            aim_yaw = _number(state.get('aim_yaw', yaw))
+            gun_pitch = _number(state.get('gun_pitch'))
+            # Hydraulic body matrices are live providers. Replaying an
+            # identical setHullAimingAnglesDelta input every render callback
+            # does not advance them; current hull pitch and Siege state below
+            # fence every input that can change that value.
+            aim_signature = (
+                lifecycle, yaw, aim_yaw, gun_pitch,
+                rotation[1], int(state.get('siege_state', 0) or 0))
+            if record.get('_authority_aim_signature') == aim_signature:
+                self._authority_aim_skips += 1
+            else:
+                self._binding.update_vehicle_aim(
+                    engine_id, yaw, aim_yaw, gun_pitch)
+                record['_authority_aim_signature'] = aim_signature
+                self._authority_aim_writes += 1
             record['projectile_collision_pose'] = \
                 self._projectile_plain_pose((x, y, z), state)
             self._run_optional_feature(
@@ -18826,6 +19281,18 @@ class BattleRuntime(object):
         self._worker_probe_bot_send_failed = 0
         self._worker_probe_bot_count = 0
         self._worker_probe_simulation_caps = 0
+        self._worker_probe_control_steps = 0
+        self._worker_probe_catchup_callbacks = 0
+        self._worker_probe_control_debt_callbacks = 0
+        self._worker_probe_max_control_step = 0.0
+        self._worker_probe_control_debt = 0.0
+        self._worker_probe_max_control_debt = 0.0
+        self._worker_probe_astar_budget_exhausted = 0
+        self._worker_probe_astar_max_pending = 0
+        self._authority_pose_writes = 0
+        self._authority_pose_skips = 0
+        self._authority_aim_writes = 0
+        self._authority_aim_skips = 0
         if self._frame_diagnostics is not None:
             self._frame_diagnostics.reset()
         self._has_sixth_sense = False

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -1843,6 +1843,8 @@ class BotRuntime(object):
         # slices inside the same render callback.
         self._refresh_control_this_step = True
         self._publish_control_this_step = True
+        self._last_update_control_steps = 0
+        self._last_update_max_control_step = 0.0
         self._water_depth_probe = (
             water_depth_probe if callable(water_depth_probe) else
             (lambda unused_position: -1.0))
@@ -4229,6 +4231,7 @@ class BotRuntime(object):
                 if not stale or not source_eligible:
                     continue
                 candidates[key] = (
+                    source_kind == 'human',
                     selected == (target_kind, target_id),
                     fire_edge, new_pair)
 
@@ -4242,24 +4245,35 @@ class BotRuntime(object):
         waiting = [key for key in prior_waiting if key in candidate_keys]
         parked = [key for key in prior_waiting if key not in candidate_keys]
         waiting_set = set(waiting)
+        # Human observers own the player-facing team view. Keep inherited
+        # human debt ahead of newly stale Bot pairs so tuple ordering cannot
+        # hide a visible client's direct observations behind the full roster.
+        human_waiting = [
+            key for key in waiting if candidates[key][0]]
+        human_new = sorted(
+            key for key, flags in candidates.items()
+            if flags[0] and key not in waiting_set)
         selected = sorted(
-            key for key, flags in candidates.items() if flags[0])
-        fire_edges = sorted(
             key for key, flags in candidates.items()
             if flags[1] and not flags[0])
-        new_pairs = sorted(
+        fire_edges = sorted(
             key for key, flags in candidates.items()
             if flags[2] and not flags[0] and not flags[1])
+        new_pairs = sorted(
+            key for key, flags in candidates.items()
+            if flags[3] and not flags[0] and not flags[1] and not flags[2])
         ordinary_waiting = [
             key for key in waiting
             if not any(candidates[key])]
         ordinary_new = sorted(
             key for key in candidate_keys
             if (key not in waiting_set and not candidates[key][0] and
-                not candidates[key][1] and not candidates[key][2]))
+                not candidates[key][1] and not candidates[key][2] and
+                not candidates[key][3]))
         order = []
         seen = set()
-        for cohort in (selected, fire_edges, new_pairs,
+        for cohort in (human_waiting, human_new, selected, fire_edges,
+                       new_pairs,
                        ordinary_waiting, ordinary_new):
             for key in cohort:
                 if key not in seen:
@@ -4275,9 +4289,9 @@ class BotRuntime(object):
         frame['parked'] = parked
         frame['order'] = order
         frame['classification'] = dict(
-            (key, ('selected' if candidates[key][0] else
-                   ('fire' if candidates[key][1] else
-                    ('new' if candidates[key][2] else 'ordinary'))))
+            (key, ('selected' if candidates[key][1] else
+                   ('fire' if candidates[key][2] else
+                    ('new' if candidates[key][3] else 'ordinary'))))
             for key in order)
         frame['next'] = min(len(order), frame['budget'])
         frame['allowed'] = set(order[:frame['next']])
@@ -8234,6 +8248,8 @@ class BotRuntime(object):
         edges can shorten any slice, so accepted rounds and their frozen launch
         poses are never skipped when a callback is late.
         """
+        self._last_update_control_steps = 0
+        self._last_update_max_control_step = 0.0
         if (not self.is_authority() or self.adapter is None or
                 self.finished):
             return []
@@ -8275,6 +8291,9 @@ class BotRuntime(object):
                             min(elapsed, 0.2))
                         elapsed = max(0.0, elapsed - frame_step)
                         step_now = now - elapsed
+                        self._last_update_control_steps += 1
+                        self._last_update_max_control_step = max(
+                            self._last_update_max_control_step, frame_step)
                         outgoing.extend(self._run_update_once(
                             frame_step, step_now, players, neighbours, True,
                             True))
@@ -8289,6 +8308,9 @@ class BotRuntime(object):
                         step_now = now - elapsed
                         publish_step = bool(
                             refresh_control or elapsed <= 1e-12)
+                        self._last_update_control_steps += 1
+                        self._last_update_max_control_step = max(
+                            self._last_update_max_control_step, frame_step)
                         outgoing.extend(self._run_update_once(
                             frame_step, step_now, players, neighbours,
                             refresh_control, publish_step))

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -64,6 +64,14 @@ HUMAN_TARGET_ID_BASE = 1000000
 # planner reads reuse the last pair result. A target fire-sequence edge still
 # invalidates the pair immediately below.
 VISIBILITY_SAMPLE_SECONDS = 1.0 / 6.0
+# Production runs a full Bot control step at 10 Hz. Without a per-render-frame
+# fence, one stale 15-vs-15 visibility cohort performs all 420 ordered static
+# rays in the same callback. Forty-eight jobs cover the complete roster in at
+# most nine eligible control frames while selected, new and firing targets are
+# promoted ahead of ordinary refreshes. Deferred pairs fail closed as direct
+# observations, leaving only the existing team-memory pose; the independent
+# final firing-lane check below remains unchanged.
+MAX_VISIBILITY_PROBES_PER_FRAME = 48
 SHOT_LANE_SECONDS = 0.20
 # Spread full-roster tactical refreshes across one second independently from
 # the 0.40-second spotting publication. A selected target still goes through
@@ -76,6 +84,12 @@ SHOT_LANE_PHASES = 29
 # render-thread spike. Spotting publication never waits for this advisory
 # shooter list; missing or expired pairs publish as not shootable.
 MAX_SHOT_LANE_PAIRS_PER_FRAME = 64
+# The final selected-target check keeps the full budget above. Production's
+# all-roster advisory scan is supplemental planner input and uses a smaller
+# independent budget. Per-pair refresh deadlines remain pending until sampled,
+# so a slow hidden worker carries the fair scan across one-second boundaries
+# instead of catching up in one render callback.
+MAX_WORKER_SHOT_LANE_PAIRS_PER_FRAME = 16
 # The server never assigns a visible target beyond 560 metres. Keep a
 # conservative 25-metre broad-phase margin for the advisory roster scan; the
 # selected target's independent 0.20-second final-fire check does not use this
@@ -1876,6 +1890,7 @@ class BotRuntime(object):
         self._friendly_repositions = {}
         self._shot_los_cache = {}
         self._shot_los_deadlines = {}
+        self._reset_shot_lane_diagnostics()
         self._physics_params = {}
         self._repair_factors = {}
         self._vision_ranges = {}
@@ -1895,6 +1910,9 @@ class BotRuntime(object):
         self._human_ram_report_cache = {}
         self.finished = False
         self._visibility_cache = {}
+        self._visibility_waiting = []
+        self._visibility_frame = None
+        self._reset_visibility_diagnostics()
         self._team_visibility_cache = {}
         self._visible_target_poses = {}
         self._spot_until = {}
@@ -1968,7 +1986,52 @@ class BotRuntime(object):
 
     def diagnostic_totals(self):
         """Return counters which never participate in simulation decisions."""
-        return {'alive_bot_ticks': int(self._alive_bot_ticks)}
+        oldest_age_ms = 0
+        if self._visibility_deferred_since:
+            oldest_age_ms = max(0, int(round(1000.0 * (
+                self._visibility_diagnostic_now - min(
+                    self._visibility_deferred_since.values())))))
+        shot_lane_oldest_due_age_ms = 0
+        if (self._shot_lane_pending_pairs > 0 and
+                self._shot_lane_due_since is not None):
+            shot_lane_oldest_due_age_ms = max(0, int(round(1000.0 * (
+                self._shot_lane_diagnostic_now -
+                self._shot_lane_due_since))))
+        return {
+            'alive_bot_ticks': int(self._alive_bot_ticks),
+            'visibility_queue_depth': len(self._visibility_waiting),
+            'visibility_queue_max_depth': int(
+                self._visibility_queue_max_depth),
+            'visibility_oldest_stale_age_ms': oldest_age_ms,
+            'visibility_oldest_stale_max_age_ms': int(
+                self._visibility_oldest_stale_max_age_ms),
+            'visibility_admitted': int(
+                self._visibility_scheduler_totals['admitted']),
+            'visibility_completed': int(
+                self._visibility_scheduler_totals['completed']),
+            'visibility_deferred': int(
+                self._visibility_scheduler_totals['deferred']),
+            'visibility_selected_services': int(
+                self._visibility_service_totals['selected']),
+            'visibility_fire_services': int(
+                self._visibility_service_totals['fire']),
+            'visibility_new_services': int(
+                self._visibility_service_totals['new']),
+            'visibility_ordinary_services': int(
+                self._visibility_service_totals['ordinary']),
+            'shot_lane_pending_pairs': int(
+                self._shot_lane_pending_pairs),
+            'shot_lane_pending_max_pairs': int(
+                self._shot_lane_pending_max_pairs),
+            'shot_lane_oldest_due_age_ms': int(
+                shot_lane_oldest_due_age_ms),
+            'shot_lane_oldest_due_max_age_ms': int(
+                self._shot_lane_oldest_due_max_age_ms),
+            'shot_lane_completed_pairs': int(
+                self._shot_lane_completed_pairs),
+            'shot_lane_budget_deferred_attempts': int(
+                self._shot_lane_budget_deferred_attempts),
+        }
 
     def _probe_started(self):
         if self._probe_clock is None:
@@ -2583,6 +2646,7 @@ class BotRuntime(object):
             self._friendly_repositions = {}
             self._shot_los_cache = {}
             self._shot_los_deadlines = {}
+            self._reset_shot_lane_diagnostics()
             self._physics_params = {}
             self._repair_factors = {}
             self._vision_ranges = {}
@@ -2603,6 +2667,9 @@ class BotRuntime(object):
             self.adapter = None
             self.finished = False
             self._visibility_cache = {}
+            self._visibility_waiting = []
+            self._visibility_frame = None
+            self._reset_visibility_diagnostics()
             self._team_visibility_cache = {}
             self._visible_target_poses = {}
             self._spot_until = {}
@@ -2656,6 +2723,9 @@ class BotRuntime(object):
             self._ballistic_solution_cache = {}
             self._friendly_repositions = {}
             self._visibility_cache = {}
+            self._visibility_waiting = []
+            self._visibility_frame = None
+            self._reset_visibility_diagnostics()
             self._team_visibility_cache = {}
             self._visible_target_poses = {}
             self._spot_until = {}
@@ -2667,6 +2737,7 @@ class BotRuntime(object):
             self._visibility_still = {}
             self._shot_los_cache = {}
             self._shot_los_deadlines = {}
+            self._reset_shot_lane_diagnostics()
             self._decision_cache = {}
             self._motion_probe_cache = {}
             self._traffic_stopping_cache = {}
@@ -3969,6 +4040,329 @@ class BotRuntime(object):
             cache[identity] = (token, result)
         return result
 
+    @staticmethod
+    def _visibility_fire_sequence(target):
+        if target.get('fire_seq') is None:
+            return None
+        try:
+            return max(0, int(target.get('fire_seq')))
+        except (TypeError, ValueError, OverflowError):
+            return None
+
+    def _reset_shot_lane_diagnostics(self):
+        """Reset pull-only supplemental lane debt at authority boundaries."""
+        self._shot_lane_pending_pairs = 0
+        self._shot_lane_pending_max_pairs = 0
+        self._shot_lane_cycle_time = None
+        self._shot_lane_due_since = None
+        self._shot_lane_diagnostic_now = 0.0
+        self._shot_lane_oldest_due_max_age_ms = 0
+        self._shot_lane_completed_pairs = 0
+        self._shot_lane_budget_deferred_attempts = 0
+
+    def _update_shot_lane_debt_diagnostics(
+            self, now, cycle_time, pending_pairs, cycle_due):
+        """Observe the existing supplemental pass without scanning it again."""
+        now = _number(now)
+        cycle_time = _number(cycle_time)
+        pending_pairs = max(0, int(pending_pairs))
+        if self._shot_lane_cycle_time != cycle_time:
+            self._shot_lane_cycle_time = cycle_time
+            self._shot_lane_due_since = None
+        self._shot_lane_diagnostic_now = now
+        self._shot_lane_pending_pairs = pending_pairs
+        self._shot_lane_pending_max_pairs = max(
+            self._shot_lane_pending_max_pairs, pending_pairs)
+        if pending_pairs <= 0:
+            self._shot_lane_due_since = None
+            return
+        if cycle_due and self._shot_lane_due_since is None:
+            # The first cycle uses a zero sentinel rather than an authority
+            # timestamp. Start its age on the first actual attempt instead of
+            # reporting the entire process clock as pre-existing debt.
+            self._shot_lane_due_since = (
+                cycle_time if cycle_time > 0.0 else now)
+        if self._shot_lane_due_since is not None:
+            age_ms = max(0, int(round(1000.0 * (
+                now - self._shot_lane_due_since))))
+            self._shot_lane_oldest_due_max_age_ms = max(
+                self._shot_lane_oldest_due_max_age_ms, age_ms)
+
+    def _reset_visibility_diagnostics(self):
+        """Reset pull-only visibility debt counters at authority boundaries."""
+        self._visibility_deferred_since = {}
+        self._visibility_diagnostic_now = 0.0
+        self._visibility_queue_max_depth = 0
+        self._visibility_oldest_stale_max_age_ms = 0
+        self._visibility_scheduler_totals = {
+            'admitted': 0, 'completed': 0, 'deferred': 0,
+        }
+        self._visibility_service_totals = {
+            'selected': 0, 'fire': 0, 'new': 0, 'ordinary': 0,
+        }
+
+    def _update_visibility_debt_diagnostics(self, now):
+        """Observe current queue debt without feeding any scheduling choice."""
+        self._visibility_diagnostic_now = _number(now)
+        depth = len(self._visibility_waiting)
+        self._visibility_queue_max_depth = max(
+            self._visibility_queue_max_depth, depth)
+        if self._visibility_deferred_since:
+            oldest_age_ms = max(0, int(round(1000.0 * (
+                self._visibility_diagnostic_now - min(
+                    self._visibility_deferred_since.values())))))
+            self._visibility_oldest_stale_max_age_ms = max(
+                self._visibility_oldest_stale_max_age_ms, oldest_age_ms)
+
+    def _begin_visibility_frame(self):
+        """Open one production render-frame budget for static LOS work."""
+        self._visibility_frame = {
+            'budget': MAX_VISIBILITY_PROBES_PER_FRAME,
+            'order': [],
+            'allowed': set(),
+            'next': 0,
+            'completed': set(),
+            'requested': set(),
+            'admitted': set(),
+            'deferred': set(),
+            'prepared': False,
+        }
+
+    def _selected_visibility_target(self, state):
+        """Return the current selected target's wire identity, if known."""
+        bot_id = int(state['id'])
+        order = self._server_orders.get(bot_id)
+        if isinstance(order, dict):
+            kind = order.get('target_kind')
+            target_id = order.get('target_id')
+            if kind in ('bot', 'human') and target_id is not None:
+                try:
+                    return kind, int(target_id)
+                except (TypeError, ValueError, OverflowError):
+                    return None
+        cached = self._decision_cache.get(bot_id)
+        if not isinstance(cached, tuple) or len(cached) < 6:
+            return None
+        command = cached[3]
+        targets = cached[5]
+        if not isinstance(command, dict) or not isinstance(targets, dict):
+            return None
+        target = targets.get(command.get('target_id'))
+        if not isinstance(target, dict):
+            return None
+        kind = target.get('kind')
+        target_id = target.get('network_id', target.get('id'))
+        if kind not in ('bot', 'human') or target_id is None:
+            return None
+        try:
+            return kind, int(target_id)
+        except (TypeError, ValueError, OverflowError):
+            return None
+
+    def _visibility_decision_due(self, state, now):
+        server_order = self._server_orders.get(state['id'])
+        cache_key = (('server', self._server_order_tokens.get(
+                          state['id'], 0))
+                     if server_order is not None else ('local',))
+        cached = self._decision_cache.get(state['id'])
+        return not (
+            cached is not None and cached[0] == cache_key and
+            _number(now) < cached[1])
+
+    def _prepare_visibility_frame(self, players, now, include_humans):
+        """Select a bounded, fair stale-pair cohort before native calls."""
+        frame = self._visibility_frame
+        if not isinstance(frame, dict) or frame.get('prepared'):
+            return False
+        frame['prepared'] = True
+        now = _number(now)
+        frame['now'] = now
+        live_bots = [state for state in self._ordered_states()
+                     if state.get('alive', True)]
+        live_humans = [raw for raw in (players or ())
+                       if (isinstance(raw, dict) and
+                           raw.get('id') is not None and
+                           raw.get('alive', True))]
+        targets = []
+        for state in live_bots:
+            targets.append(('bot', int(state['id']),
+                            int(state.get('team', 0)), state))
+        for raw in live_humans:
+            targets.append(('human', int(raw['id']),
+                            int(raw.get('team', 0)), raw))
+        sources = []
+        for state in live_bots:
+            sources.append((
+                'bot', int(state['id']), int(state.get('team', 0)),
+                self._selected_visibility_target(state),
+                self._visibility_decision_due(state, now)))
+        for raw in live_humans:
+            sources.append((
+                'human', int(raw['id']), int(raw.get('team', 0)), None,
+                bool(include_humans)))
+
+        candidates = {}
+        valid = {}
+        for (source_kind, source_id, source_team, selected,
+             source_eligible) in sources:
+            if source_team not in (1, 2):
+                continue
+            for target_kind, target_id, target_team, target in targets:
+                if target_team == source_team or target_team not in (1, 2):
+                    continue
+                key = (source_kind, source_id, target_kind, target_id)
+                cached = self._visibility_cache.get(key)
+                fire_seq = self._visibility_fire_sequence(target)
+                new_pair = cached is None
+                fire_edge = bool(
+                    cached is not None and cached[2] != fire_seq)
+                stale = bool(
+                    new_pair or fire_edge or
+                    now - _number(cached[0]) >=
+                    VISIBILITY_SAMPLE_SECONDS)
+                valid[key] = stale
+                if not stale or not source_eligible:
+                    continue
+                candidates[key] = (
+                    selected == (target_kind, target_id),
+                    fire_edge, new_pair)
+
+        for key in tuple(self._visibility_deferred_since):
+            if not valid.get(key, False):
+                self._visibility_deferred_since.pop(key, None)
+
+        candidate_keys = set(candidates)
+        prior_waiting = [key for key in self._visibility_waiting
+                         if valid.get(key, False)]
+        waiting = [key for key in prior_waiting if key in candidate_keys]
+        parked = [key for key in prior_waiting if key not in candidate_keys]
+        waiting_set = set(waiting)
+        selected = sorted(
+            key for key, flags in candidates.items() if flags[0])
+        fire_edges = sorted(
+            key for key, flags in candidates.items()
+            if flags[1] and not flags[0])
+        new_pairs = sorted(
+            key for key, flags in candidates.items()
+            if flags[2] and not flags[0] and not flags[1])
+        ordinary_waiting = [
+            key for key in waiting
+            if not any(candidates[key])]
+        ordinary_new = sorted(
+            key for key in candidate_keys
+            if (key not in waiting_set and not candidates[key][0] and
+                not candidates[key][1] and not candidates[key][2]))
+        order = []
+        seen = set()
+        for cohort in (selected, fire_edges, new_pairs,
+                       ordinary_waiting, ordinary_new):
+            for key in cohort:
+                if key not in seen:
+                    order.append(key)
+                    seen.add(key)
+        # A formerly ordinary deferred pair may have become selected or seen a
+        # fire edge; the priority cohorts above move it without duplicating it.
+        for key in waiting:
+            if key not in seen:
+                order.append(key)
+                seen.add(key)
+        frame['prior_waiting'] = prior_waiting
+        frame['parked'] = parked
+        frame['order'] = order
+        frame['classification'] = dict(
+            (key, ('selected' if candidates[key][0] else
+                   ('fire' if candidates[key][1] else
+                    ('new' if candidates[key][2] else 'ordinary'))))
+            for key in order)
+        frame['next'] = min(len(order), frame['budget'])
+        frame['allowed'] = set(order[:frame['next']])
+        return True
+
+    def _visibility_probe_completed(self, key):
+        """Retire one pair and backfill slots unused by pure-data rejects."""
+        frame = self._visibility_frame
+        if not isinstance(frame, dict):
+            return False
+        first_completion = key not in frame['completed']
+        frame['completed'].add(key)
+        self._visibility_deferred_since.pop(key, None)
+        if first_completion:
+            self._visibility_scheduler_totals['completed'] += 1
+        frame['allowed'].discard(key)
+        order = frame['order']
+        while (len(frame['allowed']) < frame['budget'] and
+               frame['next'] < len(order)):
+            candidate = order[frame['next']]
+            frame['next'] += 1
+            if candidate not in frame['completed']:
+                frame['allowed'].add(candidate)
+        return True
+
+    def _visibility_probe_allowed(self, key):
+        """Peek at the fair cohort without spending its native-query slot."""
+        frame = self._visibility_frame
+        if not isinstance(frame, dict):
+            return True
+        return bool(key in frame['allowed'] and frame['budget'] > 0)
+
+    def _visibility_probe_deferred(self, key):
+        """Record one per-callback denial without influencing fair order."""
+        frame = self._visibility_frame
+        if not isinstance(frame, dict):
+            return False
+        frame['requested'].add(key)
+        if key not in frame['deferred']:
+            frame['deferred'].add(key)
+            self._visibility_scheduler_totals['deferred'] += 1
+        self._visibility_deferred_since.setdefault(
+            key, _number(frame.get('now')))
+        return True
+
+    def _visibility_probe_admitted(self, key):
+        """Admit only the selected fair cohort in a production callback."""
+        frame = self._visibility_frame
+        if not isinstance(frame, dict):
+            return True
+        frame['requested'].add(key)
+        if key not in frame['allowed'] or frame['budget'] <= 0:
+            self._visibility_probe_deferred(key)
+            return False
+        frame['budget'] -= 1
+        if key not in frame['admitted']:
+            frame['admitted'].add(key)
+            self._visibility_scheduler_totals['admitted'] += 1
+            classification = frame.get('classification', {}).get(
+                key, 'ordinary')
+            self._visibility_service_totals[classification] += 1
+        return True
+
+    def _finish_visibility_frame(self):
+        """Carry only unfinished stale pairs into the next active callback."""
+        frame = self._visibility_frame
+        if not isinstance(frame, dict):
+            return False
+        completed = frame['completed']
+        unfinished = set(frame.get('parked', ()))
+        unfinished.update(
+            key for key in frame['order'] if key not in completed)
+        waiting = []
+        seen = set()
+        for key in frame.get('prior_waiting', ()):
+            if key in unfinished and key not in seen:
+                waiting.append(key)
+                seen.add(key)
+        for key in frame['order']:
+            if key in unfinished and key not in seen:
+                waiting.append(key)
+                seen.add(key)
+        self._visibility_waiting = waiting
+        for key in waiting:
+            self._visibility_deferred_since.setdefault(
+                key, _number(frame.get('now')))
+        self._update_visibility_debt_diagnostics(frame.get('now'))
+        self._visibility_frame = None
+        return True
+
     def _visible(self, source, target, now, tick_cache=None,
                  source_position=None, view_range_resolver=None):
         target_id = target.get('network_id', target.get('id', 0))
@@ -3987,14 +4381,20 @@ class BotRuntime(object):
                            _position(source))
         distance = _distance(source_position, target.get('position') or
                              _position(target))
-        view_range = (view_range_resolver()
-                      if callable(view_range_resolver) else
-                      self._source_view_range(source, now))
         if distance <= spotting.PROXIMITY_SPOT_DISTANCE:
             value = True
         elif distance > spotting.MAX_SPOT_DISTANCE:
             value = False
         else:
+            if not self._visibility_probe_allowed(key):
+                # Budgeted-out pairs must stop before the per-target profile,
+                # camouflage and source-view calculations. They remain queued
+                # and fail closed as direct observations until serviced.
+                self._visibility_probe_deferred(key)
+                return False
+            view_range = (view_range_resolver()
+                          if callable(view_range_resolver) else
+                          self._source_view_range(source, now))
             (base_pair, shot_factor, profile, moving,
              additive, multiplier) = self._target_detection_projection(
                  target, target_id, now, tick_cache)
@@ -4003,6 +4403,10 @@ class BotRuntime(object):
                     fired_recently):
                 value = False
             else:
+                if not self._visibility_probe_admitted(key):
+                    # A fair-slot change inside one synchronous calculation is
+                    # not expected, but preserve the same fail-closed boundary.
+                    return False
                 try:
                     self._probe_totals[0] += 1
                     probe_started = self._probe_started()
@@ -4033,6 +4437,7 @@ class BotRuntime(object):
                 value = spotting.is_detected(
                     distance, view_range, camouflage, has_line_of_sight)
         self._visibility_cache[key] = (_number(now), value, fire_seq)
+        self._visibility_probe_completed(key)
         if len(self._visibility_cache) > 1024:
             oldest = sorted(self._visibility_cache.items(),
                             key=lambda item: item[1][0])[:256]
@@ -7046,6 +7451,7 @@ class BotRuntime(object):
         cached = self._shot_los_cache.get(key)
         if cached is not None and cached[0] > window_start + 1e-9:
             self._shot_los_deadlines[key] = observation_time
+            self._shot_lane_completed_pairs += 1
             return False
         if now + 1e-9 < deadline:
             return False
@@ -7053,8 +7459,13 @@ class BotRuntime(object):
             source, target, now, force=True, probe_budget=probe_budget,
             lane_key=key, distance_cache=distance_cache)
         if value is None:
+            # This helper is used only by the supplemental roster pass. Count
+            # each pair/callback denial explicitly; it is not a unique-pair
+            # counter and never includes the independent final-fire gate.
+            self._shot_lane_budget_deferred_attempts += 1
             return False
         self._shot_los_deadlines[key] = observation_time
+        self._shot_lane_completed_pairs += 1
         return True
 
     def _pack_observations(self, aggregate, now):
@@ -7813,6 +8224,7 @@ class BotRuntime(object):
             navigator_begin(elapsed_input)
         outgoing = []
         receipt_frame_open = False
+        visibility_frame_open = False
         try:
             if not self._fixed_control:
                 # Preserve the mature engine-free seam for focused law tests
@@ -7829,6 +8241,9 @@ class BotRuntime(object):
             # retire valid deferred requests as no longer eligible.
             self._begin_world_receipt_frame()
             receipt_frame_open = True
+            if self._fixed_control:
+                self._begin_visibility_frame()
+                visibility_frame_open = True
             try:
                 if not self._fixed_control:
                     elapsed = self._accumulator
@@ -7850,6 +8265,8 @@ class BotRuntime(object):
                     outgoing.extend(self._update_once(
                         frame_step, step_now, players, neighbours))
             finally:
+                if visibility_frame_open:
+                    self._finish_visibility_frame()
                 if receipt_frame_open:
                     self._finish_world_receipt_frame()
         finally:
@@ -7901,8 +8318,12 @@ class BotRuntime(object):
         collect_cover_jobs = bool(
             publish and not self._cover_queue and
             now >= self._next_cover_refresh)
-        shot_lane_budget = [MAX_SHOT_LANE_PAIRS_PER_FRAME]
+        final_shot_lane_budget = [MAX_SHOT_LANE_PAIRS_PER_FRAME]
+        supplemental_shot_lane_budget = [
+            (MAX_WORKER_SHOT_LANE_PAIRS_PER_FRAME
+             if self._fixed_control else MAX_SHOT_LANE_PAIRS_PER_FRAME)]
         shot_lanes_ready = True
+        shot_lane_pending_pairs = 0
         neighbours = list(neighbours or []) + self._player_neighbours(players)
         # Native terrain and visibility probes run on BigWorld's render thread.
         # Build the local-overlap view lazily, only when a staggered decision is
@@ -7917,6 +8338,8 @@ class BotRuntime(object):
         # simulation slice. Share them across all observers, but never across
         # slices where motion or equipment state may change.
         visibility_tick = {}
+        self._prepare_visibility_frame(
+            players, now, collect_observation or refresh_shot_lanes)
         if collect_observation or refresh_shot_lanes:
             self._append_human_observations(
                 players, now, observation_entries, team_visibility,
@@ -8175,8 +8598,14 @@ class BotRuntime(object):
                     entry[2] = observed_target
                     if direct_visible:
                         entry[4].add(int(state['id']))
+                selected_lane = (
+                    cached_target.get('id') == command.get('target_id'))
+                lane_priority = (
+                    0 if selected_lane and command.get('fire_allowed') else
+                    (1 if selected_lane else 2))
                 observation_pairs.append((
-                    lane_source, observed_target, lane_key, key, [None]))
+                    lane_priority, lane_source, observed_target, lane_key,
+                    key, [None]))
             target_id = command.get('target_id')
             if target_id in (targets or {}):
                 # Aim/fire gating retains the observer-specific spotting flag.
@@ -8713,7 +9142,7 @@ class BotRuntime(object):
                      pending_reproof is not None or
                      self._shot_clear(
                         state, target, now,
-                        probe_budget=shot_lane_budget))):
+                        probe_budget=final_shot_lane_budget))):
                 launch_receipt = None
                 launch_preview = None
                 lane_clear = False
@@ -8798,8 +9227,9 @@ class BotRuntime(object):
         # without changing a decision.  Aggregate radio spotting first, then
         # prove every shooter lane for only those team-visible targets.  The
         # selected target's independent final-fire gate below remains live.
-        for (lane_source, observed_target, lane_key, key,
-             lane_distance) in observation_pairs:
+        observation_pairs.sort(key=lambda value: value[0])
+        for (unused_lane_priority, lane_source, observed_target, lane_key,
+             key, lane_distance) in observation_pairs:
             if not team_visibility.get(key, False):
                 continue
             if refresh_shot_lanes:
@@ -8807,12 +9237,14 @@ class BotRuntime(object):
                         shot_lane_refresh_time):
                     self._refresh_shot_clear(
                         lane_source, observed_target, now,
-                        shot_lane_refresh_time, shot_lane_budget,
+                        shot_lane_refresh_time,
+                        supplemental_shot_lane_budget,
                         lane_key=lane_key,
                         distance_cache=lane_distance)
                 if (self._shot_los_deadlines.get(lane_key) !=
                         shot_lane_refresh_time):
                     shot_lanes_ready = False
+                    shot_lane_pending_pairs += 1
             if collect_observation:
                 # Report the latest bounded tactical sample without waiting
                 # for the current one-second roster refresh. Missing or old
@@ -8825,6 +9257,17 @@ class BotRuntime(object):
                         self._control_seconds + 1e-9 and lane_sample[1]):
                     observation_entries[key][1].add(
                         int(lane_source['id']))
+        if refresh_shot_lanes:
+            self._update_shot_lane_debt_diagnostics(
+                now, shot_lane_refresh_time, shot_lane_pending_pairs,
+                shot_lane_refresh_due)
+        else:
+            # Cover work can temporarily own the supplemental window. Retain
+            # the last observed pair depth and let its due age advance without
+            # rebuilding the roster solely for diagnostics.
+            self._update_shot_lane_debt_diagnostics(
+                now, shot_lane_refresh_time,
+                self._shot_lane_pending_pairs, shot_lane_refresh_due)
         if (shot_lane_refresh_due and refresh_shot_lanes and
                 shot_lanes_ready):
             self._next_shot_lane_refresh = (

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/destructibles_sensor.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/destructibles_sensor.py
@@ -23,6 +23,8 @@ _DIAGNOSTIC_CHUNK_LIMIT = 24
 _DIAGNOSTIC_PENDING_LIMIT = 4
 _DIAGNOSTIC_CONTACT_LIMIT = 32
 _ISOLATION_LOG_TYPE_LIMIT = 11
+_EMPTY_CONTACT_RECEIPT_LIMIT = 512
+_EMPTY_PROXIMITY_RECEIPT_LIMIT = 512
 _destructible_catalog = None
 _diagnostic_writer = None
 
@@ -153,6 +155,7 @@ def _drop_isolated_destructible_1513(chunk_id, item_index=None):
 		state = globals().get('g_offh_tree_state')
 		if isinstance(state, dict):
 			state.get('chunks', {}).pop(chunk_id, None)
+	_bump_spatial_revision_1513()
 
 
 def _log_destructible_validation_1513(
@@ -434,6 +437,10 @@ def _clear_runtime_registry():
 			'g_offh_destr_isolation_logs',
 			'g_offh_destr_isolation_log_capped',
 			'g_offh_destr_diagnostics', 'g_offh_destr_diag_last_static',
+			'g_offh_destr_spatial_revision',
+			'g_offh_destr_empty_contact_receipts',
+			'g_offh_destr_empty_proximity_receipts',
+			'g_offh_destr_receipt_stats',
 			'g_offh_destr_runtime_space'):
 		globals().pop(name, None)
 
@@ -721,6 +728,121 @@ def _bin_keys_for_bounds(minimum_x, maximum_x, minimum_z, maximum_z):
 	for bin_x in xrange(minimum_bin_x, maximum_bin_x + 1):
 		for bin_z in xrange(minimum_bin_z, maximum_bin_z + 1):
 			yield bin_x, bin_z
+
+
+def _bin_rectangle_signature_1513(bounds):
+	"""Return the exact 8 m cell envelope covering XZ bounds."""
+	minimum = _destructible_bin_key(bounds[0], bounds[2])
+	maximum = _destructible_bin_key(bounds[1], bounds[3])
+	return minimum[0], maximum[0], minimum[1], maximum[1]
+
+
+def _spatial_revision_1513():
+	return int(globals().get('g_offh_destr_spatial_revision', 0))
+
+
+def _receipt_stat_1513(name, amount=1):
+	stats = globals().setdefault('g_offh_destr_receipt_stats', {})
+	stats[name] = int(stats.get(name, 0)) + int(amount)
+
+
+def _receipt_prefix_1513(name):
+	return ('contact' if name == 'g_offh_destr_empty_contact_receipts'
+		else 'proximity')
+
+
+def _bump_spatial_revision_1513():
+	"""Invalidate receipts after any exact spatial-index mutation."""
+	revision = _spatial_revision_1513() + 1
+	globals()['g_offh_destr_spatial_revision'] = revision
+	_receipt_stat_1513('spatial_invalidations')
+	for cache_name, prefix in (
+			('g_offh_destr_empty_contact_receipts', 'contact'),
+			('g_offh_destr_empty_proximity_receipts', 'proximity')):
+		state = globals().get(cache_name)
+		if isinstance(state, dict):
+			_receipt_stat_1513(
+				'%s_invalidated' % prefix,
+				len(state.get('entries', {})))
+	globals().pop('g_offh_destr_empty_contact_receipts', None)
+	globals().pop('g_offh_destr_empty_proximity_receipts', None)
+	return revision
+
+
+def _receipt_cache_get_1513(name, key):
+	state = globals().get(name)
+	if not isinstance(state, dict):
+		_receipt_stat_1513('%s_misses' % _receipt_prefix_1513(name))
+		return None
+	value = state.get('entries', {}).get(key)
+	_receipt_stat_1513('%s_%s' % (
+		_receipt_prefix_1513(name), 'hits' if value is not None else 'misses'))
+	return value
+
+
+def _receipt_cache_put_1513(name, key, value, limit):
+	"""Store one bounded battle-local receipt without OrderedDict reliance."""
+	state = globals().setdefault(name, {'entries': {}, 'order': []})
+	entries = state['entries']
+	order = state['order']
+	if key in entries:
+		entries[key] = value
+		return
+	while len(order) >= int(limit):
+		entries.pop(order.pop(0), None)
+		_receipt_stat_1513('%s_evictions' % _receipt_prefix_1513(name))
+	entries[key] = value
+	order.append(key)
+	_receipt_stat_1513('%s_stores' % _receipt_prefix_1513(name))
+
+
+def _loaded_chunk_signature_1513(manager, chunk_ids):
+	"""Return exact streamed counts, or ``None`` while any chunk is pending."""
+	loaded = getattr(
+		manager, '_DestructiblesManager__loadedChunkIDs', None)
+	if not isinstance(loaded, dict):
+		return None
+	result = []
+	for chunk_id in sorted(chunk_ids):
+		if chunk_id not in loaded:
+			return None
+		count = loaded[chunk_id]
+		if (isinstance(count, bool) or not isinstance(count, _INTEGER_TYPES) or
+				count < 0):
+			return None
+		result.append((int(chunk_id), int(count)))
+	return tuple(result)
+
+
+def _proximity_receipt_key_1513(spaceID, current_chunk, pos, vehicle_box):
+	origin_bounds = (float(pos.x) - _DESTRUCTIBLE_ORIGIN_RADIUS,
+		float(pos.x) + _DESTRUCTIBLE_ORIGIN_RADIUS,
+		float(pos.z) - _DESTRUCTIBLE_ORIGIN_RADIUS,
+		float(pos.z) + _DESTRUCTIBLE_ORIGIN_RADIUS)
+	return (int(spaceID), int(current_chunk),
+		_bin_rectangle_signature_1513(origin_bounds),
+		_bin_rectangle_signature_1513(_box_xz_bounds(vehicle_box)))
+
+
+def _empty_proximity_receipt_valid_1513(
+		key, manager, chunk_registry):
+	"""Reuse only a complete, unchanged streamed empty-cell receipt."""
+	state = globals().get('g_offh_destr_empty_proximity_receipts')
+	entry = (state.get('entries', {}).get(key)
+		if isinstance(state, dict) else None)
+	valid = (
+		not globals().get('g_offh_destr_falling_active') and
+		isinstance(entry, dict) and
+		entry.get('revision') == _spatial_revision_1513())
+	chunk_ids = entry.get('chunks') if valid else None
+	valid = (valid and isinstance(chunk_ids, tuple) and not any(
+		chunk_id not in chunk_registry for chunk_id in chunk_ids))
+	valid = (valid and
+		_loaded_chunk_signature_1513(manager, chunk_ids) ==
+		entry.get('stream_signature'))
+	_receipt_stat_1513(
+		'proximity_hits' if valid else 'proximity_misses')
+	return bool(valid)
 
 
 def _nearby_destructibles(registry, pos, vehicle_box=None):
@@ -1474,10 +1596,20 @@ def clear_local_prediction(token):
 def _catalog_contact_candidates(vehicle_box):
 	instances = globals().get('g_offh_destr_instances', {})
 	contact_bins = globals().get('g_offh_destr_contact_bins', {})
+	bounds = _box_xz_bounds(vehicle_box)
+	receipt_key = (
+		_spatial_revision_1513(), _bin_rectangle_signature_1513(bounds))
+	if _receipt_cache_get_1513(
+			'g_offh_destr_empty_contact_receipts', receipt_key):
+		return []
 	candidates = []
 	seen = set()
-	for bin_key in _bin_keys_for_bounds(*_box_xz_bounds(vehicle_box)):
-		for chunk_id, item_index in sorted(contact_bins.get(bin_key, ())):
+	had_members = False
+	for bin_key in _bin_keys_for_bounds(*bounds):
+		members = contact_bins.get(bin_key, ())
+		if members:
+			had_members = True
+		for chunk_id, item_index in sorted(members):
 			identity = (int(chunk_id), int(item_index))
 			if _destructible_isolated_1513(*identity):
 				continue
@@ -1496,6 +1628,10 @@ def _catalog_contact_candidates(vehicle_box):
 					instance['kind'], instance['item_scale'], world_box[0])
 				if candidate not in candidates:
 					candidates.append(candidate)
+	if not had_members:
+		_receipt_cache_put_1513(
+			'g_offh_destr_empty_contact_receipts', receipt_key, True,
+			_EMPTY_CONTACT_RECEIPT_LIMIT)
 	return candidates
 
 
@@ -2134,9 +2270,15 @@ def _index_catalog_instance_1513(contact_bins, key, instance,
 	"""Index one streamed instance into every exact world-footprint bin."""
 	if bin_keys is None:
 		bin_keys = _catalog_bin_keys_1513(instance['boxes'])
+	changed = False
 	for bin_key in bin_keys:
-		contact_bins.setdefault(bin_key, set()).add(key)
+		members = contact_bins.setdefault(bin_key, set())
+		before = len(members)
+		members.add(key)
+		changed = changed or len(members) != before
 	instance['bin_keys'] = tuple(sorted(bin_keys))
+	if changed:
+		_bump_spatial_revision_1513()
 	return bin_keys
 
 
@@ -2593,6 +2735,31 @@ def _try_destroy_destructible(spaceID, matInfo, yaw, vel,
 	return True
 
 
+def _drop_streamed_chunk_registry_1513(state, chunk_id):
+	"""Drop stale streamed geometry while preserving canonical destroy state."""
+	chunk_id = int(chunk_id)
+	changed = state.get('chunks', {}).pop(chunk_id, None) is not None
+	instances = globals().get('g_offh_destr_instances', {})
+	contact_bins = globals().get('g_offh_destr_contact_bins', {})
+	for identity in [key for key in list(instances) if key[0] == chunk_id]:
+		instance = instances.pop(identity)
+		changed = True
+		bin_keys = (instance.get('bin_keys')
+			if isinstance(instance, dict) else None)
+		if bin_keys is None:
+			bin_keys = list(contact_bins)
+		for bin_key in bin_keys:
+			members = contact_bins.get(bin_key)
+			if members is None:
+				continue
+			members.discard(identity)
+			if not members:
+				contact_bins.pop(bin_key, None)
+	if changed:
+		_bump_spatial_revision_1513()
+	return changed
+
+
 def _fell_trees_near(spaceID, pos, yaw, vel, td=None):
 	# Offline tree/pole felling. Online the SERVER detected tank-vs-tree
 	# contact; the client-side collision probes never return tree/column
@@ -2629,15 +2796,31 @@ def _fell_trees_near(spaceID, pos, yaw, vel, td=None):
 			globals().setdefault('g_offh_destr_pending', {})
 			globals().setdefault('g_offh_destr_falling_active', {})
 		cos_y = math.cos(yaw); sin_y = math.sin(yaw)
-		cids = set()
-		_current_cid = None
-		for _pf in (0.0, 6.0 if vel >= 0 else -6.0):
-			_mapped_cid = AreaDestructibles.chunkIDFromPosition(
-				Math.Vector3(pos.x + sin_y * _pf, pos.y,
-					pos.z + cos_y * _pf))
-			if _pf == 0.0:
-				_current_cid = _mapped_cid
-			cids.add(_mapped_cid)
+		bbox = ((-1.6, -1.0, -3.6), (1.6, 1.0, 3.6), None)
+		bbox = _vehicle_hull_bbox(td)
+		if bbox is None:
+			bbox = ((-1.6, -1.0, -3.6), (1.6, 1.0, 3.6), None)
+		try:
+			hw = max(abs(bbox[0][0]), abs(bbox[1][0]))
+			hl_b = abs(bbox[0][2])
+			hl_f = abs(bbox[1][2])
+		except (AttributeError, KeyError, TypeError, IndexError):
+			raise RuntimeError('#1513 hull hit tester bbox is invalid')
+		vehicle_box = _vehicle_swept_box(pos, yaw, vel, bbox)
+		_current_cid = AreaDestructibles.chunkIDFromPosition(
+			Math.Vector3(pos.x, pos.y, pos.z))
+		_receipt_key = None
+		if _current_cid is not None and _destructible_catalog is not None:
+			_receipt_key = _proximity_receipt_key_1513(
+				spaceID, _current_cid, pos, vehicle_box)
+			if _empty_proximity_receipt_valid_1513(
+					_receipt_key, mgr, _st['chunks']):
+				return
+		cids = set((_current_cid,))
+		_mapped_cid = AreaDestructibles.chunkIDFromPosition(
+			Math.Vector3(pos.x + sin_y * (6.0 if vel >= 0 else -6.0),
+				pos.y, pos.z + cos_y * (6.0 if vel >= 0 else -6.0)))
+		cids.add(_mapped_cid)
 		# #1513 chunks are 100 m squares.  Catalog instances can be non-uniformly
 		# scaled, so raw resource bounds cannot determine the origin reach.  Sample
 		# the current chunk plus all eight neighbours through the native mapper;
@@ -2651,27 +2834,21 @@ def _fell_trees_near(spaceID, pos, yaw, vel, td=None):
 						Math.Vector3(pos.x + _offset_x, pos.y,
 							pos.z + _offset_z)))
 		cids.discard(None)
-		bbox = ((-1.6, -1.0, -3.6), (1.6, 1.0, 3.6), None)
-		bbox = _vehicle_hull_bbox(td)
-		if bbox is None:
-			bbox = ((-1.6, -1.0, -3.6), (1.6, 1.0, 3.6), None)
-		try:
-			hw = max(abs(bbox[0][0]), abs(bbox[1][0]))
-			hl_b = abs(bbox[0][2])
-			hl_f = abs(bbox[1][2])
-		except (AttributeError, KeyError, TypeError, IndexError):
-			raise RuntimeError('#1513 hull hit tester bbox is invalid')
-		vehicle_box = _vehicle_swept_box(pos, yaw, vel, bbox)
 		instances = globals().setdefault('g_offh_destr_instances', {})
 		contact_bins = globals().setdefault(
 			'g_offh_destr_contact_bins', {})
+		_found_nearby = False
 		for cid in cids:
 			if _destructible_isolated_1513(cid):
 				continue
 			registry = _st['chunks'].get(cid)
+			_native_count = _native_chunk_destructible_count_1513(mgr, cid)
+			if (registry is not None and
+					(_native_count is None or
+					registry.get('native_count') != _native_count)):
+				_drop_streamed_chunk_registry_1513(_st, cid)
+				registry = None
 			if registry is None:
-				_native_count = _native_chunk_destructible_count_1513(
-					mgr, cid)
 				if _native_count is None:
 					if _destructible_isolated_1513(cid):
 						continue
@@ -2701,6 +2878,7 @@ def _fell_trees_near(spaceID, pos, yaw, vel, td=None):
 					continue
 				registry = {
 					'bins': {}, 'extended_bins': {}, 'count': 0,
+					'native_count': _native_count,
 					'max_radius': 0.0, 'slot_diagnostics': {},
 				}
 				_retry_registry = False
@@ -2971,6 +3149,7 @@ def _fell_trees_near(spaceID, pos, yaw, vel, td=None):
 						raise
 				if not _retry_registry:
 					_st['chunks'][cid] = registry
+					_bump_spatial_revision_1513()
 					_diagnostic_chunk_1513(
 						cid, _native_count, _dfn, registry)
 				LOG_DEBUG('DestrTree: chunk registry', cid,
@@ -2980,6 +3159,7 @@ def _fell_trees_near(spaceID, pos, yaw, vel, td=None):
 			for (_ti, _tx, _ty, _tz, _ttyp, _tfn, _thp, _tmass,
 					_world_boxes, _contact_radius) in _nearby_destructibles(
 						registry, pos, vehicle_box):
+				_found_nearby = True
 				if _destructible_isolated_1513(cid, _ti):
 					continue
 				dx = _tx - pos.x; dz = _tz - pos.z
@@ -3055,6 +3235,20 @@ def _fell_trees_near(spaceID, pos, yaw, vel, td=None):
 				_st['felled'].add(_key)
 				LOG_DEBUG('DestrTree: FELLED', cid, _ti, 'type', _ttyp,
 					'hp', _thp, 'mass', _tmass, _tfn)
+		if (_receipt_key is not None and not _found_nearby and
+				not globals().get('g_offh_destr_falling_active') and
+				all(cid in _st['chunks'] and
+					not _destructible_isolated_1513(cid) for cid in cids)):
+			_chunk_ids = tuple(sorted(cids))
+			_stream_signature = _loaded_chunk_signature_1513(
+				mgr, _chunk_ids)
+			if _stream_signature is not None:
+				_receipt_cache_put_1513(
+					'g_offh_destr_empty_proximity_receipts', _receipt_key,
+					{'revision': _spatial_revision_1513(),
+					 'chunks': _chunk_ids,
+					 'stream_signature': _stream_signature},
+					_EMPTY_PROXIMITY_RECEIPT_LIMIT)
 	except Exception:
 		raise
 
@@ -3695,6 +3889,22 @@ def registry_counts():
 			counts[name[13:]] = len(value)
 		except TypeError:
 			counts[name[13:]] = 0
+	stats = globals().get('g_offh_destr_receipt_stats', {})
+	for name in ('contact_hits', 'contact_misses', 'contact_stores',
+			'contact_evictions', 'contact_invalidated',
+			'proximity_hits', 'proximity_misses', 'proximity_stores',
+			'proximity_evictions', 'proximity_invalidated',
+			'spatial_invalidations'):
+		counts['receipt_' + name] = int(stats.get(name, 0))
+	for cache_name, output_name in (
+			('g_offh_destr_empty_contact_receipts',
+				'receipt_contact_entries'),
+			('g_offh_destr_empty_proximity_receipts',
+				'receipt_proximity_entries')):
+		state = globals().get(cache_name, {})
+		counts[output_name] = len(state.get('entries', {})) \
+			if isinstance(state, dict) else 0
+	counts['spatial_revision'] = _spatial_revision_1513()
 	return counts
 
 

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/entities/bigworld_binding.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/entities/bigworld_binding.py
@@ -450,6 +450,17 @@ class BigWorldVehicleBinding(object):
                 'remote vehicle has no authoritative presentation')
         setter(position, rotation, relax_time, now)
 
+    def settle_vehicle_motion(self, entity_id, now=None):
+        """Clear one stationary remote's pose-derived motion in place."""
+        entity = self._authority_entity_or_fail(entity_id)
+        settle = getattr(entity, 'settle_motion', None)
+        if not (bool(getattr(entity, '_offlineLANPresentation', False) or
+                     getattr(entity, '_offlineNativeRemote', False)) and
+                callable(settle)):
+            raise CapabilityError(
+                'remote vehicle has no authoritative motion settlement')
+        return bool(settle(now))
+
     def update_vehicle_aim(self, entity_id, hull_yaw, aim_yaw, gun_pitch):
         """Apply a network world aim to the exact packed Vehicle property."""
         entity = self._authority_entity_or_fail(entity_id)

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/entities/remote_vehicle.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/entities/remote_vehicle.py
@@ -1628,6 +1628,15 @@ class RemoteVehicle(object):
         self.filter.update(self.position, velocity)
         self.appearance.gear = 1 if self.filter.speed > 0.01 else 0
 
+    def settle_motion(self, now=None):
+        """Clear pose-derived motion without re-keying the hull animation."""
+        if now is not None:
+            self._last_pose_time = float(now)
+        velocity = self._math.Vector3(0.0, 0.0, 0.0)
+        self.filter.update(self.position, velocity)
+        self.appearance.gear = 0
+        return True
+
     def set_aim(self, hull_yaw, aim_yaw, gun_pitch):
         relative = ((float(aim_yaw) - float(hull_yaw) + math.pi) %
                     (2.0 * math.pi) - math.pi)

--- a/0.9.22/tests/test_port_0922_authority_worker_client.py
+++ b/0.9.22/tests/test_port_0922_authority_worker_client.py
@@ -95,9 +95,42 @@ class _WorkerRuntime(object):
             'bot_state_send_failed': 0,
             'bot_state_revision': 0,
             'bot_probes': {},
+            'bot_probe_seconds': {},
+            'probe_timing': 'pending',
             'bot_count': 0,
             'simulation_caps': 0,
             'alive_bot_ticks': 0,
+            'control': {
+                'catchup_callbacks': 0,
+                'debt_callbacks': 0,
+                'astar_budget_exhausted_callbacks': 0,
+                'astar_completed': 0,
+                'astar_failed': 0,
+            },
+            'presentation': {
+                'pose_writes': 0, 'pose_skips': 0,
+                'aim_writes': 0, 'aim_skips': 0,
+            },
+            'frame_performance': {},
+            'bot_diagnostics': {
+                'visibility_queue_depth': 0,
+                'visibility_queue_max_depth': 0,
+                'visibility_oldest_stale_age_ms': 0,
+                'visibility_oldest_stale_max_age_ms': 0,
+                'visibility_admitted': 0,
+                'visibility_completed': 0,
+                'visibility_deferred': 0,
+                'visibility_selected_services': 0,
+                'visibility_fire_services': 0,
+                'visibility_new_services': 0,
+                'visibility_ordinary_services': 0,
+                'shot_lane_pending_pairs': 0,
+                'shot_lane_pending_max_pairs': 0,
+                'shot_lane_oldest_due_age_ms': 0,
+                'shot_lane_oldest_due_max_age_ms': 0,
+                'shot_lane_completed_pairs': 0,
+                'shot_lane_budget_deferred_attempts': 0,
+            },
         }
 
     def start(self, config, message=None, lan_client=None,
@@ -1322,17 +1355,67 @@ class AuthorityWorkerClientTests(unittest.TestCase):
                     port_config, 'write_json', side_effect=write_status):
                 with mock.patch(
                         'gui.mods.offline_lan_0922.authority_worker.time.time',
-                        side_effect=(100.0, 102.0, 104.0)):
+                        side_effect=(100.0, 102.0, 104.0)), mock.patch(
+                            'gui.mods.offline_lan_0922.authority_worker.'
+                            '_windows_process_counters', side_effect=(
+                                {'cpu_seconds': 10.0,
+                                 'working_set_bytes': 100000000,
+                                 'logical_processors': 4},
+                                {'cpu_seconds': 10.8,
+                                 'working_set_bytes': 120000000,
+                                 'logical_processors': 4},
+                                {'cpu_seconds': 11.0,
+                                 'working_set_bytes': 90000000,
+                                 'logical_processors': 4})):
                     self.assertTrue(session._write_status(force=True))
                     runtime.sample.update({
+                        'frame_callbacks': 49,
                         'authority_callbacks': 48,
                         'bot_state_generated': 61,
                         'bot_state_enqueued': 60,
                         'bot_state_send_failed': 1,
                         'bot_state_revision': 52,
                         'bot_probes': {'lane': 17},
+                        'bot_probe_seconds': {'lane': 0.034},
+                        'probe_timing': 'active',
                         'bot_count': 29,
                         'alive_bot_ticks': 116,
+                        'control': {
+                            'catchup_callbacks': 3,
+                            'debt_callbacks': 2,
+                            'astar_budget_exhausted_callbacks': 4,
+                            'astar_completed': 7,
+                            'astar_failed': 1,
+                        },
+                        'presentation': {
+                            'pose_writes': 29, 'pose_skips': 29,
+                            'aim_writes': 29, 'aim_skips': 29,
+                        },
+                        'frame_performance': {
+                            'render_callback_fps': 24.0,
+                            'frame_interval_ms': {
+                                'p50': 40.0, 'p95': 80.0,
+                                'p99': 120.0, 'max': 150.0},
+                        },
+                        'bot_diagnostics': {
+                            'visibility_queue_depth': 11,
+                            'visibility_queue_max_depth': 17,
+                            'visibility_oldest_stale_age_ms': 500,
+                            'visibility_oldest_stale_max_age_ms': 900,
+                            'visibility_admitted': 20,
+                            'visibility_completed': 18,
+                            'visibility_deferred': 7,
+                            'visibility_selected_services': 8,
+                            'visibility_fire_services': 4,
+                            'visibility_new_services': 5,
+                            'visibility_ordinary_services': 3,
+                            'shot_lane_pending_pairs': 31,
+                            'shot_lane_pending_max_pairs': 404,
+                            'shot_lane_oldest_due_age_ms': 200,
+                            'shot_lane_oldest_due_max_age_ms': 1700,
+                            'shot_lane_completed_pairs': 20,
+                            'shot_lane_budget_deferred_attempts': 10,
+                        },
                     })
                     self.assertTrue(session._write_status(force=True))
                     value = json.loads(path.read_text(encoding='utf-8'))
@@ -1341,15 +1424,83 @@ class AuthorityWorkerClientTests(unittest.TestCase):
                     empty = json.loads(path.read_text(encoding='utf-8'))
 
         self.assertTrue(value['connected'])
+        self.assertTrue(value['process_performance']['available'])
+        self.assertAlmostEqual(
+            40.0, value['process_performance']['cpu_core_percent'])
+        self.assertAlmostEqual(
+            10.0, value['process_performance']['cpu_machine_percent'])
+        self.assertEqual(
+            120000000,
+            value['process_performance']['working_set_bytes'])
+        self.assertFalse(value['process_performance']['gpu_measured'])
         self.assertEqual('battle', value['phase'])
         self.assertEqual(2.0, value['runtime']['window_seconds'])
+        self.assertEqual(24.0, value['runtime']['render_callback_hz'])
         self.assertEqual(24.0, value['runtime']['callback_hz'])
         self.assertEqual(30.0, value['runtime']['bot_publication_hz'])
         self.assertEqual(52, value['runtime']['revision_delta'])
         self.assertEqual(1, value['runtime']['send_failed_delta'])
         self.assertEqual({'lane': 17}, value['runtime']['bot_probes'])
+        self.assertEqual(
+            {'lane': 17}, value['runtime']['logical_probe_delta'])
+        self.assertEqual(
+            {'lane': 8.5}, value['runtime']['logical_probe_hz'])
+        self.assertEqual(
+            {'lane': 34.0}, value['runtime']['timed_probe_ms_delta'])
+        self.assertEqual(3, value['runtime']['catchup_delta'])
+        self.assertEqual(2, value['runtime']['debt_callback_delta'])
+        self.assertEqual(
+            4, value['runtime']['astar_budget_exhausted_delta'])
+        self.assertEqual(7, value['runtime']['astar_completed_delta'])
+        self.assertEqual(1, value['runtime']['astar_failed_delta'])
+        self.assertEqual(
+            {'aim_skips': 29, 'aim_writes': 29,
+             'pose_skips': 29, 'pose_writes': 29},
+            value['runtime']['presentation_delta'])
+        self.assertEqual(
+            120.0,
+            value['runtime']['frame_performance'][
+                'frame_interval_ms']['p99'])
+        self.assertEqual(
+            11, value['runtime']['bot_diagnostics'][
+                'visibility_queue_depth'])
+        self.assertEqual(
+            20, value['runtime']['visibility_counter_delta'][
+                'visibility_admitted'])
+        self.assertEqual(
+            10.0, value['runtime']['visibility_counter_hz'][
+                'visibility_admitted'])
+        self.assertEqual(
+            31, value['runtime']['bot_diagnostics'][
+                'shot_lane_pending_pairs'])
+        self.assertEqual(
+            20, value['runtime']['shot_lane_counter_delta'][
+                'shot_lane_completed_pairs'])
+        self.assertEqual(
+            10.0, value['runtime']['shot_lane_counter_hz'][
+                'shot_lane_completed_pairs'])
+        self.assertEqual(
+            10, value['runtime']['shot_lane_counter_delta'][
+                'shot_lane_budget_deferred_attempts'])
+        self.assertEqual(
+            5.0, value['runtime']['shot_lane_counter_hz'][
+                'shot_lane_budget_deferred_attempts'])
         self.assertEqual({}, empty['runtime'])
         self.assertEqual([False, False, False], durable_values)
+
+    def test_unavailable_process_metrics_never_affect_worker_state(self):
+        session = WorkerSession({})
+        session.state = 'waiting'
+        with mock.patch(
+                'gui.mods.offline_lan_0922.authority_worker.'
+                '_windows_process_counters', return_value=None):
+            value = session._process_performance(10.0)
+
+        self.assertFalse(value['available'])
+        self.assertIsNone(value['cpu_core_percent'])
+        self.assertIsNone(value['working_set_bytes'])
+        self.assertFalse(value['gpu_measured'])
+        self.assertEqual('waiting', session.state)
 
     def test_in_memory_account_state_never_calls_json_writer(self):
         state = AccountState(path=None)

--- a/0.9.22/tests/test_port_0922_battle_runtime.py
+++ b/0.9.22/tests/test_port_0922_battle_runtime.py
@@ -4837,6 +4837,33 @@ class BattleRuntimeContractTests(unittest.TestCase):
             {'visibility': 3}, {
                 'role': 'authority', 'probe_timing': 'active'})
         third = diagnostics.begin(0.30, 0.18)
+        diagnostics.note_worker_runtime({
+            'control': {
+                'control_steps': 9, 'catchup_callbacks': 2,
+                'debt_callbacks': 1, 'control_debt_ms': 33.0,
+                'max_control_step_ms': 100.0,
+                'astar_pending': 3, 'astar_credit': 4.0,
+                'astar_budget_remaining': 0,
+                'astar_budget_exhausted_callbacks': 1,
+                'astar_completed': 5, 'astar_failed': 1,
+            },
+            'presentation': {
+                'pose_writes': 29, 'pose_skips': 58,
+                'aim_writes': 29, 'aim_skips': 58,
+            },
+            'bot_diagnostics': {
+                'visibility_queue_depth': 3,
+                'visibility_queue_max_depth': 8,
+                'visibility_oldest_stale_age_ms': 400,
+                'visibility_oldest_stale_max_age_ms': 900,
+                'shot_lane_pending_pairs': 31,
+                'shot_lane_pending_max_pairs': 404,
+                'shot_lane_oldest_due_age_ms': 200,
+                'shot_lane_oldest_due_max_age_ms': 1700,
+                'shot_lane_completed_pairs': 420,
+                'shot_lane_budget_deferred_attempts': 5000,
+            },
+        })
         wall[0] = 0.31
         diagnostics.finish(
             third, 0.30, 0.10, 0.10, {'spot': 0.001}, {},
@@ -4853,12 +4880,41 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertIn('probe_ms=', first_row)
         self.assertIn('lane:5.000', first_row)
         self.assertIn('active:29,chords:58,debt_ms:50.000', first_row)
-        self.assertIn('summary v=2', payloads[0])
+        self.assertIn('summary v=3', payloads[0])
         self.assertIn('role=authority probe_timing=active', payloads[0])
-        self.assertIn('probe_ms_avg_max', payloads[0])
+        self.assertIn('gap_ms_p50_p95_p99_max=', payloads[0])
+        self.assertIn('python_ms_p50_p95_p99_max=', payloads[0])
+        self.assertIn('logical_probes_hz_total', payloads[0])
+        self.assertIn('logical_probe_ms_avg_max', payloads[0])
+        self.assertIn('logical_probe_ms_per_s_total', payloads[0])
+        self.assertIn('worker control_steps=9 catchup=2', payloads[0])
+        self.assertIn('visibility_queue_depth_max=3/8', payloads[0])
+        self.assertIn('visibility_oldest_ms_max=400/900', payloads[0])
+        self.assertIn('shot_lane_pending_max=31/404', payloads[0])
+        self.assertIn('shot_lane_oldest_due_ms_max=200/1700', payloads[0])
+        self.assertIn('shot_lane_completed_deferred=420/5000', payloads[0])
+        self.assertIn('pose_writes_skips=29/58', payloads[0])
         self.assertIn('projectile_avg_max', payloads[0])
         self.assertIn('chords=29.00/58', payloads[0])
         self.assertIn('scans=870.00/1740', payloads[0])
+        snapshot = diagnostics.snapshot()
+        self.assertEqual(2, snapshot['samples'])
+        self.assertAlmostEqual(
+            150.0, snapshot['frame_interval_ms']['p50'])
+        self.assertAlmostEqual(
+            177.0, snapshot['frame_interval_ms']['p95'])
+        self.assertAlmostEqual(
+            179.4, snapshot['frame_interval_ms']['p99'])
+        self.assertAlmostEqual(
+            180.0, snapshot['frame_interval_ms']['max'])
+        self.assertAlmostEqual(
+            5.5, snapshot['python_callback_ms']['p50'])
+        self.assertFalse(snapshot['raw_native_calls_measured'])
+        self.assertEqual(
+            2, snapshot['worker_runtime']['control']['catchup_callbacks'])
+        self.assertEqual(
+            7, snapshot['logical_native_probes']['lane'][
+                'logical_count'])
         self.assertTrue(diagnostics._pending['emitted'])
         self.assertAlmostEqual(
             0.003, diagnostics._pending['stages']['diag_emit'])
@@ -4901,6 +4957,31 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertEqual(1.0, diagnostics._window_seconds)
         diagnostics.reset()
         self.assertEqual(0.25, diagnostics._window_seconds)
+
+    def test_frame_diagnostic_percentile_storage_is_bounded(self):
+        diagnostics = _FrameDiagnostics(
+            writer=lambda unused: None, clock=lambda: 0.0)
+        limit = diagnostics._gap_samples.maxlen
+        row = {
+            'cause': 1, 'next': 2,
+            'wall_gap': 0.01, 'raw_dt': 0.01, 'exec': 0.001,
+            'outside': 0.009, 'offframe': 0.0,
+            'bw_minus_wall': 0.0, 'tick_dt': 0.01,
+            'motion_dt': 0.01, 'emitted': False,
+            'stages': {}, 'probes': {}, 'probe_durations': {},
+            'projectile': {}, 'context': {},
+        }
+        for index in range(limit + 7):
+            value = dict(row, wall_gap=0.01 + index * 1.0e-9)
+            diagnostics._add(value)
+
+        self.assertEqual(limit, len(diagnostics._gap_samples))
+        self.assertEqual(limit, len(diagnostics._exec_samples))
+        self.assertEqual(limit, len(diagnostics._outside_samples))
+        diagnostics._format()
+        snapshot = diagnostics.snapshot()
+        self.assertEqual(limit, snapshot['distribution_samples'])
+        self.assertEqual(7, snapshot['distribution_dropped'])
 
     def test_network_deadlines_remove_main_thread_delay_from_periods(self):
         runtime = _runtime()
@@ -12875,6 +12956,72 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertFalse(battle._worker_probe_attempted)
         battle._bots.set_camera_position.assert_called_once_with(None)
 
+    def test_worker_sample_exposes_control_astar_and_timed_logical_probes(self):
+        battle = BattleRuntime(_runtime())
+        battle._worker_mode = True
+        navigator = types.SimpleNamespace(
+            searches={'first': object(), 'second': object()},
+            search_credit=0.0, search_frame_budget=0,
+            search_completed=7, search_failed=2)
+        battle._bots = types.SimpleNamespace(
+            _sample_time_us=1100000, _accumulator=0.05,
+            _control_seconds=1.0 / 30.0, navigator=navigator,
+            probe_totals=lambda: (2, 3, 4, 5, 6),
+            probe_duration_totals=lambda: (0.01, 0.02, 0.03, 0.04, 0.05),
+            probe_timing_state=lambda: 'active',
+            diagnostic_totals=lambda: {
+                'alive_bot_ticks': 29,
+                'visibility_queue_depth': 3,
+                'visibility_queue_max_depth': 8,
+                'visibility_oldest_stale_age_ms': 400,
+                'visibility_oldest_stale_max_age_ms': 900,
+                'visibility_admitted': 10,
+                'visibility_completed': 8,
+                'visibility_deferred': 4,
+                'visibility_selected_services': 3,
+                'visibility_fire_services': 2,
+                'visibility_new_services': 4,
+                'visibility_ordinary_services': 1,
+                'shot_lane_pending_pairs': 31,
+                'shot_lane_pending_max_pairs': 404,
+                'shot_lane_oldest_due_age_ms': 200,
+                'shot_lane_oldest_due_max_age_ms': 1700,
+                'shot_lane_completed_pairs': 420,
+                'shot_lane_budget_deferred_attempts': 5000})
+
+        self.assertTrue(battle._record_worker_control_diagnostics(1000000))
+        sample = battle._authority_worker_probe_sample()
+
+        self.assertEqual(1, sample['control']['control_steps'])
+        self.assertEqual(1, sample['control']['catchup_callbacks'])
+        self.assertEqual(1, sample['control']['debt_callbacks'])
+        self.assertEqual(2, sample['control']['astar_pending'])
+        self.assertEqual(
+            1, sample['control']['astar_budget_exhausted_callbacks'])
+        self.assertAlmostEqual(100.0,
+                               sample['control']['max_control_step_ms'])
+        self.assertAlmostEqual(50.0,
+                               sample['control']['control_debt_ms'])
+        self.assertEqual(2, sample['bot_probes']['visibility'])
+        self.assertAlmostEqual(
+            0.01, sample['bot_probe_seconds']['visibility'])
+        self.assertEqual('active', sample['probe_timing'])
+        self.assertEqual(29, sample['alive_bot_ticks'])
+        self.assertEqual(
+            3, sample['bot_diagnostics']['visibility_queue_depth'])
+        self.assertEqual(
+            900, sample['bot_diagnostics'][
+                'visibility_oldest_stale_max_age_ms'])
+        self.assertEqual(
+            31, sample['bot_diagnostics']['shot_lane_pending_pairs'])
+        self.assertEqual(
+            1700, sample['bot_diagnostics'][
+                'shot_lane_oldest_due_max_age_ms'])
+        self.assertEqual(
+            5000, sample['bot_diagnostics'][
+                'shot_lane_budget_deferred_attempts'])
+        self.assertFalse(sample['frame_performance'])
+
     def test_authority_replaces_local_placeholder_and_omits_remote_one(self):
         battle = BattleRuntime(_runtime())
         battle.client = _Client()
@@ -16073,6 +16220,199 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertEqual(-0.1, collision_pose['gun_pitch'])
         self.assertEqual(1, collision_pose['siege_state'])
 
+    def test_static_authority_roster_skips_repeated_pose_and_aim_writes(self):
+        battle = BattleRuntime(_runtime())
+        battle._binding = mock.Mock()
+        battle._update_bot_tracks = mock.Mock(return_value=True)
+        battle._records = dict(
+            ('bot:%d' % bot_id, {
+                'engine_id': 1000 + bot_id, 'kind': 'bot',
+                'network_id': bot_id, 'ready': True, 'tombstone': False})
+            for bot_id in range(1, 30))
+        states = tuple({
+            'id': bot_id, 'alive': True, 'health': 500,
+            'x': float(bot_id), 'y': 2.0, 'z': 9.0,
+            'yaw': 0.75, 'pitch': 0.0, 'roll': 0.0,
+            'speed': 0.0, 'movement_dir': 0, 'rotation_dir': 0,
+            'aim_yaw': 0.9, 'gun_pitch': -0.1,
+        } for bot_id in range(1, 30))
+
+        self.assertTrue(battle._apply_authority_bot_poses(states))
+        self.assertTrue(battle._apply_authority_bot_poses(states))
+
+        self.assertEqual(29, battle._binding.set_vehicle_pose.call_count)
+        self.assertEqual(29, battle._binding.update_vehicle_aim.call_count)
+        self.assertEqual(29, battle._authority_pose_writes)
+        self.assertEqual(29, battle._authority_pose_skips)
+        self.assertEqual(29, battle._authority_aim_writes)
+        self.assertEqual(29, battle._authority_aim_skips)
+        self.assertEqual(58, battle._update_bot_tracks.call_count)
+
+    def test_authority_presentation_exact_field_edges_are_not_coalesced(self):
+        state = {
+            'id': 17, 'alive': True, 'health': 500,
+            'x': 7.0, 'y': 2.0, 'z': 9.0,
+            'yaw': 0.75, 'pitch': 0.2, 'roll': -0.3,
+            'speed': 6.0, 'movement_dir': 1, 'rotation_dir': 0,
+            'aim_yaw': 0.9, 'gun_pitch': -0.1,
+            'siege_state': 0, 'siege_time_left_ms': 0,
+            'siege_transition_total_ms': 1000}
+        cases = (
+            ('x', state['x'] + 1.0e-12, True, False),
+            ('y', state['y'] + 1.0e-12, True, False),
+            ('z', state['z'] + 1.0e-12, True, False),
+            ('yaw', state['yaw'] + 1.0e-12, True, True),
+            ('pitch', state['pitch'] + 1.0e-12, True, True),
+            ('roll', state['roll'] + 1.0e-12, True, False),
+            ('speed', state['speed'] + 1.0e-12, True, False),
+            ('alive', False, True, False),
+            ('health', 0, True, False),
+            ('siege_state', 2, True, True),
+            ('aim_yaw', state['aim_yaw'] + 1.0e-12, False, True),
+            ('gun_pitch', state['gun_pitch'] + 1.0e-12, False, True),
+        )
+        for field, value, expect_pose, expect_aim in cases:
+            with self.subTest(field=field):
+                battle = BattleRuntime(_runtime())
+                battle._binding = mock.Mock()
+                battle._records = {
+                    'bot:17': {
+                        'engine_id': 11, 'kind': 'bot', 'network_id': 17,
+                        'ready': True, 'tombstone': False}}
+                self.assertTrue(battle._apply_authority_bot_poses([state]))
+                battle._binding.reset_mock()
+
+                changed = dict(state, **{field: value})
+                self.assertTrue(
+                    battle._apply_authority_bot_poses([changed]))
+                self.assertEqual(
+                    int(expect_pose),
+                    battle._binding.set_vehicle_pose.call_count)
+                self.assertEqual(
+                    int(expect_aim),
+                    battle._binding.update_vehicle_aim.call_count)
+
+    def test_authority_presentation_cache_is_fenced_by_lifecycle(self):
+        battle = BattleRuntime(_runtime())
+        battle._binding = mock.Mock()
+        state = {
+            'id': 17, 'alive': True, 'health': 500,
+            'x': 7.0, 'y': 2.0, 'z': 9.0, 'yaw': 0.75,
+            'speed': 0.0, 'aim_yaw': 0.9, 'gun_pitch': -0.1}
+        record = {
+            'engine_id': 11, 'kind': 'bot', 'network_id': 17,
+            'ready': True, 'tombstone': False}
+        battle._records = {'bot:17': record}
+        self.assertTrue(battle._apply_authority_bot_poses([state]))
+        self.assertTrue(battle._apply_authority_bot_poses([state]))
+        self.assertEqual(1, battle._binding.set_vehicle_pose.call_count)
+        self.assertEqual(1, battle._binding.update_vehicle_aim.call_count)
+
+        record['ready'] = False
+        self.assertFalse(battle._apply_authority_bot_poses([state]))
+        record['ready'] = True
+        self.assertTrue(battle._apply_authority_bot_poses([state]))
+        self.assertEqual(2, battle._binding.set_vehicle_pose.call_count)
+        self.assertEqual(2, battle._binding.update_vehicle_aim.call_count)
+
+        battle._records['bot:17'] = dict(record)
+        self.assertTrue(battle._apply_authority_bot_poses([state]))
+        self.assertEqual(3, battle._binding.set_vehicle_pose.call_count)
+        self.assertEqual(3, battle._binding.update_vehicle_aim.call_count)
+
+        battle._generation += 1
+        self.assertTrue(battle._apply_authority_bot_poses([state]))
+        self.assertEqual(4, battle._binding.set_vehicle_pose.call_count)
+        self.assertEqual(4, battle._binding.update_vehicle_aim.call_count)
+
+    def test_active_motion_rewrites_once_per_control_epoch(self):
+        battle = BattleRuntime(_runtime())
+        battle._binding = mock.Mock()
+        battle._bots = types.SimpleNamespace(_sample_time_us=100000)
+        battle._records = {
+            'bot:17': {'engine_id': 11, 'kind': 'bot', 'network_id': 17,
+                       'ready': True, 'tombstone': False}}
+        moving = {
+            'id': 17, 'alive': True, 'health': 500,
+            'x': 7.0, 'y': 2.0, 'z': 9.0, 'yaw': 0.75,
+            'speed': 1.0e-12, 'movement_dir': 1,
+            'aim_yaw': 0.9, 'gun_pitch': -0.1}
+
+        self.assertTrue(battle._apply_authority_bot_poses([moving]))
+        self.assertTrue(battle._apply_authority_bot_poses([moving]))
+        self.assertEqual(1, battle._binding.set_vehicle_pose.call_count)
+
+        battle._bots._sample_time_us = 133333
+        self.assertTrue(battle._apply_authority_bot_poses([moving]))
+        self.assertEqual(2, battle._binding.set_vehicle_pose.call_count)
+        self.assertEqual(1, battle._binding.update_vehicle_aim.call_count)
+
+        dead = dict(moving, alive=False, health=0)
+        self.assertTrue(battle._apply_authority_bot_poses([dead]))
+        battle._bots._sample_time_us = 166666
+        self.assertTrue(battle._apply_authority_bot_poses([dead]))
+        self.assertEqual(3, battle._binding.set_vehicle_pose.call_count)
+
+    def test_authority_stop_edge_settles_real_remote_filter_once(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._worker_mode = True
+        now = [10.0]
+        battle._clock = lambda: now[0]
+        factory = RemoteVehicleFactory(
+            runtime.bigworld, runtime.math, runtime.model_assembler, 7)
+        battle._remote_factory = factory
+        battle._binding = BigWorldVehicleBinding(
+            runtime.bigworld, runtime.bigworld.avatar, runtime.constants,
+            runtime.vehicles.VehicleDescr, runtime.encode_gun_angles,
+            outfit_provider=lambda unused_descriptor: '',
+            authority_entity_resolver=battle._server_entity)
+        vehicle_id = factory.create(_Descriptor(), {
+            'publicInfo': {'team': 2, 'name': 'Hidden Bot'},
+            'health': 500, 'isCrewActive': True, 'gunAnglesPacked': 0},
+            _Vector(), (0.0, 0.0, 0.0))
+        vehicle = factory.get(vehicle_id)
+        real_settle = vehicle.settle_motion
+        vehicle.settle_motion = mock.Mock(wraps=real_settle)
+        battle._bots = types.SimpleNamespace(_sample_time_us=100000)
+        battle._records = {
+            'bot:17': {
+                'engine_id': vehicle_id, 'kind': 'bot', 'network_id': 17,
+                'ready': True, 'tombstone': False}}
+        moving = {
+            'id': 17, 'alive': True, 'health': 500,
+            'x': 0.0, 'y': 0.0, 'z': 0.0, 'yaw': 0.0,
+            'speed': 5.0, 'movement_dir': 1, 'rotation_dir': 0,
+            'aim_yaw': 0.0, 'gun_pitch': 0.0}
+
+        try:
+            self.assertTrue(battle._apply_authority_bot_poses([moving]))
+            now[0] = 11.0
+            battle._bots._sample_time_us = 200000
+            moving = dict(moving, x=1.0)
+            self.assertTrue(battle._apply_authority_bot_poses([moving]))
+            self.assertGreater(vehicle.filter.speed, 0.0)
+            self.assertEqual(1, vehicle.appearance.gear)
+            vehicle.settle_motion.assert_not_called()
+
+            now[0] = 12.0
+            battle._bots._sample_time_us = 300000
+            stopped = dict(moving, x=2.0, speed=0.0, movement_dir=0)
+            self.assertTrue(battle._apply_authority_bot_poses([stopped]))
+            self.assertEqual((0.0, 0.0), vehicle.speedInfo.value)
+            self.assertEqual(0.0, vehicle.filter.speed)
+            self.assertEqual(0, vehicle.appearance.gear)
+            vehicle.settle_motion.assert_called_once_with(12.0)
+
+            now[0] = 12.1
+            battle._bots._sample_time_us = 400000
+            self.assertTrue(battle._apply_authority_bot_poses([stopped]))
+            self.assertEqual(3, battle._authority_pose_writes)
+            self.assertEqual(1, battle._authority_pose_skips)
+            vehicle.settle_motion.assert_called_once_with(12.0)
+        finally:
+            factory.destroy_all()
+
     def test_hidden_worker_authority_pose_skips_track_presentation(self):
         battle = BattleRuntime(_runtime())
         battle._worker_mode = True
@@ -16204,6 +16544,8 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertIs(descriptor, call[4])
         next_deadline = battle._bot_destructible_samples[17][0]
         self.assertAlmostEqual(runtime.bigworld.now + 0.5, next_deadline)
+        self.assertEqual(1, battle._binding.set_vehicle_pose.call_count)
+        self.assertEqual(1, battle._binding.update_vehicle_aim.call_count)
 
     def test_authority_bot_destructible_budget_is_render_rate_independent(self):
         totals = {}

--- a/0.9.22/tests/test_port_0922_battle_runtime.py
+++ b/0.9.22/tests/test_port_0922_battle_runtime.py
@@ -12964,8 +12964,10 @@ class BattleRuntimeContractTests(unittest.TestCase):
             search_credit=0.0, search_frame_budget=0,
             search_completed=7, search_failed=2)
         battle._bots = types.SimpleNamespace(
-            _sample_time_us=1100000, _accumulator=0.05,
-            _control_seconds=1.0 / 30.0, navigator=navigator,
+            _sample_time_us=2000000, _accumulator=0.1,
+            _last_update_control_steps=5,
+            _last_update_max_control_step=0.2,
+            _control_seconds=0.1, navigator=navigator,
             probe_totals=lambda: (2, 3, 4, 5, 6),
             probe_duration_totals=lambda: (0.01, 0.02, 0.03, 0.04, 0.05),
             probe_timing_state=lambda: 'active',
@@ -12992,15 +12994,15 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertTrue(battle._record_worker_control_diagnostics(1000000))
         sample = battle._authority_worker_probe_sample()
 
-        self.assertEqual(1, sample['control']['control_steps'])
+        self.assertEqual(5, sample['control']['control_steps'])
         self.assertEqual(1, sample['control']['catchup_callbacks'])
         self.assertEqual(1, sample['control']['debt_callbacks'])
         self.assertEqual(2, sample['control']['astar_pending'])
         self.assertEqual(
             1, sample['control']['astar_budget_exhausted_callbacks'])
-        self.assertAlmostEqual(100.0,
+        self.assertAlmostEqual(200.0,
                                sample['control']['max_control_step_ms'])
-        self.assertAlmostEqual(50.0,
+        self.assertAlmostEqual(100.0,
                                sample['control']['control_debt_ms'])
         self.assertEqual(2, sample['bot_probes']['visibility'])
         self.assertAlmostEqual(

--- a/0.9.22/tests/test_port_0922_bot_runtime.py
+++ b/0.9.22/tests/test_port_0922_bot_runtime.py
@@ -2002,6 +2002,122 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertEqual(21, 8 + 9 + 4)
         self.assertEqual(261, 29 * 8 + 29)
 
+    def test_countdown_receipt_cannot_authorize_changed_live_world(self):
+        command = {
+            'target_yaw': 0.0, 'throttle': 1.0, 'turn': 0.0,
+            'shell_index': 0, 'fire_allowed': False, 'target_id': None,
+            'fire_range': 0.0, 'combat_mode': 'route',
+            'aim_position': (0.0, 0.0, 200.0),
+            'face_position': (0.0, 0.0, 200.0),
+            'move_position': (0.0, 0.0, 200.0),
+            'recovery_mode': 'drive', 'movement_intent': True,
+        }
+        blocked = [False]
+        direction_calls = []
+
+        def direction(position, yaw, speed, unused_descriptor):
+            direction_calls.append((blocked[0], tuple(position), float(yaw)))
+            if blocked[0]:
+                return {
+                    'clear': False, 'collision': True, 'slope': 0.0}
+            return {'clear': True, 'collision': False, 'slope': 0.0}
+
+        class StaticGrid(object):
+            prebaked = True
+            cell_size = 4.0
+
+            def near_baked_navigation(
+                    self, unused_position, unused_radius):
+                return True
+
+            def segment_has_baked_hazard(
+                    self, unused_start, unused_end, unused_mask):
+                return False
+
+            def segment_clear(self, unused_start, unused_end):
+                return True
+
+        graph = _graph()
+        graph['bake'].update({
+            'vehicle_half_width': 2.15,
+            'edge_clearance_radii': [3.0, 6.0],
+        })
+        runtime = self.module.BotRuntime(
+            1, descriptor_resolver=lambda unused: _combat_descriptor(),
+            adapter_factory=lambda *unused, **unused_kwargs:
+                _FixedAdapter(command),
+            direction_probe=direction,
+            world_receipt_probe=lambda position, yaw, speed, unused_descriptor: {
+                'distance': 15.0, 'half_width': 1.6, 'leading': 3.5,
+                'origin': tuple(position), 'yaw': float(yaw),
+                'direction': -1 if float(speed) < 0.0 else 1,
+            },
+            ground_probe=lambda *unused: 0.0,
+            physics_ground_probe=lambda *unused: 0.0,
+            spawn_resolver=_spawn_resolver, native_motion=True,
+            baked_graph=graph)
+        runtime.battle_start(dict(
+            self.start,
+            bots=[{'id': 11, 'team': 1, 'slot': 0, 'name': 'Bot'}]))
+        runtime.navigator.grid = StaticGrid()
+        initial_position = tuple(
+            runtime.states[11][name] for name in ('x', 'y', 'z'))
+
+        self.assertTrue(runtime.prewarm_world_receipts(1.0))
+        self.assertEqual(1, len(direction_calls))
+        blocked[0] = True
+        runtime.update(.04, 3.0)
+
+        self.assertEqual(2, len(direction_calls))
+        self.assertTrue(direction_calls[-1][0])
+        self.assertEqual(0, runtime.states[11]['movement_dir'])
+        self.assertEqual(initial_position, tuple(
+            runtime.states[11][name] for name in ('x', 'y', 'z')))
+
+    def test_countdown_receipt_cannot_authorize_a_changed_live_heading(self):
+        command = {
+            'target_yaw': 0.0, 'throttle': 1.0, 'turn': 0.0,
+            'shell_index': 0, 'fire_allowed': False, 'target_id': None,
+            'fire_range': 0.0, 'combat_mode': 'route',
+            'aim_position': (0.0, 0.0, 200.0),
+            'face_position': (0.0, 0.0, 200.0),
+            'move_position': (0.0, 0.0, 200.0),
+            'recovery_mode': 'drive', 'movement_intent': True,
+        }
+        direction_calls = []
+
+        def direction(position, yaw, speed, unused_descriptor):
+            direction_calls.append((tuple(position), float(yaw), float(speed)))
+            return {'clear': True, 'collision': False, 'slope': 0.0}
+
+        runtime = self.module.BotRuntime(
+            1, descriptor_resolver=lambda unused: _combat_descriptor(),
+            adapter_factory=lambda *unused, **unused_kwargs:
+                _FixedAdapter(command),
+            direction_probe=direction,
+            world_receipt_probe=lambda position, yaw, speed, unused_descriptor: {
+                'distance': 15.0, 'half_width': 1.6, 'leading': 3.5,
+                'origin': tuple(position), 'yaw': float(yaw),
+                'direction': -1 if float(speed) < 0.0 else 1,
+            },
+            ground_probe=lambda *unused: 0.0,
+            physics_ground_probe=lambda *unused: 0.0,
+            spawn_resolver=_spawn_resolver, native_motion=True,
+            baked_graph=_graph())
+        runtime.battle_start(self.start)
+        self.assertTrue(runtime.prewarm_world_receipts(1.0))
+        self.assertEqual(1, len(direction_calls))
+        runtime.adapter.decide = (
+            lambda unused_state, unused_clear: dict(command))
+
+        # A server/native pose correction between countdown and battle start
+        # invalidates the exact heading.  The selected live direction must be
+        # proved again rather than borrowing the old receipt.
+        runtime.states[11]['yaw'] = 0.2
+        runtime.update(.04, 2.0)
+
+        self.assertEqual(2, len(direction_calls))
+
     def test_countdown_prewarm_rejects_malformed_receipt_fail_closed(self):
         runtime = self.module.BotRuntime(
             1, descriptor_resolver=lambda unused: _combat_descriptor(),
@@ -5064,6 +5180,261 @@ class BotRuntimeTests(unittest.TestCase):
         # Extra render callbacks consume neither physics nor native sensing.
         self.assertLessEqual(
             max(probe_totals.values()) - min(probe_totals.values()), 29 * 4)
+
+    def test_worker_visibility_probes_are_bounded_and_cover_every_pair(self):
+        command = self._stationary_command()
+        roster = [
+            {'id': 11 + index,
+             'team': 1 if index < 14 else 2,
+             'slot': index if index < 14 else index - 14,
+             'name': 'Visibility-%d' % index}
+            for index in range(29)
+        ]
+        frame = [0]
+        calls = []
+
+        class HoldAdapter(_FixedAdapter):
+            def decide(self, state, unused_clear):
+                self.calls.append(state['id'])
+                return dict(self.command)
+
+        def visibility(source, target, unused_fired=False):
+            calls.append((frame[0], int(source['id']),
+                          int(target['network_id'])))
+            return True
+
+        runtime = self.module.BotRuntime(
+            1, descriptor_resolver=lambda unused: _combat_descriptor(),
+            adapter_factory=lambda *unused, **unused_kwargs:
+                HoldAdapter(command),
+            direction_probe=lambda *unused: {
+                'clear': True, 'collision': False, 'slope': 0.0},
+            visibility_probe=visibility,
+            firing_lane_probe=lambda *unused: True,
+            ground_probe=lambda *unused: 0.0,
+            physics_ground_probe=lambda *unused: 0.0,
+            spawn_resolver=_spawn_resolver, baked_graph=_graph(),
+            control_seconds=self.module.WORKER_CONTROL_SECONDS)
+        runtime.battle_start(dict(self.start, bots=roster))
+
+        for frame_index in range(30):
+            frame[0] = frame_index
+            runtime.update(
+                self.module.WORKER_CONTROL_SECONDS,
+                1.0 + frame_index * self.module.WORKER_CONTROL_SECONDS)
+
+        per_frame = [sum(call[0] == frame_index for call in calls)
+                     for frame_index in range(30)]
+        self.assertLessEqual(
+            max(per_frame), self.module.MAX_VISIBILITY_PROBES_PER_FRAME)
+        expected = set(
+            (source['id'], target['id'])
+            for source in roster for target in roster
+            if source['team'] != target['team'])
+        observed = set((source_id, target_id)
+                       for unused_frame, source_id, target_id in calls)
+        self.assertEqual(expected, observed)
+        first_service = dict((pair, min(
+            call[0] for call in calls if call[1:] == pair))
+            for pair in expected)
+        self.assertLessEqual(max(first_service.values()), 14)
+
+    def test_worker_visibility_prioritizes_selected_new_and_firing_targets(self):
+        command = self._stationary_command()
+        roster = [
+            {'id': 11 + index,
+             'team': 1 if index < 14 else 2,
+             'slot': index if index < 14 else index - 14,
+             'name': 'Priority-%d' % index}
+            for index in range(29)
+        ]
+        calls = []
+
+        class HoldAdapter(_FixedAdapter):
+            def decide(self, state, unused_clear):
+                self.calls.append(state['id'])
+                return dict(self.command)
+
+        runtime = self.module.BotRuntime(
+            1, descriptor_resolver=lambda unused: _combat_descriptor(),
+            adapter_factory=lambda *unused, **unused_kwargs:
+                HoldAdapter(command),
+            direction_probe=lambda *unused: {
+                'clear': True, 'collision': False, 'slope': 0.0},
+            visibility_probe=lambda source, target, unused_fired=False: (
+                calls.append((int(source['id']),
+                              int(target['network_id']))) or True),
+            firing_lane_probe=lambda *unused: True,
+            ground_probe=lambda *unused: 0.0,
+            physics_ground_probe=lambda *unused: 0.0,
+            spawn_resolver=_spawn_resolver, baked_graph=_graph(),
+            control_seconds=self.module.WORKER_CONTROL_SECONDS)
+        runtime.battle_start(dict(self.start, bots=roster))
+
+        all_pairs = []
+        for source in roster:
+            for target in roster:
+                if source['team'] == target['team']:
+                    continue
+                key = ('bot', source['id'], 'bot', target['id'])
+                runtime._visibility_cache[key] = (0.0, False, 0)
+                all_pairs.append(key)
+        # Put the interesting pairs at the tail of the inherited fair queue;
+        # priority must come from semantics rather than encounter order.
+        runtime._visibility_waiting = list(reversed(all_pairs))
+        fired_target_id = 25
+        new_target_id = 26
+        runtime.states[fired_target_id]['fire_seq'] = 1
+        for key in tuple(runtime._visibility_cache):
+            if key[3] == new_target_id:
+                runtime._visibility_cache.pop(key)
+        selected_target_id = 39
+        runtime._server_orders[11] = {
+            'target_kind': 'bot', 'target_id': selected_target_id,
+            'fire_allowed': False, 'shell_index': 0, 'fire_range': 500.0,
+            'combat_mode': 'engage',
+        }
+        runtime._server_order_tokens[11] = 1
+
+        runtime.update(self.module.WORKER_CONTROL_SECONDS, 10.0)
+
+        observed = set(calls)
+        fired_pairs = set(
+            (source['id'], fired_target_id) for source in roster
+            if source['team'] != runtime.states[fired_target_id]['team'])
+        new_pairs = set(
+            (source['id'], new_target_id) for source in roster
+            if source['team'] != runtime.states[new_target_id]['team'])
+        self.assertTrue(fired_pairs.issubset(observed))
+        self.assertTrue(new_pairs.issubset(observed))
+        self.assertIn((11, selected_target_id), observed)
+        self.assertLessEqual(
+            len(calls), self.module.MAX_VISIBILITY_PROBES_PER_FRAME)
+        diagnostics = runtime.diagnostic_totals()
+        self.assertEqual(1, diagnostics['visibility_selected_services'])
+        self.assertEqual(14, diagnostics['visibility_fire_services'])
+        self.assertEqual(14, diagnostics['visibility_new_services'])
+        self.assertEqual(19, diagnostics['visibility_ordinary_services'])
+
+    def test_worker_denied_stale_visibility_uses_only_remembered_pose(self):
+        roster = [
+            {'id': 11, 'team': 1, 'slot': 0, 'name': 'Observer'},
+            {'id': 25, 'team': 2, 'slot': 0, 'name': 'Target'},
+        ]
+        native_calls = []
+        runtime = self.module.BotRuntime(
+            1, descriptor_resolver=lambda unused: _combat_descriptor(),
+            visibility_probe=lambda *unused: native_calls.append(True) or True,
+            ground_probe=lambda *unused: 0.0,
+            physics_ground_probe=lambda *unused: 0.0,
+            spawn_resolver=_spawn_resolver, baked_graph=_graph(),
+            control_seconds=self.module.WORKER_CONTROL_SECONDS)
+        runtime.battle_start(dict(self.start, bots=roster))
+        source = runtime.states[11]
+        target = runtime.states[25]
+        source.update(x=0.0, y=0.0, z=0.0)
+        target.update(x=0.0, y=0.0, z=200.0, fire_seq=0)
+        view_range_calls = []
+        projection_calls = []
+        original_view_range = runtime._source_view_range
+        original_projection = runtime._target_detection_projection
+        runtime._source_view_range = lambda *args: (
+            view_range_calls.append(True) or original_view_range(*args))
+        runtime._target_detection_projection = lambda *args: (
+            projection_calls.append(True) or original_projection(*args))
+        pair_key = ('bot', 11, 'bot', 25)
+        team_key = (1, 'bot', 25)
+        remembered = {
+            'position': (7.0, 1.0, 9.0),
+            'x': 7.0, 'y': 1.0, 'z': 9.0,
+            'yaw': 0.25, 'speed': 2.0,
+        }
+
+        for fire_edge in (False, True):
+            with self.subTest(fire_edge=fire_edge):
+                target['fire_seq'] = 1 if fire_edge else 0
+                runtime._visibility_cache[pair_key] = (1.0, True, 0)
+                runtime._visible_target_poses[team_key] = dict(remembered)
+                runtime._spot_until[team_key] = 20.0
+                team_spotted = {}
+                runtime._begin_visibility_frame()
+                runtime._visibility_frame['budget'] = 0
+                contacts, lookup = runtime._contacts_for(
+                    source, [], 10.0, team_spotted, {})
+                runtime._finish_visibility_frame()
+
+                self.assertEqual([], native_calls)
+                self.assertEqual([], view_range_calls)
+                self.assertEqual([], projection_calls)
+                self.assertEqual(20.0, runtime._spot_until[team_key])
+                self.assertEqual({}, team_spotted)
+                self.assertEqual(1, len(contacts))
+                self.assertTrue(contacts[0]['visible'])
+                self.assertFalse(contacts[0]['direct_visible'])
+                self.assertFalse(contacts[0]['fresh_visible'])
+                self.assertEqual(remembered['position'],
+                                 contacts[0]['position'])
+                self.assertEqual(remembered['position'],
+                                 lookup[25]['position'])
+
+    def test_worker_visibility_diagnostics_measure_queue_debt_and_reset(self):
+        command = self._stationary_command()
+        roster = [
+            {'id': 11 + index,
+             'team': 1 if index < 14 else 2,
+             'slot': index if index < 14 else index - 14,
+             'name': 'Debt-%d' % index}
+            for index in range(29)
+        ]
+        runtime = self.module.BotRuntime(
+            1, descriptor_resolver=lambda unused: _combat_descriptor(),
+            adapter_factory=lambda *unused, **unused_kwargs:
+                _FixedAdapter(command),
+            direction_probe=lambda *unused: {'clear': True, 'slope': 0.0},
+            visibility_probe=lambda *unused: True,
+            ground_probe=lambda *unused: 0.0,
+            physics_ground_probe=lambda *unused: 0.0,
+            spawn_resolver=_spawn_resolver, baked_graph=_graph(),
+            control_seconds=self.module.WORKER_CONTROL_SECONDS)
+        runtime.battle_start(dict(self.start, bots=roster))
+
+        runtime.update(self.module.WORKER_CONTROL_SECONDS, 10.0)
+        first = runtime.diagnostic_totals()
+        expected_pairs = 14 * 15 * 2
+        self.assertEqual(
+            self.module.MAX_VISIBILITY_PROBES_PER_FRAME,
+            first['visibility_admitted'])
+        self.assertEqual(first['visibility_admitted'],
+                         first['visibility_completed'])
+        self.assertEqual(expected_pairs - first['visibility_completed'],
+                         first['visibility_queue_depth'])
+        self.assertEqual(first['visibility_queue_depth'],
+                         first['visibility_deferred'])
+        self.assertEqual(first['visibility_queue_depth'],
+                         first['visibility_queue_max_depth'])
+        self.assertEqual(0, first['visibility_oldest_stale_age_ms'])
+        self.assertEqual(first['visibility_admitted'],
+                         first['visibility_new_services'])
+
+        runtime.update(self.module.WORKER_CONTROL_SECONDS, 10.1)
+        second = runtime.diagnostic_totals()
+        self.assertGreaterEqual(second['visibility_oldest_stale_age_ms'], 99)
+        self.assertGreaterEqual(
+            second['visibility_oldest_stale_max_age_ms'],
+            second['visibility_oldest_stale_age_ms'])
+
+        runtime.battle_start(dict(
+            self.start, round_id=6, bots=roster))
+        reset = runtime.diagnostic_totals()
+        for key in (
+                'visibility_queue_depth', 'visibility_queue_max_depth',
+                'visibility_oldest_stale_age_ms',
+                'visibility_oldest_stale_max_age_ms',
+                'visibility_admitted', 'visibility_completed',
+                'visibility_deferred', 'visibility_selected_services',
+                'visibility_fire_services', 'visibility_new_services',
+                'visibility_ordinary_services'):
+            self.assertEqual(0, reset[key])
 
     def test_full_roster_publication_projects_each_internal_state_once(self):
         roster = [
@@ -12967,6 +13338,131 @@ class BotRuntimeTests(unittest.TestCase):
                             [11] if contact['target_team'] == 2 else [25])
                         self.assertEqual(
                             expected, contact['shootable_by_bot_ids'])
+
+    def test_worker_supplemental_lanes_are_bounded_fair_and_selected_first(self):
+        command = self._stationary_command()
+        roster = [
+            {'id': 11 + index,
+             'team': 1 if index < 14 else 2,
+             'slot': index if index < 14 else index - 14,
+             'name': 'WorkerLane-%d' % index}
+            for index in range(29)
+        ]
+        frame = [0]
+        lane_calls = []
+
+        class HoldAdapter(_FixedAdapter):
+            def decide(self, state, unused_clear):
+                self.calls.append(state['id'])
+                return dict(self.command)
+
+            def decide_with_order(self, state, strategic, unused_clear):
+                self.server_orders.append(dict(strategic))
+                result = dict(self.command)
+                result['target_id'] = strategic.get('target_id')
+                result['fire_allowed'] = False
+                return result
+
+        def firing_lane(source, target):
+            lane_calls.append((frame[0], int(source['id']),
+                               int(target['network_id'])))
+            return True
+
+        runtime = self.module.BotRuntime(
+            1, descriptor_resolver=lambda unused: _combat_descriptor(),
+            adapter_factory=lambda *unused, **unused_kwargs:
+                HoldAdapter(command),
+            direction_probe=lambda *unused: {
+                'clear': True, 'collision': False, 'slope': 0.0},
+            visibility_probe=lambda *unused: True,
+            firing_lane_probe=firing_lane,
+            ground_probe=lambda *unused: 0.0,
+            physics_ground_probe=lambda *unused: 0.0,
+            spawn_resolver=_spawn_resolver, native_motion=True,
+            baked_graph=_graph(),
+            control_seconds=self.module.WORKER_CONTROL_SECONDS)
+        runtime.battle_start(dict(self.start, bots=roster))
+        runtime._server_orders[11] = {
+            'target_kind': 'bot', 'target_id': 25,
+            'fire_allowed': False, 'shell_index': 0,
+            'fire_range': 500.0, 'combat_mode': 'engage',
+        }
+        runtime._server_order_tokens[11] = 1
+
+        first_complete = None
+        completed_snapshot = None
+        saw_pending = False
+        for frame_index in range(80):
+            frame[0] = frame_index
+            runtime.update(
+                self.module.WORKER_CONTROL_SECONDS,
+                1.0 + frame_index * self.module.WORKER_CONTROL_SECONDS)
+            calls_before_diagnostics = len(lane_calls)
+            diagnostics = runtime.diagnostic_totals()
+            self.assertEqual(calls_before_diagnostics, len(lane_calls))
+            if diagnostics['shot_lane_pending_pairs'] > 0:
+                saw_pending = True
+            if (saw_pending and completed_snapshot is None and
+                    diagnostics['shot_lane_pending_pairs'] == 0 and
+                    diagnostics['shot_lane_completed_pairs'] >= 420):
+                completed_snapshot = diagnostics
+            observed = set((source_id, target_id)
+                           for unused_frame, source_id, target_id
+                           in lane_calls)
+            if len(observed) == 420 and first_complete is None:
+                first_complete = frame_index
+
+        per_frame = [sum(call[0] == frame_index for call in lane_calls)
+                     for frame_index in range(80)]
+        self.assertLessEqual(
+            max(per_frame),
+            self.module.MAX_WORKER_SHOT_LANE_PAIRS_PER_FRAME)
+        self.assertEqual((11, 25), lane_calls[0][1:])
+        expected = set(
+            (source['id'], target['id'])
+            for source in roster for target in roster
+            if source['team'] != target['team'])
+        self.assertTrue(expected.issubset(set(
+            (source_id, target_id)
+            for unused_frame, source_id, target_id in lane_calls)))
+        self.assertIsNotNone(first_complete)
+        # Sixteen supplemental jobs cannot complete 420 pairs inside one
+        # nominal one-second refresh. The persistent pair deadlines must carry
+        # the unfinished cohort across that boundary without starvation.
+        self.assertGreater(first_complete, 10)
+        self.assertLessEqual(first_complete, 45)
+        diagnostics = runtime.diagnostic_totals()
+        self.assertTrue(saw_pending)
+        self.assertGreater(
+            diagnostics['shot_lane_pending_max_pairs'], 0)
+        self.assertLessEqual(
+            diagnostics['shot_lane_pending_max_pairs'], 420)
+        self.assertGreaterEqual(
+            diagnostics['shot_lane_completed_pairs'], 420)
+        self.assertGreater(
+            diagnostics['shot_lane_budget_deferred_attempts'], 0)
+        self.assertGreaterEqual(
+            diagnostics['shot_lane_oldest_due_max_age_ms'], 1000)
+        self.assertLessEqual(
+            diagnostics['shot_lane_oldest_due_max_age_ms'], 5000)
+        self.assertIsNotNone(completed_snapshot)
+        self.assertEqual(
+            0, completed_snapshot['shot_lane_pending_pairs'])
+        self.assertEqual(
+            0, completed_snapshot['shot_lane_oldest_due_age_ms'])
+
+        restarted = dict(self.start)
+        restarted['round_id'] = self.start['round_id'] + 1
+        restarted['bots'] = roster
+        runtime.battle_start(restarted)
+        reset = runtime.diagnostic_totals()
+        for name in (
+                'shot_lane_pending_pairs', 'shot_lane_pending_max_pairs',
+                'shot_lane_oldest_due_age_ms',
+                'shot_lane_oldest_due_max_age_ms',
+                'shot_lane_completed_pairs',
+                'shot_lane_budget_deferred_attempts'):
+            self.assertEqual(0, reset[name])
 
     def test_unspotted_team_targets_do_not_spend_static_lane_rays(self):
         lane_pairs = []

--- a/0.9.22/tests/test_port_0922_bot_runtime.py
+++ b/0.9.22/tests/test_port_0922_bot_runtime.py
@@ -5647,6 +5647,55 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertLessEqual(
             len(calls), self.module.MAX_VISIBILITY_PROBES_PER_FRAME)
 
+    def test_slow_callback_keeps_advisory_probe_budgets_at_render_scope(self):
+        command = self._stationary_command()
+        roster = [
+            {'id': 11 + index,
+             'team': 1 if index < 14 else 2,
+             'slot': index if index < 14 else index - 14,
+             'name': 'Slow-budget-%d' % index}
+            for index in range(29)
+        ]
+        visibility_calls = []
+        lane_calls = []
+
+        class HoldAdapter(_FixedAdapter):
+            def decide(self, state, unused_clear):
+                self.calls.append(state['id'])
+                return dict(self.command)
+
+        runtime = self.module.BotRuntime(
+            1, descriptor_resolver=lambda unused: _combat_descriptor(),
+            adapter_factory=lambda *unused, **unused_kwargs:
+                HoldAdapter(command),
+            direction_probe=lambda *unused: {
+                'clear': True, 'collision': False, 'slope': 0.0},
+            visibility_probe=lambda *unused:
+                visibility_calls.append(True) or True,
+            firing_lane_probe=lambda *unused:
+                lane_calls.append(True) or True,
+            ground_probe=lambda *unused: 0.0,
+            physics_ground_probe=lambda *unused: 0.0,
+            spawn_resolver=_spawn_resolver, baked_graph=_graph(),
+            control_seconds=self.module.WORKER_CONTROL_SECONDS)
+        runtime.battle_start(dict(self.start, bots=roster))
+        for state in runtime.states.values():
+            state.update(
+                x=0.0, y=0.0,
+                z=0.0 if state['team'] == 1 else 100.0)
+
+        runtime.update(1.0, 1.0)
+
+        self.assertEqual(5, runtime._last_update_control_steps)
+        self.assertEqual(1000000, runtime._sample_time_us)
+        self.assertEqual(29, len(runtime.adapter.calls))
+        self.assertLessEqual(
+            len(visibility_calls),
+            self.module.MAX_VISIBILITY_PROBES_PER_FRAME)
+        self.assertLessEqual(
+            len(lane_calls),
+            self.module.MAX_WORKER_SHOT_LANE_PAIRS_PER_FRAME)
+
     def test_worker_denied_stale_visibility_uses_only_remembered_pose(self):
         roster = [
             {'id': 11, 'team': 1, 'slot': 0, 'name': 'Observer'},

--- a/0.9.22/tests/test_port_0922_bot_runtime.py
+++ b/0.9.22/tests/test_port_0922_bot_runtime.py
@@ -4705,6 +4705,10 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertEqual(1, len(adapter.calls))
         self.assertEqual(1000000, runtime._sample_time_us)
         self.assertAlmostEqual(0.0, runtime._accumulator)
+        self.assertEqual(5, runtime._last_update_control_steps)
+        self.assertAlmostEqual(
+            self.module.MAX_CONTROL_ELAPSED_SECONDS,
+            runtime._last_update_max_control_step)
 
     def test_worker_intermediate_ram_report_forces_state_barrier(self):
         runtime = self.module.BotRuntime(
@@ -5577,6 +5581,71 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertEqual(14, diagnostics['visibility_fire_services'])
         self.assertEqual(14, diagnostics['visibility_new_services'])
         self.assertEqual(19, diagnostics['visibility_ordinary_services'])
+
+    def test_worker_visibility_services_human_observers_before_bot_roster(self):
+        command = self._stationary_command()
+        roster = [
+            {'id': 11 + index,
+             'team': 1 if index < 14 else 2,
+             'slot': index if index < 14 else index - 14,
+             'name': 'Human-priority-%d' % index}
+            for index in range(29)
+        ]
+        calls = []
+
+        class HoldAdapter(_FixedAdapter):
+            def decide(self, state, unused_clear):
+                self.calls.append(state['id'])
+                return dict(self.command)
+
+        def visibility(source, target, unused_fired=False):
+            calls.append((
+                source.get('kind', 'bot'), int(source['id']),
+                target.get('kind', 'bot'), int(target['network_id'])))
+            return True
+
+        runtime = self.module.BotRuntime(
+            1, descriptor_resolver=lambda unused: _combat_descriptor(),
+            adapter_factory=lambda *unused, **unused_kwargs:
+                HoldAdapter(command),
+            direction_probe=lambda *unused: {
+                'clear': True, 'collision': False, 'slope': 0.0},
+            visibility_probe=visibility,
+            firing_lane_probe=lambda *unused: True,
+            ground_probe=lambda *unused: 0.0,
+            physics_ground_probe=lambda *unused: 0.0,
+            spawn_resolver=_spawn_resolver, baked_graph=_graph(),
+            control_seconds=self.module.WORKER_CONTROL_SECONDS)
+        runtime.battle_start(dict(self.start, bots=roster))
+        for state in runtime.states.values():
+            state.update(
+                x=0.0, y=0.0,
+                z=0.0 if state['team'] == 1 else 100.0)
+        players = _admit_players(
+            {'id': 1, 'team': 1, 'alive': True,
+             'vehicle': 'ussr:R11_MS-1',
+             'x': 0.0, 'y': 0.0, 'z': 0.0},
+            {'id': 2, 'team': 2, 'alive': True,
+             'vehicle': 'ussr:R11_MS-1',
+             'x': 0.0, 'y': 0.0, 'z': 100.0})
+
+        runtime.update(self.module.WORKER_CONTROL_SECONDS, 1.0,
+                       players=players)
+
+        expected_human_pairs = set()
+        for source in players:
+            for target in roster:
+                if source['team'] != target['team']:
+                    expected_human_pairs.add((
+                        'human', source['id'], 'bot', target['id']))
+            other = players[1] if source is players[0] else players[0]
+            expected_human_pairs.add((
+                'human', source['id'], 'human', other['id']))
+        observed_human_pairs = set(
+            call for call in calls if call[0] == 'human')
+        self.assertEqual(expected_human_pairs, observed_human_pairs)
+        self.assertLessEqual(
+            len(calls), self.module.MAX_VISIBILITY_PROBES_PER_FRAME)
 
     def test_worker_denied_stale_visibility_uses_only_remembered_pose(self):
         roster = [

--- a/0.9.22/tests/test_port_0922_destructibles.py
+++ b/0.9.22/tests/test_port_0922_destructibles.py
@@ -5580,6 +5580,246 @@ class DestructiblesCompatibilityTests(unittest.TestCase):
         self.assertIs(installed, destructibles_sensor._destructible_catalog)
         self.assertNotIn('g_offh_destr_instances', destructibles_sensor.__dict__)
 
+    def _empty_catalog_scan_fixture(self, streamed=True):
+        destructibles_sensor.set_catalog(_catalog({
+            'known.model': {
+                'kind': 'fragile',
+                'boxes': [[-1, -1, -1, 1, 1, 1, None]],
+            },
+        }))
+        manager = _Manager()
+        manager.space_id = 1
+        if streamed:
+            manager.set_chunk_count(22, 0)
+        mapper = mock.Mock(return_value=22)
+        area = types.ModuleType('AreaDestructibles')
+        area.g_destructiblesManager = manager
+        area.DESTR_TYPE_TREE = 1
+        area.DESTR_TYPE_FALLING_ATOM = 2
+        area.DESTR_TYPE_FRAGILE = 3
+        area.DESTR_TYPE_STRUCTURE = 4
+        area.chunkIDFromPosition = mapper
+        area.g_cache = types.SimpleNamespace(
+            getDescByFilename=lambda unused: None)
+        bigworld = types.ModuleType('BigWorld')
+        bigworld.wg_getChunkDestrFilenames = mock.Mock(return_value=())
+        bigworld.wg_getChunkMatrix = mock.Mock(return_value=
+            types.SimpleNamespace(translation=_Vector()))
+        math_module = types.ModuleType('Math')
+        math_module.Vector3 = _Vector
+        math_module.Matrix = lambda value: value
+        descriptor = _Strict1513Component(
+            hull=_Strict1513Component(
+                hitTester=types.SimpleNamespace(bbox=(
+                    (-1.6, -1.0, -3.6), (1.6, 1.0, 3.6), None))))
+        destructibles_sensor.xrange = range
+        return (manager, mapper, area, bigworld, math_module, descriptor)
+
+    def test_empty_swept_cells_avoid_repeating_full_chunk_scan_for_30_tanks(self):
+        (unused_manager, mapper, area, bigworld, math_module,
+         descriptor) = self._empty_catalog_scan_fixture()
+
+        with mock.patch.dict(
+                sys.modules, {'AreaDestructibles': area,
+                              'BigWorld': bigworld, 'Math': math_module}):
+            for index in range(30):
+                destructibles_sensor._fell_trees_near(
+                    1, _Vector(float(index) * 0.01, 0.0, 0.0),
+                    0.0, 6.0, descriptor)
+
+        # The first exact sweep maps current/forward and the surrounding 3x3
+        # chunks. Later tanks only validate the native current chunk while the
+        # complete streamed registry and the same empty swept cells are valid.
+        self.assertEqual(40, mapper.call_count)
+        bigworld.wg_getChunkDestrFilenames.assert_called_once_with(1, 22)
+        bigworld.wg_getChunkMatrix.assert_called_once_with(1, 22)
+        counts = destructibles_sensor.registry_counts()
+        self.assertEqual(29, counts['receipt_proximity_hits'])
+        self.assertEqual(1, counts['receipt_proximity_misses'])
+        self.assertEqual(1, counts['receipt_proximity_stores'])
+        self.assertEqual(1, counts['receipt_proximity_entries'])
+
+    def test_empty_swept_cell_receipt_waits_for_streaming_completion(self):
+        (manager, mapper, area, bigworld, math_module,
+         descriptor) = self._empty_catalog_scan_fixture(streamed=False)
+
+        with mock.patch.dict(
+                sys.modules, {'AreaDestructibles': area,
+                              'BigWorld': bigworld, 'Math': math_module}):
+            destructibles_sensor._fell_trees_near(
+                1, _Vector(), 0.0, 6.0, descriptor)
+            destructibles_sensor._fell_trees_near(
+                1, _Vector(), 0.0, 6.0, descriptor)
+            manager.set_chunk_count(22, 0)
+            destructibles_sensor._fell_trees_near(
+                1, _Vector(), 0.0, 6.0, descriptor)
+            destructibles_sensor._fell_trees_near(
+                1, _Vector(), 0.0, 6.0, descriptor)
+
+        # Pending scans must retry the full native mapping. Only the fourth
+        # call may reuse the empty receipt created after streaming completed.
+        self.assertEqual(34, mapper.call_count)
+        bigworld.wg_getChunkDestrFilenames.assert_called_once_with(1, 22)
+
+    def test_empty_swept_cell_receipt_drops_on_chunk_unload(self):
+        (manager, mapper, area, bigworld, math_module,
+         descriptor) = self._empty_catalog_scan_fixture()
+
+        with mock.patch.dict(
+                sys.modules, {'AreaDestructibles': area,
+                              'BigWorld': bigworld, 'Math': math_module}):
+            destructibles_sensor._fell_trees_near(
+                1, _Vector(), 0.0, 6.0, descriptor)
+            destructibles_sensor._fell_trees_near(
+                1, _Vector(), 0.0, 6.0, descriptor)
+            del manager._DestructiblesManager__loadedChunkIDs[22]
+            destructibles_sensor._fell_trees_near(
+                1, _Vector(), 0.0, 6.0, descriptor)
+
+        self.assertEqual(23, mapper.call_count)
+        self.assertNotIn(
+            22, destructibles_sensor.g_offh_tree_state['chunks'])
+        counts = destructibles_sensor.registry_counts()
+        self.assertEqual(1, counts['receipt_proximity_hits'])
+        self.assertEqual(2, counts['receipt_proximity_misses'])
+        self.assertEqual(1, counts['receipt_proximity_invalidated'])
+        self.assertEqual(0, counts['receipt_proximity_entries'])
+
+    def test_empty_swept_cell_receipt_counts_native_count_change_as_miss(self):
+        (manager, mapper, area, bigworld, math_module,
+         descriptor) = self._empty_catalog_scan_fixture()
+        bigworld.wg_getDestructibleMatrix = mock.Mock(
+            return_value=_ItemMatrix())
+
+        with mock.patch.dict(
+                sys.modules, {'AreaDestructibles': area,
+                              'BigWorld': bigworld, 'Math': math_module}):
+            destructibles_sensor._fell_trees_near(
+                1, _Vector(), 0.0, 6.0, descriptor)
+            destructibles_sensor._fell_trees_near(
+                1, _Vector(), 0.0, 6.0, descriptor)
+            manager.set_chunk_count(22, 1)
+            destructibles_sensor._fell_trees_near(
+                1, _Vector(), 0.0, 6.0, descriptor)
+
+        counts = destructibles_sensor.registry_counts()
+        self.assertEqual(1, counts['receipt_proximity_hits'])
+        self.assertEqual(2, counts['receipt_proximity_misses'])
+        self.assertEqual(2, counts['receipt_proximity_stores'])
+        self.assertEqual(1, counts['receipt_proximity_invalidated'])
+        self.assertEqual(1, counts['receipt_proximity_entries'])
+
+    def test_empty_swept_cell_receipt_invalidates_on_spatial_index_change(self):
+        (unused_manager, mapper, area, bigworld, math_module,
+         descriptor) = self._empty_catalog_scan_fixture()
+
+        with mock.patch.dict(
+                sys.modules, {'AreaDestructibles': area,
+                              'BigWorld': bigworld, 'Math': math_module}):
+            destructibles_sensor._fell_trees_near(
+                1, _Vector(), 0.0, 6.0, descriptor)
+            destructibles_sensor._fell_trees_near(
+                1, _Vector(), 0.0, 6.0, descriptor)
+            instance = {
+                'boxes': (((100.0, 0.0, 100.0),
+                           ((1.0, 0.0, 0.0), (0.0, 1.0, 0.0),
+                            (0.0, 0.0, 1.0)), None),),
+            }
+            destructibles_sensor._index_catalog_instance_1513(
+                destructibles_sensor.g_offh_destr_contact_bins,
+                (22, 7), instance)
+            destructibles_sensor._fell_trees_near(
+                1, _Vector(), 0.0, 6.0, descriptor)
+
+        # The second call uses one current-chunk validation. Adding any exact
+        # footprint invalidates all older negative spatial receipts.
+        self.assertEqual(23, mapper.call_count)
+
+    def test_empty_swept_cell_receipt_is_not_used_while_a_column_moves(self):
+        (unused_manager, mapper, area, bigworld, math_module,
+         descriptor) = self._empty_catalog_scan_fixture()
+
+        with mock.patch.dict(
+                sys.modules, {'AreaDestructibles': area,
+                              'BigWorld': bigworld, 'Math': math_module}):
+            destructibles_sensor._fell_trees_near(
+                1, _Vector(), 0.0, 6.0, descriptor)
+            destructibles_sensor.g_offh_destr_falling_active = {
+                (22, 7): {'last_refresh': None},
+            }
+            destructibles_sensor._fell_trees_near(
+                1, _Vector(), 0.0, 6.0, descriptor)
+
+        # A moving column can enter a previously empty cell. It therefore
+        # keeps the complete scan live until its final indexed pose settles.
+        self.assertEqual(22, mapper.call_count)
+
+    def test_empty_catalog_hull_cells_are_scanned_once_per_spatial_generation(self):
+        (unused_manager, unused_mapper, unused_area, unused_bigworld,
+         unused_math, descriptor) = self._empty_catalog_scan_fixture()
+        destructibles_sensor.g_offh_destr_instances = {}
+        destructibles_sensor.g_offh_destr_contact_bins = {}
+
+        with mock.patch.object(
+                destructibles_sensor, '_bin_keys_for_bounds',
+                wraps=destructibles_sensor._bin_keys_for_bounds) as bins:
+            for index in range(30):
+                self.assertFalse(destructibles_sensor._catalog_hull_contact(
+                    _Vector(float(index) * 0.01, 0.0, 0.0),
+                    0.0, 6.0, descriptor, 0.04))
+
+        self.assertEqual(1, bins.call_count)
+        counts = destructibles_sensor.registry_counts()
+        self.assertEqual(29, counts['receipt_contact_hits'])
+        self.assertEqual(1, counts['receipt_contact_misses'])
+        self.assertEqual(1, counts['receipt_contact_stores'])
+        self.assertEqual(1, counts['receipt_contact_entries'])
+
+    def test_empty_catalog_hull_receipt_expires_outside_swept_cell_envelope(self):
+        (unused_manager, unused_mapper, unused_area, unused_bigworld,
+         unused_math, descriptor) = self._empty_catalog_scan_fixture()
+        destructibles_sensor.g_offh_destr_instances = {}
+        destructibles_sensor.g_offh_destr_contact_bins = {}
+
+        with mock.patch.object(
+                destructibles_sensor, '_bin_keys_for_bounds',
+                wraps=destructibles_sensor._bin_keys_for_bounds) as bins:
+            self.assertFalse(destructibles_sensor._catalog_hull_contact(
+                _Vector(), 0.0, 6.0, descriptor, 0.04))
+            self.assertFalse(destructibles_sensor._catalog_hull_contact(
+                _Vector(6.0, 0.0, 0.0), 0.0, 6.0, descriptor, 0.04))
+
+        self.assertEqual(2, bins.call_count)
+
+    def test_new_exact_contact_invalidates_empty_catalog_hull_receipt(self):
+        (unused_manager, unused_mapper, unused_area, unused_bigworld,
+         unused_math, descriptor) = self._empty_catalog_scan_fixture()
+        destructibles_sensor.g_offh_destr_instances = {}
+        destructibles_sensor.g_offh_destr_contact_bins = {}
+        self.assertFalse(destructibles_sensor._catalog_hull_contact(
+            _Vector(), 0.0, 6.0, descriptor, 0.04))
+        instance = {
+            'filename': 'known.model',
+            'descriptor_filename': 'known.model',
+            'kind': 'fragile',
+            'item_scale': 1.0,
+            'boxes': (((0.0, 0.0, 3.8),
+                       ((0.25, 0.0, 0.0), (0.0, 0.5, 0.0),
+                        (0.0, 0.0, 0.25)), None),),
+        }
+        destructibles_sensor.g_offh_destr_instances[(22, 7)] = instance
+        destructibles_sensor._index_catalog_instance_1513(
+            destructibles_sensor.g_offh_destr_contact_bins,
+            (22, 7), instance)
+
+        self.assertTrue(destructibles_sensor._catalog_hull_contact(
+            _Vector(), 0.0, 6.0, descriptor, 0.04))
+        counts = destructibles_sensor.registry_counts()
+        self.assertEqual(2, counts['receipt_contact_misses'])
+        self.assertEqual(1, counts['receipt_contact_stores'])
+        self.assertEqual(1, counts['receipt_contact_invalidated'])
+        self.assertEqual(0, counts['receipt_contact_entries'])
+
     def test_chunk_registry_limits_each_frame_to_nearby_contact_bins(self):
         registry = {'bins': {}, 'extended_bins': {}, 'count': 0,
                     'max_radius': 4.5}

--- a/0.9.22/tools/benchmark_bot_cadence.py
+++ b/0.9.22/tools/benchmark_bot_cadence.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""Compare render-frame and fixed-30-Hz authority bot simulation costs.
+"""Compare render-frame and production fixed-cadence bot simulation costs.
 
 The render-frame case forces the production update body due on every frame;
-the fixed case uses its normal scheduler.  Both runs use the same deterministic
-29-bot roster, probes, descriptors, commands and 60 FPS timeline.
+the fixed case uses the hidden worker's explicit control scheduler. Both runs
+use the same deterministic 29-bot roster, probes, descriptors and commands.
 """
 
 import argparse
@@ -32,7 +32,7 @@ def _command():
     }
 
 
-def _runtime(visible=True):
+def _runtime(visible=True, control_seconds=None):
     module = fixtures._load()
     command = _command()
     runtime = module.BotRuntime(
@@ -46,7 +46,8 @@ def _runtime(visible=True):
         ground_probe=lambda *unused: 0.0,
         physics_ground_probe=lambda *unused: 0.0,
         spawn_resolver=fixtures._spawn_resolver,
-        baked_graph=fixtures._graph())
+        baked_graph=fixtures._graph(),
+        control_seconds=control_seconds)
     roster = []
     for index in range(29):
         team = 1 if index < 15 else 2
@@ -62,21 +63,60 @@ def _runtime(visible=True):
     return runtime
 
 
-def _run(seconds, fps, render_frame_baseline, visible=True):
-    runtime = _runtime(visible=visible)
+def _run(seconds, fps, render_frame_baseline, control_hz, visible=True):
+    control_seconds = (None if render_frame_baseline else
+                       1.0 / float(control_hz))
+    runtime = _runtime(
+        visible=visible, control_seconds=control_seconds)
     frame_count = int(round(float(seconds) * float(fps)))
     dt = 1.0 / float(fps)
     simulation_calls = 0
+    probe_rows = []
+    callback_times = []
+    previous_probes = runtime.probe_totals()
     started = time.perf_counter()
     for frame in range(frame_count):
         now = 100.0 + (frame + 1) * dt
         if render_frame_baseline:
             runtime._next_publication = now
+        callback_started = time.perf_counter()
         outgoing = runtime.update(dt, now)
+        callback_times.append(time.perf_counter() - callback_started)
         simulation_calls += int(any(
             message.get('type') == 'bot_state' for message in outgoing))
+        current_probes = runtime.probe_totals()
+        probe_rows.append(tuple(
+            current_probes[index] - previous_probes[index]
+            for index in range(len(current_probes))))
+        previous_probes = current_probes
     elapsed = time.perf_counter() - started
-    return simulation_calls, elapsed, runtime.probe_totals()
+    return (simulation_calls, elapsed, runtime.probe_totals(), probe_rows,
+            callback_times, runtime.diagnostic_totals())
+
+
+def _percentile(values, fraction):
+    values = sorted(float(value) for value in values)
+    if not values:
+        return 0.0
+    if len(values) == 1:
+        return values[0]
+    rank = min(1.0, max(0.0, float(fraction))) * (len(values) - 1)
+    lower = int(rank)
+    upper = min(len(values) - 1, lower + 1)
+    weight = rank - lower
+    return values[lower] * (1.0 - weight) + values[upper] * weight
+
+
+def _distribution(values):
+    return tuple(_percentile(values, fraction) * 1000.0
+                 for fraction in (0.50, 0.95, 0.99, 1.0))
+
+
+def _probe_maxima(rows):
+    if not rows:
+        return (0,) * len(fixtures._load().PROBE_KINDS)
+    return tuple(max(row[index] for row in rows)
+                 for index in range(len(rows[0])))
 
 
 def _publication_cost(states, projector, iterations, legacy_double_copy):
@@ -96,21 +136,28 @@ def main():
     parser.add_argument('--fps', type=int, default=60)
     parser.add_argument('--repeats', type=int, default=3)
     parser.add_argument(
+        '--control-hz', type=float, default=10.0,
+        help='fixed hidden-worker control rate (production default: 10)')
+    parser.add_argument(
         '--blocked-visibility', action='store_true',
         help='make every native visibility ray report static cover')
     args = parser.parse_args()
-    if args.seconds <= 0.0 or args.fps <= 0 or args.repeats <= 0:
-        parser.error('seconds, fps and repeats must be positive')
+    if (args.seconds <= 0.0 or args.fps <= 0 or args.repeats <= 0 or
+            args.control_hz <= 0.0):
+        parser.error('seconds, fps, repeats and control-hz must be positive')
 
     fixed_times = []
     baseline_times = []
     fixed_calls = baseline_calls = None
     for unused_repeat in range(args.repeats):
-        baseline_calls, baseline_time, baseline_probes = _run(
-            args.seconds, args.fps, True,
+        (baseline_calls, baseline_time, baseline_probes,
+         baseline_probe_rows, baseline_callback_times,
+         baseline_diagnostics) = _run(
+            args.seconds, args.fps, True, args.control_hz,
             visible=not args.blocked_visibility)
-        fixed_calls, fixed_time, fixed_probes = _run(
-            args.seconds, args.fps, False,
+        (fixed_calls, fixed_time, fixed_probes,
+         fixed_probe_rows, fixed_callback_times, fixed_diagnostics) = _run(
+            args.seconds, args.fps, False, args.control_hz,
             visible=not args.blocked_visibility)
         baseline_times.append(baseline_time)
         fixed_times.append(fixed_time)
@@ -141,17 +188,41 @@ def main():
             projection_iterations, False)
         for unused_repeat in range(args.repeats)
     ])
-    print('fps=%d bots=29 seconds=%.3f frames=%d repeats=%d' % (
-        args.fps, args.seconds,
+    print('fps=%d control_hz=%.3f bots=29 seconds=%.3f frames=%d repeats=%d' % (
+        args.fps, args.control_hz, args.seconds,
         int(round(args.seconds * args.fps)), args.repeats))
     print('render_frame_baseline calls=%d median_ms=%.3f' % (
         baseline_calls, baseline_median * 1000.0))
-    print('fixed_30hz calls=%d median_ms=%.3f' % (
+    print('fixed_control calls=%d median_ms=%.3f' % (
         fixed_calls, fixed_median * 1000.0))
-    print('render_frame_probes %s' % dict(zip(
+    print('render_frame_logical_probes %s' % dict(zip(
         runtime_module.PROBE_KINDS, baseline_probes)))
-    print('fixed_30hz_probes %s' % dict(zip(
+    print('fixed_control_logical_probes %s' % dict(zip(
         runtime_module.PROBE_KINDS, fixed_probes)))
+    print('render_frame_logical_probe_max_per_callback %s' % dict(zip(
+        runtime_module.PROBE_KINDS, _probe_maxima(baseline_probe_rows))))
+    print('fixed_control_logical_probe_max_per_callback %s' % dict(zip(
+        runtime_module.PROBE_KINDS, _probe_maxima(fixed_probe_rows))))
+    print('render_frame_callback_ms_p50_p95_p99_max %.3f/%.3f/%.3f/%.3f' %
+          _distribution(baseline_callback_times))
+    print('fixed_control_callback_ms_p50_p95_p99_max %.3f/%.3f/%.3f/%.3f' %
+          _distribution(fixed_callback_times))
+    print('fixed_control_visibility_scheduler %s' % dict(
+        (name, fixed_diagnostics.get(name)) for name in (
+            'visibility_queue_depth', 'visibility_queue_max_depth',
+            'visibility_oldest_stale_age_ms',
+            'visibility_oldest_stale_max_age_ms',
+            'visibility_admitted', 'visibility_completed',
+            'visibility_deferred', 'visibility_selected_services',
+            'visibility_fire_services', 'visibility_new_services',
+            'visibility_ordinary_services')))
+    print('fixed_control_supplemental_lane_scheduler %s' % dict(
+        (name, fixed_diagnostics.get(name)) for name in (
+            'shot_lane_pending_pairs', 'shot_lane_pending_max_pairs',
+            'shot_lane_oldest_due_age_ms',
+            'shot_lane_oldest_due_max_age_ms',
+            'shot_lane_completed_pairs',
+            'shot_lane_budget_deferred_attempts')))
     print('call_reduction=%.1f%% elapsed_speedup=%.3fx' % (
         reduction, speedup))
     print('publication_fields internal=%d wire=%d reduction=%.1f%%' % (

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,9 +12,6 @@ or editing that implementation: `0.8.2/CLAUDE.md` or `0.9.22/CLAUDE.md`.
 - Discuss plans, evidence, tradeoffs, progress, and results with Peng in
   Chinese. Keep code, comments, commit messages, logs, and shared repository
   documentation in English.
-- Use direct, ordinary Chinese terminology with Peng. Refer to the hidden
-  worker as the `hidden worker`, and describe its exact native-query or
-  rendering role directly; do not use metaphorical aliases in conversation.
 - Lead with the observed outcome and supporting evidence. Separate a confirmed
   fact from an inference, and say exactly which boundary still needs a real
   Windows client.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,9 @@ or editing that implementation: `0.8.2/CLAUDE.md` or `0.9.22/CLAUDE.md`.
 - Discuss plans, evidence, tradeoffs, progress, and results with Peng in
   Chinese. Keep code, comments, commit messages, logs, and shared repository
   documentation in English.
+- Use direct, ordinary Chinese terminology with Peng. Refer to the hidden
+  worker as the `hidden worker`, and describe its exact native-query or
+  rendering role directly; do not use metaphorical aliases in conversation.
 - Lead with the observed outcome and supporting evidence. Separate a confirmed
   fact from an inference, and say exactly which boundary still needs a real
   Windows client.


### PR DESCRIPTION
## Summary\n\n- keep the v0.6.1 Python-only authority path and leave Rust PR #7 untouched\n- bound 15-vs-15 visibility work to 48 logical probes per control callback with fair rotation and selected/fire/new-target priority\n- bound supplemental tactical firing-lane work to 16 pairs per control callback while preserving the independent final-fire safety gate\n- cache only proven-empty destructible cell envelopes with stream, spatial revision, movement, space, and lifecycle invalidation\n- skip exact duplicate authority pose and aim writes while explicitly settling stop edges\n- add hidden-worker render cadence, callback percentiles, logical probe time/rate, debt, A*, CPU, and working-set diagnostics\n- update the synthetic cadence benchmark to model the production 10 Hz control scheduler\n\n## Linux synthetic evidence\n\n29 bots, 10 Hz control, 5 seconds:\n\n| Metric | main | this branch | Change |\n| --- | ---: | ---: | ---: |\n| visibility logical probes | 10,500 | 2,352 | -77.6% |\n| supplemental/final lane logical probes | 2,232 | 788 | -64.7% |\n| all logical probes | 16,655 | 7,063 | -57.6% |\n| max visibility probes per callback | 420 | 48 | -88.6% |\n| max lane probes per callback | 64 | 16 | -75.0% |\n\nThe new fixed-control totals are identical with 60, 30, and 10 render callbacks per second. A pure-Python cProfile workload is effectively unchanged overall: 2.47386 s on main versus 2.47268 s here. The scheduler cost is offset by less visibility/profile work.\n\nThese are logical Python probe boundaries, not raw native calls or primitives. Mock timing does not prove a Windows FPS improvement.\n\nA repeated empty 30-tank destructible envelope reduces chunkIDFromPosition calls from 330 to 40. Static 29-bot presentation writes once and skips the next 29 exact duplicate pose/aim writes.\n\n## Safety boundaries\n\n- deferred stale visibility fails closed as a direct observation and keeps only the existing remembered team pose\n- missing or late supplemental lane samples are not shootable\n- accepted fire still uses its independent current final lane and friendly-lane checks\n- countdown motion receipts do not authorize the first live step; the live direction is fully re-probed\n- changed-position stop samples settle the real RemoteVehicle filter in the same callback\n- empty destructible receipts invalidate on index mutation, falling movement, stream unload/count change, space change, and reset\n\n## Validation\n\n- 0.9.22 discovery: 2,917 tests, 0 skipped\n- CPython 2.7 in-memory compile: 88 client Python files\n- launcher discovery: 493 tests, 2 Windows-only skips\n- 0.8.2 discovery: 904 tests, 0 skipped\n- Windows server/packaging contract: 23 tests\n- git diff --check\n- benchmark at 60, 30, and 10 FPS inputs\n\n## Exact Windows #1513 remaining\n\nThe draft still needs a sustained 15-vs-15 run with two visible clients on the exact #1513 Windows client. That run must capture actual render FPS/frame percentiles, logical probe timing/debt, process CPU and working set, and gameplay behavior. GPU and raw native call/primitive counts are explicitly not measured by this patch.\n\nNo tag or release is created.