### PR TITLE
Bound how long a queued A* search may park a bot

### DIFF
--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
@@ -1150,7 +1150,7 @@ class TerrainNavigator(object):
 		else:
 			self.search_failed += 1
 
-	def _cancel_bot_searches(self, bot_id):
+	def _cancel_bot_searches(self, bot_id, keep_key=None):
 		"""Discard superseded private jobs without touching shared route plans."""
 		bot_id = int(bot_id)
 		for key in list(self.searches):
@@ -1162,7 +1162,7 @@ class TerrainNavigator(object):
 				         int(path_key[1]) == bot_id)
 			except Exception:
 				owned = False
-			if owned:
+			if owned and key != keep_key:
 				self.searches.pop(key, None)
 				self.search_times.pop(key, None)
 
@@ -1288,6 +1288,14 @@ class TerrainNavigator(object):
 		search = self.searches.get(key)
 		if search is None:
 			owner = self._path_owner(path_key)
+			if owner is not None:
+				# Join and continuation keys include the Bot's current cell. A
+				# pending safe-local fallback can therefore move into a new cell
+				# and request a replacement before the old job finishes. Keep only
+				# that Bot's current private request so stale jobs cannot divide the
+				# navigator-wide expansion budget. Shared route searches and other
+				# Bots' work remain independent.
+				self._cancel_bot_searches(owner, keep_key=key)
 			edge_penalties = self._active_bot_edge_penalties(owner, now)
 			penalized_direct = bool(
 				edge_penalties and any(

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
@@ -1269,6 +1269,16 @@ class TerrainNavigator(object):
 
 	def _path(self, path_key, start, goal, now, avoid_points):
 		key = self._cache_key(path_key, goal)
+		owner = self._path_owner(path_key)
+		if owner is not None:
+			# Join and continuation keys include the Bot's current cell. A
+			# pending safe-local fallback can therefore move into a new cell
+			# and request a replacement before the old job finishes. Keep only
+			# that Bot's current private request so stale jobs cannot divide the
+			# navigator-wide expansion budget. Shared route searches and other
+			# Bots' work remain independent. Do this before a cached-path return:
+			# revisiting a cached cell still supersedes a pending job elsewhere.
+			self._cancel_bot_searches(owner, keep_key=key)
 		if key in self.paths:
 			path = self.paths[key]
 			# A probe can fail while distant chunks are still streaming. Successful
@@ -1287,15 +1297,6 @@ class TerrainNavigator(object):
 				self.grid.clear_negative_cache()
 		search = self.searches.get(key)
 		if search is None:
-			owner = self._path_owner(path_key)
-			if owner is not None:
-				# Join and continuation keys include the Bot's current cell. A
-				# pending safe-local fallback can therefore move into a new cell
-				# and request a replacement before the old job finishes. Keep only
-				# that Bot's current private request so stale jobs cannot divide the
-				# navigator-wide expansion budget. Shared route searches and other
-				# Bots' work remain independent.
-				self._cancel_bot_searches(owner, keep_key=key)
 			edge_penalties = self._active_bot_edge_penalties(owner, now)
 			penalized_direct = bool(
 				edge_penalties and any(

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
@@ -24,6 +24,12 @@ BAKED_SHALLOW_WATER_PENALTY = 4.0
 BAKED_EDGE_CLEARANCE_WEIGHT = 0.20
 BAKED_FORMAT_NAME = 'offline-lan-0922-navgraph'
 BAKED_FORMAT_VERSION = 2
+# A bot whose global search is still queued holds briefly so a job that
+# finishes within a frame or two does not produce a pointless creep. Beyond
+# that grace it makes bounded, fully probed progress instead of standing
+# still: the room-wide expansion budget is shared, so "pending" can last
+# many seconds in a full room and an unbounded hold reads as a parked tank.
+PENDING_PROGRESS_SECONDS = 0.6
 BLOCKED_STEP_REPLAN_SECONDS = 1.0
 BLOCKED_STEP_REPLAN_VERDICTS = 4
 BLOCKED_STEP_EDGE_TTL = 12.0
@@ -880,6 +886,14 @@ class TerrainNavigator(object):
 		self.fallback_modes = {}
 
 	def _set_fallback_mode(self, bot_id, mode):
+		if mode is None or mode == 'safe_direct':
+			# A real routed target ends the pending episode. A safe-local or
+			# reactive step taken *while* a search is still queued must not,
+			# or the hold grace would restart after every short step and the
+			# bot would creep instead of driving.
+			state = self.bot_states.get(int(bot_id))
+			if state is not None:
+				state.pop('pending_since', None)
 		old_mode = self.fallback_modes.get(int(bot_id))
 		if old_mode == mode:
 			return
@@ -963,8 +977,20 @@ class TerrainNavigator(object):
 		self._set_fallback_mode(bot_id, 'reactive')
 		return tuple(goal)
 
-	def _pending_target(self, bot_id, current, now, state):
-		"""Continue a proved local edge, otherwise hold without arming recovery."""
+	def _pending_target(self, bot_id, current, goal, now, state,
+			avoid_points=None):
+		"""Continue a proved local edge, else make bounded probed progress.
+
+		Returning the hull's own position is a complete stop: the driver reads it
+		as arrival and the order adapter suppresses steering entirely, so nothing
+		times the wait out and nothing recovers from it. A queued global search is
+		not evidence that standing still is safe, only that the strategic route is
+		not known yet, so after a short grace this returns the same fully probed
+		short waypoint a conclusive search failure would use. Every candidate
+		still needs supported ground, a safe grade, no deep water, no static
+		collision and no remembered failed edge; ``None`` from that search still
+		means the only safe action is to hold.
+		"""
 		last_target = state.get('last_target')
 		if last_target is not None:
 			last_target = tuple(last_target)
@@ -980,6 +1006,21 @@ class TerrainNavigator(object):
 				state['target_is_terminal'] = False
 				self._set_fallback_mode(bot_id, 'pending')
 				return last_target
+		started = state.get('pending_since')
+		if started is None:
+			started = float(now)
+			state['pending_since'] = started
+		if (goal is not None and
+				float(now) - float(started) >= PENDING_PROGRESS_SECONDS):
+			fallback = self.grid.safe_local_target(
+				current, goal, now, avoid_points,
+				1.0 if (int(bot_id) % 2) else -1.0)
+			if fallback is not None:
+				state['last_target'] = tuple(fallback)
+				state['navigation_status'] = 'pending'
+				state['target_is_terminal'] = False
+				self._set_fallback_mode(bot_id, 'safe_local')
+				return tuple(fallback)
 		state['last_target'] = tuple(current)
 		state['navigation_status'] = 'pending'
 		state['target_is_terminal'] = False
@@ -1434,7 +1475,8 @@ class TerrainNavigator(object):
 				state['target_is_terminal'] = True
 				self._set_fallback_mode(bot_id, 'safe_direct')
 				return tuple(goal)
-			return self._pending_target(bot_id, current, now, state)
+			return self._pending_target(
+				bot_id, current, goal, now, state, avoid_points)
 		if not path:
 			if self.grid.dry_segment_clear(current, goal, now):
 				state.pop('controlled_shallow_target', None)
@@ -1479,7 +1521,8 @@ class TerrainNavigator(object):
 			join_key = ('join', bot_id, self.grid.cell_for(current)) + tuple(path_key)
 			key, joined_path = self._path(join_key, current, goal, now, avoid_points)
 			if joined_path is None:
-				return self._pending_target(bot_id, current, now, state)
+				return self._pending_target(
+				bot_id, current, goal, now, state, avoid_points)
 			if not joined_path:
 				# The cached strategic path is unusable from this hull's actual
 				# position and the join search has conclusively failed. Reuse the
@@ -1536,7 +1579,8 @@ class TerrainNavigator(object):
 				self._set_fallback_mode(bot_id, None)
 				return selected
 			if continued is None:
-				return self._pending_target(bot_id, current, now, state)
+				return self._pending_target(
+				bot_id, current, goal, now, state, avoid_points)
 			return self._fallback_target(
 				bot_id, current, goal, now, avoid_points, state, True)
 		selected = tuple(path[lookahead])

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
@@ -1150,7 +1150,7 @@ class TerrainNavigator(object):
 		else:
 			self.search_failed += 1
 
-	def _cancel_bot_searches(self, bot_id, keep_key=None):
+	def _cancel_bot_searches(self, bot_id, keep_key=None, kind=None):
 		"""Discard superseded private jobs without touching shared route plans."""
 		bot_id = int(bot_id)
 		for key in list(self.searches):
@@ -1162,7 +1162,8 @@ class TerrainNavigator(object):
 				         int(path_key[1]) == bot_id)
 			except Exception:
 				owned = False
-			if owned and key != keep_key:
+			if (owned and key != keep_key and
+					(kind is None or path_key[0] == kind)):
 				self.searches.pop(key, None)
 				self.search_times.pop(key, None)
 
@@ -1274,11 +1275,14 @@ class TerrainNavigator(object):
 			# Join and continuation keys include the Bot's current cell. A
 			# pending safe-local fallback can therefore move into a new cell
 			# and request a replacement before the old job finishes. Keep only
-			# that Bot's current private request so stale jobs cannot divide the
-			# navigator-wide expansion budget. Shared route searches and other
-			# Bots' work remain independent. Do this before a cached-path return:
-			# revisiting a cached cell still supersedes a pending job elsewhere.
-			self._cancel_bot_searches(owner, keep_key=key)
+			# that Bot's current request of the same kind so stale jobs cannot
+			# divide the navigator-wide expansion budget. A cached route_join and
+			# its pending child join are separate stages of one live request, so a
+			# different private kind must remain independent. Do this before a
+			# cached-path return: revisiting a cached cell still supersedes a
+			# pending same-kind job elsewhere.
+			self._cancel_bot_searches(
+				owner, keep_key=key, kind=path_key[0])
 		if key in self.paths:
 			path = self.paths[key]
 			# A probe can fail while distant chunks are still streaming. Successful

--- a/0.9.22/tests/test_port_0922_ai.py
+++ b/0.9.22/tests/test_port_0922_ai.py
@@ -848,6 +848,32 @@ class BotAiPortTests(unittest.TestCase):
         self.assertNotIn(stale_key, navigator.search_times)
         self.assertIs(shared_search, navigator.searches[shared_key])
 
+    def test_cached_private_parent_keeps_pending_child_search(self):
+        """One live request may read a route_join while its join is pending."""
+        navigator = TerrainNavigator(
+            lambda *unused: None, baked_graph=self._baked_graph(6, 3))
+        start = (14.0, 0.0, 24.0)
+        goal = (30.0, 0.0, 24.0)
+        parent_path_key = ('route_join', 7, 1, 'lane', 1)
+        child_path_key = (('join', 7, navigator.grid.cell_for(start)) +
+                          parent_path_key)
+        parent_key = navigator._cache_key(parent_path_key, goal)
+        child_key = navigator._cache_key(child_path_key, goal)
+        cached_path = (start, goal)
+        child_search = _PendingSearch()
+        navigator.paths[parent_key] = cached_path
+        navigator.path_times[parent_key] = 1.0
+        navigator.searches[child_key] = child_search
+        navigator.search_times[child_key] = 1.0
+
+        selected_key, selected_path = navigator._path(
+            parent_path_key, start, goal, 2.0, None)
+
+        self.assertEqual(parent_key, selected_key)
+        self.assertEqual(cached_path, selected_path)
+        self.assertIs(child_search, navigator.searches[child_key])
+        self.assertEqual(1.0, navigator.search_times[child_key])
+
     def test_failed_shallow_search_keeps_reactive_local_recovery(self):
         graph = self._baked_graph(3, 1)
         graph['hazards'] = [0, 4, 0]

--- a/0.9.22/tests/test_port_0922_ai.py
+++ b/0.9.22/tests/test_port_0922_ai.py
@@ -746,6 +746,77 @@ class BotAiPortTests(unittest.TestCase):
         navigator._set_fallback_mode(7, None)
         self.assertNotIn('pending_since', state)
 
+    def test_pending_join_replaces_stale_search_after_fallback_moves(self):
+        """Cross-cell progress keeps one private job and its fair share."""
+        navigator = TerrainNavigator(
+            lambda *unused: None, baked_graph=self._baked_graph(20, 3))
+        current = (10.0, 0.0, 24.0)
+        goal = (78.0, 0.0, 24.0)
+        route_key = ('route', 1, 'blocked-join')
+        route_cache_key = navigator._cache_key(route_key, goal)
+        navigator.paths[route_cache_key] = (current, goal)
+        navigator.path_times[route_cache_key] = 1.0
+
+        shared_key = (('route', 2, 'shared-lane'),
+                      navigator.grid.cell_for(goal))
+        shared_search = _PendingSearch()
+        navigator.searches[shared_key] = shared_search
+        navigator.search_times[shared_key] = 1.0
+        created = []
+
+        def begin_plan(*unused_args, **unused_kwargs):
+            search = _PendingSearch()
+            created.append(search)
+            return search
+
+        navigator.grid.begin_plan = begin_plan
+        navigator.grid.dry_segment_clear = lambda *unused: False
+        navigator.grid.segment_clear = lambda *unused: False
+        navigator.grid.safe_local_target = lambda point, *unused: (
+            point[0] + navigator.grid.cell_size + 0.1,
+            point[1], point[2])
+
+        now = 1.0
+        selected = navigator.next_target(
+            7, current, goal, route_key, now)
+        self.assertEqual(current, selected)
+        self.assertEqual(2, len(navigator.searches))
+        self.assertIn(shared_key, navigator.searches)
+        self.assertEqual(1, len(created))
+
+        # The grace expiry supplies one safe local step without replacing the
+        # still-current join. The next request starts from another cell and
+        # must replace that private job instead of adding a third fair-share
+        # participant.
+        frame_share = MAX_SEARCH_EXPANSIONS_PER_CATCH_UP_FRAME // 2
+        now += navigation.PENDING_PROGRESS_SECONDS + 0.01
+        before_shared = shared_search.steps
+        selected = navigator.next_target(7, current, goal, route_key, now)
+        self.assertEqual(frame_share, shared_search.steps - before_shared)
+        first_join = created[0]
+        current = selected
+
+        for unused in range(5):
+            before_shared = shared_search.steps
+            now += navigation.PENDING_PROGRESS_SECONDS + 0.01
+            selected = navigator.next_target(
+                7, current, goal, route_key, now)
+            self.assertEqual(frame_share, shared_search.steps - before_shared)
+            self.assertEqual(2, len(navigator.searches))
+            self.assertIn(shared_key, navigator.searches)
+            owned = [
+                search for key, search in navigator.searches.items()
+                if navigator._path_owner(key[0]) == 7]
+            self.assertEqual(1, len(owned))
+            current = selected
+
+        self.assertEqual(6, len(created))
+        self.assertNotIn(first_join, navigator.searches.values())
+        first_join_steps = first_join.steps
+        now += navigation.PENDING_PROGRESS_SECONDS + 0.01
+        navigator.next_target(7, current, goal, route_key, now)
+        self.assertEqual(first_join_steps, first_join.steps)
+
     def test_failed_shallow_search_keeps_reactive_local_recovery(self):
         graph = self._baked_graph(3, 1)
         graph['hazards'] = [0, 4, 0]

--- a/0.9.22/tests/test_port_0922_ai.py
+++ b/0.9.22/tests/test_port_0922_ai.py
@@ -817,6 +817,37 @@ class BotAiPortTests(unittest.TestCase):
         navigator.next_target(7, current, goal, route_key, now)
         self.assertEqual(first_join_steps, first_join.steps)
 
+    def test_cached_private_path_cancels_superseded_pending_search(self):
+        """A cached current join still retires another cell's private job."""
+        navigator = TerrainNavigator(
+            lambda *unused: None, baked_graph=self._baked_graph(6, 3))
+        start = (14.0, 0.0, 24.0)
+        goal = (30.0, 0.0, 24.0)
+        stale_path_key = ('join', 7, (0, 1), 'route', 1, 'lane')
+        current_path_key = ('join', 7, (1, 1), 'route', 1, 'lane')
+        stale_key = navigator._cache_key(stale_path_key, goal)
+        current_key = navigator._cache_key(current_path_key, goal)
+        shared_key = (('route', 2, 'shared-lane'),
+                      navigator.grid.cell_for(goal))
+        stale_search = _PendingSearch()
+        shared_search = _PendingSearch()
+        navigator.searches[stale_key] = stale_search
+        navigator.searches[shared_key] = shared_search
+        navigator.search_times[stale_key] = 1.0
+        navigator.search_times[shared_key] = 1.0
+        cached_path = (start, goal)
+        navigator.paths[current_key] = cached_path
+        navigator.path_times[current_key] = 1.0
+
+        selected_key, selected_path = navigator._path(
+            current_path_key, start, goal, 2.0, None)
+
+        self.assertEqual(current_key, selected_key)
+        self.assertEqual(cached_path, selected_path)
+        self.assertNotIn(stale_key, navigator.searches)
+        self.assertNotIn(stale_key, navigator.search_times)
+        self.assertIs(shared_search, navigator.searches[shared_key])
+
     def test_failed_shallow_search_keeps_reactive_local_recovery(self):
         graph = self._baked_graph(3, 1)
         graph['hazards'] = [0, 4, 0]

--- a/0.9.22/tests/test_port_0922_ai.py
+++ b/0.9.22/tests/test_port_0922_ai.py
@@ -13,14 +13,16 @@ CLIENT_SCRIPTS = PORT_ROOT / 'src' / 'res' / 'scripts' / 'client'
 sys.path.insert(0, str(PORT_ROOT / 'server'))
 sys.path.insert(0, str(CLIENT_SCRIPTS))
 
-from gui.mods.offline_lan_0922.ai import cover, maps, reviewed_routes_20260811
+from gui.mods.offline_lan_0922.ai import (
+    cover, maps, navigation, reviewed_routes_20260811,
+)
 from gui.mods.offline_lan_0922.ai.adapter import BotAdapter
 from gui.mods.offline_lan_0922.ai.driver import LocalDriver
 from gui.mods.offline_lan_0922.ai.planner import (
     BattleDirector, build_vehicle_profile,
 )
 from gui.mods.offline_lan_0922.ai.navigation import (
-    BAKED_FATAL_HAZARDS, BAKED_SHALLOW_WATER,
+    BAKED_FATAL_HAZARDS, BAKED_SHALLOW_WATER, _distance_2d,
     MAX_SEARCH_EXPANSIONS_PER_CATCH_UP_FRAME,
     MAX_SEARCH_EXPANSIONS_PER_FRAME, SEARCH_EXPANSIONS_PER_SECOND,
     TerrainGrid, TerrainNavigator,
@@ -671,6 +673,78 @@ class BotAiPortTests(unittest.TestCase):
             current, goal, selected, minimum_request_distance=5.0))
         self.assertFalse(navigator.controlled_shallow_step(
             7, current, math.pi * 0.5))
+
+    def _pending_navigator(self):
+        """A navigator whose global search never finishes this frame."""
+        graph = self._baked_graph(9, 3)
+        hazards = [0] * 27
+        for row in range(3):
+            hazards[row * 9 + 5] = BAKED_SHALLOW_WATER
+        graph['hazards'] = hazards
+        navigator = TerrainNavigator(
+            lambda *unused: None, baked_graph=graph)
+        navigator._path = lambda *unused: (('search-result',), None)
+        return navigator
+
+    def test_pending_search_holds_only_for_a_bounded_grace(self):
+        """A queued search must not park the hull for the whole search.
+
+        The room shares one expansion budget, so a pending job can outlive
+        several seconds of real time. Holding briefly avoids a pointless creep
+        when the job finishes in a frame or two; holding forever is a parked
+        tank that the driver reads as arrival and the order adapter refuses to
+        steer at all.
+        """
+        navigator = self._pending_navigator()
+        current = (10.0, 0.0, 24.0)
+        goal = (42.0, 0.0, 24.0)
+        path_key = ('route_join', 7, 1, 'lane', 1)
+
+        held = navigator.next_target(7, current, goal, path_key, 1.0)
+        self.assertEqual(current, held)
+        self.assertEqual('pending', navigator.fallback_modes[7])
+
+        moved = navigator.next_target(
+            7, current, goal, path_key,
+            1.0 + navigation.PENDING_PROGRESS_SECONDS)
+
+        self.assertNotEqual(current, moved)
+        self.assertLess(_distance_2d(moved, goal), _distance_2d(current, goal))
+        self.assertFalse(navigator.grid.segment_has_baked_hazard(
+            current, moved, BAKED_FATAL_HAZARDS | BAKED_SHALLOW_WATER))
+        self.assertTrue(navigator.grid.segment_clear(current, moved))
+        self.assertFalse(TerrainNavigator.navigation_paused(
+            current, goal, moved, minimum_request_distance=5.0))
+
+    def test_pending_search_still_holds_when_no_safe_step_exists(self):
+        """Bounded progress never invents a step the probes did not prove."""
+        navigator = self._pending_navigator()
+        navigator.grid.safe_local_target = lambda *unused: None
+        current = (10.0, 0.0, 24.0)
+        goal = (42.0, 0.0, 24.0)
+        path_key = ('route_join', 7, 1, 'lane', 1)
+
+        navigator.next_target(7, current, goal, path_key, 1.0)
+        held = navigator.next_target(
+            7, current, goal, path_key,
+            1.0 + navigation.PENDING_PROGRESS_SECONDS)
+
+        self.assertEqual(current, held)
+        self.assertEqual('pending', navigator.fallback_modes[7])
+
+    def test_completed_route_target_restarts_the_pending_grace(self):
+        """A real routed target ends the episode; a probed step does not."""
+        navigator = self._pending_navigator()
+        current = (10.0, 0.0, 24.0)
+        goal = (42.0, 0.0, 24.0)
+        path_key = ('route_join', 7, 1, 'lane', 1)
+
+        navigator.next_target(7, current, goal, path_key, 1.0)
+        state = navigator.bot_states[7]
+        self.assertIn('pending_since', state)
+
+        navigator._set_fallback_mode(7, None)
+        self.assertNotIn('pending_since', state)
 
     def test_failed_shallow_search_keeps_reactive_local_recovery(self):
         graph = self._baked_graph(3, 1)


### PR DESCRIPTION
## Symptom

Peng, from Windows playtesting: *"bots 在家里不出来"* — bots do not leave their spawn.

## Mechanism

`TerrainNavigator._pending_target` returns the hull's **own position** while a global search is still queued (`ai/navigation.py:966-987`). Downstream:

- `LocalDriver.drive` sees `target_distance <= WAYPOINT_ARRIVAL_RADIUS` and returns `throttle 0`, `recovery_mode 'arrived'`;
- `BotAdapter._drive_order` recognises the same shape as a navigation wait (`ai/adapter.py:120-131`) and **skips `LocalDriver` entirely**, returning `recovery_mode 'nav_wait'`.

So a pending bot has no stuck timer, no separation steering, no recovery and **no timeout**. The only exit is the search completing.

That would be fine if searches were quick, but the expansion budget is navigator-wide: `_advance_searches` rotates one expansion per pending job and `SEARCH_EXPANSIONS_PER_SECOND = 960` is shared by the entire room (`ai/navigation.py:37-42, 1169-1205`).

## Evidence

Replaying the shipped `spawn_formations` and `routes` against the shipped graphs at 10 Hz, 30 bots, reconstructing the server's join-waypoint selection — time until the **last** bot received a usable target:

| map | last bot |
|---|---|
| `01_karelia` | **9.9 s** |
| `33_fjord` | 2.4 s |
| `22_slough` | 1.0 s |
| `07_lakeville` | 0.2 s |
| `04_himmelsdorf` | 0.1 s |

About half the bots get a target at `t = 0` because `_path` first tries `dry_segment_clear` and skips A* entirely. The rest wait — and on Karelia one of them waits ten seconds in the spawn.

For scale: a single A* expansion costs **26 µs** here (CPython 3, Linux x86_64), so 960/s is ~25 ms of CPU per second — about 2.5% of one core. The budget is a determinism artifact, not a CPU limit. Raising it is a separate question; this PR only stops the *hold* from being unbounded.

## Change

Hold for `PENDING_PROGRESS_SECONDS = 0.6` so a job that finishes within a frame or two does not produce a pointless creep. Past that grace, return the same fully probed short waypoint a **conclusive** search failure already uses (`grid.safe_local_target`).

The safety bar is unchanged: every candidate still needs supported ground, a safe grade, no deep water, no static collision and no remembered failed edge, and `safe_local_target` returning `None` still means the only safe action is to hold.

The grace is restarted only by a real routed target (`_set_fallback_mode` with `None` or `'safe_direct'`), never by a probed step taken while the search is still queued — otherwise the clock would restart after every short step and the bot would creep instead of driving.

## Tests

- `test_pending_search_holds_only_for_a_bounded_grace` — new, fails on `main`
- `test_pending_search_still_holds_when_no_safe_step_exists` — new
- `test_completed_route_target_restarts_the_pending_grace` — new, fails on `main`

The existing `test_pending_shallow_search_holds_without_arming_recovery` still passes: it stubs `safe_local_target` to `None`, which is exactly the "nothing safe, so hold" path.

Full `0.9.22` suite: **3014 tests, OK**.

## Not proved here

Evidence layer 1-2. Whether 0.6 s is the right grace, and how the resulting motion looks with 29 bots on the real client, needs acceptance on Chinese HD `0.9.22.0.1 #1513`.

The related finding that `nav_wait` bypasses `LocalDriver` is left alone deliberately: once `_pending_target` returns something drivable, that path is reached only when nothing safe exists, where stopping is correct. Its remaining cost is that `LocalDriver`'s internal clock does not advance — worth a separate look, not worth coupling here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)