### PR TITLE
Keep bot hull momentum through low-FPS catch-up slices

### DIFF
--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -8874,6 +8874,11 @@ class BotRuntime(object):
                 # beyond that escape edge must not veto clear space at the rear.
                 maximum_probe_distance = reactive_horizon
             cached_motion_probe = self._motion_probe_cache.get(state['id'])
+            # A frozen pose keeps this slice's realised translation at zero
+            # without claiming that the corridor is blocked, so it must not
+            # arm the failed-yaw, blocked-step or contact escalations that
+            # ``path_clear`` owns.
+            pose_frozen = False
             settled_motion = bool(
                 abs(throttle) <= 0.01 and abs(turn) <= 0.01 and
                 abs(_number(state.get('speed'))) <= 0.02 and
@@ -8906,10 +8911,17 @@ class BotRuntime(object):
                 # turn a missing/deferred/blocked sample into motion. A valid
                 # command which merely consumed or turned beyond its old clear
                 # corridor re-probes below without re-entering the planner.
+                # Withhold drive and freeze the pose, but do not delete the
+                # hull's momentum: a slice that cannot prove its corridor has
+                # not proved that a forty-tonne tank stopped. Zeroing the speed
+                # made every catch-up slice of a slow callback restart
+                # acceleration from standstill, which is the visible
+                # walk-stop-walk motion at low worker frame rates. Copied
+                # physics still decelerates below because throttle is zero.
                 motion_probe = None
                 throttle = 0.0
                 turn = 0.0
-                state['speed'] = 0.0
+                pose_frozen = True
             elif not motion_probe_reusable:
                 # Planner ranking is intentionally unable to satisfy this
                 # gate.  Every newly selected travel corridor receives its own
@@ -9017,12 +9029,19 @@ class BotRuntime(object):
                                 now, state['id'],
                                 cached_motion_probe is None)),
                     }
-                else:
+                elif not (isinstance(motion_probe, dict) and
+                          motion_probe.get('deferred', False)):
                     old_result = ((cached_motion_probe or {}).get(
                         'result') or {})
                     if not isinstance(old_result.get(
                             'world_receipt'), dict):
                         self._motion_probe_cache.pop(state['id'], None)
+                # A deferred sample only means the shared soft-static recast
+                # budget was exhausted this callback. ``_motion_probe_reusable``
+                # already documents that a deferral proves neither a wall nor a
+                # soft path, so the still-geometrically-valid cached corridor is
+                # kept and its own containment test decides the next slice.
+                # Evicting it turned a budget shortage into a catch-up hold.
             else:
                 motion_probe = cached_motion_probe['result']
             probe_deferred = bool(
@@ -9155,8 +9174,12 @@ class BotRuntime(object):
                 contact_speed = _number(state.get(
                     'destructible_contact_speed'), speed)
                 contact_v0 = speed
-                if (path_clear and abs(speed) > 0.0001 and
+                if (path_clear and not pose_frozen and
+                        abs(speed) > 0.0001 and
                         callable(self.motion_resolver)):
+                    # A frozen catch-up slice realises no translation, so the
+                    # exact resolver must not sweep (and possibly crush) along
+                    # a corridor the hull is not travelling this slice.
                     resolved_motion = True
                     if self._probe_clock is None:
                         motion_status = self.motion_resolver(
@@ -9225,7 +9248,7 @@ class BotRuntime(object):
                         state['speed'] = speed
                 if contact_deflected:
                     state['x'], state['y'], state['z'] = contact_position
-                elif path_clear:
+                elif path_clear and not pose_frozen:
                     state['x'] += math.sin(state['yaw']) * speed * step
                     state['z'] += math.cos(state['yaw']) * speed * step
                     if abs(speed) > 0.0001:

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -8893,6 +8893,15 @@ class BotRuntime(object):
                     ignore_deadline=not refresh_control))
             cached_motion_result = (
                 (cached_motion_probe or {}).get('result') or {})
+            cached_motion_geometry_reusable = bool(
+                isinstance(cached_motion_result, dict) and
+                self._probe_is_clear(cached_motion_result) and
+                self._motion_probe_covers_distance(
+                    cached_motion_probe, maximum_probe_distance) and
+                self._motion_probe_reusable(
+                    cached_motion_probe, position, travel_yaw,
+                    state.get('speed', 0.0), now, settled_motion, step,
+                    ignore_deadline=True))
             catchup_motion_reprobe = bool(
                 not refresh_control and not motion_probe_reusable and
                 isinstance(cached_motion_probe, dict) and
@@ -9002,9 +9011,10 @@ class BotRuntime(object):
                             })
                         elif isinstance(receipt, dict):
                             motion_probe['world_receipt'] = receipt
