### PR TITLE
Make a rejected player input frame recoverable

### DIFF
--- a/0.9.22/CLAUDE.md
+++ b/0.9.22/CLAUDE.md
@@ -316,6 +316,17 @@ Python-to-native call boundary. A clean Python traceback log does not prove a
 native adapter is safe, and a static disassembly does not prove the crash is
 fixed.
 
+To exercise ordered-input recovery on the exact client, arm the LAN server's
+one-shot input-fault hook before launching it:
+
+```bat
+set WOT_0922_INPUT_FAULT=aim_yaw
+```
+
+Any class in `PLAYER_INPUT_FAULT_CLASSES` breaks exactly one frame per round
+per player by rewriting one field, which then fails the production
+pre-admission validator. Leave the variable unset in normal play.
+
 ## Validation and release
 
 Ordinary changes run the focused test, the port suite, Python 2.7 source

--- a/0.9.22/COMPATIBILITY_REVIEW.md
+++ b/0.9.22/COMPATIBILITY_REVIEW.md
@@ -914,6 +914,26 @@ public shared feedback adaptor, active marker provider and real
 The ABI audit pins both the weak-proxy construction and the setup property's
 public forwarding chain.
 
+Ordered player input separates three concepts so one recoverable rejected
+frame cannot poison the rest of the round. The processed frontier is the
+contiguous sequence that reached an idempotent terminal decision, applied or
+not. The last applied input is the frame whose controls, pose, shell
+selection and gun checkpoint were committed, and it remains what a fire
+intent, pose sample, contact receipt and landing observation bind to. A
+per-sequence record keeps a bounded fingerprint plus the typed outcome, so an
+exact retry folds, a changed payload at the same sequence conflicts, a future
+gap consumes nothing, and an evicted sequence can never become new state. A
+recoverable validation failure records a rejected decision and advances only
+the processed frontier: no field is applied and no gun checkpoint is
+installed, so a fire intent bound to that sequence receives one typed
+terminal rejection rather than firing from stale muzzle state. A message that
+does not identify the current player, round or an exact sequence consumes no
+frontier at all. Both frontiers retire together on a round transition, and
+the snapshot publishes them so a reconnecting client resumes at the next
+eligible sequence. The shipping client canonicalizes the same envelope before
+queueing a frame, normalizing periodic yaw instead of clipping it, so normal
+#1513 values never produce an avoidable rejection.
+
 ## AI, room and round boundaries
 
 Humans take real team slots first. The first waiting 0.9.22 player owns map

--- a/0.9.22/server/lan_battle_server.py
+++ b/0.9.22/server/lan_battle_server.py
@@ -665,7 +665,7 @@ PLAYER_INPUT_FAULT_CLASSES = {
     "up_cosine": ("up_cosine", 1.5),
     "pose_clock": ("pose_time_us", 1.5),
     "fire_seq": ("fire_seq", True),
-    "shell_pair": ("next_shell_index", 9),
+    "shell_pair": ("next_shell_index", 10),
     "gun_checkpoint": ("gun_checkpoint", {"reload_time": 0.0}),
     "siege_state": ("siege_enabled", 1),
     "extra_field": ("damage", 1000),
@@ -8923,13 +8923,16 @@ class BattleState:
         return sequence, payload, digest
 
     def _record_player_input_decision(self, player, sequence, fingerprint,
-                                      outcome, reason=""):
+                                      outcome, reason="", field="",
+                                      active=True):
         """Advance only the terminal frontier and retain its typed outcome."""
         player.input_processed_seq = int(sequence)
         player.input_decisions[int(sequence)] = {
             "fingerprint": str(fingerprint),
             "outcome": str(outcome),
             "reason": str(reason),
+            "field": str(field),
+            "active": bool(active),
         }
         while len(player.input_decisions) > MAX_PLAYER_INPUT_DECISIONS:
             player.input_decisions.popitem(last=False)
@@ -8969,11 +8972,12 @@ class BattleState:
         self._note_player_input_rejection(
             player, sequence, reason, field, consumed=True, active=active)
         self._record_player_input_decision(
-            player, sequence, fingerprint, INPUT_OUTCOME_REJECTED, reason)
+            player, sequence, fingerprint, INPUT_OUTCOME_REJECTED, reason,
+            field, active)
         return False
 
     def _admit_applied_player_input(self, player, sequence, payload, digest):
-        """Commit one valid frame to both the terminal and applied frontier."""
+        """Reserve a validated frame on both ordered-input frontiers."""
         self._record_player_input_decision(
             player, sequence, digest, INPUT_OUTCOME_APPLIED, "")
         player.input_seq = int(sequence)
