### PR TITLE
Keep the projectile cursor cadence through slow worker frames

### DIFF
--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -11103,8 +11103,21 @@ class BattleRuntime(object):
         self._prune_projectile_position_history()
         self._projectile_target_positions = current
         if now >= self._next_projectile_progress_time:
-            self._next_projectile_progress_time = (
-                now + PROJECTILE_PROGRESS_SECONDS)
+            # Advance the deadline along the fixed cadence grid instead of
+            # restarting a whole interval from this frame.  A late worker
+            # frame otherwise pushes every following publication out by its
+            # own overshoot, so the confirmed cursor that gates tracer
+            # advancement and terminal submission degrades with worker frame
+            # time rather than staying at the intended rate.  Missed
+            # intervals are skipped, never replayed as a burst.
+            if self._next_projectile_progress_time <= 0.0:
+                self._next_projectile_progress_time = float(now)
+            overshoot = max(
+                0.0, float(now) - self._next_projectile_progress_time)
+            intervals = int(math.floor(
+                (overshoot + 1e-9) / PROJECTILE_PROGRESS_SECONDS)) + 1
+            self._next_projectile_progress_time += (
+                intervals * PROJECTILE_PROGRESS_SECONDS)
             self._publish_projectile_progress()
         return advanced
 

--- a/0.9.22/tests/test_port_0922_battle_projectiles.py
+++ b/0.9.22/tests/test_port_0922_battle_projectiles.py
@@ -12,7 +12,8 @@ ROOT = Path(__file__).resolve().parents[2]
 CLIENT_SCRIPTS = ROOT / '0.9.22' / 'src' / 'res' / 'scripts' / 'client'
 sys.path.insert(0, str(CLIENT_SCRIPTS))
 
-from gui.mods.offline_lan_0922.battle_runtime import BattleRuntime
+from gui.mods.offline_lan_0922.battle_runtime import (
+    BattleRuntime, PROJECTILE_PROGRESS_SECONDS)
 from gui.mods.offline_lan_0922.entities.native_remote_vehicle import \
     NativeRemoteVehicleFactory
 from gui.mods.offline_lan_0922.projectile_manager import InFlightProjectiles
@@ -2420,6 +2421,54 @@ class BattleProjectileTests(unittest.TestCase):
         battle._next_projectile_progress_time = 99.0
         self.assertTrue(battle._advance_projectiles(10.6))
         self.assertEqual('impact', battle.client.resolutions[0][0][3])
+
+    def test_progress_cadence_survives_slow_worker_frames(self):
+        """A late worker frame must not push the whole cadence out with it.
+
+        The confirmed cursor published here gates both tracer advancement and
+        terminal submission, so restarting a full interval from every late
+        frame would degrade projectile authority with worker frame time.
+        """
+        battle, bigworld = _battle()
+        battle._next_projectile_progress_time = 0.0
+        self.assertTrue(battle._accept_projectile_event(_event()))
+
+        step = 0.03
+        window = 1.2
+        deadlines = []
+        published = 0
+        frame = step
+        while frame <= window + 1e-9:
+            bigworld.now = frame
+            before = len(battle.client.progress)
+            battle._advance_projectiles(frame)
+            if len(battle.client.progress) > before:
+                published += 1
+                deadlines.append(battle._next_projectile_progress_time)
+            frame = round(frame + step, 10)
+
+        # Every deadline sits on the fixed cadence grid: consecutive
+        # deadlines differ by whole intervals, never by one interval plus
+        # the frame that happened to be late.
+        self.assertGreater(len(deadlines), 2)
+        for earlier, later in zip(deadlines, deadlines[1:]):
+            gap = later - earlier
+            intervals = gap / PROJECTILE_PROGRESS_SECONDS
+            self.assertAlmostEqual(
+                intervals, round(intervals), places=6,
+                msg='deadline gap %r is not a whole cadence interval' % gap)
+
+        # The publication count follows the interval, not interval + frame.
+        # Restarting the interval from each late frame yields a 0.13 s period
+        # at this frame step and would lose roughly a fifth of the updates.
+        self.assertGreaterEqual(
+            published, int(math.floor(window / PROJECTILE_PROGRESS_SECONDS)))
+
+        # A deadline is never pushed more than one interval past the frame
+        # that consumed it.
+        self.assertLess(
+            battle._next_projectile_progress_time - frame + step,
+            PROJECTILE_PROGRESS_SECONDS + 1e-9)
 
     def test_destructible_receipt_retries_with_same_progress_until_ack(self):
         battle, bigworld = _battle()


