### PR TITLE
Port lateral collision sweeps to Python runtime

### DIFF
--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -13357,6 +13357,9 @@ class BattleRuntime(object):
         world_hull_yaw = yaw if hull_yaw is None else hull_yaw
         world_motion_yaw = (None if hull_yaw is None else
                             yaw if speed >= 0.0 else yaw + math.pi)
+        destructible_motion = ({}
+                               if world_motion_yaw is None else
+                               {'motion_yaw': world_motion_yaw})
         kinetic_speed = None
         if allow_crush_drive:
             params = self._local_physics
@@ -13370,9 +13373,10 @@ class BattleRuntime(object):
             proposer = getattr(
                 self._destructibles, '_catalog_motion_proposal', None)
             proposal = (proposer(
-                self._avatar.spaceID, self._vector(position), yaw,
+                self._avatar.spaceID, self._vector(position), world_hull_yaw,
                 speed, entity.typeDescriptor, self._clock(),
-                dt=dt, kinetic_speed=kinetic_speed)
+                dt=dt, kinetic_speed=kinetic_speed,
+                **destructible_motion)
                 if callable(proposer) else None)
             # Lightweight injected adapters predating the proposal seam keep
             # using the read-only catalog path below. Production's pinned
@@ -13451,24 +13455,26 @@ class BattleRuntime(object):
         if world_status == 'hard':
             if self._destructibles is not None:
                 if self._destructibles._catalog_pending_at_hull(
-                        self._vector(position), yaw, speed,
-                        entity.typeDescriptor, self._clock(), dt):
+                        self._vector(position), world_hull_yaw, speed,
+                        entity.typeDescriptor, self._clock(), dt,
+                        **destructible_motion):
                     self._local_motion_soft_block = True
                     self._local_motion_kinds = 'broken'
                 elif self._destructibles._catalog_hull_contact(
-                        self._vector(position), yaw, speed,
-                        entity.typeDescriptor, dt):
+                        self._vector(position), world_hull_yaw, speed,
+                        entity.typeDescriptor, dt, **destructible_motion):
                     self._local_motion_kinds = 'world'
             self._local_motion_status = 'hard'
             return False
         if self._destructibles is None:
             return world_status == 'clear'
         detail = self._destructibles._catalog_motion_blocked(
-            self._avatar.spaceID, self._vector(position), yaw,
+            self._avatar.spaceID, self._vector(position), world_hull_yaw,
             speed, entity.typeDescriptor, self._clock(),
             dt=dt, kinetic_speed=kinetic_speed,
             return_detail=True,
-            kinetic_commit=False, commit_enabled=False)
+            kinetic_commit=False, commit_enabled=False,
+            **destructible_motion)
         # Keep injected legacy test/adaptor seams fail-closed.  Production's
         # exact #1513 sensor always returns the typed receipt above.
         if isinstance(detail, bool):

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -12964,6 +12964,12 @@ class BattleRuntime(object):
             self._local_motion_kinds = 'arena'
             self._local_motion_status = 'hard'
             return False
+        # Ram separation, airborne carry and wall deflection can translate the
+        # tank across its heading.  Keep the native corridor aligned with that
+        # travel while retaining the real chassis orientation and footprint.
+        world_hull_yaw = yaw if hull_yaw is None else hull_yaw
+        world_motion_yaw = (None if hull_yaw is None else
+                            yaw if speed >= 0.0 else yaw + math.pi)
         kinetic_speed = None
         if allow_crush_drive:
             params = self._local_physics
@@ -13005,9 +13011,11 @@ class BattleRuntime(object):
                         predictor(token))
                 world_status = world_collision.check_horizontal_collision(
                     self._runtime.bigworld, self._runtime.math,
-                    self._avatar.spaceID, self._vector(position), yaw, speed,
+                    self._avatar.spaceID, self._vector(position),
+                    world_hull_yaw, speed,
                     entity.typeDescriptor, self._local_airborne, dt, True,
-                    True, kinetic_speed, commit_enabled=False)
+                    True, kinetic_speed, commit_enabled=False,
+                    motion_yaw=world_motion_yaw)
                 if isinstance(world_status, bool):
                     world_status = 'hard' if world_status else 'clear'
                 if world_status not in ('clear', 'kinetic'):
@@ -13046,10 +13054,11 @@ class BattleRuntime(object):
                 return True
         world_status = world_collision.check_horizontal_collision(
             self._runtime.bigworld, self._runtime.math,
-            self._avatar.spaceID, self._vector(position), yaw, speed,
+            self._avatar.spaceID, self._vector(position),
+            world_hull_yaw, speed,
             entity.typeDescriptor, self._local_airborne, dt, True,
             bool(kinetic_speed is not None), kinetic_speed,
-            commit_enabled=False)
+            commit_enabled=False, motion_yaw=world_motion_yaw)
         if isinstance(world_status, bool):
             world_status = 'hard' if world_status else 'clear'
         if world_status == 'hard':

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/destructibles_sensor.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/destructibles_sensor.py
@@ -994,10 +994,15 @@ def _boxes_intersect(left, right):
 	right_center, right_half_axes = right[:2]
 	delta = tuple(right_center[index] - left_center[index]
 		for index in range(3))
-	axes = list(_box_face_axes(left_half_axes))
-	axes.extend(_box_face_axes(right_half_axes))
-	axes.extend(_vector_cross(left_axis, right_axis)
-		for left_axis in left_half_axes for right_axis in right_half_axes)
+	# A translated OBB is a four-generator zonotope: its three original
+	# half-axes plus half of the translation.  The separating axes for two
+	# zonotopes are the cross products of every generator pair.  Ordinary
+	# three-axis OBBs therefore retain the same 15 SAT axes, while a swept hull
+	# can preserve its real orientation without collapsing into a lossy box.
+	generators = tuple(left_half_axes) + tuple(right_half_axes)
+	axes = (_vector_cross(generators[left_index], generators[right_index])
+		for left_index in range(len(generators))
+		for right_index in range(left_index + 1, len(generators)))
 	for axis in axes:
 		length_squared = _vector_dot(axis, axis)
 		if length_squared <= 1.0e-16:
@@ -1391,7 +1396,8 @@ def _stream_baked_motion_instances_1513(spaceID, vehicle_box):
 			_stream_baked_shot_instance_1513(spaceID, identity)
 
 
-def _vehicle_swept_box(pos, yaw, vel, bbox, travel_reach=None):
+def _vehicle_swept_box(pos, yaw, vel, bbox, travel_reach=None,
+		motion_yaw=None):
 	import math
 	minimum, maximum = bbox[:2]
 	half_width = max(abs(minimum[0]), abs(maximum[0])) + 0.5
@@ -1403,6 +1409,32 @@ def _vehicle_swept_box(pos, yaw, vel, bbox, travel_reach=None):
 		reach = 0.8 + min(abs(vel) * 0.25, 1.2)
 	else:
 		reach = max(0.0, float(travel_reach))
+	if motion_yaw is not None:
+		# Ram separation, slope slip and wall deflection translate the chassis
+		# independently of its orientation.  Preserve the real hull OBB and add
+		# half of the translation as a fourth zonotope generator.  This is the
+		# exact swept volume for a fixed-orientation OBB; rotating the hull to the
+		# travel direction would lose the long front/rear corners.
+		cos_y = math.cos(yaw)
+		sin_y = math.sin(yaw)
+		center_forward = (front - back) * 0.5
+		half_forward = (front + back) * 0.5
+		motion_sin = math.sin(float(motion_yaw))
+		motion_cos = math.cos(float(motion_yaw))
+		travel_x = motion_sin * reach
+		travel_z = motion_cos * reach
+		center_y = pos.y + (minimum[1] + maximum[1]) * 0.5
+		half_y = (maximum[1] - minimum[1]) * 0.5
+		center = (
+			pos.x + sin_y * center_forward + travel_x * 0.5,
+			center_y,
+			pos.z + cos_y * center_forward + travel_z * 0.5)
+		half_axes = (
+			(cos_y * half_width, 0.0, -sin_y * half_width),
+			(0.0, half_y, 0.0),
+			(sin_y * half_forward, 0.0, cos_y * half_forward),
+			(travel_x * 0.5, 0.0, travel_z * 0.5))
+		return center, half_axes
 	if vel < 0.0:
 		minimum_forward = -(back + reach)
 		maximum_forward = front
@@ -1933,7 +1965,8 @@ def take_ground_skip_count():
 	return int(count)
 
 