@@ -9245,11 +9249,29 @@ class BattleState:
         while the next well-formed frame can still advance automatically.
         """
         with self.lock:
-            if not self._message_round_matches(message):
-                return False
             player = self.players.get(player_id)
-            if player is None or not player.connected:
+            if player is None:
                 return False
+            inactive_modern = bool(
+                self.client_build == CLIENT_BUILD_0922 and (
+                    self.phase != "battle" or
+                    self.battle_result is not None or
+                    not player.participating or not player.alive))
+            submitted_sequence = None
+            if isinstance(message, dict) and "input_seq" in message:
+                try:
+                    submitted_sequence = _exact_int(
+                        message.get("input_seq"), 1, PROJECTILE_MAX_ID)
+                except (TypeError, ValueError, OverflowError):
+                    pass
+            if not self._message_round_matches(message):
+                return self._note_player_input_rejection(
+                    player, submitted_sequence, "round_mismatch",
+                    "round_id", active=not inactive_modern)
+            if not player.connected:
+                return self._note_player_input_rejection(
+                    player, submitted_sequence, "player_disconnected",
+                    active=False)
             ledger = bool(
                 HUMAN_RAM_TIMELINE_CAPABILITY in player.capabilities)
             sequence = None
@@ -9275,7 +9297,9 @@ class BattleState:
                     if decision["outcome"] == INPUT_OUTCOME_REJECTED:
                         return self._note_player_input_rejection(
                             player, sequence, decision["reason"],
-                            "input_seq", consumed=True)
+                            decision.get("field", "input_seq"),
+                            consumed=True,
+                            active=decision.get("active", True))
                     return True
                 if sequence <= player.input_processed_seq:
                     # Evicted from the bounded ledger: safely rejected, and it
@@ -9298,12 +9322,6 @@ class BattleState:
                             sequence))
                     message = _injected_player_input_fault(
                         message, fault_class)
-            inactive_modern = False
-            if self.client_build == CLIENT_BUILD_0922:
-                inactive_modern = bool(
-                    self.phase != "battle" or
-                    self.battle_result is not None or
-                    not player.participating or not player.alive)
             (reason, field), parsed = self._player_input_frame_failure(
                 player, message, inactive_modern)
             if reason:
@@ -9329,9 +9347,14 @@ class BattleState:
                 if ledger:
                     self._record_player_input_decision(
                         player, sequence, digest,
-                        INPUT_OUTCOME_INACTIVE, "inactive")
+                        INPUT_OUTCOME_INACTIVE, "inactive", active=False)
                 return True
             if ledger:
+                # Every client-controlled validation path has returned above.
+                # Reserve the transport identity before projecting the
+                # prevalidated fields so an unexpected internal handler fault
+                # cannot recreate the original permanent sequence gap.  This
+                # is fault containment, not a general rollback transaction.
                 self._admit_applied_player_input(
                     player, sequence, payload, digest)
                 if gun_checkpoint is not None:

--- a/0.9.22/server/lan_battle_server.py
+++ b/0.9.22/server/lan_battle_server.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import argparse
 import base64
 import copy
+import hashlib
 import json
 import math
 import random
@@ -97,6 +98,8 @@ MAX_PENDING_RAM_CONTACTS = 32
 MAX_PENDING_PLAYER_DESTRUCTIBLE_CONTACTS = 16
 MAX_PLAYER_DESTRUCTIBLE_REJECTIONS = 16
 MAX_PLAYER_INPUT_FINGERPRINTS = 128
+MAX_PLAYER_INPUT_DECISIONS = 128
+MAX_PLAYER_INPUT_REJECT_REASONS = 32
 MAX_PLAYER_EQUIPMENT_FINGERPRINTS = 64
 MAX_CRITICAL_DEVICE_HP = effective_params_wire.MAX_CRITICAL_DEVICE_HP
 HUMAN_POSE_HISTORY_SECONDS = 1.5
@@ -643,6 +646,48 @@ def _validated_bot_reload_progress(raw, required=False):
             duration <= 0.0 or remaining < 0.0 or remaining > duration):
         raise ValueError("bot reload progress is invalid")
     return remaining, duration
+
+
+INPUT_OUTCOME_APPLIED = "applied"
+INPUT_OUTCOME_INACTIVE = "inactive"
+INPUT_OUTCOME_REJECTED = "rejected"
+PLAYER_INPUT_FAULT_ENV = "WOT_0922_INPUT_FAULT"
+# Deterministic acceptance hook.  Each entry rewrites exactly one field of one
+# ordered input frame into a value the shipping client never emits, so the
+# frame then fails the *production* pre-admission validator.  Nothing here
+# bypasses validation, and the hook stays inert unless the environment
+# variable names a class.
+PLAYER_INPUT_FAULT_CLASSES = {
+    "aim_yaw": ("aim_yaw", 7.0),
+    "gun_pitch": ("gun_pitch", 2.5),
+    "vehicle_yaw": ("yaw", 9.0),
+    "position": ("x", 4000.0),
+    "up_cosine": ("up_cosine", 1.5),
+    "pose_clock": ("pose_time_us", 1.5),
+    "fire_seq": ("fire_seq", True),
+    "shell_pair": ("next_shell_index", 9),
+    "gun_checkpoint": ("gun_checkpoint", {"reload_time": 0.0}),
+    "siege_state": ("siege_enabled", 1),
+    "extra_field": ("damage", 1000),
+    "missing_field": ("round_id", None),
+}
+
+
+def _player_input_fault_class():
+    """Return the armed recoverable input-fault class, or an empty string."""
+    selected = str(os.environ.get(PLAYER_INPUT_FAULT_ENV, "") or "").strip()
+    return selected if selected in PLAYER_INPUT_FAULT_CLASSES else ""
+
+
+def _injected_player_input_fault(message, fault_class):
+    """Return one copy of ``message`` broken in exactly one field."""
+    name, value = PLAYER_INPUT_FAULT_CLASSES[fault_class]
+    faulted = dict(message)
+    if value is None:
+        faulted.pop(name, None)
+    else:
+        faulted[name] = value
+    return faulted
 
 
 def _canonical_human_gun_checkpoint(raw):
@@ -1693,9 +1738,23 @@ class Player(_EndpointSendMixin):
         default_factory=OrderedDict, repr=False)
     destructible_contact_rejections: OrderedDict = field(
         default_factory=OrderedDict, repr=False)
+    # ``input_seq`` is the last *applied* ordered input: the frame
+    # whose controls, pose, shell selection and gun checkpoint were
+    # committed.  ``input_processed_seq`` is the contiguous terminal
+    # frontier, which also advances over a frame that reached an
+    # idempotent rejected or inactive decision without applying any
+    # state.  Consumers that need the current pose/gun checkpoint
+    # must keep using ``input_seq``.
     input_seq: int = 0
     input_fingerprints: OrderedDict = field(
         default_factory=OrderedDict, repr=False)
+    input_processed_seq: int = 0
+    input_decisions: OrderedDict = field(
+        default_factory=OrderedDict, repr=False)
+    last_input_reject: dict = field(default_factory=dict, repr=False)
+    input_reject_counts: dict = field(
+        default_factory=dict, repr=False)
+    input_fault_round: int = 0
     landing_observation_seq: int = 0
     landing_observation_input_seq: int = 0
     landing_observation_fingerprints: OrderedDict = field(
@@ -2836,6 +2895,11 @@ class BattleState:
             player.destructible_contact_rejections.clear()
             player.input_seq = 0
             player.input_fingerprints.clear()
+            player.input_processed_seq = 0
+            player.input_decisions.clear()
+            player.last_input_reject = {}
+            player.input_reject_counts.clear()
+            player.input_fault_round = 0
             player.landing_observation_seq = 0
             player.landing_observation_input_seq = 0
             player.landing_observation_fingerprints.clear()
@@ -8846,27 +8910,102 @@ class BattleState:
         }
 
     @staticmethod
-    def _admit_player_input(player, message):
-        """Admit one ordered input transaction and fold exact retries."""
-        try:
-            sequence = _exact_int(
-                message.get("input_seq"), 1, PROJECTILE_MAX_ID)
-            fingerprint = json.dumps(
-                message, sort_keys=True, separators=(",", ":"),
-                ensure_ascii=True)
-        except (TypeError, ValueError, OverflowError):
-            return False, False
-        previous = player.input_fingerprints.get(sequence)
-        if previous is not None:
-            return previous == fingerprint, previous == fingerprint
-        if sequence != player.input_seq + 1:
-            return False, False
-        player.input_seq = sequence
-        player.input_fingerprints[sequence] = fingerprint
+    def _player_input_identity(message):
+        """Return the exact ordered sequence, raw payload and digest.
+
+        The identity is always the raw wire payload, so an exact retry folds
+        even when a diagnostic hook later rewrites a field of the frame.
+        """
+        sequence = _exact_int(
+            message.get("input_seq"), 1, PROJECTILE_MAX_ID)
+        payload = _message_fingerprint(message)
+        digest = hashlib.sha1(payload.encode("utf-8")).hexdigest()
+        return sequence, payload, digest
+
+    def _record_player_input_decision(self, player, sequence, fingerprint,
+                                      outcome, reason=""):
+        """Advance only the terminal frontier and retain its typed outcome."""
+        player.input_processed_seq = int(sequence)
+        player.input_decisions[int(sequence)] = {
+            "fingerprint": str(fingerprint),
+            "outcome": str(outcome),
+            "reason": str(reason),
+        }
+        while len(player.input_decisions) > MAX_PLAYER_INPUT_DECISIONS:
+            player.input_decisions.popitem(last=False)
+        return outcome
+
+    def _note_player_input_rejection(self, player, sequence, reason,
+                                     field="", consumed=False, active=True):
+        """Keep one bounded typed first cause for the socket diagnostics."""
+        counts = player.input_reject_counts
+        if (reason not in counts and
+                len(counts) >= MAX_PLAYER_INPUT_REJECT_REASONS):
+            counts.clear()
+        counts[reason] = counts.get(reason, 0) + 1
+        player.last_input_reject = {
+            "reason": str(reason),
+            "field": str(field),
+            "player_id": int(player.player_id),
+            "round_id": int(self.round_id),
+            "submitted_seq": (
+                None if sequence is None else int(sequence)),
+            "expected_seq": int(player.input_processed_seq) + 1,
+            "processed_seq": int(player.input_processed_seq),
+            "applied_seq": int(player.input_seq),
+            "checkpoint_seq": int(player.gun_checkpoint_seq),
+            "active": bool(active),
+            "consumed": bool(consumed),
+            "repeats": int(counts[reason]),
+        }
+        return False
+
+    def _reject_player_input_frame(self, player, sequence, fingerprint,
+                                   reason, field="", active=True):
+        """End one expected frame without applying any part of its state."""
+        # Record the diagnostic against the pre-decision frontiers, then
+        # advance only the terminal frontier.  No control, pose, shell, gun
+        # checkpoint or contact state may be written on this path.
+        self._note_player_input_rejection(
+            player, sequence, reason, field, consumed=True, active=active)
+        self._record_player_input_decision(
+            player, sequence, fingerprint, INPUT_OUTCOME_REJECTED, reason)
+        return False
+
+    def _admit_applied_player_input(self, player, sequence, payload, digest):
+        """Commit one valid frame to both the terminal and applied frontier."""
+        self._record_player_input_decision(
+            player, sequence, digest, INPUT_OUTCOME_APPLIED, "")
+        player.input_seq = int(sequence)
+        player.input_fingerprints[int(sequence)] = payload
         while (len(player.input_fingerprints) >
                MAX_PLAYER_INPUT_FINGERPRINTS):
             player.input_fingerprints.popitem(last=False)
-        return True, False
+        return True
+
+    def player_input_rejection_log(self, player_id):
+        """Return one bounded typed first-cause line for the socket reader."""
+        with self.lock:
+            player = self.players.get(player_id)
+            detail = (
+                dict(player.last_input_reject) if player is not None else {})
+        if not detail or detail.get("round_id") != self.round_id:
+            # Nothing typed for this round: the message did not identify a
+            # live player of the current round at all.
+            return ("player-input:%d" % player_id,
+                    "PLAYER INPUT rejected sender=%d round=%d "
+                    "reason=unidentified" % (player_id, self.round_id))
+        return (
+            "player-input:%d:%s" % (player_id, detail["reason"]),
+            "PLAYER INPUT rejected sender=%s round=%s reason=%s field=%s "
+            "seq=%s expected=%s processed=%s applied=%s checkpoint=%s "
+            "active=%s consumed=%s repeats=%s" % (
+                detail["player_id"], detail["round_id"], detail["reason"],
+                detail["field"] or "-", detail["submitted_seq"],
+                detail["expected_seq"], detail["processed_seq"],
+                detail["applied_seq"], detail["checkpoint_seq"],
+                int(detail["active"]), int(detail["consumed"]),
+                detail["repeats"]))
 
     def _record_player_pose_sample(self, player, message):
         """Store one source-timed pose without extrapolating a broken clock."""
@@ -8910,67 +9049,168 @@ class BattleState:
             player.pose_history.popleft()
         return True
 
+    # Every entry is the exact static contract the shipping client
+    # canonicalizes against.  Periodic angles are normalized by the client to
+    # the principal interval; the wider period accepted here keeps an
+    # already-legal orientation valid without clipping it.
+    MODERN_INPUT_BOUNDED_FIELDS = (
+        ("forward", -1.0, 1.0),
+        ("turn", -1.0, 1.0),
+        ("speed", -200.0, 200.0),
+        ("aim_yaw", -math.pi * 2.0, math.pi * 2.0),
+        ("gun_pitch", -1.2, 1.2),
+        ("x", -2000.0, 2000.0),
+        ("y", -1000.0, 1000.0),
+        ("z", -2000.0, 2000.0),
+        ("yaw", -math.pi * 2.0, math.pi * 2.0),
+        ("pitch", -0.61, 0.61),
+        ("roll", -0.61, 0.61),
+    )
+
     def _modern_input_envelope_valid(self, player, message,
                                      validate_contacts=False):
         """Validate one input envelope without advancing any ledger."""
-        bounded_fields = {
-            "forward": (-1.0, 1.0),
-            "turn": (-1.0, 1.0),
-            "speed": (-200.0, 200.0),
-            "aim_yaw": (-math.pi * 2.0, math.pi * 2.0),
-            "gun_pitch": (-1.2, 1.2),
-            "x": (-2000.0, 2000.0),
-            "y": (-1000.0, 1000.0),
-            "z": (-2000.0, 2000.0),
-            "yaw": (-math.pi * 2.0, math.pi * 2.0),
-            "pitch": (-0.61, 0.61),
-            "roll": (-0.61, 0.61),
-        }
+        return not self._modern_input_envelope_failure(
+            player, message, validate_contacts)[0]
+
+    def _modern_input_envelope_failure(self, player, message,
+                                       validate_contacts=False):
+        """Return one typed (reason, field) failure or ("", "")."""
         try:
             _exact_int(message.get("round_id"), 1, PROJECTILE_MAX_ID)
-            for name, bounds in bounded_fields.items():
-                if name in message:
-                    _bounded_float(message[name], bounds[0], bounds[1])
-            if "pose_time_us" in message:
-                _exact_int(
-                    message["pose_time_us"], 0, MAX_MOTION_TIME_US)
-            if "fire_seq" in message:
-                _exact_int(message["fire_seq"], 0, PROJECTILE_MAX_ID)
-            if "input_seq" in message:
-                _exact_int(
-                    message["input_seq"], 1, PROJECTILE_MAX_ID)
-            elif HUMAN_RAM_TIMELINE_CAPABILITY in player.capabilities:
-                return False
         except (TypeError, ValueError, OverflowError):
-            return False
+            return "envelope_round_id", "round_id"
+        for name, low, high in self.MODERN_INPUT_BOUNDED_FIELDS:
+            if name not in message:
+                continue
+            try:
+                _bounded_float(message[name], low, high)
+            except (TypeError, ValueError, OverflowError):
+                return "envelope_numeric", name
+        for name, low, high in (
+                ("pose_time_us", 0, MAX_MOTION_TIME_US),
+                ("fire_seq", 0, PROJECTILE_MAX_ID),
+                ("input_seq", 1, PROJECTILE_MAX_ID)):
+            if name not in message:
+                continue
+            try:
+                _exact_int(message[name], low, high)
+            except (TypeError, ValueError, OverflowError):
+                return "envelope_integer", name
+        if ("input_seq" not in message and
+                HUMAN_RAM_TIMELINE_CAPABILITY in player.capabilities):
+            return "envelope_integer", "input_seq"
         if ("siege_enabled" in message and
                 not isinstance(message["siege_enabled"], bool)):
-            return False
+            return "envelope_siege", "siege_enabled"
         if not validate_contacts:
             # Active frames retain the established per-row rejection path.
             # A bad optional contact must not reject the ordered control frame
             # and leave every subsequent input stuck behind a sequence gap.
-            return True
+            return "", ""
         raw_ram_contacts = message.get("ram_contacts", [])
         if (not isinstance(raw_ram_contacts, list) or
                 len(raw_ram_contacts) > 16):
-            return False
+            return "envelope_contacts", "ram_contacts"
         for raw_ram in raw_ram_contacts:
             if self._normalize_ram_contact_envelope(
                     player, raw_ram)[0] is None:
-                return False
+                return "envelope_contacts", "ram_contacts"
         if "ram_contact" in message and self._normalize_ram_contact_envelope(
                 player, message["ram_contact"])[0] is None:
-            return False
+            return "envelope_contacts", "ram_contact"
         raw_destructible_contacts = message.get(
             "destructible_contacts", [])
         if (not isinstance(raw_destructible_contacts, list) or
                 len(raw_destructible_contacts) >
                 MAX_PENDING_PLAYER_DESTRUCTIBLE_CONTACTS):
-            return False
-        return all(
-            self._validated_player_destructible_contact(raw) is not None
-            for raw in raw_destructible_contacts)
+            return "envelope_contacts", "destructible_contacts"
+        for raw in raw_destructible_contacts:
+            if self._validated_player_destructible_contact(raw) is None:
+                return "envelope_contacts", "destructible_contacts"
+        return "", ""
+
+    def _player_input_frame_failure(self, player, message, inactive_modern):
+        """Validate one whole frame before any frontier or state advances.
+
+        Returns ``((reason, field), parsed)``.  ``reason`` is empty for a
+        frame whose complete envelope is in contract, and ``parsed`` then
+        carries the canonical shell selection, gun checkpoint and world-up
+        the caller may commit.
+        """
+        parsed = {
+            "shell_selection": None,
+            "gun_checkpoint": None,
+            "up_cosine": None,
+        }
+        if self.client_build == CLIENT_BUILD_0922:
+            fields = set(message)
+            if "type" in message and message.get("type") != "input":
+                return ("field_whitelist", "type"), parsed
+            missing = MODERN_INPUT_REQUIRED_FIELDS - fields
+            if missing:
+                return ("field_required", sorted(missing)[0]), parsed
+            extra = fields - MODERN_INPUT_FIELDS
+            if extra:
+                return ("field_whitelist", sorted(extra)[0]), parsed
+        has_next_shell = "next_shell_index" in message
+        has_shell_pending = "shell_change_pending" in message
+        if has_next_shell != has_shell_pending:
+            return ("shell_pair_shape", (
+                "next_shell_index" if has_next_shell
+                else "shell_change_pending")), parsed
+        if has_next_shell and "shell_index" not in message:
+            return ("shell_pair_shape", "shell_index"), parsed
+        if "shell_index" in message:
+            try:
+                loaded_shell = _exact_int(message.get("shell_index"), 0, 9)
+            except (TypeError, ValueError, OverflowError):
+                return ("shell_selection", "shell_index"), parsed
+            try:
+                next_shell = (_exact_int(
+                    message.get("next_shell_index"), 0, 9)
+                    if has_next_shell else loaded_shell)
+            except (TypeError, ValueError, OverflowError):
+                return ("shell_selection", "next_shell_index"), parsed
+            pending_shell = (
+                message.get("shell_change_pending")
+                if has_shell_pending else False)
+            if not isinstance(pending_shell, bool):
+                return ("shell_selection", "shell_change_pending"), parsed
+            if not pending_shell and next_shell != loaded_shell:
+                return ("shell_selection", "next_shell_index"), parsed
+            parsed["shell_selection"] = (
+                loaded_shell, next_shell, pending_shell)
+        checkpoint_required = bool(
+            message.get("type") == "input" and
+            PLAYER_FIRE_INTENT_CAPABILITY in player.capabilities)
+        if checkpoint_required and "gun_checkpoint" not in message:
+            return ("gun_checkpoint_missing", "gun_checkpoint"), parsed
+        if "gun_checkpoint" in message:
+            if (parsed["shell_selection"] is None or
+                    HUMAN_RAM_TIMELINE_CAPABILITY not in
+                    player.capabilities):
+                return ("gun_checkpoint_context", "gun_checkpoint"), parsed
+            try:
+                parsed["gun_checkpoint"] = _canonical_human_gun_checkpoint(
+                    message.get("gun_checkpoint"))
+            except (TypeError, ValueError, OverflowError):
+                return ("gun_checkpoint_shape", "gun_checkpoint"), parsed
+        if (self.client_build == CLIENT_BUILD_0922 and
+                "up_cosine" in message):
+            raw_up_cosine = message.get("up_cosine")
+            if (isinstance(raw_up_cosine, bool) or
+                    not isinstance(raw_up_cosine, (int, float)) or
+                    not math.isfinite(float(raw_up_cosine)) or
+                    not -1.0 <= float(raw_up_cosine) <= 1.0):
+                return ("world_up", "up_cosine"), parsed
+            parsed["up_cosine"] = float(raw_up_cosine)
+        if self.client_build == CLIENT_BUILD_0922:
+            reason, field = self._modern_input_envelope_failure(
+                player, message, validate_contacts=inactive_modern)
+            if reason:
+                return (reason, field), parsed
+        return ("", ""), parsed
 
     @staticmethod
     def _player_pose_for_destructible_contact(player, contact):
@@ -8991,94 +9231,109 @@ class BattleState:
         return None
 
     def update_input(self, player_id, message):
+        """Reach one idempotent terminal decision for one ordered frame.
+
+        The ordered ledger separates three concepts.  ``input_processed_seq``
+        is the contiguous frontier of frames that reached a terminal decision,
+        applied or not.  ``input_seq`` is the last frame whose gameplay state
+        was actually committed.  ``input_decisions`` remembers the bounded
+        fingerprint and typed outcome per sequence so an exact retry folds and
+        a changed payload at the same sequence conflicts.
+
+        A recoverable validation failure therefore ends that one operation
+        without applying any field and without installing a gun checkpoint,
+        while the next well-formed frame can still advance automatically.
+        """
         with self.lock:
             if not self._message_round_matches(message):
                 return False
             player = self.players.get(player_id)
             if player is None or not player.connected:
                 return False
+            ledger = bool(
+                HUMAN_RAM_TIMELINE_CAPABILITY in player.capabilities)
+            sequence = None
+            payload = ""
+            digest = ""
+            if ledger:
+                try:
+                    sequence, payload, digest = (
+                        self._player_input_identity(message))
+                except (TypeError, ValueError, OverflowError):
+                    # Without a usable exact sequence this message cannot be
+                    # allowed to consume another operation's ordered slot.
+                    return self._note_player_input_rejection(
+                        player, None, "sequence_identity", "input_seq")
+                decision = player.input_decisions.get(sequence)
+                if decision is not None:
+                    if decision["fingerprint"] != digest:
+                        # A changed payload may never replace a decision that
+                        # already became terminal at this sequence.
+                        return self._note_player_input_rejection(
+                            player, sequence, "identity_conflict",
+                            "input_seq")
+                    if decision["outcome"] == INPUT_OUTCOME_REJECTED:
+                        return self._note_player_input_rejection(
+                            player, sequence, decision["reason"],
+                            "input_seq", consumed=True)
+                    return True
+                if sequence <= player.input_processed_seq:
+                    # Evicted from the bounded ledger: safely rejected, and it
+                    # can never resurrect state.
+                    return self._note_player_input_rejection(
+                        player, sequence, "sequence_retired", "input_seq")
+                if sequence != player.input_processed_seq + 1:
+                    return self._note_player_input_rejection(
+                        player, sequence, "sequence_gap", "input_seq")
+                fault_class = _player_input_fault_class()
+                if (fault_class and
+                        player.input_fault_round != self.round_id):
+                    # Deterministic acceptance hook: break exactly one frame
+                    # per round and let the production validator reject it.
+                    player.input_fault_round = int(self.round_id)
+                    _server_log(
+                        "PLAYER INPUT fault injected sender=%d round=%d "
+                        "class=%s seq=%d" % (
+                            player.player_id, self.round_id, fault_class,
+                            sequence))
+                    message = _injected_player_input_fault(
+                        message, fault_class)
             inactive_modern = False
             if self.client_build == CLIENT_BUILD_0922:
-                fields = set(message)
-                if (("type" in message and
-                     message.get("type") != "input") or
-                        not MODERN_INPUT_REQUIRED_FIELDS.issubset(fields) or
-                        fields - MODERN_INPUT_FIELDS):
-                    # Reject the whole transaction before sequence, gun,
-                    # controls or pose state can advance.
-                    return False
                 inactive_modern = bool(
                     self.phase != "battle" or
                     self.battle_result is not None or
                     not player.participating or not player.alive)
-            shell_selection = None
-            gun_checkpoint = None
-            has_next_shell = "next_shell_index" in message
-            has_shell_pending = "shell_change_pending" in message
-            if has_next_shell != has_shell_pending:
-                return False
-            if has_next_shell and "shell_index" not in message:
-                return False
-            if "shell_index" in message:
-                try:
-                    loaded_shell = _exact_int(
-                        message.get("shell_index"), 0, 9)
-                    next_shell = (_exact_int(
-                        message.get("next_shell_index"), 0, 9)
-                        if has_next_shell else loaded_shell)
-                except (TypeError, ValueError, OverflowError):
-                    return False
-                pending_shell = (
-                    message.get("shell_change_pending")
-                    if has_shell_pending else False)
-                if (not isinstance(pending_shell, bool) or
-                        (not pending_shell and next_shell != loaded_shell)):
-                    return False
-                shell_selection = (
-                    loaded_shell, next_shell, pending_shell)
-            checkpoint_required = bool(
-                message.get("type") == "input" and
-                PLAYER_FIRE_INTENT_CAPABILITY in player.capabilities)
-            if checkpoint_required and "gun_checkpoint" not in message:
-                return False
-            if "gun_checkpoint" in message:
-                if (
-                        shell_selection is None or
-                        HUMAN_RAM_TIMELINE_CAPABILITY not in
-                        player.capabilities):
-                    return False
-                try:
-                    gun_checkpoint = _canonical_human_gun_checkpoint(
-                        message.get("gun_checkpoint"))
-                except (TypeError, ValueError, OverflowError):
-                    return False
-            reported_up_cosine = None
-            if (self.client_build == CLIENT_BUILD_0922 and
-                    "up_cosine" in message):
-                raw_up_cosine = message.get("up_cosine")
-                if (isinstance(raw_up_cosine, bool) or
-                        not isinstance(raw_up_cosine, (int, float)) or
-                        not math.isfinite(float(raw_up_cosine)) or
-                        not -1.0 <= float(raw_up_cosine) <= 1.0):
-                    return False
-                reported_up_cosine = float(raw_up_cosine)
-            if self.client_build == CLIENT_BUILD_0922:
-                if not self._modern_input_envelope_valid(
-                        player, message, validate_contacts=inactive_modern):
-                    return False
-                if inactive_modern:
-                    # A complete input frame may already be queued when death,
-                    # leave, or the round result overtakes it. Validate its
-                    # entire non-mutating envelope first, then fold it without
-                    # advancing sequence, pose, gun, or control state.
-                    return True
-            if HUMAN_RAM_TIMELINE_CAPABILITY in player.capabilities:
-                accepted, duplicate = self._admit_player_input(
-                    player, message)
-                if not accepted:
-                    return False
-                if duplicate:
-                    return True
+            (reason, field), parsed = self._player_input_frame_failure(
+                player, message, inactive_modern)
+            if reason:
+                if not ledger:
+                    # No ordered ledger to consume, but the socket reader
+                    # still needs the typed first cause instead of a generic
+                    # line.
+                    return self._note_player_input_rejection(
+                        player, None, reason, field,
+                        active=not inactive_modern)
+                return self._reject_player_input_frame(
+                    player, sequence, digest, reason, field,
+                    active=not inactive_modern)
+            shell_selection = parsed["shell_selection"]
+            gun_checkpoint = parsed["gun_checkpoint"]
+            reported_up_cosine = parsed["up_cosine"]
+            if self.client_build == CLIENT_BUILD_0922 and inactive_modern:
+                # A complete input frame may already be queued when death,
+                # leave, or the round result overtakes it. Its whole
+                # non-mutating envelope is validated above; fold it as a
+                # terminal no-op that advances only the processed frontier so
+                # the frames queued behind it never wait on a sequence gap.
+                if ledger:
+                    self._record_player_input_decision(
+                        player, sequence, digest,
+                        INPUT_OUTCOME_INACTIVE, "inactive")
+                return True
+            if ledger:
+                self._admit_applied_player_input(
+                    player, sequence, payload, digest)
                 if gun_checkpoint is not None:
                     checkpoint_seq = int(player.input_seq)
                     player.gun_checkpoint_seq = checkpoint_seq
@@ -11769,6 +12024,10 @@ class BattleState:
             "input_seq": int(player.input_seq),
             "landing_observation_seq": int(
                 player.landing_observation_seq),
+            # The terminal frontier lets a reconnecting or resynchronizing
+            # client resume at the next eligible sequence instead of retrying
+            # an identifier whose decision is already terminal.
+            "input_processed_seq": int(player.input_processed_seq),
             "siege_state": int(player.siege_state),
             "siege_time_left_ms": int(math.ceil(
                 max(0, int(player.siege_transition_ticks)) *
@@ -12580,10 +12839,13 @@ class ClientHandler(socketserver.BaseRequestHandler):
                         if message_type == "input":
                             if server.state.update_input(
                                     player.player_id, message) is False:
+                                # Rate-limit per player *and* typed reason so
+                                # the first causal field survives any later
+                                # cascade of ordering rejections.
                                 _server_log_limited(
-                                    "player-input:%d" % player.player_id,
-                                    "PLAYER INPUT rejected sender=%d" %
-                                    player.player_id)
+                                    *server.state.
+                                    player_input_rejection_log(
+                                        player.player_id))
                         elif message_type == "track_repair":
                             if not server.state.report_track_repair(
                                     player.player_id, message):

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -1512,6 +1512,8 @@ class BattleRuntime(object):
         self._player_fire_intent_history = collections.OrderedDict()
         self._player_fire_launch_pending = {}
         self._local_fire_intent = None
+        self._fire_intent_reject_round = None
+        self._fire_intent_reject_counts = {}
         self._ammo_signature = None
         self._targeting_signature = None
         self._reload_event = None
@@ -1792,6 +1794,8 @@ class BattleRuntime(object):
         self._player_fire_intent_history = collections.OrderedDict()
         self._player_fire_launch_pending = {}
         self._local_fire_intent = None
+        self._fire_intent_reject_round = None
+        self._fire_intent_reject_counts = {}
         self._ammo_signature = None
         self._targeting_signature = None
         self._reload_event = None
@@ -7293,9 +7297,23 @@ class BattleRuntime(object):
                 sequence != int(pending.get('intent_seq', 0))):
             return False
         reason = str(message.get('reason', 'rejected') or 'rejected')
-        sys.stdout.write(
-            '[Offline LAN 0.9.22] FIRE INTENT rejected intent=%d reason=%s\n'
-            % (sequence, reason))
+        # One typed terminal per reason is the root cause; the repeats behind
+        # it are the same cause observed again.  Report the first occurrence
+        # immediately and then only a bounded running count, so a cascade
+        # never reads as twenty independent failures.
+        round_id = message.get('round_id')
+        if self._fire_intent_reject_round != round_id:
+            self._fire_intent_reject_round = round_id
+            self._fire_intent_reject_counts = {}
+        counts = self._fire_intent_reject_counts
+        if reason not in counts and len(counts) >= 32:
+            counts.clear()
+        seen = counts.get(reason, 0)
+        counts[reason] = seen + 1
+        if seen == 0 or (seen + 1) % 20 == 0:
+            sys.stdout.write(
+                '[Offline LAN 0.9.22] FIRE INTENT rejected intent=%d '
+                'reason=%s repeats=%d\n' % (sequence, reason, seen + 1))
         deferred_shell = pending.get('deferred_current_shell_index')
         deferred_partial_reload = bool(
             pending.get('deferred_partial_clip_reload'))
@@ -20143,6 +20161,8 @@ class BattleRuntime(object):
         self._player_fire_intent_history = collections.OrderedDict()
         self._player_fire_launch_pending = {}
         self._local_fire_intent = None
+        self._fire_intent_reject_round = None
+        self._fire_intent_reject_counts = {}
         self._ammo_signature = None
         self._targeting_signature = None
         self._equipment_state = None

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
@@ -75,6 +75,16 @@ MAX_PROJECTILE_SPLASH_RADIUS = 100.0
 MAX_PLAYER_DISPERSION_ANGLE = 0.5
 MAX_PLAYER_CLIP_SIZE = 255
 MAX_PLAYER_RELOAD_SECONDS = 3600.0
+# The exact ordered-input wire contract enforced by the bundled LAN
+# server's pre-admission validator.  The launcher always installs the
+# matching pair, so these mirror it field for field: a frame this
+# client queues must already satisfy the same envelope.
+MAX_PLAYER_INPUT_SPEED = 200.0
+MAX_PLAYER_GUN_PITCH = 1.2
+MAX_PLAYER_INPUT_ATTITUDE = 0.61
+PLAYER_INPUT_WORLD_BOUNDS = (2000.0, 1000.0, 2000.0)
+MAX_PLAYER_RAM_CONTACTS = 16
+MAX_PLAYER_DESTRUCTIBLE_CONTACTS = 16
 MAX_PROJECTILE_PIERCING_LOSS = 100000.0
 MAX_CRITICAL_DEVICE_HP = effective_params_wire.MAX_CRITICAL_DEVICE_HP
 CRITICAL_DELTA_DEVICE_NAMES = frozenset((
@@ -385,6 +395,22 @@ def _valid_stun_contract(vehicle):
         (end == 0 and attacker_kind == '' and attacker_id == 0) or
         (end > 0 and attacker_kind in ('player', 'bot') and
          attacker_id > 0))
+
+
+def _canonical_angle(value, default=0.0):
+    """Return one mathematically equivalent angle inside [-pi, pi].
+
+    Yaw is periodic, so an accumulated turret plus hull sum is normalized
+    rather than clipped: clipping would silently point the reported gun
+    somewhere the player is not aiming, while normalization reports the exact
+    same orientation inside the server's ordered-input contract.
+    """
+    angle = _finite_float(value, default)
+    period = 2.0 * math.pi
+    angle = math.fmod(angle + math.pi, period)
+    if angle < 0.0:
+        angle += period
+    return angle - math.pi
 
 
 def _exact_finite_float(value, default=None):
@@ -1839,14 +1865,26 @@ class LANClient(object):
             self._landing_observation_pending = None
             self._landing_observation_queue = []
         next_input_seq = self._input_seq + 1
+        parsed_fire_seq = _projectile_int_range(
+            max(0, int(fire_seq or 0)), 0, MAX_PROJECTILE_ID)
+        if parsed_fire_seq is None:
+            return False
         message = {
             'type': 'input',
             'round_id': self.round_id,
             'forward': max(-1.0, min(1.0, _finite_float(forward))),
             'turn': max(-1.0, min(1.0, _finite_float(turn))),
-            'aim_yaw': _finite_float(aim_yaw),
-            'gun_pitch': _finite_float(gun_pitch),
-            'fire_seq': max(0, int(fire_seq or 0)),
+            # Periodic: hull yaw plus turret yaw can leave the principal
+            # interval, so report the equivalent canonical angle.
+            'aim_yaw': _canonical_angle(aim_yaw),
+            # Not periodic.  The gun elevation request is bounded by the wire
+            # envelope, which is far wider than any #1513 gun's descriptor
+            # pitch limits; VehicleGunRotator still owns the exact per-vehicle
+            # limits, so no reachable angle is altered here.
+            'gun_pitch': max(
+                -MAX_PLAYER_GUN_PITCH,
+                min(MAX_PLAYER_GUN_PITCH, _finite_float(gun_pitch))),
+            'fire_seq': parsed_fire_seq,
         }
         timeline_enabled = bool(
             HUMAN_RAM_TIMELINE_CAPABILITY in self.capabilities and
@@ -1854,16 +1892,26 @@ class LANClient(object):
         if timeline_enabled:
             message['input_seq'] = next_input_seq
         if position is not None and len(position) >= 3:
-            message['x'] = _finite_float(position[0])
-            message['y'] = _finite_float(position[1])
-            message['z'] = _finite_float(position[2])
-            message['yaw'] = _finite_float(yaw)
+            coordinates = [
+                _finite_float(position[index]) for index in range(3)]
+            if any(abs(coordinate) > bound for coordinate, bound in
+                   zip(coordinates, PLAYER_INPUT_WORLD_BOUNDS)):
+                # No #1513 map reaches this envelope.  Fabricating a clamped
+                # world pose would report a position the vehicle is not in, so
+                # drop the frame locally instead; the ordered sequence is
+                # committed only after the frame is queued, so nothing later
+                # is blocked.
+                return False
+            message['x'], message['y'], message['z'] = coordinates
+            message['yaw'] = _canonical_angle(yaw)
             if pitch is not None:
                 message['pitch'] = max(
-                    -0.61, min(0.61, _finite_float(pitch)))
+                    -MAX_PLAYER_INPUT_ATTITUDE,
+                    min(MAX_PLAYER_INPUT_ATTITUDE, _finite_float(pitch)))
             if roll is not None:
                 message['roll'] = max(
-                    -0.61, min(0.61, _finite_float(roll)))
+                    -MAX_PLAYER_INPUT_ATTITUDE,
+                    min(MAX_PLAYER_INPUT_ATTITUDE, _finite_float(roll)))
             if up_cosine is not None:
                 if (isinstance(up_cosine, bool) or
                         not isinstance(up_cosine, integer_types + (float,))):
@@ -1880,7 +1928,8 @@ class LANClient(object):
                 message['pose_time_us'] = parsed_pose_time
         if speed is not None:
             message['speed'] = max(
-                -200.0, min(200.0, _finite_float(speed)))
+                -MAX_PLAYER_INPUT_SPEED,
+                min(MAX_PLAYER_INPUT_SPEED, _finite_float(speed)))
         if shell_index is not None:
             parsed_shell = _projectile_int_range(shell_index, 0, 9)
             if parsed_shell is None:
@@ -1915,11 +1964,13 @@ class LANClient(object):
             message['gun_checkpoint'] = parsed_checkpoint
         if isinstance(ram_contacts, list):
             message['ram_contacts'] = [
-                dict(value) for value in ram_contacts[:16]
+                dict(value) for value in ram_contacts[
+                    :MAX_PLAYER_RAM_CONTACTS]
                 if isinstance(value, dict)]
         if isinstance(destructible_contacts, list):
             message['destructible_contacts'] = [
-                dict(value) for value in destructible_contacts[:16]
+                dict(value) for value in destructible_contacts[
+                    :MAX_PLAYER_DESTRUCTIBLE_CONTACTS]
                 if isinstance(value, dict)]
         if siege_enabled is not None:
             if not isinstance(siege_enabled, bool):
@@ -2149,6 +2200,16 @@ class LANClient(object):
             own.get('landing_observation_seq'), 0, MAX_PROJECTILE_ID)
         if input_seq is None or landing_seq is None:
             return False
+        if 'input_processed_seq' in own:
+            # The server's terminal frontier can run ahead of its last applied
+            # input when one recoverable frame was rejected.  Resume from the
+            # next eligible sequence so a reconnect never retries an
+            # identifier whose decision is already terminal.
+            processed_seq = _projectile_int_range(
+                own.get('input_processed_seq'), 0, MAX_PROJECTILE_ID)
+            if processed_seq is None or processed_seq < input_seq:
+                return False
+            input_seq = processed_seq
         if self._input_seq_round != self.round_id:
             self._input_seq_round = self.round_id
             self._input_seq = input_seq

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
@@ -569,7 +569,7 @@ def _valid_bot_equipment_contract(state, required=False):
 
 
 def _valid_player_environment_contract(state, required=False):
-    """Validate the canonical pose and landing frontier in a player row."""
+    """Validate canonical pose, input and landing frontiers in a player row."""
     required_fields = {
         'input_seq', 'up_cosine', 'landing_observation_seq'}
     if not required_fields.issubset(state):
@@ -579,8 +579,14 @@ def _valid_player_environment_contract(state, required=False):
     landing_sequence = _projectile_int_range(
         state.get('landing_observation_seq'), 0, MAX_PROJECTILE_ID)
     up_cosine = _exact_finite_float(state.get('up_cosine'))
+    processed_sequence = input_sequence
+    if 'input_processed_seq' in state:
+        processed_sequence = _projectile_int_range(
+            state.get('input_processed_seq'), 0, MAX_PROJECTILE_ID)
     return bool(
         input_sequence is not None and landing_sequence is not None and
+        processed_sequence is not None and
+        processed_sequence >= input_sequence and
         up_cosine is not None and -1.0 <= up_cosine <= 1.0)
 
 
@@ -1865,6 +1871,11 @@ class LANClient(object):
             self._landing_observation_pending = None
             self._landing_observation_queue = []
         next_input_seq = self._input_seq + 1
+        if next_input_seq > MAX_PROJECTILE_ID:
+            # The server cannot represent another ordered identity in this
+            # round.  Do not queue MAX+1 and move the local frontier into a
+            # permanent sequence gap; the next round resets both sides.
+            return False
         parsed_fire_seq = _projectile_int_range(
             max(0, int(fire_seq or 0)), 0, MAX_PROJECTILE_ID)
         if parsed_fire_seq is None:

--- a/0.9.22/tests/test_port_0922_input_ledger.py
+++ b/0.9.22/tests/test_port_0922_input_ledger.py
@@ -352,6 +352,32 @@ class OrderedInputLedgerTests(unittest.TestCase):
                 'envelope_numeric', player.last_input_reject['reason'])
             self.assertTrue(player.last_input_reject['consumed'])
 
+    def test_an_exact_rejected_retry_keeps_its_original_diagnostic(self):
+        state = _state(players=1)
+        player = self._admit_base_frame(state)
+        player.alive = False
+        player.health = 0
+        bad = _frame(
+            state,
+            ram_contacts=[_player_ram_contact(contact_x=True)])
+
+        self.assertFalse(state.update_input(1, bad))
+        first = dict(player.last_input_reject)
+        self.assertEqual('ram_contacts', first['field'])
+        self.assertFalse(first['active'])
+
+        # Lifecycle may move on before an exact transport retry arrives.  Its
+        # terminal identity still has to report the field and lifecycle state
+        # that caused the original decision, not relabel it as input_seq in
+        # the actor's current state.
+        player.alive = True
+        player.health = player.max_health
+        self.assertFalse(state.update_input(1, json.loads(json.dumps(bad))))
+        self.assertEqual(first['reason'], player.last_input_reject['reason'])
+        self.assertEqual(first['field'], player.last_input_reject['field'])
+        self.assertEqual(first['active'], player.last_input_reject['active'])
+        self.assertTrue(player.last_input_reject['consumed'])
+
     def test_an_exact_applied_retry_folds_without_reapplying(self):
         state = _state(players=1)
         player = self._admit_base_frame(state)
@@ -481,6 +507,7 @@ class OrderedInputLedgerTests(unittest.TestCase):
                 self.assertEqual(1, player.input_seq)
                 self.assertEqual(
                     'inactive', player.input_decisions[2]['outcome'])
+                self.assertFalse(player.input_decisions[2]['active'])
 
                 # A frame queued behind it is not stuck behind a gap.
                 self.assertTrue(state.update_input(1, _frame(state)))
@@ -788,7 +815,10 @@ class InputLedgerLifecycleTests(unittest.TestCase):
 
         self.assertFalse(state.update_input(1, message))
         self.assertEqual(1, player.input_processed_seq)
-        self.assertFalse(player.last_input_reject)
+        self.assertEqual(
+            'player_disconnected', player.last_input_reject['reason'])
+        self.assertFalse(player.last_input_reject['consumed'])
+        self.assertFalse(player.last_input_reject['active'])
 
         player.connected = True
         self.assertFalse(state.update_input(1, message))
@@ -801,11 +831,22 @@ class InputLedgerLifecycleTests(unittest.TestCase):
         player = state.players[1]
         self.assertTrue(state.update_input(1, _frame(state)))
 
+        # Seed an earlier same-round failure: the diagnostic for the early
+        # round fence must replace it rather than reusing this stale reason.
         self.assertFalse(state.update_input(
-            1, _frame(state, round_id=state.round_id + 1, aim_yaw=7.0)))
+            1, _frame(state, aim_yaw=7.0)))
+        self.assertEqual(
+            'envelope_numeric', player.last_input_reject['reason'])
 
-        self.assertEqual(1, player.input_processed_seq)
-        self.assertFalse(player.last_input_reject)
+        self.assertFalse(state.update_input(
+            1, _frame(
+                state, input_seq=3, round_id=state.round_id + 1,
+                aim_yaw=7.0)))
+
+        self.assertEqual(2, player.input_processed_seq)
+        self.assertEqual('round_mismatch', player.last_input_reject['reason'])
+        self.assertEqual('round_id', player.last_input_reject['field'])
+        self.assertFalse(player.last_input_reject['consumed'])
 
     def test_a_rejection_does_not_disturb_a_siege_transition(self):
         state = _state(players=1)

--- a/0.9.22/tests/test_port_0922_input_ledger.py
+++ b/0.9.22/tests/test_port_0922_input_ledger.py
@@ -1,0 +1,920 @@
+"""Ordered player-input ledger: recovery, ordering and fire interaction.
+
+One recoverable rejected input frame must end as its own terminal decision
+without applying any state, while the next well-formed frame still advances
+automatically and a later valid fire intent still reaches a projectile.
+"""
+
+import json
+from pathlib import Path
+import sys
+import unittest
+
+
+PORT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PORT_ROOT / 'server'))
+
+from lan_battle_server import (  # noqa: E402
+    MAX_PLAYER_INPUT_DECISIONS,
+    PROJECTILE_MAX_ID,
+    SIEGE_ENABLED, SIEGE_SWITCHING_OFF,
+    SIMULATION_WORKER_AUTHORITY_ID,
+)
+from test_port_0922_server_projectiles import (  # noqa: E402
+    _attach_worker_authority, _fire_intent, _gun_checkpoint, _launch,
+    _launch_authority, _player_destructible_contact, _player_ram_contact,
+    _state,
+)
+
+
+def _frame(state, player_id=1, **changes):
+    """Build one healthy wire frame at the player's next eligible sequence."""
+    player = state.players[player_id]
+    message = {
+        'type': 'input', 'round_id': state.round_id,
+        'input_seq': player.input_processed_seq + 1,
+        'pose_time_us': state._logical_motion_time_us(),
+        'forward': 0.0, 'turn': 0.0, 'speed': 0.0,
+        'aim_yaw': player.aim_yaw, 'gun_pitch': player.gun_pitch,
+        'x': player.x, 'y': player.y, 'z': player.z,
+        'yaw': player.yaw, 'pitch': player.pitch, 'roll': player.roll,
+        'fire_seq': player.fire_seq, 'shell_index': player.shell_index,
+        'next_shell_index': player.next_shell_index,
+        'shell_change_pending': player.shell_change_pending,
+        'gun_checkpoint': _gun_checkpoint(),
+    }
+    message.update(changes)
+    return json.loads(json.dumps(message))
+
+
+def _drop(state, player_id=1, field='round_id', **changes):
+    message = _frame(state, player_id, **changes)
+    message.pop(field, None)
+    return message
+
+
+def _mutable_state(player):
+    """Every gameplay field an invalid frame must never be able to write."""
+    return (
+        player.input_seq, dict(player.input_fingerprints),
+        player.gun_checkpoint_seq, dict(player.gun_checkpoint),
+        dict(player.gun_checkpoints),
+        player.forward, player.turn, player.speed,
+        player.aim_yaw, player.gun_pitch,
+        player.x, player.y, player.z, player.yaw,
+        player.pitch, player.roll, player.up_cosine,
+        player.pose_time_us, tuple(player.pose_history),
+        player.fire_seq, player.shell_index,
+        player.next_shell_index, player.shell_change_pending,
+        player.siege_state, player.siege_transition_ticks,
+        player.ram_contact_seq, dict(player.ram_contacts),
+        player.destructible_contact_seq,
+        dict(player.destructible_contacts),
+        player.health, player.alive,
+    )
+
+
+# Every pre-admission failure class that a frame with a usable exact ordered
+# sequence can hit.  Each entry must become one rejected terminal decision.
+RECOVERABLE_FAILURES = (
+    ('required_round_id', lambda state: _drop(state, field='round_id'),
+     'field_required'),
+    ('extra_field', lambda state: _frame(state, health=0),
+     'field_whitelist'),
+    ('extra_critical', lambda state: _frame(state, critical={'events': []}),
+     'field_whitelist'),
+    ('wrong_type', lambda state: _frame(state, type='equipment_intent'),
+     'field_whitelist'),
+    ('shell_pair_missing_pending',
+     lambda state: _drop(state, field='shell_change_pending'),
+     'shell_pair_shape'),
+    ('shell_pair_missing_next',
+     lambda state: _drop(state, field='next_shell_index'),
+     'shell_pair_shape'),
+    ('shell_pair_missing_loaded',
+     lambda state: _drop(state, field='shell_index'),
+     'shell_pair_shape'),
+    ('shell_index_range', lambda state: _frame(state, shell_index=10),
+     'shell_selection'),
+    ('shell_index_bool', lambda state: _frame(state, shell_index=True),
+     'shell_selection'),
+    ('next_shell_range',
+     lambda state: _frame(state, next_shell_index=10), 'shell_selection'),
+    ('pending_not_bool',
+     lambda state: _frame(state, shell_change_pending=1),
+     'shell_selection'),
+    ('pending_mismatch',
+     lambda state: _frame(
+         state, next_shell_index=1, shell_change_pending=False),
+     'shell_selection'),
+    ('gun_checkpoint_absent',
+     lambda state: _drop(state, field='gun_checkpoint'),
+     'gun_checkpoint_missing'),
+    ('gun_checkpoint_shape',
+     lambda state: _frame(state, gun_checkpoint={'reload_time': 0.0}),
+     'gun_checkpoint_shape'),
+    ('gun_checkpoint_not_dict',
+     lambda state: _frame(state, gun_checkpoint=[0.0]),
+     'gun_checkpoint_shape'),
+    ('gun_checkpoint_inconsistent',
+     lambda state: _frame(state, gun_checkpoint=_gun_checkpoint(
+         reload_time=9.0, reload_duration=5.0)),
+     'gun_checkpoint_shape'),
+    ('gun_checkpoint_clip',
+     lambda state: _frame(state, gun_checkpoint=_gun_checkpoint(
+         clip=4, clip_size=2)),
+     'gun_checkpoint_shape'),
+    ('gun_checkpoint_reload_duration',
+     lambda state: _frame(state, gun_checkpoint=_gun_checkpoint(
+         reload_duration=0.0)),
+     'gun_checkpoint_shape'),
+    ('gun_checkpoint_dispersion',
+     lambda state: _frame(state, gun_checkpoint=_gun_checkpoint(
+         dispersion=5.0)),
+     'gun_checkpoint_shape'),
+    ('up_cosine_bool', lambda state: _frame(state, up_cosine=True),
+     'world_up'),
+    ('up_cosine_string', lambda state: _frame(state, up_cosine='0.5'),
+     'world_up'),
+    ('up_cosine_range', lambda state: _frame(state, up_cosine=1.01),
+     'world_up'),
+    ('round_id_float',
+     lambda state: _frame(state, round_id=float(state.round_id)),
+     'envelope_round_id'),
+    ('forward_range', lambda state: _frame(state, forward=1.5),
+     'envelope_numeric'),
+    ('forward_bool', lambda state: _frame(state, forward=True),
+     'envelope_numeric'),
+    ('turn_range', lambda state: _frame(state, turn=-1.5),
+     'envelope_numeric'),
+    ('speed_range', lambda state: _frame(state, speed=1e300),
+     'envelope_numeric'),
+    ('aim_yaw_range', lambda state: _frame(state, aim_yaw=7.0),
+     'envelope_numeric'),
+    ('gun_pitch_range', lambda state: _frame(state, gun_pitch=2.0),
+     'envelope_numeric'),
+    ('x_range', lambda state: _frame(state, x=4000.0),
+     'envelope_numeric'),
+    ('y_range', lambda state: _frame(state, y=2000.0),
+     'envelope_numeric'),
+    ('z_range', lambda state: _frame(state, z=-4000.0),
+     'envelope_numeric'),
+    ('yaw_range', lambda state: _frame(state, yaw=9.0),
+     'envelope_numeric'),
+    ('pitch_range', lambda state: _frame(state, pitch=1.0),
+     'envelope_numeric'),
+    ('roll_range', lambda state: _frame(state, roll=-1.0),
+     'envelope_numeric'),
+    ('pose_time_fractional',
+     lambda state: _frame(state, pose_time_us=1.5), 'envelope_integer'),
+    ('pose_time_negative',
+     lambda state: _frame(state, pose_time_us=-1), 'envelope_integer'),
+    ('fire_seq_bool', lambda state: _frame(state, fire_seq=True),
+     'envelope_integer'),
+    ('fire_seq_negative', lambda state: _frame(state, fire_seq=-1),
+     'envelope_integer'),
+    ('siege_shape', lambda state: _frame(state, siege_enabled=1),
+     'envelope_siege'),
+)
+
+
+class OrderedInputLedgerTests(unittest.TestCase):
+    def _admit_base_frame(self, state, player_id=1):
+        player = state.players[player_id]
+        self.assertTrue(state.update_input(player_id, _frame(
+            state, player_id, forward=0.5, aim_yaw=0.1)))
+        self.assertEqual(1, player.input_seq)
+        self.assertEqual(1, player.input_processed_seq)
+        self.assertEqual(1, player.gun_checkpoint_seq)
+        return player
+
+    def test_each_recoverable_failure_recovers_on_the_next_frame(self):
+        for name, build, reason in RECOVERABLE_FAILURES:
+            with self.subTest(failure=name):
+                state = _state(players=1)
+                player = self._admit_base_frame(state)
+                before = _mutable_state(player)
+
+                self.assertFalse(state.update_input(1, build(state)))
+
+                # One rejected terminal record, no applied state, no gun
+                # checkpoint, and the terminal frontier moved past it.
+                self.assertEqual(before, _mutable_state(player))
+                self.assertEqual(2, player.input_processed_seq)
+                self.assertEqual(1, player.input_seq)
+                self.assertEqual(
+                    {'outcome': 'rejected', 'reason': reason},
+                    {'outcome': player.input_decisions[2]['outcome'],
+                     'reason': player.input_decisions[2]['reason']})
+                self.assertNotIn(2, player.gun_checkpoints)
+                self.assertNotIn(2, player.input_fingerprints)
+                self.assertEqual(reason, player.last_input_reject['reason'])
+                self.assertEqual(2, player.last_input_reject['submitted_seq'])
+                self.assertEqual(2, player.last_input_reject['expected_seq'])
+                self.assertEqual(1, player.last_input_reject['processed_seq'])
+                self.assertEqual(1, player.last_input_reject['applied_seq'])
+                self.assertTrue(player.last_input_reject['consumed'])
+
+                # The next well-formed frame advances automatically and its
+                # own state becomes the resulting state.
+                self.assertTrue(state.update_input(1, _frame(
+                    state, forward=-0.75, turn=0.5, speed=3.0,
+                    aim_yaw=0.3, gun_pitch=0.2, shell_index=1,
+                    next_shell_index=1, shell_change_pending=False,
+                    up_cosine=0.9)))
+                self.assertEqual(3, player.input_seq)
+                self.assertEqual(3, player.input_processed_seq)
+                self.assertEqual(3, player.gun_checkpoint_seq)
+                self.assertEqual(
+                    (-0.75, 0.5, 3.0, 0.3, 0.2, 1, 0.9),
+                    (player.forward, player.turn, player.speed,
+                     round(player.aim_yaw, 6), round(player.gun_pitch, 6),
+                     player.shell_index, player.up_cosine))
+                self.assertEqual(
+                    'applied', player.input_decisions[3]['outcome'])
+                self.assertIn(3, player.input_fingerprints)
+
+    def test_one_rejection_never_repeats_the_applied_frame(self):
+        state = _state(players=1)
+        player = self._admit_base_frame(state)
+
+        self.assertFalse(state.update_input(1, _frame(state, aim_yaw=7.0)))
+        applied = dict(player.input_fingerprints)
+
+        self.assertTrue(state.update_input(1, _frame(state, forward=0.25)))
+        self.assertEqual(sorted(applied) + [3],
+                         sorted(player.input_fingerprints))
+        self.assertEqual(
+            [1, 2, 3], sorted(player.input_decisions))
+
+    def test_unusable_sequence_identity_consumes_no_frontier(self):
+        for name, value in (
+                ('bool', True), ('fractional', 1.5), ('string', '2'),
+                ('negative', -1), ('zero', 0), ('none', None),
+                ('oversized', PROJECTILE_MAX_ID + 1)):
+            with self.subTest(sequence=name):
+                state = _state(players=1)
+                player = self._admit_base_frame(state)
+                before = _mutable_state(player)
+                decisions = dict(player.input_decisions)
+
+                self.assertFalse(state.update_input(
+                    1, _frame(state, input_seq=value)))
+
+                self.assertEqual(before, _mutable_state(player))
+                self.assertEqual(1, player.input_processed_seq)
+                self.assertEqual(decisions, dict(player.input_decisions))
+                self.assertEqual(
+                    'sequence_identity',
+                    player.last_input_reject['reason'])
+                self.assertFalse(player.last_input_reject['consumed'])
+
+                # The healthy next frame is still admitted.
+                self.assertTrue(state.update_input(1, _frame(state)))
+                self.assertEqual(2, player.input_seq)
+
+    def test_a_missing_sequence_consumes_no_frontier(self):
+        state = _state(players=1)
+        player = self._admit_base_frame(state)
+        before = _mutable_state(player)
+
+        self.assertFalse(state.update_input(
+            1, _drop(state, field='input_seq')))
+
+        self.assertEqual(before, _mutable_state(player))
+        self.assertEqual(1, player.input_processed_seq)
+        self.assertEqual(
+            'sequence_identity', player.last_input_reject['reason'])
+
+    def test_an_exhausted_sequence_space_consumes_no_frontier(self):
+        state = _state(players=1)
+        player = self._admit_base_frame(state)
+        player.input_processed_seq = PROJECTILE_MAX_ID
+        player.input_seq = PROJECTILE_MAX_ID
+        before = _mutable_state(player)
+
+        self.assertFalse(state.update_input(
+            1, _frame(state, input_seq=PROJECTILE_MAX_ID + 1)))
+        self.assertEqual(
+            'sequence_identity', player.last_input_reject['reason'])
+        self.assertFalse(player.last_input_reject['consumed'])
+
+        self.assertFalse(state.update_input(
+            1, _frame(state, input_seq=PROJECTILE_MAX_ID)))
+        self.assertEqual(
+            'sequence_retired', player.last_input_reject['reason'])
+        self.assertFalse(player.last_input_reject['consumed'])
+        self.assertEqual(before, _mutable_state(player))
+        self.assertEqual(PROJECTILE_MAX_ID, player.input_processed_seq)
+
+    def test_future_gap_and_reordered_frames_consume_no_frontier(self):
+        state = _state(players=1)
+        player = self._admit_base_frame(state)
+        before = _mutable_state(player)
+
+        for sequence in (3, 4, 500):
+            with self.subTest(sequence=sequence):
+                self.assertFalse(state.update_input(
+                    1, _frame(state, input_seq=sequence)))
+                self.assertEqual(
+                    'sequence_gap', player.last_input_reject['reason'])
+                self.assertFalse(player.last_input_reject['consumed'])
+                self.assertEqual(1, player.input_processed_seq)
+                self.assertEqual(before, _mutable_state(player))
+
+        # A reordered arrival of an already applied sequence is a retired
+        # identifier, never new state.
+        self.assertTrue(state.update_input(1, _frame(state)))
+        self.assertEqual(2, player.input_processed_seq)
+        applied = _mutable_state(player)
+        self.assertFalse(state.update_input(
+            1, _frame(state, input_seq=1, forward=1.0)))
+        self.assertEqual(
+            'identity_conflict', player.last_input_reject['reason'])
+        self.assertEqual(applied, _mutable_state(player))
+
+    def test_an_exact_rejected_retry_folds_to_the_same_result(self):
+        state = _state(players=1)
+        player = self._admit_base_frame(state)
+        bad = _frame(state, aim_yaw=7.0)
+
+        self.assertFalse(state.update_input(1, bad))
+        after_first = _mutable_state(player)
+        decision = dict(player.input_decisions[2])
+
+        for unused in range(3):
+            self.assertFalse(state.update_input(1, json.loads(
+                json.dumps(bad))))
+            self.assertEqual(after_first, _mutable_state(player))
+            self.assertEqual(2, player.input_processed_seq)
+            self.assertEqual(decision, dict(player.input_decisions[2]))
+            self.assertEqual(
+                'envelope_numeric', player.last_input_reject['reason'])
+            self.assertTrue(player.last_input_reject['consumed'])
+
+    def test_an_exact_applied_retry_folds_without_reapplying(self):
+        state = _state(players=1)
+        player = self._admit_base_frame(state)
+        good = _frame(state, forward=0.25)
+
+        self.assertTrue(state.update_input(1, good))
+        applied = _mutable_state(player)
+
+        self.assertTrue(state.update_input(1, json.loads(json.dumps(good))))
+        self.assertEqual(applied, _mutable_state(player))
+        self.assertEqual(2, player.input_processed_seq)
+
+    def test_a_changed_payload_at_a_terminal_sequence_conflicts(self):
+        state = _state(players=1)
+        player = self._admit_base_frame(state)
+
+        # Changed payload over a rejected decision.
+        self.assertFalse(state.update_input(1, _frame(state, aim_yaw=7.0)))
+        rejected = dict(player.input_decisions[2])
+        before = _mutable_state(player)
+        self.assertFalse(state.update_input(
+            1, _frame(state, input_seq=2, forward=1.0)))
+        self.assertEqual(
+            'identity_conflict', player.last_input_reject['reason'])
+        self.assertFalse(player.last_input_reject['consumed'])
+        self.assertEqual(rejected, dict(player.input_decisions[2]))
+        self.assertEqual(before, _mutable_state(player))
+
+        # Changed payload over an applied decision.
+        self.assertTrue(state.update_input(1, _frame(state, forward=0.5)))
+        applied = dict(player.input_decisions[3])
+        before = _mutable_state(player)
+        self.assertFalse(state.update_input(
+            1, _frame(state, input_seq=3, forward=-1.0)))
+        self.assertEqual(
+            'identity_conflict', player.last_input_reject['reason'])
+        self.assertEqual(applied, dict(player.input_decisions[3]))
+        self.assertEqual(before, _mutable_state(player))
+
+    def test_bounded_eviction_cannot_turn_an_old_frame_into_new_state(self):
+        state = _state(players=1)
+        player = state.players[1]
+        for unused in range(MAX_PLAYER_INPUT_DECISIONS + 4):
+            self.assertTrue(state.update_input(1, _frame(state)))
+        self.assertEqual(
+            MAX_PLAYER_INPUT_DECISIONS, len(player.input_decisions))
+        self.assertNotIn(1, player.input_decisions)
+        before = _mutable_state(player)
+
+        self.assertFalse(state.update_input(
+            1, _frame(state, input_seq=1, forward=1.0)))
+
+        self.assertEqual(
+            'sequence_retired', player.last_input_reject['reason'])
+        self.assertFalse(player.last_input_reject['consumed'])
+        self.assertEqual(before, _mutable_state(player))
+
+    def test_two_players_keep_independent_ordered_ledgers(self):
+        state = _state(players=2)
+        first = state.players[1]
+        second = state.players[2]
+        self.assertTrue(state.update_input(1, _frame(state, 1)))
+        self.assertTrue(state.update_input(2, _frame(state, 2)))
+        second_before = _mutable_state(second)
+
+        self.assertFalse(state.update_input(
+            1, _frame(state, 1, aim_yaw=7.0)))
+
+        self.assertEqual(2, first.input_processed_seq)
+        self.assertEqual(1, first.input_seq)
+        self.assertEqual(1, second.input_processed_seq)
+        self.assertEqual(second_before, _mutable_state(second))
+        self.assertFalse(second.last_input_reject)
+
+        # The unaffected player keeps advancing on its own frontier.
+        self.assertTrue(state.update_input(2, _frame(state, 2, forward=1.0)))
+        self.assertEqual(2, second.input_seq)
+        self.assertEqual(1.0, second.forward)
+
+    def test_an_active_frame_still_contains_bad_contact_rows_per_row(self):
+        state = _state(players=1)
+        player = self._admit_base_frame(state)
+
+        # Established containment: one malformed optional contact row must not
+        # reject the ordered control frame around it.
+        self.assertTrue(state.update_input(1, _frame(
+            state, forward=1.0,
+            ram_contacts=[_player_ram_contact(contact_x=True)],
+            destructible_contacts=[_player_destructible_contact(x=True)])))
+        self.assertEqual(2, player.input_seq)
+        self.assertEqual(2, player.input_processed_seq)
+        self.assertEqual(1.0, player.forward)
+        self.assertIn(1, player.ram_contact_rejections)
+        self.assertIn(1, player.destructible_contact_rejections)
+
+        # An oversized or wrongly typed batch is ignored on an active frame
+        # rather than rejecting the control frame.
+        self.assertTrue(state.update_input(1, _frame(
+            state, turn=0.5,
+            ram_contacts=[_player_ram_contact(seq=value)
+                          for value in range(2, 20)],
+            destructible_contacts='not-a-list')))
+        self.assertEqual(3, player.input_seq)
+        self.assertEqual(0.5, player.turn)
+
+    def test_an_inactive_frame_folds_as_terminal_without_applying_state(self):
+        for condition in ('waiting', 'finished', 'nonparticipating', 'dead'):
+            with self.subTest(condition=condition):
+                state = _state(players=1)
+                player = self._admit_base_frame(state)
+                if condition == 'waiting':
+                    state.phase = 'waiting'
+                elif condition == 'finished':
+                    state.battle_result = {'winner': 1}
+                elif condition == 'nonparticipating':
+                    player.participating = False
+                else:
+                    player.alive = False
+                    player.health = 0
+                before = _mutable_state(player)
+
+                self.assertTrue(state.update_input(1, _frame(
+                    state, forward=1.0, turn=1.0, speed=25.0)))
+
+                self.assertEqual(before, _mutable_state(player))
+                self.assertEqual(2, player.input_processed_seq)
+                self.assertEqual(1, player.input_seq)
+                self.assertEqual(
+                    'inactive', player.input_decisions[2]['outcome'])
+
+                # A frame queued behind it is not stuck behind a gap.
+                self.assertTrue(state.update_input(1, _frame(state)))
+                self.assertEqual(3, player.input_processed_seq)
+
+    def test_an_inactive_frame_with_a_bad_contact_row_is_terminal(self):
+        state = _state(players=1)
+        player = self._admit_base_frame(state)
+        player.alive = False
+        player.health = 0
+        before = _mutable_state(player)
+
+        self.assertFalse(state.update_input(1, _frame(
+            state, ram_contacts=[_player_ram_contact(contact_x=True)])))
+
+        self.assertEqual(before, _mutable_state(player))
+        self.assertEqual(2, player.input_processed_seq)
+        self.assertEqual(
+            'envelope_contacts', player.last_input_reject['reason'])
+        self.assertFalse(player.last_input_reject['active'])
+        self.assertTrue(player.last_input_reject['consumed'])
+
+    def test_the_rejection_log_keeps_the_first_typed_cause(self):
+        state = _state(players=1)
+        self._admit_base_frame(state)
+
+        self.assertFalse(state.update_input(1, _frame(state, aim_yaw=7.0)))
+        first_key, first_line = state.player_input_rejection_log(1)
+
+        self.assertEqual('player-input:1:envelope_numeric', first_key)
+        self.assertIn('reason=envelope_numeric', first_line)
+        self.assertIn('field=aim_yaw', first_line)
+        self.assertIn('seq=2', first_line)
+        self.assertIn('expected=2', first_line)
+        self.assertIn('processed=1', first_line)
+        self.assertIn('applied=1', first_line)
+        self.assertIn('checkpoint=1', first_line)
+
+        # A later ordering rejection uses a different rate-limit key, so the
+        # first causal field is never suppressed by the cascade behind it.
+        self.assertFalse(state.update_input(
+            1, _frame(state, input_seq=99)))
+        gap_key, gap_line = state.player_input_rejection_log(1)
+        self.assertEqual('player-input:1:sequence_gap', gap_key)
+        self.assertNotEqual(first_key, gap_key)
+        self.assertIn('seq=99', gap_line)
+        self.assertIn('expected=3', gap_line)
+
+
+class InputLedgerFireTests(unittest.TestCase):
+    def _armed_state(self):
+        state = _state(players=1)
+        player = state.players[1]
+        self.results = []
+        player.offer_reliable = lambda message: (
+            self.results.append(dict(message)) or True)
+        self.relayed = []
+        state.simulation_worker.offer_reliable = lambda message: (
+            self.relayed.append(dict(message)) or True)
+        self.assertTrue(state.update_input(1, _frame(state)))
+        return state, player
+
+    @staticmethod
+    def _gun_state(player):
+        return (player.fire_seq, player.shell_index,
+                player.next_shell_index, player.shell_change_pending,
+                dict(player.gun_checkpoint), player.gun_checkpoint_seq)
+
+    def test_fire_bound_to_a_rejected_input_has_one_idempotent_terminal(self):
+        state, player = self._armed_state()
+        self.assertFalse(state.update_input(1, _frame(state, aim_yaw=7.0)))
+        gun_before = self._gun_state(player)
+        relayed_before = len(self.relayed)
+
+        intent = _fire_intent(state, intent_seq=1, input_seq=2)
+        self.assertTrue(state.submit_fire_intent(1, intent))
+
+        self.assertEqual(
+            (False, 'gun_checkpoint_unavailable'),
+            player.fire_intent_results[1])
+        self.assertEqual('gun_checkpoint_unavailable',
+                         self.results[-1]['reason'])
+        self.assertIs(False, self.results[-1]['accepted'])
+        # No launch, and no ammunition, reload, dispersion or recoil movement.
+        self.assertEqual(relayed_before, len(self.relayed))
+        self.assertEqual(gun_before, self._gun_state(player))
+        self.assertFalse(player.pending_fire_intents)
+
+        # An exact retry folds to the same terminal without a second result.
+        results_before = len(self.results)
+        self.assertTrue(state.submit_fire_intent(1, json.loads(
+            json.dumps(intent))))
+        self.assertEqual(results_before, len(self.results))
+        self.assertEqual(gun_before, self._gun_state(player))
+
+    def test_fire_bound_to_the_last_valid_input_still_launches(self):
+        state, player = self._armed_state()
+        self.assertFalse(state.update_input(1, _frame(state, aim_yaw=7.0)))
+
+        self.assertTrue(state.submit_fire_intent(
+            1, _fire_intent(state, intent_seq=1, input_seq=1)))
+
+        relay = player.pending_fire_intents[1]
+        self.assertEqual(1, relay['input_seq'])
+        self.assertEqual(1, relay['gun_checkpoint_seq'])
+        self.assertEqual('fire_intent', self.relayed[-1]['type'])
+
+    def test_fire_bound_to_the_first_valid_post_rejection_input_relays(self):
+        state, player = self._armed_state()
+        self.assertFalse(state.update_input(1, _frame(state, aim_yaw=7.0)))
+        self.assertTrue(state.update_input(1, _frame(state)))
+        self.assertEqual(3, player.input_seq)
+        self.assertEqual(3, player.gun_checkpoint_seq)
+
+        self.assertTrue(state.submit_fire_intent(
+            1, _fire_intent(state, intent_seq=1, input_seq=3)))
+
+        relay = player.pending_fire_intents[1]
+        self.assertEqual(3, relay['input_seq'])
+        self.assertEqual(3, relay['gun_checkpoint_seq'])
+        self.assertEqual(
+            _gun_checkpoint(), relay['gun_checkpoint'])
+        self.assertEqual('fire_intent', self.relayed[-1]['type'])
+        self.assertNotIn(1, player.fire_intent_results)
+
+    def test_fire_never_falls_back_to_a_stale_or_future_checkpoint(self):
+        state, player = self._armed_state()
+        self.assertFalse(state.update_input(1, _frame(state, aim_yaw=7.0)))
+        self.assertTrue(state.update_input(1, _frame(state)))
+        gun_before = self._gun_state(player)
+        relayed_before = len(self.relayed)
+
+        # The stale, rejected, future and unknown checkpoints all fail on the
+        # checkpoint identity itself: the last good checkpoint is never
+        # substituted for a different input sequence.
+        for intent_seq, input_seq in ((1, 1), (2, 2), (3, 4), (4, 99)):
+            with self.subTest(input_seq=input_seq):
+                self.assertTrue(state.submit_fire_intent(1, _fire_intent(
+                    state, intent_seq=intent_seq, input_seq=input_seq)))
+                self.assertEqual(
+                    (False, 'gun_checkpoint_unavailable'),
+                    player.fire_intent_results[intent_seq])
+        self.assertEqual(relayed_before, len(self.relayed))
+        self.assertEqual(gun_before, self._gun_state(player))
+
+    def test_a_changed_fire_payload_at_a_used_intent_conflicts(self):
+        state, player = self._armed_state()
+        self.assertFalse(state.update_input(1, _frame(state, aim_yaw=7.0)))
+        intent = _fire_intent(state, intent_seq=1, input_seq=2)
+        self.assertTrue(state.submit_fire_intent(1, intent))
+        gun_before = self._gun_state(player)
+        results_before = len(self.results)
+
+        self.assertFalse(state.submit_fire_intent(1, dict(
+            intent, dispersion_angle=0.05)))
+
+        self.assertEqual(
+            (False, 'gun_checkpoint_unavailable'),
+            player.fire_intent_results[1])
+        self.assertEqual(results_before, len(self.results))
+        self.assertEqual(gun_before, self._gun_state(player))
+
+    def test_a_recovered_frame_still_reaches_a_projectile_terminal(self):
+        state = _state(players=2)
+        player = state.players[1]
+        self.assertTrue(state.update_input(1, _frame(state)))
+        self.assertFalse(state.update_input(1, _frame(state, aim_yaw=7.0)))
+        self.assertEqual((1, 2), (
+            player.input_seq, player.input_processed_seq))
+
+        message = _launch(shooter_id=1, shot_seq=1)
+        self.assertTrue(_launch_authority(state, message))
+
+        # The next legal frame applied, its intent was admitted and relayed,
+        # and the worker's launch became a live authoritative projectile.
+        record = state.projectiles['1:p:1:1']
+        self.assertEqual(3, record['fire_input_seq'])
+        self.assertEqual(1, record['fire_intent_seq'])
+        self.assertEqual(3, player.input_seq)
+        self.assertEqual(1, player.fire_seq)
+        self.assertFalse(player.pending_fire_intents)
+        self.assertEqual(
+            (True, '1:p:1:1'), player.fire_intent_results[1])
+
+    def test_queued_frames_and_fire_intents_keep_their_order(self):
+        state, player = self._armed_state()
+        # Everything the client had already queued before any server response
+        # could reach it, in exact FIFO order.
+        queued = [('input', _frame(state, aim_yaw=7.0))]
+        for index in range(3):
+            queued.append((
+                'input', _frame(state, input_seq=3 + index,
+                                forward=0.1 * (index + 1))))
+        queued.append((
+            'fire', _fire_intent(state, intent_seq=1, input_seq=2)))
+        queued.append((
+            'fire', _fire_intent(state, intent_seq=2, input_seq=5)))
+
+        outcomes = []
+        for kind, message in queued:
+            if kind == 'input':
+                outcomes.append(state.update_input(1, message))
+            else:
+                outcomes.append(state.submit_fire_intent(1, message))
+
+        self.assertEqual([False, True, True, True, True, True], outcomes)
+        self.assertEqual(5, player.input_seq)
+        self.assertEqual(5, player.input_processed_seq)
+        self.assertEqual(0.3, round(player.forward, 6))
+        self.assertEqual(
+            (False, 'gun_checkpoint_unavailable'),
+            player.fire_intent_results[1])
+        self.assertEqual(5, player.pending_fire_intents[2]['input_seq'])
+        self.assertEqual([1, 2], sorted(player.fire_intent_fingerprints))
+
+    def test_the_historical_cascade_recovers_without_a_battle_failure(self):
+        """Model report 124651: one rejection then 36 frames and 20 fires."""
+        state, player = self._armed_state()
+        self.assertFalse(state.update_input(1, _frame(state, aim_yaw=7.0)))
+        rejected_seq = 2
+
+        launched = []
+        for index in range(36):
+            self.assertTrue(state.update_input(1, _frame(
+                state, forward=0.02 * (index + 1))))
+            if index < 20:
+                intent_seq = index + 1
+                accepted = state.submit_fire_intent(1, _fire_intent(
+                    state, intent_seq=intent_seq,
+                    input_seq=player.input_seq))
+                self.assertTrue(accepted)
+                relay = player.pending_fire_intents.get(intent_seq)
+                self.assertIsNotNone(relay)
+                self.assertEqual(player.input_seq, relay['input_seq'])
+                launched.append(relay)
+                # Settle the barrier so the next trigger is not pending.
+                player.pending_fire_intents.pop(intent_seq)
+
+        self.assertEqual(20, len(launched))
+        self.assertEqual(38, player.input_seq)
+        self.assertEqual(38, player.input_processed_seq)
+        self.assertEqual(
+            'rejected',
+            player.input_decisions[rejected_seq]['outcome'])
+        # No global battle failure: the player stayed alive, the round is
+        # still running and the worker kept its authority.
+        self.assertTrue(player.alive)
+        self.assertTrue(player.connected)
+        self.assertIsNone(state.battle_result)
+        self.assertEqual('battle', state.phase)
+        self.assertEqual(
+            SIMULATION_WORKER_AUTHORITY_ID, state.bot_authority_id)
+        # Not one of the twenty triggers produced a terminal rejection.
+        self.assertFalse(player.fire_intent_results)
+
+
+class InputLedgerLifecycleTests(unittest.TestCase):
+    def test_a_new_round_retires_both_frontiers_coherently(self):
+        state = _state(players=1)
+        player = state.players[1]
+        self.assertTrue(state.update_input(1, _frame(state)))
+        self.assertFalse(state.update_input(1, _frame(state, aim_yaw=7.0)))
+        self.assertEqual((1, 2), (
+            player.input_seq, player.input_processed_seq))
+        stale = _frame(state, input_seq=3)
+
+        state._reset_round()
+
+        self.assertEqual((0, 0), (
+            player.input_seq, player.input_processed_seq))
+        self.assertFalse(player.input_decisions)
+        self.assertFalse(player.input_fingerprints)
+        self.assertFalse(player.last_input_reject)
+        self.assertFalse(player.input_reject_counts)
+        # A late old-round frame is a local no-op for the new round.
+        self.assertFalse(state.update_input(1, stale))
+        self.assertEqual((0, 0), (
+            player.input_seq, player.input_processed_seq))
+
+    def test_a_rejection_around_death_does_not_block_the_next_frame(self):
+        state = _state(players=1)
+        player = state.players[1]
+        self.assertTrue(state.update_input(1, _frame(state)))
+        self.assertFalse(state.update_input(1, _frame(state, aim_yaw=7.0)))
+
+        player.alive = False
+        player.health = 0
+        self.assertTrue(state.update_input(1, _frame(state, forward=1.0)))
+        self.assertEqual(3, player.input_processed_seq)
+        self.assertEqual(1, player.input_seq)
+        self.assertEqual(0.0, player.forward)
+
+        player.alive = True
+        player.health = player.max_health
+        self.assertTrue(state.update_input(1, _frame(state, forward=1.0)))
+        self.assertEqual(4, player.input_seq)
+        self.assertEqual(1.0, player.forward)
+
+    def test_a_disconnected_player_consumes_no_frontier(self):
+        state = _state(players=1)
+        player = state.players[1]
+        self.assertTrue(state.update_input(1, _frame(state)))
+        player.connected = False
+        message = _frame(state, aim_yaw=7.0)
+
+        self.assertFalse(state.update_input(1, message))
+        self.assertEqual(1, player.input_processed_seq)
+        self.assertFalse(player.last_input_reject)
+
+        player.connected = True
+        self.assertFalse(state.update_input(1, message))
+        self.assertEqual(2, player.input_processed_seq)
+        self.assertTrue(state.update_input(1, _frame(state)))
+        self.assertEqual(3, player.input_seq)
+
+    def test_a_wrong_round_frame_consumes_no_frontier(self):
+        state = _state(players=1)
+        player = state.players[1]
+        self.assertTrue(state.update_input(1, _frame(state)))
+
+        self.assertFalse(state.update_input(
+            1, _frame(state, round_id=state.round_id + 1, aim_yaw=7.0)))
+
+        self.assertEqual(1, player.input_processed_seq)
+        self.assertFalse(player.last_input_reject)
+
+    def test_a_rejection_does_not_disturb_a_siege_transition(self):
+        state = _state(players=1)
+        player = state.players[1]
+        player.vehicle = 'sweden:S21_UDES_03'
+        player.siege_state = SIEGE_ENABLED
+        self.assertTrue(state.update_input(1, _frame(state)))
+        self.assertTrue(state.update_input(
+            1, _frame(state, siege_enabled=False)))
+        self.assertEqual(SIEGE_SWITCHING_OFF, player.siege_state)
+        siege_before = (player.siege_state, player.siege_transition_ticks)
+
+        self.assertFalse(state.update_input(1, _frame(state, aim_yaw=7.0)))
+
+        self.assertEqual(siege_before, (
+            player.siege_state, player.siege_transition_ticks))
+        self.assertEqual(3, player.input_processed_seq)
+
+    def test_a_landing_observation_never_binds_to_a_rejected_input(self):
+        state = _state(players=1)
+        player = state.players[1]
+        results = []
+        player.offer_reliable = lambda message: (
+            results.append(dict(message)) or True)
+        self.assertTrue(state.update_input(1, _frame(state)))
+        self.assertFalse(state.update_input(1, _frame(state, aim_yaw=7.0)))
+        health_before = player.health
+
+        self.assertFalse(state.submit_landing_observation(1, {
+            'type': 'landing_observation', 'round_id': state.round_id,
+            'authority_epoch': state.authority_epoch,
+            'observation_seq': 1, 'input_seq': 2, 'impact_speed': 20.0,
+        }))
+
+        self.assertEqual('stale_input', results[-1]['reason'])
+        self.assertEqual(health_before, player.health)
+
+        # The applied frame that follows it can carry the observation.
+        self.assertTrue(state.update_input(1, _frame(state)))
+        self.assertTrue(state.submit_landing_observation(1, {
+            'type': 'landing_observation', 'round_id': state.round_id,
+            'authority_epoch': state.authority_epoch,
+            'observation_seq': 1, 'input_seq': 3, 'impact_speed': 20.0,
+        }))
+        self.assertLess(player.health, health_before)
+
+    def test_contacts_after_a_rejection_bind_to_the_applied_input(self):
+        state = _state(players=1)
+        player = state.players[1]
+        state.human_collision_profiles[player.player_id] = {
+            'shape': (1.5, 3.5, -0.8, 2.0),
+            'ram_profile': {
+                'spall_coefficient': 1.0, 'ramming_bonus': 0.0,
+            },
+        }
+        self.assertTrue(state.update_input(1, _frame(state)))
+        self.assertFalse(state.update_input(1, _frame(state, aim_yaw=7.0)))
+
+        self.assertTrue(state.update_input(1, _frame(
+            state, forward=1.0, speed=5.0,
+            destructible_contacts=[_player_destructible_contact()])))
+
+        self.assertEqual(3, player.input_seq)
+        contact = player.destructible_contacts.get(1)
+        if contact is not None:
+            self.assertEqual(3, contact['input_seq'])
+        else:
+            self.assertIn(1, player.destructible_contact_rejections)
+
+    def test_a_rejection_keeps_the_worker_authority_and_the_round(self):
+        state = _state(players=1)
+        player = state.players[1]
+        worker = state.simulation_worker
+        self.assertTrue(state.update_input(1, _frame(state)))
+
+        self.assertFalse(state.update_input(1, _frame(state, aim_yaw=7.0)))
+
+        # A recoverable rejection is contained to that one operation: it never
+        # drops the hidden worker, ends the round or disconnects anyone.
+        self.assertIs(worker, state.simulation_worker)
+        self.assertTrue(worker.connected)
+        self.assertEqual(
+            SIMULATION_WORKER_AUTHORITY_ID, state.bot_authority_id)
+        self.assertIsNone(state.battle_result)
+        self.assertEqual('battle', state.phase)
+        self.assertTrue(player.connected)
+        self.assertEqual(2, player.input_processed_seq)
+
+        self.assertTrue(state.update_input(1, _frame(state, forward=1.0)))
+        self.assertEqual(3, player.input_seq)
+        self.assertEqual(1.0, player.forward)
+
+    def test_recovery_survives_a_worker_authority_epoch_change(self):
+        state = _state(players=1)
+        player = state.players[1]
+        self.assertTrue(state.update_input(1, _frame(state)))
+        self.assertFalse(state.update_input(1, _frame(state, aim_yaw=7.0)))
+
+        # Worker loss and recovery inside the same round bump the authority
+        # epoch; the ordered input ledger is per actor and round, so the next
+        # legal frame still advances on the same frontier.
+        state.authority_epoch += 1
+        _attach_worker_authority(state)
+
+        self.assertTrue(state.update_input(1, _frame(state, forward=1.0)))
+        self.assertEqual(3, player.input_seq)
+        self.assertEqual(3, player.input_processed_seq)
+        self.assertEqual(1.0, player.forward)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/0.9.22/tests/test_port_0922_lan_protocol.py
+++ b/0.9.22/tests/test_port_0922_lan_protocol.py
@@ -15,7 +15,8 @@ sys.path.insert(0, str(ROOT / '0.9.22' / 'server'))
 from gui.mods.offline_lan_0922.lan_client import (
     HUMAN_RAM_TIMELINE_CAPABILITY, LANClient,
     LEAN_SNAPSHOT_MANIFEST_CAPABILITY, MAX_PROJECTILE_ID,
-    _strict_projectile_effect, project_bot_state)
+    _strict_projectile_effect, _valid_player_environment_contract,
+    project_bot_state)
 from gui.mods.offline_lan_0922.authority_worker import (
     AuthorityWorkerLANClient)
 from gui.mods.offline_lan_0922.snapshot_sync import SnapshotSync
