### PR TITLE
WIP: Add descriptor-driven suspension physics trial

### DIFF
--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -75,7 +75,8 @@ DIAGNOSTIC_TOP_FRAMES = 3
 # threshold counts still cover the complete window.
 DIAGNOSTIC_PERCENTILE_SAMPLES = 4096
 _WORKER_DIAGNOSTIC_FIELDS = (
-    'alive_bot_ticks', 'visibility_queue_depth',
+    'alive_bot_ticks', 'suspension_param_failures',
+    'visibility_queue_depth',
     'visibility_queue_max_depth', 'visibility_oldest_stale_age_ms',
     'visibility_oldest_stale_max_age_ms', 'visibility_admitted',
     'visibility_completed', 'visibility_deferred',
@@ -1461,8 +1462,17 @@ class BattleRuntime(object):
         self._ram_bot_history_index = {}
         self._ram_bot_lookup_cache = {}
         self._local_physics = None
+        self._local_suspension_params = None
+        self._local_suspension_disabled = False
+        self._local_spring_ground_memory = None
+        self._local_pseudo_ground_memory = None
         self._local_pitch = 0.0
         self._local_roll = 0.0
+        self._local_suspension_pitch_velocity = 0.0
+        self._local_suspension_roll_velocity = 0.0
+        self._local_left_flying = False
+        self._local_right_flying = False
+        self._local_support_motion_pose = None
         self._local_matrix = None
         self._local_pose_matrix = None
         self._local_stabilised_matrix = None
@@ -1741,8 +1751,17 @@ class BattleRuntime(object):
         self._ram_bot_history_index = {}
         self._ram_bot_lookup_cache = {}
         self._local_physics = None
+        self._local_suspension_params = None
+        self._local_suspension_disabled = False
+        self._local_spring_ground_memory = None
+        self._local_pseudo_ground_memory = None
         self._local_pitch = 0.0
         self._local_roll = 0.0
+        self._local_suspension_pitch_velocity = 0.0
+        self._local_suspension_roll_velocity = 0.0
+        self._local_left_flying = False
+        self._local_right_flying = False
+        self._local_support_motion_pose = None
         self._local_matrix = None
         self._local_pose_matrix = None
         self._local_stabilised_matrix = None
@@ -2984,6 +3003,7 @@ class BattleRuntime(object):
                 spawn_resolver=self._formation_pose,
                 ground_probe=self._navigation_ground,
                 physics_ground_probe=self._ground_y,
+                suspension_ground_probe=self._suspension_ground_y,
                 obstacle_probe=self._navigation_obstacle,
                 bounds=getattr(self._spawn_planner, 'bounds', None),
                 cover_probe=self._sample_bot_cover,
@@ -4348,6 +4368,60 @@ class BattleRuntime(object):
             from_y = height - 0.4
         return height
 
+    def _suspension_ground_y(
+            self, x, z, minimum_y, maximum_y, flat_maximum_y=None):
+        """Return ground inside one suspension contact's legal travel.
+
+        Unlike the navigation column, this probe must never acquire a roof or
+        an almost vertical wall as suspension support. Recast below rejected
+        layers while preserving the local broken-destructible filter on every
+        native query.
+        """
+        minimum_y = float(minimum_y)
+        maximum_y = float(maximum_y)
+        if maximum_y < minimum_y:
+            minimum_y, maximum_y = maximum_y, minimum_y
+        ground_filter = self._ground_filter(x, z)
+        start_y = maximum_y
+        for unused_layer in range(3):
+            try:
+                hit = self._collide_down(
+                    self._vector((x, start_y, z)),
+                    self._vector((x, minimum_y, z)), ground_filter)
+            except Exception as error:
+                raise RuntimeError(
+                    'native suspension ground query failed: %s' % error)
+            if hit is None:
+                return None
+            try:
+                height = float(hit[0].y)
+                normal = hit[1]
+                normal_x = float(normal.x)
+                normal_y = float(normal.y)
+                normal_z = float(normal.z)
+                normal_length = math.sqrt(
+                    normal_x * normal_x + normal_y * normal_y +
+                    normal_z * normal_z)
+            except (AttributeError, IndexError, TypeError, ValueError,
+                    OverflowError) as error:
+                raise RuntimeError(
+                    'native suspension ground hit is malformed: %s' % error)
+            if (math.isnan(height) or math.isinf(height) or
+                    math.isnan(normal_length) or math.isinf(normal_length) or
+                    normal_length <= 0.000001):
+                raise RuntimeError(
+                    'native suspension ground hit is malformed')
+            normal_y /= normal_length
+            if (minimum_y - 0.01 <= height <= maximum_y + 0.01 and
+                    vehicle_physics.suspension_support_allowed(
+                        height, normal_y, flat_maximum_y)):
+                return height
+            next_y = height - 0.02
+            if next_y <= minimum_y + 0.01 or next_y >= start_y:
+                break
+            start_y = next_y
+        return None
+
     def _navigation_ground(self, x, z, hint_y=0.0):
         """Copy the 0.8.2 same-layer graph probe, including ford depth."""
         probe_top = float(hint_y) + 8.0
@@ -5373,6 +5447,13 @@ class BattleRuntime(object):
         self._local_physics = vehicle_physics.derive_params(
             entity.typeDescriptor,
             self._local_factors(entity.typeDescriptor))
+        # The ten-spring trial is derived lazily on the first copied-physics
+        # tick. A malformed detailed chassis descriptor can then fall back to
+        # the existing support path without aborting local-vehicle startup.
+        self._local_suspension_params = None
+        self._local_suspension_disabled = False
+        self._local_spring_ground_memory = None
+        self._local_pseudo_ground_memory = None
         return True
 
     def _attach_local_presentation(self):
@@ -15091,7 +15172,8 @@ class BattleRuntime(object):
             'alive': True,
             'team': int(_number(getattr(self.client, 'team', 0))),
             'x': position[0], 'y': position[1], 'z': position[2],
-            'yaw': yaw, 'mass': own_mass,
+            'yaw': yaw, 'pitch': self._local_pitch,
+            'roll': self._local_roll, 'mass': own_mass,
             'shape': self._collision_shape(entity.typeDescriptor),
             'ram_profile': self._ram_profile(
                 entity.typeDescriptor, local=True),
@@ -15414,6 +15496,265 @@ class BattleRuntime(object):
                 centre = value
         return highest, centre
 
+    def _ensure_local_suspension_params(self, descriptor):
+        """Lazily enable the descriptor-backed ten-spring trial."""
+        if self._local_suspension_disabled:
+            return None
+        if self._local_suspension_params is None:
+            try:
+                self._local_suspension_params = \
+                    vehicle_physics.derive_suspension_params(descriptor)
+            except Exception as error:
+                self._local_suspension_params = None
+                self._local_suspension_disabled = True
+                self._local_spring_ground_memory = None
+                self._local_pseudo_ground_memory = None
+                self._warn_optional_failure(
+                    'ten-spring suspension trial', error)
+                return None
+        return self._local_suspension_params
+
+    def _local_suspension_state_snapshot(self):
+        """Freeze every local field the optional trial may mutate."""
+        names = (
+            '_local_vertical_speed', '_local_airborne',
+            '_local_fall_armed', '_local_pitch', '_local_roll',
+            '_local_suspension_pitch_velocity',
+            '_local_suspension_roll_velocity', '_local_left_flying',
+            '_local_right_flying', '_local_surface_up_cosine',
+            '_local_downhill', '_local_slope_tangent',
+            '_local_slide_speed', '_local_air_lateral',
+            '_local_turn_speed', '_local_drive_turn',
+        )
+        result = dict((name, getattr(self, name)) for name in names)
+        plane = self._local_ground_plane
+        result['_local_ground_plane'] = (
+            dict(plane) if isinstance(plane, dict) else plane)
+        result['_local_spring_ground_memory'] = (
+            list(self._local_spring_ground_memory)
+            if isinstance(self._local_spring_ground_memory, list) else
+            self._local_spring_ground_memory)
+        result['_local_pseudo_ground_memory'] = (
+            list(self._local_pseudo_ground_memory)
+            if isinstance(self._local_pseudo_ground_memory, list) else
+            self._local_pseudo_ground_memory)
+        result['_pending_landing_impacts'] = list(
+            self._pending_landing_impacts)
+        return result
+
+    def _restore_local_suspension_state(self, snapshot):
+        for name, value in snapshot.items():
+            setattr(self, name, value)
+
+    def _disable_local_suspension_trial(self, error):
+        """Fail one optional native/solver boundary back to legacy physics."""
+        self._local_suspension_params = None
+        self._local_suspension_disabled = True
+        self._local_spring_ground_memory = None
+        self._local_pseudo_ground_memory = None
+        self._warn_optional_failure('ten-spring suspension trial', error)
+
+    def _local_suspension_ground_samples(
+            self, position, yaw, probe_height=None):
+        """Sample every real damper once for this copied-physics tick."""
+        params = self._local_suspension_params
+        if not isinstance(params, dict):
+            return ()
+        if probe_height is None:
+            probe_height = position[1]
+        probe_height = float(probe_height)
+        points = vehicle_physics.suspension_world_points(
+            params, position, yaw)
+        memory = self._local_spring_ground_memory
+        if not isinstance(memory, list) or len(memory) != len(points):
+            memory = [None] * len(points)
+        result = []
+        for index, point in enumerate(points):
+            x, z = point
+            spring = params['springs'][index]
+            spring_height = (
+                probe_height - spring['z'] * math.sin(self._local_pitch) +
+                spring['x'] * math.sin(self._local_roll))
+            minimum_y = (
+                spring_height - spring['rest_length'] -
+                vehicle_physics.CONTACT_PENETRATION)
+            spring_maximum_y = (
+                spring_height + spring['max_compression'] -
+                spring['static_compression'] + 0.05)
+            maximum_y = max(
+                spring_maximum_y,
+                spring_height + params['clearance'] +
+                vehicle_physics.CONTACT_PENETRATION)
+            value = self._suspension_ground_y(
+                x, z, minimum_y, maximum_y,
+                flat_maximum_y=spring_maximum_y)
+            value, memory[index] = vehicle_physics.retained_ground_contact(
+                point, value, memory[index],
+                params['contact_memory_distance'])
+            result.append(value)
+        self._local_spring_ground_memory = memory
+        return tuple(result)
+
+    def _local_suspension_pseudo_ground_samples(
+            self, position, yaw, probe_height=None):
+        """Sample every track/belly constraint once for this physics tick."""
+        params = self._local_suspension_params
+        if not isinstance(params, dict):
+            return ()
+        if probe_height is None:
+            probe_height = position[1]
+        probe_height = float(probe_height)
+        points = vehicle_physics.suspension_pseudo_world_points(
+            params, position, yaw)
+        memory = self._local_pseudo_ground_memory
+        if not isinstance(memory, list) or len(memory) != len(points):
+            memory = [None] * len(points)
+        result = []
+        for index, point in enumerate(points):
+            x, z = point
+            contact = params['pseudo_contacts'][index]
+            point_height = (
+                probe_height + _number(contact.get('y')) -
+                contact['z'] * math.sin(self._local_pitch) +
+                contact['x'] * math.sin(self._local_roll))
+            minimum_y = (
+                point_height - params['rest_length'] -
+                vehicle_physics.CONTACT_PENETRATION)
+            rise = (params['clearance']
+                    if contact.get('kind') == 'track' else 0.0)
+            maximum_y = (
+                point_height + rise +
+                vehicle_physics.CONTACT_PENETRATION)
+            flat_maximum_y = (
+                point_height + vehicle_physics.CONTACT_PENETRATION
+                if contact.get('kind') == 'track' else None)
+            value = self._suspension_ground_y(
+                x, z, minimum_y, maximum_y,
+                flat_maximum_y=flat_maximum_y)
+            value, memory[index] = vehicle_physics.retained_ground_contact(
+                point, value, memory[index],
+                params['contact_memory_distance'])
+            result.append(value)
+        self._local_pseudo_ground_memory = memory
+        return tuple(result)
+
+    def _local_suspension_predicted_probe_height(
+            self, position, motion_pose, previous_plane):
+        """Move the query window with one already-proved terrain plane."""
+        if (motion_pose is None or not isinstance(previous_plane, dict) or
+                'center_x' not in previous_plane or
+                'center_z' not in previous_plane):
+            return float(position[1])
+        start_height = vehicle_physics.suspension_plane_height(
+            previous_plane, motion_pose[0], motion_pose[2])
+        end_height = vehicle_physics.suspension_plane_height(
+            previous_plane, position[0], position[2])
+        if start_height is None or end_height is None:
+            return float(position[1])
+        return float(position[1]) + end_height - start_height
+
+    def _local_suspension_path_is_supported(
+            self, previous_plane, current_plane, motion_pose, position):
+        """Prove a long correction's centre line with a fixed ray budget."""
+        dx = float(position[0]) - float(motion_pose[0])
+        dz = float(position[2]) - float(motion_pose[2])
+        distance = math.sqrt(dx * dx + dz * dz)
+        fractions = vehicle_physics.suspension_path_probe_fractions(distance)
+        if not fractions:
+            return True
+        start_ground = vehicle_physics.suspension_plane_height(
+            previous_plane, motion_pose[0], motion_pose[2])
+        end_ground = vehicle_physics.suspension_plane_height(
+            current_plane, position[0], position[2])
+        for fraction in fractions:
+            x = float(motion_pose[0]) + dx * fraction
+            z = float(motion_pose[2]) + dz * fraction
+            expected = start_ground + (end_ground - start_ground) * fraction
+            ground = self._suspension_ground_y(
+                x, z, expected - GROUND_PLANE_EPSILON,
+                expected + GROUND_PLANE_EPSILON,
+                flat_maximum_y=expected + GROUND_PLANE_EPSILON)
+            if (ground is None or
+                    abs(float(ground) - expected) > GROUND_PLANE_EPSILON):
+                return False
+        return True
+
+    def _local_suspension_rise_is_continuous(
+            self, position, solved_height, motion_pose,
+            previous_plane, current_plane):
+        """Authorize extra rise only when one terrain surface proves it."""
+        if (motion_pose is None or previous_plane is None or
+                current_plane is None or
+                not vehicle_physics.suspension_ground_planes_continuous(
+                    previous_plane, current_plane, motion_pose, position,
+                    GROUND_PLANE_EPSILON, GROUND_PLANE_EPSILON)):
+            return False
+        start_ground = vehicle_physics.suspension_plane_height(
+            previous_plane, motion_pose[0], motion_pose[2])
+        end_ground = vehicle_physics.suspension_plane_height(
+            current_plane, position[0], position[2])
+        terrain_rise = max(0.0, end_ground - start_ground)
+        body_rise = float(solved_height) - float(position[1])
+        if body_rise > 0.6 + terrain_rise + 0.02:
+            return False
+        return self._local_suspension_path_is_supported(
+            previous_plane, current_plane, motion_pose, position)
+
+    def _commit_local_suspension_metadata(
+            self, position, yaw, solved, ground, plane=None):
+        """Publish distinct body-attitude and terrain-slope metadata."""
+        contacting = [value for value in ground if value is not None]
+        if not contacting or solved.get('airborne'):
+            self._local_ground_plane = None
+            self._local_surface_up_cosine = None
+            self._local_downhill = (0.0, 0.0, 0.0)
+            self._local_slope_tangent = 0.0
+            return False
+        # The solved body angles include damper bounce and landing rock. Keep
+        # those angles for pose/overturn, but derive downhill grip only from
+        # the sampled terrain. Otherwise a rocking tank would manufacture a
+        # cross-slope and feed its own motion back into lateral slide.
+        body_pitch = float(solved['pitch'])
+        body_roll = float(solved['roll'])
+        self._local_surface_up_cosine = max(
+            -1.0, min(1.0,
+                      math.cos(body_pitch) * math.cos(body_roll)))
+        if plane is None:
+            plane = vehicle_physics.suspension_world_ground_plane(
+                self._local_suspension_params, ground, position, yaw,
+                GROUND_PLANE_EPSILON)
+        if plane is None:
+            self._local_ground_plane = None
+            self._local_downhill = (0.0, 0.0, 0.0)
+            self._local_slope_tangent = 0.0
+            return False
+        gradient_x = float(plane['gradient_x'])
+        gradient_z = float(plane['gradient_z'])
+        sine, cosine = math.sin(yaw), math.cos(yaw)
+        right_gradient = gradient_x * cosine - gradient_z * sine
+        forward_gradient = gradient_x * sine + gradient_z * cosine
+        slope_tangent = math.sqrt(
+            gradient_x * gradient_x + gradient_z * gradient_z)
+        if slope_tangent > 0.001:
+            downhill = (-gradient_x / slope_tangent, 0.0,
+                        -gradient_z / slope_tangent)
+        else:
+            downhill = (0.0, 0.0, 0.0)
+        self._local_ground_plane = dict(plane)
+        self._local_ground_plane.update({
+            'pitch': -math.atan2(forward_gradient, 1.0),
+            'roll': math.atan2(
+                right_gradient,
+                math.sqrt(1.0 + forward_gradient * forward_gradient)),
+            'slope_tangent': slope_tangent,
+            'up_cosine': 1.0 / math.sqrt(
+                1.0 + slope_tangent * slope_tangent),
+            'downhill': downhill,
+        })
+        self._local_downhill = downhill
+        self._local_slope_tangent = slope_tangent
+        return True
+
     def _apply_fall_damage(self, entity, impact_speed):
         """Queue a physical impact observation without mutating canonical HP."""
         maximum = max(1, int(getattr(
@@ -15457,7 +15798,7 @@ class BattleRuntime(object):
             lateral_speed * lateral_speed)
         return self._apply_fall_damage(entity, impact_speed)
 
-    def _update_vertical_motion(self, entity, position, yaw, dt):
+    def _update_vertical_motion_legacy(self, entity, position, yaw, dt):
         """Copy vertical motion while rejecting false raised support."""
         self._local_support_rise_blocked = False
         highest, centre = self._terrain_support(
@@ -15567,6 +15908,212 @@ class BattleRuntime(object):
             self._local_vertical_speed = 0.0
             self._local_airborne = False
         return position
+
+    def _update_vertical_motion(self, entity, position, yaw, dt):
+        """Contain the optional suspension trial to this local vehicle."""
+        params = self._ensure_local_suspension_params(entity.typeDescriptor)
+        if params is None:
+            return self._update_vertical_motion_legacy(
+                entity, position, yaw, dt)
+        snapshot = self._local_suspension_state_snapshot()
+        try:
+            return self._update_suspension_vertical_motion(
+                entity, position, yaw, dt)
+        except Exception as error:
+            self._restore_local_suspension_state(snapshot)
+            self._disable_local_suspension_trial(error)
+            return self._update_vertical_motion_legacy(
+                entity, position, yaw, dt)
+
+    def _update_suspension_vertical_motion(
+            self, entity, position, yaw, dt):
+        """Advance one sampled ten-spring local rigid-body tick.
+
+        The contact columns are sampled exactly once here. The solver may use
+        fixed internal substeps, but every one of those substeps consumes this
+        immutable 10-spring plus pseudo-contact snapshot.
+        """
+        params = self._local_suspension_params
+        self._local_support_rise_blocked = False
+        armed_before = bool(self._local_fall_armed)
+        tick_pose = getattr(self, '_local_support_tick_pose', None)
+        motion_pose = getattr(self, '_local_support_motion_pose', None)
+        if motion_pose is None:
+            motion_pose = tick_pose
+        previous_plane = self._local_ground_plane
+        if not armed_before:
+            # A streamed spawn may start at the provisional y=100 pose. Place
+            # it once through the existing same-layer/wide column before the
+            # only 22 suspension samples of this tick.
+            initial_ground = self._ground_y(
+                position[0], position[2], position[1], allow_wide=True)
+            if initial_ground is not None:
+                position = (
+                    position[0], float(initial_ground), position[2])
+                self._local_vertical_speed = 0.0
+                self._local_pitch = 0.0
+                self._local_roll = 0.0
+                self._local_suspension_pitch_velocity = 0.0
+                self._local_suspension_roll_velocity = 0.0
+        probe_height = self._local_suspension_predicted_probe_height(
+            position, motion_pose, previous_plane)
+        ground = self._local_suspension_ground_samples(
+            position, yaw, probe_height=probe_height)
+        pseudo_ground = self._local_suspension_pseudo_ground_samples(
+            position, yaw, probe_height=probe_height)
+        if (not armed_before and
+                (not ground or all(value is None for value in ground)) and
+                (not pseudo_ground or
+                 all(value is None for value in pseudo_ground))):
+            # Match the existing provisional-spawn contract: absence of the
+            # first streamed terrain support is not a damaging free fall.
+            self._local_vertical_speed = 0.0
+            self._local_airborne = False
+            return position
+        current_plane = vehicle_physics.suspension_world_ground_plane(
+            params, ground, position, yaw, GROUND_PLANE_EPSILON)
+        before_airborne = bool(self._local_airborne)
+        before_vertical_speed = float(self._local_vertical_speed)
+        previous_pitch = float(self._local_pitch)
+        previous_roll = float(self._local_roll)
+        physics_state = {
+            'height': float(position[1]),
+            'vertical_velocity': before_vertical_speed,
+            'pitch': previous_pitch,
+            'pitch_velocity': self._local_suspension_pitch_velocity,
+            'roll': previous_roll,
+            'roll_velocity': self._local_suspension_roll_velocity,
+        }
+        solved = vehicle_physics.damper_suspension_step(
+            params, physics_state, ground, dt, pseudo_ground)
+        values = (
+            solved['height'], solved['vertical_velocity'],
+            solved['pitch'], solved['pitch_velocity'],
+            solved['roll'], solved['roll_velocity'])
+        if any(math.isnan(value) or math.isinf(value) for value in values):
+            raise RuntimeError('player suspension produced a non-finite pose')
+        invalid_pose = (
+            abs(float(solved['height']) - position[1]) > 5.0 or
+            abs(float(solved['pitch'])) > 1.2 or
+            abs(float(solved['roll'])) > 1.2)
+        extra_rise = (
+            armed_before and bool(solved.get('contact_count')) and
+            tank_collision.support_rise_is_obstacle(
+                position[1], solved['height'], 0.6))
+        raised_support = bool(
+            extra_rise and
+            not self._local_suspension_rise_is_continuous(
+                position, solved['height'], motion_pose,
+                previous_plane, current_plane))
+        if invalid_pose or raised_support:
+            if tick_pose is not None:
+                position = tuple(tick_pose)
+            # These contacts were sampled at the rejected final X/Z pose.
+            # Retaining them after rollback can pin the restored pose to a
+            # support layer it never actually reached.
+            self._local_spring_ground_memory = None
+            self._local_pseudo_ground_memory = None
+            self._local_vertical_speed = 0.0
+            self._local_suspension_pitch_velocity = 0.0
+            self._local_suspension_roll_velocity = 0.0
+            self._local_pitch = previous_pitch
+            self._local_roll = previous_roll
+            self._local_airborne = False
+            self._local_support_rise_blocked = True
+            return position
+        position = (
+            position[0], float(solved['height']), position[2])
+        self._local_vertical_speed = float(solved['vertical_velocity'])
+        self._local_pitch = float(solved['pitch'])
+        self._local_suspension_pitch_velocity = \
+            float(solved['pitch_velocity'])
+        self._local_roll = float(solved['roll'])
+        self._local_suspension_roll_velocity = \
+            float(solved['roll_velocity'])
+        self._local_airborne = bool(solved['airborne'])
+        self._local_left_flying = bool(solved['left_flying'])
+        self._local_right_flying = bool(solved['right_flying'])
+        if solved['contact_count']:
+            self._local_fall_armed = True
+        if (before_airborne and not self._local_airborne and
+                before_vertical_speed < 0.0):
+            impact_speed = solved.get('impact_speed')
+            if impact_speed is None:
+                impact_speed = before_vertical_speed
+            self._apply_landing_impact(entity, abs(float(impact_speed)))
+        elif not before_airborne and self._local_airborne:
+            self._local_turn_speed = 0.0
+            self._local_drive_turn = 0.0
+        self._commit_local_suspension_metadata(
+            position, yaw, solved, ground, plane=current_plane)
+        return position
+
+    def _resettle_local_suspension_endpoint(
+            self, entity, start_position, position, yaw):
+        """Project suspension contacts once at one corrected X/Z endpoint."""
+        dx = float(position[0]) - float(start_position[0])
+        dz = float(position[2]) - float(start_position[2])
+        if dx * dx + dz * dz <= 1.0e-10:
+            return position
+        # A rejected vertical support must retain collision separation X/Z;
+        # only the endpoint's incoming Y and attitude are restored.
+        self._local_support_tick_pose = tuple(position)
+        self._local_support_motion_pose = tuple(start_position)
+        try:
+            return self._update_vertical_motion(
+                entity, position, yaw, 0.0)
+        finally:
+            self._local_support_tick_pose = None
+            self._local_support_motion_pose = None
+
+    def _apply_suspension_slope_slide(
+            self, position, yaw, dt, entity=None):
+        """Advance slope-driven X/Z after the ram endpoint is settled."""
+        if self._local_airborne:
+            self._local_slide_speed = 0.0
+            lateral_x, lateral_z = self._local_air_lateral
+            if abs(lateral_x) <= 0.0001 and abs(lateral_z) <= 0.0001:
+                return position
+            lateral_speed = math.sqrt(
+                lateral_x * lateral_x + lateral_z * lateral_z)
+            lateral_yaw = math.atan2(lateral_x, lateral_z)
+            candidate = (
+                position[0] + lateral_x * dt, position[1],
+                position[2] + lateral_z * dt)
+            if (entity is None or self._motion_is_clear(
+                    entity, position, lateral_yaw, lateral_speed, dt,
+                    hull_yaw=yaw)):
+                position = candidate
+            self._local_air_lateral = (
+                lateral_x * 0.995, lateral_z * 0.995)
+            return position
+        self._local_slide_speed = vehicle_physics.slope_slide_speed(
+            self._local_slide_speed, self._local_slope_tangent, dt)
+        cross_x, cross_z = math.cos(yaw), -math.sin(yaw)
+        slide_dot = (self._local_downhill[0] * cross_x +
+                     self._local_downhill[2] * cross_z)
+        slide_x = cross_x * slide_dot
+        slide_z = cross_z * slide_dot
+        self._local_air_lateral = (
+            slide_x * self._local_slide_speed,
+            slide_z * self._local_slide_speed)
+        if (self._local_slide_speed <= 0.01 or
+                (abs(slide_x) <= 0.0001 and
+                 abs(slide_z) <= 0.0001)):
+            return position
+        lateral_speed = abs(slide_dot) * self._local_slide_speed
+        lateral_yaw = math.atan2(slide_x, slide_z)
+        if (entity is not None and not self._motion_is_clear(
+                entity, position, lateral_yaw, lateral_speed, dt,
+                hull_yaw=yaw)):
+            if not self._local_motion_soft_block:
+                self._local_slide_speed = 0.0
+                self._local_air_lateral = (0.0, 0.0)
+            return position
+        return (
+            position[0] + slide_x * self._local_slide_speed * dt,
+            position[1],
+            position[2] + slide_z * self._local_slide_speed * dt)
 
     def _apply_slope_slide(self, position, yaw, dt, entity=None):
         """Copy 0.8.2 cross-heading slope slip and airborne carry."""
@@ -15942,24 +16489,67 @@ class BattleRuntime(object):
             self._local_motion_kinds = 'arena'
             self._local_motion_status = 'hard'
             contact_path = contact_path or 'arena_turn'
+        suspension_active = bool(
+            self._ensure_local_suspension_params(entity.typeDescriptor))
         self._local_support_rise_blocked = False
         self._local_support_tick_pose = tick_pose
+        self._local_support_motion_pose = tick_pose
         try:
             position = self._update_vertical_motion(
                 entity, position, yaw, dt)
         finally:
             self._local_support_tick_pose = None
-        support_blocked = self._local_support_rise_blocked
+            self._local_support_motion_pose = None
+        suspension_active = bool(
+            self._local_suspension_params is not None and
+            not self._local_suspension_disabled)
+        support_blocked = bool(self._local_support_rise_blocked)
+        ram_resolved = False
+        slide_moved = False
+        if suspension_active:
+            # Current-tick suspension now owns Y/pitch/roll before secondary
+            # horizontal contact work. This keeps world OBB checks, vertical
+            # tank overlap and native ram plate proof on one coherent pose.
+            settled_position = position
+            position = self._resolve_local_tank_contacts(
+                entity, position, yaw, dt)
+            ram_resolved = True
+            position = self._resettle_local_suspension_endpoint(
+                entity, settled_position, position, yaw)
+            support_blocked = bool(
+                support_blocked or self._local_support_rise_blocked)
+            suspension_active = bool(
+                self._local_suspension_params is not None and
+                not self._local_suspension_disabled)
+            if suspension_active and not support_blocked:
+                slide_start = position
+                position = self._apply_suspension_slope_slide(
+                    position, yaw, dt, entity)
+                dx = float(position[0]) - float(slide_start[0])
+                dz = float(position[2]) - float(slide_start[2])
+                slide_moved = dx * dx + dz * dz > 1.0e-10
+                position = self._resettle_local_suspension_endpoint(
+                    entity, slide_start, position, yaw)
+                support_blocked = bool(
+                    support_blocked or self._local_support_rise_blocked)
+                suspension_active = bool(
+                    self._local_suspension_params is not None and
+                    not self._local_suspension_disabled)
+            self._local_support_rise_blocked = support_blocked
         if support_blocked:
             self._local_speed *= 0.35 ** (dt * 60.0)
             if abs(self._local_speed) < 0.05:
                 self._local_speed = 0.0
             self._local_grind = 4
             contact_path = 'support'
-        self._ground_pitch(position, yaw, entity.typeDescriptor)
-        position = self._apply_slope_slide(position, yaw, dt, entity)
-        position = self._resolve_local_tank_contacts(
-            entity, position, yaw, dt)
+        if not suspension_active:
+            self._ground_pitch(position, yaw, entity.typeDescriptor)
+            if not slide_moved:
+                position = self._apply_slope_slide(
+                    position, yaw, dt, entity)
+            if not ram_resolved:
+                position = self._resolve_local_tank_contacts(
+                    entity, position, yaw, dt)
         self._report_local_contact_tick(
             contact_path, previous_speed, slope_pitch,
             position[1] - tick_pose[1])
@@ -17849,6 +18439,12 @@ class BattleRuntime(object):
             self._local_physics = vehicle_physics.derive_params(
                 entity.typeDescriptor,
                 self._local_factors(entity.typeDescriptor))
+            self._local_suspension_params = None
+            self._local_suspension_disabled = False
+            self._local_spring_ground_memory = None
+            self._local_pseudo_ground_memory = None
+            self._local_suspension_pitch_velocity = 0.0
+            self._local_suspension_roll_velocity = 0.0
         if record.get('local') and self._local_matrix is not None:
             self._update_local_hull_aiming(entity, 0.0)
         return True
@@ -20101,6 +20697,10 @@ class BattleRuntime(object):
         self._local_push_x = 0.0
         self._local_push_z = 0.0
         self._local_physics = None
+        self._local_suspension_params = None
+        self._local_suspension_disabled = False
+        self._local_spring_ground_memory = None
+        self._local_pseudo_ground_memory = None
         self._local_matrix = None
         self._local_pose_matrix = None
         self._local_stabilised_matrix = None
@@ -20135,6 +20735,11 @@ class BattleRuntime(object):
         self._pending_landing_impacts = []
         self._local_pitch = 0.0
         self._local_roll = 0.0
+        self._local_suspension_pitch_velocity = 0.0
+        self._local_suspension_roll_velocity = 0.0
+        self._local_left_flying = False
+        self._local_right_flying = False
+        self._local_support_motion_pose = None
         self._input_accumulator = 0.0
         self._gun_state = None
         self._gun_last_tick = None

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -167,6 +167,22 @@ BOT_OVERTURN_DANGER_COSINE = vehicle_physics.OVERTURN_DANGER_COSINE
 BOT_OVERTURN_DEATH_SECONDS = 30.0
 BOT_OVERTURN_DEATH_REASON = 7
 
+# The ten-spring trial may follow a rise above the mature 0.6 m step gate only
+# when the last and current spring batches describe one continuous terrain
+# plane.  A fixed three-point centre proof bounds the exceptional ram/contact
+# correction cost independently from the correction distance.
+SUSPENSION_BASE_RISE = 0.6
+SUSPENSION_GROUND_PLANE_EPSILON = 0.35
+SUSPENSION_GROUND_GRADIENT_EPSILON = 0.35
+
+_BOT_SUSPENSION_STATE_FIELDS = (
+    'pitch', 'terrain_pitch', 'roll', 'vertical_speed', 'airborne',
+    'grounded_once', 'suspension_pitch_velocity',
+    'suspension_roll_velocity', 'left_flying', 'right_flying',
+    'ground_height', '_spring_ground_memory', '_pseudo_ground_memory',
+    '_suspension_ground_plane',
+)
+
 # Route groups lease these lateral lanes without moving an existing member.
 # A safety rejection may narrow a lane toward zero for one macro route leg,
 # but never crosses sides or upgrades again inside that leg.
@@ -1761,6 +1777,7 @@ class BotRuntime(object):
                  artillery_launch_cancel=None,
                  spawn_resolver=None, ground_probe=None,
                  physics_ground_probe=None,
+                 suspension_ground_probe=None,
                  obstacle_probe=None, bounds=None, cover_probe=None,
                  native_motion=False, baked_graph=None, probe_clock=None,
                  motion_resolver=None, motion_report=None,
@@ -1821,6 +1838,9 @@ class BotRuntime(object):
         self._navigation_error = None
         self._ground_probe = ground_probe
         self._physics_ground_probe = physics_ground_probe
+        self._suspension_ground_probe = (
+            suspension_ground_probe
+            if callable(suspension_ground_probe) else None)
         self._obstacle_probe = obstacle_probe
         self._navigation_bounds = bounds
         self.navigator = (TerrainNavigator(
@@ -1902,6 +1922,8 @@ class BotRuntime(object):
         self._shot_los_deadlines = {}
         self._reset_shot_lane_diagnostics()
         self._physics_params = {}
+        self._suspension_params = {}
+        self._suspension_param_failures = 0
         self._repair_factors = {}
         self._vision_ranges = {}
         self._source_still = {}
@@ -2009,6 +2031,8 @@ class BotRuntime(object):
                 self._shot_lane_due_since))))
         return {
             'alive_bot_ticks': int(self._alive_bot_ticks),
+            'suspension_param_failures': int(
+                self._suspension_param_failures),
             'visibility_queue_depth': len(self._visibility_waiting),
             'visibility_queue_max_depth': int(
                 self._visibility_queue_max_depth),
@@ -2396,6 +2420,76 @@ class BotRuntime(object):
         self._physics_params[bot_id] = params
         return params
 
+    @staticmethod
+    def _reset_bot_suspension_state(state, reset_grounded=False):
+        """Discard solver-only history at a descriptor/authority boundary."""
+        if state is None:
+            return
+        state['suspension_pitch_velocity'] = 0.0
+        state['suspension_roll_velocity'] = 0.0
+        state.pop('_spring_ground_memory', None)
+        state.pop('_pseudo_ground_memory', None)
+        state.pop('_suspension_ground_plane', None)
+        if reset_grounded:
+            state['grounded_once'] = False
+
+    @staticmethod
+    def _snapshot_bot_suspension_state(state):
+        """Freeze the suspension-owned pose at a rollback boundary."""
+        snapshot = {}
+        for name in _BOT_SUSPENSION_STATE_FIELDS:
+            if name in state:
+                value = state[name]
+                if isinstance(value, list):
+                    value = list(value)
+                elif isinstance(value, dict):
+                    value = dict(value)
+                snapshot[name] = (True, value)
+            else:
+                snapshot[name] = (False, None)
+        return snapshot
+
+    @staticmethod
+    def _restore_bot_suspension_state(state, snapshot):
+        """Restore exactly one suspension snapshot, including missing keys."""
+        if not isinstance(snapshot, dict):
+            return False
+        for name in _BOT_SUSPENSION_STATE_FIELDS:
+            present, value = snapshot.get(name, (False, None))
+            if present:
+                if isinstance(value, list):
+                    value = list(value)
+                elif isinstance(value, dict):
+                    value = dict(value)
+                state[name] = value
+            else:
+                state.pop(name, None)
+        return True
+
+    def _suspension_params_for(self, bot_id):
+        """Return descriptor-derived data, disabling one unsupported Bot."""
+        bot_id = int(bot_id)
+        if self._suspension_ground_probe is None:
+            return None
+        if bot_id in self._suspension_params:
+            return self._suspension_params[bot_id]
+        descriptor = self._descriptors.get(bot_id)
+        if descriptor is None or (isinstance(descriptor, dict) and
+                                  not descriptor):
+            self._suspension_params[bot_id] = None
+            self._suspension_param_failures += 1
+            return None
+        try:
+            params = vehicle_physics.derive_suspension_params(descriptor)
+        except (AttributeError, IndexError, KeyError, RuntimeError,
+                TypeError, ValueError):
+            # The trial must not guess missing #1513 geometry and one malformed
+            # descriptor must not stop the other 28 authority vehicles.
+            params = None
+            self._suspension_param_failures += 1
+        self._suspension_params[bot_id] = params
+        return params
+
     def _install_bot_descriptor(self, bot_id, state, siege_state):
         """Install one bot's active immutable mode descriptor."""
         bot_id = int(bot_id)
@@ -2408,6 +2502,7 @@ class BotRuntime(object):
         if previous is descriptor:
             return False
         self._physics_params[bot_id] = _bot_physics_params(descriptor)
+        self._suspension_params.pop(bot_id, None)
         self._gun_yaw_limits[bot_id] = ai_driver.gun_yaw_limits(descriptor)
         gun_state = self._gun_states.get(bot_id)
         if gun_state is not None:
@@ -2419,6 +2514,11 @@ class BotRuntime(object):
         self._traffic_stopping_cache.pop(bot_id, None)
         self._cancel_artillery_intent(bot_id)
         if state is not None:
+            # A Siege descriptor changes spring geometry, not whether this
+            # already-streamed hull has ever established ground contact.
+            # Re-arming spawn placement here can teleport it to an unrelated
+            # upper support layer on the transition edge.
+            self._reset_bot_suspension_state(state)
             half_length, half_width = _hull_dimensions(descriptor)
             state['move_speed'] = _forward_speed(descriptor)
             state['view_range'] = self._cache_vision_range(
@@ -2672,6 +2772,8 @@ class BotRuntime(object):
             self._shot_los_deadlines = {}
             self._reset_shot_lane_diagnostics()
             self._physics_params = {}
+            self._suspension_params = {}
+            self._suspension_param_failures = 0
             self._repair_factors = {}
             self._vision_ranges = {}
             self._source_still = {}
@@ -2845,6 +2947,7 @@ class BotRuntime(object):
                 descriptor_pair, siege_state)
             half_length, half_width = _hull_dimensions(descriptor)
             self._descriptors[bot_id] = descriptor
+            self._suspension_params.pop(bot_id, None)
             self._gun_yaw_limits[bot_id] = \
                 ai_driver.gun_yaw_limits(descriptor)
             if bot_id not in self._gun_states:
@@ -2919,6 +3022,8 @@ class BotRuntime(object):
                 'pitch': _number(raw.get('pitch')),
                 'roll': _number(raw.get('roll')),
                 'terrain_pitch': _number(raw.get('pitch')),
+                'suspension_pitch_velocity': 0.0,
+                'suspension_roll_velocity': 0.0,
                 'suspension_pitch': 0.0,
                 'siege_state': siege_state,
                 'siege_time_left_ms': wire_time,
@@ -3137,7 +3242,7 @@ class BotRuntime(object):
         state['push_z'] = 0.0
         state['vertical_speed'] = 0.0
         state['airborne'] = False
-        state['grounded_once'] = False
+        self._reset_bot_suspension_state(state, reset_grounded=True)
         state['last_drive_pitch'] = 0.0
         self._turn_speeds[int(state['id'])] = 0.0
         return True
@@ -5117,6 +5222,213 @@ class BotRuntime(object):
         except (TypeError, ValueError):
             return False
 
+    def _suspension_ground_value(
+            self, x, z, minimum_y, maximum_y, flat_maximum_y=None):
+        """Run and time one travel-bounded native suspension ray."""
+        self._probe_totals[3] += 1
+        probe_started = self._probe_started()
+        try:
+            return self._suspension_ground_probe(
+                x, z, minimum_y, maximum_y, flat_maximum_y)
+        finally:
+            self._probe_finished(3, probe_started)
+
+    def _suspension_ground_samples(self, state, params,
+                                   probe_height=None):
+        """Sample the five damper positions on each track exactly once."""
+        position = _position(state)
+        body_height = (position[1] if probe_height is None else
+                       float(probe_height))
+        yaw = _number(state.get('yaw'))
+        points = vehicle_physics.suspension_world_points(
+            params, position, yaw)
+        memory = state.get('_spring_ground_memory')
+        if not isinstance(memory, list) or len(memory) != len(points):
+            memory = [None] * len(points)
+        pitch = _number(
+            state.get('terrain_pitch', state.get('pitch')))
+        roll = _number(state.get('roll'))
+        result = []
+        for index, point in enumerate(points):
+            x, z = point
+            spring = params['springs'][index]
+            spring_height = (
+                body_height - spring['z'] * math.sin(pitch) +
+                spring['x'] * math.sin(roll))
+            minimum_y = (
+                spring_height - spring['rest_length'] -
+                vehicle_physics.CONTACT_PENETRATION)
+            spring_maximum_y = (
+                spring_height + spring['max_compression'] -
+                spring['static_compression'] + 0.05)
+            maximum_y = max(
+                spring_maximum_y,
+                spring_height + params['clearance'] +
+                vehicle_physics.CONTACT_PENETRATION)
+            ground = self._suspension_ground_value(
+                x, z, minimum_y, maximum_y, spring_maximum_y)
+            ground, memory[index] = \
+                vehicle_physics.retained_ground_contact(
+                    point, ground, memory[index],
+                    params['contact_memory_distance'])
+            result.append(ground)
+        state['_spring_ground_memory'] = memory
+        return tuple(result)
+
+    def _suspension_pseudo_ground_samples(self, state, params,
+                                          probe_height=None):
+        """Sample track-gap and belly contacts once for this authority tick."""
+        position = _position(state)
+        body_height = (position[1] if probe_height is None else
+                       float(probe_height))
+        yaw = _number(state.get('yaw'))
+        points = vehicle_physics.suspension_pseudo_world_points(
+            params, position, yaw)
+        memory = state.get('_pseudo_ground_memory')
+        if not isinstance(memory, list) or len(memory) != len(points):
+            memory = [None] * len(points)
+        pitch = _number(
+            state.get('terrain_pitch', state.get('pitch')))
+        roll = _number(state.get('roll'))
+        result = []
+        for index, point in enumerate(points):
+            x, z = point
+            contact = params['pseudo_contacts'][index]
+            point_height = (
+                body_height + _number(contact.get('y')) -
+                contact['z'] * math.sin(pitch) +
+                contact['x'] * math.sin(roll))
+            minimum_y = (
+                point_height - params['rest_length'] -
+                vehicle_physics.CONTACT_PENETRATION)
+            rise = (params['clearance']
+                    if contact.get('kind') == 'track' else 0.0)
+            maximum_y = (
+                point_height + rise +
+                vehicle_physics.CONTACT_PENETRATION)
+            flat_maximum_y = (
+                point_height + vehicle_physics.CONTACT_PENETRATION
+                if contact.get('kind') == 'track' else None)
+            ground = self._suspension_ground_value(
+                x, z, minimum_y, maximum_y, flat_maximum_y)
+            ground, memory[index] = \
+                vehicle_physics.retained_ground_contact(
+                    point, ground, memory[index],
+                    params['contact_memory_distance'])
+            result.append(ground)
+        state['_pseudo_ground_memory'] = memory
+        return tuple(result)
+
+    @staticmethod
+    def _suspension_world_ground_plane(params, ground, position, yaw):
+        """Fit one spring batch and bind its local centre to world X/Z."""
+        return vehicle_physics.suspension_world_ground_plane(
+            params, ground, position, yaw,
+            SUSPENSION_GROUND_PLANE_EPSILON)
+
+    @staticmethod
+    def _suspension_plane_height(plane, x, z):
+        """Evaluate an anchored world-space suspension ground plane."""
+        return vehicle_physics.suspension_plane_height(plane, x, z)
+
+    def _suspension_probe_height_for_motion(
+            self, position, motion_pose, previous_plane):
+        """Carry the old body-to-ground offset along one proved plane."""
+        if motion_pose is None or previous_plane is None:
+            return float(position[1])
+        old_ground = self._suspension_plane_height(
+            previous_plane, motion_pose[0], motion_pose[2])
+        expected_ground = self._suspension_plane_height(
+            previous_plane, position[0], position[2])
+        if old_ground is None or expected_ground is None:
+            return float(position[1])
+        return float(position[1]) + expected_ground - old_ground
+
+    @staticmethod
+    def _suspension_rise_exceeds_base(body_y, support_y):
+        """Apply the mature step threshold without its speed allowance."""
+        try:
+            rise = float(support_y) - float(body_y)
+        except (TypeError, ValueError, OverflowError):
+            return False
+        return rise > SUSPENSION_BASE_RISE + 0.02
+
+    def _suspension_path_supports_plane(
+            self, previous_plane, motion_pose, position):
+        """Prove at most three interior centres along a corrected path."""
+        dx = float(position[0]) - float(motion_pose[0])
+        dz = float(position[2]) - float(motion_pose[2])
+        distance = math.sqrt(dx * dx + dz * dz)
+        for fraction in vehicle_physics.suspension_path_probe_fractions(
+                distance):
+            x = float(motion_pose[0]) + dx * fraction
+            z = float(motion_pose[2]) + dz * fraction
+            expected = self._suspension_plane_height(
+                previous_plane, x, z)
+            if expected is None:
+                return False
+            support = self._suspension_ground_value(
+                x, z,
+                expected - SUSPENSION_GROUND_PLANE_EPSILON,
+                expected + SUSPENSION_GROUND_PLANE_EPSILON,
+                expected + SUSPENSION_GROUND_PLANE_EPSILON)
+            if support is None:
+                return False
+            support = float(support)
+            if (math.isnan(support) or math.isinf(support) or
+                    abs(support - expected) >
+                    SUSPENSION_GROUND_PLANE_EPSILON):
+                return False
+        return True
+
+    def _suspension_rise_has_continuous_support(
+            self, previous_plane, current_plane, motion_pose,
+            position, solved_height):
+        """Authorize a large rise only for one continuously proved slope."""
+        if (previous_plane is None or current_plane is None or
+                motion_pose is None):
+            return False
+        old_ground = self._suspension_plane_height(
+            previous_plane, motion_pose[0], motion_pose[2])
+        expected_ground = self._suspension_plane_height(
+            previous_plane, position[0], position[2])
+        current_ground = self._suspension_plane_height(
+            current_plane, position[0], position[2])
+        if (old_ground is None or expected_ground is None or
+                current_ground is None):
+            return False
+        if not vehicle_physics.suspension_ground_planes_continuous(
+                previous_plane, current_plane, motion_pose, position,
+                SUSPENSION_GROUND_PLANE_EPSILON,
+                SUSPENSION_GROUND_GRADIENT_EPSILON):
+            return False
+        body_rise = float(solved_height) - float(position[1])
+        terrain_rise = max(0.0, current_ground - old_ground)
+        if body_rise > terrain_rise + SUSPENSION_BASE_RISE + 0.02:
+            return False
+        return self._suspension_path_supports_plane(
+            previous_plane, motion_pose, position)
+
+    def _hidden_suspension_support_is_raised(self, state):
+        """Detect an upper layer outside the bounded suspension travel."""
+        if not callable(self._physics_ground_probe):
+            return False
+        position = _position(state)
+        self._probe_totals[3] += 1
+        probe_started = self._probe_started()
+        try:
+            support = self._physics_ground_probe(
+                position[0], position[2], position[1])
+        finally:
+            self._probe_finished(3, probe_started)
+        if support is None:
+            return False
+        support = float(support)
+        if math.isnan(support) or math.isinf(support):
+            raise RuntimeError('bot centre support is non-finite')
+        return self._suspension_rise_exceeds_base(
+            position[1], support)
+
     def _terrain_support(self, state):
         """Probe centre first, then the 0.8.2 edge fallback when unsupported."""
         position = _position(state)
@@ -5270,6 +5582,11 @@ class BotRuntime(object):
 
     def _update_slope_pose(self, state, allow_ungrounded=False):
         """Refresh the four-point hull pose after this tick's ground settle."""
+        # The ten-spring solver already owns authoritative pitch and roll.
+        # A later staggered presentation sample must not overwrite that pose.
+        if getattr(self, '_suspension_params', {}).get(
+                int(state.get('id', -1))) is not None:
+            return False
         if (state.get('airborne', False) or
                 (not allow_ungrounded and not state.get(
                     'grounded_once', False))):
@@ -5432,9 +5749,176 @@ class BotRuntime(object):
             lateral_speed * lateral_speed)
         return self._apply_bot_fall_damage(state, impact_speed)
 
+    def _update_suspension_vertical_motion(
+            self, state, step, params, tick_pose=None,
+            attempted_yaw=None, suspension_motion_pose=None):
+        """Advance one Bot's contrib ten-spring rigid-body trial."""
+        bot_id = int(state['id'])
+        suspension_snapshot = self._snapshot_bot_suspension_state(state)
+        grounded_before = bool(state.get('grounded_once', False))
+        previous_plane = (dict(state['_suspension_ground_plane'])
+                          if (grounded_before and isinstance(
+                              state.get('_suspension_ground_plane'), dict))
+                          else None)
+        motion_pose = (suspension_motion_pose
+                       if suspension_motion_pose is not None else tick_pose)
+        if not grounded_before:
+            # Spawn placement remains a separate one-off centre query. The
+            # ten springs and twelve pseudo contacts are still sampled only
+            # once below, even when their numerical solver takes substeps.
+            position = _position(state)
+            self._probe_totals[3] += 1
+            probe_started = self._probe_started()
+            try:
+                initial_ground = self._physics_ground_probe(
+                    position[0], position[2], position[1])
+            finally:
+                self._probe_finished(3, probe_started)
+            if initial_ground is not None:
+                state['y'] = float(initial_ground)
+                state['vertical_speed'] = 0.0
+                state['terrain_pitch'] = 0.0
+                state['roll'] = 0.0
+                self._reset_bot_suspension_state(state)
+
+        position = _position(state)
+        probe_height = self._suspension_probe_height_for_motion(
+            position, motion_pose, previous_plane)
+        ground = self._suspension_ground_samples(
+            state, params, probe_height)
+        pseudo_ground = self._suspension_pseudo_ground_samples(
+            state, params, probe_height)
+        current_plane = self._suspension_world_ground_plane(
+            params, ground, position, _number(state.get('yaw')))
+        no_sampled_support = bool(
+            all(value is None for value in ground) and
+            all(value is None for value in pseudo_ground))
+        if (not grounded_before and
+                all(value is None for value in ground) and
+                all(value is None for value in pseudo_ground)):
+            # A streamed spawn without any local terrain proof is not a real
+            # airborne launch. Keep its provisional pose until terrain loads.
+            state['vertical_speed'] = 0.0
+            state['airborne'] = False
+            state.pop('_suspension_ground_plane', None)
+            return False
+
+        before_airborne = bool(state.get('airborne', False))
+        before_vertical_speed = _number(state.get('vertical_speed'))
+        physics_state = {
+            'height': _number(state.get('y')),
+            'vertical_velocity': before_vertical_speed,
+            'pitch': _number(
+                state.get('terrain_pitch', state.get('pitch'))),
+            'pitch_velocity': _number(
+                state.get('suspension_pitch_velocity')),
+            'roll': _number(state.get('roll')),
+            'roll_velocity': _number(
+                state.get('suspension_roll_velocity')),
+        }
+        solved = vehicle_physics.damper_suspension_step(
+            params, physics_state, ground, step, pseudo_ground)
+        values = (
+            solved['height'], solved['vertical_velocity'],
+            solved['pitch'], solved['pitch_velocity'],
+            solved['roll'], solved['roll_velocity'])
+        if any(math.isnan(value) or math.isinf(value) for value in values):
+            raise RuntimeError('bot suspension produced a non-finite pose')
+        invalid_pose = (
+            abs(solved['height'] - _number(state.get('y'))) > 5.0 or
+            abs(solved['pitch']) > 1.2 or
+            abs(solved['roll']) > 1.2)
+        raised_support = bool(
+            grounded_before and solved.get('contact_count') and
+            self._suspension_rise_exceeds_base(
+                state.get('y'), solved['height']))
+        if raised_support:
+            raised_support = not self._suspension_rise_has_continuous_support(
+                previous_plane, current_plane, motion_pose,
+                position, solved['height'])
+        hidden_raised_support = bool(
+            grounded_before and no_sampled_support and
+            self._hidden_suspension_support_is_raised(state))
+        if invalid_pose or raised_support or hidden_raised_support:
+            self._restore_bot_suspension_state(
+                state, suspension_snapshot)
+            if tick_pose is not None:
+                state['x'], state['y'], state['z'] = tick_pose
+            state['speed'] = 0.0
+            state['movement_dir'] = 0
+            state['rotation_dir'] = 0
+            state['push_x'] = 0.0
+            state['push_z'] = 0.0
+            state['vertical_speed'] = 0.0
+            state['airborne'] = False
+            # The rejected contact layer is unrelated to the restored pose.
+            # Drop its plane and contact history without re-arming spawn snap.
+            self._reset_bot_suspension_state(state)
+            self._turn_speeds[bot_id] = 0.0
+            self._invalidate_realised_motion(
+                bot_id, (_number(state.get('yaw'))
+                         if attempted_yaw is None else attempted_yaw))
+            return True
+
+        state['y'] = solved['height']
+        state['vertical_speed'] = solved['vertical_velocity']
+        state['terrain_pitch'] = solved['pitch']
+        state['suspension_pitch_velocity'] = solved['pitch_velocity']
+        state['roll'] = solved['roll']
+        state['suspension_roll_velocity'] = solved['roll_velocity']
+        state['pitch'] = (
+            solved['pitch'] + _number(state.get('suspension_pitch')))
+        state['airborne'] = bool(solved['airborne'])
+        state['left_flying'] = bool(solved['left_flying'])
+        state['right_flying'] = bool(solved['right_flying'])
+        if solved['contact_count']:
+            state['grounded_once'] = True
+            contacts = [
+                value for value in ground + pseudo_ground
+                if value is not None]
+            if contacts:
+                state['ground_height'] = sum(contacts) / len(contacts)
+        if (solved['contact_count'] and not state['airborne'] and
+                current_plane is not None):
+            state['_suspension_ground_plane'] = current_plane
+        else:
+            state.pop('_suspension_ground_plane', None)
+        if (before_airborne and not state['airborne'] and
+                before_vertical_speed < 0.0):
+            impact_speed = solved.get('impact_speed')
+            if impact_speed is None:
+                impact_speed = before_vertical_speed
+            self._apply_bot_landing_impact(
+                state, impact_speed)
+        elif not before_airborne and state['airborne']:
+            self._turn_speeds[bot_id] = 0.0
+            state['rotation_dir'] = 0
+        return False
+
     def _update_vertical_motion(self, state, step, tick_pose=None,
-                                attempted_yaw=None):
+                                attempted_yaw=None,
+                                suspension_motion_pose=None):
         """Run grounded/ballistic phases and reject false raised support."""
+        params = self._suspension_params_for(state['id'])
+        if params is not None:
+            suspension_snapshot = self._snapshot_bot_suspension_state(state)
+            try:
+                return self._update_suspension_vertical_motion(
+                    state, step, params, tick_pose, attempted_yaw,
+                    suspension_motion_pose)
+            except (AttributeError, IndexError, KeyError, RuntimeError,
+                    TypeError, ValueError, OverflowError,
+                    ZeroDivisionError):
+                # Contain a bad native sample or numerical state to this Bot.
+                # The established centre-support path is the safe trial
+                # fallback; no guessed suspension geometry is introduced.
+                self._suspension_params[int(state['id'])] = None
+                self._suspension_param_failures += 1
+                self._restore_bot_suspension_state(
+                    state, suspension_snapshot)
+                if tick_pose is not None:
+                    state['x'], state['y'], state['z'] = tick_pose
+                self._reset_bot_suspension_state(state)
         highest, centre = self._terrain_support(state)
         # Front/rear hits keep a bot supported across a narrow ditch, but use
         # their real CoM distance below so a remote valley floor cannot pull
@@ -5530,7 +6014,7 @@ class BotRuntime(object):
         return False
 
     def _guard_realised_pose(self, state, tick_pose, tick_was_safe,
-                             attempted_yaw):
+                             attempted_yaw, suspension_snapshot=None):
         """Reject a new hazard or outward map-edge drift after all motion."""
         realised_pose = _position(state)
         moved_farther_outside = not self._baked_pose_progress_clear(
@@ -5547,8 +6031,20 @@ class BotRuntime(object):
         state['rotation_dir'] = 0
         state['push_x'] = 0.0
         state['push_z'] = 0.0
-        state['vertical_speed'] = 0.0
-        state['airborne'] = False
+        if suspension_snapshot is not None:
+            # The terrain batch and solved attitude describe the rejected
+            # realised X/Z. Restore the complete pre-integration suspension
+            # pose rather than combining old position with new pitch/roll.
+            self._restore_bot_suspension_state(
+                state, suspension_snapshot)
+        else:
+            state['vertical_speed'] = 0.0
+            state['airborne'] = False
+        if (suspension_snapshot is None and
+                self._suspension_params.get(int(state['id'])) is not None):
+            # The contact batch belongs to the rejected realised pose. Drop
+            # it with the angular solver history before restoring tick_pose.
+            self._reset_bot_suspension_state(state)
         self._invalidate_realised_motion(state['id'], attempted_yaw)
         return True
 
@@ -8430,6 +8926,7 @@ class BotRuntime(object):
                 visibility_tick)
         cover_jobs = []
         tick_poses = {}
