### PR TITLE
Add guarded remote vehicle hit reactions

### DIFF
--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -8096,6 +8096,24 @@ class BattleRuntime(object):
             return False
         return True
 
+    def _present_remote_hit_reaction(self, event, target_record, direction,
+                                     effects_descr):
+        """Pass one direct-hit impulse through the native entity owner."""
+        state = target_record.get('state') or {}
+        if (event.get('splash', False) or event.get('dead', False) or
+                target_record.get('local') or
+                not target_record.get('native_remote') or
+                not bool(state.get('alive', True)) or
+                int(state.get('health', 1) or 0) <= 0):
+            return False
+        present = getattr(
+            self._remote_factory, 'present_hit_impulse', None)
+        if not callable(present):
+            return False
+        return present(
+            int(target_record['engine_id']), direction,
+            _field(effects_descr, 'targetImpulse', 0.0))
+
     def _present_combat_hit(self, event, target_record, attacker_record,
                             attacker_id):
         """Port the mature 0.8.2 hit feedback through exact #1513 APIs."""
@@ -8191,6 +8209,10 @@ class BattleRuntime(object):
             self._warn_optional_failure(
                 'projectile impact presentation', error)
             return False
+        self._run_optional_feature(
+            'projectile vehicle hit impulse',
+            self._present_remote_hit_reaction,
+            (event, target_record, direction, effects_descr))
         return True
 
     _DECAL_REPORT_LIMIT = 32

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/entities/native_remote_vehicle.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/entities/native_remote_vehicle.py
@@ -620,6 +620,37 @@ class _NativeRemoteState(object):
             entity._gun_pitch = raw_gun_pitch
         return True
 
+    def present_hit_impulse(self, direction, impulse):
+        """Call the stock reaction only while every native owner is live."""
+        if (not self._engine_owns_entity() or
+                self.presentation_capabilities.get('body_swinging') is not
+                True):
+            return False
+        entity = self.entity
+        appearance = getattr(entity, 'appearance', None)
+        vehicle_filter = getattr(entity, 'filter', None)
+        if (appearance is None or
+                getattr(appearance, 'filter', None) is not vehicle_filter or
+                getattr(appearance, 'swingingAnimator', None) is None):
+            return False
+        receive_impulse = getattr(appearance, 'receiveShotImpulse', None)
+        if not callable(receive_impulse):
+            return False
+        try:
+            impulse = float(impulse)
+            values = tuple(float(direction[index]) for index in range(3))
+        except (IndexError, TypeError, ValueError, OverflowError):
+            return False
+        if (impulse <= 0.0 or math.isnan(impulse) or math.isinf(impulse) or
+                any(math.isnan(value) or math.isinf(value)
+                    for value in values)):
+            return False
+        length = math.sqrt(sum(value * value for value in values))
+        if length <= 0.0 or abs(length - 1.0) > 0.01:
+            return False
+        receive_impulse(direction, impulse)
+        return True
+
     def update_tracks(self, left, right, mode):
         entity = self.entity
         if entity is None:
@@ -852,6 +883,12 @@ class NativeRemoteVehicleFactory(object):
         if state is None or state.entity is None:
             return False
         return state.update_siege_pose()
+
+    def present_hit_impulse(self, entity_id, direction, impulse):
+        state = self._states.get(int(entity_id))
+        if state is None or state.entity is None:
+            return False
+        return state.present_hit_impulse(direction, impulse)
 
     def request_wreck(self, unused_entity_id):
         # Vehicle.onHealthChanged owns stock damaged-model replacement.

--- a/0.9.22/tests/test_port_0922_battle_runtime.py
+++ b/0.9.22/tests/test_port_0922_battle_runtime.py
@@ -2053,6 +2053,35 @@ class NativeRemoteVehicleFactoryTests(unittest.TestCase):
         self.assertIsNone(state.entity)
         self.assertIsNone(state.model_changed)
 
