### PR TITLE
Add standalone hidden-worker performance profiler

### DIFF
--- a/0.9.22/build_hidden_worker_profiler.sh
+++ b/0.9.22/build_hidden_worker_profiler.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export PYTHONDONTWRITEBYTECODE=1
+
+port_root="$(cd "$(dirname "$0")" && pwd)"
+project_root="$(cd "$port_root/.." && pwd)"
+
+if command -v python2.7 >/dev/null 2>&1; then
+  build_output="$(python2.7 \
+    "$port_root/tools/build_hidden_worker_profiler.py" "$@")"
+elif command -v pyenv >/dev/null 2>&1 && \
+    PYENV_VERSION=2.7.18 pyenv which python2.7 >/dev/null 2>&1; then
+  py27_path="$(PYENV_VERSION=2.7.18 pyenv which python2.7)"
+  build_output="$("$py27_path" \
+    "$port_root/tools/build_hidden_worker_profiler.py" "$@")"
+else
+  build_output="$(docker run --rm --platform linux/amd64 \
+    -v "$project_root:/work" \
+    -w /work/0.9.22 \
+    python:2.7.18 \
+    python tools/build_hidden_worker_profiler.py "$@")"
+fi
+echo "$build_output"
+
+archive="$(echo "$build_output" | tail -1)"
+if [[ "$archive" == /work/* ]]; then
+  archive="$project_root/${archive#/work/}"
+fi
+if [[ -z "$archive" ]]; then
+  echo "diagnostic ZIP was not produced" >&2
+  exit 1
+fi
+python3 "$port_root/tools/validate_hidden_worker_profiler_zip.py" "$archive"
+echo "$archive"

--- a/0.9.22/build_wotmod.py
+++ b/0.9.22/build_wotmod.py
@@ -658,15 +658,14 @@ def _validate_entry(staging_root):
         raise SystemExit('unexpected Python bytecode magic: %r' % magic)
 
 
-def build():
+def build_wotmod_package(output_root):
+    """Build only the Python package, without the server/client overlay."""
     _validate_python()
     port_root = os.path.abspath(os.path.dirname(__file__))
     source_root = os.path.join(port_root, 'src')
-    dist_root = os.path.join(port_root, 'dist')
-    if not os.path.isdir(dist_root):
-        os.makedirs(dist_root)
-    _remove_stale_outputs(dist_root)
-    build_identity = _generated_build_identity()
+    output_root = os.path.abspath(output_root)
+    if not os.path.isdir(output_root):
+        os.makedirs(output_root)
     staging_parent = tempfile.mkdtemp(prefix='offline-lan-0922-')
     try:
         staging_root = os.path.join(staging_parent, 'package')
@@ -683,34 +682,47 @@ def build():
         _remove_sources(staging_root)
         _validate_entry(staging_root)
         filename = '%s_%s.wotmod' % (MOD_ID, MOD_VERSION)
-        destination = os.path.join(dist_root, filename)
+        destination = os.path.join(output_root, filename)
         _archive_tree(staging_root, destination)
         with open(destination, 'rb') as stream:
             digest = hashlib.sha256(stream.read()).hexdigest()
-        checksum_path = destination + '.sha256'
-        with open(checksum_path, 'wb') as stream:
-            stream.write(('%s  %s\n' % (digest, filename)).encode('ascii'))
-        native_bridge_source = os.path.join(
-            port_root, 'native', NATIVE_BRIDGE_FILENAME)
-        if not os.path.isfile(native_bridge_source):
-            raise SystemExit(
-                'native instance guard bridge is missing: %s' %
-                native_bridge_source)
-        native_bridge_path = os.path.join(
-            dist_root, NATIVE_BRIDGE_FILENAME)
-        shutil.copy2(native_bridge_source, native_bridge_path)
-        overlay_root, overlay_zip = _write_client_overlay(
-            dist_root, destination, checksum_path, digest,
-            native_bridge_source=native_bridge_path,
-            build_identity=build_identity)
-        print('build identity=%s version=%s' %
-              (build_identity, MOD_VERSION))
-        print(destination)
-        print('sha256=%s' % digest)
-        print(overlay_root)
-        print(overlay_zip)
+        return destination, digest
     finally:
         shutil.rmtree(staging_parent)
+
+
+def build():
+    _validate_python()
+    port_root = os.path.abspath(os.path.dirname(__file__))
+    dist_root = os.path.join(port_root, 'dist')
+    if not os.path.isdir(dist_root):
+        os.makedirs(dist_root)
+    _remove_stale_outputs(dist_root)
+    build_identity = _generated_build_identity()
+    destination, digest = build_wotmod_package(dist_root)
+    filename = os.path.basename(destination)
+    checksum_path = destination + '.sha256'
+    with open(checksum_path, 'wb') as stream:
+        stream.write(('%s  %s\n' % (digest, filename)).encode('ascii'))
+    native_bridge_source = os.path.join(
+        port_root, 'native', NATIVE_BRIDGE_FILENAME)
+    if not os.path.isfile(native_bridge_source):
+        raise SystemExit(
+            'native instance guard bridge is missing: %s' %
+            native_bridge_source)
+    native_bridge_path = os.path.join(
+        dist_root, NATIVE_BRIDGE_FILENAME)
+    shutil.copy2(native_bridge_source, native_bridge_path)
+    overlay_root, overlay_zip = _write_client_overlay(
+        dist_root, destination, checksum_path, digest,
+        native_bridge_source=native_bridge_path,
+        build_identity=build_identity)
+    print('build identity=%s version=%s' %
+          (build_identity, MOD_VERSION))
+    print(destination)
+    print('sha256=%s' % digest)
+    print(overlay_root)
+    print(overlay_zip)
 
 
 if __name__ == '__main__':

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/ai/driver.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/ai/driver.py
@@ -8,6 +8,8 @@ steering, so it is safe to exercise outside the BigWorld client.
 
 import math
 
+from gui.mods.offline_lan_0922 import hidden_worker_profiler
+
 
 WAYPOINT_ARRIVAL_RADIUS = 1.5
 TRAFFIC_WAIT_LEASE_SECONDS = 1.5
@@ -435,6 +437,18 @@ class LocalDriver(object):
 		return None
 
 	def drive(self, bot_id, position, yaw, speed, dt, target, neighbours,
+			direction_clear, velocity=None, half_length=3.5, half_width=1.7,
+			movement_intent=True, stopping_distance=None,
+			stop_at_target=True, decision_horizon=0.0):
+		"""Profile the complete local-driver boundary without changing its law."""
+		return hidden_worker_profiler.python_call(
+			'bot_driver_inclusive', self._drive_impl,
+			bot_id, position, yaw, speed, dt, target, neighbours,
+			direction_clear, velocity, half_length, half_width,
+			movement_intent, stopping_distance, stop_at_target,
+			decision_horizon)
+
+	def _drive_impl(self, bot_id, position, yaw, speed, dt, target, neighbours,
 			direction_clear, velocity=None, half_length=3.5, half_width=1.7,
 			movement_intent=True, stopping_distance=None,
 			stop_at_target=True, decision_horizon=0.0):

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
@@ -11,6 +11,7 @@ probes so it can be tested outside the legacy client.
 import heapq
 import math
 
+from gui.mods.offline_lan_0922 import hidden_worker_profiler
 from gui.mods.offline_lan_0922.ai.driver import (
 	FIRST_CANDIDATE_OFFSET, WAYPOINT_ARRIVAL_RADIUS)
 
@@ -1167,6 +1168,11 @@ class TerrainNavigator(object):
 		self._accrue_search_credit(elapsed)
 
 	def _advance_searches(self, now):
+		"""Profile one complete fair A* service boundary."""
+		return hidden_worker_profiler.python_call(
+			'bot_astar_inclusive', self._advance_searches_impl, now)
+
+	def _advance_searches_impl(self, now):
 		"""Give every pending A* task a deterministic fair frame share.
 
 		The old on-demand scheduler handed the whole frame budget to whichever bots
@@ -1212,6 +1218,7 @@ class TerrainNavigator(object):
 		self.search_credit = max(0.0, self.search_credit - processed)
 		self.search_frame_budget = max(
 			0, int(self.search_frame_budget) - processed)
+		hidden_worker_profiler.work_add('bot_astar_expansions', processed)
 		self.search_next_key = queue[0] if queue else None
 		self._trim_cache(now)
 

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -47,7 +47,7 @@ from gui.mods.offline_lan_0922.spawn_planner import SpawnPlanner
 from gui.mods.offline_lan_0922 import (
     ballistics, combat_rules, critical_damage, descriptor_donation,
     destructibles_compat, effective_params, equipment_mechanics, gun_mechanics,
-    hull_aiming, lan_client as lan_protocol,
+    hidden_worker_profiler, hull_aiming, lan_client as lan_protocol,
     loadout as loadout_law, prebaked_destructibles, prebaked_foliage,
     prebaked_navigation, native_mapping_mask, shot_geometry, spotting,
     tank_collision,
@@ -70,6 +70,9 @@ WORKER_NATIVE_PROBE_SECONDS = 5.0
 DIAGNOSTIC_INITIAL_WINDOW_SECONDS = 5.0
 DIAGNOSTIC_WINDOW_SECONDS = 30.0
 DIAGNOSTIC_TOP_FRAMES = 3
+DIAGNOSTIC_NATIVE_TRACE_SAMPLES = 32
+DIAGNOSTIC_NATIVE_TRACE_LOG_SAMPLES = 8
+DIAGNOSTIC_SEGMENT_SAMPLES_PER_CATEGORY = 8
 # A normal 30-second window at 60-120 FPS fits entirely. Pathological high
 # frame rates retain only the latest bounded sample set while exact maxima and
 # threshold counts still cover the complete window.
@@ -288,15 +291,6 @@ def _underlying_function(value):
     return getattr(value, 'im_func', getattr(value, '__func__', value))
 
 
-def _format_xyz(value):
-    """Render a Vector3 or a 3-sequence compactly for a diagnostic line."""
-    try:
-        x, y, z = _xyz(value)
-        return '(%.1f, %.1f, %.1f)' % (x, y, z)
-    except Exception:
-        return repr(value)
-
-
 _PORT_PACKAGE = 'gui.mods.offline_lan_0922'
 # Sizing these adds nothing and walking a string character by character is slow.
 _ATOMIC_TYPES = (bool, float, complex, bytes, bytearray)
@@ -457,6 +451,30 @@ class _FrameDiagnostics(object):
             (name, 0.0) for name in _PROJECTILE_METRIC_NAMES)
         self._projectile_maxima = dict(
             (name, 0.0) for name in _PROJECTILE_METRIC_NAMES)
+        self._native_profile_measured = False
+        self._native_profile_samples = 0
+        self._native_profile_elapsed = 0.0
+        self._native_query_sums = {}
+        self._native_query_maxima = {}
+        self._offframe_native_query_sums = {}
+        self._offframe_native_query_maxima = {}
+        self._python_detail_sums = {}
+        self._python_detail_maxima = {}
+        self._offframe_python_detail_sums = {}
+        self._offframe_python_detail_maxima = {}
+        self._native_frame_totals = {
+            'calls': 0, 'calls_max': 0, 'seconds': 0.0,
+            'seconds_max': 0.0, 'failures': 0}
+        self._offframe_native_frame_totals = {
+            'calls': 0, 'calls_max': 0, 'seconds': 0.0,
+            'seconds_max': 0.0, 'failures': 0}
+        self._native_trace = []
+        self._segment_samples = {}
+        self._segment_samples_seen = {}
+        self._profiler_mode = 'off'
+        self._profiler_clock_reads = 0
+        self._profiler_clock_read_estimate_ns = None
+        self._profiler_mode_frames = {}
         self._slow = []
         self._over_50 = 0
         self._over_67 = 0
@@ -472,7 +490,8 @@ class _FrameDiagnostics(object):
         self._pending = None
         self._slow = []
 
-    def begin(self, entry_wall, raw_dt, offframe=0.0):
+    def begin(self, entry_wall, raw_dt, offframe=0.0,
+              detailed_offframe=None):
         """Seal the previous callback using this callback's entry interval.
 
         ``offframe`` is the time this port's other scheduled callbacks spent
@@ -494,6 +513,8 @@ class _FrameDiagnostics(object):
                     self._clock_regressions += 1
                 off = max(0.0, float(offframe))
                 row = dict(pending)
+                row['detailed_profile'] = self._merge_interval_profile(
+                    row.get('detailed_profile'), detailed_offframe)
                 row.update({
                     'next': frame_id,
                     'wall_gap': wall_gap,
@@ -507,6 +528,50 @@ class _FrameDiagnostics(object):
         except Exception:
             self._disable()
             return frame_id
+
+    @staticmethod
+    def _merge_interval_profile(profile, interval):
+        profile = dict(profile or {})
+        if not isinstance(interval, dict):
+            return profile
+        for bucket_name in ('offframe_native', 'offframe_python'):
+            source = interval.get(bucket_name)
+            if not isinstance(source, dict):
+                continue
+            target = dict(profile.get(bucket_name) or {})
+            for key, value in source.items():
+                try:
+                    calls = int(value[0])
+                    seconds = float(value[1])
+                    failures = int(value[2])
+                    old = target.get(key, (0, 0.0, 0))
+                    target[key] = (
+                        int(old[0]) + calls,
+                        float(old[1]) + seconds,
+                        int(old[2]) + failures)
+                except (IndexError, TypeError, ValueError, OverflowError):
+                    continue
+            profile[bucket_name] = target
+        for trace_name in ('trace', 'representative_trace'):
+            source = interval.get(trace_name)
+            if isinstance(source, (list, tuple)):
+                profile[trace_name] = tuple(
+                    profile.get(trace_name) or ()) + tuple(source)
+        try:
+            profile['clock_reads'] = (
+                int(profile.get('clock_reads', 0)) +
+                int(interval.get('clock_reads', 0)))
+        except (TypeError, ValueError, OverflowError):
+            pass
+        if bool(interval.get('measured', False)):
+            profile['measured'] = True
+        for name in ('clock_read_estimate_ns', 'coverage',
+                     'filtered_segment_timing'):
+            if profile.get(name) is None and interval.get(name) is not None:
+                profile[name] = interval.get(name)
+        if profile.get('frame_ordinal') is None:
+            profile['frame_ordinal'] = interval.get('frame_ordinal')
+        return profile
 
     def _add(self, row):
         self._samples += 1
@@ -561,6 +626,47 @@ class _FrameDiagnostics(object):
             self._projectile_sums[name] += value
             self._projectile_maxima[name] = max(
                 self._projectile_maxima[name], value)
+        detailed = row.get('detailed_profile') or {}
+        self._add_profiler_mode_frame(detailed.get('mode'), row)
+        if bool(detailed.get('measured', False)):
+            self._native_profile_measured = True
+            self._native_profile_samples += 1
+            self._native_profile_elapsed += gap
+            self._profiler_mode = str(
+                detailed.get('mode') or self._profiler_mode)[:64]
+        try:
+            self._profiler_clock_reads += max(
+                0, int(detailed.get('clock_reads', 0)))
+        except (TypeError, ValueError, OverflowError):
+            pass
+        try:
+            estimate = float(detailed.get('clock_read_estimate_ns'))
+            if not math.isnan(estimate) and not math.isinf(estimate):
+                self._profiler_clock_read_estimate_ns = max(0.0, estimate)
+        except (TypeError, ValueError, OverflowError):
+            pass
+        native_frame = self._add_detailed_bucket(
+            detailed.get('native'), self._native_query_sums,
+            self._native_query_maxima)
+        offframe_native_frame = self._add_detailed_bucket(
+            detailed.get('offframe_native'),
+            self._offframe_native_query_sums,
+            self._offframe_native_query_maxima)
+        self._add_detailed_bucket(
+            detailed.get('python'), self._python_detail_sums,
+            self._python_detail_maxima)
+        self._add_detailed_bucket(
+            detailed.get('offframe_python'),
+            self._offframe_python_detail_sums,
+            self._offframe_python_detail_maxima)
+        if bool(detailed.get('measured', False)):
+            self._add_frame_totals(
+                self._native_frame_totals, native_frame)
+            self._add_frame_totals(
+                self._offframe_native_frame_totals,
+                offframe_native_frame)
+        self._add_native_trace(detailed.get('trace'))
+        self._add_segment_samples(detailed.get('representative_trace'))
         self._last_context = dict(row.get('context') or {})
         score = (gap, execution)
         inserted = False
@@ -575,6 +681,117 @@ class _FrameDiagnostics(object):
             del self._slow[DIAGNOSTIC_TOP_FRAMES:]
         if self._window_elapsed >= self._window_seconds:
             self._emit_due = True
+
+    @staticmethod
+    def _add_detailed_bucket(source, sums, maxima):
+        frame = [0, 0.0, 0]
+        if not isinstance(source, dict):
+            return tuple(frame)
+        for key, value in source.items():
+            try:
+                calls = max(0, int(value[0]))
+                seconds = max(0.0, float(value[1]))
+                failures = max(0, int(value[2]))
+            except (IndexError, TypeError, ValueError, OverflowError):
+                continue
+            if (math.isnan(seconds) or math.isinf(seconds) or
+                    len(str(key)) > 96):
+                continue
+            key = str(key)
+            total = sums.get(key)
+            if total is None:
+                total = [0, 0.0, 0]
+                sums[key] = total
+            total[0] += calls
+            total[1] += seconds
+            total[2] += failures
+            maximum = maxima.get(key)
+            if maximum is None:
+                maximum = [0, 0.0]
+                maxima[key] = maximum
+            maximum[0] = max(maximum[0], calls)
+            maximum[1] = max(maximum[1], seconds)
+            frame[0] += calls
+            frame[1] += seconds
+            frame[2] += failures
+        return tuple(frame)
+
+    @staticmethod
+    def _add_frame_totals(stats, frame):
+        calls, seconds, failures = frame
+        stats['calls'] += calls
+        stats['calls_max'] = max(stats['calls_max'], calls)
+        stats['seconds'] += seconds
+        stats['seconds_max'] = max(stats['seconds_max'], seconds)
+        stats['failures'] += failures
+
+    def _add_profiler_mode_frame(self, mode, row):
+        mode = str(mode or 'off')[:64]
+        if mode == 'off':
+            return
+        stats = self._profiler_mode_frames.get(mode)
+        if stats is None:
+            stats = {
+                'samples': 0,
+                'gap_sum': 0.0,
+                'gap_max': 0.0,
+                'exec_sum': 0.0,
+                'exec_max': 0.0,
+                'gap_samples': collections.deque(
+                    maxlen=DIAGNOSTIC_PERCENTILE_SAMPLES),
+                'exec_samples': collections.deque(
+                    maxlen=DIAGNOSTIC_PERCENTILE_SAMPLES),
+            }
+            self._profiler_mode_frames[mode] = stats
+        gap = max(0.0, float(row.get('wall_gap', 0.0)))
+        execution = max(0.0, float(row.get('exec', 0.0)))
+        stats['samples'] += 1
+        stats['gap_sum'] += gap
+        stats['gap_max'] = max(stats['gap_max'], gap)
+        stats['exec_sum'] += execution
+        stats['exec_max'] = max(stats['exec_max'], execution)
+        stats['gap_samples'].append(gap)
+        stats['exec_samples'].append(execution)
+
+    def _add_native_trace(self, rows):
+        if not isinstance(rows, (list, tuple)):
+            return
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            try:
+                elapsed = max(0.0, float(row.get('elapsed_ms', 0.0)))
+            except (TypeError, ValueError, OverflowError):
+                continue
+            if math.isnan(elapsed) or math.isinf(elapsed):
+                continue
+            copied = dict(row)
+            copied['elapsed_ms'] = elapsed
+            self._native_trace.append(copied)
+        self._native_trace.sort(
+            key=lambda value: value.get('elapsed_ms', 0.0), reverse=True)
+        del self._native_trace[DIAGNOSTIC_NATIVE_TRACE_SAMPLES:]
+
+    def _add_segment_samples(self, rows):
+        if not isinstance(rows, (list, tuple)):
+            return
+        for row in rows:
+            if (not isinstance(row, dict) or
+                    row.get('api') != 'wg_collideSegment'):
+                continue
+            category = str(row.get('category', 'other'))[:48]
+            seen = self._segment_samples_seen.get(category, 0) + 1
+            self._segment_samples_seen[category] = seen
+            bucket = self._segment_samples.setdefault(category, [])
+            copied = dict(row)
+            if len(bucket) < DIAGNOSTIC_SEGMENT_SAMPLES_PER_CATEGORY:
+                bucket.append(copied)
+                continue
+            # Deterministic reservoir sampling avoids depending on gameplay's
+            # random stream and rotates beyond the first vehicles in a cohort.
+            replacement = ((seen * 1103515245 + 12345) & 0x7fffffff) % seen
+            if replacement < DIAGNOSTIC_SEGMENT_SAMPLES_PER_CATEGORY:
+                bucket[replacement] = copied
 
     def emit_due(self):
         """Whether the next end() closes the window."""
@@ -631,13 +848,83 @@ class _FrameDiagnostics(object):
             'max': self._milliseconds(exact_maximum),
         }
 
+    def _detailed_snapshot(self, sums, maxima, samples, elapsed):
+        result = {}
+        for key in sorted(sums):
+            total = sums[key]
+            maximum = maxima.get(key, (0, 0.0))
+            result[key] = {
+                'calls': int(total[0]),
+                'calls_per_second': float(total[0]) / elapsed,
+                'calls_per_frame_avg': float(total[0]) / samples,
+                'calls_per_frame_max': int(maximum[0]),
+                'failures': int(total[2]),
+                'timed_ms_total': self._milliseconds(total[1]),
+                'timed_ms_per_second': self._milliseconds(
+                    total[1] / elapsed),
+                'timed_ms_per_frame_avg': self._milliseconds(
+                    total[1] / samples),
+                'timed_ms_per_frame_max': self._milliseconds(maximum[1]),
+            }
+        return result
+
+    def _native_frame_total_snapshot(self, stats, samples, elapsed):
+        return {
+            'timing_frames': self._native_profile_samples,
+            'timing_seconds': self._native_profile_elapsed,
+            'calls': int(stats['calls']),
+            'calls_per_second': float(stats['calls']) / elapsed,
+            'calls_per_timed_frame_avg': float(stats['calls']) / samples,
+            'calls_per_timed_frame_max': int(stats['calls_max']),
+            'failures': int(stats['failures']),
+            'timed_ms_total': self._milliseconds(stats['seconds']),
+            'timed_ms_per_second': self._milliseconds(
+                stats['seconds'] / elapsed),
+            'timed_ms_per_timed_frame_avg': self._milliseconds(
+                stats['seconds'] / samples),
+            'timed_ms_per_timed_frame_max': self._milliseconds(
+                stats['seconds_max']),
+        }
+
+    def _profiler_ab_snapshot(self):
+        result = {}
+        for mode, stats in sorted(self._profiler_mode_frames.items()):
+            samples = max(1, stats['samples'])
+            result[mode] = {
+                'samples': stats['samples'],
+                'frame_interval_ms': self._distribution(
+                    stats['gap_samples'], stats['gap_max']),
+                'python_callback_ms': self._distribution(
+                    stats['exec_samples'], stats['exec_max']),
+                'frame_interval_avg_ms': self._milliseconds(
+                    stats['gap_sum'] / samples),
+                'python_callback_avg_ms': self._milliseconds(
+                    stats['exec_sum'] / samples),
+            }
+        return result
+
     def snapshot(self):
         """Return the most recently completed bounded performance window."""
         return dict(self._last_snapshot)
 
+    def compact_snapshot(self):
+        """Return status-safe window metrics without replay endpoints."""
+        result = self.snapshot()
+        if not result:
+            return {}
+        native_trace = result.pop('native_trace', ())
+        representative = result.pop('representative_segment_trace', {})
+        result['native_trace_omitted_from_status'] = len(native_trace)
+        result['representative_trace_omitted_from_status'] = dict(
+            (str(category), len(rows))
+            for category, rows in representative.items())
+        return result
+
     def _format(self):
         samples = max(1, self._samples)
         elapsed = max(1e-9, self._window_elapsed)
+        timing_samples = max(1, self._native_profile_samples)
+        timing_elapsed = max(1e-9, self._native_profile_elapsed)
         context = self._last_context
         self._window_id += 1
         gap_distribution = self._distribution(
@@ -671,7 +958,7 @@ class _FrameDiagnostics(object):
                     self._probe_duration_maxima[name]),
             }
         self._last_snapshot = {
-            'schema': 1,
+            'schema': 2,
             'window': self._window_id,
             'round': context.get('round', '-'),
             'map': context.get('map', '-'),
@@ -688,9 +975,62 @@ class _FrameDiagnostics(object):
             'python_callback_ms': exec_distribution,
             'outside_callback_ms': outside_distribution,
             'python_stages_ms': stage_snapshot,
-            # One logical probe can contain several native calls. The current
-            # Python boundary cannot truthfully derive raw call/primitives.
-            'raw_native_calls_measured': False,
+            'raw_native_calls_measured': self._native_profile_measured,
+            'native_timing_frames': self._native_profile_samples,
+            'native_timing_seconds': self._native_profile_elapsed,
+            'native_queries': self._detailed_snapshot(
+                self._native_query_sums, self._native_query_maxima,
+                timing_samples, timing_elapsed),
+            'offframe_native_queries': self._detailed_snapshot(
+                self._offframe_native_query_sums,
+                self._offframe_native_query_maxima,
+                timing_samples, timing_elapsed),
+            'native_frame_totals': self._native_frame_total_snapshot(
+                self._native_frame_totals, timing_samples, timing_elapsed),
+            'offframe_native_frame_totals': (
+                self._native_frame_total_snapshot(
+                    self._offframe_native_frame_totals,
+                    timing_samples, timing_elapsed)),
+            'python_detail': self._detailed_snapshot(
+                self._python_detail_sums, self._python_detail_maxima,
+                timing_samples, timing_elapsed),
+            'offframe_python_detail': self._detailed_snapshot(
+                self._offframe_python_detail_sums,
+                self._offframe_python_detail_maxima,
+                timing_samples, timing_elapsed),
+            'python_detail_semantics': (
+                'inclusive_of_nested_native_do_not_sum'),
+            'native_trace': tuple(self._native_trace),
+            'representative_segment_trace': dict(
+                (category, tuple(rows))
+                for category, rows in sorted(self._segment_samples.items())),
+            'profiler': {
+                'mode': self._profiler_mode,
+                'clock_reads': self._profiler_clock_reads,
+                'clock_reads_per_second': (
+                    self._profiler_clock_reads / timing_elapsed),
+                'timing_frames': self._native_profile_samples,
+                'timing_seconds': self._native_profile_elapsed,
+                'clock_read_estimate_ns': (
+                    self._profiler_clock_read_estimate_ns),
+                'clock_read_estimate_kind': (
+                    'upper_bound_including_python_loop'),
+                'estimated_clock_overhead_ms': (
+                    None if self._profiler_clock_read_estimate_ns is None else
+                    self._profiler_clock_reads *
+                    self._profiler_clock_read_estimate_ns / 1000000.0),
+                'trace_sampling': 'first+periodic/256 then reservoir/8',
+                'coverage': 'reviewed_hidden_worker_call_sites_only',
+                'filtered_segment_timing': (
+                    'native_boundary_including_python_filter'),
+                'ab_cycle': (
+                    '30s full timing / 5s wrapper-only baseline'),
+                'ab_interpretation': (
+                    'observational timing comparison of full '
+                    'instrumentation and wrapper branch; not a causal or '
+                    'unmodified-client baseline'),
+                'ab_frames': self._profiler_ab_snapshot(),
+            },
             'logical_native_probes': probe_snapshot,
             'worker_runtime': dict(self._worker_runtime),
             'over_50_67_100': (
@@ -701,7 +1041,7 @@ class _FrameDiagnostics(object):
         prefix = '[Offline LAN 0.9.22] PERF '
         lines = [
             (prefix +
-             'summary v=3 window=%d round=%s map=%s phase=%s role=%s '
+             'summary v=4 window=%d round=%s map=%s phase=%s role=%s '
              'probe_timing=%s '
              'samples=%d seconds=%.3f fps=%.2f authority_frames=%d '
              'gap_ms_avg_max=%.3f/%.3f raw_dt_ms_avg_max=%.3f/%.3f '
@@ -832,6 +1172,98 @@ class _FrameDiagnostics(object):
                 self._milliseconds(self._probe_duration_sums[name])))
         lines.append(prefix + 'logical_probe_ms_per_s_total ' +
                      ' '.join(probe_duration_rate_values) + '\n')
+        estimated_clock_ms = (
+            '-' if self._profiler_clock_read_estimate_ns is None else
+            '%.3f' % (self._profiler_clock_reads *
+                       self._profiler_clock_read_estimate_ns / 1000000.0))
+        lines.append(
+            (prefix +
+             'profiler mode=%s clock_reads=%d clock_reads_hz=%.2f '
+             'clock_read_upper_bound_ns=%s '
+             'estimated_clock_overhead_upper_bound_ms=%s '
+             'trace_sampling=first+periodic/256_then_reservoir/8 '
+             'coverage=reviewed_hidden_worker_call_sites_only '
+             'filtered_segment_timing=includes_python_filter '
+             'ab_cycle=30s_full_timing/5s_wrapper_only_baseline '
+             'ab_scope=observational_not_causal_or_unmodified\n') % (
+                 self._profiler_mode, self._profiler_clock_reads,
+                 self._profiler_clock_reads / timing_elapsed,
+                 ('-' if self._profiler_clock_read_estimate_ns is None else
+                  '%.1f' % self._profiler_clock_read_estimate_ns),
+                 estimated_clock_ms))
+        for mode, stats in sorted(self._profiler_mode_frames.items()):
+            mode_samples = max(1, stats['samples'])
+            gap = self._distribution(
+                stats['gap_samples'], stats['gap_max'])
+            execution = self._distribution(
+                stats['exec_samples'], stats['exec_max'])
+            lines.append(
+                (prefix +
+                 'profiler_ab mode=%s samples=%d gap_ms_avg_p50_p95_max='
+                 '%.3f/%.3f/%.3f/%.3f python_ms_avg_p50_p95_max='
+                 '%.3f/%.3f/%.3f/%.3f\n') % (
+                     mode, stats['samples'],
+                     self._milliseconds(stats['gap_sum'] / mode_samples),
+                     gap['p50'], gap['p95'], gap['max'],
+                     self._milliseconds(stats['exec_sum'] / mode_samples),
+                     execution['p50'], execution['p95'], execution['max']))
+        for label, sums, maxima in (
+                ('native', self._native_query_sums,
+                 self._native_query_maxima),
+                ('native_offframe', self._offframe_native_query_sums,
+                 self._offframe_native_query_maxima)):
+            call_values = []
+            timing_values = []
+            for name in sorted(sums):
+                total = sums[name]
+                maximum = maxima.get(name, (0, 0.0))
+                call_values.append('%s=%.2f/%d/%d/%d' % (
+                    name, total[0] / timing_elapsed,
+                    total[0], maximum[0],
+                    total[2]))
+                timing_values.append('%s=%.3f/%.3f/%.3f' % (
+                    name, self._milliseconds(total[1] / timing_elapsed),
+                    self._milliseconds(total[1]),
+                    self._milliseconds(maximum[1])))
+            lines.append(prefix + label + '_calls_hz_total_max_fail ' +
+                         (' '.join(call_values) or 'none') + '\n')
+            lines.append(prefix + label + '_ms_per_s_total_max_frame ' +
+                         (' '.join(timing_values) or 'none') + '\n')
+        for label, stats in (
+                ('native_frame_total', self._native_frame_totals),
+                ('native_offframe_frame_total',
+                 self._offframe_native_frame_totals)):
+            lines.append(
+                (prefix +
+                 '%s timing_frames_seconds=%d/%.3f '
+                 'calls_hz_total_avg_max_fail=%.2f/%d/%.2f/%d/%d '
+                 'ms_per_s_total_avg_max=%.3f/%.3f/%.3f/%.3f\n') % (
+                     label, self._native_profile_samples,
+                     self._native_profile_elapsed,
+                     stats['calls'] / timing_elapsed, stats['calls'],
+                     float(stats['calls']) / timing_samples,
+                     stats['calls_max'], stats['failures'],
+                     self._milliseconds(stats['seconds'] / timing_elapsed),
+                     self._milliseconds(stats['seconds']),
+                     self._milliseconds(stats['seconds'] / timing_samples),
+                     self._milliseconds(stats['seconds_max'])))
+        for label, sums, maxima in (
+                ('python_detail', self._python_detail_sums,
+                 self._python_detail_maxima),
+                ('python_detail_offframe',
+                 self._offframe_python_detail_sums,
+                 self._offframe_python_detail_maxima)):
+            values = []
+            for name in sorted(sums):
+                total = sums[name]
+                maximum = maxima.get(name, (0, 0.0))
+                values.append('%s=%.3f/%.3f/%.3f/%d' % (
+                    name, self._milliseconds(total[1] / timing_samples),
+                    self._milliseconds(total[1] / timing_elapsed),
+                    self._milliseconds(maximum[1]), total[2]))
+            lines.append(prefix + label +
+                         '_inclusive_ms_avg_per_s_max_fail ' +
+                         (' '.join(values) or 'none') + '\n')
         lines.append(
             (prefix +
              'projectile_avg_max active=%.2f/%.0f chords=%.2f/%.0f '
@@ -854,15 +1286,62 @@ class _FrameDiagnostics(object):
                  self._projectile_maxima['scans'],
                  self._projectile_sums['candidates'] / samples,
                  self._projectile_maxima['candidates']))
+        for rank, trace in enumerate(
+                self._native_trace[:DIAGNOSTIC_NATIVE_TRACE_LOG_SAMPLES], 1):
+            result = trace.get('result') or {}
+            lines.append(
+                (prefix +
+                 'native_trace rank=%d category=%s api=%s ms=%.3f '
+                 'profiler_frame=%s '
+                 'map=%s round=%s destr_rev=%s foliage_rev=%s '
+                 'replay_candidate=%d replayable=%d filter_free=%d '
+                 'filtered=%d space=%s mask=%s '
+                 'start=%s end=%s hit=%s point=%s normal=%s material=%s '
+                 'failed=%d\n') % (
+                     rank, trace.get('category', '-'),
+                     trace.get('api', '-'),
+                     float(trace.get('elapsed_ms', 0.0)),
+                     trace.get('profiler_frame', '-'),
+                     trace.get('map', '-'), trace.get('round', '-'),
+                     trace.get('destructible_revision', '-'),
+                     trace.get('foliage_revision', '-'),
+                     int(bool(trace.get('replay_candidate', False))),
+                     int(bool(trace.get('replayable', False))),
+                     int(bool(trace.get('filter_free', False))),
+                     int(bool(trace.get('filtered', False))),
+                     trace.get('space_id', '-'), trace.get('mask', '-'),
+                     trace.get('start', '-'), trace.get('end', '-'),
+                     result.get('hit', '-'), result.get('point', '-'),
+                     result.get('normal', '-'), result.get('material', '-'),
+                     int(bool(trace.get('failed', False)))))
+        for category in sorted(self._segment_samples):
+            samples_for_category = self._segment_samples[category]
+            encoded = []
+            for trace in samples_for_category[:2]:
+                result = trace.get('result') or {}
+                encoded.append('%s|%.3f|%s/%s|%s>%s|%s|%s' % (
+                    trace.get('sample_ordinal', '-'),
+                    float(trace.get('elapsed_ms', 0.0)),
+                    trace.get('destructible_revision', '-'),
+                    trace.get('foliage_revision', '-'),
+                    trace.get('start', '-'), trace.get('end', '-'),
+                    result.get('hit', '-'), result.get('material', '-')))
+            lines.append(
+                prefix + 'segment_samples category=%s seen=%d rows=%s\n' % (
+                    category,
+                    self._segment_samples_seen.get(category, 0),
+                    ';'.join(encoded) or 'none'))
         for rank, row in enumerate(self._slow, 1):
             stages = row['stages']
             probes = row['probes']
             probe_durations = row.get('probe_durations', {})
             projectile = row.get('projectile') or {}
+            detailed = row.get('detailed_profile') or {}
             context = row.get('context') or {}
             lines.append(
                 (prefix +
-                 'slow rank=%d cause=%d next=%d gap_ms=%.3f '
+                 'slow rank=%d cause=%d next=%d profiler_frame=%s '
+                 'profiler_mode=%s gap_ms=%.3f '
                  'raw_dt_ms=%.3f bw_minus_wall_ms=%.3f '
                  'prev_exec_ms=%.3f outside_ms=%.3f '
                  'cause_tick_ms=%.3f cause_motion_ms=%.3f '
@@ -870,8 +1349,12 @@ class _FrameDiagnostics(object):
                  'airborne=%d grind=%d bots=%d outgoing=%d '
                  'transition=%d prev_emit=%d '
                  'projectile=%s stages_ms=%s logical_probes=%s '
-                 'logical_probe_ms=%s\n') % (
+                 'logical_probe_ms=%s raw_native=%s '
+                 'raw_native_offframe=%s python_detail_inclusive=%s '
+                 'python_detail_offframe_inclusive=%s\n') % (
                      rank, row['cause'], row['next'],
+                     detailed.get('frame_ordinal', '-'),
+                     detailed.get('mode', 'off'),
                      self._milliseconds(row['wall_gap']),
                      row['raw_dt'] * 1000.0,
                      row['bw_minus_wall'] * 1000.0,
@@ -908,11 +1391,34 @@ class _FrameDiagnostics(object):
                      ','.join('%s:%.3f' % (
                          name, self._milliseconds(
                              probe_durations.get(name, 0.0)))
-                              for name in PROBE_KINDS)))
+                              for name in PROBE_KINDS),
+                     ','.join('%s:%d/%.3f' % (
+                         name, int(value[0]), self._milliseconds(value[1]))
+                              for name, value in sorted(
+                                  (detailed.get('native') or {}).items())) or
+                     'none',
+                     ','.join('%s:%d/%.3f' % (
+                         name, int(value[0]), self._milliseconds(value[1]))
+                              for name, value in sorted(
+                                  (detailed.get(
+                                      'offframe_native') or {}).items())) or
+                     'none',
+                     ','.join('%s:%d/%.3f' % (
+                         name, int(value[0]), self._milliseconds(value[1]))
+                              for name, value in sorted(
+                                  (detailed.get('python') or {}).items())) or
+                     'none',
+                     ','.join('%s:%d/%.3f' % (
+                         name, int(value[0]), self._milliseconds(value[1]))
+                              for name, value in sorted(
+                                  (detailed.get(
+                                      'offframe_python') or {}).items())) or
+                     'none'))
         return ''.join(lines)
 
     def finish(self, frame_id, entry_wall, tick_dt, motion_dt, stages,
-               probes, context, probe_durations=None, projectile=None):
+               probes, context, probe_durations=None, projectile=None,
+               detailed_profile=None):
         if not self.enabled:
             return
         try:
@@ -938,6 +1444,7 @@ class _FrameDiagnostics(object):
                 'stages': stages, 'probes': probes,
                 'probe_durations': dict(probe_durations or {}),
                 'projectile': dict(projectile or {}),
+                'detailed_profile': dict(detailed_profile or {}),
                 'context': dict(context or {}), 'emitted': emitted,
             }
         except Exception:
@@ -1647,6 +2154,8 @@ class BattleRuntime(object):
         self._next_fallen_tree_foliage_refresh = 0.0
         self._fallen_tree_foliage_seen_bodies = set()
         self._fallen_tree_foliage_stable = {}
+        self._profiler_destructible_revision = 0
+        self._profiler_foliage_revision = 0
         self._projectiles = None
         self._projectile_meta = {}
         self._projectile_visual_meta = {}
@@ -1689,6 +2198,9 @@ class BattleRuntime(object):
         self._runtime = self._runtime or _load_runtime()
         self._config = dict(config or {})
         self._worker_mode = bool(self._config.get('worker_mode', False))
+        hidden_worker_profiler.reset()
+        self._profiler_destructible_revision = 0
+        self._profiler_foliage_revision = 0
         if self._worker_mode:
             self._config['native_remote_vehicles'] = False
             self._config['bot_track_animation'] = False
@@ -4286,9 +4798,13 @@ class BattleRuntime(object):
     def _collide_down(self, start, end, ground_filter):
         """Vertical probe that skips the skin of an already broken item."""
         if ground_filter is None:
-            return self._runtime.bigworld.wg_collideSegment(
+            return hidden_worker_profiler.native_call(
+                'ground', 'wg_collideSegment',
+                self._runtime.bigworld.wg_collideSegment,
                 self._avatar.spaceID, start, end, 128)
-        return self._runtime.bigworld.wg_collideSegment(
+        return hidden_worker_profiler.native_call(
+            'ground', 'wg_collideSegment',
+            self._runtime.bigworld.wg_collideSegment,
             self._avatar.spaceID, start, end, 128, ground_filter)
 
     def _ground_y(self, x, z, hint=0.0, allow_wide=False):
@@ -4461,7 +4977,9 @@ class BattleRuntime(object):
             probe_up = max(4.5, run * 0.52)
             probe_down = max(5.0, run * 0.45)
             try:
-                ground = self._runtime.bigworld.wg_collideSegment(
+                ground = hidden_worker_profiler.native_call(
+                    'motion_direction', 'wg_collideSegment',
+                    self._runtime.bigworld.wg_collideSegment,
                     self._avatar.spaceID,
                     self._vector((nx, previous_y + probe_up, nz)),
                     self._vector((nx, previous_y - probe_down, nz)), 128)
@@ -4496,7 +5014,9 @@ class BattleRuntime(object):
                     nx + lateral_x * offset, next_y + height,
                     nz + lateral_z * offset))
                 try:
-                    collision = self._runtime.bigworld.wg_collideSegment(
+                    collision = hidden_worker_profiler.native_call(
+                        'motion_direction', 'wg_collideSegment',
+                        self._runtime.bigworld.wg_collideSegment,
                         self._avatar.spaceID, ray_start, ray_end, 128)
                 except Exception:
                     collision = True
@@ -4623,7 +5143,9 @@ class BattleRuntime(object):
                 ray_start = self._vector((sx, y + height, sz))
                 ray_end = self._vector((ex, y + height, ez))
                 try:
-                    collision = self._runtime.bigworld.wg_collideSegment(
+                    collision = hidden_worker_profiler.native_call(
+                        'motion_receipt', 'wg_collideSegment',
+                        self._runtime.bigworld.wg_collideSegment,
                         self._avatar.spaceID, ray_start, ray_end, 128)
                 except Exception:
                     return False
@@ -4665,7 +5187,9 @@ class BattleRuntime(object):
                 float(end[0]) + lateral_x * offset,
                 float(end[1]) + 0.9,
                 float(end[2]) + lateral_z * offset))
-            if self._runtime.bigworld.wg_collideSegment(
+            if hidden_worker_profiler.native_call(
+                    'navigation', 'wg_collideSegment',
+                    self._runtime.bigworld.wg_collideSegment,
                     self._avatar.spaceID, ray_start, ray_end, 128) is not None:
                 return True
         return False
@@ -4675,7 +5199,8 @@ class BattleRuntime(object):
         if not callable(collide):
             return -1.0
         try:
-            value = collide(
+            value = hidden_worker_profiler.native_call(
+                'water', 'wg_collideWater', collide,
                 self._vector((point[0], point[1] + 20.0, point[2])),
                 self._vector((point[0], point[1] - 5.0, point[2])), False)
         except Exception:
@@ -4711,7 +5236,8 @@ class BattleRuntime(object):
             end = self._vector((
                 float(point[0]), float(point[1]) + 0.1,
                 float(point[2])))
-            value = collide(start, end, False)
+            value = hidden_worker_profiler.native_call(
+                'water', 'wg_collideWater', collide, start, end, False)
             return value is not None and float(value) > 0.0
         except Exception:
             return True
@@ -4983,7 +5509,9 @@ class BattleRuntime(object):
                               observer[2]))
         for height in (1.5, 2.2):
             end = self._vector((target[0], target[1] + height, target[2]))
-            if self._runtime.bigworld.wg_collideSegment(
+            if hidden_worker_profiler.native_call(
+                    'cover', 'wg_collideSegment',
+                    self._runtime.bigworld.wg_collideSegment,
                     self._avatar.spaceID, start, end, 128) is None:
                 return True
         return False
@@ -7977,6 +8505,12 @@ class BattleRuntime(object):
         if kind == 'tree':
             foliage_changed = self._activate_fallen_tree_foliage(
                 chunk_id, item_index)
+        if not already_destroyed:
+            self._profiler_destructible_revision += 1
+        if foliage_changed:
+            self._profiler_foliage_revision += 1
+        hidden_worker_profiler.update_context(
+            self._hidden_worker_profile_context())
         if already_destroyed:
             return foliage_changed
         note_destroyed = getattr(
@@ -10966,7 +11500,9 @@ class BattleRuntime(object):
                 target, body_matrix, start, end, self._runtime.math,
                 chassis_matrix=chassis_matrix) or ())
             return (tuple(item.collision for item in evidence), evidence)
-        return (tuple(target.collideSegmentExt(start, end) or ()), ())
+        return (tuple(hidden_worker_profiler.category_call(
+            'projectile_vehicle',
+            target.collideSegmentExt, start, end) or ()), ())
 
     def _projectile_chord(self, state, start, end,
                           absolute_start, absolute_end):
@@ -11368,8 +11904,12 @@ class BattleRuntime(object):
             if (decoded_sticker != sticker_id or
                     decoded_start is None or decoded_end is None or
                     decoded_start == decoded_end or
-                    not callable(local_hit_test) or
-                    not local_hit_test(decoded_start, decoded_end)):
+                    not callable(local_hit_test)):
+                return None
+            sticker_hits = hidden_worker_profiler.native_call(
+                'projectile_vehicle', 'hitTester.localHitTest',
+                local_hit_test, decoded_start, decoded_end)
+            if not sticker_hits:
                 return None
             return encoded
         except Exception:
@@ -11557,8 +12097,9 @@ class BattleRuntime(object):
                         self._runtime.math,
                         chassis_matrix=chassis_matrix) or ())
                 else:
-                    collisions = tuple(
-                        target.collideSegmentExt(burst, aim) or ())
+                    collisions = tuple(hidden_worker_profiler.category_call(
+                        'projectile_vehicle',
+                        target.collideSegmentExt, burst, aim) or ())
                 nominal = combat_rules.he_nominal_armor(
                     collisions, target.typeDescriptor)
             except Exception:
@@ -11991,7 +12532,9 @@ class BattleRuntime(object):
             requested = set(token)
             unresolved = set(row for row in requested
                 if not destructibles_authority.is_destroyed(*row))
-            world_status = world_collision.check_horizontal_collision(
+            world_status = hidden_worker_profiler.python_call(
+                'destructible_contact',
+                world_collision.check_horizontal_collision,
                 self._runtime.bigworld, self._runtime.math,
                 self._avatar.spaceID, self._vector(position), yaw, speed,
                 descriptor, False, dt, True, True, kinetic_speed,
@@ -12215,7 +12758,8 @@ class BattleRuntime(object):
         diagnostic_totals = self._worker_diagnostic_totals()
         snapshot = self._last_snapshot or {}
         frame_performance = {}
-        frame_provider = getattr(self._frame_diagnostics, 'snapshot', None)
+        frame_provider = getattr(
+            self._frame_diagnostics, 'compact_snapshot', None)
         if callable(frame_provider):
             try:
                 frame_performance = frame_provider()
@@ -12245,6 +12789,22 @@ class BattleRuntime(object):
             },
             'frame_performance': frame_performance,
         }
+
+    def _hidden_worker_profile_context(self):
+        try:
+            destructible_revision = self._profiler_destructible_revision
+            revision_reader = getattr(
+                self._destructibles, '_spatial_revision_1513', None)
+            if callable(revision_reader):
+                destructible_revision = int(revision_reader())
+            return {
+                'round': (self._start_message or {}).get('round_id', '-'),
+                'map': (self._config or {}).get('map', '-'),
+                'destructible_revision': destructible_revision,
+                'foliage_revision': self._profiler_foliage_revision,
+            }
+        except Exception:
+            return {}
 
     def authority_worker_ready_for_draw_off(self):
         """Return true only after every native simulation model is ready.
@@ -12364,6 +12924,11 @@ class BattleRuntime(object):
         diagnostics = self._frame_diagnostics
         profiling = diagnostics is not None and diagnostics.enabled
         entry_wall = _PROFILE_CLOCK() if profiling else 0.0
+        profile_active = self._worker_mode and profiling
+        detailed_offframe = hidden_worker_profiler.begin_frame(
+            profile_active,
+            context=(self._hidden_worker_profile_context()
+                     if profile_active else None))
         now = self._clock()
         frame_start = self._last_frame_time
         raw_dt = (0.0 if frame_start is None else
@@ -12387,7 +12952,9 @@ class BattleRuntime(object):
         self._offframe_seconds = 0.0
         self._effect_reports = 0
         self._spotted_signature = None
-        frame_id = (diagnostics.begin(entry_wall, raw_dt, offframe)
+        frame_id = (diagnostics.begin(
+            entry_wall, raw_dt, offframe,
+            detailed_offframe=detailed_offframe)
                     if profiling else 0)
         stages = {}
         probes = dict((name, 0) for name in PROBE_KINDS)
@@ -12397,6 +12964,7 @@ class BattleRuntime(object):
         outgoing_messages = ()
         bot_count = 0
         projectile_perf = {}
+        detailed_profile = {}
         boundary = entry_wall
         try:
             self._run_optional_feature(
@@ -12406,7 +12974,8 @@ class BattleRuntime(object):
             self._flush_pending_bot_create(now)
             self._flush_pending_entities(now)
             self._drain_event_journal()
-            self._run_optional_feature(
+            hidden_worker_profiler.python_call(
+                'foliage_dynamic', self._run_optional_feature,
                 'foliage camouflage',
                 self._refresh_fallen_tree_foliage, (now,))
             self._retry_bot_manifest(now)
@@ -12545,8 +13114,13 @@ class BattleRuntime(object):
                 self._advance_artillery_arcs(now)
                 players = self._authority_players()
                 if self._worker_mode:
-                    self._scan_authority_player_trees(players, now)
-                    self._resolve_player_destructible_contacts(players, now)
+                    hidden_worker_profiler.python_call(
+                        'destructible_scan',
+                        self._scan_authority_player_trees, players, now)
+                    hidden_worker_profiler.python_call(
+                        'destructible_contact',
+                        self._resolve_player_destructible_contacts,
+                        players, now)
                 probe_totals = getattr(self._bots, 'probe_totals', None)
                 probe_duration_totals = getattr(
                     self._bots, 'probe_duration_totals', None)
@@ -12681,6 +13255,7 @@ class BattleRuntime(object):
                 stages['lock'] = max(0.0, next_boundary - boundary)
                 boundary = next_boundary
         except Exception as error:
+            detailed_profile = hidden_worker_profiler.end_frame()
             self._fail(error)
             return
         schedule_start = _PROFILE_CLOCK() if profiling else 0.0
@@ -12738,6 +13313,7 @@ class BattleRuntime(object):
                         })
                     except Exception:
                         pass
+            detailed_profile = hidden_worker_profiler.end_frame()
             diagnostics.finish(
                 frame_id, entry_wall, tick_dt, dt, stages, probes, {
                     'round': (self._start_message or {}).get('round_id', '-'),
@@ -12755,7 +13331,8 @@ class BattleRuntime(object):
                     'grind': int(self._local_grind),
                     'transitioned': transitioned,
                 }, probe_durations=probe_durations,
-                projectile=projectile_perf)
+                projectile=projectile_perf,
+                detailed_profile=detailed_profile)
 
     def _mutable_shot_ray(self):
         """Copy #1513's native gun ray before normalising or scattering it."""
@@ -12862,10 +13439,13 @@ class BattleRuntime(object):
             if record.get('native_remote'):
                 collisions = collide_vehicle_at_matrix(
                     vehicle, vehicle.matrix, start, end,
-                    self._runtime.math)
+                    self._runtime.math,
+                    profiler_category='presentation')
             else:
                 collide = getattr(vehicle, 'collideSegmentExt', None)
-                collisions = collide(start, end) if callable(collide) else ()
+                collisions = (hidden_worker_profiler.category_call(
+                    'presentation',
+                    collide, start, end) if callable(collide) else ())
             if (collisions and min(float(item.dist) for item in collisions) +
                     _SHOT_OCCLUSION_EPSILON < target_depth):
                 return True
@@ -12946,13 +13526,16 @@ class BattleRuntime(object):
                 if record.get('native_remote'):
                     collisions = collide_vehicle_at_matrix(
                         vehicle, vehicle.matrix, start, end,
-                        self._runtime.math)
+                        self._runtime.math,
+                        profiler_category='presentation')
                     if collisions:
                         depth = min(float(item.dist) for item in collisions)
                 else:
                     collide = getattr(vehicle, 'collideSegmentExt', None)
                     if callable(collide):
-                        collisions = collide(start, end)
+                        collisions = hidden_worker_profiler.category_call(
+                            'presentation',
+                            collide, start, end)
                         if collisions:
                             depth = min(
                                 float(item.dist) for item in collisions)
@@ -12970,7 +13553,9 @@ class BattleRuntime(object):
                 chosen = engine_id
         if chosen is not None and chosen_depth is not None:
             target_end = start + direction.scale(chosen_depth)
-            world_hit = self._runtime.bigworld.wg_collideSegment(
+            world_hit = hidden_worker_profiler.native_call(
+                'presentation', 'wg_collideSegment',
+                self._runtime.bigworld.wg_collideSegment,
                 self._avatar.spaceID, start, target_end, 128)
             if (world_hit is not None and
                     (world_hit[0] - start).length +
@@ -13659,7 +14244,9 @@ class BattleRuntime(object):
                     predicted = bool(
                         token is not None and callable(predictor) and
                         predictor(token))
-                world_status = world_collision.check_horizontal_collision(
+                world_status = hidden_worker_profiler.python_call(
+                    'destructible_contact',
+                    world_collision.check_horizontal_collision,
                     self._runtime.bigworld, self._runtime.math,
                     self._avatar.spaceID, self._vector(position),
                     world_hull_yaw, speed,
@@ -13702,7 +14289,9 @@ class BattleRuntime(object):
                 # to the worker; the worker remains the sole owner of the
                 # irreversible map mutation and its canonical LAN event.
                 return True
-        world_status = world_collision.check_horizontal_collision(
+        world_status = hidden_worker_profiler.python_call(
+            'destructible_contact',
+            world_collision.check_horizontal_collision,
             self._runtime.bigworld, self._runtime.math,
             self._avatar.spaceID, self._vector(position),
             world_hull_yaw, speed,
@@ -13808,7 +14397,9 @@ class BattleRuntime(object):
             limit_name = 'speedBwd' if speed < 0.0 else 'speedFwd'
             kinetic_speed = (-float(params[limit_name]) if speed < 0.0 else
                              float(params[limit_name]))
-        world_status = world_collision.check_horizontal_collision(
+        world_status = hidden_worker_profiler.python_call(
+            'destructible_contact',
+            world_collision.check_horizontal_collision,
             self._runtime.bigworld, self._runtime.math,
             self._avatar.spaceID, pos, yaw, speed, descriptor, airborne, dt,
             True, allow_crush_drive, kinetic_speed,
@@ -13967,7 +14558,7 @@ class BattleRuntime(object):
             hit[2] + inward_normal[1] * center_depth))
         collisions = collide_vehicle_at_matrix(
             vehicle, matrix, start, end, self._runtime.math,
-            chassis_matrix=chassis_matrix)
+            chassis_matrix=chassis_matrix, profiler_category='ram')
         if not collisions:
             return None
         for collision in sorted(
@@ -15889,7 +16480,9 @@ class BattleRuntime(object):
                               source_position[2]))
         end = self._vector((target_position[0], target_position[1] + 1.5,
                             target_position[2]))
-        hit = self._runtime.bigworld.wg_collideSegment(
+        hit = hidden_worker_profiler.native_call(
+            'spotting', 'wg_collideSegment',
+            self._runtime.bigworld.wg_collideSegment,
             self._avatar.spaceID, start, end, 128)
         line_of_sight = bool(
             hit is None or
@@ -15933,7 +16526,9 @@ class BattleRuntime(object):
             if not segment:
                 return False
             start, end = segment
-            hit = self._runtime.bigworld.wg_collideSegment(
+            hit = hidden_worker_profiler.native_call(
+                'firing_lane', 'wg_collideSegment',
+                self._runtime.bigworld.wg_collideSegment,
                 self._avatar.spaceID,
                 self._vector(start), self._vector(end), 128)
             if hit is None:
@@ -16003,7 +16598,8 @@ class BattleRuntime(object):
                             collisions = collide_vehicle_at_matrix(
                                 vehicle, self._local_body_pose(), start, end,
                                 self._runtime.math,
-                                chassis_matrix=self._local_matrix)
+                                chassis_matrix=self._local_matrix,
+                                profiler_category='firing_lane')
                         elif record.get('native_remote'):
                             body_matrix, chassis_matrix = \
                                 self._projectile_vehicle_matrices(
@@ -16011,12 +16607,15 @@ class BattleRuntime(object):
                             collisions = collide_vehicle_at_matrix(
                                 vehicle, body_matrix, start, end,
                                 self._runtime.math,
-                                chassis_matrix=chassis_matrix)
+                                chassis_matrix=chassis_matrix,
+                                profiler_category='firing_lane')
                         else:
                             collide = getattr(
                                 vehicle, 'collideSegmentExt', None)
-                            collisions = (collide(start, end)
-                                          if callable(collide) else ())
+                            collisions = (hidden_worker_profiler.category_call(
+                                'firing_lane',
+                                collide, start, end)
+                                if callable(collide) else ())
                     except Exception:
                         return {'clear': False}
                     if collisions:
@@ -16103,8 +16702,7 @@ class BattleRuntime(object):
                 not getattr(source_entity, 'isStarted', False)):
             return None
         try:
-            gun_node = source_entity.model.node('HP_gunFire')
-            native = _xyz(self._runtime.math.Matrix(gun_node).translation)
+            native = self._native_muzzle_position(source_entity)
         except Exception:
             return None
         presented = source_record.get('projectile_collision_pose')
@@ -16128,6 +16726,20 @@ class BattleRuntime(object):
         """Read the same native muzzle used by the final SPG proof."""
         return self._bot_direct_launch_origin(
             source, descriptor, 0, 0, 0.0, 0.0, 0.0)
+
+    def _native_muzzle_position(self, entity):
+        """Read one exact model node and its native world transform."""
+        marker = hidden_worker_profiler.python_started('muzzle_transform')
+        failed = False
+        try:
+            gun_node = hidden_worker_profiler.native_call(
+                'muzzle', 'model.node', entity.model.node, 'HP_gunFire')
+            return _xyz(self._runtime.math.Matrix(gun_node).translation)
+        except Exception:
+            failed = True
+            raise
+        finally:
+            hidden_worker_profiler.python_finished(marker, failed)
 
     def _bot_ballistic_solution(self, source, target, descriptor,
                                 shell_index, now):
@@ -16156,8 +16768,7 @@ class BattleRuntime(object):
                 getattr(entity, 'typeDescriptor', None) is None):
             return None
         try:
-            gun_node = entity.model.node('HP_gunFire')
-            origin = _xyz(self._runtime.math.Matrix(gun_node).translation)
+            origin = self._native_muzzle_position(entity)
         except Exception:
             # A logical pose is not a muzzle proof.  SPGs wait until the
             # native model exposes the exact launch transform.
@@ -16208,7 +16819,9 @@ class BattleRuntime(object):
 
     def _artillery_arc_probe(self, start, end):
         """Return the native world hit point, or None for one clear chord."""
-        hit = self._runtime.bigworld.wg_collideSegment(
+        hit = hidden_worker_profiler.native_call(
+            'artillery', 'wg_collideSegment',
+            self._runtime.bigworld.wg_collideSegment,
             self._avatar.spaceID, self._vector(start), self._vector(end), 128)
         if hit is None:
             return None
@@ -16800,9 +17413,7 @@ class BattleRuntime(object):
         source_position = _xyz(getattr(source, 'position', state))
         target_position = _xyz(getattr(
             target, 'position', target_record.get('state', {})))
-        gun_node = source.model.node('HP_gunFire')
-        start = self._vector(
-            self._runtime.math.Matrix(gun_node).translation)
+        start = self._vector(self._native_muzzle_position(source))
         destination = self._vector((
             target_position[0], target_position[1] + 1.2,
             target_position[2]))
@@ -16850,7 +17461,9 @@ class BattleRuntime(object):
                     candidate, body_matrix, start, end,
                     self._runtime.math, chassis_matrix=chassis_matrix)
             else:
-                candidate_collisions = candidate.collideSegmentExt(start, end)
+                candidate_collisions = hidden_worker_profiler.category_call(
+                    'projectile_vehicle',
+                    candidate.collideSegmentExt, start, end)
             if not candidate_collisions:
                 continue
             nearest = min(candidate_collisions,
@@ -17861,16 +18474,21 @@ class BattleRuntime(object):
             _field(gun, 'invisibilityFactorAtShot', 1.0), 0.0, 1.0)
 
     def _foliage_camouflage_bonus(self, observer, target, fired_recently):
-        if (self._foliage is None or not self._optional_feature_enabled(
-                'foliage camouflage')):
-            return 0.0
+        marker = hidden_worker_profiler.python_started('foliage_spotting')
+        failed = False
         try:
+            if (self._foliage is None or not self._optional_feature_enabled(
+                    'foliage camouflage')):
+                return 0.0
             return self._foliage.camouflage_bonus(
                 observer, target, fired_recently)
         except Exception as error:
+            failed = True
             self._foliage = None
             self._warn_optional_failure('foliage camouflage', error)
             return 0.0
+        finally:
+            hidden_worker_profiler.python_finished(marker, failed)
 
     def _activate_fallen_tree_foliage(self, chunk_id, item_index):
         if (self._foliage is None or not self._optional_feature_enabled(
@@ -17925,12 +18543,16 @@ class BattleRuntime(object):
         center, half_sizes = profile
         bigworld = self._runtime.bigworld
         math_module = self._runtime.math
-        chunk_matrix = bigworld.wg_getChunkMatrix(
+        chunk_matrix = hidden_worker_profiler.native_call(
+            'foliage_dynamic', 'wg_getChunkMatrix',
+            bigworld.wg_getChunkMatrix,
             self._avatar.spaceID, int(chunk_id))
         chunk_translation = getattr(chunk_matrix, 'translation', None)
         if chunk_translation is None:
             return None
-        matrix = math_module.Matrix(bigworld.wg_getDestructibleMatrix(
+        matrix = math_module.Matrix(hidden_worker_profiler.native_call(
+            'foliage_dynamic', 'wg_getDestructibleMatrix',
+            bigworld.wg_getDestructibleMatrix,
             self._avatar.spaceID, int(chunk_id), int(item_index)))
         local_center = self._vector(center)
         transformed_center = matrix.applyPoint(local_center)
@@ -18035,6 +18657,10 @@ class BattleRuntime(object):
             if stable_reads >= FALLEN_TREE_FOLIAGE_STABLE_READS:
                 settle(chunk_id, item_index)
                 self._fallen_tree_foliage_stable.pop(identity, None)
+        if changed:
+            self._profiler_foliage_revision += 1
+            hidden_worker_profiler.update_context(
+                self._hidden_worker_profile_context())
         return changed
 
     def _spot_line_of_sight(self, observer, target, target_descriptor,
@@ -18058,7 +18684,9 @@ class BattleRuntime(object):
             if not segment:
                 continue
             start, end = segment
-            hit = self._runtime.bigworld.wg_collideSegment(
+            hit = hidden_worker_profiler.native_call(
+                'spotting', 'wg_collideSegment',
+                self._runtime.bigworld.wg_collideSegment,
                 self._avatar.spaceID,
                 self._vector(start), self._vector(end), 128)
             if hit is None:
@@ -18834,7 +19462,9 @@ class BattleRuntime(object):
                     target, target.matrix, start, end,
                     self._runtime.math)
             else:
-                result = target.collideSegmentExt(start, end)
+                result = hidden_worker_profiler.category_call(
+                    'projectile_vehicle',
+                    target.collideSegmentExt, start, end)
             if not result:
                 continue
             nearest = min(result, key=lambda item: float(item.dist))
@@ -18919,7 +19549,9 @@ class BattleRuntime(object):
             0.0, _number(initial_piercing_loss, 0.0))
         distance_offset = max(0.0, _number(distance_offset, 0.0))
         if self._destructibles is None:
-            hit = self._runtime.bigworld.wg_collideSegment(
+            hit = hidden_worker_profiler.native_call(
+                'projectile_world', 'wg_collideSegment',
+                self._runtime.bigworld.wg_collideSegment,
                 self._avatar.spaceID, start, end, 128)
             return {
                 'world_distance': ((hit[0] - start).length
@@ -18932,7 +19564,9 @@ class BattleRuntime(object):
         piercing_loss = initial_piercing_loss
         for unused_index in range(64):
             cursor = start + direction.scale(travelled)
-            result = self._destructibles.shot_world_distance(
+            result = hidden_worker_profiler.python_call(
+                'destructible_projectile',
+                self._destructibles.shot_world_distance,
                 self._runtime.bigworld, self._avatar.spaceID,
                 cursor, end, direction, shot)
             if not isinstance(result, dict):
@@ -19041,8 +19675,10 @@ class BattleRuntime(object):
                         self._runtime.math,
                         chassis_matrix=chassis_matrix) or ())
                 else:
-                    collisions = tuple(
-                        target.collideSegmentExt(burst_position, aim) or ())
+                    collisions = tuple(hidden_worker_profiler.category_call(
+                        'projectile_vehicle',
+                        target.collideSegmentExt,
+                        burst_position, aim) or ())
                 nominal = combat_rules.he_nominal_armor(
                     collisions, target.typeDescriptor)
             except Exception:

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -384,11 +384,23 @@ def _is_port_object(value):
 
 _FRAME_STAGE_NAMES = (
     'house', 'sync', 'critical', 'drown', 'prewarm', 'transition', 'local',
-    'outline', 'bots_update', 'bot_present', 'bot_events', 'spot', 'lock',
-    'schedule', 'diag_emit')
+    'outline', 'bot_prework', 'bot_runtime_update', 'bot_postdiag',
+    'bot_present', 'bot_messages', 'projectiles', 'spot', 'lock', 'schedule',
+    'diag_emit')
 _PROJECTILE_METRIC_NAMES = (
     'active', 'chords', 'debt', 'advance', 'terminals', 'scans',
     'candidates')
+_WORK_METRIC_NAMES = tuple(hidden_worker_profiler.WORK_COUNTERS)
+_WORK_METRIC_AGGREGATIONS = dict(
+    hidden_worker_profiler.WORK_COUNTER_AGGREGATIONS)
+_BOT_MAIN_PHASE_NAMES = (
+    'bot_setup', 'bot_control_observation', 'bot_selected_motion',
+    'bot_motion_commit_integration', 'bot_aim_fire', 'bot_supplemental',
+    'bot_tank_contacts', 'bot_vertical_ground', 'bot_publication')
+_LEGACY_STAGE_GROUPS = {
+    'bots_update': ('bot_prework', 'bot_runtime_update', 'bot_postdiag'),
+    'bot_events': ('bot_messages', 'projectiles'),
+}
 
 
 class _FrameDiagnostics(object):
@@ -441,6 +453,10 @@ class _FrameDiagnostics(object):
                                 for name in _FRAME_STAGE_NAMES)
         self._stage_maxima = dict((name, 0.0)
                                   for name in _FRAME_STAGE_NAMES)
+        self._legacy_stage_sums = dict(
+            (name, 0.0) for name in _LEGACY_STAGE_GROUPS)
+        self._legacy_stage_maxima = dict(
+            (name, 0.0) for name in _LEGACY_STAGE_GROUPS)
         self._probe_sums = dict((name, 0) for name in PROBE_KINDS)
         self._probe_maxima = dict((name, 0) for name in PROBE_KINDS)
         self._probe_duration_sums = dict(
@@ -451,6 +467,28 @@ class _FrameDiagnostics(object):
             (name, 0.0) for name in _PROJECTILE_METRIC_NAMES)
         self._projectile_maxima = dict(
             (name, 0.0) for name in _PROJECTILE_METRIC_NAMES)
+        self._work_sums = dict((name, 0.0) for name in _WORK_METRIC_NAMES)
+        self._work_maxima = dict((name, 0.0) for name in _WORK_METRIC_NAMES)
+        self._frame_work_sums = dict(
+            (name, 0.0) for name in _WORK_METRIC_NAMES)
+        self._offframe_work_sums = dict(
+            (name, 0.0) for name in _WORK_METRIC_NAMES)
+        self._work_samples = 0
+        self._work_counters_recorded = False
+        self._callback_residual_sum = 0.0
+        self._callback_residual_max = 0.0
+        self._bot_attribution_samples = 0
+        self._bot_outer_sum = 0.0
+        self._bot_outer_max = 0.0
+        self._bot_main_sum = 0.0
+        self._bot_main_max = 0.0
+        self._bot_residual_sum = 0.0
+        self._bot_residual_max = 0.0
+        self._bot_scheduler_attribution_samples = 0
+        self._bot_scheduler_sum = 0.0
+        self._bot_scheduler_max = 0.0
+        self._bot_scheduler_residual_sum = 0.0
+        self._bot_scheduler_residual_max = 0.0
         self._native_profile_measured = False
         self._native_profile_samples = 0
         self._native_profile_elapsed = 0.0
@@ -475,6 +513,8 @@ class _FrameDiagnostics(object):
         self._profiler_clock_reads = 0
         self._profiler_clock_read_estimate_ns = None
         self._profiler_mode_frames = {}
+        self._python_category_scopes = {}
+        self._python_scope_sum_rule = None
         self._slow = []
         self._over_50 = 0
         self._over_67 = 0
@@ -552,6 +592,26 @@ class _FrameDiagnostics(object):
                 except (IndexError, TypeError, ValueError, OverflowError):
                     continue
             profile[bucket_name] = target
+        for bucket_name in ('work', 'offframe_work'):
+            source = interval.get(bucket_name)
+            if not isinstance(source, dict):
+                continue
+            target = dict(profile.get(bucket_name) or {})
+            for name in _WORK_METRIC_NAMES:
+                if name not in source:
+                    continue
+                try:
+                    value = float(source[name])
+                    if math.isnan(value) or math.isinf(value) or value < 0.0:
+                        continue
+                    old = max(0.0, float(target.get(name, 0.0)))
+                    target[name] = (
+                        max(old, value)
+                        if _WORK_METRIC_AGGREGATIONS.get(name) == 'sampled_max'
+                        else old + value)
+                except (TypeError, ValueError, OverflowError):
+                    continue
+            profile[bucket_name] = target
         for trace_name in ('trace', 'representative_trace'):
             source = interval.get(trace_name)
             if isinstance(source, (list, tuple)):
@@ -566,7 +626,13 @@ class _FrameDiagnostics(object):
         if bool(interval.get('measured', False)):
             profile['measured'] = True
         for name in ('clock_read_estimate_ns', 'coverage',
-                     'filtered_segment_timing'):
+                     'filtered_segment_timing', 'work_counter_scope',
+                     'work_counter_semantics', 'python_timing_semantics',
+                     'work_counter_aggregations', 'work_counter_notes',
+                     'python_category_scopes', 'python_scope_sum_rule',
+                     'bot_update_residual_semantics',
+                     'python_thread_attribution',
+                     'offframe_python_timing_semantics'):
             if profile.get(name) is None and interval.get(name) is not None:
                 profile[name] = interval.get(name)
         if profile.get('frame_ordinal') is None:
@@ -605,11 +671,24 @@ class _FrameDiagnostics(object):
             self._sim_caps += 1
         if row.get('context', {}).get('role') == 'authority':
             self._authority_frames += 1
+        stage_total = 0.0
         for name in _FRAME_STAGE_NAMES:
             value = max(0.0, float(row['stages'].get(name, 0.0)))
             self._stage_sums[name] += value
             self._stage_maxima[name] = max(
                 self._stage_maxima[name], value)
+            stage_total += value
+        callback_residual = max(0.0, execution - stage_total)
+        self._callback_residual_sum += callback_residual
+        self._callback_residual_max = max(
+            self._callback_residual_max, callback_residual)
+        for legacy_name, components in _LEGACY_STAGE_GROUPS.items():
+            value = sum(max(
+                0.0, float(row['stages'].get(name, 0.0)))
+                for name in components)
+            self._legacy_stage_sums[legacy_name] += value
+            self._legacy_stage_maxima[legacy_name] = max(
+                self._legacy_stage_maxima[legacy_name], value)
         for name in PROBE_KINDS:
             value = max(0, int(row['probes'].get(name, 0)))
             self._probe_sums[name] += value
@@ -627,6 +706,38 @@ class _FrameDiagnostics(object):
             self._projectile_maxima[name] = max(
                 self._projectile_maxima[name], value)
         detailed = row.get('detailed_profile') or {}
+        work = detailed.get('work') or {}
+        offframe_work = detailed.get('offframe_work') or {}
+        if bool(detailed.get('work_counters_recorded', False)):
+            self._work_counters_recorded = True
+            self._work_samples += 1
+        for name in _WORK_METRIC_NAMES:
+            try:
+                frame_value = max(0.0, float(work.get(name, 0.0)))
+                offframe_value = max(
+                    0.0, float(offframe_work.get(name, 0.0)))
+                if (math.isnan(frame_value) or math.isinf(frame_value) or
+                        math.isnan(offframe_value) or
+                        math.isinf(offframe_value)):
+                    continue
+            except (TypeError, ValueError, OverflowError):
+                continue
+            if _WORK_METRIC_AGGREGATIONS.get(name) == 'sampled_max':
+                combined = max(frame_value, offframe_value)
+                self._frame_work_sums[name] = max(
+                    self._frame_work_sums[name], frame_value)
+                self._offframe_work_sums[name] = max(
+                    self._offframe_work_sums[name], offframe_value)
+                self._work_sums[name] = max(
+                    self._work_sums[name], combined)
+                self._work_maxima[name] = self._work_sums[name]
+            else:
+                combined = frame_value + offframe_value
+                self._frame_work_sums[name] += frame_value
+                self._offframe_work_sums[name] += offframe_value
+                self._work_sums[name] += combined
+                self._work_maxima[name] = max(
+                    self._work_maxima[name], combined)
         self._add_profiler_mode_frame(detailed.get('mode'), row)
         if bool(detailed.get('measured', False)):
             self._native_profile_measured = True
@@ -659,6 +770,72 @@ class _FrameDiagnostics(object):
             detailed.get('offframe_python'),
             self._offframe_python_detail_sums,
             self._offframe_python_detail_maxima)
+        scopes = detailed.get('python_category_scopes')
+        if isinstance(scopes, dict):
+            for name in hidden_worker_profiler.PYTHON_CATEGORIES:
+                scope = scopes.get(name)
+                if scope is not None:
+                    self._python_category_scopes[name] = str(scope)[:48]
+        sum_rule = detailed.get('python_scope_sum_rule')
+        if sum_rule is not None:
+            self._python_scope_sum_rule = str(sum_rule)[:256]
+        python_detail = detailed.get('python') or {}
+        main_seconds = None
+        try:
+            main_seconds = sum(max(
+                0.0, float((python_detail.get(name) or (0, 0.0))[1]))
+                for name in _BOT_MAIN_PHASE_NAMES)
+            if math.isnan(main_seconds) or math.isinf(main_seconds):
+                main_seconds = None
+        except (IndexError, TypeError, ValueError, OverflowError):
+            main_seconds = None
+        outer = python_detail.get('bot_runtime_update')
+        if (main_seconds is not None and
+                isinstance(outer, (list, tuple)) and len(outer) >= 2):
+            try:
+                outer_seconds = max(0.0, float(outer[1]))
+                if (not math.isnan(outer_seconds) and
+                        not math.isinf(outer_seconds) and
+                        not math.isnan(main_seconds) and
+                        not math.isinf(main_seconds)):
+                    residual = max(0.0, outer_seconds - main_seconds)
+                    self._bot_attribution_samples += 1
+                    self._bot_outer_sum += outer_seconds
+                    self._bot_outer_max = max(
+                        self._bot_outer_max, outer_seconds)
+                    self._bot_main_sum += main_seconds
+                    self._bot_main_max = max(
+                        self._bot_main_max, main_seconds)
+                    self._bot_residual_sum += residual
+                    self._bot_residual_max = max(
+                        self._bot_residual_max, residual)
+            except (IndexError, TypeError, ValueError, OverflowError):
+                pass
+        scheduler_rows = [
+            python_detail.get('bot_scheduler_control_refresh'),
+            python_detail.get('bot_scheduler_catchup'),
+        ]
+        if (main_seconds is not None and
+                any(isinstance(value, (list, tuple)) and len(value) >= 2
+                    for value in scheduler_rows)):
+            try:
+                scheduler_seconds = sum(max(
+                    0.0, float((value or (0, 0.0))[1]))
+                    for value in scheduler_rows)
+                if (not math.isnan(scheduler_seconds) and
+                        not math.isinf(scheduler_seconds)):
+                    scheduler_residual = max(
+                        0.0, scheduler_seconds - main_seconds)
+                    self._bot_scheduler_attribution_samples += 1
+                    self._bot_scheduler_sum += scheduler_seconds
+                    self._bot_scheduler_max = max(
+                        self._bot_scheduler_max, scheduler_seconds)
+                    self._bot_scheduler_residual_sum += scheduler_residual
+                    self._bot_scheduler_residual_max = max(
+                        self._bot_scheduler_residual_max,
+                        scheduler_residual)
+            except (IndexError, TypeError, ValueError, OverflowError):
+                pass
         if bool(detailed.get('measured', False)):
             self._add_frame_totals(
                 self._native_frame_totals, native_frame)
@@ -886,6 +1063,30 @@ class _FrameDiagnostics(object):
                 stats['seconds_max']),
         }
 
+    def _work_snapshot(self, samples, elapsed):
+        result = {}
+        for name in _WORK_METRIC_NAMES:
+            total = self._work_sums[name]
+            aggregation = _WORK_METRIC_AGGREGATIONS.get(name, 'sum')
+            if aggregation == 'sampled_max':
+                result[name] = {
+                    'aggregation': aggregation,
+                    'max': total,
+                    'render_frame_max': self._frame_work_sums[name],
+                    'offframe_max': self._offframe_work_sums[name],
+                }
+                continue
+            result[name] = {
+                'aggregation': aggregation,
+                'total': total,
+                'per_second': total / elapsed,
+                'per_frame_avg': total / samples,
+                'per_frame_max': self._work_maxima[name],
+                'render_frame_total': self._frame_work_sums[name],
+                'offframe_total': self._offframe_work_sums[name],
+            }
+        return result
+
     def _profiler_ab_snapshot(self):
         result = {}
         for mode, stats in sorted(self._profiler_mode_frames.items()):
@@ -933,6 +1134,9 @@ class _FrameDiagnostics(object):
             self._exec_samples, self._exec_max)
         outside_distribution = self._distribution(
             self._outside_samples, self._outside_max)
+        bot_samples = max(1, self._bot_attribution_samples)
+        scheduler_samples = max(
+            1, self._bot_scheduler_attribution_samples)
         stage_snapshot = {}
         for name in _FRAME_STAGE_NAMES:
             stage_snapshot[name] = {
@@ -940,6 +1144,18 @@ class _FrameDiagnostics(object):
                     self._stage_sums[name] / samples),
                 'max_ms': self._milliseconds(self._stage_maxima[name]),
             }
+        legacy_stage_snapshot = {}
+        for name, components in sorted(_LEGACY_STAGE_GROUPS.items()):
+            legacy_stage_snapshot[name] = {
+                'avg_ms': self._milliseconds(
+                    self._legacy_stage_sums[name] / samples),
+                'max_ms': self._milliseconds(
+                    self._legacy_stage_maxima[name]),
+                'derived_from': components,
+                'excluded_from_residual_sum': True,
+            }
+            # Preserve the old lookup key while identifying it as derived.
+            stage_snapshot[name] = dict(legacy_stage_snapshot[name])
         probe_snapshot = {}
         for name in PROBE_KINDS:
             probe_snapshot[name] = {
@@ -958,7 +1174,7 @@ class _FrameDiagnostics(object):
                     self._probe_duration_maxima[name]),
             }
         self._last_snapshot = {
-            'schema': 2,
+            'schema': 3,
             'window': self._window_id,
             'round': context.get('round', '-'),
             'map': context.get('map', '-'),
@@ -974,7 +1190,15 @@ class _FrameDiagnostics(object):
             'frame_interval_ms': gap_distribution,
             'python_callback_ms': exec_distribution,
             'outside_callback_ms': outside_distribution,
+            'callback_residual_ms': {
+                'avg': self._milliseconds(
+                    self._callback_residual_sum / samples),
+                'max': self._milliseconds(self._callback_residual_max),
+                'semantics': (
+                    'python_callback_minus_mutually_exclusive_frame_stages'),
+            },
             'python_stages_ms': stage_snapshot,
+            'legacy_derived_python_stages_ms': legacy_stage_snapshot,
             'raw_native_calls_measured': self._native_profile_measured,
             'native_timing_frames': self._native_profile_samples,
             'native_timing_seconds': self._native_profile_elapsed,
@@ -1000,6 +1224,46 @@ class _FrameDiagnostics(object):
                 timing_samples, timing_elapsed),
             'python_detail_semantics': (
                 'inclusive_of_nested_native_do_not_sum'),
+            'python_category_scopes': dict(self._python_category_scopes),
+            'python_scope_sum_rule': self._python_scope_sum_rule,
+            'bot_timing_attribution': {
+                'battle_outer_timing_frames': self._bot_attribution_samples,
+                'battle_outer_avg_ms': self._milliseconds(
+                    self._bot_outer_sum / bot_samples),
+                'battle_outer_max_ms': self._milliseconds(
+                    self._bot_outer_max),
+                'main_exclusive_avg_ms': self._milliseconds(
+                    self._bot_main_sum / bot_samples),
+                'main_exclusive_max_ms': self._milliseconds(
+                    self._bot_main_max),
+                'battle_outer_residual_avg_ms': self._milliseconds(
+                    self._bot_residual_sum / bot_samples),
+                'battle_outer_residual_max_ms': self._milliseconds(
+                    self._bot_residual_max),
+                'battle_outer_category': 'bot_runtime_update',
+                'scheduler_timing_frames': (
+                    self._bot_scheduler_attribution_samples),
+                'scheduler_inclusive_avg_ms': self._milliseconds(
+                    self._bot_scheduler_sum / scheduler_samples),
+                'scheduler_inclusive_max_ms': self._milliseconds(
+                    self._bot_scheduler_max),
+                'scheduler_residual_avg_ms': self._milliseconds(
+                    self._bot_scheduler_residual_sum / scheduler_samples),
+                'scheduler_residual_max_ms': self._milliseconds(
+                    self._bot_scheduler_residual_max),
+                'additive_main_categories': _BOT_MAIN_PHASE_NAMES,
+                'semantics': (
+                    hidden_worker_profiler.BOT_UPDATE_RESIDUAL_SEMANTICS),
+            },
+            'work_counters_recorded': self._work_counters_recorded,
+            'work_counter_samples': self._work_samples,
+            'work': self._work_snapshot(samples, elapsed),
+            'work_counter_aggregations': dict(_WORK_METRIC_AGGREGATIONS),
+            'work_counter_notes': dict(
+                hidden_worker_profiler.WORK_COUNTER_NOTES),
+            'work_counter_semantics': (
+                'sum counters combine frame+offframe;sampled_max gauges do not '
+                'have total/rate/average'),
             'native_trace': tuple(self._native_trace),
             'representative_segment_trace': dict(
                 (category, tuple(rows))
@@ -1030,6 +1294,10 @@ class _FrameDiagnostics(object):
                     'instrumentation and wrapper branch; not a causal or '
                     'unmodified-client baseline'),
                 'ab_frames': self._profiler_ab_snapshot(),
+                'python_thread_attribution': (
+                    hidden_worker_profiler.PYTHON_THREAD_ATTRIBUTION),
+                'offframe_python_timing_semantics': (
+                    hidden_worker_profiler.OFFFRAME_PYTHON_TIMING_SEMANTICS),
             },
             'logical_native_probes': probe_snapshot,
             'worker_runtime': dict(self._worker_runtime),
@@ -1041,7 +1309,7 @@ class _FrameDiagnostics(object):
         prefix = '[Offline LAN 0.9.22] PERF '
         lines = [
             (prefix +
-             'summary v=4 window=%d round=%s map=%s phase=%s role=%s '
+             'summary v=5 window=%d round=%s map=%s phase=%s role=%s '
              'probe_timing=%s '
              'samples=%d seconds=%.3f fps=%.2f authority_frames=%d '
              'gap_ms_avg_max=%.3f/%.3f raw_dt_ms_avg_max=%.3f/%.3f '
@@ -1140,6 +1408,40 @@ class _FrameDiagnostics(object):
                 self._milliseconds(self._stage_maxima[name])))
         lines.append(prefix + 'stages_ms_avg_max ' +
                      ' '.join(stage_values) + '\n')
+        lines.append(prefix + 'legacy_stages_ms_avg_max_derived ' +
+                     ' '.join('%s=%.3f/%.3f(%s)' % (
+                         name,
+                         self._milliseconds(
+                             self._legacy_stage_sums[name] / samples),
+                         self._milliseconds(
+                             self._legacy_stage_maxima[name]),
+                         '+'.join(_LEGACY_STAGE_GROUPS[name]))
+                         for name in sorted(_LEGACY_STAGE_GROUPS)) + '\n')
+        lines.append(
+            (prefix +
+             'attribution_ms callback_residual_avg_max=%.3f/%.3f '
+             'bot_battle_outer_frames=%d bot_battle_outer_avg_max=%.3f/%.3f '
+             'bot_main_exclusive_avg_max=%.3f/%.3f '
+             'bot_battle_outer_residual_avg_max=%.3f/%.3f '
+             'bot_scheduler_frames=%d bot_scheduler_avg_max=%.3f/%.3f '
+             'bot_scheduler_residual_avg_max=%.3f/%.3f '
+             'bot_rule=scheduler_minus_main_exclusive_nested_excluded\n') % (
+                 self._milliseconds(self._callback_residual_sum / samples),
+                 self._milliseconds(self._callback_residual_max),
+                 self._bot_attribution_samples,
+                 self._milliseconds(self._bot_outer_sum / bot_samples),
+                 self._milliseconds(self._bot_outer_max),
+                 self._milliseconds(self._bot_main_sum / bot_samples),
+                 self._milliseconds(self._bot_main_max),
+                 self._milliseconds(self._bot_residual_sum / bot_samples),
+                 self._milliseconds(self._bot_residual_max),
+                 self._bot_scheduler_attribution_samples,
+                 self._milliseconds(
+                     self._bot_scheduler_sum / scheduler_samples),
+                 self._milliseconds(self._bot_scheduler_max),
+                 self._milliseconds(
+                     self._bot_scheduler_residual_sum / scheduler_samples),
+                 self._milliseconds(self._bot_scheduler_residual_max)))
         probe_values = []
         for name in PROBE_KINDS:
             probe_values.append('%s=%.2f/%d' % (
@@ -1264,6 +1566,29 @@ class _FrameDiagnostics(object):
             lines.append(prefix + label +
                          '_inclusive_ms_avg_per_s_max_fail ' +
                          (' '.join(values) or 'none') + '\n')
+        work_avg_values = []
+        work_rate_values = []
+        work_gauge_values = []
+        for name in _WORK_METRIC_NAMES:
+            total = self._work_sums[name]
+            if total <= 0.0:
+                continue
+            if _WORK_METRIC_AGGREGATIONS.get(name) == 'sampled_max':
+                work_gauge_values.append('%s=%.0f/%.0f/%.0f' % (
+                    name, total, self._frame_work_sums[name],
+                    self._offframe_work_sums[name]))
+                continue
+            work_avg_values.append('%s=%.2f/%.0f' % (
+                name, total / samples, self._work_maxima[name]))
+            work_rate_values.append('%s=%.2f/%.0f/%.0f' % (
+                name, total / elapsed, self._frame_work_sums[name],
+                self._offframe_work_sums[name]))
+        lines.append(prefix + 'work_avg_max ' +
+                     (' '.join(work_avg_values) or 'none') + '\n')
+        lines.append(prefix + 'work_hz_frame_offframe_total ' +
+                     (' '.join(work_rate_values) or 'none') + '\n')
+        lines.append(prefix + 'work_sampled_max_window_frame_offframe ' +
+                     (' '.join(work_gauge_values) or 'none') + '\n')
         lines.append(
             (prefix +
              'projectile_avg_max active=%.2f/%.0f chords=%.2f/%.0f '
@@ -1351,7 +1676,8 @@ class _FrameDiagnostics(object):
                  'projectile=%s stages_ms=%s logical_probes=%s '
                  'logical_probe_ms=%s raw_native=%s '
                  'raw_native_offframe=%s python_detail_inclusive=%s '
-                 'python_detail_offframe_inclusive=%s\n') % (
+                 'python_detail_offframe_inclusive=%s work=%s '
+                 'work_offframe=%s callback_residual_ms=%.3f\n') % (
                      rank, row['cause'], row['next'],
                      detailed.get('frame_ordinal', '-'),
                      detailed.get('mode', 'off'),
@@ -1413,7 +1739,19 @@ class _FrameDiagnostics(object):
                               for name, value in sorted(
                                   (detailed.get(
                                       'offframe_python') or {}).items())) or
-                     'none'))
+                     'none',
+                     ','.join('%s:%.3f' % (name, float(value))
+                              for name, value in sorted(
+                                  (detailed.get('work') or {}).items())
+                              if name in _WORK_METRIC_NAMES) or 'none',
+                     ','.join('%s:%.3f' % (name, float(value))
+                              for name, value in sorted(
+                                  (detailed.get('offframe_work') or {}).items())
+                              if name in _WORK_METRIC_NAMES) or 'none',
+                     self._milliseconds(max(
+                         0.0, row['exec'] - sum(max(
+                             0.0, float(stages.get(name, 0.0)))
+                             for name in _FRAME_STAGE_NAMES)))))
         return ''.join(lines)
 
     def finish(self, frame_id, entry_wall, tick_dt, motion_dt, stages,
@@ -10642,6 +10980,11 @@ class BattleRuntime(object):
         return True
 
     def _ensure_projectile_visual(self, normalized, now):
+        return hidden_worker_profiler.python_call(
+            'projectile_visual', self._ensure_projectile_visual_impl,
+            normalized, now)
+
+    def _ensure_projectile_visual_impl(self, normalized, now):
         """Ensure late joiners and delayed snapshots see the live tracer."""
         if self._worker_mode:
             return False
@@ -10778,6 +11121,11 @@ class BattleRuntime(object):
             return None
 
     def _stop_projectile_visual(self, projectile_id, event):
+        return hidden_worker_profiler.python_call(
+            'projectile_visual', self._stop_projectile_visual_impl,
+            projectile_id, event)
+
+    def _stop_projectile_visual_impl(self, projectile_id, event):
         if self._worker_mode:
             self._projectile_visual_meta.pop(projectile_id, None)
             return False
@@ -11270,16 +11618,37 @@ class BattleRuntime(object):
         self._projectile_candidate_count = 0
         if self._projectiles is None:
             return False
-        self._flush_pending_projectile_resolutions()
-        previous = self._projectile_target_positions
-        states = self._projectiles.snapshot()
-        current_poses = self._projectile_record_poses()
-        current = dict(
-            (key, _xyz(pose)) for key, pose in current_poses.items())
-        if (len(self._projectiles) or self._projectile_visual_meta or
-                self._projectile_is_authority()):
-            self._sample_projectile_positions(now, current_poses)
-            self._prune_projectile_position_history(states)
+        terminal_marker = hidden_worker_profiler.python_started(
+            'projectile_terminal')
+        terminal_failed = False
+        try:
+            self._flush_pending_projectile_resolutions()
+        except Exception:
+            terminal_failed = True
+            raise
+        finally:
+            hidden_worker_profiler.python_finished(
+                terminal_marker, terminal_failed)
+        history_marker = hidden_worker_profiler.python_started(
+            'projectile_history')
+        history_failed = False
+        try:
+            previous = self._projectile_target_positions
+            states = self._projectiles.snapshot()
+            current_poses = self._projectile_record_poses()
+            current = dict(
+                (key, _xyz(pose)) for key, pose in current_poses.items())
+            if (len(self._projectiles) or self._projectile_visual_meta or
+                    self._projectile_is_authority()):
+                self._sample_projectile_positions(now, current_poses)
+                self._prune_projectile_position_history(states)
+        except Exception:
+            history_failed = True
+            raise
+        finally:
+            hidden_worker_profiler.python_finished(
+                history_marker, history_failed)
+        hidden_worker_profiler.work_add('projectiles_active', len(states))
         if not self._projectile_is_authority():
             self._projectile_target_positions = current
             return False
@@ -11297,11 +11666,31 @@ class BattleRuntime(object):
         advance_start = _PROFILE_CLOCK()
         self._projectile_historic_pose_cache = {}
         try:
-            self._build_projectile_spatial_bins(
-                states, now, maximum_chords=chord_budget)
-            advanced = self._projectiles.advance(
-                now, self._projectile_chord, self._projectile_terminal,
-                maximum_chords=chord_budget)
+            history_marker = hidden_worker_profiler.python_started(
+                'projectile_history')
+            history_failed = False
+            try:
+                self._build_projectile_spatial_bins(
+                    states, now, maximum_chords=chord_budget)
+            except Exception:
+                history_failed = True
+                raise
+            finally:
+                hidden_worker_profiler.python_finished(
+                    history_marker, history_failed)
+            step_marker = hidden_worker_profiler.python_started(
+                'projectile_step')
+            step_failed = False
+            try:
+                advanced = self._projectiles.advance(
+                    now, self._projectile_chord, self._projectile_terminal,
+                    maximum_chords=chord_budget)
+            except Exception:
+                step_failed = True
+                raise
+            finally:
+                hidden_worker_profiler.python_finished(
+                    step_marker, step_failed)
         finally:
             self._clear_projectile_spatial_index()
             self._projectile_historic_pose_cache = None
@@ -11316,8 +11705,24 @@ class BattleRuntime(object):
             'scans': self._projectile_scan_count,
             'candidates': self._projectile_candidate_count,
         }
-        self._prune_projectile_position_history()
-        self._projectile_target_positions = current
+        hidden_worker_profiler.work_add(
+            'projectile_segments', metrics.get('chords', 0))
+        hidden_worker_profiler.work_add(
+            'projectile_candidates', self._projectile_candidate_count)
+        hidden_worker_profiler.work_add(
+            'projectile_terminals', metrics.get('terminals', 0))
+        history_marker = hidden_worker_profiler.python_started(
+            'projectile_history')
+        history_failed = False
+        try:
+            self._prune_projectile_position_history()
+            self._projectile_target_positions = current
+        except Exception:
+            history_failed = True
+            raise
+        finally:
+            hidden_worker_profiler.python_finished(
+                history_marker, history_failed)
         if now >= self._next_projectile_progress_time:
             self._next_projectile_progress_time = (
                 now + PROJECTILE_PROGRESS_SECONDS)
@@ -11453,6 +11858,13 @@ class BattleRuntime(object):
 
     def _projectile_vehicle_collisions(self, record, target, start, end,
                                        pose=None):
+        return hidden_worker_profiler.python_call(
+            'projectile_vehicle',
+            self._projectile_vehicle_collisions_impl,
+            record, target, start, end, pose)
+
+    def _projectile_vehicle_collisions_impl(self, record, target, start, end,
+                                            pose=None):
         """Return retail ABI collisions plus private world-normal evidence."""
         if pose is not None:
             descriptor = self._projectile_descriptor_at_pose(target, pose)
@@ -11736,7 +12148,8 @@ class BattleRuntime(object):
             raise RuntimeError('nested projectile destructible context')
         self._projectile_destructible_context = projectile_id
         try:
-            scene = self._resolve_shot_scene(
+            scene = hidden_worker_profiler.python_call(
+                'projectile_world', self._resolve_shot_scene,
                 self._vector(start), self._vector(scene_end_tuple), direction,
                 self._projectile_shot(meta),
                 penetration_factor=meta.get('penetration_factor'),
@@ -12128,6 +12541,11 @@ class BattleRuntime(object):
         return effects
 
     def _projectile_terminal(self, state, terminal):
+        return hidden_worker_profiler.python_call(
+            'projectile_terminal', self._projectile_terminal_impl,
+            state, terminal)
+
+    def _projectile_terminal_impl(self, state, terminal):
         manager_key = state.get('key')
         projectile_id = (manager_key[0]
                          if isinstance(manager_key, tuple) else manager_key)
@@ -12967,28 +13385,55 @@ class BattleRuntime(object):
         detailed_profile = {}
         boundary = entry_wall
         try:
-            self._run_optional_feature(
-                'map visibility filtering',
-                self._maintain_standard_space_visibility, (now,),
-                self._disable_standard_space_visibility)
-            self._flush_pending_bot_create(now)
-            self._flush_pending_entities(now)
-            self._drain_event_journal()
+            sync_marker = hidden_worker_profiler.python_started('render_sync')
+            sync_failed = False
+            try:
+                self._run_optional_feature(
+                    'map visibility filtering',
+                    self._maintain_standard_space_visibility, (now,),
+                    self._disable_standard_space_visibility)
+                self._flush_pending_bot_create(now)
+                self._flush_pending_entities(now)
+                self._drain_event_journal()
+            except Exception:
+                sync_failed = True
+                raise
+            finally:
+                hidden_worker_profiler.python_finished(
+                    sync_marker, sync_failed)
             hidden_worker_profiler.python_call(
                 'foliage_dynamic', self._run_optional_feature,
                 'foliage camouflage',
                 self._refresh_fallen_tree_foliage, (now,))
-            self._retry_bot_manifest(now)
-            self._maybe_send_battle_ready()
+            sync_marker = hidden_worker_profiler.python_started('render_sync')
+            sync_failed = False
+            try:
+                self._retry_bot_manifest(now)
+                self._maybe_send_battle_ready()
+            except Exception:
+                sync_failed = True
+                raise
+            finally:
+                hidden_worker_profiler.python_finished(
+                    sync_marker, sync_failed)
             if profiling:
                 next_boundary = _PROFILE_CLOCK()
                 stages['house'] = max(0.0, next_boundary - boundary)
                 boundary = next_boundary
-            if self._sync is not None:
-                self._sync.advance(now)
-            if self._battle_live and self._worker_mode:
-                self._advance_player_fire_authority(rule_dt, now)
-                self._publish_player_environment(rule_dt, now)
+            sync_marker = hidden_worker_profiler.python_started('render_sync')
+            sync_failed = False
+            try:
+                if self._sync is not None:
+                    self._sync.advance(now)
+                if self._battle_live and self._worker_mode:
+                    self._advance_player_fire_authority(rule_dt, now)
+                    self._publish_player_environment(rule_dt, now)
+            except Exception:
+                sync_failed = True
+                raise
+            finally:
+                hidden_worker_profiler.python_finished(
+                    sync_marker, sync_failed)
             if profiling:
                 next_boundary = _PROFILE_CLOCK()
                 stages['sync'] = max(0.0, next_boundary - boundary)
@@ -13108,87 +13553,125 @@ class BattleRuntime(object):
                 next_boundary = _PROFILE_CLOCK()
                 stages['outline'] = max(0.0, next_boundary - boundary)
                 boundary = next_boundary
-            if self._battle_live and self._bots is not None:
-                if self._worker_mode:
-                    self._worker_probe_authority_callbacks += 1
-                self._advance_artillery_arcs(now)
-                players = self._authority_players()
-                if self._worker_mode:
-                    hidden_worker_profiler.python_call(
-                        'destructible_scan',
-                        self._scan_authority_player_trees, players, now)
-                    hidden_worker_profiler.python_call(
-                        'destructible_contact',
-                        self._resolve_player_destructible_contacts,
-                        players, now)
-                probe_totals = getattr(self._bots, 'probe_totals', None)
-                probe_duration_totals = getattr(
-                    self._bots, 'probe_duration_totals', None)
-                before_probes = None
-                before_probe_durations = None
-                if profiling and callable(probe_totals):
-                    try:
-                        before_probes = probe_totals()
-                    except Exception:
-                        before_probes = None
-                if profiling and callable(probe_duration_totals):
-                    try:
-                        before_probe_durations = probe_duration_totals()
-                    except Exception:
-                        before_probe_durations = None
-                set_camera = getattr(
-                    self._bots, 'set_camera_position', None)
-                if callable(set_camera):
-                    # A worker has no presentation camera. Using its off-map
-                    # dummy as one would lower update detail for distant bots
-                    # and make worker authority behave unlike player authority.
-                    set_camera(
-                        None if self._worker_mode else self._local_position)
-                control_sample_before = getattr(
-                    self._bots, '_sample_time_us', None)
-                outgoing_messages = self._bots.update(
-                    rule_dt, now, players=players)
-                if self._worker_mode:
-                    self._record_worker_control_diagnostics(
-                        control_sample_before)
-                after_probes = None
-                after_probe_durations = None
-                if profiling and callable(probe_totals):
-                    try:
-                        after_probes = probe_totals()
-                    except Exception:
-                        after_probes = None
-                if profiling and callable(probe_duration_totals):
-                    try:
-                        after_probe_durations = probe_duration_totals()
-                    except Exception:
-                        after_probe_durations = None
-                if (isinstance(before_probes, (list, tuple)) and
-                        isinstance(after_probes, (list, tuple)) and
-                        len(before_probes) == len(PROBE_KINDS) and
-                        len(after_probes) == len(PROBE_KINDS)):
-                    try:
-                        for index, name in enumerate(PROBE_KINDS):
-                            probes[name] += max(
-                                0, int(after_probes[index]) -
-                                int(before_probes[index]))
-                    except (TypeError, ValueError, OverflowError):
-                        probes = dict((name, 0) for name in PROBE_KINDS)
-                if (isinstance(before_probe_durations, (list, tuple)) and
-                        isinstance(after_probe_durations, (list, tuple)) and
-                        len(before_probe_durations) == len(PROBE_KINDS) and
-                        len(after_probe_durations) == len(PROBE_KINDS)):
-                    try:
-                        for index, name in enumerate(PROBE_KINDS):
-                            probe_durations[name] += max(
-                                0.0, float(after_probe_durations[index]) -
-                                float(before_probe_durations[index]))
-                    except (TypeError, ValueError, OverflowError):
-                        probe_durations = dict(
-                            (name, 0.0) for name in PROBE_KINDS)
+            bots_active = self._battle_live and self._bots is not None
+            players = ()
+            probe_totals = None
+            probe_duration_totals = None
+            before_probes = None
+            before_probe_durations = None
+            control_sample_before = None
+            if bots_active:
+                bot_marker = hidden_worker_profiler.python_started(
+                    'bot_prework')
+                bot_failed = False
+                try:
+                    if self._worker_mode:
+                        self._worker_probe_authority_callbacks += 1
+                    self._advance_artillery_arcs(now)
+                    players = self._authority_players()
+                    if self._worker_mode:
+                        hidden_worker_profiler.python_call(
+                            'destructible_scan',
+                            self._scan_authority_player_trees, players, now)
+                        hidden_worker_profiler.python_call(
+                            'destructible_contact',
+                            self._resolve_player_destructible_contacts,
+                            players, now)
+                    probe_totals = getattr(self._bots, 'probe_totals', None)
+                    probe_duration_totals = getattr(
+                        self._bots, 'probe_duration_totals', None)
+                    if profiling and callable(probe_totals):
+                        try:
+                            before_probes = probe_totals()
+                        except Exception:
+                            before_probes = None
+                    if profiling and callable(probe_duration_totals):
+                        try:
+                            before_probe_durations = probe_duration_totals()
+                        except Exception:
+                            before_probe_durations = None
+                    set_camera = getattr(
+                        self._bots, 'set_camera_position', None)
+                    if callable(set_camera):
+                        # A worker has no presentation camera. Using its off-map
+                        # dummy as one would lower update detail for distant bots
+                        # and make worker authority behave unlike player authority.
+                        set_camera(
+                            None if self._worker_mode else self._local_position)
+                    control_sample_before = getattr(
+                        self._bots, '_sample_time_us', None)
+                except Exception:
+                    bot_failed = True
+                    raise
+                finally:
+                    hidden_worker_profiler.python_finished(
+                        bot_marker, bot_failed)
             if profiling:
                 next_boundary = _PROFILE_CLOCK()
-                stages['bots_update'] = max(0.0, next_boundary - boundary)
+                stages['bot_prework'] = max(0.0, next_boundary - boundary)
+                boundary = next_boundary
+            if bots_active:
+                outgoing_messages = hidden_worker_profiler.python_call(
+                    'bot_runtime_update', self._bots.update,
+                    rule_dt, now, players=players)
+            if profiling:
+                next_boundary = _PROFILE_CLOCK()
+                stages['bot_runtime_update'] = max(
+                    0.0, next_boundary - boundary)
+                boundary = next_boundary
+            if bots_active:
+                bot_marker = hidden_worker_profiler.python_started(
+                    'bot_postdiag')
+                bot_failed = False
+                try:
+                    if self._worker_mode:
+                        self._record_worker_control_diagnostics(
+                            control_sample_before)
+                    after_probes = None
+                    after_probe_durations = None
+                    if profiling and callable(probe_totals):
+                        try:
+                            after_probes = probe_totals()
+                        except Exception:
+                            after_probes = None
+                    if profiling and callable(probe_duration_totals):
+                        try:
+                            after_probe_durations = probe_duration_totals()
+                        except Exception:
+                            after_probe_durations = None
+                    if (isinstance(before_probes, (list, tuple)) and
+                            isinstance(after_probes, (list, tuple)) and
+                            len(before_probes) == len(PROBE_KINDS) and
+                            len(after_probes) == len(PROBE_KINDS)):
+                        try:
+                            for index, name in enumerate(PROBE_KINDS):
+                                probes[name] += max(
+                                    0, int(after_probes[index]) -
+                                    int(before_probes[index]))
+                        except (TypeError, ValueError, OverflowError):
+                            probes = dict((name, 0) for name in PROBE_KINDS)
+                    if (isinstance(before_probe_durations, (list, tuple)) and
+                            isinstance(after_probe_durations, (list, tuple)) and
+                            len(before_probe_durations) == len(PROBE_KINDS) and
+                            len(after_probe_durations) == len(PROBE_KINDS)):
+                        try:
+                            for index, name in enumerate(PROBE_KINDS):
+                                probe_durations[name] += max(
+                                    0.0,
+                                    float(after_probe_durations[index]) -
+                                    float(before_probe_durations[index]))
+                        except (TypeError, ValueError, OverflowError):
+                            probe_durations = dict(
+                                (name, 0.0) for name in PROBE_KINDS)
+                except Exception:
+                    bot_failed = True
+                    raise
+                finally:
+                    hidden_worker_profiler.python_finished(
+                        bot_marker, bot_failed)
+            if profiling:
+                next_boundary = _PROFILE_CLOCK()
+                stages['bot_postdiag'] = max(0.0, next_boundary - boundary)
                 boundary = next_boundary
             if self._battle_live and self._bots is not None:
                 presentation_states = getattr(
@@ -13209,8 +13692,12 @@ class BattleRuntime(object):
                 stages['bot_present'] = max(0.0, next_boundary - boundary)
                 boundary = next_boundary
             if self._battle_live and self._bots is not None:
+                hidden_worker_profiler.work_add(
+                    'bot_messages', len(outgoing_messages))
                 for outgoing in outgoing_messages:
                     is_bot_state = outgoing.get('type') == 'bot_state'
+                    hidden_worker_profiler.work_add(
+                        'bot_rows', self._bot_message_row_count(outgoing))
                     if is_bot_state:
                         self._worker_probe_bot_generated += 1
                     accepted = self._enqueue_bot_message(outgoing)
@@ -13219,6 +13706,10 @@ class BattleRuntime(object):
                             self._worker_probe_bot_enqueued += 1
                         else:
                             self._worker_probe_bot_send_failed += 1
+            if profiling:
+                next_boundary = _PROFILE_CLOCK()
+                stages['bot_messages'] = max(0.0, next_boundary - boundary)
+                boundary = next_boundary
             if (self._battle_live and
                     (self._projectile_is_authority() or
                      self._projectile_visual_meta)):
@@ -13226,7 +13717,7 @@ class BattleRuntime(object):
                 projectile_perf = dict(self._projectile_perf)
             if profiling:
                 next_boundary = _PROFILE_CLOCK()
-                stages['bot_events'] = max(0.0, next_boundary - boundary)
+                stages['projectiles'] = max(0.0, next_boundary - boundary)
                 boundary = next_boundary
             if not self._worker_mode:
                 if self._battle_live:
@@ -16837,6 +17328,32 @@ class BattleRuntime(object):
             now, ARTILLERY_ARC_RAYS_PER_FRAME,
             self._artillery_arc_probe)
 
+    @staticmethod
+    def _bot_message_row_count(message):
+        """Return bounded logical rows without walking arbitrary payload data."""
+        if not isinstance(message, dict):
+            return 0
+        kind = message.get('type')
+        if kind == 'rules_state':
+            rules = message.get('rules')
+            bases = rules.get('bases') if isinstance(rules, dict) else None
+            return min(128, len(bases)) if isinstance(
+                bases, (list, tuple, dict)) else 0
+        fields = {
+            'bot_manifest': ('bots', 'player_collision_profiles'),
+            'bot_state': ('bots', 'launches'),
+            'bot_observation': ('contacts', 'affordances'),
+        }.get(kind)
+        if fields is None:
+            return 1 if kind in (
+                'bot_human_hit', 'bot_ram', 'battle_result') else 0
+        total = 0
+        for name in fields:
+            rows = message.get(name)
+            if isinstance(rows, (list, tuple)):
+                total += min(128, len(rows))
+        return min(256, total)
+
     def _send_bot_message(self, message):
         kind = message.get('type')
         if kind == 'bot_manifest':
@@ -19564,11 +20081,21 @@ class BattleRuntime(object):
         piercing_loss = initial_piercing_loss
         for unused_index in range(64):
             cursor = start + direction.scale(travelled)
-            result = hidden_worker_profiler.python_call(
-                'destructible_projectile',
-                self._destructibles.shot_world_distance,
-                self._runtime.bigworld, self._avatar.spaceID,
-                cursor, end, direction, shot)
+            destructible_marker = hidden_worker_profiler.python_started(
+                'projectile_destructible')
+            destructible_failed = False
+            try:
+                result = hidden_worker_profiler.python_call(
+                    'destructible_projectile',
+                    self._destructibles.shot_world_distance,
+                    self._runtime.bigworld, self._avatar.spaceID,
+                    cursor, end, direction, shot)
+            except Exception:
+                destructible_failed = True
+                raise
+            finally:
+                hidden_worker_profiler.python_finished(
+                    destructible_marker, destructible_failed)
             if not isinstance(result, dict):
                 raise RuntimeError(
                     '#1513 destructible shot result must be a dictionary')

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -20,6 +20,7 @@ from gui.mods.offline_lan_0922 import device_damage
 from gui.mods.offline_lan_0922 import effective_params
 from gui.mods.offline_lan_0922 import equipment_mechanics
 from gui.mods.offline_lan_0922 import gun_pitch_limits
+from gui.mods.offline_lan_0922 import hidden_worker_profiler
 from gui.mods.offline_lan_0922 import hull_aiming
 from gui.mods.offline_lan_0922 import prebaked_navigation
 from gui.mods.offline_lan_0922 import shot_geometry
@@ -2170,6 +2171,7 @@ class BotRuntime(object):
     def _probe_direction(self, position, yaw, speed=0.0, descriptor=None,
                          maximum_distance=None):
         """Return one canonical direction sample for planning and physics."""
+        hidden_worker_profiler.work_add('bot_motion_direction_probes')
         self._probe_totals[4] += 1
         probe_started = self._probe_started()
         try:
@@ -2255,8 +2257,10 @@ class BotRuntime(object):
         if not callable(self.world_receipt_probe):
             return None
         bot_id = int(bot_id)
+        hidden_worker_profiler.work_add('bot_receipt_requests')
         frame = self._world_receipt_frame
         if not isinstance(frame, dict):
+            hidden_worker_profiler.work_add('bot_receipt_deferred')
             return 'deferred'
         if bot_id not in frame['requested_set']:
             frame['requested'].append(bot_id)
@@ -2271,16 +2275,21 @@ class BotRuntime(object):
             # callback. Preserve a proved hard result; every other result can
             # safely use the already-complete generic corridor until the next
             # render callback refreshes the exact optimisation.
-            return (False if frame['attempt_results'].get(bot_id) is False
-                    else 'deferred')
+            if frame['attempt_results'].get(bot_id) is False:
+                return False
+            hidden_worker_profiler.work_add('bot_receipt_deferred')
+            return 'deferred'
         priority = frame['priority']
         if (frame['initial_first'] and
                 not frame['request_uncached'][bot_id]):
+            hidden_worker_profiler.work_add('bot_receipt_deferred')
             return 'deferred'
         if priority and bot_id not in priority:
+            hidden_worker_profiler.work_add('bot_receipt_deferred')
             return 'deferred'
         priority.discard(bot_id)
         if self._world_receipt_budget <= 0:
+            hidden_worker_profiler.work_add('bot_receipt_deferred')
             return 'deferred'
         self._world_receipt_budget -= 1
         frame['attempted'].add(bot_id)
@@ -2288,6 +2297,7 @@ class BotRuntime(object):
             position, yaw, speed, descriptor, maximum_distance)
         frame['attempt_results'][bot_id] = result
         if result == 'deferred':
+            hidden_worker_profiler.work_add('bot_receipt_deferred')
             frame['attempt_deferred'].append(bot_id)
         return result
 
@@ -2296,6 +2306,8 @@ class BotRuntime(object):
         """Run one measured exact receipt without changing queue ownership."""
         if not callable(self.world_receipt_probe):
             return None
+        hidden_worker_profiler.work_add('bot_receipt_attempts')
+        hidden_worker_profiler.work_add('bot_motion_receipt_probes')
         self._probe_totals[4] += 1
         probe_started = self._probe_started()
         try:
@@ -4384,6 +4396,7 @@ class BotRuntime(object):
 
     def _visible(self, source, target, now, tick_cache=None,
                  source_position=None, view_range_resolver=None):
+        hidden_worker_profiler.work_add('bot_visibility_pairs')
         target_id = target.get('network_id', target.get('id', 0))
         source_kind = source.get('kind', 'bot')
         key = (source_kind, int(source.get('id', 0)),
@@ -5107,6 +5120,7 @@ class BotRuntime(object):
         yaw = _number(state.get('yaw'))
         half_length = max(1.5, _number(state.get('half_length'), 3.5))
         sine, cosine = math.sin(yaw), math.cos(yaw)
+        hidden_worker_profiler.work_add('bot_ground_probes')
         self._probe_totals[3] += 1
         probe_started = self._probe_started()
         try:
@@ -5123,6 +5137,7 @@ class BotRuntime(object):
         for distance in (half_length, -half_length):
             x = position[0] + sine * distance
             z = position[2] + cosine * distance
+            hidden_worker_profiler.work_add('bot_ground_probes')
             self._probe_totals[3] += 1
             probe_started = self._probe_started()
             try:
@@ -5272,6 +5287,7 @@ class BotRuntime(object):
             return False
 
         def probe(sample_x, sample_z, hint):
+            hidden_worker_profiler.work_add('bot_ground_probes')
             self._probe_totals[3] += 1
             probe_started = self._probe_started()
             try:
@@ -5304,6 +5320,7 @@ class BotRuntime(object):
         # BattleRuntime's resolver infers active crush intent from this field.
         state['movement_dir'] = 0
         try:
+            hidden_worker_profiler.work_add('bot_motion_commit_sweeps')
             if self._probe_clock is None:
                 status = self.motion_resolver(
                     state['id'], position, yaw, speed,
@@ -6642,6 +6659,8 @@ class BotRuntime(object):
         previous_ram_contacts = self._ram_contacts
         current_ram_contacts = set()
         frame_ram_armors = {}
+        candidate_pair_count = 0
+        resolved_pair_count = 0
 
         def contact_armor_probe(first, second, contact):
             first_id = int(first['id'])
@@ -6680,6 +6699,7 @@ class BotRuntime(object):
                     continue
                 other = by_id[tank_id]
                 others.append(other)
+            candidate_pair_count += len(others)
             resolve_kwargs = {
                 'now': now,
                 'ram_cooldowns': self._ram_cooldowns,
@@ -6693,10 +6713,15 @@ class BotRuntime(object):
                 own, others, **resolve_kwargs)
             self._ram_cooldowns = result['cooldowns']
             current_ram_contacts.update(result['contacts'])
+            resolved_pair_count += len(result['contacts'])
             self._apply_tank_contact_response(state, result, step)
             reports.extend(self._ram_reports(
                 state, result['ram_events']))
         self._ram_contacts = frozenset(current_ram_contacts)
+        hidden_worker_profiler.work_add(
+            'bot_contact_candidate_pairs', candidate_pair_count)
+        hidden_worker_profiler.work_add(
+            'bot_contact_resolved_pairs', resolved_pair_count)
         return reports
 
     @staticmethod
@@ -7431,6 +7456,7 @@ class BotRuntime(object):
     def _shot_clear(self, source, target, now, force=False,
                     probe_budget=None, lane_key=None, distance_cache=None):
         """Probe a current static firing lane independently from team spotting."""
+        hidden_worker_profiler.work_add('bot_shot_lane_pairs')
         key = (lane_key if lane_key is not None else
                self._shot_los_key(source, target))
         if distance_cache is not None and distance_cache[0] is not None:
@@ -8294,7 +8320,11 @@ class BotRuntime(object):
                         self._last_update_control_steps += 1
                         self._last_update_max_control_step = max(
                             self._last_update_max_control_step, frame_step)
-                        outgoing.extend(self._run_update_once(
+                        hidden_worker_profiler.work_add(
+                            'bot_control_refresh_slices')
+                        outgoing.extend(hidden_worker_profiler.python_call(
+                            'bot_scheduler_control_refresh',
+                            self._run_update_once,
                             frame_step, step_now, players, neighbours, True,
                             True))
                 else:
@@ -8311,7 +8341,15 @@ class BotRuntime(object):
                         self._last_update_control_steps += 1
                         self._last_update_max_control_step = max(
                             self._last_update_max_control_step, frame_step)
-                        outgoing.extend(self._run_update_once(
+                        scheduler_category = (
+                            'bot_scheduler_control_refresh'
+                            if refresh_control else
+                            'bot_scheduler_catchup')
+                        hidden_worker_profiler.work_add(
+                            ('bot_control_refresh_slices'
+                             if refresh_control else 'bot_catchup_slices'))
+                        outgoing.extend(hidden_worker_profiler.python_call(
+                            scheduler_category, self._run_update_once,
                             frame_step, step_now, players, neighbours,
                             refresh_control, publish_step))
                         refresh_control = False
@@ -8349,7 +8387,34 @@ class BotRuntime(object):
              self._publish_control_this_step) = previous
 
     def _update_once(self, frame_step, now, players=None, neighbours=None):
+        """Time one Bot step as mutually exclusive, continuously owned phases."""
+        current_stage = [None, None]
+        work = {}
+
+        def enter_stage(category):
+            if current_stage[1] == category:
+                return
+            hidden_worker_profiler.python_finished(current_stage[0])
+            current_stage[0] = hidden_worker_profiler.python_started(category)
+            current_stage[1] = category
+
+        failed = False
+        try:
+            return self._update_once_impl(
+                frame_step, now, players, neighbours, enter_stage, work)
+        except Exception:
+            failed = True
+            raise
+        finally:
+            hidden_worker_profiler.python_finished(
+                current_stage[0], failed)
+            for name, amount in sorted(work.items()):
+                hidden_worker_profiler.work_add(name, amount)
+
+    def _update_once_impl(self, frame_step, now, players, neighbours,
+                          enter_stage, profile_work):
         """Advance one stable authority substep and preserve its events."""
+        enter_stage('bot_setup')
         publish = bool(self._publish_control_this_step)
         refresh_control = bool(self._refresh_control_this_step)
         step_duration_us = max(
@@ -8406,7 +8471,10 @@ class BotRuntime(object):
         # simulation slice. Share them across all observers, but never across
         # slices where motion or equipment state may change.
         visibility_tick = {}
-        self._prepare_visibility_frame(
+        enter_stage('bot_control_observation')
+        hidden_worker_profiler.python_call(
+            'bot_visibility_prepare_inclusive',
+            self._prepare_visibility_frame,
             players, now, collect_observation or refresh_shot_lanes)
         if collect_observation or refresh_shot_lanes:
             self._append_human_observations(
@@ -8419,9 +8487,12 @@ class BotRuntime(object):
         siege_locked_poses = {}
         integrated = set()
         for state in self.states.values():
+            enter_stage('bot_control_observation')
             if not state['alive']:
                 self._cancel_active_burst(state)
                 continue
+            profile_work['bot_live_rows'] = (
+                profile_work.get('bot_live_rows', 0) + 1)
             self._note_source_stillness(state, now)
             # Every live bot consumes the same banked authority step. Planner
             # and slope detail may still vary by distance, but skipping one
@@ -8429,6 +8500,8 @@ class BotRuntime(object):
             # contact/reload/vertical clock into the same canonical tick.
             step = frame_step
             integrated.add(state['id'])
+            profile_work['bot_integrated_rows'] = (
+                profile_work.get('bot_integrated_rows', 0) + 1)
             self._advance_bot_critical(state, step, now)
             if not state['alive']:
                 self._cancel_active_burst(state)
@@ -8468,6 +8541,9 @@ class BotRuntime(object):
                 refresh_control and
                 (not decision_cache_valid or
                  _number(now) >= decision_cache[1]))
+            if decision_due:
+                profile_work['bot_decision_due'] = (
+                    profile_work.get('bot_decision_due', 0) + 1)
             decision_deadline = None
             raw_command = None
             planner_probe_samples = {}
@@ -8494,6 +8570,8 @@ class BotRuntime(object):
                 self.navigator, 'controlled_shallow_step', None)
 
             def sample_clear(sample_yaw):
+                profile_work['bot_candidate_attempts'] = (
+                    profile_work.get('bot_candidate_attempts', 0) + 1)
                 advisory = self._planner_corridor_clear(
                     position, sample_yaw, state.get('speed', 0.0),
                     wet_escape=(baked_shallow_escape or
@@ -8504,6 +8582,9 @@ class BotRuntime(object):
                                        state['id'], position, sample_yaw)))
                 if advisory is not None:
                     return bool(advisory)
+                profile_work['bot_candidate_native_fallbacks'] = (
+                    profile_work.get(
+                        'bot_candidate_native_fallbacks', 0) + 1)
                 sample = planner_sample_direction(sample_yaw)
                 # Exhausting the soft-static recast budget is not a wall. Keep
                 # the previous drive intent; commit-side world collision still
@@ -8539,7 +8620,8 @@ class BotRuntime(object):
                 contacts = ()
                 targets = {}
             else:
-                contacts, targets = self._contacts_for(
+                contacts, targets = hidden_worker_profiler.python_call(
+                    'bot_contacts_inclusive', self._contacts_for,
                     state, players, now, team_visibility, visibility_tick)
                 if traffic_bodies is None:
                     traffic_bodies, traffic_index = self._traffic_snapshot(
@@ -8587,7 +8669,9 @@ class BotRuntime(object):
                     self._friendly_reposition_order(state, targets, now)
                 if (reposition_order is not None and
                         callable(decide_with_order)):
-                    command = decide_with_order(
+                    command = hidden_worker_profiler.python_call(
+                        'bot_planner_navigation_inclusive',
+                        decide_with_order,
                         decision_state, reposition_order, sample_clear)
                 elif server_order is not None and callable(decide_with_order):
                     server_order = dict(server_order)
@@ -8599,11 +8683,14 @@ class BotRuntime(object):
                         server_order,
                         targets.get(server_order.get('target_id')),
                         position)
-                    command = decide_with_order(
-                        decision_state, server_order,
-                        sample_clear)
+                    command = hidden_worker_profiler.python_call(
+                        'bot_planner_navigation_inclusive',
+                        decide_with_order,
+                        decision_state, server_order, sample_clear)
                 else:
-                    command = self.adapter.decide(
+                    command = hidden_worker_profiler.python_call(
+                        'bot_planner_navigation_inclusive',
+                        self.adapter.decide,
                         decision_state, sample_clear)
                 if reposition_expired:
                     # Resume the ordinary strategic movement on this frame,
@@ -8766,6 +8853,7 @@ class BotRuntime(object):
                     command['throttle'] = 0.0
                     command['turn'] = 0.0
                     command['movement_intent'] = False
+            enter_stage('bot_selected_motion')
             throttle = max(-1.0, min(1.0, _number(command['throttle'])))
             turn = max(-1.0, min(1.0, _number(command.get('turn'))))
             aim_fallback = (target.get('position') if target is not None
@@ -8870,6 +8958,11 @@ class BotRuntime(object):
                     cached_motion_probe, position, travel_yaw,
                     state.get('speed', 0.0), now, settled_motion, step,
                     ignore_deadline=not refresh_control))
+            cache_work_name = (
+                'bot_motion_cache_hits' if motion_probe_reusable else
+                'bot_motion_cache_misses')
+            profile_work[cache_work_name] = (
+                profile_work.get(cache_work_name, 0) + 1)
             cached_motion_result = (
                 (cached_motion_probe or {}).get('result') or {})
             catchup_motion_reprobe = bool(
@@ -9055,6 +9148,7 @@ class BotRuntime(object):
                 1 if throttle > 0.01 else (-1 if throttle < -0.01 else 0))
             state['rotation_dir'] = steer_dir
             self._log_direction_flip(state, path_clear, motion_probe, now)
+            enter_stage('bot_motion_commit_integration')
             if not self.native_motion:
                 params = self._physics_params.get(state['id'])
                 if params is None:
@@ -9145,6 +9239,8 @@ class BotRuntime(object):
                 if (path_clear and abs(speed) > 0.0001 and
                         callable(self.motion_resolver)):
                     resolved_motion = True
+                    hidden_worker_profiler.work_add(
+                        'bot_motion_commit_sweeps')
                     if self._probe_clock is None:
                         motion_status = self.motion_resolver(
                             state['id'], position, state['yaw'], speed,
@@ -9220,6 +9316,7 @@ class BotRuntime(object):
                         self._hard_contact_grinds[bot_id] = max(
                             0, self._hard_contact_grinds.get(bot_id, 0) - 1)
             ammo_state.publish(state)
+            enter_stage('bot_aim_fire')
             ballistic_solution, local_action_fresh = \
                 self._cadenced_ballistic_solution(
                     state, target, descriptor, state['shell_index'], now,
@@ -9330,6 +9427,7 @@ class BotRuntime(object):
                         # moving SPG must discard it and prove the next shot
                         # again after its normal safe-driver motion completes.
                         self._cancel_artillery_intent(state['id'])
+            enter_stage('bot_supplemental')
             mode = command.get('combat_mode')
             if (collect_cover_jobs and
                     target is not None and target.get('visible') and
@@ -9345,6 +9443,10 @@ class BotRuntime(object):
                                    command.get('move_position', position)))
             _clear_critical_parts_tick_cache(state)
             processed_bot_ids.add(int(state['id']))
+        enter_stage('bot_supplemental')
+        profile_work['bot_observation_pairs'] = (
+            profile_work.get('bot_observation_pairs', 0) +
+            len(observation_pairs))
         # A static firing lane is only meaningful after at least one member of
         # the observing team has spotted the target.  The server ignores the
         # shooter set for an unspotted contact, so probing all 14x15 enemy
@@ -9402,6 +9504,8 @@ class BotRuntime(object):
             completed_affordances = tuple(self._cover_results)
             self._cover_results = []
         cover_jobs.sort(key=lambda value: value[0])
+        profile_work['bot_cover_jobs'] = (
+            profile_work.get('bot_cover_jobs', 0) + len(cover_jobs))
         if collect_cover_jobs:
             self._next_cover_refresh = _number(now) + COVER_REFRESH_SECONDS
         if collect_cover_jobs and cover_jobs:
@@ -9446,6 +9550,7 @@ class BotRuntime(object):
                         'target_kind': target.get('kind', 'human'),
                         'candidates': list(candidates),
                     })
+        enter_stage('bot_tank_contacts')
         pending_ram_count = len(self._pending_ram_reports)
         self._pending_ram_reports.extend(
             self._resolve_tank_contacts(players, now, frame_step))
@@ -9467,6 +9572,7 @@ class BotRuntime(object):
             state['push_x'] = 0.0
             state['push_z'] = 0.0
             self._turn_speeds[bot_id] = 0.0
+        enter_stage('bot_vertical_ground')
         ordered_states = self._ordered_states()
         slope_candidates = []
         for state in ordered_states:
@@ -9494,6 +9600,9 @@ class BotRuntime(object):
                 visited += 1
             self._slope_pose_cursor = (
                 start + max(1, visited)) % len(slope_candidates)
+            profile_work['bot_slope_samples'] = (
+                profile_work.get('bot_slope_samples', 0) + sampled)
+        enter_stage('bot_publication')
         for state in ordered_states:
             if publish:
                 self._mark_combat_publication(state)
@@ -9511,11 +9620,15 @@ class BotRuntime(object):
             if projected is None:
                 raise RuntimeError('bot publication projection failed')
             wire_states.append(projected)
+        profile_work['bot_projected_rows'] = (
+            profile_work.get('bot_projected_rows', 0) + len(wire_states))
         self._sample_time_us = step_end_time_us
         publication = {
             'type': 'bot_state', 'bots': wire_states,
             'sample_time_us': self._sample_time_us,
         }
+        profile_work['bot_publications'] = (
+            profile_work.get('bot_publications', 0) + 1)
         if launches:
             # Never put these local-only SPG proof receipts on the LAN wire.
             # BattleRuntime retries an unaccepted launch from this compact list.

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/compat.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/compat.py
@@ -3,6 +3,8 @@ from __future__ import print_function
 import sys
 import traceback
 
+from gui.mods.offline_lan_0922 import hidden_worker_profiler
+
 try:
     import cPickle as _pickle
 except ImportError:
@@ -17,6 +19,15 @@ _OFFLINE_RETIRE_PENDING = '_offlineLANRetirePending'
 _account_settings_pinned = False
 # AccountSettings.DEFAULT_VALUES keys whose sections this port adopts once.
 _SETTINGS_KEYS = ('settings', 'filters', 'counters', 'notifications')
+
+
+def _vehicle_collision_profile_category(default):
+    semantic = hidden_worker_profiler.current_category(default)
+    return {
+        'projectile_vehicle': 'vehicle_collision_projectile',
+        'firing_lane': 'vehicle_collision_firing_lane',
+        'presentation': 'vehicle_collision_presentation',
+    }.get(semantic, 'vehicle_collision_other')
 
 
 def _entity_bytes(value, default=''):
@@ -1527,7 +1538,9 @@ class OfflineCompatibility(object):
             collisions = visible_native_remote_collisions(
                 vehicle, start_point, end_point)
             if collisions is None:
-                return compatibility._original_vehicle_collide_segment(
+                return hidden_worker_profiler.python_call(
+                    _vehicle_collision_profile_category('presentation'),
+                    compatibility._original_vehicle_collide_segment,
                     vehicle, start_point, end_point, skipGun, optimized)
             if skipGun:
                 collisions = [
@@ -1546,7 +1559,10 @@ class OfflineCompatibility(object):
             collisions = visible_native_remote_collisions(
                 vehicle, start_point, end_point)
             if collisions is None:
-                return compatibility._original_vehicle_collide_segment_ext(
+                return hidden_worker_profiler.python_call(
+                    _vehicle_collision_profile_category(
+                        'projectile_vehicle'),
+                    compatibility._original_vehicle_collide_segment_ext,
                     vehicle, start_point, end_point)
             if not collisions:
                 return None

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/destructibles_authority.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/destructibles_authority.py
@@ -19,6 +19,8 @@ import sys
 import BigWorld
 import Math
 
+from gui.mods.offline_lan_0922 import hidden_worker_profiler
+
 _state = {'spaceID': None, 'chunks': {}, 'entities': {}}
 
 _DESTRUCTIBLE_DIAGNOSTICS = False
@@ -253,7 +255,9 @@ def _apply(spaceID, chunkID, pos, kind, destrData, dedupKey,
 		'fragile': AreaDestructibles._DAMAGE_TYPE_FRAGILE,
 		'module': AreaDestructibles._DAMAGE_TYPE_MODULE,
 	}
-	AreaDestructibles.g_destructiblesManager.orderDestructibleDestroy(
+	hidden_worker_profiler.python_call(
+		'destructible_mutation',
+		AreaDestructibles.g_destructiblesManager.orderDestructibleDestroy,
 		chunkID, dmgTypes[kind], destrData, True,
 		bool(syncWithProjectile))
 	# The native operation is irreversible.  Commit the replay/dedup ledger only
@@ -297,7 +301,9 @@ def destroy_tree(spaceID, chunkID, itemIndex, fallYaw, speed, pos):
 			# wrapper dereferences NULL before Python can handle it.
 			return False
 	pitch = math.pi / 2.0
-	pc = BigWorld.wg_getDestructibleFallPitchConstr(
+	pc = hidden_worker_profiler.native_call(
+		'destructible_state', 'wg_getDestructibleFallPitchConstr',
+		BigWorld.wg_getDestructibleFallPitchConstr,
 		spaceID, chunkID, itemIndex, fallYaw)
 	try:
 		pitchConstr, _collisionFlags = pc

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/destructibles_compat.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/destructibles_compat.py
@@ -10,6 +10,8 @@ nullable result of ``wg_getDestructibleFilename`` straight to
 normally and is therefore the safe boundary for offline tree animation.
 """
 
+from gui.mods.offline_lan_0922 import hidden_worker_profiler
+
 
 _INSTALLED = False
 _SAFE_DESC_SPACE = [None]
@@ -49,7 +51,9 @@ def inspect_destructible_desc(cache, space_id, chunk_id, item_index):
     cached = _SAFE_DESC_BY_WIRE.get(key)
     if cached is not None:
         return 'resolved', cached
-    filenames = BigWorld.wg_getChunkDestrFilenames(space_id, chunk_id)
+    filenames = hidden_worker_profiler.native_call(
+        'destructible_setup', 'wg_getChunkDestrFilenames',
+        BigWorld.wg_getChunkDestrFilenames, space_id, chunk_id)
     if filenames is None:
         return 'pending', None
     if not isinstance(filenames, (list, tuple)):

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/destructibles_sensor.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/destructibles_sensor.py
@@ -5,6 +5,8 @@ The three sensor bodies below are dedented copies from ``offline_battle.py``.
 Only their former closure dependencies are supplied at module scope.
 """
 
+from gui.mods.offline_lan_0922 import hidden_worker_profiler
+
 _event_sink = None
 
 _DESTRUCTIBLE_BIN_METRES = 8.0
@@ -755,6 +757,8 @@ def _bump_spatial_revision_1513():
 	"""Invalidate receipts after any exact spatial-index mutation."""
 	revision = _spatial_revision_1513() + 1
 	globals()['g_offh_destr_spatial_revision'] = revision
+	hidden_worker_profiler.update_context({
+		'destructible_revision': revision})
 	_receipt_stat_1513('spatial_invalidations')
 	for cache_name, prefix in (
 			('g_offh_destr_empty_contact_receipts', 'contact'),
@@ -1126,7 +1130,9 @@ def _validate_native_effect_categories_1513(
 			raw_material - normal_min for raw_material in raw_materials)
 	for module_index in module_indices:
 		try:
-			native_type = bigworld.wg_getDestructibleEffectCategory(
+			native_type = hidden_worker_profiler.native_call(
+				'destructible_setup', 'wg_getDestructibleEffectCategory',
+				bigworld.wg_getDestructibleEffectCategory,
 				spaceID, chunk_id, item_index, module_index)
 		except Exception as error:
 			_isolate_destructible_1513(
@@ -1185,7 +1191,9 @@ def _stream_baked_shot_instance_1513(spaceID, identity):
 			'native_count_range', chunk_id, item_index,
 			detail='count=%s' % native_count)
 		return None
-	filenames = BigWorld.wg_getChunkDestrFilenames(spaceID, chunk_id)
+	filenames = hidden_worker_profiler.native_call(
+		'destructible_setup', 'wg_getChunkDestrFilenames',
+		BigWorld.wg_getChunkDestrFilenames, spaceID, chunk_id)
 	if filenames is None:
 		return None
 	if not isinstance(filenames, (list, tuple)):
@@ -1204,12 +1212,16 @@ def _stream_baked_shot_instance_1513(spaceID, identity):
 			'filename_slot', chunk_id, item_index,
 			detail='expected string')
 		return None
-	chunk_matrix = BigWorld.wg_getChunkMatrix(spaceID, chunk_id)
+	chunk_matrix = hidden_worker_profiler.native_call(
+		'destructible_setup', 'wg_getChunkMatrix',
+		BigWorld.wg_getChunkMatrix, spaceID, chunk_id)
 	chunk_translation = getattr(chunk_matrix, 'translation', None)
 	if chunk_translation is None:
 		return None
 	try:
-		matrix = Math.Matrix(BigWorld.wg_getDestructibleMatrix(
+		matrix = Math.Matrix(hidden_worker_profiler.native_call(
+			'destructible_setup', 'wg_getDestructibleMatrix',
+			BigWorld.wg_getDestructibleMatrix,
 			spaceID, chunk_id, item_index))
 		signature, located = _catalog_instance_for_matrix_1513(
 			matrix, chunk_translation, Math)
@@ -1843,7 +1855,9 @@ def _catalog_soft_static_path(spaceID, segment_start, segment_end,
 			if not recast_budget or int(recast_budget[0]) <= 0:
 				return 'pending_hard' if pending_contact else 'deferred'
 			recast_budget[0] = int(recast_budget[0]) - 1
-		current_hit = BigWorld.wg_collideSegment(
+		current_hit = hidden_worker_profiler.native_call(
+			'destructible_motion', 'wg_collideSegment',
+			BigWorld.wg_collideSegment,
 			spaceID, next_start, segment_end, 128)
 		if current_hit is None:
 			return 'kinetic' if kinetic_contact else True
@@ -2466,7 +2480,9 @@ def _refresh_destroyed_falling_instances_1513(spaceID, authority, now):
 			active[identity]['last_refresh'] = float(now)
 			continue
 		try:
-			matrix = Math.Matrix(BigWorld.wg_getDestructibleMatrix(
+			matrix = Math.Matrix(hidden_worker_profiler.native_call(
+				'destructible_state', 'wg_getDestructibleMatrix',
+				BigWorld.wg_getDestructibleMatrix,
 				spaceID, chunk_id, item_index))
 		except Exception as error:
 			_isolate_destructible_1513(
@@ -2897,7 +2913,9 @@ def _fell_trees_near(spaceID, pos, yaw, vel, td=None):
 					# infer a count from the diagnostic filename prefix; retry after
 					# the native streaming callback populates the manager map.
 					continue
-				_dfn = BigWorld.wg_getChunkDestrFilenames(spaceID, cid)
+				_dfn = hidden_worker_profiler.native_call(
+					'destructible_tree_scan', 'wg_getChunkDestrFilenames',
+					BigWorld.wg_getChunkDestrFilenames, spaceID, cid)
 				if _dfn is None:
 					if cid == _current_cid:
 						_diagnostic_chunk_pending_1513(
@@ -2920,7 +2938,9 @@ def _fell_trees_near(spaceID, pos, yaw, vel, td=None):
 					'max_radius': 0.0, 'slot_diagnostics': {},
 				}
 				_retry_registry = False
-				_cm_t = BigWorld.wg_getChunkMatrix(spaceID, cid).translation
+				_cm_t = hidden_worker_profiler.native_call(
+					'destructible_tree_scan', 'wg_getChunkMatrix',
+					BigWorld.wg_getChunkMatrix, spaceID, cid).translation
 				if _cm_t is None:
 					continue
 				for _ti in xrange(_native_count):
@@ -2939,7 +2959,10 @@ def _fell_trees_near(spaceID, pos, yaw, vel, td=None):
 							(_baked_slot is not None and
 								_baked_slot.get('kind') == 'falling'))
 						try:
-							_m = Math.Matrix(BigWorld.wg_getDestructibleMatrix(
+							_m = Math.Matrix(hidden_worker_profiler.native_call(
+								'destructible_tree_scan',
+								'wg_getDestructibleMatrix',
+								BigWorld.wg_getDestructibleMatrix,
 								spaceID, cid, _ti))
 						except Exception as error:
 							if not _is_known_falling:
@@ -3566,7 +3589,9 @@ def _try_destroy_solid_hit(spaceID, segment_start, hit_pt, surf_normal,
 			_probes += ((hit_pt + _incoming.scale(3.0),
 				hit_pt - _incoming.scale(2.0)),)
 		for _seg_a, _seg_b in _probes:
-			_mi = BigWorld.wg_getMatInfoNearPoint(
+			_mi = hidden_worker_profiler.native_call(
+				'destructible_motion', 'wg_getMatInfoNearPoint',
+				BigWorld.wg_getMatInfoNearPoint,
 				spaceID, _seg_a, _seg_b, hit_pt, lambda *a: False)
 			_decoded = _decode_mat_info_1513(_mi)
 			if not _solid_destructible_candidate_1513(
@@ -3730,14 +3755,18 @@ def shot_world_distance(bigworld, spaceID, start_pos, end_pos, dir_vec,
 	tree_filter = _transparent_tree_shot_filter_1513(ignored_trees)
 	tree_hits = 0
 	world_dist = 99999.0
-	world_collision = bigworld.wg_collideSegment(
+	world_collision = hidden_worker_profiler.native_call(
+		'destructible_projectile', 'wg_collideSegment',
+		bigworld.wg_collideSegment,
 		spaceID, start_pos, end_pos, 128)
 	shot_yaw = math.atan2(dir_vec.x, dir_vec.z)
 	decoded = None
 	catalog_hit = None
 	while world_collision is not None:
 		world_dist = (world_collision[0] - start_pos).length
-		mat_info = bigworld.wg_getMatInfoNearPoint(
+		mat_info = hidden_worker_profiler.native_call(
+			'destructible_projectile', 'wg_getMatInfoNearPoint',
+			bigworld.wg_getMatInfoNearPoint,
 			spaceID, start_pos,
 			world_collision[0] + dir_vec.scale(0.3),
 			world_collision[0], lambda *unused: False)
@@ -3768,7 +3797,9 @@ def shot_world_distance(bigworld, spaceID, start_pos, end_pos, dir_vec,
 			if tree_hits > 64:
 				raise RuntimeError(
 					'#1513 transparent tree shot traversal exceeded 64 hits')
-			world_collision = bigworld.wg_collideSegment(
+			world_collision = hidden_worker_profiler.native_call(
+				'destructible_projectile', 'wg_collideSegment',
+				bigworld.wg_collideSegment,
 				spaceID, start_pos, end_pos, 128, tree_filter)
 			continue
 		if destruction_accepted:
@@ -3801,7 +3832,9 @@ def shot_world_distance(bigworld, spaceID, start_pos, end_pos, dir_vec,
 					world_dist, stop_distance=world_dist,
 					stopped_by_destructible=True)
 			# Destructible broken by the shell: re-cast past the debris.
-			second = bigworld.wg_collideSegment(
+			second = hidden_worker_profiler.native_call(
+				'destructible_projectile', 'wg_collideSegment',
+				bigworld.wg_collideSegment,
 				spaceID, world_collision[0] + dir_vec.scale(0.6),
 				end_pos, 128)
 			return ((second[0] - start_pos).length
@@ -3910,7 +3943,9 @@ def shot_world_distance(bigworld, spaceID, start_pos, end_pos, dir_vec,
 		return catalog_hit['distance']
 	recast_distance = catalog_hit['exit_distance'] + _SHOT_RAY_EPSILON
 	recast_start = start_pos + dir_vec.scale(recast_distance)
-	second = bigworld.wg_collideSegment(
+	second = hidden_worker_profiler.native_call(
+		'destructible_projectile', 'wg_collideSegment',
+		bigworld.wg_collideSegment,
 		spaceID, recast_start, end_pos, 128)
 	return ((second[0] - start_pos).length
 		if second is not None else 99999.0)

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/entities/remote_vehicle.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/entities/remote_vehicle.py
@@ -42,7 +42,7 @@ def reset_pose_animation_writes():
     global _pose_object_allocations
     _pose_object_allocations = 0
 
-from gui.mods.offline_lan_0922 import tank_collision
+from gui.mods.offline_lan_0922 import hidden_worker_profiler, tank_collision
 
 try:
     _STRING_TYPES = (basestring,)
@@ -1093,7 +1093,8 @@ def encode_damage_sticker(vehicle, vehicle_matrix, start_point, end_point,
 
 def _collide_vehicle_at_matrix(vehicle, vehicle_matrix, start_point,
                                end_point, math_module, include_world_normal,
-                               chassis_matrix=None):
+                               chassis_matrix=None,
+                               profiler_category=None):
     """Run precise descriptor collision at supplied body/chassis matrices.
 
     #1513's native ``Vehicle.collideSegmentExt`` first rejects rays through
@@ -1122,6 +1123,9 @@ def _collide_vehicle_at_matrix(vehicle, vehicle_matrix, start_point,
         world_to_chassis.invert()
         chassis_start = world_to_chassis.applyPoint(start_point)
         chassis_end = world_to_chassis.applyPoint(end_point)
+    category = (hidden_worker_profiler.current_category(
+        'projectile_vehicle') if profiler_category is None else
+        profiler_category)
     hits = []
     for component_index, pair in enumerate(_pose_components(
             vehicle, math_module)):
@@ -1132,7 +1136,8 @@ def _collide_vehicle_at_matrix(vehicle, vehicle_matrix, start_point,
             continue
         start = chassis_start if component_index == 0 else body_start
         end = chassis_end if component_index == 0 else body_end
-        collisions = local_hit_test(
+        collisions = hidden_worker_profiler.native_call(
+            category, 'hitTester.localHitTest', local_hit_test,
             component_matrix.applyPoint(start),
             component_matrix.applyPoint(end))
         component_to_vehicle = None
@@ -1178,19 +1183,23 @@ def _collide_vehicle_at_matrix(vehicle, vehicle_matrix, start_point,
 
 def _collide_vehicle_evidence_at_matrix(vehicle, vehicle_matrix, start_point,
                                         end_point, math_module,
-                                        chassis_matrix=None):
+                                        chassis_matrix=None,
+                                        profiler_category='projectile_vehicle'):
     """Return world-normal evidence for the authoritative shot resolver."""
     return _collide_vehicle_at_matrix(
         vehicle, vehicle_matrix, start_point, end_point, math_module, True,
-        chassis_matrix=chassis_matrix)
+        chassis_matrix=chassis_matrix,
+        profiler_category=profiler_category)
 
 
 def collide_vehicle_at_matrix(vehicle, vehicle_matrix, start_point,
-                              end_point, math_module, chassis_matrix=None):
+                              end_point, math_module, chassis_matrix=None,
+                              profiler_category=None):
     """Return #1513's exact four-field collision values for public callers."""
     return _collide_vehicle_at_matrix(
         vehicle, vehicle_matrix, start_point, end_point, math_module, False,
-        chassis_matrix=chassis_matrix)
+        chassis_matrix=chassis_matrix,
+        profiler_category=profiler_category)
 
 
 class RemoteVehicle(object):

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/hidden_worker_profiler.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/hidden_worker_profiler.py
@@ -14,7 +14,13 @@ separate off-frame bucket and attributed to the following render interval.
 """
 
 import math
+import threading
 import time
+
+try:
+    import thread as _thread_module
+except ImportError:
+    import _thread as _thread_module
 
 
 _CLOCK = getattr(time, 'perf_counter', None)
@@ -30,24 +36,120 @@ NATIVE_CATEGORIES = (
     'destructible_setup', 'destructible_motion',
     'destructible_projectile', 'destructible_state',
     'destructible_tree_scan', 'foliage_dynamic', 'presentation', 'other')
+PYTHON_PHASE_CATEGORIES = (
+    'bot_prework', 'bot_runtime_update', 'bot_postdiag',
+    'bot_message_freeze', 'bot_message_enqueue', 'bot_message_send',
+    'worker_message_freeze', 'worker_message_enqueue',
+    'worker_message_send',
+    'bot_scheduler_control_refresh', 'bot_scheduler_catchup',
+    'bot_setup', 'bot_control_observation', 'bot_selected_motion',
+    'bot_motion_commit_integration', 'bot_aim_fire', 'bot_supplemental',
+    'bot_tank_contacts', 'bot_vertical_ground', 'bot_publication',
+    'bot_contacts_inclusive', 'bot_visibility_prepare_inclusive',
+    'bot_planner_navigation_inclusive', 'bot_astar_inclusive',
+    'bot_driver_inclusive',
+    'projectile_history', 'projectile_step', 'projectile_world',
+    'projectile_vehicle', 'projectile_destructible',
+    'projectile_terminal', 'projectile_visual', 'render_sync')
 PYTHON_CATEGORIES = (
     'foliage_spotting', 'foliage_dynamic', 'destructible_scan',
     'destructible_contact', 'destructible_projectile',
     'destructible_mutation', 'vehicle_collision_projectile',
     'vehicle_collision_firing_lane', 'vehicle_collision_presentation',
-    'vehicle_collision_other', 'muzzle_transform', 'other')
+    'vehicle_collision_other', 'muzzle_transform') + \
+    PYTHON_PHASE_CATEGORIES + ('other',)
+WORK_COUNTERS = (
+    'bot_control_refresh_slices', 'bot_catchup_slices',
+    'bot_live_rows', 'bot_integrated_rows', 'bot_decision_due',
+    'bot_candidate_attempts', 'bot_candidate_native_fallbacks',
+    'bot_motion_cache_hits', 'bot_motion_cache_misses',
+    'bot_receipt_requests', 'bot_receipt_attempts',
+    'bot_receipt_deferred', 'bot_astar_expansions',
+    'bot_contact_candidate_pairs', 'bot_contact_resolved_pairs',
+    'bot_slope_samples', 'bot_observation_pairs', 'bot_cover_jobs',
+    'bot_projected_rows', 'bot_publications',
+    'bot_visibility_pairs', 'bot_shot_lane_pairs', 'bot_ground_probes',
+    'bot_motion_direction_probes', 'bot_motion_receipt_probes',
+    'bot_motion_commit_sweeps',
+    'projectiles_active', 'projectile_segments', 'projectile_candidates',
+    'projectile_terminals', 'bot_messages', 'bot_rows')
+WORK_COUNTERS += (
+    'worker_messages', 'worker_wire_bytes', 'worker_queue_depth')
 _NATIVE_CATEGORY_LOOKUP = dict((name, True) for name in NATIVE_CATEGORIES)
 _PYTHON_CATEGORY_LOOKUP = dict((name, True) for name in PYTHON_CATEGORIES)
+_WORK_COUNTER_LOOKUP = dict((name, True) for name in WORK_COUNTERS)
+
+# A timing row is inclusive unless it belongs to one of the two explicitly
+# additive groups.  ``frame_exclusive`` categories partition the reviewed
+# outer Bot callback section. ``bot_step_exclusive`` categories partition one
+# BotRuntime physical slice.  Every other scope can overlap one of those
+# groups and must be displayed separately rather than added to it.
+PYTHON_CATEGORY_SCOPES = dict(
+    (name, 'inclusive_boundary') for name in PYTHON_CATEGORIES)
+for _name in ('bot_prework', 'bot_runtime_update', 'bot_postdiag'):
+    PYTHON_CATEGORY_SCOPES[_name] = 'frame_exclusive'
+for _name in (
+        'bot_setup', 'bot_control_observation', 'bot_selected_motion',
+        'bot_motion_commit_integration', 'bot_aim_fire', 'bot_supplemental',
+        'bot_tank_contacts', 'bot_vertical_ground', 'bot_publication'):
+    PYTHON_CATEGORY_SCOPES[_name] = 'bot_step_exclusive'
+for _name in ('bot_scheduler_control_refresh', 'bot_scheduler_catchup'):
+    PYTHON_CATEGORY_SCOPES[_name] = 'scheduler_inclusive'
+for _name in (
+        'bot_contacts_inclusive', 'bot_visibility_prepare_inclusive',
+        'bot_planner_navigation_inclusive', 'bot_astar_inclusive',
+        'bot_driver_inclusive'):
+    PYTHON_CATEGORY_SCOPES[_name] = 'nested_inclusive'
+for _name in ('worker_message_freeze', 'worker_message_enqueue',
+              'worker_message_send'):
+    PYTHON_CATEGORY_SCOPES[_name] = 'message_nested_inclusive'
+for _name in ('bot_message_freeze', 'bot_message_enqueue',
+              'bot_message_send'):
+    PYTHON_CATEGORY_SCOPES[_name] = 'legacy_bot_message_nested_inclusive'
+PYTHON_CATEGORY_SCOPES['projectile_step'] = 'projectile_outer_inclusive'
+for _name in (
+        'projectile_history', 'projectile_world', 'projectile_vehicle',
+        'projectile_destructible', 'projectile_terminal',
+        'projectile_visual'):
+    PYTHON_CATEGORY_SCOPES[_name] = 'projectile_nested_inclusive'
+PYTHON_CATEGORY_SCOPES['render_sync'] = 'frame_inclusive_boundary'
 TRACE_SAMPLES_PER_FRAME = 24
 SLOW_TRACE_MIN_SECONDS = 0.001
 REPRESENTATIVE_SEGMENT_PERIOD = 256
 REPRESENTATIVE_SEGMENTS_PER_CATEGORY_PER_FRAME = 2
 FULL_TIMING_SECONDS = 30.0
 DORMANT_BASELINE_SECONDS = 5.0
+MAX_WORK_COUNTER_VALUE = 1000000000000
+WORK_COUNTER_SCOPE = 'active_hidden_worker_session_all_modes'
+WORK_COUNTER_SEMANTICS = (
+    'nonnegative_finite_bounded_per_interval;see_work_counter_aggregations')
+WORK_COUNTER_AGGREGATIONS = dict((name, 'sum') for name in WORK_COUNTERS)
+WORK_COUNTER_AGGREGATIONS['worker_queue_depth'] = 'sampled_max'
+WORK_COUNTER_NOTES = {
+    'bot_motion_commit_sweeps': (
+        'logical_motion_resolver_requests_including_cache_fast_path;'
+        'not_native_ray_count'),
+    'worker_queue_depth': 'maximum_of_instrumented_queue_depth_samples',
+}
+PYTHON_SCOPE_SUM_RULE = (
+    'sum_only_within_frame_exclusive_or_bot_step_exclusive;'
+    'all_other_scopes_are_inclusive')
+BOT_UPDATE_RESIDUAL_SEMANTICS = (
+    'max(0,sum(scheduler_inclusive)-sum(bot_step_exclusive));'
+    'nested_inclusive_is_excluded')
+PYTHON_THREAD_ATTRIBUTION = (
+    'begin_frame_thread_is_render;other_threads_are_offframe')
+OFFFRAME_PYTHON_TIMING_SEMANTICS = (
+    'timing_at_marker_start;reported_in_completion_interval')
 _CATEGORY_PHASE = dict(
     (name, (index * 13) % REPRESENTATIVE_SEGMENT_PERIOD)
     for index, name in enumerate(NATIVE_CATEGORIES))
 _MISSING = object()
+
+try:
+    _INTEGER_TYPES = (int, long)
+except NameError:
+    _INTEGER_TYPES = (int,)
 
 
 def _empty_profile(measured=False):
@@ -55,13 +157,28 @@ def _empty_profile(measured=False):
         'measured': bool(measured),
         'native': {},
         'python': {},
+        'work': {},
         'offframe_native': {},
         'offframe_python': {},
+        'offframe_work': {},
         'trace': (),
         'representative_trace': (),
         'mode': 'off',
         'clock_reads': 0,
         'clock_read_estimate_ns': None,
+        'work_counters_recorded': False,
+        'work_counter_scope': WORK_COUNTER_SCOPE,
+        'work_counter_semantics': WORK_COUNTER_SEMANTICS,
+        'work_counter_aggregations': WORK_COUNTER_AGGREGATIONS,
+        'work_counter_notes': WORK_COUNTER_NOTES,
+        'python_timing_semantics': 'inclusive_timing_windows_only',
+        'python_category_scopes': PYTHON_CATEGORY_SCOPES,
+        'python_scope_sum_rule': PYTHON_SCOPE_SUM_RULE,
+        'bot_update_residual_semantics': BOT_UPDATE_RESIDUAL_SEMANTICS,
+        'python_thread_attribution': PYTHON_THREAD_ATTRIBUTION,
+        'offframe_python_timing_semantics': (
+            OFFFRAME_PYTHON_TIMING_SEMANTICS),
+        'offframe_python_measured': False,
         'coverage': 'reviewed_hidden_worker_call_sites_only',
         'filtered_segment_timing': (
             'native_boundary_including_python_filter'),
@@ -95,6 +212,7 @@ class HiddenWorkerProfiler(object):
                  full_timing_seconds=FULL_TIMING_SECONDS,
                  baseline_seconds=DORMANT_BASELINE_SECONDS):
         self._clock = clock or _CLOCK
+        self._state_lock = threading.RLock()
         self._calibrate_clock_reads = clock is None
         if alternate_modes is None:
             alternate_modes = clock is None
@@ -102,9 +220,21 @@ class HiddenWorkerProfiler(object):
         self._full_timing_seconds = max(
             0.001, float(full_timing_seconds))
         self._baseline_seconds = max(0.001, float(baseline_seconds))
-        self.reset()
+        self._reset_state()
 
     def reset(self):
+        try:
+            self._state_lock.acquire()
+            try:
+                self._reset_state()
+            finally:
+                self._state_lock.release()
+        except Exception:
+            # Reset is called from battle lifecycle cleanup.  A diagnostic
+            # failure must not replace that cleanup's gameplay semantics.
+            pass
+
+    def _reset_state(self):
         self.enabled = False
         self._session_active = False
         self._mode = 'off'
@@ -113,8 +243,10 @@ class HiddenWorkerProfiler(object):
         self._frame_ordinal = 0
         self._frame_native = {}
         self._frame_python = {}
+        self._frame_work = {}
         self._offframe_native = {}
         self._offframe_python = {}
+        self._offframe_work = {}
         self._trace = []
         self._trace_floor_seconds = SLOW_TRACE_MIN_SECONDS
         self._representative_trace = []
@@ -125,6 +257,17 @@ class HiddenWorkerProfiler(object):
         self._frame_clock_reads = 0
         self._offframe_clock_reads = 0
         self._clock_read_estimate_ns = None
+        self._render_thread_id = None
+        # Background timing markers from a prior battle are ignored if they
+        # complete after reset instead of contaminating the next room.
+        self._session_token = object()
+
+    @staticmethod
+    def _thread_ident():
+        try:
+            return _thread_module.get_ident()
+        except Exception:
+            return None
 
     @staticmethod
     def _note(bucket, key, elapsed, failed):
@@ -141,6 +284,41 @@ class HiddenWorkerProfiler(object):
     def _copy_bucket(bucket):
         return dict((key, (int(value[0]), float(value[1]), int(value[2])))
                     for key, value in bucket.items())
+
+    @staticmethod
+    def _work_value(value):
+        """Return one bounded work increment without coercing arbitrary data."""
+        if isinstance(value, bool):
+            return None
+        if isinstance(value, _INTEGER_TYPES):
+            if value < 0:
+                return None
+            return min(value, MAX_WORK_COUNTER_VALUE)
+        if not isinstance(value, float):
+            return None
+        if math.isnan(value) or math.isinf(value) or value < 0.0:
+            return None
+        return min(value, float(MAX_WORK_COUNTER_VALUE))
+
+    @staticmethod
+    def _work_merge(name, current, value):
+        if WORK_COUNTER_AGGREGATIONS.get(name) == 'sampled_max':
+            return max(current, value)
+        if (isinstance(current, _INTEGER_TYPES) and
+                isinstance(value, _INTEGER_TYPES)):
+            return min(current + value, MAX_WORK_COUNTER_VALUE)
+        return min(
+            float(current) + float(value), float(MAX_WORK_COUNTER_VALUE))
+
+    @staticmethod
+    def _copy_work_bucket(bucket):
+        result = {}
+        for key, value in bucket.items():
+            if isinstance(value, _INTEGER_TYPES):
+                result[key] = int(value)
+            else:
+                result[key] = float(value)
+        return result
 
     def begin_frame(self, active, context=None):
         """Open one render callback and retain prior off-frame work."""
@@ -161,6 +339,13 @@ class HiddenWorkerProfiler(object):
             if self._session_active or self._frame_open or self.enabled:
                 self.reset()
             return False
+        self._state_lock.acquire()
+        try:
+            return self._begin_active_frame(context)
+        finally:
+            self._state_lock.release()
+
+    def _begin_active_frame(self, context):
         # If a callback escaped before end_frame(), preserve its observations
         # with the interval that is about to be sealed.  Diagnostics must not
         # retain mutable frame buckets across callbacks.
@@ -175,9 +360,14 @@ class HiddenWorkerProfiler(object):
                 row[0] += value[0]
                 row[1] += value[1]
                 row[2] += value[2]
+            for key, value in self._frame_work.items():
+                self._offframe_work[key] = self._work_merge(
+                    key,
+                    self._offframe_work.get(key, 0), value)
             self._offframe_clock_reads += self._frame_clock_reads
         interval_profile = self._detach_interval_profile()
         self._session_active = True
+        self._render_thread_id = self._thread_ident()
         self._frame_ordinal += 1
         if self._phase_started is None:
             self._phase_started = self._clock() if self._alternate_modes else 0.0
@@ -199,6 +389,7 @@ class HiddenWorkerProfiler(object):
             self._calibrate_clock()
         self._frame_native = {}
         self._frame_python = {}
+        self._frame_work = {}
         self._trace = []
         self._trace_floor_seconds = SLOW_TRACE_MIN_SECONDS
         self._representative_trace = []
@@ -211,6 +402,7 @@ class HiddenWorkerProfiler(object):
 
     def _detach_interval_profile(self):
         if (not self._offframe_native and not self._offframe_python and
+                not self._offframe_work and
                 not self._trace and not self._representative_trace and
                 not self._offframe_clock_reads):
             return False
@@ -218,18 +410,35 @@ class HiddenWorkerProfiler(object):
             'measured': bool(self.enabled),
             'offframe_native': self._copy_bucket(self._offframe_native),
             'offframe_python': self._copy_bucket(self._offframe_python),
+            'work': {},
+            'offframe_work': self._copy_work_bucket(self._offframe_work),
             'trace': tuple(self._trace),
             'representative_trace': tuple(self._representative_trace),
             'mode': self._mode,
             'clock_reads': int(self._offframe_clock_reads),
             'clock_read_estimate_ns': self._clock_read_estimate_ns,
             'frame_ordinal': self._frame_ordinal,
+            'work_counters_recorded': True,
+            'work_counter_scope': WORK_COUNTER_SCOPE,
+            'work_counter_semantics': WORK_COUNTER_SEMANTICS,
+            'work_counter_aggregations': WORK_COUNTER_AGGREGATIONS,
+            'work_counter_notes': WORK_COUNTER_NOTES,
+            'python_timing_semantics': 'inclusive_timing_windows_only',
+            'python_category_scopes': PYTHON_CATEGORY_SCOPES,
+            'python_scope_sum_rule': PYTHON_SCOPE_SUM_RULE,
+            'bot_update_residual_semantics': (
+                BOT_UPDATE_RESIDUAL_SEMANTICS),
+            'python_thread_attribution': PYTHON_THREAD_ATTRIBUTION,
+            'offframe_python_timing_semantics': (
+                OFFFRAME_PYTHON_TIMING_SEMANTICS),
+            'offframe_python_measured': bool(self._offframe_python),
             'coverage': 'reviewed_hidden_worker_call_sites_only',
             'filtered_segment_timing': (
                 'native_boundary_including_python_filter'),
         }
         self._offframe_native = {}
         self._offframe_python = {}
+        self._offframe_work = {}
         self._trace = []
         self._trace_floor_seconds = SLOW_TRACE_MIN_SECONDS
         self._representative_trace = []
@@ -239,17 +448,34 @@ class HiddenWorkerProfiler(object):
 
     def end_frame(self):
         """Close the current callback and detach its immutable sample."""
-        try:
-            return self._end_frame()
-        except Exception:
-            self._frame_open = False
-            self._frame_native = {}
-            self._frame_python = {}
-            self._trace = []
-            self._representative_trace = []
-            self._representative_frame_counts = {}
-            self._frame_clock_reads = 0
+        if not self._session_active:
             return _empty_profile(False)
+        profile = _empty_profile(False)
+        locked = False
+        try:
+            self._state_lock.acquire()
+            locked = True
+            profile = self._end_frame()
+        except Exception:
+            try:
+                self._frame_open = False
+                self._frame_native = {}
+                self._frame_python = {}
+                self._frame_work = {}
+                self._trace = []
+                self._representative_trace = []
+                self._representative_frame_counts = {}
+                self._frame_clock_reads = 0
+            except Exception:
+                pass
+            profile = _empty_profile(False)
+        finally:
+            if locked:
+                try:
+                    self._state_lock.release()
+                except Exception:
+                    pass
+        return profile
 
     def _end_frame(self):
         if not self._session_active:
@@ -259,17 +485,22 @@ class HiddenWorkerProfiler(object):
             profile['mode'] = 'wrapper_only_baseline'
             profile['frame_ordinal'] = self._frame_ordinal
             profile['clock_read_estimate_ns'] = self._clock_read_estimate_ns
+            profile['work'] = self._copy_work_bucket(self._frame_work)
+            profile['work_counters_recorded'] = True
             self._frame_open = False
             self._frame_native = {}
             self._frame_python = {}
+            self._frame_work = {}
             self._frame_clock_reads = 0
             return profile
         profile = {
             'measured': True,
             'native': self._copy_bucket(self._frame_native),
             'python': self._copy_bucket(self._frame_python),
+            'work': self._copy_work_bucket(self._frame_work),
             'offframe_native': {},
             'offframe_python': {},
+            'offframe_work': {},
             'trace': tuple(sorted(
                 self._trace, key=lambda row: row.get('elapsed_ms', 0.0),
                 reverse=True)),
@@ -278,12 +509,27 @@ class HiddenWorkerProfiler(object):
             'clock_reads': int(self._frame_clock_reads),
             'clock_read_estimate_ns': self._clock_read_estimate_ns,
             'frame_ordinal': self._frame_ordinal,
+            'work_counters_recorded': True,
+            'work_counter_scope': WORK_COUNTER_SCOPE,
+            'work_counter_semantics': WORK_COUNTER_SEMANTICS,
+            'work_counter_aggregations': WORK_COUNTER_AGGREGATIONS,
+            'work_counter_notes': WORK_COUNTER_NOTES,
+            'python_timing_semantics': 'inclusive_timing_windows_only',
+            'python_category_scopes': PYTHON_CATEGORY_SCOPES,
+            'python_scope_sum_rule': PYTHON_SCOPE_SUM_RULE,
+            'bot_update_residual_semantics': (
+                BOT_UPDATE_RESIDUAL_SEMANTICS),
+            'python_thread_attribution': PYTHON_THREAD_ATTRIBUTION,
+            'offframe_python_timing_semantics': (
+                OFFFRAME_PYTHON_TIMING_SEMANTICS),
+            'offframe_python_measured': False,
             'coverage': 'reviewed_hidden_worker_call_sites_only',
             'filtered_segment_timing': (
                 'native_boundary_including_python_filter'),
         }
         self._frame_native = {}
         self._frame_python = {}
+        self._frame_work = {}
         self._trace = []
         self._trace_floor_seconds = SLOW_TRACE_MIN_SECONDS
         self._representative_trace = []
@@ -304,12 +550,50 @@ class HiddenWorkerProfiler(object):
         except Exception:
             self._clock_read_estimate_ns = None
 
-    def _read_clock(self):
-        if self._frame_open:
+    def _read_clock(self, owner=None):
+        if owner is None:
+            owner = 'frame' if self._frame_open else 'offframe'
+        if owner == 'frame':
             self._frame_clock_reads += 1
         else:
             self._offframe_clock_reads += 1
         return self._clock()
+
+    def _bucket_owner(self):
+        thread_id = self._thread_ident()
+        if (self._frame_open and self._render_thread_id is not None and
+                thread_id == self._render_thread_id):
+            return 'frame'
+        return 'offframe'
+
+    def work_add(self, name, value=1):
+        """Add one bounded work-unit observation without reading the clock."""
+        try:
+            if not self._session_active:
+                return False
+            name = str(name)
+            if name not in _WORK_COUNTER_LOOKUP:
+                return False
+            value = self._work_value(value)
+            if value is None:
+                return False
+            if self._bucket_owner() == 'frame':
+                self._frame_work[name] = self._work_merge(
+                    name,
+                    self._frame_work.get(name, 0), value)
+                return True
+            self._state_lock.acquire()
+            try:
+                if not self._session_active:
+                    return False
+                self._offframe_work[name] = self._work_merge(
+                    name,
+                    self._offframe_work.get(name, 0), value)
+                return True
+            finally:
+                self._state_lock.release()
+        except Exception:
+            return False
 
     def update_context(self, context):
         try:
@@ -506,22 +790,51 @@ class HiddenWorkerProfiler(object):
         if not self.enabled:
             return None
         try:
-            return (_safe_name(category, _PYTHON_CATEGORY_LOOKUP),
-                    self._read_clock())
+            category = _safe_name(category, _PYTHON_CATEGORY_LOOKUP)
+            owner = self._bucket_owner()
+            if owner == 'frame':
+                return (category, self._read_clock('frame'), owner,
+                        self._session_token)
+            self._state_lock.acquire()
+            try:
+                # The render callback may have changed A/B mode while this
+                # background thread waited for the interval swap.
+                if not self.enabled or not self._session_active:
+                    return None
+                return (category, self._read_clock('offframe'), owner,
+                        self._session_token)
+            finally:
+                self._state_lock.release()
         except Exception:
             return None
 
     def python_finished(self, marker, failed=False):
-        if marker is None or not self.enabled:
+        if marker is None:
             return False
         try:
-            category, started = marker
-            elapsed = float(self._read_clock()) - float(started)
-            if math.isnan(elapsed) or math.isinf(elapsed):
-                elapsed = 0.0
-            self._note(
-                self._python_bucket(), category, elapsed, bool(failed))
-            return True
+            category, started, owner, session_token = marker
+            if owner == 'frame':
+                if session_token is not self._session_token:
+                    return False
+                elapsed = float(self._read_clock('frame')) - float(started)
+                if math.isnan(elapsed) or math.isinf(elapsed):
+                    elapsed = 0.0
+                self._note(
+                    self._frame_python, category, elapsed, bool(failed))
+                return True
+            self._state_lock.acquire()
+            try:
+                if session_token is not self._session_token:
+                    return False
+                elapsed = (float(self._read_clock('offframe')) -
+                           float(started))
+                if math.isnan(elapsed) or math.isinf(elapsed):
+                    elapsed = 0.0
+                self._note(
+                    self._offframe_python, category, elapsed, bool(failed))
+                return True
+            finally:
+                self._state_lock.release()
         except Exception:
             return False
 
@@ -556,6 +869,10 @@ def update_context(context):
 
 def reset():
     return _PROFILER.reset()
+
+
+def work_add(name, value=1):
+    return _PROFILER.work_add(name, value)
 
 
 def native_call(category, api, function, *args, **kwargs):

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/hidden_worker_profiler.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/hidden_worker_profiler.py
@@ -1,0 +1,583 @@
+from __future__ import print_function
+
+"""Low-overhead timings for explicit hidden-worker query call sites.
+
+The pinned client exposes native functions through extension-module objects
+that are neither safe nor consistently mutable.  This module deliberately
+does not monkey-patch those objects.  A reviewed call site passes the original
+callable here, and it is invoked exactly once.
+
+Profiling remains dormant until ``begin_frame(True)``.  Calls made by visible
+clients therefore pay only one boolean branch.  Once a hidden-worker frame has
+completed, explicitly instrumented scheduled callbacks are retained in a
+separate off-frame bucket and attributed to the following render interval.
+"""
+
+import math
+import time
+
+
+_CLOCK = getattr(time, 'perf_counter', None)
+if not callable(_CLOCK):
+    _CLOCK = time.clock
+
+
+NATIVE_CATEGORIES = (
+    'spotting', 'firing_lane', 'cover', 'ground', 'navigation',
+    'motion_receipt', 'motion_direction', 'motion_commit',
+    'water', 'muzzle', 'projectile_world', 'projectile_vehicle', 'ram',
+    'artillery',
+    'destructible_setup', 'destructible_motion',
+    'destructible_projectile', 'destructible_state',
+    'destructible_tree_scan', 'foliage_dynamic', 'presentation', 'other')
+PYTHON_CATEGORIES = (
+    'foliage_spotting', 'foliage_dynamic', 'destructible_scan',
+    'destructible_contact', 'destructible_projectile',
+    'destructible_mutation', 'vehicle_collision_projectile',
+    'vehicle_collision_firing_lane', 'vehicle_collision_presentation',
+    'vehicle_collision_other', 'muzzle_transform', 'other')
+_NATIVE_CATEGORY_LOOKUP = dict((name, True) for name in NATIVE_CATEGORIES)
+_PYTHON_CATEGORY_LOOKUP = dict((name, True) for name in PYTHON_CATEGORIES)
+TRACE_SAMPLES_PER_FRAME = 24
+SLOW_TRACE_MIN_SECONDS = 0.001
+REPRESENTATIVE_SEGMENT_PERIOD = 256
+REPRESENTATIVE_SEGMENTS_PER_CATEGORY_PER_FRAME = 2
+FULL_TIMING_SECONDS = 30.0
+DORMANT_BASELINE_SECONDS = 5.0
+_CATEGORY_PHASE = dict(
+    (name, (index * 13) % REPRESENTATIVE_SEGMENT_PERIOD)
+    for index, name in enumerate(NATIVE_CATEGORIES))
+_MISSING = object()
+
+
+def _empty_profile(measured=False):
+    return {
+        'measured': bool(measured),
+        'native': {},
+        'python': {},
+        'offframe_native': {},
+        'offframe_python': {},
+        'trace': (),
+        'representative_trace': (),
+        'mode': 'off',
+        'clock_reads': 0,
+        'clock_read_estimate_ns': None,
+        'coverage': 'reviewed_hidden_worker_call_sites_only',
+        'filtered_segment_timing': (
+            'native_boundary_including_python_filter'),
+    }
+
+
+def _safe_name(value, allowed):
+    try:
+        name = str(value)
+    except Exception:
+        return 'other'
+    return name if name in allowed else 'other'
+
+
+def _safe_api(api):
+    # All API names are source constants.  Keep a defensive bound so a bad
+    # diagnostic caller cannot create unbounded keys in the 32-bit process.
+    try:
+        api = str(api)
+    except Exception:
+        api = 'native'
+    if not api or len(api) > 48:
+        return 'native'
+    return api
+
+
+class HiddenWorkerProfiler(object):
+    """Collect bounded call counts and wall durations for one process."""
+
+    def __init__(self, clock=None, alternate_modes=None,
+                 full_timing_seconds=FULL_TIMING_SECONDS,
+                 baseline_seconds=DORMANT_BASELINE_SECONDS):
+        self._clock = clock or _CLOCK
+        self._calibrate_clock_reads = clock is None
+        if alternate_modes is None:
+            alternate_modes = clock is None
+        self._alternate_modes = bool(alternate_modes)
+        self._full_timing_seconds = max(
+            0.001, float(full_timing_seconds))
+        self._baseline_seconds = max(0.001, float(baseline_seconds))
+        self.reset()
+
+    def reset(self):
+        self.enabled = False
+        self._session_active = False
+        self._mode = 'off'
+        self._phase_started = None
+        self._frame_open = False
+        self._frame_ordinal = 0
+        self._frame_native = {}
+        self._frame_python = {}
+        self._offframe_native = {}
+        self._offframe_python = {}
+        self._trace = []
+        self._trace_floor_seconds = SLOW_TRACE_MIN_SECONDS
+        self._representative_trace = []
+        self._representative_frame_counts = {}
+        self._segment_seen = {}
+        self._context = {}
+        self._category_stack = []
+        self._frame_clock_reads = 0
+        self._offframe_clock_reads = 0
+        self._clock_read_estimate_ns = None
+
+    @staticmethod
+    def _note(bucket, key, elapsed, failed):
+        row = bucket.get(key)
+        if row is None:
+            row = [0, 0.0, 0]
+            bucket[key] = row
+        row[0] += 1
+        row[1] += max(0.0, float(elapsed))
+        if failed:
+            row[2] += 1
+
+    @staticmethod
+    def _copy_bucket(bucket):
+        return dict((key, (int(value[0]), float(value[1]), int(value[2])))
+                    for key, value in bucket.items())
+
+    def begin_frame(self, active, context=None):
+        """Open one render callback and retain prior off-frame work."""
+        try:
+            return self._begin_frame(active, context)
+        except Exception:
+            try:
+                self.reset()
+            except Exception:
+                pass
+            return False
+
+    def _begin_frame(self, active, context):
+        active = bool(active)
+        if not active:
+            # Visible clients call this on every render callback.  Once no
+            # hidden-worker session is active, keep that path to one branch.
+            if self._session_active or self._frame_open or self.enabled:
+                self.reset()
+            return False
+        # If a callback escaped before end_frame(), preserve its observations
+        # with the interval that is about to be sealed.  Diagnostics must not
+        # retain mutable frame buckets across callbacks.
+        if self._frame_open:
+            for key, value in self._frame_native.items():
+                row = self._offframe_native.setdefault(key, [0, 0.0, 0])
+                row[0] += value[0]
+                row[1] += value[1]
+                row[2] += value[2]
+            for key, value in self._frame_python.items():
+                row = self._offframe_python.setdefault(key, [0, 0.0, 0])
+                row[0] += value[0]
+                row[1] += value[1]
+                row[2] += value[2]
+            self._offframe_clock_reads += self._frame_clock_reads
+        interval_profile = self._detach_interval_profile()
+        self._session_active = True
+        self._frame_ordinal += 1
+        if self._phase_started is None:
+            self._phase_started = self._clock() if self._alternate_modes else 0.0
+            self._mode = 'timing+bounded_trace'
+        elif self._alternate_modes:
+            now = self._clock()
+            duration = (self._full_timing_seconds
+                        if self._mode == 'timing+bounded_trace' else
+                        self._baseline_seconds)
+            if float(now) - float(self._phase_started) >= duration:
+                self._mode = (
+                    'wrapper_only_baseline'
+                    if self._mode == 'timing+bounded_trace' else
+                    'timing+bounded_trace')
+                self._phase_started = now
+        self.enabled = self._mode == 'timing+bounded_trace'
+        if (self._clock_read_estimate_ns is None and
+                self._calibrate_clock_reads and self.enabled):
+            self._calibrate_clock()
+        self._frame_native = {}
+        self._frame_python = {}
+        self._trace = []
+        self._trace_floor_seconds = SLOW_TRACE_MIN_SECONDS
+        self._representative_trace = []
+        self._representative_frame_counts = {}
+        self._frame_clock_reads = 0
+        self._frame_open = True
+        if isinstance(context, dict):
+            self._context = self._safe_context(context)
+        return interval_profile
+
+    def _detach_interval_profile(self):
+        if (not self._offframe_native and not self._offframe_python and
+                not self._trace and not self._representative_trace and
+                not self._offframe_clock_reads):
+            return False
+        profile = {
+            'measured': bool(self.enabled),
+            'offframe_native': self._copy_bucket(self._offframe_native),
+            'offframe_python': self._copy_bucket(self._offframe_python),
+            'trace': tuple(self._trace),
+            'representative_trace': tuple(self._representative_trace),
+            'mode': self._mode,
+            'clock_reads': int(self._offframe_clock_reads),
+            'clock_read_estimate_ns': self._clock_read_estimate_ns,
+            'frame_ordinal': self._frame_ordinal,
+            'coverage': 'reviewed_hidden_worker_call_sites_only',
+            'filtered_segment_timing': (
+                'native_boundary_including_python_filter'),
+        }
+        self._offframe_native = {}
+        self._offframe_python = {}
+        self._trace = []
+        self._trace_floor_seconds = SLOW_TRACE_MIN_SECONDS
+        self._representative_trace = []
+        self._representative_frame_counts = {}
+        self._offframe_clock_reads = 0
+        return profile
+
+    def end_frame(self):
+        """Close the current callback and detach its immutable sample."""
+        try:
+            return self._end_frame()
+        except Exception:
+            self._frame_open = False
+            self._frame_native = {}
+            self._frame_python = {}
+            self._trace = []
+            self._representative_trace = []
+            self._representative_frame_counts = {}
+            self._frame_clock_reads = 0
+            return _empty_profile(False)
+
+    def _end_frame(self):
+        if not self._session_active:
+            return _empty_profile(False)
+        if not self.enabled:
+            profile = _empty_profile(False)
+            profile['mode'] = 'wrapper_only_baseline'
+            profile['frame_ordinal'] = self._frame_ordinal
+            profile['clock_read_estimate_ns'] = self._clock_read_estimate_ns
+            self._frame_open = False
+            self._frame_native = {}
+            self._frame_python = {}
+            self._frame_clock_reads = 0
+            return profile
+        profile = {
+            'measured': True,
+            'native': self._copy_bucket(self._frame_native),
+            'python': self._copy_bucket(self._frame_python),
+            'offframe_native': {},
+            'offframe_python': {},
+            'trace': tuple(sorted(
+                self._trace, key=lambda row: row.get('elapsed_ms', 0.0),
+                reverse=True)),
+            'representative_trace': tuple(self._representative_trace),
+            'mode': self._mode,
+            'clock_reads': int(self._frame_clock_reads),
+            'clock_read_estimate_ns': self._clock_read_estimate_ns,
+            'frame_ordinal': self._frame_ordinal,
+            'coverage': 'reviewed_hidden_worker_call_sites_only',
+            'filtered_segment_timing': (
+                'native_boundary_including_python_filter'),
+        }
+        self._frame_native = {}
+        self._frame_python = {}
+        self._trace = []
+        self._trace_floor_seconds = SLOW_TRACE_MIN_SECONDS
+        self._representative_trace = []
+        self._representative_frame_counts = {}
+        self._frame_clock_reads = 0
+        self._frame_open = False
+        return profile
+
+    def _calibrate_clock(self):
+        """Upper-bound clock reads once, including the Python loop cost."""
+        try:
+            reads = 64
+            started = self._clock()
+            for unused_index in range(reads):
+                self._clock()
+            elapsed = max(0.0, float(self._clock()) - float(started))
+            self._clock_read_estimate_ns = elapsed * 1.0e9 / float(reads + 2)
+        except Exception:
+            self._clock_read_estimate_ns = None
+
+    def _read_clock(self):
+        if self._frame_open:
+            self._frame_clock_reads += 1
+        else:
+            self._offframe_clock_reads += 1
+        return self._clock()
+
+    def update_context(self, context):
+        try:
+            if self.enabled and isinstance(context, dict):
+                self._context.update(self._safe_context(context))
+                return True
+        except Exception:
+            pass
+        return False
+
+    @staticmethod
+    def _safe_context(context):
+        result = {}
+        for name in ('map', 'round', 'destructible_revision',
+                     'foliage_revision'):
+            if name not in context:
+                continue
+            value = context.get(name)
+            if isinstance(value, (bool, int, float)) or value is None:
+                result[name] = value
+            else:
+                try:
+                    result[name] = str(value)[:96]
+                except Exception:
+                    result[name] = '-'
+        return result
+
+    @staticmethod
+    def _vector3(value):
+        try:
+            return (float(value[0]), float(value[1]), float(value[2]))
+        except (IndexError, TypeError, ValueError):
+            try:
+                return (float(value.x), float(value.y), float(value.z))
+            except (AttributeError, TypeError, ValueError):
+                return None
+
+    def _trace_native(self, category, api, args, result, elapsed, failed):
+        """Retain slow calls plus a periodic category-stratified sample."""
+        category_name = category
+        representative = False
+        seen = None
+        if api == 'wg_collideSegment':
+            seen = self._segment_seen.get(category_name, 0) + 1
+            self._segment_seen[category_name] = seen
+            phase = _CATEGORY_PHASE.get(category_name, 0)
+            representative = bool(
+                seen == 1 or seen % REPRESENTATIVE_SEGMENT_PERIOD == phase)
+            if (representative and
+                    self._representative_frame_counts.get(
+                        category_name, 0) >=
+                    REPRESENTATIVE_SEGMENTS_PER_CATEGORY_PER_FRAME):
+                representative = False
+        keep_slow = bool(
+            elapsed >= self._trace_floor_seconds and
+            (len(self._trace) < TRACE_SAMPLES_PER_FRAME or
+             elapsed > self._trace_floor_seconds))
+        if not keep_slow and not representative:
+            return
+        row = dict(self._context)
+        row.update({
+            'category': category_name,
+            'api': api,
+            'elapsed_ms': max(0.0, float(elapsed)) * 1000.0,
+            'failed': bool(failed),
+            'profiler_frame': self._frame_ordinal,
+        })
+        if api == 'wg_collideSegment' and len(args) >= 4:
+            try:
+                row.update({
+                    'space_id': int(args[0]),
+                    'start': self._vector3(args[1]),
+                    'end': self._vector3(args[2]),
+                    'mask': int(args[3]),
+                    # A fifth-argument Python filter closes over dynamic state;
+                    # preserve the sample but do not claim it is standalone.
+                    'filtered': len(args) > 4,
+                    'filter_free': len(args) == 4,
+                    'timing_includes_python_filter': len(args) > 4,
+                    # Even a filter-free ray can hit destructibles or foliage
+                    # whose dynamic event stream is outside this sample.
+                    'replay_candidate': len(args) == 4,
+                    'replayable': False,
+                })
+            except (TypeError, ValueError, OverflowError):
+                row['replayable'] = False
+            if result is _MISSING:
+                row['result'] = {'exception': True}
+            elif result is None:
+                row['result'] = {'hit': False}
+            else:
+                hit = {'hit': True}
+                try:
+                    hit['point'] = self._vector3(result[0])
+                except (IndexError, TypeError):
+                    pass
+                try:
+                    hit['normal'] = self._vector3(result[1])
+                except (IndexError, TypeError):
+                    pass
+                try:
+                    material = result[2]
+                    if isinstance(material, (bool, int, float)):
+                        hit['material'] = material
+                    else:
+                        hit['material'] = str(material)[:96]
+                except (IndexError, TypeError, ValueError):
+                    pass
+                row['result'] = hit
+        else:
+            row['replayable'] = False
+        if keep_slow:
+            self._trace.append(row)
+            self._trace.sort(
+                key=lambda value: value.get('elapsed_ms', 0.0),
+                reverse=True)
+            del self._trace[TRACE_SAMPLES_PER_FRAME:]
+            if len(self._trace) >= TRACE_SAMPLES_PER_FRAME:
+                self._trace_floor_seconds = max(
+                    SLOW_TRACE_MIN_SECONDS,
+                    self._trace[-1].get('elapsed_ms', 0.0) / 1000.0)
+        if representative:
+            representative_row = dict(row)
+            representative_row['sample_ordinal'] = seen
+            representative_row['sampling'] = 'first+periodic/%d' % \
+                REPRESENTATIVE_SEGMENT_PERIOD
+            self._representative_trace.append(representative_row)
+            self._representative_frame_counts[category_name] = (
+                self._representative_frame_counts.get(category_name, 0) + 1)
+
+    def _native_bucket(self):
+        return (self._frame_native if self._frame_open else
+                self._offframe_native)
+
+    def _python_bucket(self):
+        return (self._frame_python if self._frame_open else
+                self._offframe_python)
+
+    def current_category(self, default='other'):
+        if self._category_stack:
+            return self._category_stack[-1]
+        return _safe_name(default, _NATIVE_CATEGORY_LOOKUP)
+
+    def category_call(self, category, function, *args, **kwargs):
+        """Supply semantic context without claiming the wrapper is native."""
+        if not self.enabled:
+            return function(*args, **kwargs)
+        self._category_stack.append(
+            _safe_name(category, _NATIVE_CATEGORY_LOOKUP))
+        try:
+            return function(*args, **kwargs)
+        finally:
+            self._category_stack.pop()
+
+    def native_call(self, category, api, function, *args, **kwargs):
+        """Invoke one original native callable and record it exactly once."""
+        if not self.enabled:
+            return function(*args, **kwargs)
+        try:
+            started = self._read_clock()
+        except Exception:
+            # A diagnostic clock failure cannot suppress the operation being
+            # observed or replace its return/exception semantics.
+            return function(*args, **kwargs)
+        failed = False
+        result = _MISSING
+        try:
+            result = function(*args, **kwargs)
+            return result
+        except Exception:
+            failed = True
+            raise
+        finally:
+            try:
+                elapsed = float(self._read_clock()) - float(started)
+                if math.isnan(elapsed) or math.isinf(elapsed):
+                    elapsed = 0.0
+                category_name = _safe_name(
+                    category, _NATIVE_CATEGORY_LOOKUP)
+                api_name = _safe_api(api)
+                self._note(
+                    self._native_bucket(),
+                    '%s.%s' % (category_name, api_name),
+                    elapsed, failed)
+                self._trace_native(
+                    category_name, api_name, args, result, elapsed, failed)
+            except Exception:
+                # Diagnostics are observational and may never alter the
+                # physical result or turn a local failure into a round failure.
+                pass
+
+    def python_started(self, category):
+        """Return an opaque start marker for a reviewed Python hot section."""
+        if not self.enabled:
+            return None
+        try:
+            return (_safe_name(category, _PYTHON_CATEGORY_LOOKUP),
+                    self._read_clock())
+        except Exception:
+            return None
+
+    def python_finished(self, marker, failed=False):
+        if marker is None or not self.enabled:
+            return False
+        try:
+            category, started = marker
+            elapsed = float(self._read_clock()) - float(started)
+            if math.isnan(elapsed) or math.isinf(elapsed):
+                elapsed = 0.0
+            self._note(
+                self._python_bucket(), category, elapsed, bool(failed))
+            return True
+        except Exception:
+            return False
+
+    def python_call(self, category, function, *args, **kwargs):
+        if not self.enabled:
+            return function(*args, **kwargs)
+        marker = self.python_started(category)
+        failed = False
+        try:
+            return function(*args, **kwargs)
+        except Exception:
+            failed = True
+            raise
+        finally:
+            self.python_finished(marker, failed)
+
+
+_PROFILER = HiddenWorkerProfiler()
+
+
+def begin_frame(active, context=None):
+    return _PROFILER.begin_frame(active, context=context)
+
+
+def end_frame():
+    return _PROFILER.end_frame()
+
+
+def update_context(context):
+    return _PROFILER.update_context(context)
+
+
+def reset():
+    return _PROFILER.reset()
+
+
+def native_call(category, api, function, *args, **kwargs):
+    return _PROFILER.native_call(category, api, function, *args, **kwargs)
+
+
+def current_category(default='other'):
+    return _PROFILER.current_category(default)
+
+
+def category_call(category, function, *args, **kwargs):
+    return _PROFILER.category_call(
+        category, function, *args, **kwargs)
+
+
+def python_started(category):
+    return _PROFILER.python_started(category)
+
+
+def python_finished(marker, failed=False):
+    return _PROFILER.python_finished(marker, failed)
+
+
+def python_call(category, function, *args, **kwargs):
+    return _PROFILER.python_call(category, function, *args, **kwargs)

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/internal_geometry.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/internal_geometry.py
@@ -1,5 +1,7 @@
 import math
 
+from gui.mods.offline_lan_0922 import hidden_worker_profiler
+
 
 GEOMETRY_MODE = 'profile'
 
@@ -87,7 +89,9 @@ def _line_intervals(hit_tester, start, end, axis):
 		except Exception:
 			start_value = start
 			end_value = end
-		collisions = hit_tester.localHitTest(start_value, end_value)
+		collisions = hidden_worker_profiler.native_call(
+			'projectile_vehicle', 'hitTester.localHitTest',
+			hit_tester.localHitTest, start_value, end_value)
 	except Exception:
 		return ()
 	if not collisions:

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
@@ -11,6 +11,7 @@ import uuid
 from gui.mods.offline_lan_0922 import effective_params as effective_params_wire
 from gui.mods.offline_lan_0922 import burst_mechanics
 from gui.mods.offline_lan_0922 import equipment_mechanics
+from gui.mods.offline_lan_0922 import hidden_worker_profiler
 from gui.mods.offline_lan_0922 import siege_mechanics
 from gui.mods.offline_lan_0922 import spotting
 
@@ -180,11 +181,23 @@ class _OutboundPayloadError(Exception):
 class _PreencodedOutbound(object):
     """Immutable wire bytes owned by the reliable outbound queue."""
 
-    __slots__ = ('payload', 'coalesce_key')
+    __slots__ = ('payload', 'coalesce_key', 'profiled_worker_message')
 
-    def __init__(self, payload, coalesce_key=None):
+    def __init__(self, payload, coalesce_key=None,
+                 profiled_worker_message=False):
         self.payload = payload
         self.coalesce_key = coalesce_key
+        self.profiled_worker_message = bool(profiled_worker_message)
+
+
+class _ProfiledWorkerOutbound(dict):
+    """Plain JSON mapping tagged only inside the reliable worker queue."""
+
+
+def _is_profiled_worker_message(message):
+    if isinstance(message, _PreencodedOutbound):
+        return bool(message.profiled_worker_message)
+    return isinstance(message, _ProfiledWorkerOutbound)
 
 
 def _json_text_size(value):
@@ -3319,6 +3332,13 @@ class LANClient(object):
             return item
 
     def _send_wire(self, message, sock, generation):
+        if not _is_profiled_worker_message(message):
+            return self._send_wire_impl(message, sock, generation)
+        return hidden_worker_profiler.python_call(
+            'worker_message_send', self._send_wire_impl,
+            message, sock, generation)
+
+    def _send_wire_impl(self, message, sock, generation):
         """Write one queued message, encoding generic payloads on demand."""
         try:
             if isinstance(message, _PreencodedOutbound):
@@ -3341,6 +3361,9 @@ class LANClient(object):
                 sent = self._send_payload(payload, sock, generation)
                 if sent is not True:
                     return sent
+            if _is_profiled_worker_message(message):
+                hidden_worker_profiler.work_add(
+                    'worker_wire_bytes', len(payload))
             return True
         except Exception as error:
             if self._record_transport_error(error, generation, sock):
@@ -3410,6 +3433,8 @@ class LANClient(object):
     def _enqueue_outbound(self, message, encoded_size, generation):
         """Apply the common generation, FIFO and queue-size boundaries."""
         overflow = False
+        admitted_depth = None
+        profiled_worker_message = _is_profiled_worker_message(message)
         with self._outbound_lock:
             if (generation != self._transport_generation or
                     not self._outbound_accepting or self._stopping or
@@ -3469,11 +3494,17 @@ class LANClient(object):
                     self._outbound_queue.append((
                         self._outbound_seq, message, encoded_size))
                     self._outbound_bytes += encoded_size
+            if not overflow and profiled_worker_message:
+                admitted_depth = len(self._outbound_queue)
         if overflow:
             # Queue pressure is backpressure, not transport corruption.  Keep
             # every already accepted FIFO event and let the caller retry or
             # supersede this checkpoint after the sender drains capacity.
             return False
+        if admitted_depth is not None:
+            hidden_worker_profiler.work_add('worker_messages')
+            hidden_worker_profiler.work_add(
+                'worker_queue_depth', admitted_depth)
         self._outbound_event.set()
         return True
 
@@ -3496,18 +3527,39 @@ class LANClient(object):
                     not self._outbound_accepting):
                 return False
             generation = self._transport_generation
+        profiled_worker_message = (
+            self.player_id == WORKER_AUTHORITY_ID)
+        freeze_marker = (hidden_worker_profiler.python_started(
+            'worker_message_freeze') if profiled_worker_message else None)
+        freeze_failed = False
         try:
             payload = (json.dumps(
                 message, separators=(',', ':'), allow_nan=False) +
                 '\n').encode('utf-8')
         except Exception:
+            freeze_failed = True
             return False
+        finally:
+            hidden_worker_profiler.python_finished(
+                freeze_marker, freeze_failed)
         encoded_size = len(payload)
         if encoded_size > MAX_MESSAGE_BYTES:
             return False
-        return self._enqueue_outbound(
-            _PreencodedOutbound(payload, coalesce_key), encoded_size,
-            generation)
+        frozen = _PreencodedOutbound(
+            payload, coalesce_key,
+            profiled_worker_message=profiled_worker_message)
+        enqueue_marker = (hidden_worker_profiler.python_started(
+            'worker_message_enqueue') if profiled_worker_message else None)
+        enqueue_failed = False
+        try:
+            return self._enqueue_outbound(
+                frozen, encoded_size, generation)
+        except Exception:
+            enqueue_failed = True
+            raise
+        finally:
+            hidden_worker_profiler.python_finished(
+                enqueue_marker, enqueue_failed)
 
     def _send(self, message):
         """Freeze and enqueue one reliable message without wire I/O."""
@@ -3517,14 +3569,36 @@ class LANClient(object):
                     not self._outbound_accepting):
                 return False
             generation = self._transport_generation
+        profiled_worker_message = (
+            self.player_id == WORKER_AUTHORITY_ID)
+        freeze_marker = (hidden_worker_profiler.python_started(
+            'worker_message_freeze') if profiled_worker_message else None)
+        freeze_failed = False
         try:
             frozen, estimated_size = _freeze_outbound(message, [0])
         except Exception:
+            freeze_failed = True
             return False
+        finally:
+            hidden_worker_profiler.python_finished(
+                freeze_marker, freeze_failed)
         estimated_size += 1
         if estimated_size > MAX_MESSAGE_BYTES:
             return False
-        return self._enqueue_outbound(frozen, estimated_size, generation)
+        if profiled_worker_message:
+            frozen = _ProfiledWorkerOutbound(frozen)
+        enqueue_marker = (hidden_worker_profiler.python_started(
+            'worker_message_enqueue') if profiled_worker_message else None)
+        enqueue_failed = False
+        try:
+            return self._enqueue_outbound(
+                frozen, estimated_size, generation)
+        except Exception:
+            enqueue_failed = True
+            raise
+        finally:
+            hidden_worker_profiler.python_finished(
+                enqueue_marker, enqueue_failed)
 
     def _schedule_poll(self):
         if self._poll_callback is not None:

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/world_collision.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/world_collision.py
@@ -5,6 +5,7 @@ from gui.mods.offline_lan_0922.destructibles_sensor import (
 	_catalog_soft_static_path, _diagnostic_static_recast_1513,
 	_try_destroy_solid_hit, _vehicle_hull_bbox,
 	horizontal_collision_filter)
+from gui.mods.offline_lan_0922 import hidden_worker_profiler
 
 
 _MAX_DRIVABLE_GRADIENT = 1.28
@@ -18,8 +19,11 @@ def _collide_horizontal(spaceID, start, end):
 	import BigWorld
 	broken_filter = horizontal_collision_filter(start, end)
 	if broken_filter is None:
-		return BigWorld.wg_collideSegment(spaceID, start, end, 128)
-	return BigWorld.wg_collideSegment(
+		return hidden_worker_profiler.native_call(
+			'motion_commit', 'wg_collideSegment', BigWorld.wg_collideSegment,
+			spaceID, start, end, 128)
+	return hidden_worker_profiler.native_call(
+		'motion_commit', 'wg_collideSegment', BigWorld.wg_collideSegment,
 		spaceID, start, end, 128, broken_filter)
 
 
@@ -84,7 +88,8 @@ def _ground_profile(spaceID, Math, pos, sx, sz, sin_y, cos_y, direction,
 		distance = segment * sample_index
 		x = sx + sin_y * distance * direction
 		z = sz + cos_y * distance * direction
-		ground = BigWorld.wg_collideSegment(
+		ground = hidden_worker_profiler.native_call(
+			'motion_commit', 'wg_collideSegment', BigWorld.wg_collideSegment,
 			spaceID, Math.Vector3(x, pos.y + 12.0, z),
 			Math.Vector3(x, pos.y - probe_down, z), 128)
 		if ground is None:

--- a/0.9.22/tests/test_port_0922_battle_runtime.py
+++ b/0.9.22/tests/test_port_0922_battle_runtime.py
@@ -2739,6 +2739,33 @@ class RemoteVehicleFactoryTests(unittest.TestCase):
         self.assertEqual(-20.0, local_start.z)
         self.assertEqual(80.0, local_end.z)
 
+    def test_pose_collider_inherits_semantic_profiler_category(self):
+        descriptor = _Descriptor()
+        descriptor.hull.hitTester = types.SimpleNamespace(
+            localHitTest=mock.Mock(return_value=[]))
+        vehicle = _Vehicle(
+            11, descriptor, _Vector(), (0.0, 0.0, 0.0),
+            {'health': 500})
+        categories = []
+
+        def invoke(category, unused_api, function, *args, **kwargs):
+            categories.append(category)
+            return function(*args, **kwargs)
+
+        with mock.patch.object(
+                remote_vehicle_module.hidden_worker_profiler,
+                'current_category', return_value='firing_lane') as current:
+            with mock.patch.object(
+                    remote_vehicle_module.hidden_worker_profiler,
+                    'native_call', side_effect=invoke):
+                collide_vehicle_at_matrix(
+                    vehicle, _Matrix(), _Vector(), _Vector(0.0, 0.0, 1.0),
+                    types.SimpleNamespace(Vector3=_Vector, Matrix=_Matrix))
+
+        current.assert_called_once_with('projectile_vehicle')
+        self.assertTrue(categories)
+        self.assertEqual({'firing_lane'}, set(categories))
+
     def test_pose_collider_keeps_hydraulic_chassis_on_ground_matrix(self):
         descriptor = _Descriptor()
         chassis_tester = types.SimpleNamespace(
@@ -4880,7 +4907,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertIn('probe_ms=', first_row)
         self.assertIn('lane:5.000', first_row)
         self.assertIn('active:29,chords:58,debt_ms:50.000', first_row)
-        self.assertIn('summary v=3', payloads[0])
+        self.assertIn('summary v=4', payloads[0])
         self.assertIn('role=authority probe_timing=active', payloads[0])
         self.assertIn('gap_ms_p50_p95_p99_max=', payloads[0])
         self.assertIn('python_ms_p50_p95_p99_max=', payloads[0])
@@ -4918,6 +4945,133 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertTrue(diagnostics._pending['emitted'])
         self.assertAlmostEqual(
             0.003, diagnostics._pending['stages']['diag_emit'])
+
+    def test_frame_diagnostics_use_timing_denominator_and_total_raw_max(self):
+        diagnostics = _FrameDiagnostics(
+            clock=lambda: 0.0, writer=lambda unused: None)
+
+        def row(gap, detailed, cause):
+            return {
+                'cause': cause, 'next': cause + 1,
+                'wall_gap': gap, 'raw_dt': gap, 'exec': 0.01,
+                'outside': max(0.0, gap - 0.01), 'offframe': 0.0,
+                'bw_minus_wall': 0.0, 'tick_dt': gap,
+                'motion_dt': gap, 'stages': {}, 'probes': {},
+                'probe_durations': {}, 'projectile': {},
+                'detailed_profile': detailed,
+                'context': {'role': 'authority'}, 'emitted': False,
+            }
+
+        trace = {
+            'category': 'spotting', 'api': 'wg_collideSegment',
+            'elapsed_ms': 2.0, 'profiler_frame': 1,
+            'start': (0.0, 0.0, 0.0), 'end': (1.0, 0.0, 0.0),
+            'result': {'hit': False}, 'sample_ordinal': 1,
+        }
+        diagnostics._add(row(2.0, {
+            'measured': True, 'mode': 'timing+bounded_trace',
+            'frame_ordinal': 1, 'clock_reads': 10,
+            'native': {
+                'spotting.wg_collideSegment': (2, 0.010, 0),
+                'ground.wg_collideSegment': (3, 0.020, 1),
+            },
+            'offframe_native': {}, 'python': {},
+            'offframe_python': {}, 'trace': (trace,),
+            'representative_trace': (trace,),
+        }, 1))
+        diagnostics._add(row(8.0, {
+            'measured': False, 'mode': 'wrapper_only_baseline',
+            'frame_ordinal': 2, 'clock_reads': 0,
+        }, 2))
+
+        payload = diagnostics._format()
+        snapshot = diagnostics.snapshot()
+
+        self.assertIn('segment_samples category=spotting', payload)
+        self.assertEqual(1, snapshot['native_timing_frames'])
+        self.assertAlmostEqual(2.0, snapshot['native_timing_seconds'])
+        self.assertAlmostEqual(
+            1.0, snapshot['native_queries'][
+                'spotting.wg_collideSegment']['calls_per_second'])
+        totals = snapshot['native_frame_totals']
+        self.assertEqual(5, totals['calls'])
+        self.assertAlmostEqual(2.5, totals['calls_per_second'])
+        self.assertEqual(5, totals['calls_per_timed_frame_max'])
+        self.assertAlmostEqual(30.0, totals['timed_ms_per_timed_frame_max'])
+        self.assertIn('timing+bounded_trace',
+                      snapshot['profiler']['ab_frames'])
+        self.assertIn('wrapper_only_baseline',
+                      snapshot['profiler']['ab_frames'])
+
+        compact = diagnostics.compact_snapshot()
+        self.assertNotIn('native_trace', compact)
+        self.assertNotIn('representative_segment_trace', compact)
+        self.assertEqual(1, compact['native_trace_omitted_from_status'])
+        self.assertEqual(
+            {'spotting': 1},
+            compact['representative_trace_omitted_from_status'])
+
+    def test_frame_diagnostics_attach_offframe_detail_to_sealed_gap(self):
+        diagnostics = _FrameDiagnostics(
+            clock=lambda: 0.0, writer=lambda unused: None)
+        first = diagnostics.begin(0.0, 0.0)
+        diagnostics.finish(
+            first, 0.0, 0.0, 0.0, {}, {}, {}, detailed_profile={
+                'measured': True, 'mode': 'timing+bounded_trace',
+                'frame_ordinal': 1, 'native': {}, 'python': {},
+                'offframe_native': {}, 'offframe_python': {},
+            })
+        interval = {
+            'measured': True, 'mode': 'timing+bounded_trace',
+            'frame_ordinal': 1, 'clock_reads': 2,
+            'offframe_native': {
+                'destructible_state.wg_getDestructibleMatrix': (
+                    1, 0.004, 0)},
+            'offframe_python': {}, 'trace': (),
+            'representative_trace': (),
+        }
+
+        diagnostics.begin(
+            0.1, 0.1, detailed_offframe=interval)
+
+        key = 'destructible_state.wg_getDestructibleMatrix'
+        self.assertEqual(1, diagnostics._offframe_native_query_sums[key][0])
+        self.assertEqual(
+            1, diagnostics._slow[0]['detailed_profile'][
+                'offframe_native'][key][0])
+
+    def test_frame_diagnostics_emit_window_with_segment_sample(self):
+        wall = [0.0]
+        payloads = []
+        diagnostics = _FrameDiagnostics(
+            clock=lambda: wall[0], writer=payloads.append,
+            window_seconds=0.25)
+        trace = {
+            'category': 'spotting', 'api': 'wg_collideSegment',
+            'elapsed_ms': 1.5, 'profiler_frame': 1,
+            'sample_ordinal': 1, 'start': (0.0, 0.0, 0.0),
+            'end': (1.0, 0.0, 0.0), 'result': {'hit': False},
+        }
+        first = diagnostics.begin(0.0, 0.0)
+        diagnostics.finish(
+            first, 0.0, 0.0, 0.0, {}, {}, {}, detailed_profile={
+                'measured': True, 'mode': 'timing+bounded_trace',
+                'frame_ordinal': 1, 'native': {
+                    'spotting.wg_collideSegment': (1, 0.0015, 0)},
+                'python': {}, 'offframe_native': {},
+                'offframe_python': {}, 'trace': (trace,),
+                'representative_trace': (trace,),
+            })
+        diagnostics.begin(0.30, 0.30)
+        wall[0] = 0.31
+
+        diagnostics.finish(2, 0.30, 0.0, 0.0, {}, {}, {})
+
+        self.assertTrue(diagnostics.enabled)
+        self.assertEqual(1, len(payloads))
+        self.assertIn('summary v=4', payloads[0])
+        self.assertIn(
+            'segment_samples category=spotting', payloads[0])
 
     def test_frame_diagnostics_disable_themselves_when_logging_fails(self):
         wall = [0.0]

--- a/0.9.22/tests/test_port_0922_battle_runtime.py
+++ b/0.9.22/tests/test_port_0922_battle_runtime.py
@@ -4860,7 +4860,11 @@ class BattleRuntimeContractTests(unittest.TestCase):
         second = diagnostics.begin(0.12, 0.12)
         wall[0] = 0.125
         diagnostics.finish(
-            second, 0.12, 0.10, 0.10, {'bots_update': 0.002},
+            second, 0.12, 0.10, 0.10, {
+                'bot_prework': 0.0005,
+                'bot_runtime_update': 0.001,
+                'bot_postdiag': 0.0005,
+            },
             {'visibility': 3}, {
                 'role': 'authority', 'probe_timing': 'active'})
         third = diagnostics.begin(0.30, 0.18)
@@ -4907,7 +4911,10 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertIn('probe_ms=', first_row)
         self.assertIn('lane:5.000', first_row)
         self.assertIn('active:29,chords:58,debt_ms:50.000', first_row)
-        self.assertIn('summary v=4', payloads[0])
+        self.assertIn('summary v=5', payloads[0])
+        self.assertIn(
+            'bots_update=1.000/2.000('
+            'bot_prework+bot_runtime_update+bot_postdiag)', payloads[0])
         self.assertIn('role=authority probe_timing=active', payloads[0])
         self.assertIn('gap_ms_p50_p95_p99_max=', payloads[0])
         self.assertIn('python_ms_p50_p95_p99_max=', payloads[0])
@@ -5019,7 +5026,10 @@ class BattleRuntimeContractTests(unittest.TestCase):
             first, 0.0, 0.0, 0.0, {}, {}, {}, detailed_profile={
                 'measured': True, 'mode': 'timing+bounded_trace',
                 'frame_ordinal': 1, 'native': {}, 'python': {},
+                'work': {'bot_messages': 1, 'bot_rows': 29,
+                         'worker_queue_depth': 3},
                 'offframe_native': {}, 'offframe_python': {},
+                'offframe_work': {}, 'work_counters_recorded': True,
             })
         interval = {
             'measured': True, 'mode': 'timing+bounded_trace',
@@ -5027,7 +5037,11 @@ class BattleRuntimeContractTests(unittest.TestCase):
             'offframe_native': {
                 'destructible_state.wg_getDestructibleMatrix': (
                     1, 0.004, 0)},
-            'offframe_python': {}, 'trace': (),
+            'offframe_python': {},
+            'offframe_work': {
+                'bot_messages': 2, 'bot_rows': 58,
+                'worker_queue_depth': 7},
+            'work_counters_recorded': True, 'trace': (),
             'representative_trace': (),
         }
 
@@ -5039,6 +5053,87 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertEqual(
             1, diagnostics._slow[0]['detailed_profile'][
                 'offframe_native'][key][0])
+        self.assertEqual(3, diagnostics._work_sums['bot_messages'])
+        self.assertEqual(87, diagnostics._work_sums['bot_rows'])
+        self.assertEqual(7, diagnostics._work_sums['worker_queue_depth'])
+        self.assertEqual(
+            7, diagnostics._slow[0]['detailed_profile'][
+                'offframe_work']['worker_queue_depth'])
+
+    def test_frame_diagnostics_report_callback_and_bot_residuals(self):
+        diagnostics = _FrameDiagnostics(
+            clock=lambda: 0.0, writer=lambda unused: None)
+        main = {
+            'bot_setup': (1, 0.002, 0),
+            'bot_control_observation': (1, 0.006, 0),
+            'bot_selected_motion': (1, 0.004, 0),
+            'bot_motion_commit_integration': (1, 0.005, 0),
+            'bot_aim_fire': (1, 0.003, 0),
+            'bot_supplemental': (1, 0.001, 0),
+            'bot_tank_contacts': (1, 0.001, 0),
+            'bot_vertical_ground': (1, 0.002, 0),
+            'bot_publication': (1, 0.001, 0),
+        }
+        detailed_python = dict(main)
+        detailed_python['bot_runtime_update'] = (1, 0.034, 0)
+        detailed_python['bot_scheduler_control_refresh'] = (1, 0.020, 0)
+        detailed_python['bot_scheduler_catchup'] = (1, 0.010, 0)
+        # This overlaps the exclusive phases and must not enter the residual.
+        detailed_python['bot_astar_inclusive'] = (1, 0.020, 0)
+        diagnostics._add({
+            'cause': 1, 'next': 2,
+            'wall_gap': 0.1, 'raw_dt': 0.1, 'exec': 0.050,
+            'outside': 0.05, 'offframe': 0.0,
+            'bw_minus_wall': 0.0, 'tick_dt': 0.1, 'motion_dt': 0.1,
+            'stages': {
+                'bot_prework': 0.003, 'bot_runtime_update': 0.034,
+                'bot_postdiag': 0.002,
+            },
+            'probes': {}, 'probe_durations': {}, 'projectile': {},
+            'detailed_profile': {
+                'measured': True, 'python': detailed_python,
+                'offframe_python': {}, 'native': {},
+                'offframe_native': {}, 'work': {
+                    'worker_messages': 2, 'worker_wire_bytes': 4096,
+                    'worker_queue_depth': 5,
+                }, 'offframe_work': {'worker_queue_depth': 9},
+                'work_counters_recorded': True,
+                'python_category_scopes': {
+                    'bot_runtime_update': 'frame_exclusive',
+                    'bot_setup': 'bot_step_exclusive',
+                },
+                'python_scope_sum_rule': 'sum exclusive groups only',
+            },
+            'context': {'role': 'worker'}, 'emitted': False,
+        })
+
+        payload = diagnostics._format()
+        snapshot = diagnostics.snapshot()
+
+        self.assertAlmostEqual(
+            11.0, snapshot['callback_residual_ms']['avg'])
+        attribution = snapshot['bot_timing_attribution']
+        self.assertAlmostEqual(34.0, attribution['battle_outer_avg_ms'])
+        self.assertAlmostEqual(25.0, attribution['main_exclusive_avg_ms'])
+        self.assertAlmostEqual(
+            9.0, attribution['battle_outer_residual_avg_ms'])
+        self.assertAlmostEqual(
+            5.0, attribution['scheduler_residual_avg_ms'])
+        self.assertAlmostEqual(
+            39.0, snapshot['python_stages_ms']['bots_update']['avg_ms'])
+        self.assertEqual(
+            4096, snapshot['work']['worker_wire_bytes']['total'])
+        queue = snapshot['work']['worker_queue_depth']
+        self.assertEqual('sampled_max', queue['aggregation'])
+        self.assertEqual(9, queue['max'])
+        self.assertNotIn('total', queue)
+        self.assertIn(
+            'bot_battle_outer_residual_avg_max=9.000/9.000', payload)
+        self.assertIn(
+            'bot_scheduler_residual_avg_max=5.000/5.000', payload)
+        self.assertIn(
+            'work_sampled_max_window_frame_offframe '
+            'worker_queue_depth=9/5/9', payload)
 
     def test_frame_diagnostics_emit_window_with_segment_sample(self):
         wall = [0.0]
@@ -5069,7 +5164,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
 
         self.assertTrue(diagnostics.enabled)
         self.assertEqual(1, len(payloads))
-        self.assertIn('summary v=4', payloads[0])
+        self.assertIn('summary v=5', payloads[0])
         self.assertIn(
             'segment_samples category=spotting', payloads[0])
 

--- a/0.9.22/tests/test_port_0922_bot_runtime.py
+++ b/0.9.22/tests/test_port_0922_bot_runtime.py
@@ -14550,6 +14550,115 @@ class BotRuntimeTests(unittest.TestCase):
         # Reading the report clears the window's counters.
         self.assertEqual((), runtime.load_report()['busiest'])
 
+    def test_profiler_partitions_one_bot_step_and_counts_its_work(self):
+        profiler = self.module.hidden_worker_profiler
+        runtime = self.runtime
+        runtime.battle_start(self.start)
+        profiler.reset()
+        try:
+            profiler.begin_frame(True)
+            outgoing = runtime.update(.04, 1.0)
+            profile = profiler.end_frame()
+        finally:
+            profiler.reset()
+
+        self.assertTrue(profile['measured'])
+        self.assertTrue(outgoing)
+        main_categories = (
+            'bot_setup', 'bot_control_observation',
+            'bot_selected_motion', 'bot_motion_commit_integration',
+            'bot_aim_fire', 'bot_supplemental', 'bot_tank_contacts',
+            'bot_vertical_ground', 'bot_publication')
+        for category in main_categories:
+            self.assertIn(category, profile['python'])
+            self.assertGreaterEqual(profile['python'][category][0], 1)
+            self.assertEqual(0, profile['python'][category][2])
+        scheduler_seconds = profile['python'][
+            'bot_scheduler_control_refresh'][1]
+        main_seconds = sum(
+            profile['python'][category][1]
+            for category in main_categories)
+        self.assertGreaterEqual(scheduler_seconds + 1.0e-9, main_seconds)
+        for category in (
+                'bot_visibility_prepare_inclusive',
+                'bot_contacts_inclusive',
+                'bot_planner_navigation_inclusive'):
+            self.assertIn(category, profile['python'])
+        self.assertEqual(1, profile['work']['bot_control_refresh_slices'])
+        self.assertEqual(1, profile['work']['bot_live_rows'])
+        self.assertEqual(1, profile['work']['bot_integrated_rows'])
+        self.assertEqual(1, profile['work']['bot_decision_due'])
+        self.assertEqual(1, profile['work']['bot_projected_rows'])
+        self.assertEqual(1, profile['work']['bot_publications'])
+        self.assertGreaterEqual(profile['work']['bot_ground_probes'], 1)
+        self.assertGreaterEqual(
+            profile['work']['bot_motion_direction_probes'], 1)
+
+    def test_profiler_separates_refresh_and_catchup_slices(self):
+        command = self._stationary_command()
+        runtime = self.module.BotRuntime(
+            1, descriptor_resolver=lambda unused: _combat_descriptor(),
+            adapter_factory=lambda *unused, **unused_kwargs:
+                _FixedAdapter(command),
+            direction_probe=lambda *unused: {
+                'clear': True, 'collision': False, 'slope': 0.0},
+            ground_probe=lambda *unused: 0.0,
+            physics_ground_probe=lambda *unused: 0.0,
+            spawn_resolver=_spawn_resolver, baked_graph=_graph(),
+            control_seconds=self.module.WORKER_CONTROL_SECONDS)
+        runtime.battle_start(self.start)
+        profiler = self.module.hidden_worker_profiler
+        profiler.reset()
+        try:
+            profiler.begin_frame(True)
+            runtime.update(.45, 1.0)
+            profile = profiler.end_frame()
+        finally:
+            profiler.reset()
+
+        self.assertEqual(1, profile['work']['bot_control_refresh_slices'])
+        self.assertEqual(2, profile['work']['bot_catchup_slices'])
+        self.assertEqual(
+            1, profile['python']['bot_scheduler_control_refresh'][0])
+        self.assertEqual(2, profile['python']['bot_scheduler_catchup'][0])
+        self.assertEqual(3, profile['python']['bot_setup'][0])
+
+    def test_profiler_wraps_driver_and_astar_boundaries(self):
+        class PendingSearch(object):
+            def __init__(self):
+                self.done = False
+                self.last_frame = None
+                self.calls = 0
+
+            def step(self, budget):
+                self.calls += int(budget)
+                return False
+
+        profiler = self.module.hidden_worker_profiler
+        driver = self.module.ai_driver.LocalDriver()
+        navigator = self.module.TerrainNavigator(
+            lambda unused_x, unused_z, unused_y: 0.0)
+        pending = PendingSearch()
+        navigator.searches = {('pending',): pending}
+        navigator.begin_frame(.1)
+        navigator.search_credit = 3.0
+        navigator.search_frame_budget = 3
+        profiler.reset()
+        try:
+            profiler.begin_frame(True)
+            driver.drive(
+                11, (0.0, 0.0, 0.0), 0.0, 0.0, .1,
+                (0.0, 0.0, 20.0), (), lambda unused_yaw: True)
+            navigator._advance_searches(1.0)
+            profile = profiler.end_frame()
+        finally:
+            profiler.reset()
+
+        self.assertEqual(1, profile['python']['bot_driver_inclusive'][0])
+        self.assertEqual(1, profile['python']['bot_astar_inclusive'][0])
+        self.assertEqual(3, pending.calls)
+        self.assertEqual(3, profile['work']['bot_astar_expansions'])
+
 
 class BotOwnStationaryVisionTests(unittest.TestCase):
     """A bot's own stereoscope was evaluated once at registration with zero

--- a/0.9.22/tests/test_port_0922_hidden_worker_profiler.py
+++ b/0.9.22/tests/test_port_0922_hidden_worker_profiler.py
@@ -1,5 +1,6 @@
 import pathlib
 import sys
+import threading
 import unittest
 
 
@@ -7,11 +8,28 @@ ROOT = pathlib.Path(__file__).resolve().parents[2]
 CLIENT_ROOT = ROOT / '0.9.22' / 'src' / 'res' / 'scripts' / 'client'
 sys.path.insert(0, str(CLIENT_ROOT))
 
-from gui.mods.offline_lan_0922.hidden_worker_profiler import \
-    HiddenWorkerProfiler
+from gui.mods.offline_lan_0922.hidden_worker_profiler import (
+    BOT_UPDATE_RESIDUAL_SEMANTICS,
+    MAX_WORK_COUNTER_VALUE,
+    PYTHON_CATEGORY_SCOPES,
+    HiddenWorkerProfiler,
+)
+from gui.mods.offline_lan_0922 import hidden_worker_profiler
 
 
 class HiddenWorkerProfilerTests(unittest.TestCase):
+    @staticmethod
+    def _incrementing_clock():
+        state = {'value': 0.0}
+        lock = threading.Lock()
+
+        def clock():
+            with lock:
+                state['value'] += 0.001
+                return state['value']
+
+        return clock
+
     def test_inactive_profiler_invokes_original_once_without_reading_clock(self):
         clock_calls = []
         calls = []
@@ -220,6 +238,189 @@ class HiddenWorkerProfilerTests(unittest.TestCase):
         now[0] = 1.7
         profiler.begin_frame(True)
         self.assertEqual('timing+bounded_trace', profiler.end_frame()['mode'])
+
+    def test_phase_categories_publish_non_additive_scope_metadata(self):
+        clock = iter((1.0, 1.002, 2.0, 2.003, 3.0, 3.004,
+                      4.0, 4.005, 5.0, 5.006))
+        profiler = HiddenWorkerProfiler(clock=lambda: next(clock))
+        profiler.begin_frame(True)
+
+        for category in (
+                'bot_setup', 'bot_astar_inclusive',
+                'bot_scheduler_catchup', 'projectile_step',
+                'worker_message_send'):
+            profiler.python_call(category, lambda: None)
+        profile = profiler.end_frame()
+
+        self.assertNotIn('other', profile['python'])
+        self.assertEqual(
+            'bot_step_exclusive',
+            profile['python_category_scopes']['bot_setup'])
+        self.assertEqual(
+            'nested_inclusive',
+            profile['python_category_scopes']['bot_astar_inclusive'])
+        self.assertEqual(
+            'scheduler_inclusive',
+            profile['python_category_scopes']['bot_scheduler_catchup'])
+        self.assertEqual(
+            'projectile_outer_inclusive',
+            profile['python_category_scopes']['projectile_step'])
+        self.assertEqual(
+            'message_nested_inclusive',
+            profile['python_category_scopes']['worker_message_send'])
+        self.assertEqual(
+            BOT_UPDATE_RESIDUAL_SEMANTICS,
+            profile['bot_update_residual_semantics'])
+        self.assertIn('all_other_scopes_are_inclusive',
+                      profile['python_scope_sum_rule'])
+        self.assertEqual(PYTHON_CATEGORY_SCOPES,
+                         profile['python_category_scopes'])
+
+    def test_work_counters_are_bounded_validated_and_clock_free(self):
+        clock_calls = []
+        profiler = HiddenWorkerProfiler(
+            clock=lambda: clock_calls.append(True) or 0.0)
+        profiler.begin_frame(True)
+
+        self.assertTrue(profiler.work_add('bot_live_rows', 2))
+        self.assertTrue(profiler.work_add('bot_live_rows', 0.5))
+        self.assertTrue(profiler.work_add(
+            'bot_motion_commit_sweeps', MAX_WORK_COUNTER_VALUE))
+        self.assertTrue(profiler.work_add('bot_motion_commit_sweeps', 1))
+        self.assertTrue(profiler.work_add('worker_queue_depth', 4))
+        self.assertTrue(profiler.work_add('worker_queue_depth', 2))
+        self.assertTrue(profiler.work_add('worker_queue_depth', 7))
+        self.assertFalse(profiler.work_add('unbounded-key', 1))
+        self.assertFalse(profiler.work_add('bot_rows', True))
+        self.assertFalse(profiler.work_add('bot_rows', -1))
+        self.assertFalse(profiler.work_add('bot_rows', float('nan')))
+        self.assertFalse(profiler.work_add('bot_rows', float('inf')))
+        self.assertFalse(profiler.work_add('bot_rows', '3'))
+        profile = profiler.end_frame()
+
+        self.assertEqual([], clock_calls)
+        self.assertEqual(2.5, profile['work']['bot_live_rows'])
+        self.assertEqual(
+            MAX_WORK_COUNTER_VALUE,
+            profile['work']['bot_motion_commit_sweeps'])
+        self.assertEqual(7, profile['work']['worker_queue_depth'])
+        self.assertNotIn('unbounded-key', profile['work'])
+        self.assertNotIn('bot_rows', profile['work'])
+        self.assertTrue(profile['work_counters_recorded'])
+        self.assertEqual(
+            'sampled_max',
+            profile['work_counter_aggregations']['worker_queue_depth'])
+        self.assertIn(
+            'not_native_ray_count',
+            profile['work_counter_notes']['bot_motion_commit_sweeps'])
+        self.assertTrue(callable(hidden_worker_profiler.work_add))
+
+    def test_wrapper_only_baseline_keeps_work_without_timing(self):
+        now = [0.0]
+        profiler = HiddenWorkerProfiler(
+            clock=lambda: now[0], alternate_modes=True,
+            full_timing_seconds=1.0, baseline_seconds=5.0)
+        profiler.begin_frame(True)
+        profiler.end_frame()
+        now[0] = 1.1
+        profiler.begin_frame(True)
+
+        self.assertTrue(profiler.work_add('projectile_segments', 11))
+        marker = profiler.python_started('projectile_step')
+        profile = profiler.end_frame()
+
+        self.assertIsNone(marker)
+        self.assertFalse(profile['measured'])
+        self.assertEqual('wrapper_only_baseline', profile['mode'])
+        self.assertEqual(11, profile['work']['projectile_segments'])
+        self.assertEqual({}, profile['python'])
+        self.assertEqual(0, profile['clock_reads'])
+        self.assertTrue(profile['work_counters_recorded'])
+
+    def test_inactive_and_visible_sessions_reject_work(self):
+        clock_calls = []
+        profiler = HiddenWorkerProfiler(
+            clock=lambda: clock_calls.append(True) or 0.0)
+
+        self.assertFalse(profiler.work_add('bot_rows'))
+        self.assertFalse(profiler.begin_frame(False))
+        self.assertFalse(profiler.work_add('bot_rows'))
+        self.assertEqual([], clock_calls)
+        self.assertFalse(profiler.end_frame()['work_counters_recorded'])
+
+    def test_render_thread_offframe_work_is_detached_next_interval(self):
+        profiler = HiddenWorkerProfiler(clock=lambda: 0.0)
+        profiler.begin_frame(True)
+        profiler.end_frame()
+
+        self.assertTrue(profiler.work_add('worker_wire_bytes', 128))
+        interval = profiler.begin_frame(True)
+
+        self.assertEqual(128, interval['offframe_work']['worker_wire_bytes'])
+        self.assertEqual({}, interval['work'])
+        self.assertEqual(
+            'active_hidden_worker_session_all_modes',
+            interval['work_counter_scope'])
+
+    def test_background_python_marker_is_never_charged_to_render_frame(self):
+        profiler = HiddenWorkerProfiler(clock=self._incrementing_clock())
+        profiler.begin_frame(True)
+        completed = []
+
+        def run_background_send():
+            marker = profiler.python_started('worker_message_send')
+            profiler.work_add('worker_wire_bytes', 64)
+            completed.append(profiler.python_finished(marker))
+
+        thread = threading.Thread(target=run_background_send)
+        thread.start()
+        thread.join()
+        frame = profiler.end_frame()
+        interval = profiler.begin_frame(True)
+
+        self.assertEqual([True], completed)
+        self.assertEqual({}, frame['python'])
+        self.assertEqual({}, frame['work'])
+        self.assertEqual(
+            1, interval['offframe_python']['worker_message_send'][0])
+        self.assertEqual(64, interval['offframe_work']['worker_wire_bytes'])
+        self.assertTrue(interval['offframe_python_measured'])
+        self.assertEqual(
+            'begin_frame_thread_is_render;other_threads_are_offframe',
+            interval['python_thread_attribution'])
+
+    def test_background_marker_crossing_interval_swap_is_not_lost(self):
+        profiler = HiddenWorkerProfiler(clock=self._incrementing_clock())
+        profiler.begin_frame(True)
+        marker_started = threading.Event()
+        allow_finish = threading.Event()
+        completed = []
+
+        def run_background_send():
+            marker = profiler.python_started('worker_message_send')
+            marker_started.set()
+            allow_finish.wait(2.0)
+            completed.append(profiler.python_finished(marker))
+
+        thread = threading.Thread(target=run_background_send)
+        thread.start()
+        self.assertTrue(marker_started.wait(2.0))
+        profiler.end_frame()
+        first_interval = profiler.begin_frame(True)
+        allow_finish.set()
+        thread.join(2.0)
+        self.assertFalse(thread.is_alive())
+        profiler.end_frame()
+        second_interval = profiler.begin_frame(True)
+
+        self.assertEqual([True], completed)
+        self.assertNotIn(
+            'worker_message_send', first_interval.get('offframe_python', {}))
+        self.assertEqual(
+            1, second_interval['offframe_python']['worker_message_send'][0])
+        self.assertEqual(
+            'timing_at_marker_start;reported_in_completion_interval',
+            second_interval['offframe_python_timing_semantics'])
 
 
 if __name__ == '__main__':

--- a/0.9.22/tests/test_port_0922_hidden_worker_profiler.py
+++ b/0.9.22/tests/test_port_0922_hidden_worker_profiler.py
@@ -1,0 +1,226 @@
+import pathlib
+import sys
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+CLIENT_ROOT = ROOT / '0.9.22' / 'src' / 'res' / 'scripts' / 'client'
+sys.path.insert(0, str(CLIENT_ROOT))
+
+from gui.mods.offline_lan_0922.hidden_worker_profiler import \
+    HiddenWorkerProfiler
+
+
+class HiddenWorkerProfilerTests(unittest.TestCase):
+    def test_inactive_profiler_invokes_original_once_without_reading_clock(self):
+        clock_calls = []
+        calls = []
+        profiler = HiddenWorkerProfiler(
+            clock=lambda: clock_calls.append(True))
+
+        value = profiler.native_call(
+            'spotting', 'wg_collideSegment',
+            lambda argument: calls.append(argument) or 7, 3)
+
+        self.assertEqual(7, value)
+        self.assertEqual([3], calls)
+        self.assertEqual([], clock_calls)
+        self.assertFalse(profiler.end_frame()['measured'])
+
+        self.assertFalse(profiler.begin_frame(False))
+        self.assertFalse(profiler.begin_frame(False))
+        self.assertEqual([], clock_calls)
+
+    def test_native_calls_are_counted_by_category_api_time_and_failure(self):
+        clock = iter((1.0, 1.004, 2.0, 2.006))
+        calls = []
+        profiler = HiddenWorkerProfiler(clock=lambda: next(clock))
+        profiler.begin_frame(True)
+
+        self.assertEqual('hit', profiler.native_call(
+            'spotting', 'wg_collideSegment',
+            lambda: calls.append('first') or 'hit'))
+        with self.assertRaisesRegex(RuntimeError, 'native failed'):
+            profiler.native_call(
+                'spotting', 'wg_collideSegment',
+                lambda: (_ for _ in ()).throw(RuntimeError('native failed')))
+        profile = profiler.end_frame()
+
+        self.assertEqual(['first'], calls)
+        self.assertTrue(profile['measured'])
+        row = profile['native']['spotting.wg_collideSegment']
+        self.assertEqual((2, 1), (row[0], row[2]))
+        self.assertAlmostEqual(0.010, row[1])
+
+    def test_start_clock_failure_preserves_original_call_semantics(self):
+        def broken_clock():
+            raise RuntimeError('diagnostic clock failed')
+
+        calls = []
+        profiler = HiddenWorkerProfiler(clock=broken_clock)
+        profiler.begin_frame(True)
+
+        value = profiler.native_call(
+            'spotting', 'wg_collideSegment',
+            lambda: calls.append('return') or 17)
+        self.assertEqual(17, value)
+        with self.assertRaisesRegex(ValueError, 'original failed'):
+            profiler.native_call(
+                'spotting', 'wg_collideSegment',
+                lambda: (calls.append('raise'),
+                         (_ for _ in ()).throw(
+                             ValueError('original failed')))[1])
+
+        self.assertEqual(['return', 'raise'], calls)
+
+    def test_scheduled_calls_stay_separate_from_the_next_render_callback(self):
+        clock = iter((1.0, 1.003, 2.0, 2.005, 3.0, 3.0))
+        profiler = HiddenWorkerProfiler(clock=lambda: next(clock))
+        profiler.begin_frame(True)
+        profiler.native_call(
+            'ground', 'wg_collideSegment', lambda: None)
+        first = profiler.end_frame()
+        profiler.native_call(
+            'destructible_state', 'wg_getDestructibleMatrix', lambda: None)
+        interval = profiler.begin_frame(True)
+        marker = profiler.python_started('foliage_dynamic')
+        profiler.python_finished(marker)
+        second = profiler.end_frame()
+
+        first_row = first['native']['ground.wg_collideSegment']
+        self.assertEqual((1, 0), (first_row[0], first_row[2]))
+        self.assertAlmostEqual(0.003, first_row[1])
+        second_row = interval['offframe_native'][
+            'destructible_state.wg_getDestructibleMatrix']
+        self.assertEqual((1, 0), (second_row[0], second_row[2]))
+        self.assertAlmostEqual(0.005, second_row[1])
+        self.assertEqual({}, second['offframe_native'])
+        self.assertEqual((1, 0.0, 0), second['python']['foliage_dynamic'])
+
+    def test_unknown_categories_are_bounded_to_other(self):
+        clock = iter((1.0, 1.001))
+        profiler = HiddenWorkerProfiler(clock=lambda: next(clock))
+        profiler.begin_frame(True)
+
+        profiler.native_call('attacker supplied category', 'x' * 80,
+                             lambda: None)
+        profile = profiler.end_frame()
+
+        self.assertEqual(['other.native'], list(profile['native']))
+        row = profile['native']['other.native']
+        self.assertEqual((1, 0), (row[0], row[2]))
+        self.assertAlmostEqual(0.001, row[1])
+
+    def test_ram_is_a_first_class_category(self):
+        clock = iter((1.0, 1.002))
+        profiler = HiddenWorkerProfiler(clock=lambda: next(clock))
+        profiler.begin_frame(True)
+
+        profiler.native_call(
+            'ram', 'hitTester.localHitTest', lambda: ())
+        profile = profiler.end_frame()
+
+        self.assertIn('ram.hitTester.localHitTest', profile['native'])
+        self.assertNotIn('other.hitTester.localHitTest', profile['native'])
+
+    def test_category_context_routes_only_the_nested_native_boundary(self):
+        clock = iter((1.0, 1.003))
+        profiler = HiddenWorkerProfiler(clock=lambda: next(clock))
+        profiler.begin_frame(True)
+
+        def python_vehicle_wrapper():
+            return profiler.native_call(
+                profiler.current_category('projectile_vehicle'),
+                'hitTester.localHitTest', lambda: ('hit',))
+
+        result = profiler.category_call(
+            'firing_lane', python_vehicle_wrapper)
+        profile = profiler.end_frame()
+
+        self.assertEqual(('hit',), result)
+        self.assertEqual(
+            ['firing_lane.hitTester.localHitTest'],
+            list(profile['native']))
+
+    def test_slow_trace_preserves_context_result_and_filter_semantics(self):
+        clock = iter((1.0, 1.002, 2.0, 2.002))
+        profiler = HiddenWorkerProfiler(clock=lambda: next(clock))
+        profiler.begin_frame(True, context={
+            'map': '05_prohorovka',
+            'round': 'round-7',
+            'destructible_revision': 11,
+            'foliage_revision': 4,
+        })
+        result = ((4.0, 5.0, 6.0), (0.0, 1.0, 0.0), 37)
+
+        self.assertEqual(result, profiler.native_call(
+            'spotting', 'wg_collideSegment', lambda *unused: result,
+            9, (1.0, 2.0, 3.0), (7.0, 8.0, 9.0), 128))
+        profiler.native_call(
+            'ground', 'wg_collideSegment', lambda *unused: None,
+            9, (1.0, 3.0, 3.0), (1.0, -3.0, 3.0), 128,
+            lambda unused: True)
+        profile = profiler.end_frame()
+
+        self.assertEqual(1, profile['frame_ordinal'])
+        self.assertEqual(2, len(profile['trace']))
+        trace = next(row for row in profile['trace']
+                     if row['category'] == 'spotting')
+        self.assertEqual('05_prohorovka', trace['map'])
+        self.assertEqual('round-7', trace['round'])
+        self.assertEqual(11, trace['destructible_revision'])
+        self.assertEqual(4, trace['foliage_revision'])
+        self.assertEqual(1, trace['profiler_frame'])
+        self.assertEqual(37, trace['result']['material'])
+        self.assertTrue(trace['filter_free'])
+        self.assertTrue(trace['replay_candidate'])
+        self.assertFalse(trace['replayable'])
+        self.assertFalse(trace['timing_includes_python_filter'])
+        filtered = next(row for row in profile['trace']
+                        if row['category'] == 'ground')
+        self.assertTrue(filtered['filtered'])
+        self.assertFalse(filtered['filter_free'])
+        self.assertFalse(filtered['replay_candidate'])
+        self.assertTrue(filtered['timing_includes_python_filter'])
+
+    def test_representative_segment_sampling_hits_periodic_boundary(self):
+        now = [0.0]
+
+        def clock():
+            now[0] += 0.0000001
+            return now[0]
+
+        profiler = HiddenWorkerProfiler(clock=clock)
+        profiler.begin_frame(True, context={
+            'destructible_revision': 2, 'foliage_revision': 3})
+        for index in range(256):
+            profiler.native_call(
+                'spotting', 'wg_collideSegment', lambda *unused: None,
+                1, (index, 0, 0), (index + 1, 0, 0), 128)
+        profile = profiler.end_frame()
+
+        samples = profile['representative_trace']
+        self.assertEqual([1, 256], [
+            row['sample_ordinal'] for row in samples])
+        self.assertLessEqual(len(samples), 2)
+
+    def test_alternates_full_timing_with_wrapper_only_baseline(self):
+        now = [0.0]
+        profiler = HiddenWorkerProfiler(
+            clock=lambda: now[0], alternate_modes=True,
+            full_timing_seconds=1.0, baseline_seconds=0.5)
+
+        profiler.begin_frame(True)
+        self.assertEqual('timing+bounded_trace', profiler.end_frame()['mode'])
+        now[0] = 1.1
+        profiler.begin_frame(True)
+        baseline = profiler.end_frame()
+        self.assertEqual('wrapper_only_baseline', baseline['mode'])
+        self.assertFalse(baseline['measured'])
+        now[0] = 1.7
+        profiler.begin_frame(True)
+        self.assertEqual('timing+bounded_trace', profiler.end_frame()['mode'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/0.9.22/tests/test_port_0922_hidden_worker_profiler_package.py
+++ b/0.9.22/tests/test_port_0922_hidden_worker_profiler_package.py
@@ -216,9 +216,10 @@ class HiddenWorkerProfilerPackageTests(unittest.TestCase):
                 'Get-Process -Name "WorldOfTanks"',
                 'Get-Process -Name "WoT-Offline-Battles-Launcher"',
                 '.offline-hidden-worker-profiler-backup',
-                'A profiler backup already exists', 'Get-Sha256',
+                'Updated hidden-worker profiler to build', 'Get-Sha256',
                 'Expected exactly one v0.6.2',
-                'previousPackages', 'diagnosticBuildIdentity'):
+                'previousPackages', 'diagnosticBuildIdentity',
+                'Original launcher WOTMOD backup remains at'):
             self.assertIn(required, source)
         self.assertNotIn('build_identity.json', source)
         self.assertNotIn('server_endpoint.json', source)
@@ -231,6 +232,8 @@ class HiddenWorkerProfilerPackageTests(unittest.TestCase):
 
     def test_collector_uses_only_fixed_paths_and_pid_scoped_counters(self):
         source = (TOOLS_ROOT / 'collect_hidden_worker_profile.ps1').read_text(
+            encoding='utf-8')
+        batch = (TOOLS_ROOT / 'COLLECT_HIDDEN_WORKER_PROFILE.bat').read_text(
             encoding='utf-8')
         for required in (
                 'authority_worker_status.json', 'process_id',
@@ -247,19 +250,22 @@ class HiddenWorkerProfilerPackageTests(unittest.TestCase):
             self.assertIn(required, source)
         self.assertNotIn('Get-ChildItem -Path $env:', source)
         self.assertNotIn('-Recurse', source)
+        self.assertIn('[int]$Seconds = 90', source)
+        self.assertIn('set "CAPTURE_SECONDS=90"', batch)
 
-    def test_install_text_explains_separate_worker_copy_and_restoration(self):
+    def test_install_text_explains_launcher_workflow_and_restoration(self):
         text = self.builder.install_text('profiler-test-a')
-        self.assertIn('let it finish its normal installation', text)
-        self.assertIn('exact same launcher build', text)
+        self.assertIn('let it finish its normal v0.6.2 installation', text)
+        self.assertIn('still start the game, LAN server, visible client and hidden', text)
+        self.assertIn('through that same launcher', text)
+        self.assertIn('avoids rebuilding or replacing', text)
+        self.assertIn('exact same launcher to start the battle', text)
         self.assertIn('do not switch to another launcher build', text)
-        self.assertIn('System baseline first', text)
-        self.assertIn('missing diagnostic', text)
-        self.assertIn('is expected for this first report', text)
-        self.assertIn('whole-product system baseline', text)
-        self.assertIn('after the launcher package', text)
-        self.assertIn('wrapper-only observational baseline', text)
-        self.assertIn('not an unmodified-client or causal comparison', text)
+        self.assertIn('start the battle normally', text)
+        self.assertIn('updates it in place', text)
+        self.assertIn('preserves the original launcher WOTMOD backup', text)
+        self.assertIn('one comprehensive profile', text)
+        self.assertIn('default capture is 90 seconds', text)
         self.assertIn('another physical #1513 client copy', text)
         self.assertIn('installer again', text)
         self.assertIn('restores the exact WOTMOD files', text)

--- a/0.9.22/tests/test_port_0922_hidden_worker_profiler_package.py
+++ b/0.9.22/tests/test_port_0922_hidden_worker_profiler_package.py
@@ -1,0 +1,270 @@
+import hashlib
+import importlib.util
+import inspect
+import json
+from pathlib import Path
+import tempfile
+import unittest
+import zipfile
+
+
+PORT_ROOT = Path(__file__).resolve().parents[1]
+TOOLS_ROOT = PORT_ROOT / 'tools'
+
+
+def _load(name):
+    path = TOOLS_ROOT / (name + '.py')
+    spec = importlib.util.spec_from_file_location(name + '_test', path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_stored_tree(archive, names):
+    directories = set()
+    for name in names:
+        parts = name.split('/')[:-1]
+        for index in range(1, len(parts) + 1):
+            directories.add('/'.join(parts[:index]) + '/')
+    for directory in sorted(directories):
+        archive.writestr(directory, b'')
+
+
+def _powershell_tokens(source):
+    """Tokenize delimiters/try blocks while ignoring strings and comments."""
+    tokens = []
+    index = 0
+    length = len(source)
+    while index < length:
+        character = source[index]
+        if character == '#':
+            newline = source.find('\n', index + 1)
+            index = length if newline < 0 else newline + 1
+            continue
+        if character in "'\"":
+            quote = character
+            index += 1
+            while index < length:
+                if source[index] == '`':
+                    index += 2
+                    continue
+                if source[index] == quote:
+                    if (quote == "'" and index + 1 < length and
+                            source[index + 1] == quote):
+                        index += 2
+                        continue
+                    index += 1
+                    break
+                index += 1
+            else:
+                raise AssertionError('unterminated PowerShell string')
+            continue
+        if character in '{}()[]':
+            tokens.append(character)
+            index += 1
+            continue
+        if character.isalpha() or character == '_':
+            end = index + 1
+            while (end < length and
+                   (source[end].isalnum() or source[end] == '_')):
+                end += 1
+            tokens.append(source[index:end].lower())
+            index = end
+            continue
+        index += 1
+    return tokens
+
+
+def _assert_powershell_structure(test_case, path):
+    tokens = _powershell_tokens(path.read_text(encoding='utf-8'))
+    opening = {'{': '}', '(': ')', '[': ']'}
+    closing = {value: key for key, value in opening.items()}
+    stack = []
+    matching = {}
+    for index, token in enumerate(tokens):
+        if token in opening:
+            stack.append((token, index))
+        elif token in closing:
+            test_case.assertTrue(stack, '%s has an extra %s' % (path, token))
+            start, start_index = stack.pop()
+            test_case.assertEqual(
+                closing[token], start,
+                '%s has mismatched %s ... %s' % (path, start, token))
+            matching[start_index] = index
+    test_case.assertEqual([], stack, '%s has unclosed delimiters' % path)
+    for index, token in enumerate(tokens):
+        if token != 'try':
+            continue
+        test_case.assertLess(index + 1, len(tokens))
+        test_case.assertEqual(
+            '{', tokens[index + 1], '%s try has no block' % path)
+        end = matching[index + 1]
+        test_case.assertLess(end + 1, len(tokens))
+        test_case.assertIn(
+            tokens[end + 1], ('catch', 'finally'),
+            '%s try block is not followed by catch/finally' % path)
+
+
+class HiddenWorkerProfilerPackageTests(unittest.TestCase):
+    def setUp(self):
+        self.builder = _load('build_hidden_worker_profiler')
+        self.validator = _load('validate_hidden_worker_profiler_zip')
+
+    def _inner_wotmod(self):
+        expected = {self.validator.validate_wotmod.ENTRY}
+        payloads = {
+            'meta.xml': (
+                b'<root><id>org.peng.offline_lan_0922</id>'
+                b'<version>0.6.2</version></root>'),
+            self.validator.validate_wotmod.ENTRY: b'\x03\xf3\r\ncompiled',
+        }
+        with tempfile.NamedTemporaryFile(suffix='.wotmod') as stream:
+            with zipfile.ZipFile(stream.name, 'w', zipfile.ZIP_STORED) as archive:
+                _write_stored_tree(archive, payloads)
+                for name, payload in sorted(payloads.items()):
+                    archive.writestr(name, payload)
+            return Path(stream.name).read_bytes(), expected
+
+    def _outer_zip(self, path, mutate_marker=None, extras=None):
+        wotmod, expected = self._inner_wotmod()
+        marker = self.builder.build_marker(
+            'profiler-test-a',
+            Path(self.validator.PACKAGE_MEMBER).name,
+            hashlib.sha256(wotmod).hexdigest(),
+            'a' * 40,
+            True)
+        if mutate_marker is not None:
+            mutate_marker(marker)
+        payloads = dict((name, b'payload')
+                        for name in self.validator.REQUIRED_FILES)
+        payloads[self.validator.PACKAGE_MEMBER] = wotmod
+        payloads[self.validator.MARKER_FILENAME] = (
+            json.dumps(marker).encode('utf-8'))
+        payloads.update(extras or {})
+        with zipfile.ZipFile(path, 'w', zipfile.ZIP_STORED) as archive:
+            _write_stored_tree(archive, payloads)
+            for name, payload in sorted(payloads.items()):
+                archive.writestr(name, payload)
+        return expected
+
+    def test_package_only_builder_has_no_server_or_launcher_dependency(self):
+        source = inspect.getsource(
+            self.builder.build_wotmod.build_wotmod_package)
+        self.assertNotIn('SERVER_FILENAME', source)
+        self.assertNotIn('_write_client_overlay', source)
+        self.assertNotIn('launcher', source.lower())
+
+    def test_default_diagnostic_identity_is_explicit_and_bounded(self):
+        identity = self.builder.diagnostic_build_identity(
+            environ={}, now=0, random_hex='abcdef1234569999')
+        self.assertEqual(
+            'profiler-19700101T000000Z-abcdef123456', identity)
+        self.assertLessEqual(len(identity), 96)
+
+    def test_explicit_diagnostic_identity_is_validated(self):
+        self.assertEqual(
+            'windows-run-17',
+            self.builder.diagnostic_build_identity(environ={
+                self.builder.DIAGNOSTIC_IDENTITY_ENV: 'windows-run-17'}))
+        with self.assertRaisesRegex(SystemExit, 'is invalid'):
+            self.builder.diagnostic_build_identity(environ={
+                self.builder.DIAGNOSTIC_IDENTITY_ENV: '../outside'})
+
+    def test_valid_delta_has_one_same_id_wotmod_and_no_user_state(self):
+        with tempfile.TemporaryDirectory() as directory:
+            archive = Path(directory) / 'profiler.zip'
+            expected = self._outer_zip(archive)
+            marker = self.validator.validate(
+                archive, expected_pyc_members=expected)
+        self.assertEqual('profiler-test-a', marker['diagnosticBuildIdentity'])
+        self.assertEqual(
+            'org.peng.offline_lan_0922_0.6.2.wotmod',
+            marker['packageFile'])
+        self.assertNotIn(
+            'build_identity.json', self.validator.REQUIRED_FILES)
+        self.assertFalse(
+            self.validator.FORBIDDEN_STATE_FILES.intersection(
+                Path(name).name for name in self.validator.REQUIRED_FILES))
+
+    def test_delta_rejects_an_unexpected_user_state_member(self):
+        with tempfile.TemporaryDirectory() as directory:
+            archive = Path(directory) / 'profiler.zip'
+            expected = self._outer_zip(
+                archive, extras={
+                    'payload/mods/configs/offline_lan_0922/'
+                    'server_endpoint.json': b'private'})
+            with self.assertRaisesRegex(ValueError, 'member manifest mismatch'):
+                self.validator.validate(
+                    archive, expected_pyc_members=expected)
+
+    def test_delta_rejects_a_wotmod_that_does_not_match_the_marker(self):
+        with tempfile.TemporaryDirectory() as directory:
+            archive = Path(directory) / 'profiler.zip'
+            expected = self._outer_zip(
+                archive,
+                mutate_marker=lambda marker: marker.__setitem__(
+                    'packageSha256', '0' * 64))
+            with self.assertRaisesRegex(ValueError, 'checksum mismatch'):
+                self.validator.validate(
+                    archive, expected_pyc_members=expected)
+
+    def test_install_and_uninstall_are_reversible_and_fail_closed(self):
+        source = (TOOLS_ROOT / 'hidden_worker_profiler_package.ps1').read_text(
+            encoding='utf-8')
+        for required in (
+                'WorldOfTanks.exe', '0\\.9\\.22\\.0\\.1', '#1513',
+                'Get-Process -Name "WorldOfTanks"',
+                'Get-Process -Name "WoT-Offline-Battles-Launcher"',
+                '.offline-hidden-worker-profiler-backup',
+                'A profiler backup already exists', 'Get-Sha256',
+                'Expected exactly one v0.6.2',
+                'previousPackages', 'diagnosticBuildIdentity'):
+            self.assertIn(required, source)
+        self.assertNotIn('build_identity.json', source)
+        self.assertNotIn('server_endpoint.json', source)
+        self.assertNotIn('garage_state.json', source)
+
+    def test_powershell_package_tools_have_balanced_control_structure(self):
+        for name in ('hidden_worker_profiler_package.ps1',
+                     'collect_hidden_worker_profile.ps1'):
+            _assert_powershell_structure(self, TOOLS_ROOT / name)
+
+    def test_collector_uses_only_fixed_paths_and_pid_scoped_counters(self):
+        source = (TOOLS_ROOT / 'collect_hidden_worker_profile.ps1').read_text(
+            encoding='utf-8')
+        for required in (
+                'authority_worker_status.json', 'process_id',
+                'heartbeat_epoch', 'heartbeat became stale',
+                'Get-Process -Id $workerPid',
+                'ProcessName -ne "WorldOfTanks"',
+                'changed PID', 'another game folder',
+                'GPU Engine(*pid_${ProcessId}_*)',
+                'no PID-scoped GPU Engine counter instance',
+                'offline-worker-python.log',
+                'WoTOfflineBattles', 'launcher.log',
+                'collection_manifest.json', 'runtime.frame_performance',
+                'PERF and slow-frame lines', '$captureRoot + ".zip"'):
+            self.assertIn(required, source)
+        self.assertNotIn('Get-ChildItem -Path $env:', source)
+        self.assertNotIn('-Recurse', source)
+
+    def test_install_text_explains_separate_worker_copy_and_restoration(self):
+        text = self.builder.install_text('profiler-test-a')
+        self.assertIn('let it finish its normal installation', text)
+        self.assertIn('exact same launcher build', text)
+        self.assertIn('do not switch to another launcher build', text)
+        self.assertIn('System baseline first', text)
+        self.assertIn('missing diagnostic', text)
+        self.assertIn('is expected for this first report', text)
+        self.assertIn('whole-product system baseline', text)
+        self.assertIn('after the launcher package', text)
+        self.assertIn('wrapper-only observational baseline', text)
+        self.assertIn('not an unmodified-client or causal comparison', text)
+        self.assertIn('another physical #1513 client copy', text)
+        self.assertIn('installer again', text)
+        self.assertIn('restores the exact WOTMOD files', text)
+        self.assertIn('unavailable rather than estimating it', text)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/0.9.22/tests/test_port_0922_lan_client_queue.py
+++ b/0.9.22/tests/test_port_0922_lan_client_queue.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import threading
 import time
 import unittest
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -12,6 +13,7 @@ sys.path.insert(0, str(
     ROOT / '0.9.22' / 'src' / 'res' / 'scripts' / 'client'))
 
 from gui.mods.offline_lan_0922 import lan_client as lan_client_module
+from gui.mods.offline_lan_0922 import hidden_worker_profiler
 from gui.mods.offline_lan_0922.authority_worker import (
     AuthorityWorkerLANClient)
 from gui.mods.offline_lan_0922.lan_client import LANClient
@@ -209,6 +211,75 @@ class LanClientQueueTests(unittest.TestCase):
              'bot_observation'],
             [item[1]['type'] for item in queued])
         self.assertEqual((1, 2), queued[0][1]['nested']['values'])
+
+    def test_visible_outbound_does_not_enter_worker_profile_boundaries(self):
+        client = self.activate()
+        with mock.patch.object(
+                hidden_worker_profiler, 'python_started') as started, \
+                mock.patch.object(
+                    hidden_worker_profiler, 'work_add') as work_add:
+            self.assertTrue(client._send({
+                'type': 'projectile_progress', 'projectiles': []}))
+
+        started.assert_not_called()
+        work_add.assert_not_called()
+        self.assertIs(type(client._outbound_queue[0][1]), dict)
+
+    def test_worker_generic_outbound_profiles_main_and_sender_boundaries(self):
+        client = self.activate(worker=True)
+        sock = client.sock
+        profiler = hidden_worker_profiler.HiddenWorkerProfiler(
+            clock=time.perf_counter, alternate_modes=False)
+        original = hidden_worker_profiler._PROFILER
+        hidden_worker_profiler._PROFILER = profiler
+        try:
+            hidden_worker_profiler.begin_frame(True)
+            message = {
+                'type': 'projectile_progress', 'projectiles': [{'id': 7}]}
+            self.assertTrue(client._send(message))
+            queued = client._dequeue_outbound(
+                client._transport_generation)
+            self.assertIsInstance(
+                queued[1], lan_client_module._ProfiledWorkerOutbound)
+            thread = threading.Thread(
+                target=client._send_wire,
+                args=(queued[1], sock, client._transport_generation))
+            thread.start()
+            thread.join(1.0)
+            self.assertFalse(thread.is_alive())
+            frame = hidden_worker_profiler.end_frame()
+            interval = hidden_worker_profiler.begin_frame(True)
+        finally:
+            hidden_worker_profiler.reset()
+            hidden_worker_profiler._PROFILER = original
+
+        self.assertIn('worker_message_freeze', frame['python'])
+        self.assertIn('worker_message_enqueue', frame['python'])
+        self.assertEqual(1, frame['work']['worker_messages'])
+        self.assertEqual(1, frame['work']['worker_queue_depth'])
+        self.assertIn('worker_message_send', interval['offframe_python'])
+        expected = (json.dumps(
+            message, separators=(',', ':')) + '\n').encode('utf-8')
+        self.assertEqual([expected], sock.sent)
+        self.assertEqual(
+            len(expected), interval['offframe_work']['worker_wire_bytes'])
+
+    def test_worker_preencoded_tag_preserves_wire_and_coalescing(self):
+        client = self.activate(worker=True)
+        first = {'type': 'projectile_progress', 'revision': 1}
+        second = {'type': 'projectile_progress', 'revision': 2}
+
+        self.assertTrue(client._send_preencoded_trusted(
+            first, coalesce_key=('projectile_progress',)))
+        self.assertTrue(client._send_preencoded_trusted(
+            second, coalesce_key=('projectile_progress',)))
+
+        self.assertEqual(1, len(client._outbound_queue))
+        queued = client._outbound_queue[0][1]
+        self.assertIsInstance(queued, lan_client_module._PreencodedOutbound)
+        self.assertTrue(queued.profiled_worker_message)
+        self.assertEqual(
+            second, json.loads(queued.payload.decode('utf-8')))
 
     def test_battle_ready_canonicalizes_spawn_planner_team_keys(self):
         client = self.activate()

--- a/0.9.22/tools/COLLECT_HIDDEN_WORKER_PROFILE.bat
+++ b/0.9.22/tools/COLLECT_HIDDEN_WORKER_PROFILE.bat
@@ -1,0 +1,15 @@
+@echo off
+setlocal
+
+set "GAME_ROOT=%~1"
+set "CAPTURE_SECONDS=%~2"
+if not defined GAME_ROOT if exist "%~dp0WorldOfTanks.exe" set "GAME_ROOT=%~dp0"
+if not defined GAME_ROOT set /p "GAME_ROOT=Folder containing WorldOfTanks.exe: "
+if not defined CAPTURE_SECONDS set "CAPTURE_SECONDS=60"
+
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File ^
+  "%~dp0collect_hidden_worker_profile.ps1" ^
+  -GameRoot "%GAME_ROOT%" -Seconds %CAPTURE_SECONDS% -OutputRoot "%~dp0"
+set "RESULT=%ERRORLEVEL%"
+if not "%RESULT%"=="0" pause
+exit /b %RESULT%

--- a/0.9.22/tools/COLLECT_HIDDEN_WORKER_PROFILE.bat
+++ b/0.9.22/tools/COLLECT_HIDDEN_WORKER_PROFILE.bat
@@ -3,13 +3,13 @@ setlocal
 
 set "GAME_ROOT=%~1"
 set "CAPTURE_SECONDS=%~2"
-if not defined GAME_ROOT if exist "%~dp0WorldOfTanks.exe" set "GAME_ROOT=%~dp0"
+if not defined GAME_ROOT if exist "%~dp0WorldOfTanks.exe" set "GAME_ROOT=%~dp0."
 if not defined GAME_ROOT set /p "GAME_ROOT=Folder containing WorldOfTanks.exe: "
 if not defined CAPTURE_SECONDS set "CAPTURE_SECONDS=60"
 
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File ^
   "%~dp0collect_hidden_worker_profile.ps1" ^
-  -GameRoot "%GAME_ROOT%" -Seconds %CAPTURE_SECONDS% -OutputRoot "%~dp0"
+  -GameRoot "%GAME_ROOT%" -Seconds %CAPTURE_SECONDS%
 set "RESULT=%ERRORLEVEL%"
 if not "%RESULT%"=="0" pause
 exit /b %RESULT%

--- a/0.9.22/tools/COLLECT_HIDDEN_WORKER_PROFILE.bat
+++ b/0.9.22/tools/COLLECT_HIDDEN_WORKER_PROFILE.bat
@@ -1,15 +1,17 @@
 @echo off
-setlocal
+setlocal DisableDelayedExpansion
 
 set "GAME_ROOT=%~1"
 set "CAPTURE_SECONDS=%~2"
 if not defined GAME_ROOT if exist "%~dp0WorldOfTanks.exe" set "GAME_ROOT=%~dp0."
 if not defined GAME_ROOT set /p "GAME_ROOT=Folder containing WorldOfTanks.exe: "
 if not defined CAPTURE_SECONDS set "CAPTURE_SECONDS=60"
+set "WOT_HIDDEN_WORKER_PROFILER_GAME_ROOT=%GAME_ROOT%"
+set "WOT_HIDDEN_WORKER_PROFILER_OUTPUT_ROOT=%~dp0"
 
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File ^
   "%~dp0collect_hidden_worker_profile.ps1" ^
-  -GameRoot "%GAME_ROOT%" -Seconds %CAPTURE_SECONDS%
+  -Seconds %CAPTURE_SECONDS%
 set "RESULT=%ERRORLEVEL%"
 if not "%RESULT%"=="0" pause
 exit /b %RESULT%

--- a/0.9.22/tools/COLLECT_HIDDEN_WORKER_PROFILE.bat
+++ b/0.9.22/tools/COLLECT_HIDDEN_WORKER_PROFILE.bat
@@ -5,7 +5,7 @@ set "GAME_ROOT=%~1"
 set "CAPTURE_SECONDS=%~2"
 if not defined GAME_ROOT if exist "%~dp0WorldOfTanks.exe" set "GAME_ROOT=%~dp0."
 if not defined GAME_ROOT set /p "GAME_ROOT=Folder containing WorldOfTanks.exe: "
-if not defined CAPTURE_SECONDS set "CAPTURE_SECONDS=60"
+if not defined CAPTURE_SECONDS set "CAPTURE_SECONDS=90"
 set "WOT_HIDDEN_WORKER_PROFILER_GAME_ROOT=%GAME_ROOT%"
 set "WOT_HIDDEN_WORKER_PROFILER_OUTPUT_ROOT=%~dp0"
 

--- a/0.9.22/tools/INSTALL_HIDDEN_WORKER_PROFILER.bat
+++ b/0.9.22/tools/INSTALL_HIDDEN_WORKER_PROFILER.bat
@@ -1,13 +1,14 @@
 @echo off
-setlocal
+setlocal DisableDelayedExpansion
 
 set "GAME_ROOT=%~1"
 if not defined GAME_ROOT if exist "%~dp0WorldOfTanks.exe" set "GAME_ROOT=%~dp0."
 if not defined GAME_ROOT set /p "GAME_ROOT=Folder containing WorldOfTanks.exe: "
+set "WOT_HIDDEN_WORKER_PROFILER_GAME_ROOT=%GAME_ROOT%"
 
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File ^
   "%~dp0hidden_worker_profiler_package.ps1" ^
-  -Action Install -GameRoot "%GAME_ROOT%"
+  -Action Install
 set "RESULT=%ERRORLEVEL%"
 if not "%RESULT%"=="0" pause
 exit /b %RESULT%

--- a/0.9.22/tools/INSTALL_HIDDEN_WORKER_PROFILER.bat
+++ b/0.9.22/tools/INSTALL_HIDDEN_WORKER_PROFILER.bat
@@ -2,7 +2,7 @@
 setlocal
 
 set "GAME_ROOT=%~1"
-if not defined GAME_ROOT if exist "%~dp0WorldOfTanks.exe" set "GAME_ROOT=%~dp0"
+if not defined GAME_ROOT if exist "%~dp0WorldOfTanks.exe" set "GAME_ROOT=%~dp0."
 if not defined GAME_ROOT set /p "GAME_ROOT=Folder containing WorldOfTanks.exe: "
 
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File ^

--- a/0.9.22/tools/INSTALL_HIDDEN_WORKER_PROFILER.bat
+++ b/0.9.22/tools/INSTALL_HIDDEN_WORKER_PROFILER.bat
@@ -1,0 +1,13 @@
+@echo off
+setlocal
+
+set "GAME_ROOT=%~1"
+if not defined GAME_ROOT if exist "%~dp0WorldOfTanks.exe" set "GAME_ROOT=%~dp0"
+if not defined GAME_ROOT set /p "GAME_ROOT=Folder containing WorldOfTanks.exe: "
+
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File ^
+  "%~dp0hidden_worker_profiler_package.ps1" ^
+  -Action Install -GameRoot "%GAME_ROOT%"
+set "RESULT=%ERRORLEVEL%"
+if not "%RESULT%"=="0" pause
+exit /b %RESULT%

--- a/0.9.22/tools/UNINSTALL_HIDDEN_WORKER_PROFILER.bat
+++ b/0.9.22/tools/UNINSTALL_HIDDEN_WORKER_PROFILER.bat
@@ -2,7 +2,7 @@
 setlocal
 
 set "GAME_ROOT=%~1"
-if not defined GAME_ROOT if exist "%~dp0WorldOfTanks.exe" set "GAME_ROOT=%~dp0"
+if not defined GAME_ROOT if exist "%~dp0WorldOfTanks.exe" set "GAME_ROOT=%~dp0."
 if not defined GAME_ROOT set /p "GAME_ROOT=Folder containing WorldOfTanks.exe: "
 
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File ^

--- a/0.9.22/tools/UNINSTALL_HIDDEN_WORKER_PROFILER.bat
+++ b/0.9.22/tools/UNINSTALL_HIDDEN_WORKER_PROFILER.bat
@@ -1,0 +1,13 @@
+@echo off
+setlocal
+
+set "GAME_ROOT=%~1"
+if not defined GAME_ROOT if exist "%~dp0WorldOfTanks.exe" set "GAME_ROOT=%~dp0"
+if not defined GAME_ROOT set /p "GAME_ROOT=Folder containing WorldOfTanks.exe: "
+
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File ^
+  "%~dp0hidden_worker_profiler_package.ps1" ^
+  -Action Uninstall -GameRoot "%GAME_ROOT%"
+set "RESULT=%ERRORLEVEL%"
+if not "%RESULT%"=="0" pause
+exit /b %RESULT%

--- a/0.9.22/tools/UNINSTALL_HIDDEN_WORKER_PROFILER.bat
+++ b/0.9.22/tools/UNINSTALL_HIDDEN_WORKER_PROFILER.bat
@@ -1,13 +1,14 @@
 @echo off
-setlocal
+setlocal DisableDelayedExpansion
 
 set "GAME_ROOT=%~1"
 if not defined GAME_ROOT if exist "%~dp0WorldOfTanks.exe" set "GAME_ROOT=%~dp0."
 if not defined GAME_ROOT set /p "GAME_ROOT=Folder containing WorldOfTanks.exe: "
+set "WOT_HIDDEN_WORKER_PROFILER_GAME_ROOT=%GAME_ROOT%"
 
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File ^
   "%~dp0hidden_worker_profiler_package.ps1" ^
-  -Action Uninstall -GameRoot "%GAME_ROOT%"
+  -Action Uninstall
 set "RESULT=%ERRORLEVEL%"
 if not "%RESULT%"=="0" pause
 exit /b %RESULT%

--- a/0.9.22/tools/build_hidden_worker_profiler.py
+++ b/0.9.22/tools/build_hidden_worker_profiler.py
@@ -1,0 +1,215 @@
+"""Build a reversible diagnostic delta for an existing #1513 install."""
+
+from __future__ import print_function
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+
+
+TOOLS_ROOT = os.path.abspath(os.path.dirname(__file__))
+PORT_ROOT = os.path.abspath(os.path.join(TOOLS_ROOT, '..'))
+PROJECT_ROOT = os.path.abspath(os.path.join(PORT_ROOT, '..'))
+if PORT_ROOT not in sys.path:
+    sys.path.insert(0, PORT_ROOT)
+
+import build_wotmod
+
+
+DIAGNOSTIC_IDENTITY_ENV = 'WOT_OFFLINE_PROFILER_BUILD_IDENTITY'
+DIAGNOSTIC_IDENTITY_PATTERN = re.compile(
+    r'^[A-Za-z0-9][A-Za-z0-9._-]{0,95}$')
+MARKER_FILENAME = 'hidden_worker_profiler_build.json'
+PACKAGE_PREFIX = 'WoT-0.9.22-Hidden-Worker-Profiler-'
+INSTALLER_FILES = (
+    'INSTALL_HIDDEN_WORKER_PROFILER.bat',
+    'UNINSTALL_HIDDEN_WORKER_PROFILER.bat',
+    'COLLECT_HIDDEN_WORKER_PROFILE.bat',
+    'hidden_worker_profiler_package.ps1',
+    'collect_hidden_worker_profile.ps1',
+)
+
+
+def diagnostic_build_identity(environ=None, now=None, random_hex=None):
+    environ = os.environ if environ is None else environ
+    explicit = str(environ.get(DIAGNOSTIC_IDENTITY_ENV, '') or '').strip()
+    if explicit:
+        if DIAGNOSTIC_IDENTITY_PATTERN.match(explicit) is None:
+            raise SystemExit('%s is invalid' % DIAGNOSTIC_IDENTITY_ENV)
+        return explicit
+    now = time.time() if now is None else float(now)
+    random_hex = uuid.uuid4().hex if random_hex is None else str(random_hex)
+    stamp = time.strftime('%Y%m%dT%H%M%SZ', time.gmtime(now))
+    return 'profiler-%s-%s' % (stamp, random_hex[:12])
+
+
+def _git_value(arguments):
+    with open(os.devnull, 'wb') as null_stream:
+        try:
+            return subprocess.check_output(
+                ['git'] + list(arguments), cwd=PROJECT_ROOT,
+                stderr=null_stream).decode('ascii', 'replace').strip()
+        except (OSError, subprocess.CalledProcessError):
+            return None
+
+
+def source_identity():
+    revision = _git_value(('rev-parse', 'HEAD'))
+    if revision is None or re.match(r'^[0-9a-f]{40}$', revision) is None:
+        revision = 'unknown'
+    status = _git_value((
+        'status', '--porcelain', '--untracked-files=all', '--', '0.9.22'))
+    # A source tree whose cleanliness cannot be established is not clean.
+    dirty = True if status is None else bool(status)
+    return revision, dirty
+
+
+def build_marker(build_identity, package_name, package_digest,
+                 source_revision, source_dirty):
+    return {
+        'schema': 1,
+        'diagnostic': 'hidden_worker_profiler',
+        'diagnosticBuildIdentity': str(build_identity),
+        'baseModId': build_wotmod.MOD_ID,
+        'baseSemanticVersion': build_wotmod.MOD_VERSION,
+        'packageFile': str(package_name),
+        'packageSha256': str(package_digest),
+        'sourceRevision': str(source_revision),
+        'sourceDirty': bool(source_dirty),
+    }
+
+
+def install_text(build_identity):
+    return """WoT 0.9.22 #1513 hidden-worker profiler
+================================================
+
+Diagnostic build: {identity}
+
+This is a reversible delta for an existing v0.6.2 launcher installation. Run
+that same v0.6.2 launcher once and let it finish its normal installation before
+using this ZIP. The ZIP does not contain the LAN server, baked map data, native
+bridge, launcher, or any player-owned configuration. It replaces the one existing
+org.peng.offline_lan_0922 WOTMOD and keeps a private backup for uninstall.
+
+System baseline first
+---------------------
+
+Extract this ZIP before installing its payload. Start one ordinary 15-vs-15
+battle with the currently installed v0.6.2 product and run
+COLLECT_HIDDEN_WORKER_PROFILE.bat for 60 seconds. A missing diagnostic marker
+is expected for this first report. Stop the room and every client, then install
+the profiler and repeat the same map, lineup, visible-client count and
+60-second collection.
+
+The build marker records the diagnostic package's exact source revision. That
+revision can include main-branch changes made after the launcher package you
+currently have, even though both packages retain semantic version 0.6.2.
+Therefore this before/after pair is a whole-product system baseline, not an
+isolated estimate of profiler overhead. Within the diagnostic build, the light
+phase is only a wrapper-only observational baseline: it measures the extra
+clocks, aggregation and bounded trace work, but still includes wrapper dispatch
+and is not an unmodified-client or causal comparison.
+
+Install
+-------
+
+1. Close every visible client and hidden worker.
+2. Extract this ZIP. Do not copy payload files by hand.
+3. Run INSTALL_HIDDEN_WORKER_PROFILER.bat. If the ZIP is not extracted in the
+   game folder, enter the exact folder that contains WorldOfTanks.exe, or pass
+   it as the first argument.
+4. Continue using the exact same launcher build. Do not request a forced
+   repair/reinstall and do not switch to another launcher build while collecting
+   evidence, because either action intentionally restores its bundled mod.
+
+Normally the launcher starts the visible client and hidden worker from the
+same selected client folder, so one install covers both. If a diagnostic setup
+uses another physical #1513 client copy for the hidden worker, run the
+installer again with that copy as its argument.
+
+Collect
+-------
+
+While a 15-vs-15 battle is running, run COLLECT_HIDDEN_WORKER_PROFILE.bat.
+The default capture is 60 seconds. Its optional arguments are the game folder
+and capture seconds. The collector reads the PID from
+authority_worker_status.json, samples CPU and working set, attempts Windows'
+PID-scoped GPU Engine counter, and creates a ZIP beside these scripts. If the
+GPU counter is unavailable or localised differently, the samples record it as
+unavailable rather than estimating it. The report also copies the worker and
+launcher logs when their fixed paths are available. These logs can contain
+local paths and session addresses; inspect the report before sharing it.
+
+Uninstall
+---------
+
+Close every client, then run UNINSTALL_HIDDEN_WORKER_PROFILER.bat against the
+same game folder. It verifies the installed diagnostic package, removes it,
+and restores the exact WOTMOD files and diagnostic marker that existed before
+installation. Saved endpoint, garage, account and battle-result files are not
+read, packaged, changed or deleted.
+""".format(identity=build_identity)
+
+
+def build(output_root):
+    build_identity = diagnostic_build_identity()
+    source_revision, source_dirty = source_identity()
+    output_root = os.path.abspath(output_root)
+    if not os.path.isdir(output_root):
+        os.makedirs(output_root)
+    work_root = tempfile.mkdtemp(prefix='hidden-worker-profiler-')
+    try:
+        compiled_root = os.path.join(work_root, 'compiled')
+        package_path, package_digest = build_wotmod.build_wotmod_package(
+            compiled_root)
+        bundle_root = os.path.join(work_root, 'bundle')
+        payload_mod_root = os.path.join(
+            bundle_root, 'payload', 'mods', '0.9.22.0.1')
+        os.makedirs(payload_mod_root)
+        package_name = os.path.basename(package_path)
+        shutil.copy2(package_path, os.path.join(payload_mod_root, package_name))
+
+        marker = build_marker(
+            build_identity, package_name, package_digest,
+            source_revision, source_dirty)
+        with open(os.path.join(bundle_root, MARKER_FILENAME), 'wb') as stream:
+            payload = json.dumps(marker, indent=2, sort_keys=True) + '\n'
+            stream.write(payload.encode('utf-8'))
+        with open(os.path.join(
+                bundle_root, 'INSTALL_HIDDEN_WORKER_PROFILER.txt'), 'wb') as stream:
+            stream.write(install_text(build_identity).encode('utf-8'))
+        for filename in INSTALLER_FILES:
+            shutil.copy2(os.path.join(TOOLS_ROOT, filename), bundle_root)
+        build_wotmod._copy_legal_files(bundle_root)
+
+        archive_name = PACKAGE_PREFIX + build_identity + '.zip'
+        archive_path = os.path.join(output_root, archive_name)
+        build_wotmod._archive_tree(bundle_root, archive_path)
+        print('diagnostic build identity=%s' % build_identity)
+        print('source revision=%s dirty=%s' %
+              (source_revision, 'yes' if source_dirty else 'no'))
+        print(archive_path)
+        return archive_path
+    finally:
+        shutil.rmtree(work_root)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--output', default=os.path.join(PORT_ROOT, 'dist'),
+        help='directory that receives the diagnostic ZIP')
+    arguments = parser.parse_args(argv)
+    build(arguments.output)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/0.9.22/tools/build_hidden_worker_profiler.py
+++ b/0.9.22/tools/build_hidden_worker_profiler.py
@@ -92,42 +92,36 @@ def install_text(build_identity):
 
 Diagnostic build: {identity}
 
-This is a reversible delta for an existing v0.6.2 launcher installation. Run
-that same v0.6.2 launcher once and let it finish its normal installation before
+This is a reversible diagnostic WOTMOD for an existing v0.6.2 launcher
+installation. You still start the game, LAN server, visible client and hidden
+worker through that same launcher. This ZIP only avoids rebuilding or replacing
+the launcher itself.
+
+Run the launcher once and let it finish its normal v0.6.2 installation before
 using this ZIP. The ZIP does not contain the LAN server, baked map data, native
-bridge, launcher, or any player-owned configuration. It replaces the one existing
-org.peng.offline_lan_0922 WOTMOD and keeps a private backup for uninstall.
+bridge, launcher, or any player-owned configuration. It replaces the one
+existing org.peng.offline_lan_0922 WOTMOD and keeps a private backup for
+uninstall.
 
-System baseline first
----------------------
-
-Extract this ZIP before installing its payload. Start one ordinary 15-vs-15
-battle with the currently installed v0.6.2 product and run
-COLLECT_HIDDEN_WORKER_PROFILE.bat for 60 seconds. A missing diagnostic marker
-is expected for this first report. Stop the room and every client, then install
-the profiler and repeat the same map, lineup, visible-client count and
-60-second collection.
-
-The build marker records the diagnostic package's exact source revision. That
-revision can include main-branch changes made after the launcher package you
-currently have, even though both packages retain semantic version 0.6.2.
-Therefore this before/after pair is a whole-product system baseline, not an
-isolated estimate of profiler overhead. Within the diagnostic build, the light
-phase is only a wrapper-only observational baseline: it measures the extra
-clocks, aggregation and bounded trace work, but still includes wrapper dispatch
-and is not an unmodified-client or causal comparison.
+This build records one comprehensive profile: hidden-worker render frames,
+Bot scheduler/control/planning/motion/aim/publication phases, projectile phases,
+message freezing/enqueue/sending, native-query categories, unit counts, queue
+health, process CPU/GPU use and working set. Timing and counters are aggregated;
+it does not emit one log line per Bot operation.
 
 Install
 -------
 
-1. Close every visible client and hidden worker.
+1. Close the launcher, every visible client and hidden worker.
 2. Extract this ZIP. Do not copy payload files by hand.
 3. Run INSTALL_HIDDEN_WORKER_PROFILER.bat. If the ZIP is not extracted in the
    game folder, enter the exact folder that contains WorldOfTanks.exe, or pass
-   it as the first argument.
-4. Continue using the exact same launcher build. Do not request a forced
-   repair/reinstall and do not switch to another launcher build while collecting
-   evidence, because either action intentionally restores its bundled mod.
+   it as the first argument. If an earlier profiler build is still installed,
+   this updates it in place and preserves the original launcher WOTMOD backup.
+4. Reopen and use the exact same launcher to start the battle normally. Do not
+   request a forced repair/reinstall and do not switch to another launcher build
+   while collecting evidence, because either action intentionally restores its
+   bundled mod.
 
 Normally the launcher starts the visible client and hidden worker from the
 same selected client folder, so one install covers both. If a diagnostic setup
@@ -138,7 +132,8 @@ Collect
 -------
 
 While a 15-vs-15 battle is running, run COLLECT_HIDDEN_WORKER_PROFILE.bat.
-The default capture is 60 seconds. Its optional arguments are the game folder
+The default capture is 90 seconds, so one report spans multiple detailed and
+lightweight profiler windows. Its optional arguments are the game folder
 and capture seconds. The collector reads the PID from
 authority_worker_status.json, samples CPU and working set, attempts Windows'
 PID-scoped GPU Engine counter, and creates a ZIP beside these scripts. If the

--- a/0.9.22/tools/collect_hidden_worker_profile.ps1
+++ b/0.9.22/tools/collect_hidden_worker_profile.ps1
@@ -143,7 +143,8 @@ function New-ReportZip([string]$CaptureRoot, [string]$ZipPath) {
 }
 
 try {
-    $resolvedRoot = [System.IO.Path]::GetFullPath($GameRoot.Trim().Trim('"'))
+    $resolvedRoot = [System.IO.Path]::GetFullPath(
+        $GameRoot.Trim().Trim([char]34))
     if (-not [System.IO.File]::Exists((Join-Path $resolvedRoot "WorldOfTanks.exe"))) {
         throw "WorldOfTanks.exe is missing from: $resolvedRoot"
     }
@@ -184,7 +185,8 @@ try {
         }
     }
 
-    $resolvedOutput = [System.IO.Path]::GetFullPath($OutputRoot)
+    $resolvedOutput = [System.IO.Path]::GetFullPath(
+        $OutputRoot.Trim().Trim([char]34))
     if (-not [System.IO.Directory]::Exists($resolvedOutput)) {
         New-Item -ItemType Directory -Path $resolvedOutput -Force | Out-Null
     }

--- a/0.9.22/tools/collect_hidden_worker_profile.ps1
+++ b/0.9.22/tools/collect_hidden_worker_profile.ps1
@@ -1,0 +1,423 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$GameRoot,
+
+    [ValidateRange(5, 3600)]
+    [int]$Seconds = 60,
+
+    [ValidateRange(1, 30)]
+    [int]$IntervalSeconds = 2,
+
+    [string]$OutputRoot = $PSScriptRoot
+)
+
+$ErrorActionPreference = "Stop"
+$Utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+
+function Read-JsonFile([string]$Path) {
+    return Get-Content -LiteralPath $Path -Raw -Encoding UTF8 | ConvertFrom-Json
+}
+
+function Write-JsonFile([string]$Path, $Value) {
+    $payload = ($Value | ConvertTo-Json -Depth 16) + "`n"
+    [System.IO.File]::WriteAllText($Path, $payload, $Utf8NoBom)
+}
+
+function Add-JsonLine([string]$Path, $Value) {
+    $line = ($Value | ConvertTo-Json -Depth 16 -Compress) + "`n"
+    [System.IO.File]::AppendAllText($Path, $line, $Utf8NoBom)
+}
+
+function Get-HeartbeatAge($Status) {
+    try {
+        $epoch = [double]$Status.heartbeat_epoch
+        if ([double]::IsNaN($epoch) -or [double]::IsInfinity($epoch)) {
+            return $null
+        }
+        $unixNow = ([DateTime]::UtcNow - [DateTime]::SpecifyKind(
+            [DateTime]"1970-01-01", "Utc")).TotalSeconds
+        return $unixNow - $epoch
+    }
+    catch {
+        return $null
+    }
+}
+
+function Read-WorkerStatus([string]$Path) {
+    try {
+        $status = Read-JsonFile $Path
+        $processId = [int]$status.process_id
+        if ($status.schema -ne 1 -or $status.role -ne "simulation_worker" -or
+                $processId -le 0) {
+            throw "invalid status shape"
+        }
+        return $status
+    }
+    catch {
+        return $null
+    }
+}
+
+function Read-GpuCounters([int]$ProcessId) {
+    if ($null -eq (Get-Command Get-Counter -ErrorAction SilentlyContinue)) {
+        return @{
+            available = $false
+            source = "windows_gpu_engine_counter"
+            reason = "Get-Counter is unavailable"
+            engines = @()
+        }
+    }
+    try {
+        $counterPath = "\GPU Engine(*pid_${ProcessId}_*)\Utilization Percentage"
+        $sample = Get-Counter -Counter $counterPath -ErrorAction Stop
+        $engines = @($sample.CounterSamples | Where-Object {
+            $_.InstanceName -like "*pid_${ProcessId}_*"
+        } | ForEach-Object {
+            @{
+                instance = [string]$_.InstanceName
+                cookedValue = [double]$_.CookedValue
+                path = [string]$_.Path
+            }
+        })
+        if ($engines.Count -eq 0) {
+            return @{
+                available = $false
+                source = "windows_gpu_engine_counter"
+                reason = "no PID-scoped GPU Engine counter instance"
+                engines = @()
+            }
+        }
+        return @{
+            available = $true
+            source = "windows_gpu_engine_counter"
+            reason = $null
+            engines = $engines
+        }
+    }
+    catch {
+        return @{
+            available = $false
+            source = "windows_gpu_engine_counter"
+            reason = [string]$_.Exception.Message
+            engines = @()
+        }
+    }
+}
+
+function Copy-Evidence(
+        [string]$Source,
+        [string]$DestinationName,
+        [System.Collections.ArrayList]$Included,
+        [System.Collections.ArrayList]$Missing,
+        [string]$CaptureRoot) {
+    if ([string]::IsNullOrWhiteSpace($Source) -or
+            -not [System.IO.File]::Exists($Source)) {
+        [void]$Missing.Add(@{ name = $DestinationName; source = $Source })
+        return
+    }
+    try {
+        Copy-Item -LiteralPath $Source -Destination (
+            Join-Path $CaptureRoot $DestinationName)
+        [void]$Included.Add(@{ name = $DestinationName; source = $Source })
+    }
+    catch {
+        [void]$Missing.Add(@{
+            name = $DestinationName
+            source = $Source
+            reason = [string]$_.Exception.Message
+        })
+    }
+}
+
+function New-ReportZip([string]$CaptureRoot, [string]$ZipPath) {
+    if ($null -ne (Get-Command Compress-Archive -ErrorAction SilentlyContinue)) {
+        Compress-Archive -Path (Join-Path $CaptureRoot "*") `
+            -DestinationPath $ZipPath -Force
+        return
+    }
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    [System.IO.Compression.ZipFile]::CreateFromDirectory(
+        $CaptureRoot, $ZipPath,
+        [System.IO.Compression.CompressionLevel]::Optimal, $false)
+}
+
+try {
+    $resolvedRoot = [System.IO.Path]::GetFullPath($GameRoot.Trim().Trim('"'))
+    if (-not [System.IO.File]::Exists((Join-Path $resolvedRoot "WorldOfTanks.exe"))) {
+        throw "WorldOfTanks.exe is missing from: $resolvedRoot"
+    }
+    $statusPath = Join-Path $resolvedRoot (
+        "mods\configs\offline_lan_0922\authority_worker_status.json")
+    $initialStatus = Read-WorkerStatus $statusPath
+    if ($null -eq $initialStatus) {
+        throw "A live authority_worker_status.json with a worker PID was not found. Start a battle first."
+    }
+    $workerPid = [int]$initialStatus.process_id
+    $heartbeatAge = Get-HeartbeatAge $initialStatus
+    if ($null -eq $heartbeatAge -or $heartbeatAge -lt -5 -or
+            $heartbeatAge -gt 10) {
+        throw "authority_worker_status.json is stale; start a live battle before collecting."
+    }
+    $initialProcess = Get-Process -Id $workerPid -ErrorAction SilentlyContinue
+    if ($null -eq $initialProcess -or
+            [string]$initialProcess.ProcessName -ne "WorldOfTanks") {
+        throw "The worker PID in authority_worker_status.json is not running: $workerPid"
+    }
+    $expectedProcessPath = [System.IO.Path]::GetFullPath(
+        (Join-Path $resolvedRoot "WorldOfTanks.exe"))
+    $observedProcessPath = $null
+    try {
+        $observedProcessPath = [string]$initialProcess.Path
+    }
+    catch {
+        # Some Windows process policies deny Path while still exposing PID and
+        # ProcessName. The exact name and fresh status remain mandatory.
+    }
+    if (-not [string]::IsNullOrWhiteSpace($observedProcessPath)) {
+        $observedProcessPath = [System.IO.Path]::GetFullPath(
+            $observedProcessPath)
+        if (-not [string]::Equals(
+                $expectedProcessPath, $observedProcessPath,
+                [System.StringComparison]::OrdinalIgnoreCase)) {
+            throw "The status PID belongs to a WorldOfTanks.exe in another game folder."
+        }
+    }
+
+    $resolvedOutput = [System.IO.Path]::GetFullPath($OutputRoot)
+    if (-not [System.IO.Directory]::Exists($resolvedOutput)) {
+        New-Item -ItemType Directory -Path $resolvedOutput -Force | Out-Null
+    }
+    $stamp = [DateTime]::UtcNow.ToString("yyyyMMddTHHmmssZ")
+    $captureBase = Join-Path $resolvedOutput ("hidden-worker-profile-" + $stamp)
+    $captureRoot = $captureBase
+    while ([System.IO.Directory]::Exists($captureRoot) -or
+            [System.IO.File]::Exists($captureRoot) -or
+            [System.IO.File]::Exists($captureRoot + ".zip")) {
+        $captureRoot = $captureBase + "-" + (
+            [Guid]::NewGuid().ToString("N").Substring(0, 8))
+    }
+    New-Item -ItemType Directory -Path $captureRoot | Out-Null
+    $samplesPath = Join-Path $captureRoot "process-and-status-samples.jsonl"
+    $startedUtc = [DateTime]::UtcNow
+    $deadline = $startedUtc.AddSeconds($Seconds)
+    $previousCpuSeconds = $null
+    $previousSampleUtc = $null
+    $lastStatus = $initialStatus
+    $sampleCount = 0
+    $collectionFailure = $null
+    while ([DateTime]::UtcNow -lt $deadline) {
+        $sampleStarted = [DateTime]::UtcNow
+        $status = Read-WorkerStatus $statusPath
+        if ($null -eq $status) {
+            $collectionFailure = "worker status became unreadable"
+            Add-JsonLine $samplesPath @{
+                schema = 1
+                sampledAtUtc = $sampleStarted.ToString("o")
+                workerPid = $workerPid
+                terminalFailure = $collectionFailure
+            }
+            break
+        }
+        if ([int]$status.process_id -ne $workerPid) {
+            $collectionFailure = "worker status changed PID"
+        }
+        else {
+            $currentHeartbeatAge = Get-HeartbeatAge $status
+            if ($null -eq $currentHeartbeatAge -or
+                    $currentHeartbeatAge -lt -5 -or
+                    $currentHeartbeatAge -gt 10) {
+                $collectionFailure = "worker status heartbeat became stale"
+            }
+        }
+        if ($null -ne $collectionFailure) {
+            Add-JsonLine $samplesPath @{
+                schema = 1
+                sampledAtUtc = $sampleStarted.ToString("o")
+                workerPid = $workerPid
+                terminalFailure = $collectionFailure
+                workerStatus = $status
+            }
+            break
+        }
+        $lastStatus = $status
+        $processRecord = @{
+            available = $false
+            source = "Get-Process"
+            cpuSeconds = $null
+            cpuCorePercent = $null
+            cpuMachinePercent = $null
+            logicalProcessors = [Environment]::ProcessorCount
+            workingSetBytes = $null
+            privateBytes = $null
+        }
+        $process = Get-Process -Id $workerPid -ErrorAction SilentlyContinue
+        if ($null -eq $process -or
+                [string]$process.ProcessName -ne "WorldOfTanks") {
+            $collectionFailure = "worker process exited or changed identity"
+        }
+        else {
+            $currentProcessPath = $null
+            try {
+                $currentProcessPath = [string]$process.Path
+            }
+            catch {
+            }
+            if (-not [string]::IsNullOrWhiteSpace($currentProcessPath) -and
+                    -not [string]::Equals(
+                        $expectedProcessPath,
+                        [System.IO.Path]::GetFullPath($currentProcessPath),
+                        [System.StringComparison]::OrdinalIgnoreCase)) {
+                $collectionFailure = "worker process changed game folder"
+            }
+            else {
+                $process.Refresh()
+                $cpuSeconds = [double]$process.TotalProcessorTime.TotalSeconds
+                $processRecord.available = $true
+                $processRecord.cpuSeconds = $cpuSeconds
+                $processRecord.workingSetBytes = [Int64]$process.WorkingSet64
+                $processRecord.privateBytes = [Int64]$process.PrivateMemorySize64
+                if ($null -ne $previousCpuSeconds -and $null -ne $previousSampleUtc) {
+                    $wallSeconds = ($sampleStarted - $previousSampleUtc).TotalSeconds
+                    if ($wallSeconds -gt 0 -and $cpuSeconds -ge $previousCpuSeconds) {
+                        $corePercent = 100.0 * (
+                            $cpuSeconds - $previousCpuSeconds) / $wallSeconds
+                        $processRecord.cpuCorePercent = $corePercent
+                        $processRecord.cpuMachinePercent = $corePercent / [Math]::Max(
+                            1, [Environment]::ProcessorCount)
+                    }
+                }
+                $previousCpuSeconds = $cpuSeconds
+                $previousSampleUtc = $sampleStarted
+            }
+        }
+        $gpuRecord = @{
+            available = $false
+            source = "windows_gpu_engine_counter"
+            reason = "worker process identity is unavailable"
+            engines = @()
+        }
+        if ($null -eq $collectionFailure) {
+            $gpuRecord = Read-GpuCounters $workerPid
+        }
+        Add-JsonLine $samplesPath @{
+            schema = 1
+            sampledAtUtc = $sampleStarted.ToString("o")
+            workerPid = $workerPid
+            process = $processRecord
+            gpu = $gpuRecord
+            workerStatus = $status
+            terminalFailure = $collectionFailure
+        }
+        $sampleCount += 1
+        if ($null -ne $collectionFailure) {
+            break
+        }
+        $remaining = $IntervalSeconds - (
+            [DateTime]::UtcNow - $sampleStarted).TotalSeconds
+        if ($remaining -gt 0) {
+            Start-Sleep -Milliseconds ([int]($remaining * 1000.0))
+        }
+    }
+
+    Write-JsonFile (Join-Path $captureRoot "authority_worker_status.json") $lastStatus
+    $included = New-Object System.Collections.ArrayList
+    $missing = New-Object System.Collections.ArrayList
+    Copy-Evidence (Join-Path $resolvedRoot "offline-worker-python.log") `
+        "hidden-worker.log" $included $missing $captureRoot
+    Copy-Evidence (Join-Path $resolvedRoot "offline-worker-starter.log") `
+        "hidden-worker-starter.log" $included $missing $captureRoot
+    Copy-Evidence (Join-Path $resolvedRoot "offline-player-python.log") `
+        "visible-client.log" $included $missing $captureRoot
+    Copy-Evidence (Join-Path $resolvedRoot (
+        "mods\configs\offline_lan_0922\hidden_worker_profiler_build.json")) `
+        "hidden_worker_profiler_build.json" $included $missing $captureRoot
+
+    $launcherRoot = $null
+    if (-not [string]::IsNullOrWhiteSpace($env:LOCALAPPDATA)) {
+        $launcherRoot = Join-Path $env:LOCALAPPDATA "WoTOfflineBattles"
+    }
+    $launcherLog = $null
+    $latestSessionPath = $null
+    if ($null -ne $launcherRoot) {
+        $launcherLog = Join-Path $launcherRoot "launcher.log"
+        $latestSessionPath = Join-Path $launcherRoot "latest-error-report-session.json"
+    }
+    Copy-Evidence $launcherLog "launcher.log" $included $missing $captureRoot
+    Copy-Evidence $latestSessionPath "latest-error-report-session.json" `
+        $included $missing $captureRoot
+    if ($null -ne $latestSessionPath -and [System.IO.File]::Exists($latestSessionPath)) {
+        try {
+            $session = Read-JsonFile $latestSessionPath
+            $sessionId = [string]$session.id
+            $sessionGameRoot = [System.IO.Path]::GetFullPath(
+                [string]$session.gameRoot)
+            if (-not [string]::Equals(
+                    $resolvedRoot, $sessionGameRoot,
+                    [System.StringComparison]::OrdinalIgnoreCase)) {
+                [void]$missing.Add(@{
+                    name = "server.log"
+                    source = $latestSessionPath
+                    reason = "latest launcher session belongs to another game root"
+                })
+            }
+            elseif ($sessionId -match "^[0-9]{8}T[0-9]{6}Z-[0-9a-f]{12}$") {
+                $sessionServerLog = Join-Path $launcherRoot (
+                    "session-logs\" + $sessionId + "\server.log")
+                Copy-Evidence $sessionServerLog "server.log" `
+                    $included $missing $captureRoot
+            }
+            else {
+                [void]$missing.Add(@{
+                    name = "server.log"
+                    source = $latestSessionPath
+                    reason = "latest launcher session id is unavailable"
+                })
+            }
+        }
+        catch {
+            [void]$missing.Add(@{
+                name = "server.log"
+                source = "latest-error-report-session.json"
+                reason = [string]$_.Exception.Message
+            })
+        }
+    }
+    else {
+        [void]$missing.Add(@{ name = "server.log"; source = $null })
+    }
+
+    Write-JsonFile (Join-Path $captureRoot "collection_manifest.json") @{
+        schema = 1
+        diagnostic = "hidden_worker_profiler_collection"
+        gameRoot = $resolvedRoot
+        workerPid = $workerPid
+        startedAtUtc = $startedUtc.ToString("o")
+        endedAtUtc = [DateTime]::UtcNow.ToString("o")
+        requestedSeconds = $Seconds
+        intervalSeconds = $IntervalSeconds
+        samples = $sampleCount
+        terminatedEarly = ($null -ne $collectionFailure)
+        terminalFailure = $collectionFailure
+        included = @($included)
+        missing = @($missing)
+        runtimeEvidence = @(
+            "authority_worker_status.json runtime.frame_performance",
+            "hidden-worker.log PERF and slow-frame lines"
+        )
+        gpuRule = "PID-scoped Windows GPU Engine counters only; unavailable is not estimated"
+    }
+    $zipPath = $captureRoot + ".zip"
+    New-ReportZip $captureRoot $zipPath
+    Write-Host "Collected hidden-worker profile: $zipPath"
+    Write-Host "Review the report before sharing it; logs can contain local paths and session addresses."
+    if ($null -ne $collectionFailure) {
+        [Console]::Error.WriteLine("Collection stopped early: $collectionFailure")
+        exit 2
+    }
+    exit 0
+}
+catch {
+    [Console]::Error.WriteLine([string]$_.Exception.Message)
+    exit 1
+}

--- a/0.9.22/tools/collect_hidden_worker_profile.ps1
+++ b/0.9.22/tools/collect_hidden_worker_profile.ps1
@@ -1,7 +1,6 @@
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory = $true)]
-    [string]$GameRoot,
+    [string]$GameRoot = $env:WOT_HIDDEN_WORKER_PROFILER_GAME_ROOT,
 
     [ValidateRange(5, 3600)]
     [int]$Seconds = 60,
@@ -9,7 +8,7 @@ param(
     [ValidateRange(1, 30)]
     [int]$IntervalSeconds = 2,
 
-    [string]$OutputRoot = $PSScriptRoot
+    [string]$OutputRoot = $env:WOT_HIDDEN_WORKER_PROFILER_OUTPUT_ROOT
 )
 
 $ErrorActionPreference = "Stop"
@@ -142,9 +141,21 @@ function New-ReportZip([string]$CaptureRoot, [string]$ZipPath) {
         [System.IO.Compression.CompressionLevel]::Optimal, $false)
 }
 
+function Resolve-FullPath([string]$Value, [string]$Label) {
+    if ([string]::IsNullOrWhiteSpace($Value)) {
+        throw "$Label path is empty."
+    }
+    $candidate = $Value.Trim().Trim([char]34)
+    try {
+        return [System.IO.Path]::GetFullPath($candidate)
+    }
+    catch {
+        throw "$Label path is invalid: $candidate"
+    }
+}
+
 try {
-    $resolvedRoot = [System.IO.Path]::GetFullPath(
-        $GameRoot.Trim().Trim([char]34))
+    $resolvedRoot = Resolve-FullPath $GameRoot "Game folder"
     if (-not [System.IO.File]::Exists((Join-Path $resolvedRoot "WorldOfTanks.exe"))) {
         throw "WorldOfTanks.exe is missing from: $resolvedRoot"
     }
@@ -185,8 +196,7 @@ try {
         }
     }
 
-    $resolvedOutput = [System.IO.Path]::GetFullPath(
-        $OutputRoot.Trim().Trim([char]34))
+    $resolvedOutput = Resolve-FullPath $OutputRoot "Report folder"
     if (-not [System.IO.Directory]::Exists($resolvedOutput)) {
         New-Item -ItemType Directory -Path $resolvedOutput -Force | Out-Null
     }

--- a/0.9.22/tools/collect_hidden_worker_profile.ps1
+++ b/0.9.22/tools/collect_hidden_worker_profile.ps1
@@ -3,7 +3,7 @@ param(
     [string]$GameRoot = $env:WOT_HIDDEN_WORKER_PROFILER_GAME_ROOT,
 
     [ValidateRange(5, 3600)]
-    [int]$Seconds = 60,
+    [int]$Seconds = 90,
 
     [ValidateRange(1, 30)]
     [int]$IntervalSeconds = 2,
@@ -414,8 +414,8 @@ try {
         included = @($included)
         missing = @($missing)
         runtimeEvidence = @(
-            "authority_worker_status.json runtime.frame_performance",
-            "hidden-worker.log PERF and slow-frame lines"
+            "authority_worker_status.json runtime.frame_performance with detailed phase timings and work counters",
+            "hidden-worker.log PERF and slow-frame lines with native-query and Python phase summaries"
         )
         gpuRule = "PID-scoped Windows GPU Engine counters only; unavailable is not estimated"
     }

--- a/0.9.22/tools/hidden_worker_profiler_package.ps1
+++ b/0.9.22/tools/hidden_worker_profiler_package.ps1
@@ -4,8 +4,7 @@ param(
     [ValidateSet("Install", "Uninstall")]
     [string]$Action,
 
-    [Parameter(Mandatory = $true)]
-    [string]$GameRoot
+    [string]$GameRoot = $env:WOT_HIDDEN_WORKER_PROFILER_GAME_ROOT
 )
 
 $ErrorActionPreference = "Stop"

--- a/0.9.22/tools/hidden_worker_profiler_package.ps1
+++ b/0.9.22/tools/hidden_worker_profiler_package.ps1
@@ -1,0 +1,286 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("Install", "Uninstall")]
+    [string]$Action,
+
+    [Parameter(Mandatory = $true)]
+    [string]$GameRoot
+)
+
+$ErrorActionPreference = "Stop"
+$ModPattern = "org.peng.offline_lan_0922*.wotmod"
+$DiagnosticMarkerName = "hidden_worker_profiler_build.json"
+$BackupDirectoryName = ".offline-hidden-worker-profiler-backup"
+$BackupManifestName = "backup_manifest.json"
+
+function Get-Sha256([string]$Path) {
+    $algorithm = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $stream = [System.IO.File]::OpenRead($Path)
+        try {
+            return ([System.BitConverter]::ToString(
+                $algorithm.ComputeHash($stream))).Replace("-", "").ToLowerInvariant()
+        }
+        finally {
+            $stream.Dispose()
+        }
+    }
+    finally {
+        $algorithm.Dispose()
+    }
+}
+
+function Read-JsonFile([string]$Path) {
+    return Get-Content -LiteralPath $Path -Raw -Encoding UTF8 | ConvertFrom-Json
+}
+
+function Assert-ExactClient([string]$Root) {
+    if (-not [System.IO.File]::Exists((Join-Path $Root "WorldOfTanks.exe"))) {
+        throw "WorldOfTanks.exe is missing from: $Root"
+    }
+    $versionPath = Join-Path $Root "version.xml"
+    if (-not [System.IO.File]::Exists($versionPath)) {
+        throw "version.xml is missing from: $Root"
+    }
+    $version = Get-Content -LiteralPath $versionPath -Raw
+    if ($version -notmatch "0\.9\.22\.0\.1" -or $version -notmatch "#1513") {
+        throw "This diagnostic package supports only 0.9.22.0.1 #1513."
+    }
+    if (@(Get-Process -Name "WorldOfTanks" -ErrorAction SilentlyContinue).Count -ne 0 -or
+            @(Get-Process -Name "WoT-Offline-Battles-Launcher" -ErrorAction SilentlyContinue).Count -ne 0) {
+        throw "Close the launcher, every visible client and hidden worker before changing the mod."
+    }
+}
+
+function Read-DiagnosticMarker([string]$Path) {
+    $marker = Read-JsonFile $Path
+    if ($marker.schema -ne 1 -or
+            $marker.diagnostic -ne "hidden_worker_profiler" -or
+            $marker.baseModId -ne "org.peng.offline_lan_0922" -or
+            $marker.baseSemanticVersion -ne "0.6.2" -or
+            [string]::IsNullOrWhiteSpace([string]$marker.diagnosticBuildIdentity) -or
+            [string]$marker.packageFile -ne
+                "org.peng.offline_lan_0922_0.6.2.wotmod" -or
+            [string]$marker.packageSha256 -notmatch "^[0-9a-f]{64}$") {
+        throw "The hidden-worker profiler build marker is invalid."
+    }
+    return $marker
+}
+
+function Install-Profiler(
+        [string]$Root,
+        [string]$ModDirectory,
+        [string]$MarkerPath,
+        [string]$BackupRoot) {
+    if ([System.IO.Directory]::Exists($BackupRoot) -or
+            [System.IO.File]::Exists($BackupRoot)) {
+        throw "A profiler backup already exists. Uninstall it before installing another build: $BackupRoot"
+    }
+
+    $sourceMarkerPath = Join-Path $PSScriptRoot $DiagnosticMarkerName
+    $marker = Read-DiagnosticMarker $sourceMarkerPath
+    $sourcePackage = Join-Path (
+        Join-Path (Join-Path $PSScriptRoot "payload") "mods\0.9.22.0.1") (
+        [string]$marker.packageFile)
+    if (-not [System.IO.File]::Exists($sourcePackage)) {
+        throw "The diagnostic WOTMOD is missing: $sourcePackage"
+    }
+    if ((Get-Sha256 $sourcePackage) -ne [string]$marker.packageSha256) {
+        throw "The diagnostic WOTMOD does not match its build marker."
+    }
+
+    $packages = @()
+    if ([System.IO.Directory]::Exists($ModDirectory)) {
+        $packages = @(Get-ChildItem -LiteralPath $ModDirectory -Filter $ModPattern -File)
+    }
+    if ($packages.Count -ne 1 -or $packages[0].Name -ne
+            "org.peng.offline_lan_0922_0.6.2.wotmod") {
+        throw "Expected exactly one v0.6.2 org.peng.offline_lan_0922 WOTMOD. Install or repair v0.6.2 with the launcher first."
+    }
+
+    $backupPackages = Join-Path $BackupRoot "packages"
+    New-Item -ItemType Directory -Path $backupPackages -Force | Out-Null
+    $hadMarker = [System.IO.File]::Exists($MarkerPath)
+    $backupMarker = Join-Path $BackupRoot "previous_diagnostic_marker.json"
+    $movedPackages = @()
+    $installedPackage = Join-Path $ModDirectory ([string]$marker.packageFile)
+    $packageTemporary = Join-Path $ModDirectory (
+        ".hidden-worker-profiler-" + [Guid]::NewGuid().ToString("N") + ".tmp")
+    $markerDirectory = Split-Path -Parent $MarkerPath
+    $markerTemporary = Join-Path $markerDirectory (
+        ".hidden-worker-profiler-marker-" + [Guid]::NewGuid().ToString("N") + ".tmp")
+    $markerBackedUp = $false
+    $diagnosticPackageInstalled = $false
+    $diagnosticMarkerInstalled = $false
+    try {
+        foreach ($package in $packages) {
+            $backup = Join-Path $backupPackages $package.Name
+            Move-Item -LiteralPath $package.FullName -Destination $backup
+            $movedPackages += $backup
+        }
+        if ($hadMarker) {
+            Move-Item -LiteralPath $MarkerPath -Destination $backupMarker
+            $markerBackedUp = $true
+        }
+        if (-not [System.IO.Directory]::Exists($ModDirectory)) {
+            New-Item -ItemType Directory -Path $ModDirectory -Force | Out-Null
+        }
+        if (-not [System.IO.Directory]::Exists($markerDirectory)) {
+            New-Item -ItemType Directory -Path $markerDirectory -Force | Out-Null
+        }
+        Copy-Item -LiteralPath $sourcePackage -Destination $packageTemporary
+        Move-Item -LiteralPath $packageTemporary -Destination $installedPackage
+        $diagnosticPackageInstalled = $true
+        Copy-Item -LiteralPath $sourceMarkerPath -Destination $markerTemporary
+        Move-Item -LiteralPath $markerTemporary -Destination $MarkerPath
+        $diagnosticMarkerInstalled = $true
+        @{
+            schema = 1
+            diagnosticBuildIdentity = [string]$marker.diagnosticBuildIdentity
+            packageFile = [string]$marker.packageFile
+            packageSha256 = [string]$marker.packageSha256
+            previousPackages = @($packages | ForEach-Object { $_.Name })
+            previousDiagnosticMarker = $hadMarker
+        } | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath (
+            Join-Path $BackupRoot $BackupManifestName) -Encoding UTF8
+    }
+    catch {
+        Remove-Item -LiteralPath $packageTemporary -Force -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath $markerTemporary -Force -ErrorAction SilentlyContinue
+        if ($diagnosticPackageInstalled) {
+            Remove-Item -LiteralPath $installedPackage -Force -ErrorAction SilentlyContinue
+        }
+        if ($diagnosticMarkerInstalled) {
+            Remove-Item -LiteralPath $MarkerPath -Force -ErrorAction SilentlyContinue
+        }
+        foreach ($backup in $movedPackages) {
+            if ([System.IO.File]::Exists($backup)) {
+                Move-Item -LiteralPath $backup -Destination (
+                    Join-Path $ModDirectory (Split-Path -Leaf $backup))
+            }
+        }
+        if ($markerBackedUp -and [System.IO.File]::Exists($backupMarker)) {
+            Move-Item -LiteralPath $backupMarker -Destination $MarkerPath
+        }
+        Remove-Item -LiteralPath $BackupRoot -Recurse -Force -ErrorAction SilentlyContinue
+        throw
+    }
+    Write-Host "Installed hidden-worker profiler build $($marker.diagnosticBuildIdentity)."
+    Write-Host "Backup: $BackupRoot"
+}
+
+function Uninstall-Profiler(
+        [string]$Root,
+        [string]$ModDirectory,
+        [string]$MarkerPath,
+        [string]$BackupRoot) {
+    $backupManifestPath = Join-Path $BackupRoot $BackupManifestName
+    if (-not [System.IO.File]::Exists($backupManifestPath)) {
+        throw "No complete hidden-worker profiler backup was found: $BackupRoot"
+    }
+    $backup = Read-JsonFile $backupManifestPath
+    if ($backup.schema -ne 1 -or
+            [string]$backup.packageFile -ne
+                "org.peng.offline_lan_0922_0.6.2.wotmod" -or
+            [string]$backup.packageSha256 -notmatch "^[0-9a-f]{64}$") {
+        throw "The hidden-worker profiler backup manifest is invalid."
+    }
+    $installedPackage = Join-Path $ModDirectory ([string]$backup.packageFile)
+    if ([System.IO.File]::Exists($installedPackage) -and
+            (Get-Sha256 $installedPackage) -ne [string]$backup.packageSha256) {
+        throw "The installed WOTMOD changed after profiling. Recovery files were preserved."
+    }
+    $otherPackages = @()
+    if ([System.IO.Directory]::Exists($ModDirectory)) {
+        $otherPackages = @(Get-ChildItem -LiteralPath $ModDirectory -Filter $ModPattern -File |
+            Where-Object { $_.FullName -ne $installedPackage })
+    }
+    if ($otherPackages.Count -ne 0) {
+        throw "Another org.peng.offline_lan_0922 WOTMOD appeared after install. Recovery files were preserved."
+    }
+    if ([System.IO.File]::Exists($MarkerPath)) {
+        $installedMarker = Read-DiagnosticMarker $MarkerPath
+        if ([string]$installedMarker.diagnosticBuildIdentity -ne
+                [string]$backup.diagnosticBuildIdentity -or
+                [string]$installedMarker.packageSha256 -ne
+                [string]$backup.packageSha256) {
+            throw "The diagnostic marker changed after install. Recovery files were preserved."
+        }
+    }
+
+    $savedCurrent = Join-Path $BackupRoot "installed_diagnostic.wotmod"
+    $savedMarker = Join-Path $BackupRoot "installed_diagnostic_marker.json"
+    if ([System.IO.File]::Exists($savedCurrent) -or
+            [System.IO.File]::Exists($savedMarker)) {
+        throw "An earlier uninstall did not finish cleanly. Recovery files were preserved."
+    }
+    $restoredPackages = @()
+    try {
+        if ([System.IO.File]::Exists($installedPackage)) {
+            Move-Item -LiteralPath $installedPackage -Destination $savedCurrent
+        }
+        if ([System.IO.File]::Exists($MarkerPath)) {
+            Move-Item -LiteralPath $MarkerPath -Destination $savedMarker
+        }
+        foreach ($name in @($backup.previousPackages)) {
+            $leaf = [System.IO.Path]::GetFileName([string]$name)
+            if ($leaf -ne [string]$name -or $leaf -notlike $ModPattern) {
+                throw "The profiler backup contains an invalid package name."
+            }
+            $source = Join-Path (Join-Path $BackupRoot "packages") $leaf
+            if (-not [System.IO.File]::Exists($source)) {
+                throw "The profiler backup is incomplete: $leaf"
+            }
+            $target = Join-Path $ModDirectory $leaf
+            Move-Item -LiteralPath $source -Destination $target
+            $restoredPackages += $target
+        }
+        if ([bool]$backup.previousDiagnosticMarker) {
+            $previousMarker = Join-Path $BackupRoot "previous_diagnostic_marker.json"
+            if (-not [System.IO.File]::Exists($previousMarker)) {
+                throw "The previous diagnostic marker backup is missing."
+            }
+            Move-Item -LiteralPath $previousMarker -Destination $MarkerPath
+        }
+    }
+    catch {
+        foreach ($target in $restoredPackages) {
+            if ([System.IO.File]::Exists($target)) {
+                Move-Item -LiteralPath $target -Destination (
+                    Join-Path (Join-Path $BackupRoot "packages") (
+                        Split-Path -Leaf $target))
+            }
+        }
+        if ([System.IO.File]::Exists($savedCurrent)) {
+            Move-Item -LiteralPath $savedCurrent -Destination $installedPackage
+        }
+        if ([System.IO.File]::Exists($savedMarker)) {
+            Move-Item -LiteralPath $savedMarker -Destination $MarkerPath
+        }
+        throw
+    }
+    Remove-Item -LiteralPath $BackupRoot -Recurse -Force
+    Write-Host "Removed hidden-worker profiler build $($backup.diagnosticBuildIdentity)."
+    Write-Host "Restored $($restoredPackages.Count) previous WOTMOD file(s)."
+}
+
+try {
+    $resolvedRoot = [System.IO.Path]::GetFullPath($GameRoot.Trim().Trim('"'))
+    Assert-ExactClient $resolvedRoot
+    $modDirectory = Join-Path $resolvedRoot "mods\0.9.22.0.1"
+    $markerPath = Join-Path $resolvedRoot (
+        "mods\configs\offline_lan_0922\" + $DiagnosticMarkerName)
+    $backupRoot = Join-Path $resolvedRoot $BackupDirectoryName
+    if ($Action -eq "Install") {
+        Install-Profiler $resolvedRoot $modDirectory $markerPath $backupRoot
+    }
+    else {
+        Uninstall-Profiler $resolvedRoot $modDirectory $markerPath $backupRoot
+    }
+    exit 0
+}
+catch {
+    [Console]::Error.WriteLine([string]$_.Exception.Message)
+    exit 1
+}

--- a/0.9.22/tools/hidden_worker_profiler_package.ps1
+++ b/0.9.22/tools/hidden_worker_profiler_package.ps1
@@ -266,7 +266,8 @@ function Uninstall-Profiler(
 }
 
 try {
-    $resolvedRoot = [System.IO.Path]::GetFullPath($GameRoot.Trim().Trim('"'))
+    $resolvedRoot = [System.IO.Path]::GetFullPath(
+        $GameRoot.Trim().Trim([char]34))
     Assert-ExactClient $resolvedRoot
     $modDirectory = Join-Path $resolvedRoot "mods\0.9.22.0.1"
     $markerPath = Join-Path $resolvedRoot (

--- a/0.9.22/tools/hidden_worker_profiler_package.ps1
+++ b/0.9.22/tools/hidden_worker_profiler_package.ps1
@@ -67,16 +67,145 @@ function Read-DiagnosticMarker([string]$Path) {
     return $marker
 }
 
+function Update-Profiler(
+        [string]$ModDirectory,
+        [string]$MarkerPath,
+        [string]$BackupRoot,
+        [string]$SourceMarkerPath,
+        [string]$SourcePackage,
+        $Marker) {
+    $backupManifestPath = Join-Path $BackupRoot $BackupManifestName
+    if (-not [System.IO.File]::Exists($backupManifestPath)) {
+        throw "The existing profiler backup is incomplete: $BackupRoot"
+    }
+    $backup = Read-JsonFile $backupManifestPath
+    if ($backup.schema -ne 1 -or
+            [string]$backup.packageFile -ne
+                "org.peng.offline_lan_0922_0.6.2.wotmod" -or
+            [string]$backup.packageSha256 -notmatch "^[0-9a-f]{64}$" -or
+            [string]::IsNullOrWhiteSpace(
+                [string]$backup.diagnosticBuildIdentity)) {
+        throw "The existing profiler backup manifest is invalid."
+    }
+
+    $installedPackage = Join-Path $ModDirectory ([string]$backup.packageFile)
+    if (-not [System.IO.File]::Exists($installedPackage) -or
+            (Get-Sha256 $installedPackage) -ne
+                [string]$backup.packageSha256) {
+        throw "The installed profiler changed after its backup was created. Recovery files were preserved."
+    }
+    if (-not [System.IO.File]::Exists($MarkerPath)) {
+        throw "The installed profiler marker is missing. Recovery files were preserved."
+    }
+    $installedMarker = Read-DiagnosticMarker $MarkerPath
+    if ([string]$installedMarker.diagnosticBuildIdentity -ne
+            [string]$backup.diagnosticBuildIdentity -or
+            [string]$installedMarker.packageSha256 -ne
+            [string]$backup.packageSha256) {
+        throw "The installed profiler does not match its backup. Recovery files were preserved."
+    }
+    foreach ($name in @($backup.previousPackages)) {
+        $leaf = [System.IO.Path]::GetFileName([string]$name)
+        if ($leaf -ne [string]$name -or $leaf -notlike $ModPattern -or
+                -not [System.IO.File]::Exists((Join-Path (
+                    Join-Path $BackupRoot "packages") $leaf))) {
+            throw "The original launcher WOTMOD backup is incomplete. Recovery files were preserved."
+        }
+    }
+    if ([bool]$backup.previousDiagnosticMarker -and
+            -not [System.IO.File]::Exists((Join-Path $BackupRoot (
+                "previous_diagnostic_marker.json")))) {
+        throw "The original diagnostic marker backup is incomplete. Recovery files were preserved."
+    }
+
+    if ([string]$installedMarker.diagnosticBuildIdentity -eq
+            [string]$Marker.diagnosticBuildIdentity -and
+            [string]$installedMarker.packageSha256 -eq
+            [string]$Marker.packageSha256) {
+        Write-Host "Hidden-worker profiler build $($Marker.diagnosticBuildIdentity) is already installed."
+        return
+    }
+
+    $suffix = [Guid]::NewGuid().ToString("N")
+    $markerDirectory = Split-Path -Parent $MarkerPath
+    $newPackageTemporary = Join-Path $ModDirectory (
+        ".hidden-worker-profiler-new-$suffix.tmp")
+    $newMarkerTemporary = Join-Path $markerDirectory (
+        ".hidden-worker-profiler-marker-new-$suffix.tmp")
+    $newManifestTemporary = Join-Path $BackupRoot (
+        ".backup-manifest-new-$suffix.tmp")
+    $oldPackageTemporary = Join-Path $BackupRoot (
+        ".installed-profiler-old-$suffix.wotmod")
+    $oldMarkerTemporary = Join-Path $BackupRoot (
+        ".installed-profiler-marker-old-$suffix.json")
+    $oldManifestTemporary = Join-Path $BackupRoot (
+        ".backup-manifest-old-$suffix.json")
+
+    Copy-Item -LiteralPath $SourcePackage -Destination $newPackageTemporary
+    Copy-Item -LiteralPath $SourceMarkerPath -Destination $newMarkerTemporary
+    @{
+        schema = 1
+        diagnosticBuildIdentity = [string]$Marker.diagnosticBuildIdentity
+        packageFile = [string]$Marker.packageFile
+        packageSha256 = [string]$Marker.packageSha256
+        previousPackages = @($backup.previousPackages)
+        previousDiagnosticMarker = [bool]$backup.previousDiagnosticMarker
+    } | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath (
+        $newManifestTemporary) -Encoding UTF8
+
+    try {
+        Move-Item -LiteralPath $installedPackage -Destination (
+            $oldPackageTemporary)
+        Move-Item -LiteralPath $MarkerPath -Destination $oldMarkerTemporary
+        Move-Item -LiteralPath $backupManifestPath -Destination (
+            $oldManifestTemporary)
+        Move-Item -LiteralPath $newPackageTemporary -Destination (
+            $installedPackage)
+        Move-Item -LiteralPath $newMarkerTemporary -Destination $MarkerPath
+        Move-Item -LiteralPath $newManifestTemporary -Destination (
+            $backupManifestPath)
+    }
+    catch {
+        if ([System.IO.File]::Exists($oldPackageTemporary)) {
+            Remove-Item -LiteralPath $installedPackage -Force `
+                -ErrorAction SilentlyContinue
+            Move-Item -LiteralPath $oldPackageTemporary -Destination (
+                $installedPackage)
+        }
+        if ([System.IO.File]::Exists($oldMarkerTemporary)) {
+            Remove-Item -LiteralPath $MarkerPath -Force `
+                -ErrorAction SilentlyContinue
+            Move-Item -LiteralPath $oldMarkerTemporary -Destination $MarkerPath
+        }
+        if ([System.IO.File]::Exists($oldManifestTemporary)) {
+            Remove-Item -LiteralPath $backupManifestPath -Force `
+                -ErrorAction SilentlyContinue
+            Move-Item -LiteralPath $oldManifestTemporary -Destination (
+                $backupManifestPath)
+        }
+        Remove-Item -LiteralPath $newPackageTemporary -Force `
+            -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath $newMarkerTemporary -Force `
+            -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath $newManifestTemporary -Force `
+            -ErrorAction SilentlyContinue
+        throw
+    }
+    Remove-Item -LiteralPath $oldPackageTemporary -Force `
+        -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $oldMarkerTemporary -Force `
+        -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $oldManifestTemporary -Force `
+        -ErrorAction SilentlyContinue
+    Write-Host "Updated hidden-worker profiler to build $($Marker.diagnosticBuildIdentity)."
+    Write-Host "Original launcher WOTMOD backup remains at: $BackupRoot"
+}
+
 function Install-Profiler(
         [string]$Root,
         [string]$ModDirectory,
         [string]$MarkerPath,
         [string]$BackupRoot) {
-    if ([System.IO.Directory]::Exists($BackupRoot) -or
-            [System.IO.File]::Exists($BackupRoot)) {
-        throw "A profiler backup already exists. Uninstall it before installing another build: $BackupRoot"
-    }
-
     $sourceMarkerPath = Join-Path $PSScriptRoot $DiagnosticMarkerName
     $marker = Read-DiagnosticMarker $sourceMarkerPath
     $sourcePackage = Join-Path (
@@ -96,6 +225,15 @@ function Install-Profiler(
     if ($packages.Count -ne 1 -or $packages[0].Name -ne
             "org.peng.offline_lan_0922_0.6.2.wotmod") {
         throw "Expected exactly one v0.6.2 org.peng.offline_lan_0922 WOTMOD. Install or repair v0.6.2 with the launcher first."
+    }
+
+    if ([System.IO.Directory]::Exists($BackupRoot)) {
+        Update-Profiler $ModDirectory $MarkerPath $BackupRoot `
+            $sourceMarkerPath $sourcePackage $marker
+        return
+    }
+    if ([System.IO.File]::Exists($BackupRoot)) {
+        throw "The profiler backup path is occupied by a file: $BackupRoot"
     }
 
     $backupPackages = Join-Path $BackupRoot "packages"

--- a/0.9.22/tools/validate_hidden_worker_profiler_zip.py
+++ b/0.9.22/tools/validate_hidden_worker_profiler_zip.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+
+"""Validate the exact contents of a hidden-worker profiler delta ZIP."""
+
+import argparse
+from collections import Counter
+import hashlib
+import json
+from pathlib import Path
+import re
+import sys
+import tempfile
+import zipfile
+
+
+TOOLS_ROOT = Path(__file__).resolve().parent
+PORT_ROOT = TOOLS_ROOT.parent
+sys.path.insert(0, str(TOOLS_ROOT))
+import validate_wotmod
+
+
+MOD_ID = 'org.peng.offline_lan_0922'
+MOD_VERSION = '0.6.2'
+MARKER_FILENAME = 'hidden_worker_profiler_build.json'
+PACKAGE_MEMBER = (
+    'payload/mods/0.9.22.0.1/' + MOD_ID + '_' + MOD_VERSION + '.wotmod')
+REQUIRED_FILES = {
+    'INSTALL_HIDDEN_WORKER_PROFILER.bat',
+    'UNINSTALL_HIDDEN_WORKER_PROFILER.bat',
+    'COLLECT_HIDDEN_WORKER_PROFILE.bat',
+    'hidden_worker_profiler_package.ps1',
+    'collect_hidden_worker_profile.ps1',
+    'INSTALL_HIDDEN_WORKER_PROFILER.txt',
+    MARKER_FILENAME,
+    PACKAGE_MEMBER,
+    'LICENSE',
+    'THIRD_PARTY_NOTICES.md',
+    'licenses/Boost-1.0.txt',
+}
+FORBIDDEN_STATE_FILES = {
+    'server_endpoint.json', 'account_state.json', 'garage_state.json',
+    'postbattle_state.json', 'waiting_room_state.json', 'config.json',
+    'build_identity.json', 'launcher_install.json',
+}
+IDENTITY_PATTERN = re.compile(r'^[A-Za-z0-9][A-Za-z0-9._-]{0,95}$')
+
+
+def _file_members(archive):
+    return {info.filename for info in archive.infolist()
+            if not info.filename.endswith('/')}
+
+
+def _expected_directories(files):
+    directories = set()
+    for name in files:
+        parts = name.split('/')[:-1]
+        for index in range(1, len(parts) + 1):
+            directories.add('/'.join(parts[:index]) + '/')
+    return directories
+
+
+def validate(path, expected_pyc_members=None):
+    path = Path(path)
+    with zipfile.ZipFile(str(path), 'r') as archive:
+        member_names = archive.namelist()
+        duplicates = sorted(
+            name for name, count in Counter(member_names).items()
+            if count != 1)
+        if duplicates:
+            raise ValueError('duplicate archive members: %s' % duplicates)
+        for info in archive.infolist():
+            name = info.filename
+            parts = name.rstrip('/').split('/')
+            if (not name or '\\' in name or
+                    any(not part or part in ('.', '..') for part in parts)):
+                raise ValueError('diagnostic ZIP contains an invalid path')
+            if info.compress_type != zipfile.ZIP_STORED:
+                raise ValueError(
+                    'diagnostic ZIP member is not stored: %s' % name)
+        corrupt_member = archive.testzip()
+        if corrupt_member is not None:
+            raise ValueError('archive CRC failed: %s' % corrupt_member)
+        files = _file_members(archive)
+        if files != REQUIRED_FILES:
+            raise ValueError(
+                'diagnostic member manifest mismatch: missing=%s extra=%s' %
+                (sorted(REQUIRED_FILES - files),
+                 sorted(files - REQUIRED_FILES)))
+        directories = {
+            info.filename for info in archive.infolist()
+            if info.filename.endswith('/')}
+        if directories != _expected_directories(REQUIRED_FILES):
+            raise ValueError('diagnostic directory manifest mismatch')
+        forbidden = sorted(
+            name for name in files
+            if Path(name).name.lower() in FORBIDDEN_STATE_FILES)
+        if forbidden:
+            raise ValueError(
+                'diagnostic ZIP contains user/package state: %s' % forbidden)
+        marker = json.loads(archive.read(MARKER_FILENAME).decode('utf-8'))
+        package_payload = archive.read(PACKAGE_MEMBER)
+
+    required_marker = {
+        'schema', 'diagnostic', 'diagnosticBuildIdentity', 'baseModId',
+        'baseSemanticVersion', 'packageFile', 'packageSha256',
+        'sourceRevision', 'sourceDirty',
+    }
+    if (not isinstance(marker, dict) or set(marker) != required_marker or
+            marker.get('schema') != 1 or
+            marker.get('diagnostic') != 'hidden_worker_profiler' or
+            marker.get('baseModId') != MOD_ID or
+            marker.get('baseSemanticVersion') != MOD_VERSION or
+            marker.get('packageFile') != Path(PACKAGE_MEMBER).name or
+            not isinstance(marker.get('sourceDirty'), bool) or
+            IDENTITY_PATTERN.fullmatch(
+                str(marker.get('diagnosticBuildIdentity') or '')) is None or
+            re.fullmatch(r'(?:[0-9a-f]{40}|unknown)',
+                         str(marker.get('sourceRevision') or '')) is None or
+            re.fullmatch(r'[0-9a-f]{64}',
+                         str(marker.get('packageSha256') or '')) is None):
+        raise ValueError('diagnostic build marker is invalid')
+    actual_digest = hashlib.sha256(package_payload).hexdigest()
+    if actual_digest != marker['packageSha256']:
+        raise ValueError('diagnostic WOTMOD checksum mismatch')
+
+    handle = tempfile.NamedTemporaryFile(suffix='.wotmod', delete=False)
+    temporary = Path(handle.name)
+    try:
+        handle.write(package_payload)
+        handle.close()
+        validate_wotmod.validate(
+            temporary, expected_members=expected_pyc_members)
+    finally:
+        try:
+            handle.close()
+        except Exception:
+            pass
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+    return marker
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('archive')
+    arguments = parser.parse_args(argv)
+    try:
+        marker = validate(arguments.archive)
+    except (OSError, ValueError, zipfile.BadZipFile) as error:
+        parser.error(str(error))
+    print('validated hidden-worker profiler build %s' %
+          marker['diagnosticBuildIdentity'])
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/launcher/tests/test_launcher_core.py
+++ b/launcher/tests/test_launcher_core.py
@@ -1217,6 +1217,19 @@ class ClientInstallTest(unittest.TestCase):
         }, core.installed_payload_identity(
             self.game, core.PORT_0_9_22))
 
+    def test_same_build_identity_keeps_a_diagnostic_wotmod_replacement(self):
+        package = (
+            "mods/0.9.22.0.1/org.peng.offline_lan_0922_9.9.9.wotmod")
+        self._stage_0_9_22(content="bundled", build_identity="test-build-a")
+        core.install_client_mod(self.game, core.PORT_0_9_22, self.payload)
+        self._write(self.game, package, "diagnostic replacement")
+
+        actions = core.install_client_mod(
+            self.game, core.PORT_0_9_22, self.payload)
+
+        self.assertEqual("diagnostic replacement", self._read(package))
+        self.assertIn("Install decision: keep", " ".join(actions))
+
     def test_a_missing_required_file_forces_a_reinstall(self):
         self._stage_0_9_22()
         core.install_client_mod(self.game, core.PORT_0_9_22, self.payload)


### PR DESCRIPTION
## Summary

- instrument reviewed hidden-worker native query boundaries and Python hot sections
- correlate bounded query samples with render-frame and slow-frame diagnostics
- alternate 30 seconds of full timing with a 5-second wrapper-only observational baseline
- add a reversible standalone v0.6.2 diagnostic WOTMOD installer and report collector

## Measured fields

- render callback FPS and frame-time percentiles
- BattleRuntime callback/stage time and outside-callback time
- raw native calls, time, failures, per-frame maxima, and off-frame work
- spotting, firing-lane, movement receipt/direction/commit, ground/water, projectiles, vehicle collision, foliage, and destructible categories
- queue/control/A* metrics plus hidden-worker CPU, GPU-counter availability, and working/private set

## Validation

- 0.9.22 unittest discovery: 2,969 passed
- launcher unittest discovery: 494 passed, 2 skipped
- 0.8.2 regression discovery: 904 passed
- CPython 2.7 compilation: 89 client files
- standalone profiler package validation passed

## Remaining evidence

PowerShell execution and the actual #1513 FPS/query/CPU/GPU results still require a sustained Windows 15-vs-15 run with two visible clients. The before/after installed-product comparison is not an isolated profiler-overhead measurement when the installed launcher predates this main revision.