+        tick_suspension_states = {}
         tick_safe = {}
         attempted_yaws = {}
         siege_locked_poses = {}
@@ -8469,6 +8966,8 @@ class BotRuntime(object):
             self._advance_bot_siege(state, step)
             position = _position(state)
             tick_poses[state['id']] = position
+            tick_suspension_states[state['id']] = \
+                self._snapshot_bot_suspension_state(state)
             tick_safe[state['id']] = prebaked_navigation.pose_is_safe(
                 self.baked_graph, position, shoulder_cells=0)
             server_order = self._server_orders.get(state['id'])
@@ -9459,16 +9958,6 @@ class BotRuntime(object):
                         'target_kind': target.get('kind', 'human'),
                         'candidates': list(candidates),
                     })
-        pending_ram_count = len(self._pending_ram_reports)
-        self._pending_ram_reports.extend(
-            self._resolve_tank_contacts(players, now, frame_step))
-        if (not publish and
-                len(self._pending_ram_reports) > pending_ram_count):
-            # A ram report is a one-shot state barrier. Publish the contact
-            # pose from this exact physical slice before the event; waiting for
-            # the callback's final pose can move both hulls beyond the server's
-            # bounded proximity validation and silently discard a real hit.
-            publish = True
         for bot_id, locked_pose in siege_locked_poses.items():
             state = self.states.get(bot_id)
             if state is None:
@@ -9482,6 +9971,8 @@ class BotRuntime(object):
             self._turn_speeds[bot_id] = 0.0
         ordered_states = self._ordered_states()
         slope_candidates = []
+        support_blocked_by_id = {}
+        settled_poses = {}
         for state in ordered_states:
             if state.get('alive', True) and state['id'] in integrated:
                 attempted_yaw = attempted_yaws.get(
@@ -9489,11 +9980,64 @@ class BotRuntime(object):
                 support_blocked = self._update_vertical_motion(
                     state, frame_step,
                     tick_poses[state['id']], attempted_yaw)
-                if not support_blocked:
-                    self._guard_realised_pose(
-                        state, tick_poses[state['id']], tick_safe[state['id']],
-                        attempted_yaw)
+                support_blocked_by_id[state['id']] = bool(support_blocked)
+                settled_poses[state['id']] = _position(state)
                 slope_candidates.append(state)
+        # Ram vertical overlap and native plate proof must use this slice's
+        # settled Y/pitch/roll, not the previous suspension pose. Resolve the
+        # complete roster only after every live body reaches that boundary.
+        pending_ram_count = len(self._pending_ram_reports)
+        self._pending_ram_reports.extend(
+            self._resolve_tank_contacts(players, now, frame_step))
+        # A Siege transition is immobile for its complete starting slice.
+        # Contacts may still observe and report the settled locked body, but
+        # their separation correction cannot move it after the earlier lock.
+        for bot_id, locked_pose in siege_locked_poses.items():
+            state = self.states.get(bot_id)
+            if state is None:
+                continue
+            state['x'], state['z'], state['yaw'] = locked_pose
+            state['speed'] = 0.0
+            state['movement_dir'] = 0
+            state['rotation_dir'] = 0
+            state['push_x'] = 0.0
+            state['push_z'] = 0.0
+            self._turn_speeds[bot_id] = 0.0
+        if (not publish and
+                len(self._pending_ram_reports) > pending_ram_count):
+            # A ram report is a one-shot state barrier. Publish the contact
+            # pose from this exact physical slice before the event; waiting for
+            # the callback's final pose can move both hulls beyond the server's
+            # bounded proximity validation and silently discard a real hit.
+            publish = True
+        for state in slope_candidates:
+            bot_id = int(state['id'])
+            attempted_yaw = attempted_yaws.get(
+                bot_id, state.get('yaw', 0.0))
+            settled = settled_poses[bot_id]
+            current = _position(state)
+            moved_after_settle = (
+                abs(current[0] - settled[0]) > 0.000001 or
+                abs(current[2] - settled[2]) > 0.000001)
+            if (moved_after_settle and
+                    self._suspension_params_for(bot_id) is not None):
+                # Tank separation is usually absent. When it changes X/Z,
+                # sample the realised endpoint once and project constraints
+                # with zero elapsed time. If that endpoint is invalid, retain
+                # the separation X/Z while restoring the settled Y.
+                rollback_pose = (current[0], settled[1], current[2])
+                support_blocked_by_id[bot_id] = bool(
+                    support_blocked_by_id.get(bot_id, False) or
+                    self._update_vertical_motion(
+                        state, 0.0, rollback_pose, attempted_yaw,
+                        suspension_motion_pose=settled))
+            if not support_blocked_by_id.get(bot_id, False):
+                self._guard_realised_pose(
+                    state, tick_poses[bot_id], tick_safe[bot_id],
+                    attempted_yaw,
+                    (tick_suspension_states.get(bot_id)
+                     if self._suspension_params.get(bot_id) is not None
+                     else None))
         self._alive_bot_ticks += len(slope_candidates)
         if refresh_control and slope_candidates:
             start = self._slope_pose_cursor % len(slope_candidates)

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/vehicle_physics.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/vehicle_physics.py
@@ -27,6 +27,7 @@ import math
 G = 9.81
 GRAVITY_FACTOR = 1.25          # WG: tanks live under 1.25 g 'arcade gravity'
 GRAVITY = G * GRAVITY_FACTOR   # 12.26 m/s^2 - falls, slopes, all force laws
+WEIGHT_SCALE = 0.001
 COHESION = 1.3                 # WG: physics.brakeFriction (brake/hold grip)
 # Exact #1513 ``g_defaultTankXPhysicsCfg`` supplies longitudinal terrain grip
 # as a two-point curve over the ground normal's Y component. It keeps full
@@ -40,6 +41,13 @@ SLOPE_GRIP_LNG_FULL_Y = math.cos(math.radians(27.5))
 SLOPE_GRIP_LNG_FULL = 1.0
 SLOPE_GRIP_LNG_MIN_Y = math.cos(math.radians(32.0))
 SLOPE_GRIP_LNG_MIN = 0.1
+# The contrib suspension trial applies a separate side-slip projection. These
+# two points came from the contributed implementation; this repository has not
+# proved that they reproduce the #1513 native curve.
+SLOPE_GRIP_SDW_FULL_Y = math.cos(math.radians(24.5))
+SLOPE_GRIP_SDW_FULL = 1.0
+SLOPE_GRIP_SDW_MIN_Y = math.cos(math.radians(29.0))
+SLOPE_GRIP_SDW_MIN = 0.1
 # Track-slip drag when rolling UP a grade past SLIP_THRESHOLD_TAN: extra
 # deceleration = SLIP_DRAG * (tan(grade) - SLIP_THRESHOLD_TAN) * g. Bleeds the
 # 'coast up a mountain on momentum' - real tracks slip and stop dead.
@@ -100,6 +108,41 @@ GROUND_FOLLOW_BASE = 0.6
 GROUND_FOLLOW_MIN = 0.8
 GROUND_FOLLOW_MAX = 2.5
 GROUND_PITCH_LIMIT = 0.96
+# Contrib suspension trial. Descriptor geometry and detailed-xphysics values
+# remain client-owned inputs; the interpolation and rigid solver below are a
+# derived projection whose native gameplay feel still needs Windows evidence.
+SUSP_COMPRESSION_MIN = 0.85
+SUSP_COMPRESSION_MIN_MASS = 60.0
+SUSP_COMPRESSION_MAX = 0.88
+SUSP_COMPRESSION_MAX_MASS = 30.0
+CLEARANCE_SCALE = 1.75
+CLEARANCE_MIN = 0.55
+CLEARANCE_MAX = 0.60
+CLEARANCE_TO_LENGTH_MIN = 0.085
+CLEARANCE_TO_LENGTH_MAX = 0.112
+HARD_RATIO_MIN = 0.50
+HARD_RATIO_MAX = 0.52
+SERVER_PHYSICS_HZ = 30.0
+SERVER_PHYSICS_SUBSTEPS = 2
+SERVER_PHYSICS_STEP = 1.0 / (
+	SERVER_PHYSICS_HZ * SERVER_PHYSICS_SUBSTEPS)
+SERVER_PHYSICS_MAX_SUBSTEPS = 12
+SERVER_PHYSICS_CONSTRAINT_ITERATIONS = 10
+SUSPENSION_PATH_MAX_PROBES = 3
+SUSPENSION_PATH_PROBE_SPACING = 1.0
+SERVER_PHYSICS_DAMPING_RATIO_BASE = 0.75
+SERVER_PHYSICS_DAMPING_RATIO_SCALE = 0.25
+SERVER_PHYSICS_MAX_SPRING_FORCE_FACTOR = 6.0
+AIRBORNE_ANGULAR_DAMPING = 4.0
+AIRBORNE_ANGULAR_SPEED_LIMIT = 0.6
+FREEZE_ANG_ACCEL_EPSILON = 0.35
+FREEZE_ACCEL_EPSILON = 0.4
+FREEZE_VEL_EPSILON = 0.15
+FREEZE_ANG_VEL_EPSILON = 0.06
+ALLOWED_PENETRATION = 0.01
+CONTACT_PENETRATION = 0.1
+TRACKS_PENETRATION = 0.01
+SUSPENSION_GEOMETRY_EPSILON = 0.01
 # Grounded hulls use the same four glancing directions after an exact hard
 # contact. These angles and decay constants used to live only in the visible
 # player's integrator while copied Bots stopped with a separate fixed factor.
@@ -423,6 +466,897 @@ def derive_params(td, factors=None):
 	return p
 
 
+def _value(component, name, default=None):
+	if isinstance(component, dict):
+		return component.get(name, default)
+	return getattr(component, name, default)
+
+
+def _required_value(component, name, context):
+	value = _value(component, name)
+	if value is None:
+		raise ValueError(
+			'%s is required by the contrib suspension trial' % context)
+	return value
+
+
+def _finite_number(value, context):
+	try:
+		value = float(value)
+	except (TypeError, ValueError) as error:
+		raise ValueError('%s is invalid: %s' % (context, error))
+	if math.isnan(value) or math.isinf(value):
+		raise ValueError('%s is not finite' % context)
+	return value
+
+
+def _number_tuple(values, context):
+	try:
+		return tuple(
+			_finite_number(value, '%s[%d]' % (context, index))
+			for index, value in enumerate(values))
+	except TypeError as error:
+		raise ValueError('%s is invalid: %s' % (context, error))
+
+
+def _linear_interpolate(value, minimum, maximum, lower, upper):
+	if maximum == minimum:
+		return float(lower)
+	ratio = (float(value) - float(minimum)) / (
+		float(maximum) - float(minimum))
+	ratio = max(0.0, min(1.0, ratio))
+	return float(lower) + (float(upper) - float(lower)) * ratio
+
+
+def _suspension_compression(mass_tons):
+	return _linear_interpolate(
+		mass_tons, SUSP_COMPRESSION_MIN_MASS,
+		SUSP_COMPRESSION_MAX_MASS,
+		SUSP_COMPRESSION_MIN, SUSP_COMPRESSION_MAX)
+
+
+def _hard_ratio(clearance, chassis_length):
+	ratio = float(clearance) / max(float(chassis_length), 0.01)
+	return _linear_interpolate(
+		ratio, CLEARANCE_TO_LENGTH_MIN, CLEARANCE_TO_LENGTH_MAX,
+		HARD_RATIO_MIN, HARD_RATIO_MAX)
+
+
+def _detailed_chassis_config(descriptor):
+	try:
+		tank_type = _required_value(
+			descriptor, 'type', 'vehicle type descriptor')
+		xphysics = _required_value(
+			tank_type, 'xphysics', 'vehicle xphysics')
+		detailed = xphysics['detailed']
+		configs = detailed['chassis']
+		chassis = _required_value(
+			descriptor, 'chassis', 'vehicle chassis descriptor')
+		name = _required_value(chassis, 'name', 'selected chassis name')
+		config = configs[name]
+	except (KeyError, TypeError) as error:
+		raise ValueError(
+			'detailed chassis xphysics is unavailable: %s' % error)
+	if not isinstance(config, dict):
+		raise ValueError('detailed chassis xphysics must be a dictionary')
+	return config
+
+
+def _bbox(component, context):
+	tester = _required_value(component, 'hitTester', '%s hitTester' % context)
+	bounds = _required_value(tester, 'bbox', '%s hitTester bbox' % context)
+	try:
+		minimum = bounds[0]
+		maximum = bounds[1]
+		dimensions = tuple(
+			_finite_number(maximum[index], '%s bbox maximum' % context) -
+			_finite_number(minimum[index], '%s bbox minimum' % context)
+			for index in range(3))
+	except (IndexError, TypeError) as error:
+		raise ValueError('%s hitTester bbox is invalid: %s' % (
+			context, error))
+	if any(value <= 0.0 for value in dimensions):
+		raise ValueError('%s hitTester bbox has no volume' % context)
+	return minimum, maximum, dimensions
+
+
+def _suspension_wheel_radius(chassis, config):
+	raw = config.get('wheelRadius')
+	if raw is not None:
+		radius = _finite_number(
+			raw, 'detailed chassis wheelRadius')
+		if radius > 0.0:
+			return radius
+	try:
+		radius = _finite_number(
+			chassis.wheels.groups[0].radius,
+			'selected chassis wheel radius')
+	except (AttributeError, IndexError, TypeError):
+		radius = 0.0
+	if radius <= 0.0:
+		raise ValueError(
+			'wheel radius is required by the contrib suspension trial')
+	return radius
+
+
+def derive_suspension_params(descriptor):
+	'''Build the contributed ten-spring rigid-body trial for one tank.
+
+	The descriptor supplies all geometry and detailed-chassis values. The
+	remaining interpolation constants are a derived contrib projection, not
+	evidence that this Python solver is identical to the #1513 native solver.
+	'''
+	physics = derive_params(descriptor)
+	descriptor_physics = _required_value(
+		descriptor, 'physics', 'vehicle physics descriptor')
+	mass = _finite_number(
+		_required_value(descriptor_physics, 'weight', 'vehicle physics weight'),
+		'vehicle physics weight')
+	if mass <= 0.0:
+		raise ValueError('vehicle physics weight must be positive')
+	# Keep derive_params as the unit owner and reject any unexpected divergence
+	# instead of silently simulating suspension with a generic mass.
+	if abs(float(physics['mass']) - mass) > 1.0e-6:
+		raise ValueError('vehicle physics mass projection is inconsistent')
+	chassis = _required_value(
+		descriptor, 'chassis', 'vehicle chassis descriptor')
+	hull = _required_value(descriptor, 'hull', 'vehicle hull descriptor')
+	unused_chassis_min, unused_chassis_max, chassis_size = _bbox(
+		chassis, 'chassis')
+	hull_minimum, unused_hull_max, unused_hull_size = _bbox(hull, 'hull')
+	width, chassis_height, chassis_length = chassis_size
+	hull_position = _required_value(
+		chassis, 'hullPosition', 'selected chassis hullPosition')
+	try:
+		clearance_raw = (
+			_finite_number(hull_position[1], 'chassis hullPosition.y') +
+			_finite_number(hull_minimum[1], 'hull bbox minimum.y'))
+	except (IndexError, TypeError) as error:
+		raise ValueError('selected chassis hullPosition is invalid: %s' % error)
+	if clearance_raw <= 0.0:
+		raise ValueError('descriptor ground clearance must be positive')
+	clearance = clearance_raw * CLEARANCE_SCALE
+	clearance = max(
+		CLEARANCE_MIN * chassis_height,
+		min(CLEARANCE_MAX * chassis_height, clearance))
+	mass_tons = mass * WEIGHT_SCALE
+	compression_ratio = _suspension_compression(mass_tons)
+	rest_length = clearance / max(compression_ratio, 0.01)
+	static_compression = max(0.01, rest_length - clearance)
+	hard_ratio = _hard_ratio(clearance, chassis_length)
+	config = _detailed_chassis_config(descriptor)
+	positions = _number_tuple(
+		_required_value(config, 'roadWheelPositions',
+			'detailed chassis roadWheelPositions'),
+		'detailed chassis roadWheelPositions')
+	if len(positions) != 5:
+		raise ValueError(
+			'contrib suspension trial requires five road-wheel positions')
+	position_limit = chassis_length * 0.5
+	if any(abs(value) > position_limit + SUSPENSION_GEOMETRY_EPSILON
+			for value in positions):
+		raise ValueError(
+			'roadWheelPositions extend beyond the chassis bbox')
+	stiffness_factors = _number_tuple(
+		_required_value(config, 'stiffnessFactors',
+			'detailed chassis stiffnessFactors'),
+		'detailed chassis stiffnessFactors')
+	if len(stiffness_factors) != len(positions):
+		raise ValueError(
+			'stiffnessFactors must match the five road-wheel positions')
+	if any(value <= 0.0 for value in stiffness_factors):
+		raise ValueError('stiffnessFactors must be positive')
+	left_factor = _finite_number(
+		_required_value(config, 'stiffness0',
+			'detailed chassis stiffness0'),
+		'detailed chassis stiffness0')
+	right_factor = _finite_number(
+		_required_value(config, 'stiffness1',
+			'detailed chassis stiffness1'),
+		'detailed chassis stiffness1')
+	if left_factor <= 0.0 or right_factor <= 0.0:
+		raise ValueError('detailed chassis stiffness must be positive')
+	damping_value = _finite_number(
+		_required_value(config, 'damping', 'detailed chassis damping'),
+		'detailed chassis damping')
+	if damping_value < 0.0:
+		raise ValueError('detailed chassis damping must not be negative')
+	damping_ratio = max(0.55, min(
+		1.25, SERVER_PHYSICS_DAMPING_RATIO_BASE +
+		SERVER_PHYSICS_DAMPING_RATIO_SCALE * damping_value))
+	track_x = abs(_finite_number(
+		_required_value(descriptor_physics, 'trackCenterOffset',
+			'vehicle physics trackCenterOffset'),
+		'vehicle physics trackCenterOffset'))
+	if (track_x <= 0.0 or
+			track_x > width * 0.5 + SUSPENSION_GEOMETRY_EPSILON):
+		raise ValueError(
+			'vehicle physics trackCenterOffset lies outside the chassis bbox')
+	raw_springs = []
+	for side, x, side_factor in (
+			('left', -track_x, left_factor),
+			('right', track_x, right_factor)):
+		for index, z in enumerate(positions):
+			raw_springs.append((
+				side, x, z, stiffness_factors[index] * side_factor))
+	weight_total = sum(row[3] for row in raw_springs)
+	if weight_total <= 0.0:
+		raise ValueError('suspension stiffness weights must be positive')
+	springs = []
+	for side, x, z, weight in raw_springs:
+		sprung_mass = mass * weight / weight_total
+		stiffness = sprung_mass * GRAVITY / static_compression
+		damping = 2.0 * damping_ratio * math.sqrt(
+			stiffness * sprung_mass)
+		springs.append({
+			'side': side, 'x': x, 'z': z,
+			'mass': sprung_mass, 'stiffness': stiffness,
+			'damping': damping,
+			'rest_length': rest_length,
+			'static_compression': static_compression,
+			'max_compression': max(
+				static_compression,
+				rest_length - clearance * hard_ratio),
+			'max_force': sprung_mass * GRAVITY *
+				SERVER_PHYSICS_MAX_SPRING_FORCE_FACTOR,
+		})
+	pseudo_contacts = []
+	for side, x in (('left', -track_x), ('right', track_x)):
+		for index in range(len(positions) - 1):
+			pseudo_contacts.append({
+				'side': side, 'kind': 'track', 'x': x, 'y': 0.0,
+				'z': (positions[index] + positions[index + 1]) * 0.5,
+				'penetration': TRACKS_PENETRATION,
+			})
+	# Centre-line belly points keep a ridge between both tracks from vanishing
+	# between the ten spring queries.
+	for index in range(len(positions) - 1):
+		pseudo_contacts.append({
+			'side': None, 'kind': 'body', 'x': 0.0, 'y': clearance,
+			'z': (positions[index] + positions[index + 1]) * 0.5,
+			'penetration': ALLOWED_PENETRATION,
+		})
+	body_height = _finite_number(
+		_required_value(config, 'bodyHeight', 'detailed chassis bodyHeight'),
+		'detailed chassis bodyHeight')
+	if body_height <= 0.0:
+		raise ValueError('detailed chassis bodyHeight must be positive')
+	inertia_factors = _number_tuple(
+		_required_value(config, 'hullInertiaFactors',
+			'detailed chassis hullInertiaFactors'),
+		'detailed chassis hullInertiaFactors')
+	if len(inertia_factors) != 3 or any(
+			value <= 0.0 for value in inertia_factors):
+		raise ValueError(
+			'hullInertiaFactors must contain three positive values')
+	wheel_radius = _suspension_wheel_radius(chassis, config)
+	pitch_inertia = max(
+		1.0, mass * (body_height ** 2 + chassis_length ** 2) /
+		12.0 * inertia_factors[0])
+	roll_inertia = max(
+		1.0, mass * (body_height ** 2 + width ** 2) /
+		12.0 * inertia_factors[2])
+	return {
+		'mass': mass, 'width': width, 'length': chassis_length,
+		'clearance': clearance, 'rest_length': rest_length,
+		'static_compression': static_compression,
+		'hard_ratio': hard_ratio,
+		'contact_memory_distance': max(
+			0.25, min(0.9, wheel_radius * 2.0)),
+		'pitch_inertia': pitch_inertia,
+		'roll_inertia': roll_inertia,
+		'springs': tuple(springs),
+		'pseudo_contacts': tuple(pseudo_contacts),
+		'fixed_step': SERVER_PHYSICS_STEP,
+		'constraint_iterations': SERVER_PHYSICS_CONSTRAINT_ITERATIONS,
+	}
+
+
+def suspension_world_points(params, position, yaw):
+	'''Return one world x/z query point for each trial damper spring.'''
+	x, unused_y, z = map(float, position)
+	sine, cosine = math.sin(float(yaw)), math.cos(float(yaw))
+	result = []
+	for spring in params['springs']:
+		local_x = float(spring['x'])
+		local_z = float(spring['z'])
+		result.append((
+			x + cosine * local_x + sine * local_z,
+			z - sine * local_x + cosine * local_z))
+	return tuple(result)
+
+
+def suspension_pseudo_world_points(params, position, yaw):
+	'''Return world x/z query points for the twelve trial pseudo contacts.'''
+	x, unused_y, z = map(float, position)
+	sine, cosine = math.sin(float(yaw)), math.cos(float(yaw))
+	result = []
+	for contact in params.get('pseudo_contacts', ()):
+		local_x = float(contact['x'])
+		local_z = float(contact['z'])
+		result.append((
+			x + cosine * local_x + sine * local_z,
+			z - sine * local_x + cosine * local_z))
+	return tuple(result)
+
+
+def suspension_ground_plane(params, ground_heights,
+		maximum_residual=None):
+	'''Fit terrain gradients from contacted springs, not body attitude.
+
+	Suspension pitch and roll contain transient damper motion. Feeding that
+	rocking back into slope grip would invent a hill on flat ground, so callers
+	use this least-squares contact plane for terrain-only metadata.
+	'''
+	try:
+		if len(ground_heights) != len(params['springs']):
+			return None
+	except (KeyError, TypeError):
+		return None
+	rows = []
+	for index, spring in enumerate(params['springs']):
+		ground = ground_heights[index]
+		if ground is None:
+			continue
+		try:
+			x = float(spring['x'])
+			z = float(spring['z'])
+			y = float(ground)
+		except (KeyError, TypeError, ValueError):
+			return None
+		if any(math.isnan(value) or math.isinf(value)
+				for value in (x, z, y)):
+			return None
+		rows.append((x, z, y))
+	if len(rows) < 3:
+		return None
+	count = float(len(rows))
+	mean_x = sum(row[0] for row in rows) / count
+	mean_z = sum(row[1] for row in rows) / count
+	mean_y = sum(row[2] for row in rows) / count
+	xx = xz = zz = xy = zy = 0.0
+	for x, z, y in rows:
+		dx = x - mean_x
+		dz = z - mean_z
+		dy = y - mean_y
+		xx += dx * dx
+		xz += dx * dz
+		zz += dz * dz
+		xy += dx * dy
+		zy += dz * dy
+	determinant = xx * zz - xz * xz
+	if determinant <= 1.0e-8:
+		return None
+	x_gradient = (xy * zz - zy * xz) / determinant
+	z_gradient = (zy * xx - xy * xz) / determinant
+	center_y = mean_y - x_gradient * mean_x - z_gradient * mean_z
+	residual = max(abs(
+		y - (center_y + x_gradient * x + z_gradient * z))
+		for x, z, y in rows)
+	if maximum_residual is not None:
+		try:
+			limit = max(0.0, float(maximum_residual))
+		except (TypeError, ValueError):
+			return None
+		if residual > limit:
+			return None
+	return {
+		'center_y': center_y,
+		'x_gradient': x_gradient,
+		'z_gradient': z_gradient,
+		'max_residual': residual,
+		'contact_count': len(rows),
+	}
+
+
+def suspension_world_ground_plane(params, ground_heights, position, yaw,
+		maximum_residual=None):
+	'''Fit one suspension plane in stable world-space coordinates.'''
+	local_plane = suspension_ground_plane(
+		params, ground_heights, maximum_residual)
+	if local_plane is None:
+		return None
+	try:
+		center_x = float(position[0])
+		center_z = float(position[2])
+		yaw = float(yaw)
+	except (IndexError, TypeError, ValueError, OverflowError):
+		return None
+	if any(math.isnan(value) or math.isinf(value)
+			for value in (center_x, center_z, yaw)):
+		return None
+	right_gradient = float(local_plane['x_gradient'])
+	forward_gradient = float(local_plane['z_gradient'])
+	sine, cosine = math.sin(yaw), math.cos(yaw)
+	gradient_x = forward_gradient * sine + right_gradient * cosine
+	gradient_z = forward_gradient * cosine - right_gradient * sine
+	center_y = float(local_plane['center_y'])
+	max_residual = float(local_plane['max_residual'])
+	if any(math.isnan(value) or math.isinf(value) for value in (
+			center_y, gradient_x, gradient_z, max_residual)):
+		return None
+	return {
+		'center_x': center_x,
+		'center_z': center_z,
+		'center_y': center_y,
+		'gradient_x': gradient_x,
+		'gradient_z': gradient_z,
+		'max_residual': max_residual,
+		'contact_count': int(local_plane['contact_count']),
+	}
+
+
+def suspension_plane_height(plane, x, z):
+	'''Project a world-space ground plane to one horizontal position.'''
+	if not isinstance(plane, dict):
+		return None
+	try:
+		values = (
+			float(plane['center_x']), float(plane['center_z']),
+			float(plane['center_y']), float(plane['gradient_x']),
+			float(plane['gradient_z']), float(x), float(z))
+	except (KeyError, TypeError, ValueError, OverflowError):
+		return None
+	if any(math.isnan(value) or math.isinf(value) for value in values):
+		return None
+	center_x, center_z, center_y, gradient_x, gradient_z, x, z = values
+	height = (center_y + gradient_x * (x - center_x) +
+		gradient_z * (z - center_z))
+	if math.isnan(height) or math.isinf(height):
+		return None
+	return height
+
+
+def suspension_ground_planes_continuous(
+		previous, current, start_position, end_position,
+		height_tolerance, gradient_tolerance):
+	'''Reject a layer jump or slope break between two world-space planes.'''
+	try:
+		start_x = float(start_position[0])
+		start_z = float(start_position[2])
+		end_x = float(end_position[0])
+		end_z = float(end_position[2])
+		height_tolerance = float(height_tolerance)
+		gradient_tolerance = float(gradient_tolerance)
+	except (IndexError, TypeError, ValueError, OverflowError):
+		return False
+	values = (start_x, start_z, end_x, end_z,
+		height_tolerance, gradient_tolerance)
+	if (any(math.isnan(value) or math.isinf(value) for value in values) or
+			height_tolerance < 0.0 or gradient_tolerance < 0.0):
+		return False
+	previous_start = suspension_plane_height(previous, start_x, start_z)
+	current_start = suspension_plane_height(current, start_x, start_z)
+	previous_end = suspension_plane_height(previous, end_x, end_z)
+	current_end = suspension_plane_height(current, end_x, end_z)
+	if any(value is None for value in (
+			previous_start, current_start, previous_end, current_end)):
+		return False
+	if (abs(previous_start - current_start) > height_tolerance or
+			abs(previous_end - current_end) > height_tolerance):
+		return False
+	try:
+		difference_x = (
+			float(current['gradient_x']) - float(previous['gradient_x']))
+		difference_z = (
+			float(current['gradient_z']) - float(previous['gradient_z']))
+	except (KeyError, TypeError, ValueError, OverflowError):
+		return False
+	return (difference_x * difference_x + difference_z * difference_z <=
+		gradient_tolerance * gradient_tolerance + 1.0e-12)
+
+
+def suspension_path_probe_fractions(distance):
+	'''Return a fixed-budget set of interior continuity checkpoints.'''
+	try:
+		distance = max(0.0, float(distance))
+	except (TypeError, ValueError):
+		return ()
+	steps = min(SUSPENSION_PATH_MAX_PROBES, max(
+		0, int(math.ceil(distance / SUSPENSION_PATH_PROBE_SPACING)) - 1))
+	return tuple(
+		float(index + 1) / float(steps + 1) for index in range(steps))
+
+
+def suspension_support_allowed(height, normal_y, flat_maximum_y=None):
+	'''Validate spring travel and the incline-only penetration extension.'''
+	height = float(height)
+	normal_y = float(normal_y)
+	if (math.isnan(height) or math.isinf(height) or
+			math.isnan(normal_y) or math.isinf(normal_y)):
+		return False
+	if normal_y <= 0.5:
+		return False
+	if (flat_maximum_y is None or
+			height <= float(flat_maximum_y) + 0.01):
+		return True
+	return normal_y < 0.995
+
+
+def retained_ground_contact(point, ground, memory, maximum_distance):
+	'''Keep one recent ground contact across a short wheel-scale gap.'''
+	try:
+		x, z = float(point[0]), float(point[1])
+		distance = max(0.0, float(maximum_distance))
+	except (IndexError, TypeError, ValueError, OverflowError):
+		return None, None
+	if any(math.isnan(value) or math.isinf(value)
+			for value in (x, z, distance)):
+		return None, None
+	if ground is not None:
+		try:
+			ground = float(ground)
+		except (TypeError, ValueError, OverflowError):
+			return None, None
+		if math.isnan(ground) or math.isinf(ground):
+			return None, None
+		return ground, (x, z, ground, x, z, 0.0, False)
+	if memory is None:
+		return None, None
+	try:
+		origin_x = float(memory[0])
+		origin_z = float(memory[1])
+		height = float(memory[2])
+		last_x = float(memory[3])
+		last_z = float(memory[4])
+		travelled = max(0.0, float(memory[5]))
+		last_query_missed = bool(memory[6])
+		values = (origin_x, origin_z, height, last_x, last_z, travelled)
+		if any(math.isnan(value) or math.isinf(value) for value in values):
+			return None, None
+		step_x = x - last_x
+		step_z = z - last_z
+		step_sq = step_x * step_x + step_z * step_z
+		# One miss covers a transient query hole. Repeating that miss without
+		# moving proves the support vanished and must release it.
+		if step_sq <= 1.0e-10:
+			if last_query_missed:
+				return None, None
+			return height, (
+				origin_x, origin_z, height, x, z, travelled, True)
+		dx = x - origin_x
+		dz = z - origin_z
+		travelled += math.sqrt(step_sq)
+		if (dx * dx + dz * dz <= distance * distance + 1.0e-12 and
+				travelled <= distance + 1.0e-9):
+			return height, (
+				origin_x, origin_z, height, x, z, travelled, True)
+	except (IndexError, TypeError, ValueError, OverflowError):
+		pass
+	return None, None
+
+
+def _rigid_point_height(state, point):
+	pitch = float(state.get('pitch', 0.0))
+	roll = float(state.get('roll', 0.0))
+	return (float(state['height']) + float(point.get('y', 0.0)) -
+		float(point['z']) * math.sin(pitch) +
+		float(point['x']) * math.sin(roll))
+
+
+def _rigid_point_velocity(state, point):
+	pitch = float(state.get('pitch', 0.0))
+	roll = float(state.get('roll', 0.0))
+	return (float(state.get('vertical_velocity', 0.0)) -
+		float(point['z']) * math.cos(pitch) *
+		float(state.get('pitch_velocity', 0.0)) +
+		float(point['x']) * math.cos(roll) *
+		float(state.get('roll_velocity', 0.0)))
+
+
+def _spring_height(state, spring):
+	return _rigid_point_height(state, spring)
+
+
+def _spring_point_velocity(state, spring):
+	return _rigid_point_velocity(state, spring)
+
+
+def _suspension_contact_keys(params, state, ground_heights,
+		pseudo_ground_heights):
+	'''Return final geometric contacts, separated from within-step impacts.'''
+	contacts = set()
+	left = set()
+	right = set()
+	for index, spring in enumerate(params['springs']):
+		ground = ground_heights[index]
+		if ground is None:
+			continue
+		compression = (
+			spring['static_compression'] + float(ground) -
+			_spring_height(state, spring))
+		if compression <= 0.0:
+			continue
+		key = ('spring', index)
+		contacts.add(key)
+		if spring['side'] == 'left':
+			left.add(key)
+		elif spring['side'] == 'right':
+			right.add(key)
+	for index, contact in enumerate(params.get('pseudo_contacts', ())):
+		ground = pseudo_ground_heights[index]
+		if ground is None:
+			continue
+		gap = float(ground) - _rigid_point_height(state, contact)
+		if gap < -CONTACT_PENETRATION:
+			continue
+		key = ('pseudo', index)
+		contacts.add(key)
+		if contact.get('side') == 'left':
+			left.add(key)
+		elif contact.get('side') == 'right':
+			right.add(key)
+	return contacts, left, right
+
+
+def suspension_limit_excess(params, state, ground_heights):
+	'''Return the largest compression beyond a projected hard limit.'''
+	maximum = 0.0
+	for index, spring in enumerate(params['springs']):
+		ground = ground_heights[index]
+		if ground is None:
+			continue
+		compression = (
+			spring['static_compression'] + float(ground) -
+			_spring_height(state, spring))
+		maximum = max(maximum, compression - spring['max_compression'])
+	return maximum
+
+
+def _project_suspension_limits(params, state, ground_heights,
+		pseudo_ground_heights=None):
+	'''Resolve hard limits with an order-independent worst-contact projection.'''
+	inv_mass = 1.0 / params['mass']
+	inv_pitch = 1.0 / params['pitch_inertia']
+	inv_roll = 1.0 / params['roll_inertia']
+	constraints = []
+	for index, spring in enumerate(params['springs']):
+		ground = ground_heights[index]
+		if ground is not None:
+			constraints.append((
+				('spring', index), spring, float(ground),
+				float(spring['max_compression']) -
+				float(spring['static_compression'])))
+	pseudo_ground_heights = pseudo_ground_heights or ()
+	for index, contact in enumerate(params.get('pseudo_contacts', ())):
+		ground = (pseudo_ground_heights[index]
+			if index < len(pseudo_ground_heights) else None)
+		if ground is not None:
+			constraints.append((
+				('pseudo', index), contact, float(ground),
+				float(contact.get('penetration', ALLOWED_PENETRATION))))
+	touched = set()
+	for unused_iteration in range(params['constraint_iterations']):
+		rows = []
+		maximum_excess = 0.0
+		for key, point, ground, penetration in constraints:
+			excess = (
+				ground - _rigid_point_height(state, point) - penetration)
+			if excess <= 1.0e-5:
+				continue
+			touched.add(key)
+			pitch_grad = float(point['z']) * math.cos(state['pitch'])
+			roll_grad = -float(point['x']) * math.cos(state['roll'])
+			denominator = (inv_mass + pitch_grad * pitch_grad * inv_pitch +
+				roll_grad * roll_grad * inv_roll)
+			if denominator <= 1.0e-12:
+				continue
+			rows.append((
+				point, excess, pitch_grad, roll_grad, denominator))
+			maximum_excess = max(maximum_excess, excess)
+		if not rows:
+			break
+		# Project only the equally deepest contacts. Averaging every violated
+		# half-space makes a severe contact advance by roughly 1/N per pass and
+		# leaves centimetres of penetration at the fixed iteration budget. The
+		# maximum-residual (Motzkin) projection converges quickly; grouping ties
+		# and using fsum keeps symmetric axles/tracks and input order unbiased.
+		tie_tolerance = max(1.0e-10, maximum_excess * 1.0e-8)
+		selected = tuple(row for row in rows
+			if maximum_excess - row[1] <= tie_tolerance)
+		position_height = []
+		position_pitch = []
+		position_roll = []
+		velocity_height = []
+		velocity_pitch = []
+		velocity_roll = []
+		for point, excess, pitch_grad, roll_grad, denominator in selected:
+			point_velocity = _rigid_point_velocity(state, point)
+			if point_velocity < 0.0:
+				velocity_impulse = -point_velocity / denominator
+				velocity_height.append(velocity_impulse * inv_mass)
+				velocity_pitch.append(
+					-velocity_impulse * pitch_grad * inv_pitch)
+				velocity_roll.append(
+					-velocity_impulse * roll_grad * inv_roll)
+			else:
+				velocity_height.append(0.0)
+				velocity_pitch.append(0.0)
+				velocity_roll.append(0.0)
+			impulse = excess / denominator
+			position_height.append(impulse * inv_mass)
+			position_pitch.append(-impulse * pitch_grad * inv_pitch)
+			position_roll.append(-impulse * roll_grad * inv_roll)
+		scale = 1.0 / float(len(selected))
+		state['vertical_velocity'] += math.fsum(velocity_height) * scale
+		state['pitch_velocity'] += math.fsum(velocity_pitch) * scale
+		state['roll_velocity'] += math.fsum(velocity_roll) * scale
+		state['height'] += math.fsum(position_height) * scale
+		state['pitch'] += math.fsum(position_pitch) * scale
+		state['roll'] += math.fsum(position_roll) * scale
+	# The nonlinear sine pose can leave a tiny residual after the bounded
+	# angular iterations. A final conservative heave is itself a real position
+	# projection (not a reported-value clamp) and satisfies every half-space at
+	# once without adding pitch/roll bias or another iterative sweep.
+	remaining_excess = 0.0
+	for key, point, ground, penetration in constraints:
+		excess = ground - _rigid_point_height(state, point) - penetration
+		if excess > 0.0:
+			remaining_excess = max(remaining_excess, excess)
+			touched.add(key)
+	if remaining_excess > 0.0:
+		state['height'] += remaining_excess + 1.0e-9
+	return touched
+
+
+def damper_suspension_step(params, state, ground_heights, dt,
+		pseudo_ground_heights=None):
+	'''Advance the contrib ten-spring heave/pitch/roll trial.'''
+	if not isinstance(state, dict):
+		raise ValueError('suspension state must be a dictionary')
+	if len(ground_heights) != len(params['springs']):
+		raise ValueError('suspension ground sample count mismatch')
+	pseudo_contacts = params.get('pseudo_contacts', ())
+	if pseudo_ground_heights is None:
+		pseudo_ground_heights = (None,) * len(pseudo_contacts)
+	if len(pseudo_ground_heights) != len(pseudo_contacts):
+		raise ValueError('pseudo-contact ground sample count mismatch')
+	result = {
+		'height': float(state.get('height', 0.0)),
+		'vertical_velocity': float(state.get('vertical_velocity', 0.0)),
+		'pitch': float(state.get('pitch', 0.0)),
+		'pitch_velocity': float(state.get('pitch_velocity', 0.0)),
+		'roll': float(state.get('roll', 0.0)),
+		'roll_velocity': float(state.get('roll_velocity', 0.0)),
+	}
+	total = max(0.0, min(0.2, float(dt)))
+	steps = min(SERVER_PHYSICS_MAX_SUBSTEPS, max(
+		1, int(math.ceil(total / params['fixed_step']))))
+	step = total / float(steps) if steps else 0.0
+	touched_keys = set()
+	maximum_compression = 0.0
+	impact_speed = None
+	contact_transition_seen = False
+	vertical_acceleration = 0.0
+	pitch_acceleration = 0.0
+	roll_acceleration = 0.0
+	for unused_step in range(steps):
+		total_force = -params['mass'] * GRAVITY
+		pitch_torque = 0.0
+		roll_torque = 0.0
+		substep_contacts = 0
+		substep_vertical_speed = result['vertical_velocity']
+		for index, spring in enumerate(params['springs']):
+			ground = ground_heights[index]
+			if ground is None:
+				continue
+			compression = (
+				spring['static_compression'] + float(ground) -
+				_spring_height(result, spring))
+			if compression <= 0.0:
+				continue
+			maximum_compression = max(maximum_compression, compression)
+			key = ('spring', index)
+			touched_keys.add(key)
+			substep_contacts += 1
+			if (not contact_transition_seen and
+					substep_vertical_speed < 0.0):
+				impact_speed = (substep_vertical_speed
+					if impact_speed is None else
+					min(impact_speed, substep_vertical_speed))
+			force = (spring['stiffness'] * compression -
+				spring['damping'] *
+				_spring_point_velocity(result, spring))
+			if compression > spring['max_compression']:
+				excess = compression - spring['max_compression']
+				force += spring['stiffness'] * 8.0 * excess * (
+					1.0 + excess / max(spring['max_compression'], 0.01))
+			force = max(0.0, min(spring['max_force'], force))
+			total_force += force
+			pitch_torque -= float(spring['z']) * math.cos(
+				result['pitch']) * force
+			roll_torque += float(spring['x']) * math.cos(
+				result['roll']) * force
+		for index, contact in enumerate(pseudo_contacts):
+			ground = pseudo_ground_heights[index]
+			if ground is None:
+				continue
+			gap = float(ground) - _rigid_point_height(result, contact)
+			if gap < -CONTACT_PENETRATION:
+				continue
+			key = ('pseudo', index)
+			touched_keys.add(key)
+			substep_contacts += 1
+			if (not contact_transition_seen and
+					substep_vertical_speed < 0.0):
+				impact_speed = (substep_vertical_speed
+					if impact_speed is None else
+					min(impact_speed, substep_vertical_speed))
+		if substep_contacts:
+			contact_transition_seen = True
+		if substep_contacts == 0:
+			decay = math.exp(-AIRBORNE_ANGULAR_DAMPING * step)
+			result['pitch_velocity'] = max(
+				-AIRBORNE_ANGULAR_SPEED_LIMIT,
+				min(AIRBORNE_ANGULAR_SPEED_LIMIT,
+					result['pitch_velocity'])) * decay
+			result['roll_velocity'] = max(
+				-AIRBORNE_ANGULAR_SPEED_LIMIT,
+				min(AIRBORNE_ANGULAR_SPEED_LIMIT,
+					result['roll_velocity'])) * decay
+		vertical_acceleration = total_force / params['mass']
+		pitch_acceleration = pitch_torque / params['pitch_inertia']
+		roll_acceleration = roll_torque / params['roll_inertia']
+		result['vertical_velocity'] += vertical_acceleration * step
+		result['pitch_velocity'] += pitch_acceleration * step
+		result['roll_velocity'] += roll_acceleration * step
+		result['height'] += result['vertical_velocity'] * step
+		result['pitch'] += result['pitch_velocity'] * step
+		result['roll'] += result['roll_velocity'] * step
+		pre_projection_speed = result['vertical_velocity']
+		projected = _project_suspension_limits(
+			params, result, ground_heights, pseudo_ground_heights)
+		if projected:
+			if (not contact_transition_seen and
+					pre_projection_speed < 0.0):
+				impact_speed = (pre_projection_speed if impact_speed is None else
+					min(impact_speed, pre_projection_speed))
+			contact_transition_seen = True
+			touched_keys.update(projected)
+	contact_keys, left_contact_keys, right_contact_keys = \
+		_suspension_contact_keys(
+			params, result, ground_heights, pseudo_ground_heights)
+	contact_count = len(contact_keys)
+	# A contact may begin during the final integration after the last force and
+	# hard-limit query. The final-pose query is then the first proof available
+	# in this outer step, so preserve its post-gravity/pre-contact CoM speed for
+	# the runtime's airborne-to-grounded landing gate.
+	if contact_keys and not contact_transition_seen:
+		if result['vertical_velocity'] < 0.0:
+			impact_speed = result['vertical_velocity']
+		contact_transition_seen = True
+	touched_keys.update(contact_keys)
+	if contact_count:
+		if (abs(vertical_acceleration) < FREEZE_ACCEL_EPSILON and
+				abs(result['vertical_velocity']) < FREEZE_VEL_EPSILON):
+			result['vertical_velocity'] = 0.0
+		if (abs(pitch_acceleration) < FREEZE_ANG_ACCEL_EPSILON and
+				abs(result['pitch_velocity']) < FREEZE_ANG_VEL_EPSILON):
+			result['pitch_velocity'] = 0.0
+		if (abs(roll_acceleration) < FREEZE_ANG_ACCEL_EPSILON and
+				abs(result['roll_velocity']) < FREEZE_ANG_VEL_EPSILON):
+			result['roll_velocity'] = 0.0
+	result['contact_count'] = contact_count
+	result['airborne'] = contact_count == 0
+	result['left_flying'] = not bool(left_contact_keys)
+	result['right_flying'] = not bool(right_contact_keys)
+	result['contacted_this_step'] = bool(touched_keys)
+	result['touched_contact_count'] = len(touched_keys)
+	result['impact_speed'] = impact_speed
+	result['max_compression'] = maximum_compression
+	result['max_limit_excess'] = max(
+		0.0, suspension_limit_excess(params, result, ground_heights))
+	for index, contact in enumerate(pseudo_contacts):
+		ground = pseudo_ground_heights[index]
+		if ground is None:
+			continue
+		result['max_limit_excess'] = max(
+			result['max_limit_excess'], float(ground) -
+			_rigid_point_height(result, contact) -
+			float(contact.get('penetration', ALLOWED_PENETRATION)))
+	return result
+
+
 def longitudinal_slope_grip(slope_pitch):
 	'''Return #1513's terrain pulling grip for this fore/aft slope.
 
@@ -443,6 +1377,19 @@ def longitudinal_slope_grip(slope_pitch):
 		grip = (SLOPE_GRIP_LNG_MIN + progress *
 			(SLOPE_GRIP_LNG_FULL - SLOPE_GRIP_LNG_MIN))
 	return grip * DRIVE_TRACTION
+
+
+def lateral_slope_grip(normal_y):
+	'''Return the contrib trial's low-cost side-grip interpolation.'''
+	normal_y = max(0.0, min(1.0, float(normal_y)))
+	if normal_y >= SLOPE_GRIP_SDW_FULL_Y:
+		return SLOPE_GRIP_SDW_FULL
+	if normal_y <= SLOPE_GRIP_SDW_MIN_Y:
+		return SLOPE_GRIP_SDW_MIN
+	span = SLOPE_GRIP_SDW_FULL_Y - SLOPE_GRIP_SDW_MIN_Y
+	progress = (normal_y - SLOPE_GRIP_SDW_MIN_Y) / span
+	return (SLOPE_GRIP_SDW_MIN + progress *
+		(SLOPE_GRIP_SDW_FULL - SLOPE_GRIP_SDW_MIN))
 
 
 def engine_force(p, v, throttle, slope_pitch=0.0):
@@ -715,24 +1662,27 @@ def slope_cohesion(ny):
 
 
 def slope_slide_speed(cur, slope_tan, dt):
-	'''WG-faithful passive slope slide along the fall line. The tracks HOLD the
-	hull while tan(theta) <= effective cohesion (~46 deg with slope decay,
-	~52 deg on firm ground) - a parked tank does NOT creep down ordinary hills.
-	Past the grip limit the hull accelerates down-slope by the EXCESS
-	g*(sin - coh*cos), regardless of throttle: engine force acts along the hull
-	heading (handled by longitudinal_step), it cannot stop the LATERAL fall-line
-	slip. The caller applies only the cross-heading component so the two never
-	double-count. Below the grip limit the residual bleeds off fast.'''
+	'''Advance passive slope slide along the fall line.
+
+	The contrib trial reduces side hold over its two-point normal-y curve. This
+	is intentionally cheap, but native equivalence and gameplay feel are not yet
+	proved. The caller applies only the cross-heading component so longitudinal
+	drive and this lateral slip do not double-count.
+	'''
 	theta = math.atan(slope_tan)
+	hold_tangent = (
+		SLIDE_HOLD_TAN * lateral_slope_grip(math.cos(theta)))
 	# Lateral fall-line hold: tracks resist SIDEWAYS slip only up to SLIDE_HOLD_TAN
 	# (gentler than the brake COHESION), so a hull cannot perch across a steep bank
 	# it is only leaning on. Past it, slip down the excess.
-	if slope_tan <= SLIDE_HOLD_TAN:
+	if slope_tan <= hold_tangent:
 		cur -= COHESION * GRAVITY * dt   # holds: kill any residual slide fast
 		return cur if cur > 0.0 else 0.0
 	# accelerate by the grip-excess, minus a track drag proportional to slide
 	# speed -> settles at a natural terrain-dependent terminal, not a flat cap.
-	cur += (GRAVITY * (math.sin(theta) - SLIDE_HOLD_TAN * math.cos(theta)) - SLIDE_DRAG * cur) * dt
+	cur += (GRAVITY * (
+		math.sin(theta) - hold_tangent * math.cos(theta)) -
+		SLIDE_DRAG * cur) * dt
 	if cur < 0.0:
 		cur = 0.0
 	elif cur > SLIDE_MAX:

--- a/0.9.22/tests/test_port_0922_battle_runtime.py
+++ b/0.9.22/tests/test_port_0922_battle_runtime.py
@@ -537,6 +537,33 @@ class _Descriptor(object):
                 self.turret.hitTester, self.gun.hitTester)
 
 