+    def test_native_hit_impulse_requires_live_bound_swinging_owner(self):
+        runtime = _runtime()
+        vehicle_filter = object()
+        receive_impulse = mock.Mock()
+        appearance = types.SimpleNamespace(
+            filter=vehicle_filter, swingingAnimator=object(),
+            receiveShotImpulse=receive_impulse)
+        entity = types.SimpleNamespace(
+            id=44, inWorld=True, isStarted=True,
+            filter=vehicle_filter, appearance=appearance)
+        bigworld = types.SimpleNamespace(entities={44: entity})
+        state = _NativeRemoteState(
+            bigworld, runtime.math, mock.Mock(), None,
+            _Vector(), (0.0, 0.0, 0.0))
+        state.entity = entity
+        state.presentation_capabilities['body_swinging'] = True
+        direction = _Vector(1.0, 0.0, 0.0)
+
+        self.assertTrue(state.present_hit_impulse(direction, 0.75))
+        self.assertFalse(state.present_hit_impulse(
+            direction, float('nan')))
+        appearance.filter = object()
+        self.assertFalse(state.present_hit_impulse(direction, 0.75))
+        appearance.filter = vehicle_filter
+        bigworld.entities[44] = object()
+        self.assertFalse(state.present_hit_impulse(direction, 0.75))
+
+        receive_impulse.assert_called_once_with(direction, 0.75)
+
     def test_native_siege_authority_uses_hydraulic_body_and_ground_chassis(self):
         runtime = _runtime()
         native_body = _Matrix()
@@ -10382,6 +10411,106 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertEqual([10, 9], [
             value['eventType']
             for value in battle._avatar.battle_events[0]])