@@ -1397,6 +1398,16 @@ class ShippingClientInputContractTests(unittest.TestCase):
 
         self.assertEqual(committed, self.client._input_seq)
 
+    def test_an_exhausted_input_sequence_is_not_queued_or_advanced(self):
+        self.client._input_seq_round = self.client.round_id
+        self.client._input_seq = MAX_PROJECTILE_ID
+        sent = len(self.sent)
+
+        self.assertFalse(self._send())
+
+        self.assertEqual(sent, len(self.sent))
+        self.assertEqual(MAX_PROJECTILE_ID, self.client._input_seq)
+
     def test_the_client_resumes_from_the_server_terminal_frontier(self):
         self.client.round_id = 7
         self.client._input_seq_round = 7
@@ -1412,6 +1423,19 @@ class ShippingClientInputContractTests(unittest.TestCase):
         # A frontier that contradicts the applied sequence is not adopted.
         self.assertFalse(self.client._adopt_player_input_frontier([
             _snapshot_player(input_seq=8, input_processed_seq=6)]))
+
+    def test_snapshot_validation_covers_the_terminal_frontier_relation(self):
+        self.assertTrue(_valid_player_environment_contract(
+            _snapshot_player(input_seq=4), required=True))
+        self.assertTrue(_valid_player_environment_contract(
+            _snapshot_player(input_seq=4, input_processed_seq=6),
+            required=True))
+        self.assertFalse(_valid_player_environment_contract(
+            _snapshot_player(input_seq=4, input_processed_seq=3),
+            required=True))
+        self.assertFalse(_valid_player_environment_contract(
+            _snapshot_player(input_seq=4, input_processed_seq=True),
+            required=True))
 
     def test_the_server_publishes_both_input_frontiers(self):
         self.assertTrue(self._send())
