### PR TITLE
Fix slope contact physics

### DIFF
--- a/0.9.22/server/lan_battle_server.py
+++ b/0.9.22/server/lan_battle_server.py
@@ -9275,6 +9275,8 @@ class BattleState:
                             "y": round(float(sample["y"]), 4),
                             "z": round(float(sample["z"]), 4),
                             "yaw": round(float(sample["yaw"]), 5),
+                            "pitch": round(float(sample["pitch"]), 5),
+                            "roll": round(float(sample["roll"]), 5),
                             "forward": round(float(sample["forward"]), 4),
                         })
                         player.destructible_contacts[seq] = contact

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -12062,10 +12062,17 @@ class BattleRuntime(object):
                     float(contact.get('x')), float(contact.get('y')),
                     float(contact.get('z')))
                 yaw = float(contact.get('yaw'))
+                pitch = float(contact.get(
+                    'pitch', state.get('pitch', 0.0)))
+                roll = float(contact.get(
+                    'roll', state.get('roll', 0.0)))
             except (TypeError, ValueError, OverflowError):
                 continue
             if (token is None or player_id <= 0 or seq <= 0 or
-                    not 0.0 < dt <= 0.1 or forward * speed <= 0.0):
+                    not 0.0 < dt <= 0.1 or forward * speed <= 0.0 or
+                    math.isnan(pitch) or math.isinf(pitch) or
+                    math.isnan(roll) or math.isinf(roll) or
+                    abs(pitch) > 0.61 or abs(roll) > 0.61):
                 continue
             descriptor = self._resolve_player_descriptor(state)
             params = self._player_effective_snapshot(state)['physics']
@@ -12086,7 +12093,7 @@ class BattleRuntime(object):
                 self._runtime.bigworld, self._runtime.math,
                 self._avatar.spaceID, self._vector(position), yaw, speed,
                 descriptor, False, dt, True, True, kinetic_speed,
-                commit_enabled=False)
+                commit_enabled=False, pitch=pitch, roll=roll)
             if isinstance(world_status, bool):
                 world_status = 'hard' if world_status else 'clear'
             # The visible endpoint streams only the identities intersecting
@@ -13840,6 +13847,7 @@ class BattleRuntime(object):
                     world_hull_yaw, speed,
                     entity.typeDescriptor, self._local_airborne, dt, True,
                     True, kinetic_speed, commit_enabled=False,
+                    pitch=self._local_pitch, roll=self._local_roll,
                     motion_yaw=world_motion_yaw)
                 if isinstance(world_status, bool):
                     world_status = 'hard' if world_status else 'clear'
@@ -13883,7 +13891,9 @@ class BattleRuntime(object):
             world_hull_yaw, speed,
             entity.typeDescriptor, self._local_airborne, dt, True,
             bool(kinetic_speed is not None), kinetic_speed,
-            commit_enabled=False, motion_yaw=world_motion_yaw)
+            commit_enabled=False,
+            pitch=self._local_pitch, roll=self._local_roll,
+            motion_yaw=world_motion_yaw)
         if isinstance(world_status, bool):
             world_status = 'hard' if world_status else 'clear'
         if world_status == 'hard':
@@ -13946,7 +13956,8 @@ class BattleRuntime(object):
         return status in ('clear', 'crushed')
 
     def _resolve_bot_motion(self, bot_id, position, yaw, speed,
-                            descriptor, dt, now, commit_enabled=True):
+                            descriptor, dt, now, commit_enabled=True,
+                            motion_yaw=None):
         """Resolve Bot contact: static world first, then exact catalog."""
         pos = self._vector(position)
         bot_state = getattr(self._bots, 'states', {}).get(int(bot_id), {})
@@ -13964,15 +13975,20 @@ class BattleRuntime(object):
         if not callable(corridor_reusable):
             corridor_reusable = getattr(
                 self._bots, 'motion_world_receipt_reusable', None)
-        travel_yaw = (float(yaw) if speed >= 0.0 else
-                      float(yaw) + math.pi)
+        travel_yaw = (
+            float(motion_yaw) if motion_yaw is not None else
+            float(yaw) if speed >= 0.0 else float(yaw) + math.pi)
+        destructible_motion = (
+            {} if motion_yaw is None else
+            {'motion_yaw': float(motion_yaw)})
         if (self._destructibles is not None and not airborne and
                 movement_dir * float(speed) > 0.0 and rotation_dir == 0 and
                 abs(turn_speed) <= 0.01 and callable(corridor_reusable) and
                 corridor_reusable(
                     bot_id, position, travel_yaw, speed, now, dt) and
                 not self._destructibles._catalog_hull_contact(
-                    pos, yaw, speed, descriptor, dt)):
+                    pos, yaw, speed, descriptor, dt,
+                    **destructible_motion)):
             return 'clear'
         allow_crush_drive = (
             not airborne and
@@ -13987,14 +14003,19 @@ class BattleRuntime(object):
             self._runtime.bigworld, self._runtime.math,
             self._avatar.spaceID, pos, yaw, speed, descriptor, airborne, dt,
             True, allow_crush_drive, kinetic_speed,
-            commit_enabled=commit_enabled)
+            commit_enabled=commit_enabled,
+            pitch=_number(bot_state.get(
+                'terrain_pitch', bot_state.get('pitch'))),
+            roll=_number(bot_state.get('roll')),
+            motion_yaw=motion_yaw)
         if isinstance(world_status, bool):
             world_status = 'hard' if world_status else 'clear'
         self._bot_motion_kinds[int(bot_id)] = '-'
         if world_status == 'hard':
             if (self._destructibles is not None and
                     self._destructibles._catalog_pending_at_hull(
-                        pos, yaw, speed, descriptor, now, dt)):
+                    pos, yaw, speed, descriptor, now, dt,
+                    **destructible_motion)):
                 self._bot_motion_kinds[int(bot_id)] = 'broken'
                 return 'soft'
             return 'hard'
@@ -14009,7 +14030,7 @@ class BattleRuntime(object):
             self._avatar.spaceID, pos, yaw, speed, descriptor, now,
             dt=dt, kinetic_speed=kinetic_speed, return_detail=True,
             kinetic_commit=allow_crush_drive and commit_enabled,
-            commit_enabled=commit_enabled)
+            commit_enabled=commit_enabled, **destructible_motion)
         if isinstance(detail, bool):
             detail = {'status': 'hard' if detail else 'clear'}
         elif isinstance(detail, str):

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -5420,7 +5420,18 @@ class BotRuntime(object):
             lateral_speed * lateral_speed)
         return self._apply_bot_fall_damage(state, impact_speed)
 