+
+    def test_direct_remote_hits_use_the_stock_target_impulse(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        battle._remote_factory = mock.Mock()
+        battle._remote_factory.get.side_effect = runtime.bigworld.entity
+        battle._remote_factory.present_hit_impulse.return_value = True
+        target = _Vehicle(10, _Descriptor(), _Vector(), (0, 0, 0),
+                          {'health': 500})
+        attacker = _Vehicle(11, _Descriptor(), _Vector(10, 0, 0),
+                            (0, 0, 0), {'health': 500})
+        runtime.vehicles.g_cache.shotEffects[3]['targetImpulse'] = 0.75
+        runtime.bigworld.entities.update({10: target, 11: attacker})
+        target_record = {
+            'engine_id': 10, 'state': {'health': 500, 'alive': True},
+            'spot_visible': True, 'native_remote': True,
+            'kind': 'bot', 'network_id': 1, 'local': False}
+        attacker_record = {
+            'engine_id': 11,
+            'state': {'health': 500, 'x': 10.0, 'y': 0.0, 'z': 0.0},
+            'kind': 'bot', 'network_id': 2, 'local': False}
+        for shot_result in (0, 1, 2):
+            event = {
+                'kind': 'bot_bot_hit', 'world_pose': True,
+                'x': 0.5, 'y': 1.0, 'z': 0.0, 'shell_index': 0,
+                'shot_result': shot_result, 'damage': 40,
+                'source': 'shot'}
+
+            self.assertTrue(battle._present_combat_hit(
+                event, target_record, attacker_record, 11))
+
+        self.assertEqual(
+            3, battle._remote_factory.present_hit_impulse.call_count)
+        for call in battle._remote_factory.present_hit_impulse.call_args_list:
+            engine_id, direction, impulse = call.args
+            self.assertEqual(10, engine_id)
+            self.assertEqual(0.75, impulse)
+            self.assertAlmostEqual(-1.0, direction.x)
+            self.assertAlmostEqual(0.0, direction.y)
+            self.assertAlmostEqual(0.0, direction.z)
+
+    def test_remote_hit_reaction_skips_splash_local_and_dead_targets(self):
+        battle = BattleRuntime(_runtime())
+        battle._remote_factory = mock.Mock()
+        record = {
+            'engine_id': 10, 'state': {'health': 500, 'alive': True},
+            'native_remote': True, 'local': False}
+        direction = _Vector(1.0, 0.0, 0.0)
+        effects_descr = {'targetImpulse': 0.75}
+
+        self.assertFalse(battle._present_remote_hit_reaction(
+            {'splash': True}, record, direction, effects_descr))
+        local_record = dict(record, local=True)
+        self.assertFalse(battle._present_remote_hit_reaction(
+            {}, local_record, direction, effects_descr))
+        dead_record = dict(record, state={'health': 0, 'alive': False})
+        self.assertFalse(battle._present_remote_hit_reaction(
+            {'dead': True}, dead_record, direction, effects_descr))
+
+        battle._remote_factory.present_hit_impulse.assert_not_called()
+
+    def test_remote_hit_reaction_failure_does_not_disable_impact_effects(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        battle._remote_factory = mock.Mock()
+        battle._remote_factory.get.side_effect = runtime.bigworld.entity
+        battle._remote_factory.present_hit_impulse.side_effect = \
+            RuntimeError('native reaction failed')
+        target = _Vehicle(10, _Descriptor(), _Vector(), (0, 0, 0),
+                          {'health': 500})
+        attacker = _Vehicle(11, _Descriptor(), _Vector(10, 0, 0),
+                            (0, 0, 0), {'health': 500})
+        runtime.vehicles.g_cache.shotEffects[3]['targetImpulse'] = 0.75
+        runtime.bigworld.entities.update({10: target, 11: attacker})
+        target_record = {
+            'engine_id': 10, 'state': {'health': 500, 'alive': True},
+            'spot_visible': True, 'native_remote': True,
+            'kind': 'bot', 'network_id': 1, 'local': False}
+        attacker_record = {
+            'engine_id': 11,
+            'state': {'health': 500, 'x': 10.0, 'y': 0.0, 'z': 0.0},
+            'kind': 'bot', 'network_id': 2, 'local': False}
+        event = {
+            'kind': 'bot_bot_hit', 'world_pose': True,
+            'x': 0.5, 'y': 1.0, 'z': 0.0, 'shell_index': 0,
+            'shot_result': 2, 'damage': 40, 'source': 'shot'}
+
+        self.assertTrue(battle._present_combat_hit(
+            event, target_record, attacker_record, 11))
+        self.assertTrue(battle._present_combat_hit(
+            event, target_record, attacker_record, 11))
+
+        self.assertEqual(
+            1, battle._remote_factory.present_hit_impulse.call_count)
+        self.assertEqual(2, battle._avatar.terrainEffects.addNew.call_count)
+        self.assertIn(
+            'projectile vehicle hit impulse',
+            battle._disabled_optional_features)
 
     def test_native_impact_effect_exception_keeps_nonvisual_feedback(self):
         runtime = _runtime()


### PR DESCRIPTION
## Summary

- present the stock shot effect's `targetImpulse` for direct hits on live, non-local native remote vehicles
- route the call through `NativeRemoteVehicleFactory`, with current BigWorld entity ownership, lifecycle, body-swinging capability, appearance/filter identity, animator, direction, and impulse guards
- keep the reaction visual-only and optional: it does not change authoritative damage or combat state, skips splash/local/dead targets, and a Python exception disables only this presentation feature for the round

## Validation

- `git diff --check`
- CPython 2.7.18 source compile: 88 client files
- focused hit-reaction tests: 4 passed
- `test_port_0922_battle_runtime.py`: 657 passed

## Native verification boundary

This PR is intentionally a draft. The pinned Chinese HD `0.9.22.0.1 #1513` `scripts.pkg`/PYC evidence available in this repository does not prove the `CompoundAppearance.receiveShotImpulse(direction, impulse)` ABI, guards, ownership, or lifecycle, and the current ABI audit does not cover this call.

The 0.8.2 implementation records two same-address native `EXCEPTION_ACCESS_VIOLATION 0xC0000005 Read@0x8` failures after this category of call was enabled on a filter-less mock fashion. That does not prove that a live stock #1513 `CompoundAppearance` will crash—the adapter here is deliberately limited to an engine-owned remote entity whose stock appearance is still bound to its current filter and swinging animator—but it is concrete evidence that the boundary is native-risky.

Python `try`/`except` can isolate a Python exception; it cannot contain a native access violation. Before this is considered ready, it needs an exact #1513 Windows client playtest with ProcDump configured to capture the first-chance/full failure (or a minidump if that is the only available evidence), together with the matching package revision, `python.log`, and session logs.