-                if (motion_probe is not None and
-                        not (isinstance(motion_probe, dict) and
-                             motion_probe.get('deferred', False))):
+                probe_was_deferred = bool(
+                    isinstance(motion_probe, dict) and
+                    motion_probe.get('deferred', False))
+                if motion_probe is not None and not probe_was_deferred:
                     receipt_pending = bool(
                         isinstance(motion_probe, dict) and
                         motion_probe.get('_world_receipt_pending', False))
@@ -9029,19 +9039,36 @@ class BotRuntime(object):
                                 now, state['id'],
                                 cached_motion_probe is None)),
                     }
-                elif not (isinstance(motion_probe, dict) and
-                          motion_probe.get('deferred', False)):
+                elif probe_was_deferred:
+                    if cached_motion_geometry_reusable:
+                        # The expired proof still contains this exact motion
+                        # ray. Use it for this callback while the fair recast
+                        # budget catches up on a later refresh.
+                        motion_probe = cached_motion_result
+                    else:
+                        # A proof for another pose, heading or shorter target
+                        # cannot license the newly selected corridor. Retiring
+                        # it makes the remaining catch-up slices hold without
+                        # repeating the same deferred native probe.
+                        self._motion_probe_cache.pop(state['id'], None)
+                        if cached_motion_probe is not None:
+                            # Preserve the established no-cache behaviour: an
+                            # exact resolver may still admit this first slice.
+                            # Only the stale proof introduced by this change
+                            # must not grant motion in its unrelated corridor.
+                            throttle = 0.0
+                            turn = 0.0
+                            pose_frozen = True
+                else:
                     old_result = ((cached_motion_probe or {}).get(
                         'result') or {})
                     if not isinstance(old_result.get(
                             'world_receipt'), dict):
                         self._motion_probe_cache.pop(state['id'], None)
                 # A deferred sample only means the shared soft-static recast