### PR DESCRIPTION
## Summary

The hidden worker publishes its projectile collision cursor on a fixed `PROJECTILE_PROGRESS_SECONDS` (0.10 s) interval, but the deadline was recomputed as `now + interval` from whichever frame happened to consume it. A frame that lands late pushes every following publication out by its own overshoot instead of returning to the intended grid.

Advance the deadline by whole intervals from the previous deadline. Missed intervals are skipped, never replayed as a burst. **No tuned constant changes** — `PROJECTILE_PROGRESS_SECONDS` stays at 0.10.

## Why this cursor matters

It is not cosmetic bookkeeping:

- `_advance_projectile_visuals` may only move a tracer **up to** the confirmed cursor.
- `_submit_projectile_resolution` refuses to send a terminal while its progress proposal is still unacknowledged (`progress_pending`).

So a degraded publish rate delays both projectile presentation and hit resolution.

## Measured loss

The loss is a beat between the worker frame period and the interval, not a linear decay. Frame times that divide 100 ms exactly are unaffected; the band the hidden worker actually operates in is not.

| worker FPS | frame | before | after | lost |
|---|---|---|---|---|
| 60 | 17 ms | 9.85 Hz | 10.05 Hz | 2% |
| 30 | 33 ms | 7.60 Hz | 10.05 Hz | **24%** |
| 25 | 40 ms | 8.35 Hz | 10.05 Hz | 17% |
| 20 | 50 ms | 10.00 Hz | 10.05 Hz | 0% |
| 15 | 67 ms | 7.50 Hz | 10.05 Hz | **25%** |
| 12 | 83 ms | 6.05 Hz | 10.05 Hz | **40%** |
| 10 | 100 ms | 10.00 Hz | 10.00 Hz | 0% |
| ≤8 | ≥125 ms | frame-limited | frame-limited | 0% |

Low hidden-worker frame rates are a known live condition in this port (#8, #9, #24).

## Rule and precedent

Root `CLAUDE.md`: *"Apply elapsed time when an update is late rather than throwing the interval away."*

The replacement is the idiom this codebase already uses in two places — `_update_spotting` and `bot_runtime`'s control publication.

## Scope

Audited every other `now + interval` deadline in this port and deliberately left them alone:

- RPM presentation, target outline refresh, and the two compound/outline diagnostics are deliberately rate-limited presentation.
- Bot spawn spacing wants a genuine minimum gap, so `now + interval` is the correct semantics there.
- The authority worker's 1 s / 2 s heartbeats carry ample margin against a 5 s liveness timeout.

## Validation

- New test `test_progress_cadence_survives_slow_worker_frames` drives `_advance_projectiles` at a 30 ms frame step and asserts consecutive deadlines differ by whole cadence intervals. **Verified it fails on the pre-fix code**: `deadline gap 0.12 is not a whole cadence interval`.
- Projectile suite: 97 tests, OK.
- Full 0.9.22 suite: `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s 0.9.22/tests -p "test_*.py"` — 3235 tests, OK.
- CPython 2.7.18 compile of the changed client module.
- Branch is based on current `main` (`3be3499`); no merge needed.

No package, tag, or release is included.

## Exact-client evidence boundary

This is a pure-data cadence proof. It does not prove anything about #1513 rendering. Windows acceptance is still what would show whether the restored publish rate is visible in tracer smoothness or hit-registration feel, and the real hidden-worker frame rate on Peng's machine determines which row of the table above applies.