-    def _support_rise_follows_tick_path(self, state, centre, tick_pose):
+    @staticmethod
+    def _tick_horizontal_travel(state, tick_pose):
+        """Return realised x/z travel from the pre-integration tick pose."""
+        if (not isinstance(tick_pose, (list, tuple)) or
+                len(tick_pose) < 3):
+            return 0.0
+        delta_x = _number(state.get('x')) - _number(tick_pose[0])
+        delta_z = _number(state.get('z')) - _number(tick_pose[2])
+        return math.sqrt(delta_x * delta_x + delta_z * delta_z)
+
+    def _support_rise_follows_tick_path(self, state, centre, tick_pose,
+                                        horizontal_travel):
         """Confirm a suspicious raised support through bounded interior rays.
 
         Normal grounding still spends only its centre ray.  This helper is
@@ -5439,7 +5450,7 @@ class BotRuntime(object):
         start_z = _number(tick_pose[2])
         delta_x = _number(state.get('x')) - start_x
         delta_z = _number(state.get('z')) - start_z
-        distance = math.sqrt(delta_x * delta_x + delta_z * delta_z)
+        distance = max(0.0, _number(horizontal_travel))
         rise = float(centre) - start_y
         if (distance <= 0.0001 or rise <= 0.0 or
                 rise > distance * 0.55 + 0.02):
@@ -5485,6 +5496,27 @@ class BotRuntime(object):
                 _number(state.get('speed')),
                 _number(state.get('last_drive_pitch')), step)
             max_climb = max(0.6, speed * step * 2.5)
+            support_rise_obstacle = bool(
+                state.get('grounded_once', False) and
+                tank_collision.support_rise_is_obstacle(
+                    state.get('y'), centre, max_climb))
+            support_rise_continuous = False
+            if support_rise_obstacle:
+                horizontal_travel = self._tick_horizontal_travel(
+                    state, tick_pose)
+                support_rise_continuous = \
+                    self._support_rise_follows_tick_path(
+                        state, centre, tick_pose, horizontal_travel)
+                if support_rise_continuous:
+                    # A ram/contact correction may move sideways while the
+                    # longitudinal speed is zero. Settle only the exact rise
+                    # admitted by that realised sweep in the same tick. The
+                    # displacement is proof geometry, not powered-drive climb
+                    # credit, and nothing carries into the next tick.
+                    proved_support_rise = max(
+                        0.0, float(centre) - _number(tick_pose[1]))
+                    max_climb = max(
+                        max_climb, proved_support_rise)
             com_gap = state['y'] - ground
             land_y = ground if centre is None else centre
             if not state.get('grounded_once', False):
@@ -5492,10 +5524,7 @@ class BotRuntime(object):
                 state['vertical_speed'] = 0.0
                 state['airborne'] = False
                 state['grounded_once'] = True
-            elif (tank_collision.support_rise_is_obstacle(
-                    state.get('y'), centre, max_climb) and
-                    not self._support_rise_follows_tick_path(
-                        state, centre, tick_pose)):
+            elif support_rise_obstacle and not support_rise_continuous:
                 # The centre ray hit a wagon deck, roof, or large prop only
                 # after this tick's horizontal integration put the hull partly
                 # inside it. Restore only this tick's pose and let LocalDriver

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -5304,16 +5304,20 @@ class BotRuntime(object):
         # BattleRuntime's resolver infers active crush intent from this field.
         state['movement_dir'] = 0
         try:
+            hull_yaw = _number(state.get('yaw'))
+            motion_yaw = yaw if _number(speed) >= 0.0 else yaw + math.pi
             if self._probe_clock is None:
                 status = self.motion_resolver(
-                    state['id'], position, yaw, speed,
-                    descriptor, step, now, commit_enabled)
+                    state['id'], position, hull_yaw, speed,
+                    descriptor, step, now, commit_enabled,
+                    motion_yaw=motion_yaw)
             else:
                 probe_started = self._probe_started()
                 try:
                     status = self.motion_resolver(
-                        state['id'], position, yaw, speed,
-                        descriptor, step, now, commit_enabled)
+                        state['id'], position, hull_yaw, speed,
+                        descriptor, step, now, commit_enabled,
+                        motion_yaw=motion_yaw)
                 finally:
                     self._probe_finished(4, probe_started)
         finally:
@@ -5416,6 +5420,57 @@ class BotRuntime(object):
             lateral_speed * lateral_speed)
         return self._apply_bot_fall_damage(state, impact_speed)
 
+    def _support_rise_follows_tick_path(self, state, centre, tick_pose):
+        """Confirm a suspicious raised support through bounded interior rays.
+
+        Normal grounding still spends only its centre ray.  This helper is
+        called only after that endpoint rose beyond the hard step limit.  At
+        most four interior samples split a legal 0.2-second hull sweep into
+        segments no longer than 1.5 metres; every segment must remain inside
+        the same 0.55 grade accepted by the native direction probe.  A longer
+        sweep fails closed instead of making this exceptional check unbounded.
+        """
+        if (centre is None or
+                not isinstance(tick_pose, (list, tuple)) or
+                len(tick_pose) < 3):
+            return False
+        start_x = _number(tick_pose[0])
+        start_y = _number(tick_pose[1])
+        start_z = _number(tick_pose[2])
+        delta_x = _number(state.get('x')) - start_x
+        delta_z = _number(state.get('z')) - start_z
+        distance = math.sqrt(delta_x * delta_x + delta_z * delta_z)
+        rise = float(centre) - start_y
+        if (distance <= 0.0001 or rise <= 0.0 or
+                rise > distance * 0.55 + 0.02):
+            return False
+        segment_count = max(2, int(math.ceil(distance / 1.5)))
+        if segment_count > 5:
+            return False
+        maximum_segment_rise = (
+            distance / float(segment_count) * 0.55 + 0.02)
+        previous_support = start_y
+        for index in range(1, segment_count):
+            fraction = float(index) / float(segment_count)
+            sample_x = start_x + delta_x * fraction
+            sample_z = start_z + delta_z * fraction
+            sample_hint = start_y + rise * fraction
+            self._probe_totals[3] += 1
+            probe_started = self._probe_started()
+            try:
+                support = self._physics_ground_probe(
+                    sample_x, sample_z, sample_hint)
+            finally:
+                self._probe_finished(3, probe_started)
+            if support is None:
+                return False
+            support = float(support)
+            if abs(support - previous_support) > maximum_segment_rise:
+                return False
+            previous_support = support
+        return abs(float(centre) - previous_support) <= \
+            maximum_segment_rise
+
     def _update_vertical_motion(self, state, step, tick_pose=None,
                                 attempted_yaw=None):
         """Run grounded/ballistic phases and reject false raised support."""
@@ -5437,8 +5492,10 @@ class BotRuntime(object):
                 state['vertical_speed'] = 0.0
                 state['airborne'] = False
                 state['grounded_once'] = True
-            elif tank_collision.support_rise_is_obstacle(
-                    state.get('y'), centre, max_climb):
+            elif (tank_collision.support_rise_is_obstacle(
+                    state.get('y'), centre, max_climb) and
+                    not self._support_rise_follows_tick_path(
+                        state, centre, tick_pose)):
                 # The centre ray hit a wagon deck, roof, or large prop only
                 # after this tick's horizontal integration put the hull partly
                 # inside it. Restore only this tick's pose and let LocalDriver

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/world_collision.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/world_collision.py
@@ -93,13 +93,41 @@ def _ground_profile(spaceID, Math, pos, sx, sz, sin_y, cos_y, direction,
 	return heights, segment
 
 
+def _hull_pose_y(pitch, roll):
+	"""Return local right/up/forward contributions to world height."""
+	import math
+	pitch = float(pitch)
+	roll = float(roll)
+	if pitch == 0.0 and roll == 0.0:
+		return 0.0, 1.0, 0.0
+	pitch_cos = math.cos(pitch)
+	return (
+		pitch_cos * math.sin(roll),
+		pitch_cos * math.cos(roll),
+		-math.sin(pitch))
+
+
+def _posed_ray(Math, pos, x1, z1, x2, z2, local_start, local_end,
+		height, pose_y):
+	"""Rotate one copied collision lane with the authoritative hull pose."""
+	right_y, up_y, forward_y = pose_y
+	start_y = (float(pos.y) + float(local_start[0]) * right_y +
+		float(height) * up_y + float(local_start[1]) * forward_y)
+	end_y = (float(pos.y) + float(local_end[0]) * right_y +
+		float(height) * up_y + float(local_end[1]) * forward_y)
+	return (
+		Math.Vector3(x1, start_y, z1),
+		Math.Vector3(x2, end_y, z2))
+
+
 def _raised_ray_has_wall(spaceID, Math, pos, x1, z1, x2, z2,
-		target_length, maximum_gradient=_MAX_DRIVABLE_GRADIENT):
+		local_start, local_end, pose_y, target_length,
+		maximum_gradient=_MAX_DRIVABLE_GRADIENT):
 	"""A drivable lower slope must not hide an independent wall above it."""
-	import BigWorld
 	for height in (1.1, 1.6):
-		start = Math.Vector3(x1, pos.y + height, z1)
-		end = Math.Vector3(x2, pos.y + height, z2)
+		start, end = _posed_ray(
+			Math, pos, x1, z1, x2, z2, local_start, local_end,
+			height, pose_y)
 		collision = _collide_horizontal(spaceID, start, end)
 		if collision is None:
 			continue
@@ -213,7 +241,7 @@ def check_horizontal_collision(bigworld, math_module, *args, **kwargs):
 def _check_horizontal_collision(spaceID, pos, yaw, vel, td=None,
 		airborne=False, dt=0.04, return_status=False,
 		allow_kinetic=False, kinetic_speed=None, commit_enabled=True,
-		motion_yaw=None):
+		motion_yaw=None, pitch=0.0, roll=0.0):
 	import math, BigWorld, Math
 	try:
 		hw = 1.5
@@ -244,6 +272,7 @@ def _check_horizontal_collision(spaceID, pos, yaw, vel, td=None,
 			_ahead = max(0.4, abs(vel) * dt + 0.2)
 		cos_y = math.cos(yaw)
 		sin_y = math.sin(yaw)
+		pose_y = _hull_pose_y(pitch, roll)
 		lane_segments = []
 		if motion_yaw is None:
 			# Keep the shipped longitudinal probe byte-for-byte in geometry and
@@ -320,11 +349,21 @@ def _check_horizontal_collision(spaceID, pos, yaw, vel, td=None,
 		for (x1, z1, x2, z2, target_len,
 				profile_x, profile_z, profile_sin, profile_cos,
 				profile_direction, profile_look) in lane_segments:
+			start_dx, start_dz = x1 - pos.x, z1 - pos.z
+			end_dx, end_dz = x2 - pos.x, z2 - pos.z
+			local_start = (
+				start_dx * cos_y - start_dz * sin_y,
+				start_dx * sin_y + start_dz * cos_y)
+			local_end = (
+				end_dx * cos_y - end_dz * sin_y,
+				end_dx * sin_y + end_dz * cos_y)
 			
 			# Spodní paprsek pro pevnou geometrii (0.6m nad zemí)
-			start_bot = Math.Vector3(x1, pos.y + 0.6, z1)
-			end_bot = Math.Vector3(x2, pos.y + 0.6, z2)
+			start_bot, end_bot = _posed_ray(
+				Math, pos, x1, z1, x2, z2, local_start, local_end,
+				0.6, pose_y)
 			col_bot = _collide_horizontal(spaceID, start_bot, end_bot)
+			target_len = (end_bot - start_bot).length
 			
 			if col_bot is not None:
 				d_bot = (col_bot[0] - start_bot).length
@@ -360,6 +399,7 @@ def _check_horizontal_collision(spaceID, pos, yaw, vel, td=None,
 							_drivable_surface(col_bot, _gradient_limit)):
 						if _raised_ray_has_wall(
 								spaceID, Math, pos, x1, z1, x2, z2,
+								local_start, local_end, pose_y,
 								target_len, _gradient_limit):
 							return 'hard' if return_status else True
 						continue
@@ -371,8 +411,10 @@ def _check_horizontal_collision(spaceID, pos, yaw, vel, td=None,
 					# heights use the same read-only exact-OBB recast path.
 					_lane_hits = [(d_bot, start_bot, end_bot, col_bot)]
 					for _height in (1.1, 1.6):
-						_ray_start = Math.Vector3(x1, pos.y + _height, z1)
-						_ray_end = Math.Vector3(x2, pos.y + _height, z2)
+						_ray_start, _ray_end = _posed_ray(
+							Math, pos, x1, z1, x2, z2,
+							local_start, local_end, _height,
+							pose_y)
 						_ray_hit = _collide_horizontal(
 							spaceID, _ray_start, _ray_end)
 						if _ray_hit is None:
@@ -400,8 +442,10 @@ def _check_horizontal_collision(spaceID, pos, yaw, vel, td=None,
 				# three empty lower lanes could classify a real upper collision clear.
 				_upper_hits = []
 				for _height in (1.1, 1.6):
-					_ray_start = Math.Vector3(x1, pos.y + _height, z1)
-					_ray_end = Math.Vector3(x2, pos.y + _height, z2)
+					_ray_start, _ray_end = _posed_ray(
+						Math, pos, x1, z1, x2, z2,
+						local_start, local_end, _height,
+						pose_y)
 					_ray_hit = _collide_horizontal(
 						spaceID, _ray_start, _ray_end)
 					if _ray_hit is None:

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/world_collision.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/world_collision.py
@@ -4,12 +4,13 @@
 from gui.mods.offline_lan_0922.destructibles_sensor import (
 	_catalog_soft_static_path, _diagnostic_static_recast_1513,
 	_try_destroy_solid_hit, _vehicle_hull_bbox,
-	horizontal_collision_filter)
+	ground_collision_filter, horizontal_collision_filter)
 
 
 _MAX_DRIVABLE_GRADIENT = 1.28
 _MAX_DESCENDING_GRADIENT = 1.75
 _MIN_DRIVABLE_HEIGHT_CHANGE = 0.15
+_GROUND_HIT_EPSILON = 1.0e-3
 _WORLD_SOFT_RECAST_BUDGET = 4
 
 
@@ -93,6 +94,52 @@ def _ground_profile(spaceID, Math, pos, sx, sz, sin_y, cos_y, direction,
 	return heights, segment
 
 
+def _hit_matches_ground_profile(collision, heights, segment_length,
+		profile_x, profile_z, profile_sin, profile_cos, profile_direction):
+	"""Return a coarse seam candidate; exact native top must confirm it."""
+	try:
+		values = [float(value) for value in heights]
+		segment = float(segment_length)
+		if len(values) < 2 or segment <= 0.0:
+			return False
+		point = collision[0]
+		distance = float(profile_direction) * (
+			(float(point.x) - float(profile_x)) * float(profile_sin) +
+			(float(point.z) - float(profile_z)) * float(profile_cos))
+		profile_length = segment * (len(values) - 1)
+		if distance < 0.0 or distance > profile_length:
+			return False
+		index = min(len(values) - 2, int(distance / segment))
+		fraction = (distance - index * segment) / segment
+		ground_y = (values[index] +
+			(values[index + 1] - values[index]) * fraction)
+		return abs(float(point.y) - ground_y) <= _MIN_DRIVABLE_HEIGHT_CHANGE
+	except (AttributeError, IndexError, TypeError, ValueError,
+			ZeroDivisionError):
+		return False
+
+
+def _hit_matches_exact_ground_top(spaceID, Math, pos, collision, look):
+	"""Confirm that a coarse-profile candidate is the native top at its XZ."""
+	import BigWorld
+	try:
+		point = collision[0]
+		probe_down = max(
+			5.0, float(look) * _MAX_DESCENDING_GRADIENT + 1.0)
+		start = Math.Vector3(point.x, pos.y + 12.0, point.z)
+		end = Math.Vector3(point.x, pos.y - probe_down, point.z)
+		broken_filter = ground_collision_filter(point.x, point.z)
+		top = (BigWorld.wg_collideSegment(spaceID, start, end, 128)
+			if broken_filter is None else
+			BigWorld.wg_collideSegment(
+				spaceID, start, end, 128, broken_filter))
+		return (top is not None and
+			abs(float(top[0].y) - float(point.y)) <=
+			_GROUND_HIT_EPSILON)
+	except (AttributeError, IndexError, TypeError, ValueError):
+		return False
+
+
 def _hull_pose_y(pitch, roll):
 	"""Return local right/up/forward contributions to world height."""
 	import math
@@ -105,6 +152,28 @@ def _hull_pose_y(pitch, roll):
 		pitch_cos * math.sin(roll),
 		pitch_cos * math.cos(roll),
 		-math.sin(pitch))
+
+
+def _hull_pose_endpoint(local_start, local_end, half_width,
+		half_length_back, half_length_front):
+	"""Stop pose extrapolation where a lane leaves the hull footprint."""
+	start_right = float(local_start[0])
+	start_forward = float(local_start[1])
+	delta_right = float(local_end[0]) - start_right
+	delta_forward = float(local_end[1]) - start_forward
+	fraction = 1.0
+	for start, delta, lower, upper in (
+			(start_right, delta_right, -float(half_width), float(half_width)),
+			(start_forward, delta_forward, -float(half_length_back),
+				float(half_length_front))):
+		if delta > 0.0:
+			fraction = min(fraction, (upper - start) / delta)
+		elif delta < 0.0:
+			fraction = min(fraction, (lower - start) / delta)
+	fraction = max(0.0, min(1.0, fraction))
+	return (
+		start_right + delta_right * fraction,
+		start_forward + delta_forward * fraction)
 
 
 def _posed_ray(Math, pos, x1, z1, x2, z2, local_start, local_end,
@@ -122,7 +191,7 @@ def _posed_ray(Math, pos, x1, z1, x2, z2, local_start, local_end,
 
 def _raised_ray_has_wall(spaceID, Math, pos, x1, z1, x2, z2,
 		local_start, local_end, pose_y, target_length,
-		maximum_gradient=_MAX_DRIVABLE_GRADIENT):
+		maximum_gradient=_MAX_DRIVABLE_GRADIENT, ground_profile=None):
 	"""A drivable lower slope must not hide an independent wall above it."""
 	for height in (1.1, 1.6):
 		start, end = _posed_ray(
@@ -131,9 +200,20 @@ def _raised_ray_has_wall(spaceID, Math, pos, x1, z1, x2, z2,
 		collision = _collide_horizontal(spaceID, start, end)
 		if collision is None:
 			continue
-		if ((collision[0] - start).length < target_length and
-				not _drivable_surface(collision, maximum_gradient)):
-			return True
+		if (collision[0] - start).length >= target_length:
+			continue
+		if _drivable_surface(collision, maximum_gradient):
+			continue
+		if (ground_profile is not None and
+				_hit_matches_ground_profile(
+					collision, ground_profile[0], ground_profile[1],
+					ground_profile[2], ground_profile[3],
+					ground_profile[4], ground_profile[5],
+					ground_profile[6])):
+			if _hit_matches_exact_ground_top(
+					spaceID, Math, pos, collision, ground_profile[7]):
+				continue
+		return True
 	return False
 
 
@@ -354,9 +434,18 @@ def _check_horizontal_collision(spaceID, pos, yaw, vel, td=None,
 			local_start = (
 				start_dx * cos_y - start_dz * sin_y,
 				start_dx * sin_y + start_dz * cos_y)
-			local_end = (
+			ray_local_end = (
 				end_dx * cos_y - end_dz * sin_y,
 				end_dx * sin_y + end_dz * cos_y)
+			# Keep the footprint start, but stop pose growth at the first hull edge.
+			# This chord is a conservative witness inside the swept hull volume;
+			# extrapolating pitch/roll through look-ahead can pass over a real wall.
+			local_end = _hull_pose_endpoint(
+				local_start, ray_local_end, hw, hl_back, hl_front)
+			pose_clamped = (
+				pose_y != (0.0, 1.0, 0.0) and
+				(abs(local_end[0] - ray_local_end[0]) > 1.0e-9 or
+				 abs(local_end[1] - ray_local_end[1]) > 1.0e-9))
 			
 			# Spodní paprsek pro pevnou geometrii (0.6m nad zemí)
 			start_bot, end_bot = _posed_ray(
@@ -375,10 +464,13 @@ def _check_horizontal_collision(spaceID, pos, yaw, vel, td=None,
 					_heights = ()
 					_segment = 0.0
 					_gradient_limit = _MAX_DESCENDING_GRADIENT
-					# A vertical wall cannot become terrain under either directional
-					# limit, so avoid seven extra ground rays on the common hard-hit path.
-					# Only a surface that could be a slope earns the exact lane profile.
-					if _drivable_surface(col_bot, _gradient_limit):
+					_profile_allowed = not (pose_clamped and airborne)
+					# A normal level-pose wall avoids the seven ground rays. A swept
+					# chord whose endpoint height is clamped at the first hull edge can
+					# meet terrain later, so that bounded case earns the existing profile.
+					if (_profile_allowed and (
+							_drivable_surface(col_bot, _gradient_limit) or
+							pose_clamped)):
 						_heights, _segment = _ground_profile(
 							spaceID, Math, pos, profile_x, profile_z,
 							profile_sin, profile_cos, profile_direction,
@@ -394,13 +486,28 @@ def _check_horizontal_collision(spaceID, pos, yaw, vel, td=None,
 							# a small prop. An ascent/descent outside its directional
 							# bound remains solid instead of falling into prop handling.
 							return 'hard' if return_status else True
+					_surface_is_ground = (
+						_profile_allowed and
+						_drivable_surface(col_bot, _gradient_limit))
+					if (_profile_allowed and not _surface_is_ground and
+							pose_clamped and _hit_matches_ground_profile(
+								col_bot, _heights, _segment,
+								profile_x, profile_z,
+								profile_sin, profile_cos,
+								profile_direction)):
+						_surface_is_ground = _hit_matches_exact_ground_top(
+							spaceID, Math, pos, col_bot, profile_look)
 					if (_heights and
 							_drivable_ground_profile(_heights, _segment) and
-							_drivable_surface(col_bot, _gradient_limit)):
+							_surface_is_ground):
 						if _raised_ray_has_wall(
 								spaceID, Math, pos, x1, z1, x2, z2,
 								local_start, local_end, pose_y,
-								target_len, _gradient_limit):
+								target_len, _gradient_limit,
+								(_heights, _segment,
+								 profile_x, profile_z,
+								 profile_sin, profile_cos,
+								 profile_direction, profile_look)):
 							return 'hard' if return_status else True
 						continue
 					# Treat every occupied hull height as independent evidence.  The

--- a/0.9.22/tests/test_port_0922_battle_runtime.py
+++ b/0.9.22/tests/test_port_0922_battle_runtime.py
@@ -7685,6 +7685,8 @@ class BattleRuntimeContractTests(unittest.TestCase):
         battle = BattleRuntime(runtime)
         battle._avatar = runtime.bigworld.avatar
         battle._arena_bounds = (-300.0, -300.0, 300.0, 300.0)
+        battle._local_pitch = 0.2
+        battle._local_roll = -0.15
         entity = _Vehicle(
             10, _Descriptor(), _Vector(), (0, 0, 0), {'health': 500})
 
@@ -7707,6 +7709,8 @@ class BattleRuntimeContractTests(unittest.TestCase):
                 math.pi * 0.5, world_probe.call_args.args[4])
             self.assertEqual(
                 0.0, world_probe.call_args.kwargs['motion_yaw'])
+            self.assertEqual(0.2, world_probe.call_args.kwargs['pitch'])
+            self.assertEqual(-0.15, world_probe.call_args.kwargs['roll'])
 
             world_probe.reset_mock()
             self.assertTrue(battle._motion_is_clear(
@@ -14666,6 +14670,42 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertFalse(sensor_call.kwargs['commit_enabled'])
         self.assertFalse(sensor_call.kwargs['kinetic_commit'])
 
+    def test_bot_glancing_probe_keeps_hull_pose_and_travel_separate(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        battle._bots = types.SimpleNamespace(states={
+            11: {
+                'movement_dir': 0, 'airborne': False, 'yaw': 0.4,
+                'terrain_pitch': 0.2, 'suspension_pitch': 0.25,
+                'pitch': 0.45, 'roll': -0.15,
+            },
+        })
+        battle._destructibles = mock.Mock()
+        battle._destructibles._catalog_motion_blocked.return_value = {
+            'status': 'clear', 'token': None,
+            'accepted_now': False, 'used_kinetic_speed': False,
+        }
+
+        with mock.patch(
+                'gui.mods.offline_lan_0922.battle_runtime.'
+                'world_collision.check_horizontal_collision',
+                return_value='clear') as world_probe:
+            status = battle._resolve_bot_motion(
+                11, (1.0, 2.0, 3.0), 0.4, 4.0,
+                _Descriptor(), 0.04, 10.0, motion_yaw=-0.55)
+
+        self.assertEqual('clear', status)
+        self.assertAlmostEqual(0.4, world_probe.call_args.args[4])
+        self.assertAlmostEqual(
+            -0.55, world_probe.call_args.kwargs['motion_yaw'])
+        self.assertAlmostEqual(0.2, world_probe.call_args.kwargs['pitch'])
+        self.assertAlmostEqual(-0.15, world_probe.call_args.kwargs['roll'])
+        sensor_call = (
+            battle._destructibles._catalog_motion_blocked.call_args)
+        self.assertAlmostEqual(0.4, sensor_call.args[2])
+        self.assertAlmostEqual(-0.55, sensor_call.kwargs['motion_yaw'])
+
     def test_bot_clear_catalog_guard_skips_per_frame_world_probe(self):
         runtime = _runtime()
         battle = BattleRuntime(runtime)
@@ -18988,9 +19028,11 @@ class BattleRuntimeContractTests(unittest.TestCase):
             'id': 2, 'vehicle': 'ussr:R11_MS-1',
             'vehicle_compact_descr': 'dGVzdA==',
             'effective_params': _effective_params_snapshot(),
+            'pitch': -0.3, 'roll': 0.25,
             'destructible_contacts': [{
                 'seq': 3, 'x': 1.0, 'y': 2.0, 'z': 3.0,
-                'yaw': 0.25, 'speed': 8.0, 'dt': 0.04,
+                'yaw': 0.25, 'pitch': 0.2, 'roll': -0.15,
+                'speed': 8.0, 'dt': 0.04,
                 'forward': 1.0, 'token': requested,
             }],
         }
@@ -19007,11 +19049,13 @@ class BattleRuntimeContractTests(unittest.TestCase):
                 mock.patch(
                     'gui.mods.offline_lan_0922.battle_runtime.'
                     'world_collision.check_horizontal_collision',
-                    return_value='hard'):
+                    return_value='hard') as world_probe:
             self.assertEqual(
                 1, battle._resolve_player_destructible_contacts(
                     [player], 12.5))
 
+        self.assertEqual(0.2, world_probe.call_args.kwargs['pitch'])
+        self.assertEqual(-0.15, world_probe.call_args.kwargs['roll'])
         battle._destructibles._catalog_motion_blocked.assert_not_called()
         battle.client.send_player_destructible_contact_result.\
             assert_called_once_with(2, 3, False, requested)

--- a/0.9.22/tests/test_port_0922_bot_runtime.py
+++ b/0.9.22/tests/test_port_0922_bot_runtime.py
@@ -3595,6 +3595,41 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertAlmostEqual(4.0 / 3.0, calls[1])
         self.assertAlmostEqual(8.0 / 3.0, calls[2])
 
+    def test_lateral_contact_correction_settles_only_proved_rise_once(self):
+        calls = []
+
+        def ground(x, unused_z, unused_y):
+            calls.append(x)
+            return x * 0.4
+
+        runtime = self.module.BotRuntime(
+            1, physics_ground_probe=ground)
+        state = {
+            'id': 11, 'x': 5.0, 'y': 0.0, 'z': 0.0, 'yaw': 0.0,
+            'speed': 0.0, 'half_length': 3.0,
+            'movement_dir': 0, 'rotation_dir': 0,
+            'push_x': 0.0, 'push_z': 0.0,
+            'vertical_speed': 0.0, 'airborne': False,
+            'grounded_once': True, 'last_drive_pitch': 0.0,
+        }
+
+        first_blocked = runtime._update_vertical_motion(
+            state, 0.2, (0.0, 0.0, 0.0), 0.0)
+        first_y = state['y']
+        first_call_count = len(calls)
+        second_tick_pose = (state['x'], state['y'], state['z'])
+        second_blocked = runtime._update_vertical_motion(
+            state, 0.2, second_tick_pose, 0.0)
+
+        self.assertEqual((False, False), (first_blocked, second_blocked))
+        # Five metres of correction proves this exact two-metre support rise;
+        # it must not become a 12.5-metre powered-drive placement budget.
+        self.assertAlmostEqual(2.0, first_y)
+        self.assertAlmostEqual(2.0, state['y'])
+        # First tick: centre plus three exceptional profile samples. Second
+        # settled tick: the unchanged one-centre-ray path.
+        self.assertEqual((4, 5), (first_call_count, len(calls)))
+
     def test_low_fps_bot_still_rejects_a_vertical_support_step(self):
         calls = []
 

--- a/0.9.22/tests/test_port_0922_bot_runtime.py
+++ b/0.9.22/tests/test_port_0922_bot_runtime.py
@@ -3091,7 +3091,7 @@ class BotRuntimeTests(unittest.TestCase):
 
         hard_calls = []
 
-        def hard_resolver(*args):
+        def hard_resolver(*args, **unused_kwargs):
             hard_calls.append(args)
             return 'hard'
 
@@ -3175,14 +3175,14 @@ class BotRuntimeTests(unittest.TestCase):
         calls = []
         destroyed = []
 
-        def resolver(*args):
+        def resolver(*args, **kwargs):
             commit_enabled = args[7] if len(args) > 7 else True
-            calls.append((args, commit_enabled))
+            calls.append((args, kwargs, commit_enabled))
             if len(calls) == 1:
                 return 'hard'
             if commit_enabled:
-                destroyed.append(args[2])
-            if args[2] == -0.55:
+                destroyed.append(kwargs['motion_yaw'])
+            if kwargs['motion_yaw'] == -0.55:
                 return 'crushed' if commit_enabled else 'clear'
             return 'hard'
 
@@ -3207,10 +3207,12 @@ class BotRuntimeTests(unittest.TestCase):
             self.module.vehicle_physics.hard_contact_step(
                 contact_speed, .04, grinding=False, slide_yaw=-0.55)
         self.assertEqual(4, len(calls))
-        self.assertEqual([0.55, -0.55, -0.55],
+        self.assertEqual([0.0, 0.0, 0.0],
                          [call[0][2] for call in calls[1:]])
+        self.assertEqual([0.55, -0.55, -0.55],
+                         [call[1]['motion_yaw'] for call in calls[1:]])
         self.assertEqual([False, False, True],
-                         [call[1] for call in calls[1:]])
+                         [call[2] for call in calls[1:]])
         self.assertEqual([-0.55], destroyed)
         self.assertAlmostEqual(expected_speed, state['speed'])
         self.assertAlmostEqual(delta_x, state['x'])
@@ -3218,6 +3220,28 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertEqual(
             self.module.vehicle_physics.HARD_CONTACT_GRIND_TICKS,
             runtime._hard_contact_grinds[11])
+
+    def test_reverse_passive_probe_uses_signed_motion_not_hull_yaw(self):
+        calls = []
+
+        def resolver(*args, **kwargs):
+            calls.append((args, kwargs))
+            return 'clear'
+
+        runtime = self.module.BotRuntime(1, motion_resolver=resolver)
+        state = {'id': 11, 'yaw': 0.4, 'movement_dir': -1}
+
+        status = runtime._passive_motion_status(
+            state, (1.0, 2.0, 3.0), -0.15, -4.0, {}, 0.04, 1.0,
+            commit_enabled=False)
+
+        self.assertEqual('clear', status)
+        self.assertEqual(-1, state['movement_dir'])
+        self.assertEqual(1, len(calls))
+        self.assertAlmostEqual(0.4, calls[0][0][2])
+        self.assertAlmostEqual(math.pi - 0.15,
+                               calls[0][1]['motion_yaw'])
+        self.assertFalse(calls[0][0][7])
 
     def test_realised_hard_contact_invalidates_cached_command_and_probe(self):
         attempted_yaw = 0.25
@@ -3248,7 +3272,7 @@ class BotRuntimeTests(unittest.TestCase):
             direction_probe=lambda *unused: {
                 'clear': False, 'collision': True, 'water': False,
                 'slope': 0.0},
-            motion_resolver=lambda *unused: status[0],
+            motion_resolver=lambda *unused, **unused_kwargs: status[0],
             ground_probe=lambda *unused: 0.0,
             physics_ground_probe=lambda *unused: 0.0,
             spawn_resolver=_spawn_resolver, baked_graph=_graph())
@@ -3542,6 +3566,118 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertEqual(2.0, state['y'])
         self.assertFalse(state['airborne'])
         self.assertFalse(support_blocked)
+
+    def test_low_fps_bot_follows_a_continuous_rising_support_profile(self):
+        calls = []
+
+        def ground(unused_x, z, unused_y):
+            calls.append(z)
+            return z * 0.22
+
+        runtime = self.module.BotRuntime(
+            1, physics_ground_probe=ground)
+        state = {
+            'id': 11, 'x': 0.0, 'y': 0.0, 'z': 4.0, 'yaw': 0.0,
+            'speed': 20.0, 'half_length': 3.0,
+            'vertical_speed': 0.0, 'airborne': False,
+            'grounded_once': True,
+            'last_drive_pitch': -math.atan(0.22),
+        }
+
+        support_blocked = runtime._update_vertical_motion(
+            state, 0.2, (0.0, 0.0, 0.0), 0.0)
+
+        self.assertFalse(support_blocked)
+        self.assertAlmostEqual(0.88, state['y'])
+        self.assertEqual(20.0, state['speed'])
+        self.assertEqual(3, len(calls))
+        self.assertAlmostEqual(4.0, calls[0])
+        self.assertAlmostEqual(4.0 / 3.0, calls[1])
+        self.assertAlmostEqual(8.0 / 3.0, calls[2])
+
+    def test_low_fps_bot_still_rejects_a_vertical_support_step(self):
+        calls = []
+
+        def ground(unused_x, z, unused_y):
+            calls.append(z)
+            return 0.88 if z >= 2.0 else 0.0
+
+        runtime = self.module.BotRuntime(
+            1, physics_ground_probe=ground)
+        state = {
+            'id': 11, 'x': 0.0, 'y': 0.0, 'z': 4.0, 'yaw': 0.0,
+            'speed': 20.0, 'half_length': 3.0,
+            'movement_dir': 1, 'rotation_dir': 0,
+            'push_x': 0.0, 'push_z': 0.0,
+            'vertical_speed': 0.0, 'airborne': False,
+            'grounded_once': True,
+            'last_drive_pitch': -math.atan(0.22),
+        }
+
+        support_blocked = runtime._update_vertical_motion(
+            state, 0.2, (0.0, 0.0, 0.0), 0.0)
+
+        self.assertTrue(support_blocked)
+        self.assertEqual((0.0, 0.0, 0.0),
+                         (state['x'], state['y'], state['z']))
+        self.assertEqual(0.0, state['speed'])
+        self.assertEqual(3, len(calls))
+
+    def test_suspicious_support_profile_rejects_an_interior_drop(self):
+        calls = []
+
+        def ground(unused_x, z, unused_y):
+            calls.append(z)
+            if z >= 6.9:
+                return 0.91
+            if z < 1.5:
+                return -2.0
+            return -2.0 + (z - 1.4) / 1.4 * 0.79
+
+        runtime = self.module.BotRuntime(
+            1, physics_ground_probe=ground)
+        state = {
+            'id': 11, 'x': 0.0, 'y': 0.0, 'z': 7.0, 'yaw': 0.0,
+            'speed': 35.0, 'half_length': 3.0,
+            'movement_dir': 1, 'rotation_dir': 0,
+            'push_x': 0.0, 'push_z': 0.0,
+            'vertical_speed': 0.0, 'airborne': False,
+            'grounded_once': True,
+            'last_drive_pitch': -math.atan(0.13),
+        }
+
+        support_blocked = runtime._update_vertical_motion(
+            state, 0.2, (0.0, 0.0, 0.0), 0.0)
+
+        self.assertTrue(support_blocked)
+        self.assertEqual((0.0, 0.0, 0.0),
+                         (state['x'], state['y'], state['z']))
+        self.assertEqual(2, len(calls))
+
+    def test_suspicious_support_profile_uses_at_most_four_extra_rays(self):
+        calls = []
+
+        def ground(unused_x, z, unused_y):
+            calls.append(z)
+            return z * 0.13
+
+        runtime = self.module.BotRuntime(
+            1, physics_ground_probe=ground)
+        state = {
+            'id': 11, 'x': 0.0, 'y': 0.0, 'z': 7.0, 'yaw': 0.0,
+            'speed': 35.0, 'half_length': 3.0,
+            'vertical_speed': 0.0, 'airborne': False,
+            'grounded_once': True,
+            'last_drive_pitch': -math.atan(0.13),
+        }
+
+        support_blocked = runtime._update_vertical_motion(
+            state, 0.2, (0.0, 0.0, 0.0), 0.0)
+
+        self.assertFalse(support_blocked)
+        self.assertEqual(5, len(calls))
+        self.assertEqual(5, dict(zip(
+            self.module.PROBE_KINDS, runtime.probe_totals()))['ground'])
 
     def test_grounded_bot_rejects_raised_centre_support_and_recovers(self):
         failures = []

--- a/0.9.22/tests/test_port_0922_server_projectiles.py
+++ b/0.9.22/tests/test_port_0922_server_projectiles.py
@@ -652,6 +652,24 @@ class ServerProjectileLedgerTests(unittest.TestCase):
         self.assertEqual(2, player.input_seq)
         self.assertEqual(1.0, player.forward)
 
+    def test_destructible_contact_freezes_bound_pose_attitude(self):
+        state = _state(players=1)
+        relayed = []
+        state.simulation_worker.offer_reliable = (
+            lambda message: relayed.append(message) or True)
+
+        self.assertTrue(_update_player_input(
+            state, 1, forward=1.0, speed=5.0,
+            pitch=0.2, roll=-0.15,
+            destructible_contacts=[_player_destructible_contact()]))
+
+        contact = state.players[1].destructible_contacts[1]
+        self.assertEqual((0.2, -0.15), (
+            contact['pitch'], contact['roll']))
+        self.assertEqual((0.2, -0.15), (
+            relayed[0]['player']['destructible_contacts'][0]['pitch'],
+            relayed[0]['player']['destructible_contacts'][0]['roll']))
+
     def test_player_environment_skips_overtaken_rows_and_keeps_live_rows(self):
         state = _state(players=2)
         dead = state.players[1]

--- a/0.9.22/tests/test_port_0922_world_collision.py
+++ b/0.9.22/tests/test_port_0922_world_collision.py
@@ -898,6 +898,98 @@ class WorldCollisionTests(unittest.TestCase):
         self.assertFalse(blocked)
         self.assertTrue(horizontal_calls)
 
+    def test_hull_pitch_keeps_lower_rays_above_rising_terrain_seam(self):
+        gradient = 0.20
+        seam_normal = _Vector(0.0, 0.0, -1.0)
+
+        def collide(unused_space, start, end, unused_mask):
+            if abs(start.y - end.y) > 10.0:
+                return (_Vector(start.x, gradient * start.z, start.z),)
+            delta_y = end.y - start.y
+            delta_z = end.z - start.z
+            denominator = delta_y - gradient * delta_z
+            if abs(denominator) <= 1.0e-9:
+                return None
+            progress = (gradient * start.z - start.y) / denominator
+            if not 0.0 <= progress <= 1.0:
+                return None
+            return (_Vector(
+                start.x, start.y + delta_y * progress,
+                start.z + delta_z * progress), seam_normal, 0)
+
+        bigworld = types.SimpleNamespace(
+            wg_collideSegment=collide,
+            wg_getMatInfoNearPoint=_miss_mat_info_1513)
+        math_module = types.SimpleNamespace(Vector3=_Vector)
+
+        self.assertTrue(world_collision.check_horizontal_collision(
+            bigworld, math_module, 1, _Vector(), 0.0, 5.0,
+            None, False, 0.04))
+        self.assertFalse(world_collision.check_horizontal_collision(
+            bigworld, math_module, 1, _Vector(), 0.0, 5.0,
+            None, False, 0.04, pitch=-math.atan(gradient)))
+
+    def test_hull_roll_poses_lanes_without_adding_native_rays(self):
+        calls = []
+
+        def collide(unused_space, start, end, unused_mask):
+            calls.append((start, end))
+            return None
+
+        bigworld = types.SimpleNamespace(
+            wg_collideSegment=collide,
+            wg_getMatInfoNearPoint=_miss_mat_info_1513)
+        math_module = types.SimpleNamespace(Vector3=_Vector)
+
+        self.assertFalse(world_collision.check_horizontal_collision(
+            bigworld, math_module, 1, _Vector(), 0.0, 5.0,
+            None, False, 0.04))
+        level_ray_count = len(calls)
+        calls[:] = []
+
+        roll = 0.20
+        self.assertFalse(world_collision.check_horizontal_collision(
+            bigworld, math_module, 1, _Vector(), 0.0, 5.0,
+            None, False, 0.04, roll=roll))
+        self.assertEqual(level_ray_count, len(calls))
+        lower_rays = calls[::3]
+        self.assertEqual(3, len(lower_rays))
+        for (start, end), local_right in zip(
+                lower_rays, (-1.5, 0.0, 1.5)):
+            expected_y = (0.6 * math.cos(roll) +
+                          local_right * math.sin(roll))
+            self.assertAlmostEqual(expected_y, start.y)
+            self.assertAlmostEqual(expected_y, end.y)
+            self.assertAlmostEqual(local_right, start.x)
+            self.assertAlmostEqual(local_right, end.x)
+            self.assertAlmostEqual(-0.5, start.z)
+            self.assertAlmostEqual(3.9, end.z)
+
+    def test_posed_ray_composes_roll_before_pitch(self):
+        math_module = types.SimpleNamespace(Vector3=_Vector)
+        pos = _Vector(4.0, 7.0, 9.0)
+        local_start = (1.4, -2.3)
+        local_end = (-0.8, 3.1)
+        pitch = 0.31
+        roll = -0.22
+        height = 0.85
+
+        pose_y = world_collision._hull_pose_y(pitch, roll)
+        start, end = world_collision._posed_ray(
+            math_module, pos, 2.0, 3.0, 5.0, 6.0,
+            local_start, local_end, height, pose_y)
+
+        def expected_y(local):
+            return (pos.y + math.cos(pitch) * (
+                local[0] * math.sin(roll) +
+                height * math.cos(roll)) -
+                local[1] * math.sin(pitch))
+
+        self.assertAlmostEqual(expected_y(local_start), start.y)
+        self.assertAlmostEqual(expected_y(local_end), end.y)
+        self.assertEqual((2.0, 3.0), (start.x, start.z))
+        self.assertEqual((5.0, 6.0), (end.x, end.z))
+
     def test_gradually_descending_ground_remains_drivable(self):
         horizontal_calls = []
 

--- a/0.9.22/tests/test_port_0922_world_collision.py
+++ b/0.9.22/tests/test_port_0922_world_collision.py
@@ -695,6 +695,7 @@ class WorldCollisionTests(unittest.TestCase):
                         bigworld, math_module, 1, _Vector(), 0.0, velocity,
                         descriptor, False, 0.04,
                         motion_yaw=motion_yaw))
+                self.assertEqual(15, len(horizontal_calls))
                 lower_rays = [
                     (start, end) for start, end in horizontal_calls
                     if abs(start.y - 0.6) < 0.001]
@@ -929,6 +930,474 @@ class WorldCollisionTests(unittest.TestCase):
             bigworld, math_module, 1, _Vector(), 0.0, 5.0,
             None, False, 0.04, pitch=-math.atan(gradient)))
 
+    def test_clamped_long_lookahead_still_admits_continuous_slope(self):
+        gradient = 0.20
+        math_module = types.SimpleNamespace(Vector3=_Vector)
+
+        for velocity, world_gradient in (
+                (20.0, gradient), (-20.0, -gradient)):
+            counts = {'ground': 0, 'horizontal': 0}
+
+            def collide(unused_space, start, end, unused_mask):
+                if abs(start.y - end.y) > 10.0:
+                    counts['ground'] += 1
+                    ground_y = world_gradient * start.z
+                    if min(start.y, end.y) <= ground_y <= max(start.y, end.y):
+                        return (_Vector(start.x, ground_y, start.z),)
+                    return None
+                counts['horizontal'] += 1
+                delta_y = end.y - start.y
+                delta_z = end.z - start.z
+                denominator = delta_y - world_gradient * delta_z
+                if abs(denominator) <= 1.0e-9:
+                    return None
+                progress = (world_gradient * start.z - start.y) / denominator
+                if not 0.0 <= progress <= 1.0:
+                    return None
+                return (_Vector(
+                    start.x, start.y + delta_y * progress,
+                    start.z + delta_z * progress),
+                    _Vector(0.0, 0.0, -1.0), 0)
+
+            bigworld = types.SimpleNamespace(
+                wg_collideSegment=collide,
+                wg_getMatInfoNearPoint=_miss_mat_info_1513)
+
+            self.assertFalse(world_collision.check_horizontal_collision(
+                bigworld, math_module, 1, _Vector(), 0.0, velocity,
+                None, False, 0.20,
+                pitch=-math.atan(world_gradient)))
+            self.assertEqual(9, counts['horizontal'])
+            self.assertEqual(24, counts['ground'])
+
+    def test_exact_top_rejects_wall_hidden_by_coarse_profile(self):
+        gradient = 0.20
+        wall_z = 6.813
+        wall_bottom = gradient * wall_z
+        wall_top = wall_bottom + 0.61
+        exact_wall_queries = [0]
+        wall_hits = []
+
+        def collide(unused_space, start, end, unused_mask):
+            if abs(start.y - end.y) > 10.0:
+                at_wall = abs(start.z - wall_z) <= 1.0e-6
+                if at_wall:
+                    exact_wall_queries[0] += 1
+                top_y = wall_top if at_wall else gradient * start.z
+                if min(start.y, end.y) <= top_y <= max(start.y, end.y):
+                    return (_Vector(start.x, top_y, start.z),)
+                return None
+            candidates = []
+            delta_y = end.y - start.y
+            delta_z = end.z - start.z
+            terrain_denominator = delta_y - gradient * delta_z
+            if abs(terrain_denominator) > 1.0e-9:
+                progress = (
+                    gradient * start.z - start.y) / terrain_denominator
+                if 0.0 <= progress <= 1.0:
+                    candidates.append((progress, _Vector(
+                        start.x, start.y + delta_y * progress,
+                        start.z + delta_z * progress)))
+            if abs(delta_z) > 1.0e-9:
+                progress = (wall_z - start.z) / delta_z
+                if 0.0 <= progress <= 1.0:
+                    hit_y = start.y + delta_y * progress
+                    if wall_bottom <= hit_y <= wall_top:
+                        wall_hits.append(hit_y)
+                        candidates.append((progress, _Vector(
+                            start.x, hit_y, wall_z)))
+            if not candidates:
+                return None
+            unused_progress, point = min(candidates, key=lambda row: row[0])
+            return point, _Vector(0.0, 0.0, -1.0), 0
+
+        bigworld = types.SimpleNamespace(
+            wg_collideSegment=collide,
+            wg_getMatInfoNearPoint=_miss_mat_info_1513)
+        math_module = types.SimpleNamespace(Vector3=_Vector)
+
+        self.assertEqual('hard',
+            world_collision.check_horizontal_collision(
+                bigworld, math_module, 1, _Vector(), 0.0, 35.0,
+                None, False, 0.20, True, commit_enabled=False,
+                pitch=-math.atan(gradient)))
+        self.assertEqual(1, exact_wall_queries[0])
+        self.assertTrue(wall_hits)
+        self.assertAlmostEqual(0.130194, wall_hits[0] - wall_bottom,
+                               places=5)
+
+    def test_level_point_six_one_wall_needs_no_ground_queries(self):
+        wall_z = 6.813
+        wall_top = 0.61
+        ground_queries = [0]
+
+        def collide(unused_space, start, end, unused_mask):
+            if abs(start.y - end.y) > 10.0:
+                ground_queries[0] += 1
+                return (_Vector(start.x, 0.0, start.z),)
+            delta_z = end.z - start.z
+            if abs(delta_z) <= 1.0e-9:
+                return None
+            progress = (wall_z - start.z) / delta_z
+            if not 0.0 <= progress <= 1.0:
+                return None
+            hit_y = start.y + (end.y - start.y) * progress
+            if not 0.0 <= hit_y <= wall_top:
+                return None
+            return (_Vector(start.x, hit_y, wall_z),
+                    _Vector(0.0, 0.0, -1.0), 0)
+
+        bigworld = types.SimpleNamespace(
+            wg_collideSegment=collide,
+            wg_getMatInfoNearPoint=_miss_mat_info_1513)
+        math_module = types.SimpleNamespace(Vector3=_Vector)
+
+        self.assertEqual('hard',
+            world_collision.check_horizontal_collision(
+                bigworld, math_module, 1, _Vector(), 0.0, 35.0,
+                None, False, 0.20, True, commit_enabled=False))
+        self.assertEqual(0, ground_queries[0])
+
+    def test_exact_ground_top_uses_one_millimetre_epsilon(self):
+        point = _Vector(1.0, 2.0, 3.0)
+        top_y = [point.y]
+        calls = []
+
+        def collide(unused_space, start, end, unused_mask):
+            calls.append((start, end))
+            return (_Vector(start.x, top_y[0], start.z),)
+
+        bigworld = types.ModuleType('BigWorld')
+        bigworld.wg_collideSegment = collide
+        math_module = types.SimpleNamespace(Vector3=_Vector)
+        collision = (point, _Vector(0.0, 0.0, -1.0), 0)
+
+        with mock.patch.dict(sys.modules, {'BigWorld': bigworld}):
+            top_y[0] = point.y + world_collision._GROUND_HIT_EPSILON
+            self.assertTrue(world_collision._hit_matches_exact_ground_top(
+                1, math_module, _Vector(), collision, 10.0))
+            top_y[0] += 1.0e-6
+            self.assertFalse(world_collision._hit_matches_exact_ground_top(
+                1, math_module, _Vector(), collision, 10.0))
+
+        self.assertEqual(2, len(calls))
+
+    def test_exact_top_filter_skips_broken_skin_to_terrain(self):
+        gradient = 0.20
+        profile_look = 3.5 + 20.0 * 0.20 + 0.20
+        profile_segment = profile_look / 6.0
+        profile_samples = [
+            profile_segment * index for index in range(7)]
+        filtered_queries = []
+
+        def reject_broken(*hit):
+            return tuple(hit[2:4]) != (37, 22)
+
+        def collide(unused_space, start, end, unused_mask, *callbacks):
+            if abs(start.y - end.y) > 10.0:
+                terrain_y = gradient * start.z
+                is_profile_sample = any(
+                    abs(start.z - sample) <= 1.0e-6
+                    for sample in profile_samples)
+                if not is_profile_sample:
+                    if callbacks:
+                        filtered_queries.append((start, end, callbacks[0]))
+                        if not callbacks[0](75, 0, 37, 22):
+                            return (_Vector(start.x, terrain_y, start.z),)
+                    return (_Vector(start.x, terrain_y + 0.40, start.z),)
+                return (_Vector(start.x, terrain_y, start.z),)
+            delta_y = end.y - start.y
+            delta_z = end.z - start.z
+            denominator = delta_y - gradient * delta_z
+            if abs(denominator) <= 1.0e-9:
+                return None
+            progress = (gradient * start.z - start.y) / denominator
+            if not 0.0 <= progress <= 1.0:
+                return None
+            return (_Vector(
+                start.x, start.y + delta_y * progress,
+                start.z + delta_z * progress),
+                _Vector(0.0, 0.0, -1.0), 0)
+
+        bigworld = types.SimpleNamespace(
+            wg_collideSegment=collide,
+            wg_getMatInfoNearPoint=_miss_mat_info_1513)
+        math_module = types.SimpleNamespace(Vector3=_Vector)
+
+        with mock.patch.object(
+                world_collision, 'ground_collision_filter',
+                return_value=reject_broken) as filter_factory:
+            self.assertFalse(world_collision.check_horizontal_collision(
+                bigworld, math_module, 1, _Vector(), 0.0, 20.0,
+                None, False, 0.20, pitch=-math.atan(gradient)))
+
+        self.assertEqual(3, filter_factory.call_count)
+        self.assertEqual(3, len(filtered_queries))
+        self.assertTrue(all(row[2] is reject_broken
+                            for row in filtered_queries))
+
+    def test_raised_chords_ignore_matching_long_slope_seams(self):
+        gradient = 0.50
+        math_module = types.SimpleNamespace(Vector3=_Vector)
+
+        for velocity, world_gradient in (
+                (20.0, gradient), (-20.0, -gradient)):
+            counts = {'ground': 0, 'horizontal': 0, 'seams': 0}
+
+            def collide(unused_space, start, end, unused_mask):
+                if abs(start.y - end.y) > 10.0:
+                    counts['ground'] += 1
+                    ground_y = world_gradient * start.z
+                    if min(start.y, end.y) <= ground_y <= max(start.y, end.y):
+                        return (_Vector(start.x, ground_y, start.z),)
+                    return None
+                counts['horizontal'] += 1
+                delta_y = end.y - start.y
+                delta_z = end.z - start.z
+                denominator = delta_y - world_gradient * delta_z
+                if abs(denominator) <= 1.0e-9:
+                    return None
+                progress = (world_gradient * start.z - start.y) / denominator
+                if not 0.0 <= progress <= 1.0:
+                    return None
+                counts['seams'] += 1
+                return (_Vector(
+                    start.x, start.y + delta_y * progress,
+                    start.z + delta_z * progress),
+                    _Vector(0.0, 0.0, -1.0), 0)
+
+            bigworld = types.SimpleNamespace(
+                wg_collideSegment=collide,
+                wg_getMatInfoNearPoint=_miss_mat_info_1513)
+
+            self.assertFalse(world_collision.check_horizontal_collision(
+                bigworld, math_module, 1, _Vector(), 0.0, velocity,
+                None, False, 0.20,
+                pitch=-math.atan(world_gradient)))
+            self.assertEqual(9, counts['horizontal'])
+            self.assertEqual(9, counts['seams'])
+            self.assertEqual(30, counts['ground'])
+
+    def test_airborne_posed_chord_cannot_bypass_slope_cliff(self):
+        gradient = 0.50
+        math_module = types.SimpleNamespace(Vector3=_Vector)
+
+        for velocity, world_gradient in (
+                (20.0, gradient), (-20.0, -gradient)):
+            ground_calls = [0]
+
+            def collide(unused_space, start, end, unused_mask):
+                if abs(start.y - end.y) > 10.0:
+                    ground_calls[0] += 1
+                    ground_y = world_gradient * start.z
+                    if min(start.y, end.y) <= ground_y <= max(start.y, end.y):
+                        return (_Vector(start.x, ground_y, start.z),)
+                    return None
+                delta_y = end.y - start.y
+                delta_z = end.z - start.z
+                denominator = delta_y - world_gradient * delta_z
+                if abs(denominator) <= 1.0e-9:
+                    return None
+                progress = (world_gradient * start.z - start.y) / denominator
+                if not 0.0 <= progress <= 1.0:
+                    return None
+                return (_Vector(
+                    start.x, start.y + delta_y * progress,
+                    start.z + delta_z * progress),
+                    _Vector(0.0, 1.0, -world_gradient), 0)
+
+            bigworld = types.SimpleNamespace(
+                wg_collideSegment=collide,
+                wg_getMatInfoNearPoint=_miss_mat_info_1513)
+
+            self.assertEqual('hard',
+                world_collision.check_horizontal_collision(
+                    bigworld, math_module, 1, _Vector(), 0.0, velocity,
+                    None, True, 0.20, True, commit_enabled=False,
+                    pitch=-math.atan(world_gradient)))
+            self.assertEqual(0, ground_calls[0])
+
+    def test_pitch_does_not_lift_lookahead_over_wall_beyond_hull(self):
+        wall_top = 1.75
+        pitch = math.atan(0.40)
+        math_module = types.SimpleNamespace(Vector3=_Vector)
+
+        for velocity, hull_pitch, wall_z in (
+                (20.0, -pitch, 4.5), (-20.0, pitch, -4.5)):
+            for airborne in (False, True):
+                calls = []
+
+                def collide(unused_space, start, end, unused_mask):
+                    calls.append((start, end))
+                    if abs(start.y - end.y) > 10.0:
+                        ground_y = (0.40 * min(start.z, 3.5)
+                                    if velocity > 0.0 else
+                                    -0.40 * max(start.z, -3.5))
+                        if (min(start.y, end.y) <= ground_y <=
+                                max(start.y, end.y)):
+                            return (_Vector(start.x, ground_y, start.z),)
+                        return None
+                    delta_z = end.z - start.z
+                    if abs(delta_z) <= 1.0e-9:
+                        return None
+                    progress = (wall_z - start.z) / delta_z
+                    if not 0.0 <= progress <= 1.0:
+                        return None
+                    hit_y = start.y + (end.y - start.y) * progress
+                    if not 0.0 <= hit_y <= wall_top:
+                        return None
+                    return (_Vector(start.x, hit_y, wall_z),
+                            _Vector(0.0, 0.0, -1.0), 0)
+
+                bigworld = types.SimpleNamespace(
+                    wg_collideSegment=collide,
+                    wg_getMatInfoNearPoint=_miss_mat_info_1513)
+
+                self.assertEqual('hard',
+                    world_collision.check_horizontal_collision(
+                        bigworld, math_module, 1, _Vector(), 0.0, velocity,
+                        None, airborne, 0.10, True, pitch=hull_pitch))
+                self.assertTrue(calls)
+                ground_calls = [
+                    call for call in calls
+                    if abs(call[0].y - call[1].y) > 10.0]
+                self.assertEqual(not airborne, bool(ground_calls))
+                unused_start, end = calls[0]
+                footprint_end = 3.5 if velocity > 0.0 else -3.5
+                pose_y = world_collision._hull_pose_y(hull_pitch, 0.0)
+                expected_end_y = (
+                    0.6 * pose_y[1] + footprint_end * pose_y[2])
+                self.assertAlmostEqual(expected_end_y, end.y)
+                self.assertAlmostEqual(
+                    5.7 if velocity > 0.0 else -5.7, end.z)
+
+    def test_pitched_upper_chord_hits_suspended_beam_after_crest(self):
+        beam_bottom = 1.95
+        beam_top = 2.15
+        pitch = math.atan(0.40)
+        math_module = types.SimpleNamespace(Vector3=_Vector)
+
+        for velocity, hull_pitch, wall_z in (
+                (20.0, -pitch, 4.5), (-20.0, pitch, -4.5)):
+            def collide(unused_space, start, end, unused_mask):
+                delta_z = end.z - start.z
+                if abs(delta_z) <= 1.0e-9:
+                    return None
+                progress = (wall_z - start.z) / delta_z
+                if not 0.0 <= progress <= 1.0:
+                    return None
+                hit_y = start.y + (end.y - start.y) * progress
+                if not beam_bottom <= hit_y <= beam_top:
+                    return None
+                return (_Vector(start.x, hit_y, wall_z),
+                        _Vector(0.0, 0.0, -1.0), 0)
+
+            bigworld = types.SimpleNamespace(
+                wg_collideSegment=collide,
+                wg_getMatInfoNearPoint=_miss_mat_info_1513)
+
+            self.assertEqual('hard',
+                world_collision.check_horizontal_collision(
+                    bigworld, math_module, 1, _Vector(), 0.0, velocity,
+                    None, True, 0.10, True, commit_enabled=False,
+                    pitch=hull_pitch))
+
+    def test_roll_lateral_chord_does_not_pass_low_side_wall(self):
+        roll = math.atan(0.40)
+        wall_top = 1.10
+        math_module = types.SimpleNamespace(Vector3=_Vector)
+
+        for velocity, motion_yaw, hull_roll, wall_x in (
+                (20.0, math.pi / 2.0, roll, 1.7),
+                (-20.0, math.pi * 1.5, -roll, -1.7)):
+            def collide(unused_space, start, end, unused_mask):
+                delta_x = end.x - start.x
+                if abs(delta_x) <= 1.0e-9:
+                    return None
+                progress = (wall_x - start.x) / delta_x
+                if not 0.0 <= progress <= 1.0:
+                    return None
+                hit_y = start.y + (end.y - start.y) * progress
+                if not 0.0 <= hit_y <= wall_top:
+                    return None
+                hit_z = start.z + (end.z - start.z) * progress
+                return (_Vector(wall_x, hit_y, hit_z),
+                        _Vector(-math.sin(motion_yaw), 0.0,
+                                -math.cos(motion_yaw)), 0)
+
+            bigworld = types.SimpleNamespace(
+                wg_collideSegment=collide,
+                wg_getMatInfoNearPoint=_miss_mat_info_1513)
+
+            self.assertEqual('hard',
+                world_collision.check_horizontal_collision(
+                    bigworld, math_module, 1, _Vector(), 0.0, velocity,
+                    None, True, 0.10, True, commit_enabled=False,
+                    motion_yaw=motion_yaw, roll=hull_roll))
+
+    def test_diagonal_lookahead_does_not_pitch_over_low_wall(self):
+        pitch = math.atan(0.40)
+        ahead = 20.0 * 0.10 + 0.20
+        math_module = types.SimpleNamespace(Vector3=_Vector)
+
+        for velocity, motion_yaw, hull_pitch in (
+                (20.0, 0.65, -pitch),
+                (-20.0, 0.65 + math.pi, pitch)):
+            direction_x = math.sin(motion_yaw)
+            direction_z = math.cos(motion_yaw)
+            center_front = min(
+                1.5 / abs(direction_x), 3.5 / abs(direction_z))
+            wall_u = center_front + 0.80
+            start_u = -0.5
+            end_u = center_front + ahead
+            local_start = (
+                direction_x * start_u, direction_z * start_u)
+            local_end = (
+                direction_x * center_front,
+                direction_z * center_front)
+            pose_y = world_collision._hull_pose_y(hull_pitch, 0.0)
+
+            def posed_y(local):
+                return (0.6 * pose_y[1] + local[0] * pose_y[0] +
+                        local[1] * pose_y[2])
+
+            progress = (wall_u - start_u) / (end_u - start_u)
+            clamped_y = (posed_y(local_start) +
+                         (posed_y(local_end) - posed_y(local_start)) *
+                         progress)
+            extrapolated_local = (
+                direction_x * wall_u, direction_z * wall_u)
+            wall_top = (clamped_y + posed_y(extrapolated_local)) * 0.5
+
+            def collide(unused_space, start, end, unused_mask):
+                start_projection = (start.x * direction_x +
+                                    start.z * direction_z)
+                end_projection = (end.x * direction_x +
+                                  end.z * direction_z)
+                delta = end_projection - start_projection
+                if abs(delta) <= 1.0e-9:
+                    return None
+                hit_progress = (wall_u - start_projection) / delta
+                if not 0.0 <= hit_progress <= 1.0:
+                    return None
+                hit_y = start.y + (end.y - start.y) * hit_progress
+                if not 0.0 <= hit_y <= wall_top:
+                    return None
+                hit_x = start.x + (end.x - start.x) * hit_progress
+                hit_z = start.z + (end.z - start.z) * hit_progress
+                return (_Vector(hit_x, hit_y, hit_z),
+                        _Vector(-direction_x, 0.0, -direction_z), 0)
+
+            bigworld = types.SimpleNamespace(
+                wg_collideSegment=collide,
+                wg_getMatInfoNearPoint=_miss_mat_info_1513)
+
+            self.assertEqual('hard',
+                world_collision.check_horizontal_collision(
+                    bigworld, math_module, 1, _Vector(), 0.0, velocity,
+                    None, True, 0.10, True, commit_enabled=False,
+                    motion_yaw=motion_yaw, pitch=hull_pitch))
+
     def test_hull_roll_poses_lanes_without_adding_native_rays(self):
         calls = []
 
@@ -945,6 +1414,7 @@ class WorldCollisionTests(unittest.TestCase):
             bigworld, math_module, 1, _Vector(), 0.0, 5.0,
             None, False, 0.04))
         level_ray_count = len(calls)
+        self.assertEqual(9, level_ray_count)
         calls[:] = []
 
         roll = 0.20


### PR DESCRIPTION
## Summary

- pose the existing hull collision rays with authoritative terrain pitch and roll without adding native rays
- distinguish the hull heading from signed glancing travel so diagonal/reverse contact sweeps keep the real footprint
- admit a suspicious low-FPS support rise only when bounded interior ground samples prove a continuous slope
- freeze player contact pitch/roll at the server-admitted pose before the hidden worker rechecks the world

## Performance

- ordinary grounding keeps its existing single centre query
- suspicious support rises add 0-4 interior ground queries and fail closed beyond 7.5 m
- ordinary longitudinal world sweeps remain 9 native rays; existing cross-heading sweeps remain at most 15
- no alpha6 10/22-point suspension loop is introduced

## Validation

- `python3 -m unittest discover -s 0.9.22/tests -p 'test_*.py' -v` — 2965 passed
- focused battle runtime tests — 635 passed
- focused world collision tests — 44 passed
- focused server projectile/contact tests — 94 passed
- CPython 2.7 source compile for the three changed client modules
- `git diff --check`

Exact #1513 Windows gameplay feel and native worker frame cost still require client acceptance.