-                # budget was exhausted this callback. ``_motion_probe_reusable``
-                # already documents that a deferral proves neither a wall nor a
-                # soft path, so the still-geometrically-valid cached corridor is
-                # kept and its own containment test decides the next slice.
-                # Evicting it turned a budget shortage into a catch-up hold.
+                # budget was exhausted this callback. It proves neither a wall
+                # nor a new clear corridor, so only an old clear proof which
+                # still geometrically contains the requested motion may remain.
             else:
                 motion_probe = cached_motion_probe['result']
             probe_deferred = bool(

--- a/0.9.22/tests/test_port_0922_bot_runtime.py
+++ b/0.9.22/tests/test_port_0922_bot_runtime.py
@@ -5176,6 +5176,63 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertEqual(
             proved['result'], runtime._motion_probe_cache[11]['result'])
 
+    def test_deferred_new_heading_drops_stale_cache_and_freezes_pose(self):
+        """A proof for another heading cannot authorize catch-up motion."""
+        command = self._stationary_command()
+        command.update({
+            'target_yaw': math.pi / 2.0,
+            'throttle': 1.0,
+            'combat_mode': 'route',
+            'move_position': (100.0, 0.0, 0.0),
+            'recovery_mode': 'drive',
+            'movement_intent': True,
+        })
+        direction_calls = []
+        motion_calls = []
+        runtime = self.module.BotRuntime(
+            1, descriptor_resolver=lambda unused: _combat_descriptor(),
+            adapter_factory=lambda *unused, **kwargs: _FixedAdapter(command),
+            direction_probe=lambda *unused: direction_calls.append(1) or {
+                'clear': True, 'collision': False, 'slope': 0.0,
+                'deferred': True},
+            motion_resolver=lambda *unused: motion_calls.append(1) or 'clear',
+            ground_probe=lambda *unused: 0.0,
+            physics_ground_probe=lambda *unused: 0.0,
+            spawn_resolver=_spawn_resolver, baked_graph=_graph(),
+            control_seconds=self.module.WORKER_CONTROL_SECONDS)
+        runtime.battle_start(self.start)
+        runtime.navigator = None
+        state = runtime.states[11]
+        state.update(x=0.0, y=0.0, z=0.0, yaw=math.pi / 2.0,
+                     speed=8.0, grounded_once=True)
+        runtime._motion_probe_cache[11] = {
+            'result': {
+                'clear': True, 'collision': False, 'slope': 0.0},
+            'position': (0.0, 0.0, 0.0),
+            'yaw': 0.0,
+            'maximum_distance': None,
+            'probe_distance': 20.0,
+            'probe_leading': 3.5,
+            'deadline': 999.0,
+        }
+        original_decision_seconds = self.module.DECISION_SECONDS
+        original_pose_safe = self.module.prebaked_navigation.pose_is_safe
+        self.module.DECISION_SECONDS = 2.0
+        self.module.prebaked_navigation.pose_is_safe = (
+            lambda *unused, **unused_kwargs: True)
+        try:
+            runtime.update(1.0, 1.0)
+        finally:
+            self.module.DECISION_SECONDS = original_decision_seconds
+            self.module.prebaked_navigation.pose_is_safe = original_pose_safe
+
+        self.assertEqual(2, len(direction_calls))
+        self.assertEqual([], motion_calls)
+        self.assertEqual((0.0, 0.0), (state['x'], state['z']))
+        self.assertEqual(0, state['movement_dir'])
+        self.assertLess(state['speed'], 8.0)
+        self.assertNotIn(11, runtime._motion_probe_cache)
+
     def test_low_fps_catchup_keeps_hull_momentum(self):
         """A slow callback must not restart acceleration from standstill.
 

--- a/0.9.22/tests/test_port_0922_bot_runtime.py
+++ b/0.9.22/tests/test_port_0922_bot_runtime.py
@@ -5091,6 +5091,128 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertAlmostEqual(0.0, runtime._accumulator)
         self.assertEqual(1, len(adapter.calls))
 
+    def _drive_runtime(self, direction_probe):
+        """One driving Bot whose only variable is the direction probe."""
+        command = self._stationary_command()
+        command.update({
+            'throttle': 1.0, 'combat_mode': 'route',
+            'move_position': (0.0, 0.0, 400.0),
+            'recovery_mode': 'drive', 'movement_intent': True,
+        })
+        runtime = self.module.BotRuntime(
+            1, descriptor_resolver=lambda unused: _combat_descriptor(),
+            adapter_factory=lambda *unused, **kwargs: _FixedAdapter(command),
+            direction_probe=direction_probe,
+            ground_probe=lambda *unused: 0.0,
+            physics_ground_probe=lambda *unused: 0.0,
+            spawn_resolver=_spawn_resolver, baked_graph=_graph(),
+            control_seconds=self.module.WORKER_CONTROL_SECONDS)
+        runtime.battle_start(self.start)
+        runtime.navigator = None
+        runtime.states[11].update(
+            x=0.0, y=0.0, z=0.0, yaw=0.0, speed=8.0, grounded_once=True)
+        return runtime
+
+    @staticmethod
+    def _recast_budget_probe(budget=4):
+        """Model the shared per-callback soft-static recast budget.
+
+        Production resets ``BOT_SOFT_RECAST_BUDGET`` once per render callback
+        and every direction probe that must recast past a proved-crushable OBB
+        consumes one token. Exhaustion returns a ``deferred`` sample, which
+        proves neither a wall nor a clear path.
+        """
+        tokens = [budget]
+
+        def probe(*unused):
+            sample = {'clear': True, 'collision': False, 'slope': 0.0}
+            if tokens[0] <= 0:
+                sample['deferred'] = True
+            else:
+                tokens[0] -= 1
+            return sample
+        probe.reset = lambda: tokens.__setitem__(0, budget)
+        return probe
+
+    def _drive_distance(self, frames, dt, probe):
+        runtime = self._drive_runtime(probe)
+        state = runtime.states[11]
+        original_decision_seconds = self.module.DECISION_SECONDS
+        original_pose_safe = self.module.prebaked_navigation.pose_is_safe
+        self.module.DECISION_SECONDS = 2.0
+        self.module.prebaked_navigation.pose_is_safe = (
+            lambda *unused, **unused_kwargs: True)
+        try:
+            for frame in range(frames):
+                probe.reset()
+                runtime.update(dt, 1.0 + (frame + 1) * dt)
+        finally:
+            self.module.DECISION_SECONDS = original_decision_seconds
+            self.module.prebaked_navigation.pose_is_safe = original_pose_safe
+        return state['z'], state
+
+    def test_deferred_probe_keeps_the_proved_corridor(self):
+        """A budget deferral is not evidence of a wall, so the cache stays."""
+        probe = self._recast_budget_probe()
+        runtime = self._drive_runtime(probe)
+        original_decision_seconds = self.module.DECISION_SECONDS
+        original_pose_safe = self.module.prebaked_navigation.pose_is_safe
+        self.module.DECISION_SECONDS = 2.0
+        self.module.prebaked_navigation.pose_is_safe = (
+            lambda *unused, **unused_kwargs: True)
+        try:
+            runtime.update(0.1, 1.1)
+            self.assertIn(11, runtime._motion_probe_cache)
+            proved = runtime._motion_probe_cache[11]
+            # Second callback: no tokens at all, so every sample is deferred.
+            probe.reset()
+            for unused in range(4):
+                probe(None)
+            runtime.update(0.1, 1.2)
+        finally:
+            self.module.DECISION_SECONDS = original_decision_seconds
+            self.module.prebaked_navigation.pose_is_safe = original_pose_safe
+        self.assertIn(11, runtime._motion_probe_cache)
+        self.assertEqual(
+            proved['result'], runtime._motion_probe_cache[11]['result'])
+
+    def test_low_fps_catchup_keeps_hull_momentum(self):
+        """A slow callback must not restart acceleration from standstill.
+
+        Both runs simulate the same two seconds against the same command and
+        the same per-callback probe budget; only the callback partitioning
+        differs. One token per callback is the interesting case: the refresh
+        slice spends it and every catch-up slice of the same callback is then
+        deferred. Withholding drive and freezing the pose is correct, but
+        deleting ``state['speed']`` made the low-rate run rebuild its velocity
+        from zero on every callback. Measured over 2.0 s at 10 Hz vs 2 Hz:
+        16.0 m either way when the budget is not exhausted; with one token the
+        2 Hz run travelled 5.5 m and ended at 3.7 m/s before this change and
+        9.2 m ending at 5.4 m/s after it.
+        """
+        fast, unused_fast_state = self._drive_distance(
+            20, 0.1, self._recast_budget_probe(1))
+        slow, slow_state = self._drive_distance(
+            4, 0.5, self._recast_budget_probe(1))
+        self.assertGreater(fast, 15.0)
+        self.assertGreater(slow, fast * 0.5)
+        self.assertGreater(abs(slow_state['speed']), 4.5)
+
+    def test_catchup_without_any_proved_corridor_still_stops(self):
+        """Preserving momentum must not license travel through unknown space.
+
+        With no recast tokens at all no corridor is ever proved, so the hull
+        must withhold drive and come to rest rather than coast on a corridor
+        the worker could not sample.
+        """
+        fast, unused_fast_state = self._drive_distance(
+            20, 0.1, self._recast_budget_probe(4))
+        stalled, stalled_state = self._drive_distance(
+            4, 0.5, self._recast_budget_probe(0))
+        self.assertGreater(fast, 15.0)
+        self.assertLess(stalled, fast * 0.35)
+        self.assertAlmostEqual(0.0, stalled_state['speed'], places=3)
+
     def test_worker_one_hz_holds_one_drive_plan_through_bounded_slices(self):
         command = self._stationary_command()
         command.update({


### PR DESCRIPTION
## Symptom

Peng, from Windows playtesting: *"worker fps 低的情况下还会行动一顿一顿的"* — at low hidden-worker frame rates bot motion becomes visibly stop-and-go.

## Mechanism

A slow worker callback is simulated as bounded catch-up substeps (`bot_runtime.py:8317-8333`, `MAX_CONTROL_ELAPSED_SECONDS = 0.20`). Only the first substep carries `refresh_control`; the rest reuse the cached corridor.

When a substep could neither reuse nor re-prove that corridor, `catchup_motion_hold` fired and executed:

```python
motion_probe = None
throttle = 0.0
turn = 0.0
state['speed'] = 0.0        # bot_runtime.py:8912
```

That last line is not a throttle release — it deletes a moving hull's momentum. The next callback then rebuilt velocity from standstill.

The precondition for that hold is a missing motion-probe cache, and the cache was evicted whenever a fresh sample came back `deferred` (`bot_runtime.py:9020-9025`). A deferral only means the shared `BOT_SOFT_RECAST_BUDGET` ran out for that render callback. `_motion_probe_reusable` already documents (`:4930-4934`) that a deferral "proves neither a wall nor a soft path" — the cache writer contradicted it. Because that budget is per callback rather than per elapsed second, low FPS produces more deferrals, which produce more holds, which stop the bots.

## Change

1. **Freeze the pose instead of deleting the speed.** A `pose_frozen` flag withholds the realised translation for that slice and also skips the exact motion resolver, so nothing is swept or crushed along an unproved corridor. The hull keeps the speed copied physics gives it and decelerates naturally because throttle is zero.
2. **A deferred sample no longer evicts a still-valid cached corridor.** Its own containment test (`_motion_probe_reusable`) decides the next slice.

`path_clear` is deliberately untouched: a frozen slice must not arm `remember_failure`, `report_blocked_step` or the contact escalations, which is why this is a separate flag rather than a `path_clear = False`.

## Evidence

Measured with the real module, 29-bot fixtures, identical adapter command, identical 2.0 s of simulated time, one recast token per callback — only the callback partitioning differs:

| | before | after |
|---|---|---|
| 10 Hz (20 × 0.1 s) | 15.9 m | 15.9 m |
| 2 Hz (4 × 0.5 s) | 5.5 m, ending 3.7 m/s | **9.2 m, ending 5.4 m/s** |
| 2 Hz, budget never exhausted | 15.9 m | 15.9 m |
| 2 Hz, no tokens at all | 2.2 m, ending 0.0 m/s | 3.2 m, **ending 0.0 m/s** |

The last row is the safety property: with no corridor ever proved the hull still comes to rest rather than coasting through unknown space. `test_catchup_without_any_proved_corridor_still_stops` pins it.

## Tests

- `test_deferred_probe_keeps_the_proved_corridor` — new, fails on `main`
- `test_low_fps_catchup_keeps_hull_momentum` — new, fails on `main`
- `test_catchup_without_any_proved_corridor_still_stops` — new guard, passes on both by design

Full `0.9.22` suite: **3014 tests, OK** (`python -m unittest discover -s 0.9.22/tests -p "test_*.py"`, `PYTHONDONTWRITEBYTECODE=1`).

## Not proved here

Evidence layer 1-2 only. The resulting motion feel, native physics response and absence of new jitter on Chinese HD `0.9.22.0.1 #1513` still require acceptance on the exact Windows client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)