@@ -1498,6 +1522,26 @@ class InputFaultInjectionTests(unittest.TestCase):
                     self.assertTrue(
                         self.state.update_input(1, self._frame()))
                     self.assertEqual(3, self.player.input_seq)
+
+    def test_shell_pair_fault_is_illegal_at_every_valid_shell_index(self):
+        for shell_index in range(10):
+            with self.subTest(shell_index=shell_index):
+                self.setUp()
+                frame = self._frame()
+                frame.update({
+                    'shell_index': shell_index,
+                    'next_shell_index': shell_index,
+                    'shell_change_pending': False,
+                })
+                with mock.patch.dict(
+                        os.environ,
+                        {PLAYER_INPUT_FAULT_ENV: 'shell_pair'}):
+                    self.assertFalse(self.state.update_input(1, frame))
+                self.assertEqual(1, self.player.input_processed_seq)
+                self.assertEqual(0, self.player.input_seq)
+                self.assertEqual(
+                    'shell_selection',
+                    self.player.last_input_reject['reason'])
 
 
 class OrderedEventVocabularyTests(unittest.TestCase):

--- a/0.9.22/tests/test_port_0922_lan_protocol.py
+++ b/0.9.22/tests/test_port_0922_lan_protocol.py
@@ -1,5 +1,6 @@
 import json
 import math
