### PR TITLE
Fix reload transactions during shell changes

### DIFF
--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -3190,6 +3190,11 @@ class BattleRuntime(object):
     def _begin_battle(self):
         if self._battle_live:
             return False
+        # Close the final prebattle interval while reload progression is still
+        # frozen.  Otherwise the first live ammo callback charges that old gap
+        # to the opening reload cycle.
+        if self._gun_state is not None:
+            self._advance_local_gun_edge(self._gun_state)
         duration = self._battle_seconds()
         deadline = getattr(self.client, 'combat_end_deadline', None)
         if deadline is not None:
@@ -6383,6 +6388,42 @@ class BattleRuntime(object):
         state.reload_time = next_duration * remaining_fraction
         return True
 
+    def _advance_local_gun_edge(self, state, now=None):
+        """Close the old gun timeline before one synchronous state mutation.
+
+        ``send_current`` advances again when it freezes the outgoing
+        checkpoint.  That remains necessary for ordinary movement and aiming
+        inputs, but it is too late for a caller which has already started a
+        new reload cycle: the complete gap since ``_gun_last_tick`` would then
+        be charged to the new cycle.  Mutating paths use this helper first so
+        the later sender advance contains only time elapsed after the edge.
+
+        Lightweight contract tests construct a GunState without starting the
+        battle clock.  There is no elapsed timeline to close in that case.
+        """
+        if (state is None or self._worker_mode or
+                self._gun_last_tick is None):
+            return None
+        if state is not self._gun_state:
+            raise RuntimeError('local gun edge does not own the active state')
+        if self._server is None:
+            raise RuntimeError('player gun edge has no server identity')
+        entity = self._server_entity(self._server.vehicle_id)
+        if entity is None or entity.typeDescriptor is None:
+            raise RuntimeError('player gun edge has no vehicle descriptor')
+        now = self._clock() if now is None else float(now)
+        advanced = self._advance_local_gun_to(entity, now)
+        if advanced is not state:
+            raise RuntimeError('player gun edge replaced the active state')
+        return entity, now
+
+    def _apply_current_reload_factor(self, state, entity):
+        """Apply the live critical factor before publishing a new cycle."""
+        if state is None or entity is None:
+            return False
+        return self._rescale_current_reload(
+            state, critical_damage.stat_factor(entity, 'reload'))
+
     def _advance_local_gun_to(self, entity, now=None):
         """Advance the presented gun to one exact wall-clock edge.
 
@@ -6404,8 +6445,6 @@ class BattleRuntime(object):
             self._gun_last_tick = now
         dt = max(0.0, now - self._gun_last_tick)
         self._gun_last_tick = now
-        reload_rescaled = self._rescale_current_reload(
-            state, critical_damage.stat_factor(entity, 'reload'))
         previous_reload = state.reload_time
         state.tick(
             dt, self._battle_live, self._local_speed,
@@ -6414,6 +6453,12 @@ class BattleRuntime(object):
                 entity, 'dispersion'),
             aim_time_factor=critical_damage.stat_factor(
                 entity, 'aim_time'))
+        # A critical or descriptor factor observed at this edge applies after
+        # the elapsed interval owned by the preceding state.  Rescaling first
+        # would apply a newly damaged or repaired reload factor retroactively
+        # to the whole callback gap.
+        reload_rescaled = self._rescale_current_reload(
+            state, critical_damage.stat_factor(entity, 'reload'))
         self._report_crew_penalty(entity)
         self._publish_ammo_state(state)
         self._tick_equipment_cooldowns(now)
@@ -6503,16 +6548,21 @@ class BattleRuntime(object):
         return True
 
     def _reload_partial_clip_now(self, state):
+        edge = self._advance_local_gun_edge(state)
+        entity = edge[0] if edge is not None else None
         previous_reload = state.reload_time
         previous_duration = state.reload_duration
         if not state.reload_partial_clip():
             return False
+        self._apply_current_reload_factor(state, entity)
         if previous_reload > 0.0:
             self._publish_reload_event(
                 0.0, previous_duration, force=True)
         self._publish_ammo_state(state, force=True)
         self._publish_reload_event(
             state.reload_time, state.reload_duration, force=True)
+        if self._sender is not None:
+            self._sender.send_current()
         return True
 
     def _publish_loaded_shell_change(
@@ -6532,12 +6582,20 @@ class BattleRuntime(object):
         self._sender.send_current()
 
     def _switch_current_shell(self, state, index):
+        edge = self._advance_local_gun_edge(state)
+        entity = edge[0] if edge is not None else None
         previous_reload = state.reload_time
         previous_duration = state.reload_duration
-        instant = self._roll_loader_intuition()
+        # The pre-1.13 loader_intuition perk does not work with cassette
+        # guns.  Retail's server owned this eligibility decision even though
+        # #1513 keeps a generic client-side notification consumer.
+        instant = (
+            state.clip_size <= 1 and state.burst_count <= 1 and
+            self._roll_loader_intuition())
         changed = state.sync_shell_index(index, instant=instant)
         if not changed:
             return False
+        self._apply_current_reload_factor(state, entity)
         self._publish_loaded_shell_change(
             state, previous_reload, previous_duration)
         if instant:
@@ -6591,26 +6649,39 @@ class BattleRuntime(object):
             shell = _field(shot, 'shell', {})
             if int(_field(shell, 'compactDescr', 0)) != int(value):
                 continue
-            previous_reload = state.reload_time
-            previous_duration = state.reload_duration
-            previous_selection = (
-                int(state.shot_index), state.pending_index)
             if code == current_shells:
                 pending_fire = self._local_fire_intent
                 if isinstance(pending_fire, dict):
                     # The physical round was frozen at the trigger edge. Keep
                     # it loaded until that shot is accepted or rejected; the
                     # requested shell can still be queued for the shot boundary.
-                    state.request_shell_index(index)
+                    edge = self._advance_local_gun_edge(state)
+                    entity = edge[0] if edge is not None else None
+                    previous_reload = state.reload_time
+                    previous_duration = state.reload_duration
+                    previous_selection = (
+                        int(state.shot_index), state.pending_index)
+                    changed = state.request_shell_index(index)
                     pending_fire['deferred_current_shell_index'] = int(index)
-                    if previous_selection != (
+                    if changed:
+                        self._apply_current_reload_factor(state, entity)
+                        self._publish_loaded_shell_change(
+                            state, previous_reload, previous_duration)
+                    elif previous_selection != (
                             int(state.shot_index), state.pending_index):
                         self._sender.send_current()
                     return True
                 self._switch_current_shell(state, index)
                 return True
+            edge = self._advance_local_gun_edge(state)
+            entity = edge[0] if edge is not None else None
+            previous_reload = state.reload_time
+            previous_duration = state.reload_duration
+            previous_selection = (
+                int(state.shot_index), state.pending_index)
             changed = state.request_shell_index(index)
             if changed:
+                self._apply_current_reload_factor(state, entity)
                 self._publish_loaded_shell_change(
                     state, previous_reload, previous_duration)
             elif previous_selection != (
@@ -8613,7 +8684,14 @@ class BattleRuntime(object):
                 record, event, canonical)
             if (entity is not None and should_apply and
                     canonical != record.get('critical_state')):
+                gun_edge = None
+                if record.get('local') and self._gun_state is not None:
+                    gun_edge = self._advance_local_gun_edge(self._gun_state)
                 events = critical_damage.apply_payload(entity, critical)
+                if gun_edge is not None:
+                    # Apply loader/ammo-rack factors at their canonical event
+                    # edge instead of retroactively over the callback gap.
+                    self._advance_local_gun_to(entity, gun_edge[1])
                 state['critical'] = canonical
                 record['critical_state'] = canonical
                 self._present_critical(record, events, attacker_id)
@@ -8740,7 +8818,12 @@ class BattleRuntime(object):
         entity = self._server_entity(record['engine_id'])
         if entity is None:
             return False
+        gun_edge = None
+        if record.get('local') and self._gun_state is not None:
+            gun_edge = self._advance_local_gun_edge(self._gun_state)
         events = critical_damage.apply_payload(entity, canonical)
+        if gun_edge is not None:
+            self._advance_local_gun_to(entity, gun_edge[1])
         record['critical_state'] = canonical
         state = dict(record.get('state') or {})
         state['critical'] = canonical
@@ -9205,13 +9288,21 @@ class BattleRuntime(object):
                 'canonical local shot does not acknowledge its trigger')
         gun = self._gun_state
         if gun is not None:
-            if shell_index != gun.shot_index or not gun.commit_fire(
-                    critical_damage.stat_factor(
-                        self._server_entity(record['engine_id']), 'reload')):
+            edge = self._advance_local_gun_edge(gun)
+            entity = (edge[0] if edge is not None else
+                      self._server_entity(record['engine_id']))
+            reload_factor = critical_damage.stat_factor(entity, 'reload')
+            if (shell_index != gun.shot_index or
+                    not gun.commit_fire(reload_factor)):
                 raise RuntimeError(
                     'canonical local shot violates presented gun state')
             if pending.get('deferred_partial_clip_reload'):
                 gun.reload_partial_clip()
+            # commit_fire applies the factor to a normal empty-magazine cycle.
+            # A queued shell promotion or deferred partial reload replaces that
+            # duration with the base reload, so normalize the final transaction
+            # state before its first native publication and checkpoint.
+            self._rescale_current_reload(gun, reload_factor)
             self._publish_ammo_state(gun, force=True)
             self._publish_reload_event(
                 gun.reload_time, gun.reload_duration, force=True)
@@ -17361,6 +17452,11 @@ class BattleRuntime(object):
         if not bool(getattr(descriptor, 'hasSiegeMode', False)):
             record['presented_siege_state'] = disabled
             return False
+        gun_edge = None
+        if record.get('local') and self._gun_state is not None:
+            # The native Siege callback may synchronously swap the composite
+            # descriptor.  Settle the old gun law before crossing that edge.
+            gun_edge = self._advance_local_gun_edge(self._gun_state)
         self._binding.update_vehicle_siege_state(
             record['engine_id'], siege_state,
             float(time_left_ms) / 1000.0)
@@ -17376,8 +17472,19 @@ class BattleRuntime(object):
                 entity, siege_state in (
                     siege_states.ENABLED, siege_states.SWITCHING_OFF))
         if record.get('local') and self._gun_state is not None:
-            self._gun_state.adopt_descriptor(entity.typeDescriptor)
+            gun_changed = self._gun_state.adopt_descriptor(
+                entity.typeDescriptor)
             self._targeting_signature = None
+            if gun_edge is not None:
+                # Re-evaluate the new reload duration at the exact same edge;
+                # no pre-Siege elapsed time can enter the new descriptor law.
+                self._advance_local_gun_to(entity, gun_edge[1])
+            # Only a visible clock-owning transaction donates this descriptor
+            # edge.  Worker records have no local sender/gun timeline, while
+            # lightweight harnesses may intentionally omit that timeline.
+            if (gun_changed and gun_edge is not None and
+                    self._sender is not None):
+                self._sender.send_current()
         if record.get('local') and self._local_physics is not None:
             self._local_physics = vehicle_physics.derive_params(
                 entity.typeDescriptor,

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/compat.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/compat.py
@@ -244,6 +244,9 @@ def _load_runtime():
     from OfflineMapCreator import g_offlineMapCreator
     from PlayerEvents import g_playerEvents
     from connection_mgr import LOGIN_STATUS
+    from gui.battle_control import avatar_getter
+    from gui.battle_control.controllers.consumables.ammo_ctrl import \
+        AmmoController
     from gui.Scaleform.daapi.view.battle.shared.debug_panel import DebugPanel
     from gui.Scaleform.daapi.view.battle.shared.markers2d.plugins import \
         VehicleMarkerPlugin
@@ -263,6 +266,8 @@ def _load_runtime():
     runtime.account_module = Account
     runtime.avatar_module = Avatar
     runtime.avatar_input_handler = AvatarInputHandler
+    runtime.avatar_getter = avatar_getter
+    runtime.ammo_controller_type = AmmoController
     runtime.control_modes = ControlModes
     runtime.avatar_position_control = AvatarPositionControl
     runtime.acceleration_smoother_type = AccelerationSmoother
@@ -514,6 +519,7 @@ class OfflineCompatibility(object):
         self._original_avatar_aux_physics = None
         self._original_avatar_get_speeds = None
         self._original_avatar_auto_aim = None
+        self._original_ammo_change_setting = None
         self._original_arcade_handle_key_event = None
         self._original_strategic_camera_update = None
         self._strategic_camera_update_wrapper = None
@@ -572,6 +578,7 @@ class OfflineCompatibility(object):
         self._avatar_aux_physics_wrapper = None
         self._avatar_get_speeds_wrapper = None
         self._avatar_auto_aim_wrapper = None
+        self._ammo_change_setting_wrapper = None
         self._arcade_handle_key_event_wrapper = None
         self._sniper_handle_key_event_wrapper = None
         self._control_mode_changed_wrapper = None
@@ -623,6 +630,8 @@ class OfflineCompatibility(object):
         runtime = self._runtime
         account_type = runtime.account_module.PlayerAccount
         avatar_type = runtime.avatar_module.PlayerAvatar
+        ammo_controller_type = getattr(
+            runtime, 'ammo_controller_type', None)
         vehicle_type = getattr(
             getattr(runtime, 'vehicle_module', None), 'Vehicle', None)
         vehicle_marker_type = getattr(
@@ -706,6 +715,16 @@ class OfflineCompatibility(object):
             'autoAim', getattr(avatar_type, 'autoAim', None))
         if self._original_avatar_auto_aim is None:
             raise RuntimeError('#1513 Avatar.autoAim is unavailable')
+        if ammo_controller_type is not None:
+            self._original_ammo_change_setting = (
+                ammo_controller_type.__dict__.get(
+                    'changeSetting', getattr(
+                        ammo_controller_type, 'changeSetting', None)))
+            if (self._original_ammo_change_setting is None or
+                    getattr(runtime, 'avatar_getter', None) is None):
+                raise RuntimeError(
+                    '#1513 AmmoController shell-setting boundary is '
+                    'unavailable')
         if arcade_control_type is None or sniper_control_type is None:
             raise RuntimeError('#1513 target-lock control modes are unavailable')
         self._original_arcade_handle_key_event = (
@@ -1812,6 +1831,36 @@ class OfflineCompatibility(object):
                 vehicleId=vehicle_id)
             return None
 
+        def ammo_change_setting(controller, int_cd, avatar=None):
+            """Let one offline CURRENT transaction own its native edge order.
+
+            Stock #1513 optimistically applies CURRENT_SHELLS before invoking
+            the cell mailbox.  The LAN runtime must close the old positive
+            reload before it publishes the new current shell, otherwise the
+            old completion edge is attributed to the new ammo slot.  NEXT and
+            every non-offline call retain the unmodified stock behavior.
+            """
+            if not compatibility._battle_active:
+                return compatibility._original_ammo_change_setting(
+                    controller, int_cd, avatar)
+            getter = runtime.avatar_getter
+            if not getter.isVehicleAlive(avatar):
+                return False
+            code = controller.getNextSettingCode(int_cd)
+            settings = getattr(runtime.constants, 'VEHICLE_SETTING', None)
+            current_shells = getattr(settings, 'CURRENT_SHELLS', None)
+            if current_shells is None or code != current_shells:
+                return compatibility._original_ammo_change_setting(
+                    controller, int_cd, avatar)
+            if not getter.isPlayerOnArena(avatar):
+                return compatibility._original_ammo_change_setting(
+                    controller, int_cd, avatar)
+            # AvatarServerBridge invokes BattleRuntime synchronously.  That
+            # transaction publishes old reload 0, CURRENT_SHELLS and the new
+            # positive duration before this stock input call returns.
+            getter.changeVehicleSetting(code, int_cd, avatar)
+            return True
+
         def handle_target_lock_input(original, control, is_down, key, mods,
                                      event):
             if not compatibility._battle_active:
@@ -2228,6 +2277,7 @@ class OfflineCompatibility(object):
         self._avatar_aux_physics_wrapper = avatar_aux_physics
         self._avatar_get_speeds_wrapper = avatar_get_speeds
         self._avatar_auto_aim_wrapper = avatar_auto_aim
+        self._ammo_change_setting_wrapper = ammo_change_setting
         self._arcade_handle_key_event_wrapper = arcade_handle_key_event
         self._sniper_handle_key_event_wrapper = sniper_handle_key_event
         self._strategic_camera_update_wrapper = strategic_camera_update
@@ -2282,6 +2332,8 @@ class OfflineCompatibility(object):
             if self._original_avatar_get_speeds is not None:
                 avatar_type.getOwnVehicleSpeeds = avatar_get_speeds
             avatar_type.autoAim = avatar_auto_aim
+            if ammo_controller_type is not None:
+                ammo_controller_type.changeSetting = ammo_change_setting
             arcade_control_type.handleKeyEvent = arcade_handle_key_event
             sniper_control_type.handleKeyEvent = sniper_handle_key_event
             strategic_camera_type._StrategicCamera__cameraUpdate = (
@@ -2345,6 +2397,8 @@ class OfflineCompatibility(object):
         runtime = self._runtime
         account_type = runtime.account_module.PlayerAccount
         avatar_type = runtime.avatar_module.PlayerAvatar
+        ammo_controller_type = getattr(
+            runtime, 'ammo_controller_type', None)
         vehicle_type = getattr(
             getattr(runtime, 'vehicle_module', None), 'Vehicle', None)
         vehicle_marker_type = getattr(
@@ -2431,6 +2485,12 @@ class OfflineCompatibility(object):
                 avatar_type.__dict__.get('autoAim') is
                 self._avatar_auto_aim_wrapper):
             avatar_type.autoAim = self._original_avatar_auto_aim
+        if (ammo_controller_type is not None and
+                self._original_ammo_change_setting is not None and
+                ammo_controller_type.__dict__.get('changeSetting') is
+                self._ammo_change_setting_wrapper):
+            ammo_controller_type.changeSetting = (
+                self._original_ammo_change_setting)
         if (arcade_control_type is not None and
                 self._original_arcade_handle_key_event is not None and
                 arcade_control_type.__dict__.get('handleKeyEvent') is

--- a/0.9.22/tests/test_port_0922.py
+++ b/0.9.22/tests/test_port_0922.py
@@ -1629,6 +1629,84 @@ class OfflineCompatibilityTests(unittest.TestCase):
         compatibility.fini()
         self.assertIs(original, runtime.bigworld.__class__.serverTime)
 
+    def test_offline_current_shell_change_defers_stock_optimistic_update(self):
+        compatibility_module = _load_port_source('compat')
+        runtime, unused_operations = self._runtime()
+        settings = types.SimpleNamespace(CURRENT_SHELLS=0, NEXT_SHELLS=1)
+        runtime.constants.VEHICLE_SETTING = settings
+        calls = []
+        state = {'alive': True, 'on_arena': True}
+
+        getter = types.SimpleNamespace(
+            isVehicleAlive=lambda unused_avatar: state['alive'],
+            isPlayerOnArena=lambda unused_avatar: state['on_arena'],
+            updateVehicleSetting=lambda code, value, unused_avatar: \
+                calls.append(('update', code, value)),
+            changeVehicleSetting=lambda code, value, unused_avatar: \
+                calls.append(('change', code, value)))
+        runtime.avatar_getter = getter
+
+        class AmmoController(object):
+            def __init__(self, code):
+                self.code = code
+
+            def getNextSettingCode(self, unused_int_cd):
+                return self.code
+
+            def changeSetting(self, int_cd, avatar=None):
+                if not getter.isVehicleAlive(avatar):
+                    return False
+                code = self.getNextSettingCode(int_cd)
+                if code is None:
+                    return False
+                getter.updateVehicleSetting(code, int_cd, avatar)
+                if getter.isPlayerOnArena(avatar):
+                    getter.changeVehicleSetting(code, int_cd, avatar)
+                return True
+
+        runtime.ammo_controller_type = AmmoController
+        original = AmmoController.__dict__['changeSetting']
+        compatibility = compatibility_module.OfflineCompatibility(runtime)
+        compatibility.install()
+
+        controller = AmmoController(settings.CURRENT_SHELLS)
+        self.assertTrue(controller.changeSetting(102, avatar='outside'))
+        self.assertEqual([
+            ('update', settings.CURRENT_SHELLS, 102),
+            ('change', settings.CURRENT_SHELLS, 102),
+        ], calls)
+
+        compatibility.configure_battle()
+        calls[:] = []
+        self.assertTrue(controller.changeSetting(102, avatar='battle'))
+        self.assertEqual([
+            ('change', settings.CURRENT_SHELLS, 102),
+        ], calls)
+
+        calls[:] = []
+        controller.code = settings.NEXT_SHELLS
+        self.assertTrue(controller.changeSetting(102, avatar='battle'))
+        self.assertEqual([
+            ('update', settings.NEXT_SHELLS, 102),
+            ('change', settings.NEXT_SHELLS, 102),
+        ], calls)
+
+        calls[:] = []
+        controller.code = settings.CURRENT_SHELLS
+        state['on_arena'] = False
+        self.assertTrue(controller.changeSetting(102, avatar='loading'))
+        self.assertEqual([
+            ('update', settings.CURRENT_SHELLS, 102),
+        ], calls)
+
+        calls[:] = []
+        state['alive'] = False
+        self.assertFalse(controller.changeSetting(102, avatar='dead'))
+        self.assertEqual([], calls)
+
+        compatibility.fini()
+        self.assertIs(original, AmmoController.__dict__['changeSetting'])
+
     def test_offline_battle_debug_panel_uses_lan_transport_health(self):
         compatibility_module = _load_port_source('compat')
         runtime, operations = self._runtime()

--- a/0.9.22/tests/test_port_0922_battle_runtime.py
+++ b/0.9.22/tests/test_port_0922_battle_runtime.py
@@ -6591,6 +6591,12 @@ class BattleRuntimeContractTests(unittest.TestCase):
             battle, battle._gun_state,
             runtime.constants.VEHICLE_SETTING, client, record)
 
+    def _last_input_gun_checkpoint(self, client):
+        messages = [message for message in client.sent
+                    if message[0] == 'input']
+        self.assertTrue(messages)
+        return messages[-1][2]['gun_checkpoint']
+
     def test_next_shell_setting_waits_for_the_loaded_round(self):
         battle, state, settings = self._shell_change_battle()
 
@@ -6868,6 +6874,339 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertEqual(0.0, state.reload_time)
         self.assertEqual(1, state.clip)
         self.assertTrue(state.can_fire(True))
+
+    def test_shell_switch_consumes_old_elapsed_before_new_reload_cycle(self):
+        battle, state, settings, client, unused_record = \
+            self._pending_fire_shell_change_battle()
+        state.reload = 6.0
+        state.clip = 0
+        state.reload_time = 4.0
+        state.reload_duration = 6.0
+        clock = [100.0]
+        battle._clock = lambda: clock[0]
+        battle._gun_last_tick = 99.7
+        battle._reload_event = (4.0, 6.0)
+
+        self.assertTrue(battle.change_vehicle_setting(
+            settings.NEXT_SHELLS, 102))
+        self.assertAlmostEqual(3.7, state.reload_time)
+
+        clock[0] = 100.4
+        battle._avatar.reload_updates[:] = []
+        self.assertTrue(battle.change_vehicle_setting(
+            settings.CURRENT_SHELLS, 102))
+
+        positive = [event for event in battle._avatar.reload_updates
+                    if event[1] > 0.0]
+        checkpoint = self._last_input_gun_checkpoint(client)
+        self.assertEqual([(10, 6.0, 6.0)], positive)
+        self.assertEqual(6.0, state.reload_time)
+        self.assertEqual(6.0, state.reload_duration)
+        self.assertEqual(6.0, checkpoint['reload_time'])
+        self.assertEqual(6.0, checkpoint['reload_duration'])
+        self.assertEqual(100.4, battle._gun_last_tick)
+
+    def test_deferred_stock_current_closes_old_shell_before_new_reload(self):
+        battle, state, settings, unused_client, unused_record = \
+            self._pending_fire_shell_change_battle()
+        state.reload = 6.0
+        state.clip = 0
+        state.reload_time = 3.0
+        state.reload_duration = 6.0
+        stock = {'current': 101, 'next': 101}
+        events = []
+
+        def update_setting(unused_vehicle_id, code, value):
+            value = int(value)
+            if code == settings.NEXT_SHELLS:
+                if stock['next'] != value:
+                    stock['next'] = value
+                    events.append(('next', value))
+            elif code == settings.CURRENT_SHELLS:
+                if stock['current'] != value:
+                    stock['current'] = value
+                    events.append(('current', value))
+
+        def update_reload(unused_vehicle_id, time_left, base_time):
+            events.append((
+                'reload', stock['current'], float(time_left),
+                float(base_time)))
+
+        battle._avatar.updateVehicleSetting = update_setting
+        battle._avatar.updateVehicleGunReloadTime = update_reload
+
+        def stock_change_setting(value):
+            if value == stock['current'] and value == stock['next']:
+                return False
+            code = (settings.CURRENT_SHELLS
+                    if value == stock['next'] else settings.NEXT_SHELLS)
+            # OfflineCompatibility preserves the stock optimistic NEXT edge,
+            # but defers CURRENT to the synchronous local bridge so the old
+            # reload can be closed while the old shell still owns it.
+            if code != settings.CURRENT_SHELLS:
+                battle._avatar.updateVehicleSetting(10, code, value)
+            return battle._sender.change_vehicle_setting(10, code, value)
+
+        self.assertTrue(stock_change_setting(102))
+        self.assertTrue(stock_change_setting(102))
+
+        reload_events = [event for event in events
+                         if event[0] == 'reload']
+        self.assertEqual([
+            ('reload', 101, 0.0, 6.0),
+            ('reload', 102, 6.0, 6.0),
+        ], reload_events)
+        self.assertEqual(1, len([
+            event for event in reload_events
+            if event[1] == 102 and event[2] > 0.0]))
+
+    def test_partial_clip_reload_starts_at_setting_edge_and_sends_checkpoint(self):
+        battle, state, settings, client, unused_record = \
+            self._pending_fire_shell_change_battle(clip_size=3, clip=2)
+        state.reload = 6.0
+        state.reload_time = 0.0
+        state.reload_duration = 6.0
+        clock = [200.0]
+        battle._clock = lambda: clock[0]
+        battle._gun_last_tick = 199.8
+
+        self.assertTrue(battle.change_vehicle_setting(
+            settings.NEXT_SHELLS, 102))
+        input_count = len([
+            message for message in client.sent if message[0] == 'input'])
+
+        clock[0] = 200.5
+        battle._avatar.reload_updates[:] = []
+        self.assertTrue(battle.change_vehicle_setting(
+            settings.RELOAD_PARTIAL_CLIP, 0))
+
+        messages = [message for message in client.sent
+                    if message[0] == 'input']
+        checkpoint = self._last_input_gun_checkpoint(client)
+        self.assertEqual(input_count + 1, len(messages))
+        self.assertEqual([(10, 6.0, 6.0)], [
+            event for event in battle._avatar.reload_updates
+            if event[1] > 0.0])
+        self.assertEqual(1, state.shot_index)
+        self.assertIsNone(state.pending_index)
+        self.assertEqual(0, state.clip)
+        self.assertEqual(6.0, state.reload_time)
+        self.assertEqual(6.0, checkpoint['reload_time'])
+        self.assertEqual(1, messages[-1][2]['shell_index'])
+        self.assertFalse(messages[-1][2]['shell_change_pending'])
+        self.assertEqual(200.5, battle._gun_last_tick)
+
+    def test_rejected_fire_starts_deferred_shell_reload_at_rejection_edge(self):
+        battle, state, settings, client, unused_record = \
+            self._pending_fire_shell_change_battle()
+        state.reload = 6.0
+        clock = [300.0]
+        battle._clock = lambda: clock[0]
+        battle._gun_last_tick = 299.5
+
+        self.assertTrue(battle.shoot(0.0, 0.0))
+        pending = dict(battle._local_fire_intent)
+        clock[0] = 300.1
+        self.assertTrue(battle.change_vehicle_setting(
+            settings.NEXT_SHELLS, 102))
+        self.assertTrue(battle.change_vehicle_setting(
+            settings.CURRENT_SHELLS, 102))
+
+        clock[0] = 301.0
+        battle._avatar.reload_updates[:] = []
+        self.assertTrue(battle.on_fire_intent_result({
+            'type': 'fire_intent_result', 'round_id': 7,
+            'player_id': 1, 'intent_seq': pending['intent_seq'],
+            'accepted': False, 'reason': 'projectile_launch_rejected',
+        }))
+
+        checkpoint = self._last_input_gun_checkpoint(client)
+        messages = [message for message in client.sent
+                    if message[0] == 'input']
+        self.assertEqual([(10, 6.0, 6.0)], [
+            event for event in battle._avatar.reload_updates
+            if event[1] > 0.0])
+        self.assertEqual(6.0, state.reload_time)
+        self.assertEqual(6.0, checkpoint['reload_time'])
+        self.assertEqual(1, messages[-1][2]['shell_index'])
+        self.assertEqual(301.0, battle._gun_last_tick)
+
+    def test_damaged_ammo_rack_shell_switch_publishes_one_scaled_cycle(self):
+        battle, state, settings, client, unused_record = \
+            self._pending_fire_shell_change_battle()
+        state.reload = 6.0
+        state.clip = 0
+        state.reload_time = 6.0
+        state.reload_duration = 12.0
+        clock = [400.0]
+        battle._clock = lambda: clock[0]
+        battle._gun_last_tick = 400.0
+        battle._reload_event = (6.0, 12.0)
+
+        def damaged_factor(unused_entity, stat):
+            return 2.0 if stat == 'reload' else 1.0
+
+        with mock.patch(
+                'gui.mods.offline_lan_0922.battle_runtime.'
+                'critical_damage.stat_factor', side_effect=damaged_factor):
+            self.assertTrue(battle.change_vehicle_setting(
+                settings.NEXT_SHELLS, 102))
+            clock[0] = 400.5
+            battle._avatar.reload_updates[:] = []
+            self.assertTrue(battle.change_vehicle_setting(
+                settings.CURRENT_SHELLS, 102))
+
+        checkpoint = self._last_input_gun_checkpoint(client)
+        self.assertEqual([
+            (10, 0.0, 12.0),
+            (10, 12.0, 12.0),
+        ], battle._avatar.reload_updates)
+        self.assertEqual(12.0, state.reload_time)
+        self.assertEqual(12.0, state.reload_duration)
+        self.assertEqual(12.0, checkpoint['reload_time'])
+        self.assertEqual(12.0, checkpoint['reload_duration'])
+        self.assertEqual(400.5, battle._gun_last_tick)
+
+    def test_loader_intuition_switch_closes_old_reload_and_stays_loaded(self):
+        battle, state, settings, client, unused_record = \
+            self._pending_fire_shell_change_battle(clip_size=1, clip=0)
+        state.reload = 6.0
+        state.reload_time = 3.0
+        state.reload_duration = 6.0
+        initial_ammo = tuple(state.ammo)
+        battle._roll_loader_intuition = lambda: True
+        clock = [500.0]
+        battle._clock = lambda: clock[0]
+        battle._gun_last_tick = 499.6
+
+        stock = {
+            'current': 101, 'next': 101, 'reload': 3.0,
+            'base': 6.0, 'ammo': {101: (20, 0), 102: (10, 0)},
+        }
+        events = []
+
+        def update_setting(unused_vehicle_id, code, value):
+            value = int(value)
+            if code == settings.NEXT_SHELLS:
+                if stock['next'] != value:
+                    stock['next'] = value
+                    events.append(('next', value))
+            elif code == settings.CURRENT_SHELLS:
+                if stock['current'] != value:
+                    stock['current'] = value
+                    events.append(('current', value))
+
+        def update_ammo(unused_vehicle_id, compact_descr, quantity,
+                        quantity_in_clip, unused_time_remaining):
+            compact_descr = int(compact_descr)
+            stock['ammo'][compact_descr] = (
+                int(quantity), int(quantity_in_clip))
+            events.append(('ammo', compact_descr, int(quantity_in_clip)))
+
+        def update_reload(unused_vehicle_id, time_left, base_time):
+            stock['reload'] = float(time_left)
+            stock['base'] = float(base_time)
+            events.append((
+                'reload', stock['current'], stock['reload'], stock['base']))
+
+        def update_misc(unused_vehicle_id, code, unused_int_arg,
+                        unused_float_args):
+            status = battle._runtime.constants.VEHICLE_MISC_STATUS
+            self.assertEqual(status.LOADER_INTUITION_WAS_USED, code)
+            # This mirrors #1513 AmmoController.useLoaderIntuition: it only
+            # refills the selected cassette after native reload state is 0.
+            self.assertEqual(0.0, stock['reload'])
+            self.assertEqual(102, stock['current'])
+            for compact_descr, (quantity, unused_clip) in list(
+                    stock['ammo'].items()):
+                stock['ammo'][compact_descr] = (quantity, 0)
+            quantity = stock['ammo'][stock['current']][0]
+            stock['ammo'][stock['current']] = (
+                quantity, min(state.clip_size, quantity))
+            events.append(('intuition', stock['current']))
+
+        battle._avatar.updateVehicleSetting = update_setting
+        battle._avatar.updateVehicleAmmo = update_ammo
+        battle._avatar.updateVehicleGunReloadTime = update_reload
+        battle._avatar.updateVehicleMiscStatus = update_misc
+
+        def stock_change_setting(value):
+            if value == stock['current'] and value == stock['next']:
+                return False
+            code = (settings.CURRENT_SHELLS
+                    if value == stock['next'] else settings.NEXT_SHELLS)
+            if code != settings.CURRENT_SHELLS:
+                battle._avatar.updateVehicleSetting(10, code, value)
+            return battle._sender.change_vehicle_setting(10, code, value)
+
+        self.assertTrue(stock_change_setting(102))
+        input_count = len([
+            message for message in client.sent if message[0] == 'input'])
+        events[:] = []
+        clock[0] = 500.3
+        self.assertTrue(stock_change_setting(102))
+
+        messages = [message for message in client.sent
+                    if message[0] == 'input']
+        payload = messages[-1][2]
+        checkpoint = payload['gun_checkpoint']
+        self.assertEqual([
+            ('reload', 101, 0.0, 6.0),
+            ('ammo', 101, 0),
+            ('ammo', 102, 1),
+            ('current', 102),
+            ('reload', 102, 0.0, 6.0),
+            ('intuition', 102),
+        ], events)
+        self.assertEqual(input_count + 1, len(messages))
+        self.assertEqual(1, state.shot_index)
+        self.assertIsNone(state.pending_index)
+        self.assertEqual(1, state.clip)
+        self.assertEqual(0.0, state.reload_time)
+        self.assertEqual(initial_ammo, tuple(state.ammo))
+        self.assertTrue(state.can_fire(True))
+        self.assertEqual((10, 1), stock['ammo'][102])
+        self.assertEqual(1, payload['shell_index'])
+        self.assertEqual(1, payload['next_shell_index'])
+        self.assertFalse(payload['shell_change_pending'])
+        self.assertEqual(1, checkpoint['clip'])
+        self.assertEqual(1, checkpoint['clip_size'])
+        self.assertEqual(0.0, checkpoint['reload_time'])
+        self.assertEqual(6.0, checkpoint['reload_duration'])
+
+        events[:] = []
+        clock[0] = 501.3
+        battle._advance_local_gun_to(battle._server_entity(10))
+        self.assertEqual([], [event for event in events
+                             if event[0] == 'reload' and event[2] > 0.0])
+        self.assertEqual(1, state.clip)
+        self.assertEqual(0.0, state.reload_time)
+
+    def test_loader_intuition_is_not_rolled_for_an_autoloader(self):
+        battle, state, settings, client, unused_record = \
+            self._pending_fire_shell_change_battle(clip_size=3, clip=3)
+        state.reload = 6.0
+        state.reload_time = 0.0
+        state.reload_duration = 6.0
+        battle._roll_loader_intuition = mock.Mock(return_value=True)
+
+        self.assertTrue(battle.change_vehicle_setting(
+            settings.NEXT_SHELLS, 102))
+        self.assertTrue(battle.change_vehicle_setting(
+            settings.CURRENT_SHELLS, 102))
+
+        checkpoint = self._last_input_gun_checkpoint(client)
+        battle._roll_loader_intuition.assert_not_called()
+        self.assertEqual(1, state.shot_index)
+        self.assertIsNone(state.pending_index)
+        self.assertEqual(0, state.clip)
+        self.assertEqual(6.0, state.reload_time)
+        self.assertEqual(6.0, state.reload_duration)
+        self.assertFalse(state.can_fire(True))
+        self.assertEqual(0, checkpoint['clip'])
+        self.assertEqual(3, checkpoint['clip_size'])
+        self.assertEqual(6.0, checkpoint['reload_time'])
+        self.assertEqual([], battle._avatar.misc_statuses)
 
     def test_loader_intuition_swaps_at_once_and_notifies_the_hud(self):
         battle, state, settings = self._shell_change_battle()

--- a/0.9.22/tools/audit_client_abi.py
+++ b/0.9.22/tools/audit_client_abi.py
@@ -403,6 +403,7 @@ EXPECTED_ABI = {
         'AmmoController.getNextSettingCode': ('self', 'intCD'),
         'AmmoController.setNextShellCD': ('self', 'intCD'),
         'AmmoController.setCurrentShellCD': ('self', 'intCD'),
+        'AmmoController.useLoaderIntuition': ('self',),
     },
     'scripts/client/account_helpers/AccountSettings.pyc': {
         'AccountSettings.__readSection': ('ds', 'name'),
@@ -1117,7 +1118,8 @@ EXPECTED_CODE_NAMES = {
             'updateVehicleDestroyTimer', 'SIEGE_MODE_STATE_CHANGED',
             'VEHICLE_SIEGE_STATE', 'SWITCHING_ON', 'SWITCHING_OFF',
             'moveVehicleByCurrentKeys', 'SIEGE_MODE',
-            '_PlayerAvatar__onSiegeStateUpdated'),
+            '_PlayerAvatar__onSiegeStateUpdated',
+            'LOADER_INTUITION_WAS_USED', 'useLoaderIntuition'),
         'PlayerAvatar.__onSiegeStateUpdated': (
             'BigWorld', 'entity', 'typeDescriptor', 'hasSiegeMode',
             'onSiegeStateUpdated', 'isPlayerVehicle'),
@@ -1133,6 +1135,16 @@ EXPECTED_CODE_NAMES = {
             '_endTime', 'BigWorld', 'serverTime'),
         'ArenaPeriodController.__tick': (
             '_calculate', '_updateCountdown'),
+    },
+    'scripts/client/gui/battle_control/controllers/consumables/'
+    'ammo_ctrl.pyc': {
+        'AmmoController.changeSetting': (
+            'avatar_getter', 'isVehicleAlive', 'getNextSettingCode',
+            'updateVehicleSetting', 'isPlayerOnArena',
+            'changeVehicleSetting'),
+        'AmmoController.useLoaderIntuition': (
+            '_AmmoController__gunSettings', 'clip', 'size',
+            'isGunReloading', 'setShells'),
     },
     'scripts/client/gui/battle_control/controllers/vehicle_state_ctrl.pyc': {
         '_SpeedStateHandler._invalidate': (


### PR DESCRIPTION
## Summary

- settle the local gun clock at each shell, reload, critical-state, and Siege descriptor mutation edge
- let the offline runtime own the exact CURRENT shell transaction instead of accepting the stock client's optimistic pre-update
- preserve ordered native reload events and authoritative checkpoints for normal, partial, deferred, and Intuition shell changes
- restore the pre-1.13 Intuition eligibility rule so cassette and burst guns do not roll the perk

## Validation

- targeted reload/shell-switch regression selection: 10 passed
- 0.9.22 battle-runtime contracts: 660 passed
- 0.9.22 client/compatibility contracts: 152 passed
- edited runtime, compatibility, and ABI-audit sources compile with Python 2.7.18
- `git diff --check` passed

The full repository matrix is intentionally left to GitHub Actions. Exact Windows #1513 native HUD/BigWorld acceptance remains to be run.