+def _suspension_descriptor():
+    """Return one fixture with every client-owned trial suspension field."""
+    descriptor = _Descriptor()
+    descriptor.physics.update({
+        'weight': 12000.0,
+        'trackCenterOffset': 1.2,
+    })
+    descriptor.chassis.name = 'test_chassis'
+    descriptor.type.xphysics = {
+        'detailed': {
+            'chassis': {
+                'test_chassis': {
+                    'roadWheelPositions': (-2.8, -1.4, 0.0, 1.4, 2.8),
+                    'stiffnessFactors': (1.0, 1.0, 1.0, 1.0, 1.0),
+                    'stiffness0': 1.0,
+                    'stiffness1': 1.0,
+                    'damping': 0.2,
+                    'bodyHeight': 1.6,
+                    'hullInertiaFactors': (1.0, 1.0, 1.8),
+                    'wheelRadius': 0.4,
+                },
+            },
+        },
+    }
+    return descriptor
+
+
 class _VehicleDescr(object):
     def __new__(cls, typeName=None, compactDescr=None):
         return _Descriptor(
@@ -5229,6 +5256,8 @@ class BattleRuntimeContractTests(unittest.TestCase):
         battle._avatar = runtime.bigworld.avatar
         battle._arena_bounds = (-300.0, -300.0, 300.0, 300.0)
         battle._local_physics = {'mass': 25000.0}
+        battle._local_pitch = 0.23
+        battle._local_roll = -0.17
         battle._contact_tanks = mock.Mock(return_value=[])
         battle._poll_local_ram_contact_episodes = mock.Mock()
         battle._baked_pose_safe = mock.Mock(return_value=False)
@@ -5251,6 +5280,11 @@ class BattleRuntimeContractTests(unittest.TestCase):
 
         self.assertAlmostEqual(300.8, position[0])
         self.assertFalse(battle._baked_pose_safe(position))
+        proof_body = battle._poll_local_ram_contact_episodes.call_args.args[1]
+        self.assertEqual((301.0, 0.0, 0.0), (
+            proof_body['x'], proof_body['y'], proof_body['z']))
+        self.assertAlmostEqual(0.23, proof_body['pitch'])
+        self.assertAlmostEqual(-0.17, proof_body['roll'])
 
     def test_local_bot_ram_receipt_preserves_pre_separation_pose(self):
         runtime = _runtime()
@@ -13618,6 +13652,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
             probe_timing_state=lambda: 'active',
             diagnostic_totals=lambda: {
                 'alive_bot_ticks': 29,
+                'suspension_param_failures': 2,
                 'visibility_queue_depth': 3,
                 'visibility_queue_max_depth': 8,
                 'visibility_oldest_stale_age_ms': 400,
@@ -13654,6 +13689,8 @@ class BattleRuntimeContractTests(unittest.TestCase):
             0.01, sample['bot_probe_seconds']['visibility'])
         self.assertEqual('active', sample['probe_timing'])
         self.assertEqual(29, sample['alive_bot_ticks'])
+        self.assertEqual(
+            2, sample['bot_diagnostics']['suspension_param_failures'])
         self.assertEqual(
             3, sample['bot_diagnostics']['visibility_queue_depth'])
         self.assertEqual(
@@ -16270,6 +16307,565 @@ class BattleRuntimeContractTests(unittest.TestCase):
         battle._ground_y.assert_called()
         self.assertGreater(battle._local_position[2], 8.0)
         self.assertEqual(4.0, battle._local_speed)
+
+    def test_suspension_probe_skips_flat_roof_above_spring_limit(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        calls = []
+
+        def collision(unused_space, start, end, unused_mask):
+            calls.append((start.y, end.y))
+            if len(calls) == 1:
+                return (_Vector(start.x, 0.7, start.z),
+                        _Vector(0.0, 1.0, 0.0))
+            return (_Vector(start.x, 0.0, start.z),
+                    _Vector(0.0, 1.0, 0.0))
+
+        runtime.bigworld.wg_collideSegment = collision
+
+        self.assertEqual(
+            0.0,
+            battle._suspension_ground_y(
+                2.0, 3.0, -1.0, 1.0, flat_maximum_y=0.2))
+        self.assertEqual(2, len(calls))
+        self.assertAlmostEqual(0.68, calls[1][0])
+        self.assertTrue(all(end == -1.0 for unused_start, end in calls))
+
+    def test_suspension_probe_rejects_wall_and_normalises_ground_normal(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        hits = iter((
+            (_Vector(1.0, 0.4, 2.0), _Vector(1.0, 0.0, 0.0)),
+            (_Vector(1.0, 0.1, 2.0), _Vector(0.0, 2.0, 0.0)),
+        ))
+        runtime.bigworld.wg_collideSegment = \
+            lambda *unused: next(hits)
+
+        self.assertEqual(
+            0.1,
+            battle._suspension_ground_y(1.0, 2.0, -0.5, 0.8))
+
+    def test_suspension_probe_preserves_broken_skin_filter_on_recast(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        skin_filter = lambda unused_hit: False
+        battle._destructibles = types.SimpleNamespace(
+            ground_collision_filter=lambda unused_x, unused_z: skin_filter)
+        filters = []
+
+        def collision(unused_space, start, unused_end, unused_mask,
+                      ground_filter):
+            filters.append(ground_filter)
+            if len(filters) == 1:
+                return (_Vector(start.x, 0.3, start.z),
+                        _Vector(1.0, 0.0, 0.0))
+            return (_Vector(start.x, 0.0, start.z),
+                    _Vector(0.0, 1.0, 0.0))
+
+        runtime.bigworld.wg_collideSegment = collision
+
+        self.assertEqual(
+            0.0,
+            battle._suspension_ground_y(0.0, 0.0, -0.5, 0.8))
+        self.assertEqual([skin_filter, skin_filter], filters)
+
+    def test_suspension_probe_allows_incline_extension_not_flat_support(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        runtime.bigworld.wg_collideSegment = lambda *unused: (
+            _Vector(0.0, 0.6, 0.0), _Vector(0.0, 0.8, 0.6))
+
+        self.assertEqual(
+            0.6,
+            battle._suspension_ground_y(
+                0.0, 0.0, -0.5, 0.8, flat_maximum_y=0.2))
+
+    def test_suspension_probe_propagates_native_query_failure(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        runtime.bigworld.wg_collideSegment = mock.Mock(
+            side_effect=ValueError('native query failed'))
+
+        with self.assertRaisesRegex(
+                RuntimeError, 'native suspension ground query failed'):
+            battle._suspension_ground_y(0.0, 0.0, -0.5, 0.8)
+
+    def test_suspension_probe_propagates_malformed_native_hit(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        runtime.bigworld.wg_collideSegment = mock.Mock(
+            return_value=(_Vector(0.0, 0.0, 0.0),))
+
+        with self.assertRaisesRegex(
+                RuntimeError, 'native suspension ground hit is malformed'):
+            battle._suspension_ground_y(0.0, 0.0, -0.5, 0.8)
+
+    def test_local_suspension_samples_twenty_two_columns_once_per_tick(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        battle._local_fall_armed = True
+        entity = _Vehicle(
+            10, _suspension_descriptor(), _Vector(), (0, 0, 0),
+            {'health': 500})
+        battle._suspension_ground_y = mock.Mock(return_value=0.0)
+
+        with mock.patch.object(
+                vehicle_physics, 'damper_suspension_step',
+                wraps=vehicle_physics.damper_suspension_step) as solver:
+            position = battle._update_vertical_motion(
+                entity, (0.0, 0.0, 0.0), 0.0, 0.1)
+
+        self.assertEqual(22, battle._suspension_ground_y.call_count)
+        solver.assert_called_once()
+        self.assertEqual(10, len(solver.call_args[0][2]))
+        self.assertEqual(12, len(solver.call_args[0][4]))
+        self.assertAlmostEqual(0.0, position[1], places=6)
+        self.assertFalse(battle._local_airborne)
+        self.assertFalse(battle._local_left_flying)
+        self.assertFalse(battle._local_right_flying)
+
+    def test_local_suspension_solves_slope_pitch_and_ground_metadata(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        battle._local_fall_armed = True
+        entity = _Vehicle(
+            10, _suspension_descriptor(), _Vector(), (0, 0, 0),
+            {'health': 500})
+        battle._suspension_ground_y = mock.Mock(
+            side_effect=lambda unused_x, z, *unused_args, **unused_kw:
+            0.08 * z)
+
+        position = battle._update_vertical_motion(
+            entity, (0.0, 0.0, 0.0), 0.0, 0.05)
+
+        self.assertEqual(22, battle._suspension_ground_y.call_count)
+        self.assertFalse(battle._local_airborne)
+        self.assertLess(battle._local_pitch, 0.0)
+        self.assertLess(abs(battle._local_roll), 0.02)
+        self.assertGreater(battle._local_slope_tangent, 0.0)
+        self.assertAlmostEqual(0.08, battle._local_slope_tangent, places=6)
+        self.assertIsNotNone(battle._local_ground_plane)
+        self.assertTrue(math.isfinite(position[1]))
+
+    def test_local_suspension_rock_does_not_invent_a_terrain_slope(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        params = vehicle_physics.derive_suspension_params(
+            _suspension_descriptor())
+        battle._local_suspension_params = params
+        solved = {
+            'pitch': 0.3,
+            'roll': -0.2,
+            'airborne': False,
+        }
+
+        committed = battle._commit_local_suspension_metadata(
+            (0.0, 0.0, 0.0), 0.0, solved,
+            (0.0,) * len(params['springs']))
+
+        self.assertTrue(committed)
+        self.assertEqual(0.0, battle._local_slope_tangent)
+        self.assertEqual((0.0, 0.0, 0.0), battle._local_downhill)
+        self.assertAlmostEqual(
+            math.cos(0.3) * math.cos(-0.2),
+            battle._local_surface_up_cosine)
+
+    def test_local_suspension_enters_ballistic_state_without_contacts(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        battle._local_fall_armed = True
+        entity = _Vehicle(
+            10, _suspension_descriptor(), _Vector(0.0, 5.0, 0.0),
+            (0, 0, 0), {'health': 500})
+        battle._suspension_ground_y = mock.Mock(return_value=None)
+
+        position = battle._update_vertical_motion(
+            entity, (0.0, 5.0, 0.0), 0.0, 0.1)
+
+        self.assertEqual(22, battle._suspension_ground_y.call_count)
+        self.assertTrue(battle._local_airborne)
+        self.assertTrue(battle._local_left_flying)
+        self.assertTrue(battle._local_right_flying)
+        self.assertLess(battle._local_vertical_speed, 0.0)
+        self.assertLess(position[1], 5.0)
+        self.assertIsNone(battle._local_ground_plane)
+
+    def test_local_suspension_keeps_main_support_rise_rollback(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        battle._local_fall_armed = True
+        battle._local_support_tick_pose = (0.0, 0.0, 0.0)
+        entity = _Vehicle(
+            10, _suspension_descriptor(), _Vector(), (0, 0, 0),
+            {'health': 500})
+        battle._suspension_ground_y = mock.Mock(return_value=0.0)
+        raised = {
+            'height': 0.8,
+            'vertical_velocity': 0.0,
+            'pitch': 0.0,
+            'pitch_velocity': 0.0,
+            'roll': 0.0,
+            'roll_velocity': 0.0,
+            'contact_count': 1,
+            'airborne': False,
+            'left_flying': False,
+            'right_flying': False,
+        }
+
+        with mock.patch.object(
+                vehicle_physics, 'damper_suspension_step',
+                return_value=raised):
+            position = battle._update_vertical_motion(
+                entity, (0.0, 0.0, 0.2), 0.0, 0.04)
+
+        self.assertEqual((0.0, 0.0, 0.0), position)
+        self.assertTrue(battle._local_support_rise_blocked)
+        self.assertFalse(battle._local_airborne)
+        self.assertIsNone(battle._local_spring_ground_memory)
+        self.assertIsNone(battle._local_pseudo_ground_memory)
+        self.assertEqual(22, battle._suspension_ground_y.call_count)
+
+    def test_local_suspension_ram_distance_does_not_authorise_high_platform(
+            self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        battle._local_fall_armed = True
+        battle._local_speed = 0.0
+        battle._local_support_tick_pose = (2.0, 0.0, 0.0)
+        battle._local_support_motion_pose = (0.0, 0.0, 0.0)
+        battle._local_ground_plane = {
+            'center_x': 0.0, 'center_z': 0.0, 'center_y': 0.0,
+            'gradient_x': 0.0, 'gradient_z': 0.0,
+        }
+        entity = _Vehicle(
+            10, _suspension_descriptor(), _Vector(), (0, 0, 0),
+            {'health': 500})
+        battle._suspension_ground_y = mock.Mock(return_value=0.8)
+        raised = {
+            'height': 0.8,
+            'vertical_velocity': 0.0,
+            'pitch': 0.0,
+            'pitch_velocity': 0.0,
+            'roll': 0.0,
+            'roll_velocity': 0.0,
+            'contact_count': 1,
+            'airborne': False,
+            'left_flying': False,
+            'right_flying': False,
+        }
+
+        with mock.patch.object(
+                vehicle_physics, 'damper_suspension_step',
+                return_value=raised):
+            position = battle._update_vertical_motion(
+                entity, (2.0, 0.0, 0.0), 0.0, 0.04)
+
+        self.assertEqual((2.0, 0.0, 0.0), position)
+        self.assertTrue(battle._local_support_rise_blocked)
+        self.assertEqual(22, battle._suspension_ground_y.call_count)
+
+    def test_local_suspension_continuous_slope_authorises_bounded_high_rise(
+            self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        battle._local_fall_armed = True
+        battle._local_speed = 0.0
+        battle._local_support_tick_pose = (5.0, 0.0, 0.0)
+        battle._local_support_motion_pose = (0.0, 0.0, 0.0)
+        battle._local_ground_plane = {
+            'center_x': 0.0, 'center_z': 0.0, 'center_y': 0.0,
+            'gradient_x': 0.2, 'gradient_z': 0.0,
+        }
+        entity = _Vehicle(
+            10, _suspension_descriptor(), _Vector(), (0, 0, 0),
+            {'health': 500})
+        battle._suspension_ground_y = mock.Mock(
+            side_effect=lambda x, unused_z, *unused_args, **unused_kw:
+            0.2 * x)
+        raised = {
+            'height': 1.0,
+            'vertical_velocity': 0.0,
+            'pitch': 0.0,
+            'pitch_velocity': 0.0,
+            'roll': 0.0,
+            'roll_velocity': 0.0,
+            'contact_count': 10,
+            'airborne': False,
+            'left_flying': False,
+            'right_flying': False,
+        }
+
+        with mock.patch.object(
+                vehicle_physics, 'damper_suspension_step',
+                return_value=raised):
+            position = battle._update_vertical_motion(
+                entity, (5.0, 0.0, 0.0), 0.0, 0.0)
+
+        self.assertEqual((5.0, 1.0, 0.0), position)
+        self.assertFalse(battle._local_support_rise_blocked)
+        # One endpoint scan (22) plus the fixed maximum of three centre
+        # checkpoints proves this five-metre correction without 22-ray
+        # segmentation along the entire path.
+        self.assertEqual(25, battle._suspension_ground_y.call_count)
+
+    def test_local_suspension_missing_path_support_rejects_high_rise(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        battle._local_fall_armed = True
+        battle._local_support_tick_pose = (5.0, 0.0, 0.0)
+        battle._local_support_motion_pose = (0.0, 0.0, 0.0)
+        battle._local_ground_plane = {
+            'center_x': 0.0, 'center_z': 0.0, 'center_y': 0.0,
+            'gradient_x': 0.2, 'gradient_z': 0.0,
+        }
+        entity = _Vehicle(
+            10, _suspension_descriptor(), _Vector(), (0, 0, 0),
+            {'health': 500})
+        calls = [0]
+
+        def ground(x, unused_z, *unused_args, **unused_kw):
+            calls[0] += 1
+            return 0.2 * x if calls[0] <= 22 else None
+
+        battle._suspension_ground_y = mock.Mock(side_effect=ground)
+        raised = {
+            'height': 1.0,
+            'vertical_velocity': 0.0,
+            'pitch': 0.0,
+            'pitch_velocity': 0.0,
+            'roll': 0.0,
+            'roll_velocity': 0.0,
+            'contact_count': 10,
+            'airborne': False,
+            'left_flying': False,
+            'right_flying': False,
+        }
+
+        with mock.patch.object(
+                vehicle_physics, 'damper_suspension_step',
+                return_value=raised):
+            position = battle._update_vertical_motion(
+                entity, (5.0, 0.0, 0.0), 0.0, 0.0)
+
+        self.assertEqual((5.0, 0.0, 0.0), position)
+        self.assertTrue(battle._local_support_rise_blocked)
+        # The first missing checkpoint fails closed; it does not spend the
+        # rest of the three-ray exceptional budget.
+        self.assertEqual(23, battle._suspension_ground_y.call_count)
+
+    def test_local_suspension_settles_ram_then_slide_at_each_endpoint(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        client = _Client()
+        battle.client = client
+        battle._avatar = runtime.bigworld.avatar
+        descriptor = _suspension_descriptor()
+        entity = _Vehicle(
+            10, descriptor, _Vector(), (0, 0, 0), {'health': 500})
+        runtime.bigworld.entities[10] = entity
+        battle._server = types.SimpleNamespace(vehicle_id=10)
+        battle._sender = types.SimpleNamespace(
+            forward=0.0, turn=0.0, handbrake=False,
+            send_current=lambda: client.send_input('current'))
+        battle._local_position = (0.0, 0.0, 0.0)
+        battle._local_descriptor = descriptor
+        battle._attach_local_presentation()
+        battle._local_fall_armed = True
+        battle._destructibles = mock.Mock()
+        battle._destructibles.take_ground_skip_count.return_value = 0
+        battle._smoothed_drive_pitch = mock.Mock(return_value=0.0)
+        battle._suspension_ground_y = mock.Mock(
+            side_effect=lambda x, unused_z, *unused_args, **unused_kw:
+            0.08 * x)
+        order = []
+
+        def ram_correct(unused_entity, position, unused_yaw, unused_dt):
+            order.append(('ram', tuple(position), battle._local_pitch,
+                          battle._local_roll))
+            return (position[0] + 0.2, position[1], position[2])
+
+        def slope_slide(position, unused_yaw, unused_dt,
+                        unused_entity=None):
+            order.append(('slide', tuple(position), battle._local_pitch,
+                          battle._local_roll))
+            return (position[0], position[1], position[2] + 0.2)
+
+        battle._resolve_local_tank_contacts = mock.Mock(
+            side_effect=ram_correct)
+        battle._apply_suspension_slope_slide = mock.Mock(
+            side_effect=slope_slide)
+        real_solver = vehicle_physics.damper_suspension_step
+
+        def solve(*args):
+            order.append(('settle', args[3]))
+            return real_solver(*args)
+
+        with mock.patch(
+                'gui.mods.offline_lan_0922.battle_runtime.'
+                'vehicle_physics.longitudinal_step', return_value=0.0), \
+                mock.patch(
+                    'gui.mods.offline_lan_0922.battle_runtime.'
+                    'vehicle_physics.traverse_step', return_value=0.0), \
+                mock.patch.object(
+                    vehicle_physics, 'damper_suspension_step',
+                    side_effect=solve) as solver:
+            battle._drive_local_step(0.1)
+
+        self.assertEqual(
+            ['settle', 'ram', 'settle', 'slide', 'settle'],
+            [row[0] for row in order])
+        ram_input = order[1]
+        slide_input = order[3]
+        self.assertTrue(abs(ram_input[3]) > 0.001)
+        self.assertGreater(slide_input[1][1], ram_input[1][1])
+        self.assertEqual(0.2, slide_input[1][0])
+        self.assertEqual([0.1, 0.0, 0.0], [
+            call.args[3] for call in solver.call_args_list])
+        self.assertEqual(66, battle._suspension_ground_y.call_count)
+        self.assertAlmostEqual(0.2, battle._local_position[0])
+        self.assertAlmostEqual(0.2, battle._local_position[2])
+        self.assertFalse(battle._local_support_rise_blocked)
+
+    def test_local_ram_correction_follows_continuous_slope_across_two_ticks(
+            self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        client = _Client()
+        battle.client = client
+        battle._avatar = runtime.bigworld.avatar
+        descriptor = _suspension_descriptor()
+        entity = _Vehicle(
+            10, descriptor, _Vector(), (0, 0, 0), {'health': 500})
+        runtime.bigworld.entities[10] = entity
+        battle._server = types.SimpleNamespace(vehicle_id=10)
+        battle._sender = types.SimpleNamespace(
+            forward=0.0, turn=0.0, handbrake=False,
+            send_current=lambda: client.send_input('current'))
+        battle._local_position = (0.0, 0.0, 0.0)
+        battle._local_descriptor = descriptor
+        battle._attach_local_presentation()
+        battle._local_fall_armed = True
+        battle._destructibles = mock.Mock()
+        battle._destructibles.take_ground_skip_count.return_value = 0
+        battle._smoothed_drive_pitch = mock.Mock(return_value=0.0)
+        battle._suspension_ground_y = mock.Mock(
+            side_effect=lambda x, unused_z, *unused_args, **unused_kw:
+            0.2 * x)
+        battle._apply_suspension_slope_slide = mock.Mock(
+            side_effect=lambda position, unused_yaw, unused_dt,
+            unused_entity=None: position)
+
+        def ram_correct(unused_entity, position, unused_yaw, unused_dt):
+            return (position[0] + 5.0, position[1], position[2])
+
+        battle._resolve_local_tank_contacts = mock.Mock(
+            side_effect=ram_correct)
+
+        with mock.patch(
+                'gui.mods.offline_lan_0922.battle_runtime.'
+                'vehicle_physics.longitudinal_step', return_value=0.0), \
+                mock.patch(
+                    'gui.mods.offline_lan_0922.battle_runtime.'
+                    'vehicle_physics.traverse_step', return_value=0.0), \
+                mock.patch.object(
+                    vehicle_physics, 'damper_suspension_step',
+                    wraps=vehicle_physics.damper_suspension_step) as solver:
+            battle._drive_local_step(0.1)
+            first_height = battle._local_position[1]
+            battle._drive_local_step(0.1)
+
+        self.assertEqual([0.1, 0.0, 0.1, 0.0], [
+            call.args[3] for call in solver.call_args_list])
+        # Each tick uses 22 primary + 22 endpoint columns, and the exceptional
+        # five-metre rise proof spends exactly three centre checkpoints.
+        self.assertEqual(94, battle._suspension_ground_y.call_count)
+        self.assertAlmostEqual(10.0, battle._local_position[0])
+        self.assertGreater(first_height, 0.6)
+        self.assertGreater(battle._local_position[1], first_height + 0.6)
+        self.assertFalse(battle._local_support_rise_blocked)
+
+    def test_invalid_suspension_descriptor_keeps_existing_support_path(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        battle._terrain_support = mock.Mock(return_value=(0.0, 0.0))
+        entity = _Vehicle(
+            10, _Descriptor(), _Vector(), (0, 0, 0), {'health': 500})
+
+        position = battle._update_vertical_motion(
+            entity, (0.0, 0.0, 0.0), 0.0, 0.04)
+
+        self.assertEqual((0.0, 0.0, 0.0), position)
+        self.assertIsNone(battle._local_suspension_params)
+        self.assertTrue(battle._local_suspension_disabled)
+        battle._terrain_support.assert_called_once()
+
+    def test_native_suspension_failure_disables_trial_and_uses_legacy(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        battle._local_fall_armed = True
+        battle._local_pitch = 0.17
+        battle._local_roll = -0.09
+        battle._local_suspension_pitch_velocity = 0.4
+        battle._local_suspension_roll_velocity = -0.2
+        battle._local_spring_ground_memory = [(0.0, 0.0, 0.0)] * 10
+        battle._local_pseudo_ground_memory = [(0.0, 0.0, 0.0)] * 12
+        entity = _Vehicle(
+            10, _suspension_descriptor(), _Vector(), (0, 0, 0),
+            {'health': 500})
+        battle._suspension_ground_y = mock.Mock(
+            side_effect=RuntimeError('native suspension query failed'))
+        battle._terrain_support = mock.Mock(return_value=(0.0, 0.0))
+
+        position = battle._update_vertical_motion(
+            entity, (0.0, 0.0, 0.0), 0.0, 0.04)
+
+        self.assertEqual((0.0, 0.0, 0.0), position)
+        self.assertTrue(battle._local_suspension_disabled)
+        self.assertIsNone(battle._local_suspension_params)
+        self.assertIsNone(battle._local_spring_ground_memory)
+        self.assertIsNone(battle._local_pseudo_ground_memory)
+        self.assertAlmostEqual(0.17, battle._local_pitch)
+        self.assertAlmostEqual(-0.09, battle._local_roll)
+        battle._terrain_support.assert_called_once()
+
+    def test_suspension_solver_failure_disables_trial_and_uses_legacy(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        battle._local_fall_armed = True
+        battle._local_vertical_speed = -2.0
+        entity = _Vehicle(
+            10, _suspension_descriptor(), _Vector(), (0, 0, 0),
+            {'health': 500})
+        battle._suspension_ground_y = mock.Mock(return_value=0.0)
+        battle._terrain_support = mock.Mock(return_value=(0.0, 0.0))
+
+        with mock.patch.object(
+                vehicle_physics, 'damper_suspension_step',
+                side_effect=ValueError('solver failed')):
+            position = battle._update_vertical_motion(
+                entity, (0.0, 0.0, 0.0), 0.0, 0.04)
+
+        self.assertEqual((0.0, 0.0, 0.0), position)
+        self.assertTrue(battle._local_suspension_disabled)
+        self.assertEqual(0.0, battle._local_vertical_speed)
+        self.assertFalse(battle._local_airborne)
+        battle._terrain_support.assert_called_once()
 
     def test_grounded_player_rejects_raised_support_as_hard_collision(self):
         runtime = _runtime()

--- a/0.9.22/tests/test_port_0922_bot_runtime.py
+++ b/0.9.22/tests/test_port_0922_bot_runtime.py
@@ -171,6 +171,31 @@ def _combat_descriptor(reload_time=0.5, clip=(2, 0.2),
         hull=hull, maxHealth=1000)
 
 
+def _suspension_descriptor():
+    descriptor = _combat_descriptor()
+    descriptor.physics.update({
+        'weight': 25000.0,
+        'enginePower': 500000.0,
+        'terrainResistance': (1.0, 1.0, 1.0),
+        'specificFriction': 1.0,
+        'trackCenterOffset': 1.35,
+    })
+    descriptor.chassis.name = 'testChassis'
+    descriptor.type = types.SimpleNamespace(xphysics={
+        'detailed': {'chassis': {'testChassis': {
+            'roadWheelPositions': (-2.4, -1.2, 0.0, 1.2, 2.4),
+            'stiffnessFactors': (1.0, 1.0, 1.0, 1.0, 1.0),
+            'stiffness0': 1.0,
+            'stiffness1': 1.0,
+            'damping': 0.2,
+            'bodyHeight': 1.4,
+            'hullInertiaFactors': (1.0, 1.0, 1.8),
+            'wheelRadius': 0.4,
+        }}},
+    })
+    return descriptor
+
+
 def _critical_descriptor():
     descriptor = _combat_descriptor()
     descriptor.chassis.maxHealth = 170
@@ -3680,6 +3705,412 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertEqual([0.0, 3.0, -3.0], calls)
         self.assertEqual(3, dict(zip(
             self.module.PROBE_KINDS, runtime.probe_totals()))['ground'])
+
+    def _suspension_case(self, terrain):
+        descriptor = _suspension_descriptor()
+        calls = []
+
+        def suspension_ground(
+                x, z, minimum_y, maximum_y, flat_maximum_y=None):
+            calls.append((x, z, minimum_y, maximum_y, flat_maximum_y))
+            value = terrain(x, z)
+            if value is None:
+                return None
+            if isinstance(value, tuple):
+                height, normal_y = value
+            else:
+                height, normal_y = value, 1.0
+            if not (minimum_y - 0.01 <= height <= maximum_y + 0.01):
+                return None
+            if not self.module.vehicle_physics.suspension_support_allowed(
+                    height, normal_y, flat_maximum_y):
+                return None
+            return height
+
+        def centre_ground(x, z, unused_hint):
+            value = terrain(x, z)
+            return value[0] if isinstance(value, tuple) else value
+
+        runtime = self.module.BotRuntime(
+            1,
+            physics_ground_probe=centre_ground,
+            suspension_ground_probe=suspension_ground)
+        runtime._descriptors[11] = descriptor
+        runtime._turn_speeds[11] = 0.0
+        state = {
+            'id': 11, 'x': 0.0, 'y': 0.0, 'z': 0.0, 'yaw': 0.0,
+            'speed': 4.0, 'half_length': 3.5, 'half_width': 1.5,
+            'movement_dir': 1, 'rotation_dir': 0,
+            'push_x': 0.0, 'push_z': 0.0,
+            'air_lateral_x': 0.0, 'air_lateral_z': 0.0,
+            'slide_speed': 0.0,
+            'vertical_speed': 0.0, 'airborne': False,
+            'grounded_once': True, 'last_drive_pitch': 0.0,
+            'pitch': 0.0, 'terrain_pitch': 0.0, 'roll': 0.0,
+            'suspension_pitch': 0.0,
+            'suspension_pitch_velocity': 0.0,
+            'suspension_roll_velocity': 0.0,
+        }
+        return runtime, state, calls
+
+    def _full_suspension_case(self, terrain):
+        """Build the real update/ram/end-point suspension chain."""
+        descriptor = _suspension_descriptor()
+        calls = []
+
+        def suspension_ground(
+                x, z, minimum_y, maximum_y, flat_maximum_y=None):
+            calls.append((x, z, minimum_y, maximum_y, flat_maximum_y))
+            value = terrain(x, z)
+            if value is None:
+                return None
+            if isinstance(value, tuple):
+                height, normal_y = value
+            else:
+                height, normal_y = value, 1.0
+            if not (minimum_y - 0.01 <= height <= maximum_y + 0.01):
+                return None
+            if not self.module.vehicle_physics.suspension_support_allowed(
+                    height, normal_y, flat_maximum_y):
+                return None
+            return height
+
+        def centre_ground(x, z, unused_hint):
+            value = terrain(x, z)
+            return value[0] if isinstance(value, tuple) else value
+
+        graph = _graph()
+        graph['bounds'] = (-20.0, -20.0, 20.0, 20.0)
+        runtime = self.module.BotRuntime(
+            1, descriptor_resolver=lambda unused: descriptor,
+            adapter_factory=lambda *unused, **kwargs: _FixedAdapter(
+                self._stationary_command()),
+            direction_probe=lambda *unused: {
+                'clear': True, 'collision': False, 'slope': 0.0},
+            ground_probe=centre_ground,
+            physics_ground_probe=centre_ground,
+            suspension_ground_probe=suspension_ground,
+            spawn_resolver=_spawn_resolver, baked_graph=graph,
+            control_seconds=self.module.WORKER_CONTROL_SECONDS)
+        runtime.battle_start(self.start)
+        state = runtime.states[11]
+        state.update({
+            'x': 0.0, 'y': 0.0, 'z': 0.0, 'yaw': 0.0,
+            'speed': 0.0, 'movement_dir': 0, 'rotation_dir': 0,
+            'push_x': 0.0, 'push_z': 0.0,
+            'vertical_speed': 0.0, 'airborne': False,
+            'grounded_once': True, 'last_drive_pitch': 0.0,
+            'pitch': 0.0, 'terrain_pitch': 0.0, 'roll': 0.0,
+            'suspension_pitch': 0.0,
+            'suspension_pitch_velocity': 0.0,
+            'suspension_roll_velocity': 0.0,
+        })
+        return runtime, state, calls
+
+    def test_ten_spring_bot_samples_22_contacts_once_per_outer_tick(self):
+        runtime, state, calls = self._suspension_case(
+            lambda unused_x, unused_z: 0.0)
+        original = self.module.vehicle_physics.damper_suspension_step
+        solver_calls = []
+
+        def solve(params, physics_state, ground, dt, pseudo_ground=None):
+            solver_calls.append((len(ground), len(pseudo_ground), dt))
+            return original(
+                params, physics_state, ground, dt, pseudo_ground)
+
+        self.module.vehicle_physics.damper_suspension_step = solve
+        try:
+            before = runtime.probe_totals()[3]
+            blocked = runtime._update_vertical_motion(state, 0.2)
+        finally:
+            self.module.vehicle_physics.damper_suspension_step = original
+
+        self.assertFalse(blocked)
+        self.assertEqual([(10, 12, 0.2)], solver_calls)
+        self.assertEqual(22, len(calls))
+        self.assertEqual(22, runtime.probe_totals()[3] - before)
+        self.assertFalse(state['airborne'])
+        self.assertAlmostEqual(0.0, state['y'], places=5)
+        self.assertAlmostEqual(0.0, state['pitch'], places=5)
+        self.assertAlmostEqual(0.0, state['roll'], places=5)
+
+    def test_ten_spring_bot_remains_stable_on_flat_ground(self):
+        runtime, state, unused_calls = self._suspension_case(
+            lambda unused_x, unused_z: 0.0)
+
+        for unused_tick in range(120):
+            self.assertFalse(runtime._update_vertical_motion(
+                state, 1.0 / 30.0))
+
+        self.assertTrue(state['grounded_once'])
+        self.assertFalse(state['airborne'])
+        self.assertAlmostEqual(0.0, state['y'], places=5)
+        self.assertAlmostEqual(0.0, state['vertical_speed'], places=5)
+        self.assertAlmostEqual(0.0, state['pitch'], places=5)
+        self.assertAlmostEqual(0.0, state['roll'], places=5)
+
+    def test_ten_spring_bot_keeps_small_slope_and_wheel_gap_ridge_moving(self):
+        def slope(unused_x, z):
+            return 0.06 * z, 0.998
+
+        track_x = 3.0 * 0.45
+
+        def ridge(x, z):
+            if (abs(abs(x) - track_x) < 0.05 and
+                    abs(abs(z) - 0.6) < 0.05):
+                return 0.25, 0.95
+            return 0.0, 1.0
+
+        original = self.module.tank_collision.support_rise_is_obstacle
+
+        def old_hard_stop(*unused):
+            raise AssertionError('legacy centre support gate was used')
+
+        self.module.tank_collision.support_rise_is_obstacle = old_hard_stop
+        try:
+            for terrain in (slope, ridge):
+                with self.subTest(terrain=terrain.__name__):
+                    runtime, state, unused_calls = \
+                        self._suspension_case(terrain)
+                    self.assertFalse(runtime._update_vertical_motion(
+                        state, 1.0 / 30.0))
+                    self.assertEqual(4.0, state['speed'])
+                    self.assertTrue(state['grounded_once'])
+                    self.assertFalse(state['airborne'])
+        finally:
+            self.module.tank_collision.support_rise_is_obstacle = original
+
+    def test_ten_spring_bot_transitions_airborne_and_reports_landing(self):
+        enabled = [True]
+        runtime, state, unused_calls = self._suspension_case(
+            lambda unused_x, unused_z: 0.0 if enabled[0] else None)
+        runtime._update_vertical_motion(state, 1.0 / 30.0)
+
+        enabled[0] = False
+        state['z'] += 2.0
+        runtime._update_vertical_motion(state, 0.1)
+
+        self.assertTrue(state['airborne'])
+        self.assertLess(state['vertical_speed'], 0.0)
+        self.assertLess(state['y'], 0.0)
+
+        impacts = []
+        runtime._apply_bot_landing_impact = (
+            lambda unused_state, speed: impacts.append(speed) or 0)
+        enabled[0] = True
+        state['y'] = 0.05
+        state['vertical_speed'] = -8.0
+        runtime._update_vertical_motion(state, 0.1)
+
+        self.assertFalse(state['airborne'])
+        self.assertEqual([-8.0], impacts)
+
+    def test_flat_five_metre_suspension_landing_reports_once_without_torque(self):
+        runtime, state, unused_calls = self._suspension_case(
+            lambda unused_x, unused_z: 0.0)
+        state.update({
+            'y': 5.0, 'vertical_speed': 0.0, 'airborne': True,
+            'pitch': 0.0, 'terrain_pitch': 0.0, 'roll': 0.0,
+            'suspension_pitch_velocity': 0.0,
+            'suspension_roll_velocity': 0.0,
+        })
+        impacts = []
+        runtime._apply_bot_landing_impact = (
+            lambda unused_state, speed: impacts.append(speed) or 0)
+        maximum_attitude = 0.0
+
+        for unused_tick in range(180):
+            self.assertFalse(runtime._update_vertical_motion(
+                state, 1.0 / 30.0))
+            maximum_attitude = max(
+                maximum_attitude,
+                abs(state['pitch']), abs(state['roll']),
+                abs(state['suspension_pitch_velocity']),
+                abs(state['suspension_roll_velocity']))
+
+        self.assertEqual(1, len(impacts))
+        self.assertLessEqual(impacts[0], -9.0)
+        self.assertLess(maximum_attitude, 1.0e-7)
+        self.assertFalse(state['airborne'])
+        self.assertAlmostEqual(0.0, state['y'], places=5)
+        self.assertAlmostEqual(0.0, state['vertical_speed'], places=5)
+
+    def test_ram_endpoint_follows_one_continuous_slope_across_two_frames(self):
+        normal_y = 1.0 / math.sqrt(1.0 + 0.4 * 0.4)
+        runtime, state, calls = self._full_suspension_case(
+            lambda x, unused_z: (0.4 * x, normal_y))
+        contact_frames = []
+
+        def ram_correction(unused_players, unused_now, unused_step):
+            contact_frames.append((state['x'], state['z']))
+            if len(contact_frames) == 1:
+                state['x'] += 5.0
+            return []
+
+        runtime._resolve_tank_contacts = ram_correction
+
+        runtime.update(0.1, 1.0)
+        first_pose = (state['x'], state['y'], state['z'])
+        runtime.update(0.1, 1.1)
+
+        self.assertEqual(2, len(contact_frames))
+        self.assertAlmostEqual(5.0, first_pose[0], places=6)
+        self.assertGreater(first_pose[1], 1.8)
+        self.assertAlmostEqual(5.0, state['x'], places=6)
+        self.assertAlmostEqual(2.0, state['y'], delta=0.01)
+        self.assertFalse(state['airborne'])
+        self.assertTrue(state['grounded_once'])
+        self.assertIsInstance(state.get('_suspension_ground_plane'), dict)
+        # 22 primary + 22 endpoint + three bounded path centres, followed by
+        # one ordinary 22-column batch on the next frame.
+        self.assertEqual(69, len(calls))
+
+    def test_ram_endpoint_rejects_equal_height_discontinuous_platform(self):
+        runtime, state, unused_calls = self._full_suspension_case(
+            lambda x, unused_z: 0.0 if x < 2.5 else 2.0)
+        contact_frames = []
+
+        def ram_correction(unused_players, unused_now, unused_step):
+            contact_frames.append((state['x'], state['z']))
+            if len(contact_frames) == 1:
+                state['x'] += 5.0
+            return []
+
+        runtime._resolve_tank_contacts = ram_correction
+
+        runtime.update(0.1, 1.0)
+        first_pose = (state['x'], state['y'], state['z'])
+        runtime.update(0.1, 1.1)
+
+        # Ram separation X/Z is retained, but the unproved upper layer never
+        # becomes ground on either frame.
+        self.assertAlmostEqual(5.0, first_pose[0], places=6)
+        self.assertAlmostEqual(0.0, first_pose[1], places=6)
+        self.assertAlmostEqual(0.0, first_pose[2], places=6)
+        self.assertAlmostEqual(5.0, state['x'], places=6)
+        self.assertAlmostEqual(0.0, state['y'], places=6)
+        self.assertAlmostEqual(0.0, state['z'], places=6)
+        self.assertFalse(state['airborne'])
+        self.assertTrue(state['grounded_once'])
+        self.assertNotIn('_suspension_ground_plane', state)
+        self.assertEqual(0.0, state['speed'])
+
+    def test_sampled_inclined_high_support_cannot_lift_grounded_bot(self):
+        runtime, state, calls = self._suspension_case(
+            lambda unused_x, unused_z: (0.8, 0.98))
+
+        blocked = runtime._update_vertical_motion(
+            state, 0.1, (0.0, 0.0, 0.0), 0.0)
+
+        self.assertTrue(blocked)
+        self.assertEqual(22, len(calls))
+        self.assertAlmostEqual(0.0, state['y'], places=6)
+        self.assertFalse(state['airborne'])
+        self.assertTrue(state['grounded_once'])
+        self.assertEqual(0.0, state['speed'])
+        self.assertNotIn('_suspension_ground_plane', state)
+
+    def test_suspension_query_failure_falls_back_for_only_that_bot(self):
+        runtime, state, unused_calls = self._suspension_case(
+            lambda unused_x, unused_z: 0.0)
+        state.update(pitch=0.2, terrain_pitch=0.2, roll=-0.1)
+        runtime._suspension_ground_probe = (
+            lambda *unused: (_ for _ in ()).throw(
+                RuntimeError('native query failed')))
+        runtime._physics_ground_probe = lambda *unused: 0.25
+
+        blocked = runtime._update_vertical_motion(
+            state, 0.1, (0.0, 0.0, 0.0), 0.0)
+
+        self.assertFalse(blocked)
+        self.assertIsNone(runtime._suspension_params[state['id']])
+        self.assertEqual(
+            1, runtime.diagnostic_totals()['suspension_param_failures'])
+        self.assertAlmostEqual(0.25, state['y'])
+        self.assertAlmostEqual(0.2, state['pitch'])
+        self.assertAlmostEqual(-0.1, state['roll'])
+        self.assertNotIn('_spring_ground_memory', state)
+        self.assertNotIn('_suspension_ground_plane', state)
+
+    def test_missing_suspension_descriptor_is_localized_to_legacy_support(self):
+        runtime = self.module.BotRuntime(
+            1,
+            physics_ground_probe=lambda *unused: 0.5,
+            suspension_ground_probe=lambda *unused: 0.5)
+        runtime._descriptors[11] = _combat_descriptor()
+        state = {
+            'id': 11, 'x': 0.0, 'y': 0.0, 'z': 0.0, 'yaw': 0.0,
+            'speed': 0.0, 'half_length': 3.0,
+            'vertical_speed': 0.0, 'airborne': False,
+            'grounded_once': False, 'last_drive_pitch': 0.0,
+        }
+
+        self.assertFalse(runtime._update_vertical_motion(state, 0.1))
+
+        self.assertEqual(0.5, state['y'])
+        self.assertEqual(
+            1, runtime.diagnostic_totals()['suspension_param_failures'])
+
+    def test_suspension_pose_guard_discards_rejected_contact_history(self):
+        runtime, state, unused_calls = self._suspension_case(
+            lambda unused_x, unused_z: 0.0)
+        self.assertIsNotNone(runtime._suspension_params_for(state['id']))
+        state.update(
+            x=2.0,
+            suspension_pitch_velocity=0.4,
+            suspension_roll_velocity=-0.3,
+            _spring_ground_memory=[(1.0, 2.0, 0.0)],
+            _pseudo_ground_memory=[(1.0, 2.0, 0.0)])
+        runtime._baked_pose_progress_clear = lambda *unused: False
+
+        guarded = runtime._guard_realised_pose(
+            state, (0.0, 0.0, 0.0), True, 0.0)
+
+        self.assertTrue(guarded)
+        self.assertNotIn('_spring_ground_memory', state)
+        self.assertNotIn('_pseudo_ground_memory', state)
+        self.assertEqual(0.0, state['suspension_pitch_velocity'])
+        self.assertEqual(0.0, state['suspension_roll_velocity'])
+
+    def test_suspension_pose_guard_restores_tick_attitude_snapshot(self):
+        runtime, state, unused_calls = self._suspension_case(
+            lambda unused_x, unused_z: 0.0)
+        self.assertIsNotNone(runtime._suspension_params_for(state['id']))
+        state.update({
+            'pitch': 0.12, 'terrain_pitch': 0.08, 'roll': -0.06,
+            'vertical_speed': -1.5, 'airborne': True,
+            'suspension_pitch_velocity': 0.3,
+            'suspension_roll_velocity': -0.2,
+            '_spring_ground_memory': [(0.0, 0.0, 0.0)],
+            '_suspension_ground_plane': {
+                'center_x': 0.0, 'center_z': 0.0, 'center_y': 0.0,
+                'gradient_x': 0.0, 'gradient_z': 0.0,
+            },
+        })
+        snapshot = runtime._snapshot_bot_suspension_state(state)
+        state.update({
+            'x': 2.0, 'y': 0.8, 'pitch': -0.4,
+            'terrain_pitch': -0.4, 'roll': 0.5,
+            'vertical_speed': 0.0, 'airborne': False,
+            '_spring_ground_memory': [(2.0, 0.0, 0.8)],
+        })
+        runtime._baked_pose_progress_clear = lambda *unused: False
+
+        guarded = runtime._guard_realised_pose(
+            state, (0.0, 0.0, 0.0), True, 0.0, snapshot)
+
+        self.assertTrue(guarded)
+        self.assertEqual((0.0, 0.0, 0.0),
+                         (state['x'], state['y'], state['z']))
+        self.assertAlmostEqual(0.12, state['pitch'])
+        self.assertAlmostEqual(0.08, state['terrain_pitch'])
+        self.assertAlmostEqual(-0.06, state['roll'])
+        self.assertAlmostEqual(-1.5, state['vertical_speed'])
+        self.assertTrue(state['airborne'])
+        self.assertEqual([(0.0, 0.0, 0.0)],
+                         state['_spring_ground_memory'])
+        self.assertEqual(0.0,
+                         state['_suspension_ground_plane']['center_y'])
 
     def test_vertical_motion_uses_centre_without_sampling_higher_ends(self):
         calls = []
@@ -8457,11 +8888,21 @@ class BotRuntimeTests(unittest.TestCase):
 
             self.assertIs(travel, runtime._descriptors[11])
             self.assertEqual(31000.0, state['mass'])
+            state.update({
+                'grounded_once': True,
+                '_spring_ground_memory': [(0.0, 0.0, 0.0)],
+                '_pseudo_ground_memory': [(0.0, 0.0, 0.0)],
+                '_suspension_ground_plane': {'center_y': 0.0},
+            })
             runtime._set_bot_siege_state(
                 state, self.module.siege_mechanics.ENABLED)
 
             self.assertIs(siege, runtime._descriptors[11])
             self.assertEqual(32000.0, state['mass'])
+            self.assertTrue(state['grounded_once'])
+            self.assertNotIn('_spring_ground_memory', state)
+            self.assertNotIn('_pseudo_ground_memory', state)
+            self.assertNotIn('_suspension_ground_plane', state)
             self.assertEqual([travel, siege], calls)
         finally:
             self.module._bot_physics_params = original

--- a/0.9.22/tests/test_port_0922_vehicle_physics.py
+++ b/0.9.22/tests/test_port_0922_vehicle_physics.py
@@ -98,6 +98,434 @@ class VehiclePhysicsDescriptorTests(unittest.TestCase):
         self.assertEqual(1.15, params['nativePowerRatio'])
 
 
+class VehiclePhysicsSuspensionTrialTests(unittest.TestCase):
+
+    @staticmethod
+    def _descriptor():
+        chassis_name = 'trial-chassis'
+        detailed_chassis = {
+            'roadWheelPositions': (-2.0, -1.0, 0.0, 1.0, 2.0),
+            'stiffnessFactors': (1.0, 1.0, 1.0, 1.0, 1.0),
+            'stiffness0': 1.0,
+            'stiffness1': 1.0,
+            'damping': 0.2,
+            'bodyHeight': 0.95,
+            'hullInertiaFactors': (1.0, 1.0, 1.8),
+            'wheelRadius': 0.35,
+        }
+        return types.SimpleNamespace(
+            physics={
+                'weight': 21000.0,
+                'enginePower': 430.0 * 735.5,
+                'trackCenterOffset': 1.2,
+            },
+            type=_Strict1513Component(xphysics={
+                'detailed': {'chassis': {
+                    chassis_name: detailed_chassis,
+                }},
+            }),
+            chassis=_Strict1513Component(
+                name=chassis_name,
+                rotationSpeed=0.75,
+                hullPosition=(0.0, 1.0, 0.0),
+                hitTester=_Strict1513Component(bbox=(
+                    (-1.4, -0.5, -2.6), (1.4, 0.7, 2.6)))),
+            hull=_Strict1513Component(
+                hitTester=_Strict1513Component(bbox=(
+                    (-1.2, -0.65, -2.2), (1.2, 0.65, 2.2)))))
+
+    @staticmethod
+    def _state(**overrides):
+        state = {
+            'height': 0.0,
+            'vertical_velocity': 0.0,
+            'pitch': 0.0,
+            'pitch_velocity': 0.0,
+            'roll': 0.0,
+            'roll_velocity': 0.0,
+        }
+        state.update(overrides)
+        return state
+
+    @staticmethod
+    def _plane_samples(params, x_gradient=0.0, z_gradient=0.0):
+        ground = tuple(
+            x_gradient * spring['x'] + z_gradient * spring['z']
+            for spring in params['springs'])
+        pseudo_ground = tuple(
+            x_gradient * contact['x'] + z_gradient * contact['z']
+            for contact in params['pseudo_contacts'])
+        return ground, pseudo_ground
+
+    def setUp(self):
+        self.params = vehicle_physics.derive_suspension_params(
+            self._descriptor())
+
+    def test_parameter_projection_uses_ten_springs_and_twelve_contacts(self):
+        self.assertEqual(10, len(self.params['springs']))
+        self.assertEqual(12, len(self.params['pseudo_contacts']))
+        self.assertEqual(
+            {-1.2, 1.2},
+            {spring['x'] for spring in self.params['springs']})
+        self.assertEqual(
+            8,
+            sum(contact['kind'] == 'track'
+                for contact in self.params['pseudo_contacts']))
+        self.assertEqual(
+            4,
+            sum(contact['kind'] == 'body'
+                for contact in self.params['pseudo_contacts']))
+
+        points = vehicle_physics.suspension_world_points(
+            self.params, (10.0, 99.0, 20.0), math.pi * 0.5)
+        self.assertAlmostEqual(8.0, points[0][0])
+        self.assertAlmostEqual(21.2, points[0][1])
+        self.assertEqual(
+            12,
+            len(vehicle_physics.suspension_pseudo_world_points(
+                self.params, (10.0, 99.0, 20.0), math.pi * 0.5)))
+
+    def test_missing_client_geometry_or_detailed_values_are_rejected(self):
+        cases = []
+        descriptor = self._descriptor()
+        descriptor.physics.pop('weight')
+        cases.append(('weight', descriptor))
+        descriptor = self._descriptor()
+        descriptor.physics.pop('trackCenterOffset')
+        cases.append(('trackCenterOffset', descriptor))
+        descriptor = self._descriptor()
+        descriptor.hull = _Strict1513Component()
+        cases.append(('hitTester', descriptor))
+        descriptor = self._descriptor()
+        del descriptor.type.xphysics['detailed']['chassis'][
+            'trial-chassis']['roadWheelPositions']
+        cases.append(('roadWheelPositions', descriptor))
+
+        for expected, descriptor in cases:
+            with self.subTest(field=expected):
+                with self.assertRaisesRegex(ValueError, expected):
+                    vehicle_physics.derive_suspension_params(descriptor)
+
+    def test_flat_support_stays_at_static_equilibrium(self):
+        ground, pseudo_ground = self._plane_samples(self.params)
+
+        solved = vehicle_physics.damper_suspension_step(
+            self.params, self._state(), ground, 1.0 / 30.0,
+            pseudo_ground)
+
+        self.assertAlmostEqual(0.0, solved['height'], places=12)
+        self.assertAlmostEqual(0.0, solved['vertical_velocity'], places=12)
+        self.assertAlmostEqual(0.0, solved['pitch'], places=12)
+        self.assertAlmostEqual(0.0, solved['roll'], places=12)
+        self.assertFalse(solved['airborne'])
+        self.assertEqual(18, solved['contact_count'])
+
+    def test_longitudinal_plane_converges_to_pitch(self):
+        gradient = 0.16
+        ground, pseudo_ground = self._plane_samples(
+            self.params, z_gradient=gradient)
+        state = self._state()
+
+        for unused in range(240):
+            state = vehicle_physics.damper_suspension_step(
+                self.params, state, ground, 1.0 / 60.0,
+                pseudo_ground)
+
+        self.assertAlmostEqual(
+            -math.asin(gradient), state['pitch'], delta=0.015)
+        self.assertFalse(state['airborne'])
+
+    def test_one_side_plane_converges_to_roll(self):
+        gradient = 0.14
+        ground, pseudo_ground = self._plane_samples(
+            self.params, x_gradient=gradient)
+        state = self._state()
+
+        for unused in range(240):
+            state = vehicle_physics.damper_suspension_step(
+                self.params, state, ground, 1.0 / 60.0,
+                pseudo_ground)
+
+        self.assertAlmostEqual(
+            math.asin(gradient), state['roll'], delta=0.015)
+        self.assertFalse(state['airborne'])
+
+    def test_hard_limit_projects_excess_without_a_time_step(self):
+        ground = [None] * len(self.params['springs'])
+        ground[0] = 1.0
+        before = vehicle_physics.suspension_limit_excess(
+            self.params, self._state(), ground)
+
+        solved = vehicle_physics.damper_suspension_step(
+            self.params, self._state(), ground, 0.0)
+
+        self.assertGreater(before, 0.5)
+        self.assertLess(solved['max_limit_excess'], before * 0.01)
+
+    def test_multi_contact_projection_converges_independent_of_order(self):
+        gradient_x = 0.11178082363228886
+        gradient_z = 0.09193766567849293
+        center_y = 0.13635492625737228
+        ground = tuple(
+            center_y + gradient_x * spring['x'] +
+            gradient_z * spring['z']
+            for spring in self.params['springs'])
+        pseudo_ground = tuple(
+            center_y + gradient_x * contact['x'] +
+            gradient_z * contact['z']
+            for contact in self.params['pseudo_contacts'])
+        state = self._state(
+            height=-0.11332251894566656,
+            vertical_velocity=-17.82973166273263,
+            pitch=-0.2283978856788303,
+            pitch_velocity=0.4857510890352834,
+            roll=0.008904000398357759,
+            roll_velocity=-0.05963721979826242)
+
+        solved = vehicle_physics.damper_suspension_step(
+            self.params, state, ground, 1.0 / 60.0, pseudo_ground)
+        reversed_params = dict(self.params)
+        reversed_params['springs'] = tuple(reversed(self.params['springs']))
+        reversed_params['pseudo_contacts'] = tuple(
+            reversed(self.params['pseudo_contacts']))
+        reversed_solved = vehicle_physics.damper_suspension_step(
+            reversed_params, state, tuple(reversed(ground)), 1.0 / 60.0,
+            tuple(reversed(pseudo_ground)))
+
+        self.assertLessEqual(solved['max_limit_excess'], 1.0e-6)
+        self.assertLessEqual(reversed_solved['max_limit_excess'], 1.0e-6)
+        for name in ('height', 'vertical_velocity', 'pitch',
+                     'pitch_velocity', 'roll', 'roll_velocity'):
+            self.assertAlmostEqual(
+                solved[name], reversed_solved[name], places=12,
+                msg=name)
+
+    def test_airborne_state_falls_and_damps_angular_velocity(self):
+        ground = (None,) * len(self.params['springs'])
+        pseudo_ground = (None,) * len(self.params['pseudo_contacts'])
+
+        solved = vehicle_physics.damper_suspension_step(
+            self.params,
+            self._state(height=5.0, pitch_velocity=2.0,
+                        roll_velocity=-2.0),
+            ground, 0.1, pseudo_ground)
+
+        self.assertTrue(solved['airborne'])
+        self.assertLess(solved['height'], 5.0)
+        self.assertLess(solved['vertical_velocity'], 0.0)
+        self.assertLess(abs(solved['pitch_velocity']), 0.6)
+        self.assertLess(abs(solved['roll_velocity']), 0.6)
+
+    def test_within_step_touch_is_distinct_from_final_airborne_state(self):
+        ground, pseudo_ground = self._plane_samples(self.params)
+
+        solved = vehicle_physics.damper_suspension_step(
+            self.params,
+            self._state(vertical_velocity=10.0),
+            ground, 1.0 / 60.0, pseudo_ground)
+
+        self.assertTrue(solved['contacted_this_step'])
+        self.assertGreater(solved['touched_contact_count'], 0)
+        self.assertEqual(0, solved['contact_count'])
+        self.assertTrue(solved['airborne'])
+        self.assertTrue(solved['left_flying'])
+        self.assertTrue(solved['right_flying'])
+        self.assertIsNone(solved['impact_speed'])
+
+    def test_symmetric_five_metre_drop_reports_one_unbiased_impact(self):
+        ground, pseudo_ground = self._plane_samples(self.params)
+        state = self._state(height=5.0)
+        impact = None
+
+        for unused_tick in range(12):
+            state = vehicle_physics.damper_suspension_step(
+                self.params, state, ground, 0.1, pseudo_ground)
+            if state['impact_speed'] is not None:
+                impact = state['impact_speed']
+                break
+
+        self.assertIsNotNone(impact)
+        self.assertLessEqual(impact, -9.8)
+        self.assertTrue(state['contacted_this_step'])
+        self.assertFalse(state['airborne'])
+        self.assertAlmostEqual(0.0, state['pitch'], places=10)
+        self.assertAlmostEqual(0.0, state['pitch_velocity'], places=10)
+        self.assertAlmostEqual(0.0, state['roll'], places=10)
+        self.assertAlmostEqual(0.0, state['roll_velocity'], places=10)
+
+    def test_final_substep_touch_preserves_threshold_crossing_speed(self):
+        ground, pseudo_ground = self._plane_samples(self.params)
+
+        solved = vehicle_physics.damper_suspension_step(
+            self.params,
+            self._state(height=1.1, vertical_velocity=-9.5),
+            ground, 0.1, pseudo_ground)
+
+        expected_impact = -9.5 - vehicle_physics.GRAVITY * 0.1
+        self.assertFalse(solved['airborne'])
+        self.assertEqual(18, solved['contact_count'])
+        self.assertTrue(solved['contacted_this_step'])
+        self.assertEqual(18, solved['touched_contact_count'])
+        self.assertAlmostEqual(expected_impact, solved['impact_speed'],
+                               places=12)
+        self.assertEqual(
+            0, vehicle_physics.fall_damage(1000, -9.5))
+        self.assertGreater(
+            vehicle_physics.fall_damage(1000, solved['impact_speed']), 0)
+
+    def test_soft_touch_records_the_first_negative_contact_speed(self):
+        ground, pseudo_ground = self._plane_samples(self.params)
+
+        solved = vehicle_physics.damper_suspension_step(
+            self.params,
+            self._state(height=0.1, vertical_velocity=-0.2),
+            ground, 0.1, pseudo_ground)
+
+        self.assertTrue(solved['contacted_this_step'])
+        self.assertFalse(solved['airborne'])
+        self.assertAlmostEqual(-0.2, solved['impact_speed'], places=12)
+        self.assertAlmostEqual(0.0, solved['pitch'], places=10)
+        self.assertAlmostEqual(0.0, solved['roll'], places=10)
+
+    def test_support_filter_and_contact_memory_are_bounded(self):
+        self.assertTrue(vehicle_physics.suspension_support_allowed(
+            1.0, 1.0, 1.0))
+        self.assertFalse(vehicle_physics.suspension_support_allowed(
+            1.2, 1.0, 1.0))
+        self.assertTrue(vehicle_physics.suspension_support_allowed(
+            1.2, 0.9, 1.0))
+        self.assertFalse(vehicle_physics.suspension_support_allowed(
+            1.0, 0.5, 1.0))
+
+        ground, memory = vehicle_physics.retained_ground_contact(
+            (1.0, 2.0), 3.0, None, 0.5)
+        self.assertEqual(3.0, ground)
+        retained, stationary_miss = vehicle_physics.retained_ground_contact(
+            (1.0, 2.0), None, memory, 0.5)
+        self.assertEqual(3.0, retained)
+        self.assertEqual(
+            (None, None),
+            vehicle_physics.retained_ground_contact(
+                (1.0, 2.0), None, stationary_miss, 0.5))
+        retained, moved_memory = vehicle_physics.retained_ground_contact(
+            (1.2, 2.2), None, memory, 0.5)
+        self.assertEqual(3.0, retained)
+        self.assertNotEqual(memory, moved_memory)
+        self.assertEqual(
+            (None, None),
+            vehicle_physics.retained_ground_contact(
+                (1.2, 2.2), None, moved_memory, 0.5))
+        self.assertEqual(
+            (None, None),
+            vehicle_physics.retained_ground_contact(
+                (1.6, 2.0), None, memory, 0.5))
+
+        unused_ground, memory = vehicle_physics.retained_ground_contact(
+            (0.0, 0.0), 4.0, None, 0.5)
+        for point in ((0.1, 0.0), (0.1, 0.1), (0.0, 0.1),
+                      (0.0, 0.0), (-0.1, 0.0)):
+            retained, memory = vehicle_physics.retained_ground_contact(
+                point, None, memory, 0.5)
+            self.assertEqual(4.0, retained)
+        self.assertEqual(
+            (None, None),
+            vehicle_physics.retained_ground_contact(
+                (-0.1, -0.1), None, memory, 0.5))
+
+    def test_ground_plane_uses_contacts_and_rejects_a_discontinuity(self):
+        gradient_x = 0.12
+        gradient_z = -0.08
+        ground = tuple(
+            2.5 + gradient_x * spring['x'] +
+            gradient_z * spring['z']
+            for spring in self.params['springs'])
+
+        plane = vehicle_physics.suspension_ground_plane(
+            self.params, ground, maximum_residual=0.01)
+
+        self.assertAlmostEqual(2.5, plane['center_y'])
+        self.assertAlmostEqual(gradient_x, plane['x_gradient'])
+        self.assertAlmostEqual(gradient_z, plane['z_gradient'])
+        self.assertEqual(10, plane['contact_count'])
+        broken = list(ground)
+        broken[0] += 1.0
+        self.assertIsNone(vehicle_physics.suspension_ground_plane(
+            self.params, broken, maximum_residual=0.35))
+
+    def test_world_ground_plane_projects_height_and_checks_continuity(self):
+        gradient_x = 0.12
+        gradient_z = -0.08
+        ground = tuple(
+            2.5 + gradient_x * spring['x'] +
+            gradient_z * spring['z']
+            for spring in self.params['springs'])
+        start = (10.0, 99.0, 20.0)
+        end = (12.0, 99.0, 21.0)
+
+        plane = vehicle_physics.suspension_world_ground_plane(
+            self.params, ground, start, math.pi * 0.5,
+            maximum_residual=0.01)
+
+        self.assertEqual((10.0, 20.0),
+                         (plane['center_x'], plane['center_z']))
+        self.assertAlmostEqual(2.5, plane['center_y'])
+        self.assertAlmostEqual(-0.08, plane['gradient_x'])
+        self.assertAlmostEqual(-0.12, plane['gradient_z'])
+        expected = 2.5 - 0.08 * 2.0 - 0.12
+        self.assertAlmostEqual(
+            expected,
+            vehicle_physics.suspension_plane_height(plane, 12.0, 21.0))
+
+        current = dict(plane)
+        current.update(center_x=12.0, center_z=21.0, center_y=expected)
+        self.assertTrue(vehicle_physics.suspension_ground_planes_continuous(
+            plane, current, start, end, 0.01, 0.01))
+        raised = dict(current, center_y=expected + 0.2)
+        self.assertFalse(vehicle_physics.suspension_ground_planes_continuous(
+            plane, raised, start, end, 0.05, 0.01))
+        tilted = dict(current, gradient_x=current['gradient_x'] + 0.1)
+        self.assertFalse(vehicle_physics.suspension_ground_planes_continuous(
+            plane, tilted, start, end, 0.5, 0.05))
+
+        self.assertIsNone(vehicle_physics.suspension_plane_height(
+            {'center_x': float('nan')}, 0.0, 0.0))
+        self.assertFalse(vehicle_physics.suspension_ground_planes_continuous(
+            plane, {}, start, end, 0.1, 0.1))
+
+    def test_contact_correction_uses_bounded_interior_path_probes(self):
+        self.assertEqual(
+            (), vehicle_physics.suspension_path_probe_fractions(0.2))
+        fractions = vehicle_physics.suspension_path_probe_fractions(5.0)
+        self.assertEqual(3, len(fractions))
+        self.assertTrue(all(0.0 < value < 1.0 for value in fractions))
+        self.assertTrue(all(
+            fractions[index] > fractions[index - 1]
+            for index in range(1, len(fractions))))
+        self.assertEqual(
+            vehicle_physics.SUSPENSION_PATH_MAX_PROBES,
+            len(vehicle_physics.suspension_path_probe_fractions(100.0)))
+
+    def test_side_grip_curve_releases_a_cross_slope_progressively(self):
+        self.assertEqual(1.0, vehicle_physics.lateral_slope_grip(1.0))
+        self.assertAlmostEqual(
+            0.1,
+            vehicle_physics.lateral_slope_grip(
+                vehicle_physics.SLOPE_GRIP_SDW_MIN_Y))
+        midpoint_y = (
+            vehicle_physics.SLOPE_GRIP_SDW_FULL_Y +
+            vehicle_physics.SLOPE_GRIP_SDW_MIN_Y) * 0.5
+        self.assertAlmostEqual(
+            0.55, vehicle_physics.lateral_slope_grip(midpoint_y))
+        self.assertEqual(
+            0.0,
+            vehicle_physics.slope_slide_speed(
+                0.0, math.tan(math.radians(24.0)), 0.1))
+        self.assertGreater(
+            vehicle_physics.slope_slide_speed(
+                0.0, math.tan(math.radians(25.0)), 0.1),
+            0.0)
+
+
 class VehiclePhysicsHardContactTests(unittest.TestCase):
 
     def test_candidate_yaws_keep_the_shared_glancing_order(self):


### PR DESCRIPTION
## Summary

- derive ten suspension springs from the exact vehicle descriptor, with twelve bounded pseudo contacts for track gaps and belly support
- solve heave, pitch, roll, airborne transitions, landing speed, terrain attitude, and lateral slope grip for both the local vehicle and hidden-worker Bots
- resample corrected ram and slope-slide endpoints, while requiring terrain-plane and path continuity before accepting rises above the normal suspension window
- contain missing descriptors and native-query failures to the affected vehicle and fall back to the established legacy support path

## Source provenance

The supplied contrib archive identifies its inner mod as 0.6.0-alpha.6, not 0.6.2. Ten source files differ from the Alpha6 baseline; the suspension solver is client/worker code and is not implemented in the bundled LAN server. This PR ports only the useful physics law into the current 0.6.3 architecture instead of replacing the launcher, server, or unrelated current modules with the older snapshot.

## Safety and behavior boundaries

- finite vertical segment queries are not a swept OBB and do not replace the separate projectile/world collision work
- raised platforms and discontinuous support fail closed; a continuous ram-corrected slope is allowed across frames
- solver substeps reuse one contact snapshot and do not add native queries
- visual attitude filtering, decorative acceleration swing, hit reaction sway, spotting checkpoints, launcher/server replacement, and PR #17 projectile sweep work are intentionally excluded

## Static performance budget

The hidden worker runs fixed vehicle control at 10 Hz.

- normal: 22 logical suspension columns per Bot per authority step
- 29 Bots: 638 logical columns per step, or 6,380 logical columns/second
- the #1513 adapter may recast one logical column at most three times, so the normal-path hard ceiling is 19,140 native segment calls/second
- a simultaneous large ram-correction case is bounded at 50 logical columns per Bot per step; local physics is 22 normally and at most 75 when ram correction and slope slide both move and both require continuity proof

These are static upper bounds. Exact #1513 Windows FPS, native-call cost, and gameplay feel remain unproved and are the reason this PR is Draft.

## Validation

- 41 vehicle-physics tests passed
- 688 battle-runtime tests passed
- 12 focused Bot suspension/rollback/landing tests passed on the final snapshot
- the full 327-test BotRuntimeTests suite passed before the final isolated landing-edge correction; its affected landing tests were rerun afterward
- all three production modules compile with CPython 2.7
- git diff --check passed