+import os
 import re
 import sys
 from pathlib import Path
@@ -13,14 +14,18 @@ sys.path.insert(0, str(ROOT / '0.9.22' / 'server'))
 
 from gui.mods.offline_lan_0922.lan_client import (
     HUMAN_RAM_TIMELINE_CAPABILITY, LANClient,
-    LEAN_SNAPSHOT_MANIFEST_CAPABILITY, _strict_projectile_effect,
-    project_bot_state)
+    LEAN_SNAPSHOT_MANIFEST_CAPABILITY, MAX_PROJECTILE_ID,
+    _strict_projectile_effect, project_bot_state)
 from gui.mods.offline_lan_0922.authority_worker import (
     AuthorityWorkerLANClient)
 from gui.mods.offline_lan_0922.snapshot_sync import SnapshotSync
 from lan_battle_server import (
     BattleState, CLIENT_BUILD_082, CLIENT_BUILD_0922, Player,
-    _bot_combat_log_message, _server_event_log_message, _server_log)
+    PLAYER_FIRE_INTENT_CAPABILITY, PLAYER_INPUT_FAULT_CLASSES,
+    PLAYER_INPUT_FAULT_ENV, PREBATTLE_SECONDS,
+    RAM_CONTACT_LEDGER_CAPABILITY, TICK_HZ,
+    _bot_combat_log_message, _player_input_fault_class,
+    _server_event_log_message, _server_log)
 from effective_params_fixture import effective_params
 
 