-def _catalog_pending_at_hull(pos, yaw, vel, td, now, dt=0.04):
+def _catalog_pending_at_hull(pos, yaw, vel, td, now, dt=0.04,
+		motion_yaw=None):
 	"""Return whether a fragile/module hide window still covers the hull.
 
 	This is classification only.  Callers keep the pose blocked while the native
@@ -1945,7 +1978,8 @@ def _catalog_pending_at_hull(pos, yaw, vel, td, now, dt=0.04):
 	if _destructible_catalog is None or bbox is None:
 		return False
 	vehicle_box = _vehicle_swept_box(
-		pos, yaw, vel, bbox, _motion_travel_reach(vel, dt))
+		pos, yaw, vel, bbox, _motion_travel_reach(vel, dt),
+		motion_yaw=motion_yaw)
 	pending = globals().get('g_offh_destr_pending', {})
 	for candidate in _catalog_contact_candidates(vehicle_box):
 		deadline = pending.get((candidate[0], candidate[1], candidate[2]))
@@ -1954,14 +1988,16 @@ def _catalog_pending_at_hull(pos, yaw, vel, td, now, dt=0.04):
 	return False
 
 
-def _catalog_hull_contact(pos, yaw, vel, td, dt=0.04):
+def _catalog_hull_contact(pos, yaw, vel, td, dt=0.04,
+		motion_yaw=None):
 	"""Cheap contact-bin guard for the copied player/Bot pose integrators."""
 	bbox = _vehicle_hull_bbox(td)
 	if _destructible_catalog is None or bbox is None:
 		return False
 	return bool(_catalog_contact_candidates(
 		_vehicle_swept_box(
-			pos, yaw, vel, bbox, _motion_travel_reach(vel, dt))))
+			pos, yaw, vel, bbox, _motion_travel_reach(vel, dt),
+			motion_yaw=motion_yaw)))
 
 
 def _catalog_motion_result(status, token=None, accepted_now=False,
@@ -1988,7 +2024,7 @@ def _catalog_motion_result(status, token=None, accepted_now=False,
 def _catalog_motion_blocked(spaceID, pos, yaw, vel, td, now,
 		return_status=False, dt=0.04, kinetic_speed=None,
 		return_detail=False, kinetic_commit=False, commit_enabled=True,
-		proposal_only=False):
+		proposal_only=False, motion_yaw=None):
 	"""Resolve exact streamed OBB contact before committing local movement."""
 	if proposal_only and (not return_detail or not kinetic_commit):
 		raise ValueError(
@@ -2007,7 +2043,8 @@ def _catalog_motion_blocked(spaceID, pos, yaw, vel, td, now,
 	auth = _get_destr_authority()
 	_refresh_destroyed_falling_instances_1513(spaceID, auth, now)
 	vehicle_box = _vehicle_swept_box(
-		pos, yaw, vel, bbox, _motion_travel_reach(vel, dt))
+		pos, yaw, vel, bbox, _motion_travel_reach(vel, dt),
+		motion_yaw=motion_yaw)
 	# The visible player does not run the authority Bot scan that normally
 	# populates the live item registry.  Admit only checksum-pinned wires in the
 	# current hull bins through the same read-only native validation as shells.
@@ -2024,7 +2061,7 @@ def _catalog_motion_blocked(spaceID, pos, yaw, vel, td, now,
 	instances = globals().get('g_offh_destr_instances', {})
 	contact_box = (_vehicle_contact_box(
 		pos, yaw, bbox, travel=float(vel) * max(0.0, float(dt)))
-		if kinetic_speed is not None else None)
+		if kinetic_speed is not None and motion_yaw is None else None)
 	blocked = False
 	crushed = False
 	kinetic = False
@@ -2178,12 +2215,13 @@ def _catalog_motion_blocked(spaceID, pos, yaw, vel, td, now,
 
 
 def _catalog_motion_proposal(spaceID, pos, yaw, vel, td, now,
-		dt=0.04, kinetic_speed=None):
+		dt=0.04, kinetic_speed=None, motion_yaw=None):
 	"""Return a mutation-free exact hull-sweep proposal for worker review."""
 	return _catalog_motion_blocked(
 		spaceID, pos, yaw, vel, td, now, dt=dt,
 		kinetic_speed=kinetic_speed, return_detail=True,
-		kinetic_commit=True, commit_enabled=True, proposal_only=True)
+		kinetic_commit=True, commit_enabled=True, proposal_only=True,
+		motion_yaw=motion_yaw)
 
 
 def _catalog_instance_boxes(chunkID, itemIndex, filename, kind,

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/world_collision.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/world_collision.py
@@ -242,57 +242,89 @@ def _check_horizontal_collision(spaceID, pos, yaw, vel, td=None,
 			# 1.2 m cap was shorter than a 20 m/s tank's 2 m slow-frame step and
 			# could miss a hard wall immediately behind a crushed light prop.
 			_ahead = max(0.4, abs(vel) * dt + 0.2)
-		# Hull yaw owns the OBB.  Lateral impulses may supply a different
-		# direction for the swept corridor without rotating that footprint.
 		cos_y = math.cos(yaw)
 		sin_y = math.sin(yaw)
-		right_x, right_z = cos_y, -sin_y
-		forward_x, forward_z = sin_y, cos_y
-		explicit_motion_yaw = motion_yaw is not None
+		lane_segments = []
 		if motion_yaw is None:
-			motion_yaw = (float(yaw) if vel > 0.0 else
-				float(yaw) + math.pi)
-		motion_sin = math.sin(float(motion_yaw))
-		motion_cos = math.cos(float(motion_yaw))
-		perp_x, perp_z = motion_cos, -motion_sin
-		forward_dot = (
-			motion_sin * forward_x + motion_cos * forward_z)
-		right_dot = motion_sin * right_x + motion_cos * right_z
-		leading_extent = (abs(right_dot) * hw + max(
-			forward_dot * -hl_back, forward_dot * hl_front))
-		perp_forward_dot = (
-			perp_x * forward_x + perp_z * forward_z)
-		perp_right_dot = perp_x * right_x + perp_z * right_z
-		lateral_right_extent = abs(perp_right_dot) * hw
-		lateral_min = lateral_right_extent * -1.0 + min(
-			perp_forward_dot * -hl_back,
-			perp_forward_dot * hl_front)
-		lateral_max = lateral_right_extent + max(
-			perp_forward_dot * -hl_back,
-			perp_forward_dot * hl_front)
-		lane_offsets = (lateral_min, 0.0, lateral_max)
-		if not explicit_motion_yaw and vel <= 0.0:
-			# The reverse motion basis points its perpendicular to the old
-			# right-to-left lane order.  Retain the legacy left/centre/right
-			# evaluation order because a lane may own one native prop commit.
-			lane_offsets = (lateral_max, 0.0, lateral_min)
+			# Keep the shipped longitudinal probe byte-for-byte in geometry and
+			# lane order.  The explicit path below is only for cross-heading
+			# translation introduced by ram, slip and wall deflection.
+			back_margin = -0.5 if vel > 0.0 else 0.5
+			front_margin = ((hl_front + _ahead) if vel > 0.0 else
+				-(hl_back + _ahead))
+			direction = 1.0 if vel >= 0.0 else -1.0
+			look = (hl_front if vel > 0.0 else hl_back) + _ahead
+			target_len = abs(back_margin) + look
+			for offset_x in (-hw, 0.0, hw):
+				sx = pos.x + cos_y * offset_x
+				sz = pos.z - sin_y * offset_x
+				x1 = sx + sin_y * back_margin
+				z1 = sz + cos_y * back_margin
+				x2 = sx + sin_y * front_margin
+				z2 = sz + cos_y * front_margin
+				lane_segments.append((
+					x1, z1, x2, z2, target_len,
+					sx, sz, sin_y, cos_y, direction, look))
+		else:
+			# The supplied yaw is already the true signed travel direction.
+			# Sweep each real hull corner plus the centre line.  A diagonal
+			# projection can leave a corner metres behind the old shared u=-0.5
+			# start, while strict lateral/longitudinal motion merges back to three
+			# lanes.
+			motion_sin = math.sin(float(motion_yaw))
+			motion_cos = math.cos(float(motion_yaw))
+			perp_x, perp_z = motion_cos, -motion_sin
+			right_u = motion_sin * cos_y - motion_cos * sin_y
+			forward_u = motion_sin * sin_y + motion_cos * cos_y
+			right_v = perp_x * cos_y - perp_z * sin_y
+			forward_v = perp_x * sin_y + perp_z * cos_y
+			projected = []
+			for hull_right, hull_forward in (
+					(-hw, -hl_back), (hw, -hl_back),
+					(hw, hl_front), (-hw, hl_front)):
+				corner_u = right_u * hull_right + forward_u * hull_forward
+				corner_v = right_v * hull_right + forward_v * hull_forward
+				projected.append((corner_v, corner_u, corner_u + _ahead))
+			limits = []
+			if right_u > 1.0e-9:
+				limits.append(hw / right_u)
+			elif right_u < -1.0e-9:
+				limits.append(-hw / right_u)
+			if forward_u > 1.0e-9:
+				limits.append(hl_front / forward_u)
+			elif forward_u < -1.0e-9:
+				limits.append(-hl_back / forward_u)
+			center_front = min(limits) if limits else 0.0
+			projected.append((0.0, -0.5, center_front + _ahead))
+			merged = []
+			for lane_v, start_u, end_u in sorted(projected):
+				if merged and abs(lane_v - merged[-1][0]) <= 1.0e-7:
+					previous_v, previous_start, previous_end = merged[-1]
+					merged[-1] = (
+						previous_v, min(previous_start, start_u),
+						max(previous_end, end_u))
+				else:
+					merged.append((lane_v, start_u, end_u))
+			for lane_v, start_u, end_u in merged:
+				x1 = pos.x + perp_x * lane_v + motion_sin * start_u
+				z1 = pos.z + perp_z * lane_v + motion_cos * start_u
+				x2 = pos.x + perp_x * lane_v + motion_sin * end_u
+				z2 = pos.z + perp_z * lane_v + motion_cos * end_u
+				target_len = end_u - start_u
+				lane_segments.append((
+					x1, z1, x2, z2, target_len,
+					x1, z1, motion_sin, motion_cos, 1.0, target_len))
 		_crush_state = [False]
 		_kinetic_contact = False
 
-		for offset_x in lane_offsets:
-			sx = pos.x + perp_x * offset_x
-			sz = pos.z + perp_z * offset_x
-
-			x1 = sx - motion_sin * 0.5
-			z1 = sz - motion_cos * 0.5
-			x2 = sx + motion_sin * (leading_extent + _ahead)
-			z2 = sz + motion_cos * (leading_extent + _ahead)
+		for (x1, z1, x2, z2, target_len,
+				profile_x, profile_z, profile_sin, profile_cos,
+				profile_direction, profile_look) in lane_segments:
 			
 			# Spodní paprsek pro pevnou geometrii (0.6m nad zemí)
 			start_bot = Math.Vector3(x1, pos.y + 0.6, z1)
 			end_bot = Math.Vector3(x2, pos.y + 0.6, z2)
 			col_bot = _collide_horizontal(spaceID, start_bot, end_bot)
-			target_len = 0.5 + leading_extent + _ahead
 			
 			if col_bot is not None:
 				d_bot = (col_bot[0] - start_bot).length
@@ -301,7 +333,6 @@ def _check_horizontal_collision(spaceID, pos, yaw, vel, td=None,
 					# exact lane has a continuous non-flat ground profile and the
 					# native contact normal is also a drivable surface. This handles
 					# downhill terrain without hiding a wall merely located on a hill.
-					_look = leading_extent + _ahead
 					_heights = ()
 					_segment = 0.0
 					_gradient_limit = _MAX_DESCENDING_GRADIENT
@@ -310,8 +341,9 @@ def _check_horizontal_collision(spaceID, pos, yaw, vel, td=None,
 					# Only a surface that could be a slope earns the exact lane profile.
 					if _drivable_surface(col_bot, _gradient_limit):
 						_heights, _segment = _ground_profile(
-							spaceID, Math, pos, sx, sz,
-							motion_sin, motion_cos, 1.0, _look)
+							spaceID, Math, pos, profile_x, profile_z,
+							profile_sin, profile_cos, profile_direction,
+							profile_look)
 						_gradient_limit = _profile_gradient_limit(_heights)
 						if (_heights and
 								abs(float(_heights[-1]) -

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/world_collision.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/world_collision.py
@@ -212,7 +212,8 @@ def check_horizontal_collision(bigworld, math_module, *args, **kwargs):
 
 def _check_horizontal_collision(spaceID, pos, yaw, vel, td=None,
 		airborne=False, dt=0.04, return_status=False,
-		allow_kinetic=False, kinetic_speed=None, commit_enabled=True):
+		allow_kinetic=False, kinetic_speed=None, commit_enabled=True,
+		motion_yaw=None):
 	import math, BigWorld, Math
 	try:
 		hw = 1.5
@@ -241,29 +242,57 @@ def _check_horizontal_collision(spaceID, pos, yaw, vel, td=None,
 			# 1.2 m cap was shorter than a 20 m/s tank's 2 m slow-frame step and
 			# could miss a hard wall immediately behind a crushed light prop.
 			_ahead = max(0.4, abs(vel) * dt + 0.2)
-		back_margin = -0.5 if vel > 0 else 0.5
-		front_margin = (hl_front + _ahead) if vel > 0 else -(hl_back + _ahead)
-		
+		# Hull yaw owns the OBB.  Lateral impulses may supply a different
+		# direction for the swept corridor without rotating that footprint.
 		cos_y = math.cos(yaw)
 		sin_y = math.sin(yaw)
+		right_x, right_z = cos_y, -sin_y
+		forward_x, forward_z = sin_y, cos_y
+		explicit_motion_yaw = motion_yaw is not None
+		if motion_yaw is None:
+			motion_yaw = (float(yaw) if vel > 0.0 else
+				float(yaw) + math.pi)
+		motion_sin = math.sin(float(motion_yaw))
+		motion_cos = math.cos(float(motion_yaw))
+		perp_x, perp_z = motion_cos, -motion_sin
+		forward_dot = (
+			motion_sin * forward_x + motion_cos * forward_z)
+		right_dot = motion_sin * right_x + motion_cos * right_z
+		leading_extent = (abs(right_dot) * hw + max(
+			forward_dot * -hl_back, forward_dot * hl_front))
+		perp_forward_dot = (
+			perp_x * forward_x + perp_z * forward_z)
+		perp_right_dot = perp_x * right_x + perp_z * right_z
+		lateral_right_extent = abs(perp_right_dot) * hw
+		lateral_min = lateral_right_extent * -1.0 + min(
+			perp_forward_dot * -hl_back,
+			perp_forward_dot * hl_front)
+		lateral_max = lateral_right_extent + max(
+			perp_forward_dot * -hl_back,
+			perp_forward_dot * hl_front)
+		lane_offsets = (lateral_min, 0.0, lateral_max)
+		if not explicit_motion_yaw and vel <= 0.0:
+			# The reverse motion basis points its perpendicular to the old
+			# right-to-left lane order.  Retain the legacy left/centre/right
+			# evaluation order because a lane may own one native prop commit.
+			lane_offsets = (lateral_max, 0.0, lateral_min)
 		_crush_state = [False]
 		_kinetic_contact = False
 
-		for offset_x in (-hw, 0, hw):
-			sx = pos.x + cos_y * offset_x
-			sz = pos.z - sin_y * offset_x
-			
-			x1 = sx + sin_y * back_margin
-			z1 = sz + cos_y * back_margin
-			x2 = sx + sin_y * front_margin
-			z2 = sz + cos_y * front_margin
+		for offset_x in lane_offsets:
+			sx = pos.x + perp_x * offset_x
+			sz = pos.z + perp_z * offset_x
+
+			x1 = sx - motion_sin * 0.5
+			z1 = sz - motion_cos * 0.5
+			x2 = sx + motion_sin * (leading_extent + _ahead)
+			z2 = sz + motion_cos * (leading_extent + _ahead)
 			
 			# Spodní paprsek pro pevnou geometrii (0.6m nad zemí)
 			start_bot = Math.Vector3(x1, pos.y + 0.6, z1)
 			end_bot = Math.Vector3(x2, pos.y + 0.6, z2)
 			col_bot = _collide_horizontal(spaceID, start_bot, end_bot)
-			target_len = (abs(back_margin) +
-				(hl_front if vel > 0 else hl_back) + _ahead)
+			target_len = 0.5 + leading_extent + _ahead
 			
 			if col_bot is not None:
 				d_bot = (col_bot[0] - start_bot).length
@@ -272,8 +301,7 @@ def _check_horizontal_collision(spaceID, pos, yaw, vel, td=None,
 					# exact lane has a continuous non-flat ground profile and the
 					# native contact normal is also a drivable surface. This handles
 					# downhill terrain without hiding a wall merely located on a hill.
-					_direction = 1.0 if vel >= 0 else -1.0
-					_look = (hl_front if vel > 0 else hl_back) + _ahead
+					_look = leading_extent + _ahead
 					_heights = ()
 					_segment = 0.0
 					_gradient_limit = _MAX_DESCENDING_GRADIENT
@@ -282,8 +310,8 @@ def _check_horizontal_collision(spaceID, pos, yaw, vel, td=None,
 					# Only a surface that could be a slope earns the exact lane profile.
 					if _drivable_surface(col_bot, _gradient_limit):
 						_heights, _segment = _ground_profile(
-							spaceID, Math, pos, sx, sz, sin_y, cos_y,
-							_direction, _look)
+							spaceID, Math, pos, sx, sz,
+							motion_sin, motion_cos, 1.0, _look)
 						_gradient_limit = _profile_gradient_limit(_heights)
 						if (_heights and
 								abs(float(_heights[-1]) -

--- a/0.9.22/tests/test_port_0922_battle_runtime.py
+++ b/0.9.22/tests/test_port_0922_battle_runtime.py
@@ -7207,6 +7207,19 @@ class BattleRuntimeContractTests(unittest.TestCase):
                 entity, (296.49, 7.0, 0.0), 0.0, 1.0, 0.1,
                 hull_yaw=math.pi * 0.5))
             world_probe.assert_called_once()
+            self.assertAlmostEqual(
+                math.pi * 0.5, world_probe.call_args.args[4])
+            self.assertEqual(
+                0.0, world_probe.call_args.kwargs['motion_yaw'])
+
+            world_probe.reset_mock()
+            self.assertTrue(battle._motion_is_clear(
+                entity, (0.0, 7.0, 0.0), 0.25, -1.0, 0.1,
+                hull_yaw=1.0))
+            self.assertAlmostEqual(1.0, world_probe.call_args.args[4])
+            self.assertAlmostEqual(
+                0.25 + math.pi,
+                world_probe.call_args.kwargs['motion_yaw'])
 
     def test_supported_map_installs_catalog_before_native_destructible_reset(self):
         runtime = _runtime()

--- a/0.9.22/tests/test_port_0922_battle_runtime.py
+++ b/0.9.22/tests/test_port_0922_battle_runtime.py
@@ -7302,6 +7302,34 @@ class BattleRuntimeContractTests(unittest.TestCase):
                 0.25 + math.pi,
                 world_probe.call_args.kwargs['motion_yaw'])
 
+            catalog = types.SimpleNamespace(
+                _catalog_motion_blocked=mock.Mock(
+                    return_value={'status': 'clear'}),
+                _catalog_pending_at_hull=mock.Mock(return_value=False),
+                _catalog_hull_contact=mock.Mock(return_value=False))
+            battle._destructibles = catalog
+            world_probe.reset_mock()
+            self.assertTrue(battle._motion_is_clear(
+                entity, (0.0, 7.0, 0.0), 0.55, 1.0, 0.1,
+                hull_yaw=0.0))
+            blocked_call = catalog._catalog_motion_blocked.call_args
+            self.assertEqual(0.0, blocked_call.args[2])
+            self.assertEqual(0.55, blocked_call.kwargs['motion_yaw'])
+
+            world_probe.return_value = 'hard'
+            self.assertFalse(battle._motion_is_clear(
+                entity, (0.0, 7.0, 0.0), 1.0, -1.0, 0.1,
+                hull_yaw=0.25))
+            pending_call = catalog._catalog_pending_at_hull.call_args
+            hull_call = catalog._catalog_hull_contact.call_args
+            self.assertEqual(0.25, pending_call.args[1])
+            self.assertEqual(0.25, hull_call.args[1])
+            self.assertAlmostEqual(
+                1.0 + math.pi,
+                pending_call.kwargs['motion_yaw'])
+            self.assertAlmostEqual(
+                1.0 + math.pi, hull_call.kwargs['motion_yaw'])
+
     def test_supported_map_installs_catalog_before_native_destructible_reset(self):
         runtime = _runtime()
         runtime.area_destructibles = object()

--- a/0.9.22/tests/test_port_0922_destructibles.py
+++ b/0.9.22/tests/test_port_0922_destructibles.py
@@ -5820,6 +5820,110 @@ class DestructiblesCompatibilityTests(unittest.TestCase):
         self.assertEqual(1, counts['receipt_contact_invalidated'])
         self.assertEqual(0, counts['receipt_contact_entries'])
 
+    def test_lateral_catalog_sweep_keeps_long_hull_corner_in_both_directions(
+            self):
+        self._empty_catalog_scan_fixture()
+        descriptor = _Strict1513Component(
+            hull=_Strict1513Component(
+                hitTester=types.SimpleNamespace(bbox=(
+                    (-1.6, -1.0, -4.0), (1.6, 1.0, 6.0), None))))
+
+        for item_index, motion_yaw, contact_x in (
+                (7, math.pi * 0.5, 2.5),
+                (8, -math.pi * 0.5, -2.5)):
+            instance = {
+                'filename': 'known.model',
+                'descriptor_filename': 'known.model',
+                'kind': 'fragile',
+                'item_scale': 1.0,
+                'boxes': (((contact_x, 0.0, 5.5),
+                           ((0.25, 0.0, 0.0), (0.0, 0.5, 0.0),
+                            (0.0, 0.0, 0.25)), None),),
+            }
+            destructibles_sensor.g_offh_destr_instances = {
+                (22, item_index): instance}
+            destructibles_sensor.g_offh_destr_contact_bins = {}
+            destructibles_sensor._index_catalog_instance_1513(
+                destructibles_sensor.g_offh_destr_contact_bins,
+                (22, item_index), instance)
+
+            self.assertTrue(destructibles_sensor._catalog_hull_contact(
+                _Vector(), 0.0, 5.0, descriptor, 0.2,
+                motion_yaw=motion_yaw))
+
+    def test_lateral_catalog_sweep_excludes_rotated_hull_false_region(self):
+        self._empty_catalog_scan_fixture()
+        descriptor = _Strict1513Component(
+            hull=_Strict1513Component(
+                hitTester=types.SimpleNamespace(bbox=(
+                    (-1.6, -1.0, -4.0), (1.6, 1.0, 6.0), None))))
+        instance = {
+            'filename': 'known.model',
+            'descriptor_filename': 'known.model',
+            'kind': 'fragile',
+            'item_scale': 1.0,
+            'boxes': (((5.5, 0.0, 0.0),
+                       ((0.25, 0.0, 0.0), (0.0, 0.5, 0.0),
+                        (0.0, 0.0, 0.25)), None),),
+        }
+        destructibles_sensor.g_offh_destr_instances = {(22, 7): instance}
+        destructibles_sensor.g_offh_destr_contact_bins = {}
+        destructibles_sensor._index_catalog_instance_1513(
+            destructibles_sensor.g_offh_destr_contact_bins,
+            (22, 7), instance)
+
+        self.assertFalse(destructibles_sensor._catalog_hull_contact(
+            _Vector(), 0.0, 5.0, descriptor, 0.2,
+            motion_yaw=math.pi * 0.5))
+
+    def test_diagonal_swept_zonotope_excludes_its_empty_aabb_corner(self):
+        bbox = ((-1.6, -1.0, -4.0), (1.6, 1.0, 6.0), None)
+        swept = destructibles_sensor._vehicle_swept_box(
+            _Vector(), 0.0, 5.0, bbox, 1.0, motion_yaw=0.55)
+        bounds = destructibles_sensor._box_xz_bounds(swept)
+        outside = (
+            (-2.0, 0.0, 6.7),
+            ((0.05, 0.0, 0.0), (0.0, 0.5, 0.0),
+             (0.0, 0.0, 0.05)), None)
+
+        self.assertLess(bounds[0], outside[0][0])
+        self.assertGreater(bounds[1], outside[0][0])
+        self.assertLess(bounds[2], outside[0][2])
+        self.assertGreater(bounds[3], outside[0][2])
+        self.assertFalse(destructibles_sensor._boxes_intersect(
+            swept, outside))
+
+    def test_lateral_catalog_contact_invalidates_warm_empty_receipt(self):
+        self._empty_catalog_scan_fixture()
+        descriptor = _Strict1513Component(
+            hull=_Strict1513Component(
+                hitTester=types.SimpleNamespace(bbox=(
+                    (-1.6, -1.0, -4.0), (1.6, 1.0, 6.0), None))))
+        destructibles_sensor.g_offh_destr_instances = {}
+        destructibles_sensor.g_offh_destr_contact_bins = {}
+        self.assertFalse(destructibles_sensor._catalog_hull_contact(
+            _Vector(), 0.0, 5.0, descriptor, 0.2,
+            motion_yaw=math.pi * 0.5))
+        instance = {
+            'filename': 'known.model',
+            'descriptor_filename': 'known.model',
+            'kind': 'fragile',
+            'item_scale': 1.0,
+            'boxes': (((2.5, 0.0, 5.5),
+                       ((0.25, 0.0, 0.0), (0.0, 0.5, 0.0),
+                        (0.0, 0.0, 0.25)), None),),
+        }
+        destructibles_sensor.g_offh_destr_instances[(22, 7)] = instance
+        destructibles_sensor._index_catalog_instance_1513(
+            destructibles_sensor.g_offh_destr_contact_bins,
+            (22, 7), instance)
+
+        self.assertTrue(destructibles_sensor._catalog_hull_contact(
+            _Vector(), 0.0, 5.0, descriptor, 0.2,
+            motion_yaw=math.pi * 0.5))
+        counts = destructibles_sensor.registry_counts()
+        self.assertEqual(1, counts['receipt_contact_invalidated'])
+
     def test_chunk_registry_limits_each_frame_to_nearby_contact_bins(self):
         registry = {'bins': {}, 'extended_bins': {}, 'count': 0,
                     'max_radius': 4.5}

--- a/0.9.22/tests/test_port_0922_world_collision.py
+++ b/0.9.22/tests/test_port_0922_world_collision.py
@@ -595,13 +595,177 @@ class WorldCollisionTests(unittest.TestCase):
             if abs(start.y - 0.6) < 0.001]
         self.assertEqual(3, len(lower_rays))
         for start, end in lower_rays:
-            self.assertAlmostEqual(-0.5, start.x)
             self.assertAlmostEqual(1.9, end.x)
             self.assertGreater(end.x, start.x)
             self.assertAlmostEqual(start.z, end.z)
-        lane_positions = sorted(start.z for start, unused_end in lower_rays)
-        for actual, expected in zip(lane_positions, (-4.0, 0.0, 6.0)):
-            self.assertAlmostEqual(expected, actual)
+        lanes = sorted((start.z, start.x)
+                       for start, unused_end in lower_rays)
+        for (actual_z, actual_x), (expected_z, expected_x) in zip(
+                lanes, ((-4.0, -1.5), (0.0, -0.5), (6.0, -1.5))):
+            self.assertAlmostEqual(expected_z, actual_z)
+            self.assertAlmostEqual(expected_x, actual_x)
+
+    def test_diagonal_motion_sweeps_each_projected_extreme_corner(self):
+        descriptor = _Strict1513Component(
+            hull=_Strict1513Component(
+                hitTester=_Strict1513Component(bbox=(
+                    (-1.6, -1.0, -4.0),
+                    (1.6, 1.0, 6.0), None))))
+        math_module = types.ModuleType('Math')
+        math_module.Vector3 = _Vector
+
+        for motion_yaw, velocity in (
+                (0.55, 5.0), (-0.55, 5.0),
+                (1.0, 5.0), (-1.0, 5.0),
+                (0.55 + math.pi, -5.0)):
+            motion_x = math.sin(motion_yaw)
+            motion_z = math.cos(motion_yaw)
+            perp_x = motion_z
+            perp_z = -motion_x
+            corners = []
+            for corner_x, corner_z in (
+                    (-1.5, -4.0), (1.5, -4.0),
+                    (1.5, 6.0), (-1.5, 6.0)):
+                corners.append((
+                    corner_x * motion_x + corner_z * motion_z,
+                    corner_x * perp_x + corner_z * perp_z,
+                    corner_x, corner_z))
+            extremes = (
+                min(corners, key=lambda value: value[1]),
+                max(corners, key=lambda value: value[1]))
+            candidates = [value for value in extremes if value[0] < -0.5]
+            self.assertTrue(candidates)
+            unused_u, unused_v, corner_x, corner_z = min(candidates)
+            obstacle_x = corner_x + motion_x * 0.1
+            obstacle_z = corner_z + motion_z * 0.1
+
+            def collide(unused_space, start, end, unused_mask):
+                delta_x = end.x - start.x
+                delta_z = end.z - start.z
+                length_squared = delta_x * delta_x + delta_z * delta_z
+                if length_squared <= 1.0e-12:
+                    return None
+                progress = ((obstacle_x - start.x) * delta_x +
+                            (obstacle_z - start.z) * delta_z) / length_squared
+                if progress < 0.0 or progress > 1.0:
+                    return None
+                nearest_x = start.x + delta_x * progress
+                nearest_z = start.z + delta_z * progress
+                distance_squared = ((nearest_x - obstacle_x) ** 2 +
+                                    (nearest_z - obstacle_z) ** 2)
+                if distance_squared > 1.0e-10:
+                    return None
+                return (_Vector(nearest_x, start.y, nearest_z),
+                        _Vector(0.0, 0.0, -1.0), 0)
+
+            bigworld = types.ModuleType('BigWorld')
+            bigworld.wg_collideSegment = collide
+            bigworld.wg_getMatInfoNearPoint = _miss_mat_info_1513
+
+            self.assertEqual(
+                'hard', world_collision.check_horizontal_collision(
+                    bigworld, math_module, 1, _Vector(), 0.0, velocity,
+                    descriptor, False, 0.04, True,
+                    commit_enabled=False, motion_yaw=motion_yaw))
+
+    def test_diagonal_motion_lower_rays_cover_all_four_corner_paths(self):
+        descriptor = _Strict1513Component(
+            hull=_Strict1513Component(
+                hitTester=_Strict1513Component(bbox=(
+                    (-1.6, -1.0, -4.0),
+                    (1.6, 1.0, 6.0), None))))
+        math_module = types.ModuleType('Math')
+        math_module.Vector3 = _Vector
+
+        for velocity in (5.0, -5.0):
+            for candidate_yaw in (0.55, -0.55, 1.0, -1.0):
+                motion_yaw = (candidate_yaw if velocity > 0.0 else
+                              candidate_yaw + math.pi)
+                horizontal_calls = []
+
+                def collide(unused_space, start, end, unused_mask):
+                    horizontal_calls.append((start, end))
+                    return None
+
+                bigworld = types.ModuleType('BigWorld')
+                bigworld.wg_collideSegment = collide
+                bigworld.wg_getMatInfoNearPoint = _miss_mat_info_1513
+                self.assertFalse(
+                    world_collision.check_horizontal_collision(
+                        bigworld, math_module, 1, _Vector(), 0.0, velocity,
+                        descriptor, False, 0.04,
+                        motion_yaw=motion_yaw))
+                lower_rays = [
+                    (start, end) for start, end in horizontal_calls
+                    if abs(start.y - 0.6) < 0.001]
+                self.assertEqual(5, len(lower_rays))
+                motion_x = math.sin(motion_yaw)
+                motion_z = math.cos(motion_yaw)
+                for corner_x, corner_z in (
+                        (-1.5, -4.0), (1.5, -4.0),
+                        (1.5, 6.0), (-1.5, 6.0)):
+                    target_x = corner_x + motion_x * 0.1
+                    target_z = corner_z + motion_z * 0.1
+                    distances = []
+                    for start, end in lower_rays:
+                        delta_x = end.x - start.x
+                        delta_z = end.z - start.z
+                        length_squared = (
+                            delta_x * delta_x + delta_z * delta_z)
+                        progress = ((target_x - start.x) * delta_x +
+                                    (target_z - start.z) * delta_z)
+                        progress = max(
+                            0.0, min(1.0, progress / length_squared))
+                        nearest_x = start.x + delta_x * progress
+                        nearest_z = start.z + delta_z * progress
+                        distances.append(
+                            (nearest_x - target_x) ** 2 +
+                            (nearest_z - target_z) ** 2)
+                    self.assertLess(min(distances), 1.0e-10)
+
+    def test_diagonal_drivable_profile_samples_the_hit_corner_segment(self):
+        descriptor = _Strict1513Component(
+            hull=_Strict1513Component(
+                hitTester=_Strict1513Component(bbox=(
+                    (-1.6, -1.0, -4.0),
+                    (1.6, 1.0, 6.0), None))))
+        hit_segment = []
+
+        def collide(unused_space, start, end, unused_mask):
+            if abs(start.y - 0.6) < 0.001 and not hit_segment:
+                hit_segment.append((start, end))
+                return (_Vector(
+                    (start.x + end.x) * 0.5, start.y,
+                    (start.z + end.z) * 0.5),
+                    _Vector(0.0, 1.0, 0.0), 0)
+            return None
+
+        def ground_profile(unused_space, unused_math, unused_pos,
+                           unused_x, unused_z, unused_sin, unused_cos,
+                           unused_direction, look, segment_count=6):
+            segment = float(look) / float(segment_count)
+            return ([index * segment * 0.5
+                     for index in range(segment_count + 1)], segment)
+
+        bigworld = types.ModuleType('BigWorld')
+        bigworld.wg_collideSegment = collide
+        bigworld.wg_getMatInfoNearPoint = _miss_mat_info_1513
+        math_module = types.ModuleType('Math')
+        math_module.Vector3 = _Vector
+        with mock.patch.object(
+                world_collision, '_ground_profile',
+                side_effect=ground_profile) as profile:
+            self.assertFalse(world_collision.check_horizontal_collision(
+                bigworld, math_module, 1, _Vector(), 0.0, 5.0,
+                descriptor, False, 0.04, motion_yaw=0.55))
+
+        start, end = hit_segment[0]
+        call = profile.call_args.args
+        self.assertAlmostEqual(start.x, call[3])
+        self.assertAlmostEqual(start.z, call[4])
+        self.assertAlmostEqual(
+            ((end.x - start.x) ** 2 + (end.z - start.z) ** 2) ** 0.5,
+            call[8])
 
     def test_omitted_motion_yaw_preserves_forward_and_reverse_sweeps(self):
         descriptor = _Strict1513Component(

--- a/0.9.22/tests/test_port_0922_world_collision.py
+++ b/0.9.22/tests/test_port_0922_world_collision.py
@@ -567,6 +567,89 @@ class WorldCollisionTests(unittest.TestCase):
         self.assertFalse(blocked)
         self.assertTrue(horizontal_calls)
 
+    def test_sideways_motion_sweeps_hull_width_across_front_back_lanes(self):
+        horizontal_calls = []
+
+        def collide(unused_space, start, end, unused_mask):
+            horizontal_calls.append((start, end))
+            return None
+
+        bigworld = types.ModuleType('BigWorld')
+        bigworld.wg_collideSegment = collide
+        bigworld.wg_getMatInfoNearPoint = _miss_mat_info_1513
+        math_module = types.ModuleType('Math')
+        math_module.Vector3 = _Vector
+        descriptor = _Strict1513Component(
+            hull=_Strict1513Component(
+                hitTester=_Strict1513Component(bbox=(
+                    (-1.6, -1.0, -4.0),
+                    (1.6, 1.0, 6.0), None))))
+
+        blocked = world_collision.check_horizontal_collision(
+            bigworld, math_module, 1, _Vector(), 0.0, 5.0,
+            descriptor, False, 0.04, motion_yaw=math.pi / 2.0)
+
+        self.assertFalse(blocked)
+        lower_rays = [
+            (start, end) for start, end in horizontal_calls
+            if abs(start.y - 0.6) < 0.001]
+        self.assertEqual(3, len(lower_rays))
+        for start, end in lower_rays:
+            self.assertAlmostEqual(-0.5, start.x)
+            self.assertAlmostEqual(1.9, end.x)
+            self.assertGreater(end.x, start.x)
+            self.assertAlmostEqual(start.z, end.z)
+        lane_positions = sorted(start.z for start, unused_end in lower_rays)
+        for actual, expected in zip(lane_positions, (-4.0, 0.0, 6.0)):
+            self.assertAlmostEqual(expected, actual)
+
+    def test_omitted_motion_yaw_preserves_forward_and_reverse_sweeps(self):
+        descriptor = _Strict1513Component(
+            hull=_Strict1513Component(
+                hitTester=_Strict1513Component(bbox=(
+                    (-1.6, -1.0, -4.0),
+                    (1.6, 1.0, 6.0), None))))
+
+        def lower_rays_for(velocity):
+            horizontal_calls = []
+
+            def collide(unused_space, start, end, unused_mask):
+                horizontal_calls.append((start, end))
+                return None
+
+            bigworld = types.ModuleType('BigWorld')
+            bigworld.wg_collideSegment = collide
+            bigworld.wg_getMatInfoNearPoint = _miss_mat_info_1513
+            math_module = types.ModuleType('Math')
+            math_module.Vector3 = _Vector
+            blocked = world_collision.check_horizontal_collision(
+                bigworld, math_module, 1, _Vector(), 0.0, velocity,
+                descriptor, False, 0.04)
+            self.assertFalse(blocked)
+            lower_rays = [
+                (start, end) for start, end in horizontal_calls
+                if abs(start.y - 0.6) < 0.001]
+            self.assertEqual(3, len(lower_rays))
+            return lower_rays
+
+        forward_rays = lower_rays_for(5.0)
+        reverse_rays = lower_rays_for(-5.0)
+
+        for start, end in forward_rays:
+            self.assertAlmostEqual(-0.5, start.z)
+            self.assertAlmostEqual(6.4, end.z)
+            self.assertGreater(end.z, start.z)
+            self.assertAlmostEqual(start.x, end.x)
+        for start, end in reverse_rays:
+            self.assertAlmostEqual(0.5, start.z)
+            self.assertAlmostEqual(-4.4, end.z)
+            self.assertLess(end.z, start.z)
+            self.assertAlmostEqual(start.x, end.x)
+        for rays in (forward_rays, reverse_rays):
+            lane_positions = [start.x for start, unused_end in rays]
+            for actual, expected in zip(lane_positions, (-1.5, 0.0, 1.5)):
+                self.assertAlmostEqual(expected, actual)
+
     def test_slow_frame_sweep_reaches_wall_beyond_old_lookahead_cap(self):
         wall_z = [5.0]
         horizontal_ends = []


### PR DESCRIPTION
## Summary

- separate hull orientation from the actual horizontal motion direction
- sweep the full oriented chassis footprint during ram separation, airborne carry, and wall deflection
- preserve the legacy forward/reverse lane order when no explicit lateral motion is supplied
- keep all existing hard-wall, terrain-profile, and crushable-prop checks in the final collision gate

## Why

A tank can be translated sideways while its hull still points elsewhere. The previous collision rays only followed hull forward/reverse, so a lateral displacement could miss geometry along the real travel corridor.

## Validation

- 38/38 world-collision tests passed
- 617/617 BattleRuntime tests passed
- CPython 2.7 source compilation passed
- git diff/check passed

## Remaining boundary

Static and pure-data tests prove corridor construction and adapter behavior. Exact #1513 Windows playtesting is still needed to prove native ray timing and vehicle feel.