@@ -1232,6 +1237,267 @@ class LanProtocolTests(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+class ShippingClientInputContractTests(unittest.TestCase):
+    """Frames built by the shipping client must satisfy the real validator.
+
+    The launcher always installs the matching client/server pair, so any frame
+    ``LANClient.send_input`` queues has to pass the bundled server's
+    pre-admission validation.  Anything that does not is a contract mismatch
+    that would show up in play as a stream of rejected input.
+    """
+
+    def setUp(self):
+        self.client = LANClient('127.0.0.1', 28782, 'P', 'ussr:MS-1')
+        self.client.ready = True
+        self.client.phase = 'battle'
+        self.client.player_id = 1
+        self.client.host_player_id = 1
+        self.client.bot_authority_id = -1
+        self.client.capabilities = (
+            HUMAN_RAM_TIMELINE_CAPABILITY, PLAYER_FIRE_INTENT_CAPABILITY,
+            RAM_CONTACT_LEDGER_CAPABILITY)
+        self.client.server_capabilities = self.client.capabilities
+        self.sent = []
+        self.client._send = lambda message, **unused: (
+            self.sent.append(message) or True)
+        self.state = BattleState(map_name='04_himmelsdorf')
+        self.state.client_build = CLIENT_BUILD_0922
+        self.state.phase = 'battle'
+        self.state.tick = int(round(PREBATTLE_SECONDS * TICK_HZ))
+        self.player = Player(
+            1, _Socket(), ('127.0.0.1', 1), team=1, slot=0,
+            client_position=True,
+            capabilities=self.client.capabilities,
+            effective_params=effective_params())
+        self.state.players[1] = self.player
+        self.client.round_id = self.state.round_id
+
+    def _checkpoint(self):
+        return {
+            'reload_time': 0.0, 'reload_duration': 5.0,
+            'clip': 1, 'clip_size': 1, 'dispersion': 0.02,
+        }
+
+    def _send(self, **changes):
+        keyword_args = {
+            'position': (0.0, 0.0, 0.0),
+            'yaw': 0.0,
+            'pitch': 0.0,
+            'roll': 0.0,
+            'up_cosine': 1.0,
+            'speed': 0.0,
+            'shell_index': 0,
+            'next_shell_index': 0,
+            'shell_change_pending': False,
+            'gun_checkpoint': self._checkpoint(),
+            'pose_time_us': self.state._logical_motion_time_us(),
+        }
+        keyword_args.update(changes)
+        forward = keyword_args.pop('forward', 0.0)
+        turn = keyword_args.pop('turn', 0.0)
+        aim_yaw = keyword_args.pop('aim_yaw', 0.0)
+        gun_pitch = keyword_args.pop('gun_pitch', 0.0)
+        return self.client.send_input(
+            forward, turn, aim_yaw, gun_pitch, **keyword_args)
+
+    def test_natural_client_frames_are_admitted_by_the_server(self):
+        # Angle wrap boundaries, full control range, both shell states, siege
+        # and contact rows: everything a real driving session produces.
+        cases = (
+            ('origin', {}),
+            ('wrapped_aim', {'aim_yaw': 3.5, 'yaw': 3.5}),
+            ('wrapped_aim_negative', {'aim_yaw': -3.5, 'yaw': -3.5}),
+            ('turret_plus_hull', {'aim_yaw': math.pi + math.pi}),
+            ('many_turns', {'aim_yaw': 40.0 * math.pi + 0.25}),
+            ('pi_seam', {'aim_yaw': math.pi, 'yaw': -math.pi}),
+            ('full_throttle', {'forward': 1.0, 'turn': -1.0, 'speed': 25.0}),
+            ('reverse', {'forward': -1.0, 'turn': 1.0, 'speed': -12.5}),
+            ('steep_hull', {'pitch': 0.6, 'roll': -0.6, 'up_cosine': 0.5}),
+            ('steep_hull_beyond', {'pitch': 1.4, 'roll': -1.4}),
+            ('gun_up', {'gun_pitch': -0.4}),
+            ('gun_down', {'gun_pitch': 0.25}),
+            ('gun_beyond_envelope', {'gun_pitch': -math.pi / 2.0}),
+            ('shell_change', {
+                'shell_index': 0, 'next_shell_index': 2,
+                'shell_change_pending': True}),
+            ('last_shell', {
+                'shell_index': 9, 'next_shell_index': 9,
+                'shell_change_pending': False}),
+            ('siege_on', {'siege_enabled': True}),
+            ('siege_off', {'siege_enabled': False}),
+            ('fire_seq', {'fire_seq': 12}),
+            ('clip_gun', {'gun_checkpoint': {
+                'reload_time': 2.5, 'reload_duration': 5.0,
+                'clip': 3, 'clip_size': 6, 'dispersion': 0.04}}),
+            ('empty_clip', {'gun_checkpoint': {
+                'reload_time': 5.0, 'reload_duration': 5.0,
+                'clip': 0, 'clip_size': 1, 'dispersion': 0.5}}),
+            ('map_corner', {'position': (-999.0, -80.0, 999.0)}),
+            ('ram_rows', {'ram_contacts': [{'seq': value}
+                                           for value in range(1, 20)]}),
+            ('destructible_rows', {
+                'destructible_contacts': [{'seq': value}
+                                          for value in range(1, 20)]}),
+        )
+        for name, changes in cases:
+            with self.subTest(frame=name):
+                self.assertTrue(self._send(**changes))
+                message = self.sent[-1]
+                self.assertEqual(
+                    self.player.input_processed_seq + 1,
+                    message['input_seq'])
+                # The server's own pre-admission validator, not a copy of it.
+                self.assertEqual(
+                    ('', ''),
+                    self.state._player_input_frame_failure(
+                        self.player, message, False)[0])
+                self.assertTrue(self.state.update_input(1, message))
+                self.assertEqual(
+                    message['input_seq'], self.player.input_seq)
+
+    def test_periodic_angles_are_normalized_not_clipped(self):
+        for raw in (3.5, -3.5, 7.0, -7.0, 40.0 * math.pi + 0.25,
+                    math.pi, -math.pi):
+            with self.subTest(aim_yaw=raw):
+                self.assertTrue(self._send(aim_yaw=raw, yaw=raw))
+                message = self.sent[-1]
+                for name in ('aim_yaw', 'yaw'):
+                    value = message[name]
+                    self.assertLessEqual(abs(value), math.pi + 1e-9)
+                    # Mathematically the same orientation, not an endpoint.
+                    difference = (raw - value) / (2.0 * math.pi)
+                    self.assertAlmostEqual(
+                        difference, round(difference), places=9)
+
+    def test_an_out_of_world_pose_is_dropped_without_using_a_sequence(self):
+        self.assertTrue(self._send())
+        self.assertTrue(self.state.update_input(1, self.sent[-1]))
+        committed = self.client._input_seq
+
+        for position in ((3000.0, 0.0, 0.0), (0.0, 2000.0, 0.0),
+                         (0.0, 0.0, -3000.0)):
+            with self.subTest(position=position):
+                self.assertFalse(self._send(position=position))
+                self.assertEqual(committed, self.client._input_seq)
+
+        # The dropped frames consumed no identifier, so the next frame is
+        # still the server's exact next eligible sequence.
+        self.assertTrue(self._send())
+        self.assertEqual(committed + 1, self.client._input_seq)
+        self.assertTrue(self.state.update_input(1, self.sent[-1]))
+        self.assertEqual(committed + 1, self.player.input_seq)
+
+    def test_an_out_of_range_fire_sequence_is_dropped_locally(self):
+        self.assertTrue(self._send())
+        committed = self.client._input_seq
+
+        self.assertFalse(self._send(fire_seq=MAX_PROJECTILE_ID + 1))
+
+        self.assertEqual(committed, self.client._input_seq)
+
+    def test_the_client_resumes_from_the_server_terminal_frontier(self):
+        self.client.round_id = 7
+        self.client._input_seq_round = 7
+        self.client._input_seq = 4
+        self.client._landing_observation_round = 7
+
+        # Applied 4, terminal 6: two later frames reached a terminal decision
+        # the client has not folded yet.
+        self.assertTrue(self.client._adopt_player_input_frontier([
+            _snapshot_player(input_seq=4, input_processed_seq=6)]))
+        self.assertEqual(6, self.client._input_seq)
+
+        # A frontier that contradicts the applied sequence is not adopted.
+        self.assertFalse(self.client._adopt_player_input_frontier([
+            _snapshot_player(input_seq=8, input_processed_seq=6)]))
+
+    def test_the_server_publishes_both_input_frontiers(self):
+        self.assertTrue(self._send())
+        self.assertTrue(self.state.update_input(1, self.sent[-1]))
+        self.assertFalse(self.state.update_input(1, dict(
+            self.sent[-1], input_seq=2, health=0)))
+
+        public = self.state._public_player(self.player)
+
+        self.assertEqual(1, public['input_seq'])
+        self.assertEqual(2, public['input_processed_seq'])
+
+
+class InputFaultInjectionTests(unittest.TestCase):
+    """The Windows acceptance hook must use the production validator."""
+
+    def setUp(self):
+        self.state = BattleState(map_name='04_himmelsdorf')
+        self.state.client_build = CLIENT_BUILD_0922
+        self.state.phase = 'battle'
+        self.state.tick = int(round(PREBATTLE_SECONDS * TICK_HZ))
+        self.player = Player(
+            1, _Socket(), ('127.0.0.1', 1), team=1, slot=0,
+            client_position=True,
+            capabilities=(
+                HUMAN_RAM_TIMELINE_CAPABILITY, PLAYER_FIRE_INTENT_CAPABILITY,
+                RAM_CONTACT_LEDGER_CAPABILITY),
+            effective_params=effective_params())
+        self.state.players[1] = self.player
+
+    def _frame(self):
+        player = self.player
+        return {
+            'type': 'input', 'round_id': self.state.round_id,
+            'input_seq': player.input_processed_seq + 1,
+            'pose_time_us': self.state._logical_motion_time_us(),
+            'forward': 0.0, 'turn': 0.0, 'speed': 0.0,
+            'aim_yaw': 0.0, 'gun_pitch': 0.0,
+            'x': player.x, 'y': player.y, 'z': player.z,
+            'yaw': player.yaw, 'pitch': 0.0, 'roll': 0.0,
+            'fire_seq': 0, 'shell_index': 0, 'next_shell_index': 0,
+            'shell_change_pending': False,
+            'gun_checkpoint': {
+                'reload_time': 0.0, 'reload_duration': 5.0,
+                'clip': 1, 'clip_size': 1, 'dispersion': 0.02,
+            },
+        }
+
+    def test_the_hook_is_inert_unless_a_class_is_armed(self):
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop(PLAYER_INPUT_FAULT_ENV, None)
+            self.assertEqual('', _player_input_fault_class())
+            self.assertTrue(self.state.update_input(1, self._frame()))
+            self.assertEqual(1, self.player.input_seq)
+
+    def test_an_unknown_class_is_ignored(self):
+        with mock.patch.dict(
+                os.environ, {PLAYER_INPUT_FAULT_ENV: 'not_a_class'}):
+            self.assertEqual('', _player_input_fault_class())
+            self.assertTrue(self.state.update_input(1, self._frame()))
+
+    def test_one_armed_class_breaks_exactly_one_frame_per_round(self):
+        for fault_class in sorted(PLAYER_INPUT_FAULT_CLASSES):
+            with self.subTest(fault=fault_class):
+                self.setUp()
+                self.assertTrue(self.state.update_input(1, self._frame()))
+                with mock.patch.dict(
+                        os.environ,
+                        {PLAYER_INPUT_FAULT_ENV: fault_class}):
+                    self.assertFalse(
+                        self.state.update_input(1, self._frame()))
+                    # It fails production validation, so the terminal frontier
+                    # advances and nothing was applied.
+                    self.assertEqual(2, self.player.input_processed_seq)
+                    self.assertEqual(1, self.player.input_seq)
+                    self.assertEqual(
+                        'rejected',
+                        self.player.input_decisions[2]['outcome'])
+                    self.assertTrue(
+                        self.player.last_input_reject['consumed'])
+
+                    # Exactly one frame per round: the next one applies even
+                    # while the hook stays armed.
+                    self.assertTrue(
+                        self.state.update_input(1, self._frame()))
+                    self.assertEqual(3, self.player.input_seq)
 
 
 class OrderedEventVocabularyTests(unittest.TestCase):

--- a/0.9.22/tests/test_port_0922_server_projectiles.py
+++ b/0.9.22/tests/test_port_0922_server_projectiles.py
@@ -92,7 +92,7 @@ def _update_player_input(state, player_id, **changes):
     player = state.players[player_id]
     message = {
         'type': 'input', 'round_id': state.round_id,
-        'input_seq': player.input_seq + 1,
+        'input_seq': player.input_processed_seq + 1,
         'pose_time_us': state._logical_motion_time_us(),
         'forward': 0.0, 'turn': 0.0, 'speed': 0.0,
         'aim_yaw': player.aim_yaw, 'gun_pitch': player.gun_pitch,
@@ -174,7 +174,7 @@ def _launch_authority(state, message, before_launch=None):
     if 'fire_intent_seq' not in message:
         player_id = int(message['shooter_id'])
         player = state.players[player_id]
-        input_seq = player.input_seq + 1
+        input_seq = player.input_processed_seq + 1
         self_time = state._logical_motion_time_us()
         if not state.update_input(player_id, {
                 'type': 'input', 'round_id': state.round_id,
@@ -491,19 +491,25 @@ class ServerProjectileLedgerTests(unittest.TestCase):
     def test_modern_input_whitelist_rejects_before_state_advances(self):
         state = _state(players=1)
         player = state.players[1]
-        base = {
-            'type': 'input', 'round_id': state.round_id,
-            'input_seq': 1,
-            'pose_time_us': state._logical_motion_time_us(),
-            'forward': 0.75, 'turn': -0.25, 'speed': 0.0,
-            'aim_yaw': 0.2, 'gun_pitch': 0.05,
-            'x': player.x, 'y': player.y, 'z': player.z,
-            'yaw': player.yaw, 'pitch': player.pitch,
-            'roll': player.roll, 'fire_seq': 0,
-            'shell_index': 0, 'next_shell_index': 0,
-            'shell_change_pending': False,
-            'gun_checkpoint': _gun_checkpoint(),
-        }
+
+
+        def frame(**changes):
+            message = {
+                'type': 'input', 'round_id': state.round_id,
+                'input_seq': player.input_processed_seq + 1,
+                'pose_time_us': state._logical_motion_time_us(),
+                'forward': 0.75, 'turn': -0.25, 'speed': 0.0,
+                'aim_yaw': 0.2, 'gun_pitch': 0.05,
+                'x': player.x, 'y': player.y, 'z': player.z,
+                'yaw': player.yaw, 'pitch': player.pitch,
+                'roll': player.roll, 'fire_seq': 0,
+                'shell_index': 0, 'next_shell_index': 0,
+                'shell_change_pending': False,
+                'gun_checkpoint': _gun_checkpoint(),
+            }
+            message.update(changes)
+            return json.loads(json.dumps(message))
+
         before = (
             player.input_seq, dict(player.input_fingerprints),
             player.gun_checkpoint_seq, dict(player.gun_checkpoint),
@@ -515,26 +521,34 @@ class ServerProjectileLedgerTests(unittest.TestCase):
             ('reported_health', 0),
             ('automatic_equipment_response', {'equipment_id': 21}),
             ('destructible_verdict', {'destroyed': True}),
+            ('type', 'equipment_intent'),
         )
-        for field, value in forbidden:
+        for index, (field, value) in enumerate(forbidden):
             with self.subTest(field=field):
-                message = json.loads(json.dumps(base))
-                message[field] = value
-                self.assertFalse(state.update_input(1, message))
+                rejected_seq = player.input_processed_seq + 1
+                self.assertFalse(
+                    state.update_input(1, frame(**{field: value})))
+                # No applied state, and no gun checkpoint, from a frame that
+                # never passed the whitelist.
                 self.assertEqual(before, (
                     player.input_seq, dict(player.input_fingerprints),
                     player.gun_checkpoint_seq, dict(player.gun_checkpoint),
                     player.forward, player.turn, player.health, player.alive,
                 ))
+                # The terminal frontier still advances so the next legal frame
+                # is not stuck behind this rejected sequence forever.
+                self.assertEqual(index + 1, player.input_processed_seq)
+                self.assertEqual(
+                    'rejected',
+                    player.input_decisions[rejected_seq]['outcome'])
+                self.assertNotIn(rejected_seq, player.gun_checkpoints)
 
-        wrong_type = json.loads(json.dumps(base))
-        wrong_type['type'] = 'equipment_intent'
-        self.assertFalse(state.update_input(1, wrong_type))
-        self.assertEqual(0, player.input_seq)
-        self.assertTrue(state.update_input(1, base))
-        self.assertEqual((1, 1, 0.75, -0.25), (
+        recovered_seq = player.input_processed_seq + 1
+        self.assertTrue(state.update_input(1, frame()))
+        self.assertEqual((recovered_seq, recovered_seq, 0.75, -0.25), (
             player.input_seq, player.gun_checkpoint_seq,
             player.forward, player.turn))
+        self.assertEqual(recovered_seq, player.input_processed_seq)
 
     def test_modern_input_folds_inactive_player_frame_as_noop(self):
         for condition in ('waiting', 'loading', 'finished',


### PR DESCRIPTION
Fixes the ordered player-input protocol defect behind report
`20260902-124651` (official `0.6.2`, `github-33503345197-1`, third round,
`83_kharkiv`, player id 2): after the last accepted shot at input sequence
`16825`, the server logged 36 `PLAYER INPUT rejected` lines over three minutes
and all 20 fire intents `28`-`47` terminated as `gun_checkpoint_unavailable`,
while the player stayed alive at 1800 health until they left.

Diagnosed read-only on `main` `3b6a287`. The server log records only a generic
rejection, so the first bad field in that historical session stays unknown —
nothing here claims it was a particular angle, shell field or checkpoint.

## The defect

One transport-visible sequence was simultaneously the receipt, validation,
applied-control, pose and gun-checkpoint frontier, with no terminal
representation for a rejected expected frame:

- `LANClient.send_input()` commits `_input_seq` after the frame reaches the
  reliable FIFO, so the client advances to `N+1`;
- `BattleState.update_input()` could reject that frame during pre-admission
  validation and leave the server at `N`;
- `_admit_player_input()` requires exactly `player.input_seq + 1`, so the
  legal `N+2` was a gap, and so was every frame after it;
- `submit_fire_intent()` found no admitted checkpoint for those sequences and
  returned `gun_checkpoint_unavailable` for the rest of the round.

Reproducible at the baseline without a Windows client: `aim_yaw=7.0` is
accepted and queued by `send_input()` but rejected by
`_modern_input_envelope_valid()`, which limits it to `[-2*pi, 2*pi]`.

## The protocol model

Three concepts are now explicit:

- **`input_processed_seq`** — the contiguous frontier of frames that reached an
  idempotent terminal decision, applied or not.
- **`input_seq`** — unchanged meaning: the last *applied* frame. Every consumer
  was audited and still binds to it (fire checkpoint identity, pose samples,
  ram/destructible `input_seq` stamps, landing-observation `known_input`,
  worker environment rows, snapshot).
- **`input_decisions`** — bounded per-sequence record of a SHA-1 digest of the
  raw wire payload plus the typed outcome (`applied` / `inactive` /
  `rejected`) and reason.

`update_input()` reaches exactly one decision per sequence:

| arrival | result |
| --- | --- |
| valid envelope at `processed + 1` | terminal/applied identity is reserved, then prevalidated gameplay fields are projected; both frontiers advance |
| recoverable failure at `processed + 1` | rejected record; **only** the processed frontier advances; nothing applied, no checkpoint |
| exact retry of a terminal sequence | folds to the same typed result, no mutation |
| changed payload at a terminal sequence | `identity_conflict`, consumes nothing |
| `> processed + 1` | `sequence_gap`, consumes nothing |
| `<= processed` and evicted | `sequence_retired`, consumes nothing |
| unusable/missing/oversized sequence, wrong round, wrong actor | consumes nothing |

An inactive frame (death, leave, battle result, non-participating) still folds
without applying state, but now advances the processed frontier so the frames
already queued behind it are not stuck. Both frontiers retire together in
`_reset_round()`.

Recoverable classes: field whitelist/required-field, shell pair shape, shell
selection, gun-checkpoint missing/shape/context, `up_cosine`, every numeric and
integer envelope field, siege shape, and — on an inactive frame — contact
subrecords. Active frames keep the per-row contact containment from `57707e5`.

## Follow-up review fixes

The direct review found and fixed five edge cases on top of the original ledger:

- a rejected decision now retains its original offending field and lifecycle
  state for exact retries;
- wrong-round and disconnected early returns replace stale diagnostics without
  consuming an ordered identity;
- the `shell_pair` acceptance hook now injects the always-illegal shell index 10,
  including when the live shell is index 9;
- local sequence exhaustion fails before queueing or advancing;
- inbound snapshots reject `input_processed_seq < input_seq`.

All client-controlled validation failures still return before gameplay mutation.
The applied decision is reserved before projecting already validated fields so an
unexpected internal handler fault cannot recreate a permanent sequence gap; this
is fault containment, not a general rollback transaction for arbitrary internal
exceptions.

## Fire, ammunition and reload

A rejected frame never creates or reuses a gun checkpoint, so a fire intent
bound to it gets one idempotent `gun_checkpoint_unavailable` terminal with
ammunition, loaded/next shell, reload, dispersion and recoil untouched and no
worker relay. A fire bound to the last valid pre-rejection input still
launches; after the next valid frame applies, a fire bound to its exact
checkpoint is admitted, relayed and becomes a live projectile. Stale, future,
duplicate and changed checkpoints all fail on checkpoint identity — the last
good checkpoint is never substituted.

## Client contract alignment

Every field `send_input()` emits was audited against every server-side
pre-admission check. Fixed mismatches:

- `aim_yaw` and vehicle `yaw`: normalized to `[-pi, pi]`. Periodic, so this is
  mathematically equivalent — not a clip. `align_aim` sums hull plus turret
  yaw, and `stop_tracking` echoes an accumulated native angle, so the sum could
  leave the accepted period.
- `gun_pitch`: bounded by the wire envelope (`+/-1.2` rad). The `_track` path
  computes `-atan2(dy, horizontal)`, which reaches `+/-pi/2`. `VehicleGunRotator`
  still owns the exact per-vehicle descriptor limits, which are far inside
  `1.2` rad, so no reachable angle is altered.
- position and `fire_seq`: validated against the server envelope and the frame
  is dropped locally if out of contract. `send_input()` commits `_input_seq`
  only after the frame is queued, so a dropped frame consumes no identifier.
  Clamping a world pose would have reported a position the vehicle is not in.
- `speed`, `pitch`, `roll`, ram/destructible row limits: already aligned, now
  expressed as named mirrors of the server contract instead of literals.

`_public_player` publishes `input_processed_seq` and
`_adopt_player_input_frontier` resumes from it, so a reconnecting client never
retries an identifier whose decision is already terminal. Snapshot validation now
requires the optional processed frontier to be in range and not behind the applied
frontier. The client also refuses to queue `MAX_PROJECTILE_ID + 1`, leaving both
local and server frontiers unchanged until the next round resets them. No protocol
version bump: the field is additive, the launcher always installs the matching
pair, and the client reads it optionally.

## Diagnostics

`PLAYER INPUT rejected sender=<id>` becomes a typed first cause with reason,
offending field, submitted/expected/processed/applied/checkpoint sequences,
lifecycle state and a repeat count, rate limited per player **and reason** so
the first causal line survives a later cascade of ordering rejections. No
payload dump, no position stream, bounded reason table. Exact retries of a
rejected frame retain the original field and lifecycle state. Wrong-round and
disconnected early rejections refresh this typed record instead of reusing a stale
same-round cause.

The client's `FIRE INTENT rejected` line is rate limited per round and reason,
so twenty repeats of one cause no longer read as twenty root causes.

## Windows acceptance hook

`WOT_0922_INPUT_FAULT=<class>` breaks exactly one frame per round per player by
rewriting one field, which then fails the **production** pre-admission
validator — nothing bypasses validation, and the hook is inert unless armed.
Classes: `aim_yaw`, `gun_pitch`, `vehicle_yaw`, `position`, `up_cosine`,
`pose_clock`, `fire_seq`, `shell_pair`, `gun_checkpoint`, `siege_state`,
`extra_field`, `missing_field`. Documented in `0.9.22/CLAUDE.md`.

## Tests

Final-tree validation after the follow-up fixes:

- `python3 -m unittest discover -s 0.9.22/tests` — 3056 tests, OK;
- focused input-ledger and LAN-protocol suites — 99 tests, OK;
- `python3 -m unittest discover -s tests` in `0.8.2` — 904 tests, OK;
- CPython 2.7 compilation of the changed client sources — OK;
- `git diff --check` — clean.

The existing packaging work on this branch remains unchanged. A final Windows
launcher artifact and its bundled server still require the x64 packaging workflow.

## Not proved

Static tests prove the ledger, ordering and fire logic. They cannot prove the
values and timing the exact BigWorld client emits. Acceptance still needs the
#1513 Windows client with a matching packaged server and worker:

1. arm one fault class, drive, inject the single failure and keep steering —
   later input must change authoritative movement without rejoining;
2. fire on the rejected frame — one explicit local terminal, ammo/reload
   unchanged;
3. send a valid next frame and fire again — server admission, worker launch,
   projectile terminal, feedback, correct ammo/reload;
4. repeat with later frames already queued to exercise the real FIFO race;
5. repeat across death and a round transition;
6. separately drive and aim through natural angle-wrap boundaries and exercise
   all shell/siege/contact fields, confirming no steady stream of rejections;
7. capture coherent launcher, server, `python.log` and worker logs — the first
   typed rejection must be visible without a cascade flood.

The pre-existing untracked `0.9.22/rust_server/` tree is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

