### PR TITLE
Contain the frame's presentation pulls instead of failing the round

### DIFF
--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -13440,10 +13440,18 @@ class BattleRuntime(object):
                 # control scheduler consumes elapsed time. RemoteVehicle's
                 # MatrixAnimation interpolates between changed poses; exact
                 # duplicate render pulls do not require native rewrites.
-                presented = self._run_optional_feature(
-                    'bot pose presentation',
-                    self._present_authority_bot_poses,
-                    (presentation_states, now), disable=False)
+                if self._worker_mode:
+                    # The worker also commits native destructible queries and
+                    # canonical projectile collision poses here. Keep those
+                    # failures loud before Bot state publication or projectile
+                    # advancement can make the frame irreversible.
+                    presented = self._present_authority_bot_poses(
+                        presentation_states, now)
+                else:
+                    presented = self._run_optional_feature(
+                        'bot pose presentation',
+                        self._present_authority_bot_poses,
+                        (presentation_states, now), disable=False)
                 if presented:
                     bot_count = presented[0]
             if profiling:

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -2598,12 +2598,19 @@ class BattleRuntime(object):
         return True
 
     def _run_optional_feature(self, feature, callback, args=(),
-                              on_error=None):
-        """Run one presentation boundary without widening frame failure."""
+                              on_error=None, disable=True, kwargs=None):
+        """Run one presentation boundary without widening frame failure.
+
+        ``disable`` retires the feature for the round, which suits a boundary
+        whose native resources cannot be trusted again once it has failed.
+        Pass ``disable=False`` for a per-frame presentation pull that must be
+        retried: retiring bot poses or spotting for a whole round turns one
+        transient native failure into frozen Bots or permanent blindness.
+        """
         if not self._optional_feature_enabled(feature):
             return False
         try:
-            return callback(*args)
+            return callback(*args, **(kwargs or {}))
         except Exception as error:
             if callable(on_error):
                 try:
@@ -2612,7 +2619,7 @@ class BattleRuntime(object):
                     error = RuntimeError(
                         '%s; disable cleanup failed: %s' % (
                             error, cleanup_error))
-            self._warn_optional_failure(feature, error)
+            self._warn_optional_failure(feature, error, disable=disable)
             return False
 
     def _disable_standard_space_visibility(self):
@@ -13419,9 +13426,12 @@ class BattleRuntime(object):
                 # control scheduler consumes elapsed time. RemoteVehicle's
                 # MatrixAnimation interpolates between changed poses; exact
                 # duplicate render pulls do not require native rewrites.
-                states = presentation_states(now)
-                bot_count = len(states)
-                self._apply_authority_bot_poses(states)
+                presented = self._run_optional_feature(
+                    'bot pose presentation',
+                    self._present_authority_bot_poses,
+                    (presentation_states, now), disable=False)
+                if presented:
+                    bot_count = presented[0]
             if profiling:
                 next_boundary = _PROFILE_CLOCK()
                 stages['bot_present'] = max(0.0, next_boundary - boundary)
@@ -13448,12 +13458,16 @@ class BattleRuntime(object):
                 boundary = next_boundary
             if not self._worker_mode:
                 if self._battle_live:
-                    self._update_spotting(now)
+                    self._run_optional_feature(
+                        'spotting', self._update_spotting, (now,),
+                        disable=False)
                 elif self._prebattle_deadline is not None:
                     # The minimap view circle is live during the countdown, but
                     # enemy spotting and its LAN report stay behind the battle
                     # gate.  This also lets still devices arm before 00:00.
-                    self._update_spotting(now, hud_only=True)
+                    self._run_optional_feature(
+                        'spotting', self._update_spotting, (now,),
+                        disable=False, kwargs={'hud_only': True})
             if profiling:
                 next_boundary = _PROFILE_CLOCK()
                 stages['spot'] = max(0.0, next_boundary - boundary)
@@ -13465,9 +13479,13 @@ class BattleRuntime(object):
                 if not callable(validate_lock):
                     raise RuntimeError(
                         '#1513 target-lock lifecycle boundary is unavailable')
-                validate_lock(self._avatar)
+                self._run_optional_feature(
+                    'target lock validation', validate_lock, (self._avatar,),
+                    disable=False)
             self._worker_probe_bot_count = bot_count
-            self._advance_authority_worker_probe()
+            self._run_optional_feature(
+                'authority worker probe',
+                self._advance_authority_worker_probe)
             if profiling:
                 next_boundary = _PROFILE_CLOCK()
                 stages['lock'] = max(0.0, next_boundary - boundary)
@@ -17052,6 +17070,17 @@ class BattleRuntime(object):
             record.pop('_authority_pose_signature', None)
             record.pop('_authority_aim_signature', None)
             record.pop('_authority_projectile_pose_cache', None)
+
+    def _present_authority_bot_poses(self, presentation_states, now):
+        """Pull and apply one accepted authority pose set.
+
+        Returned as a one-tuple so a zero-Bot frame stays distinguishable
+        from the ``False`` that ``_run_optional_feature`` reports when the
+        boundary failed or is retired.
+        """
+        states = presentation_states(now)
+        self._apply_authority_bot_poses(states)
+        return (len(states),)
 
     def _apply_authority_bot_poses(self, states):
         """Present copied 0.8.2 bot poses through the remote filter."""

--- a/0.9.22/tests/test_port_0922_battle_runtime.py
+++ b/0.9.22/tests/test_port_0922_battle_runtime.py
@@ -13364,6 +13364,112 @@ class BattleRuntimeContractTests(unittest.TestCase):
     def test_battle_frame_requests_the_next_render_frame(self):
         self.assertEqual(0.0, FRAME_SECONDS)
 
+    def _live_frame_battle(self, runtime):
+        """One battle-live runtime whose frame reaches the guarded pulls."""
+        battle = BattleRuntime(runtime)
+        battle.client = types.SimpleNamespace()
+        battle.state = 'running'
+        battle._battle_live = True
+        battle._last_frame_time = 0.98
+        battle._avatar = runtime.bigworld.avatar
+        battle._frame_diagnostics = None
+        battle._flush_pending_bot_create = mock.Mock()
+        battle._flush_pending_entities = mock.Mock()
+        battle._drain_event_journal = mock.Mock()
+        battle._maybe_send_battle_ready = mock.Mock()
+        battle._tick_critical_states = mock.Mock()
+        battle._tick_drowning = mock.Mock()
+        battle._tick_overturn = mock.Mock()
+        battle._drive_local = mock.Mock()
+        battle._update_spotting = mock.Mock()
+        battle._schedule = mock.Mock()
+        battle._fail = mock.Mock()
+        return battle
+
+    def test_a_failing_spotting_pull_is_retried_not_retired(self):
+        """Spotting is pulled every frame, so one failure must not blind the round."""
+        runtime = _runtime()
+        runtime.bigworld.now = 1.0
+        battle = self._live_frame_battle(runtime)
+        battle._update_spotting = mock.Mock(
+            side_effect=RuntimeError('vision query failed'))
+
+        with contextlib.redirect_stdout(io.StringIO()) as log:
+            battle._frame()
+            battle._frame()
+
+        self.assertEqual('running', battle.state)
+        battle._fail.assert_not_called()
+        self.assertEqual(2, battle._schedule.call_count)
+        # disable=False: the boundary is retried on the next frame instead of
+        # being retired for the round.
+        self.assertEqual(2, battle._update_spotting.call_count)
+        self.assertIn('spotting', log.getvalue())
+        self.assertIn('degraded for this round', log.getvalue())
+
+    def test_a_failing_bot_pose_pull_is_retried_not_retired(self):
+        """A transient pose failure must not freeze every Bot for the round."""
+        runtime = _runtime()
+        runtime.bigworld.now = 1.0
+        battle = self._live_frame_battle(runtime)
+        presentation_states = mock.Mock(
+            side_effect=RuntimeError('authority pose pull failed'))
+        battle._bots = types.SimpleNamespace(
+            presentation_states=presentation_states,
+            is_authority=lambda: False,
+            update=mock.Mock(return_value=()))
+        battle._advance_artillery_arcs = mock.Mock()
+        battle._authority_players = mock.Mock(return_value=())
+        battle._enqueue_bot_message = mock.Mock(return_value=True)
+
+        with contextlib.redirect_stdout(io.StringIO()) as log:
+            battle._frame()
+            battle._frame()
+
+        self.assertEqual('running', battle.state)
+        battle._fail.assert_not_called()
+        self.assertEqual(2, battle._schedule.call_count)
+        self.assertEqual(2, presentation_states.call_count)
+        self.assertIn('bot pose presentation', log.getvalue())
+
+    def test_a_failing_target_lock_validation_does_not_end_the_round(self):
+        """Releasing a stale stock lock is presentation hygiene, not authority."""
+        runtime = _runtime()
+        runtime.bigworld.now = 1.0
+        battle = self._live_frame_battle(runtime)
+        runtime.compatibility.validate_target_lock = mock.Mock(
+            side_effect=RuntimeError('auto aim read failed'))
+
+        with contextlib.redirect_stdout(io.StringIO()) as log:
+            battle._frame()
+            battle._frame()
+
+        self.assertEqual('running', battle.state)
+        battle._fail.assert_not_called()
+        self.assertEqual(2, battle._schedule.call_count)
+        self.assertEqual(
+            2, runtime.compatibility.validate_target_lock.call_count)
+        self.assertIn('target lock validation', log.getvalue())
+
+    def test_local_driving_failure_still_ends_the_round(self):
+        """Authority steps stay loud.
+
+        A frozen local player with no reported error is worse than a clean
+        round failure, so _drive_local must never be moved behind
+        _run_optional_feature.
+        """
+        runtime = _runtime()
+        runtime.bigworld.now = 1.0
+        battle = self._live_frame_battle(runtime)
+        error = RuntimeError('local control step failed')
+        battle._drive_local = mock.Mock(side_effect=error)
+
+        with contextlib.redirect_stdout(io.StringIO()):
+            battle._frame()
+
+        battle._fail.assert_called_once_with(error)
+        battle._schedule.assert_not_called()
+
     def test_optional_frame_failures_disable_features_not_the_round(self):
         runtime = _runtime()
         runtime.bigworld.now = 1.0

--- a/0.9.22/tests/test_port_0922_battle_runtime.py
+++ b/0.9.22/tests/test_port_0922_battle_runtime.py
@@ -13432,6 +13432,37 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertEqual(2, presentation_states.call_count)
         self.assertIn('bot pose presentation', log.getvalue())
 
+    def test_worker_bot_pose_failure_stops_state_and_projectile_commit(self):
+        """Worker collision poses must fail before irreversible frame work."""
+        runtime = _runtime()
+        runtime.bigworld.now = 1.0
+        battle = self._live_frame_battle(runtime)
+        battle._worker_mode = True
+        error = RuntimeError('authority collision pose failed')
+        presentation_states = mock.Mock(side_effect=error)
+        update = mock.Mock(return_value=({'type': 'bot_state'},))
+        battle._bots = types.SimpleNamespace(
+            presentation_states=presentation_states,
+            is_authority=lambda: True,
+            update=update)
+        battle._advance_player_fire_authority = mock.Mock()
+        battle._publish_player_environment = mock.Mock()
+        battle._advance_artillery_arcs = mock.Mock()
+        battle._authority_players = mock.Mock(return_value=())
+        battle._resolve_player_destructible_contacts = mock.Mock()
+        battle._record_worker_control_diagnostics = mock.Mock()
+        battle._enqueue_bot_message = mock.Mock(return_value=True)
+        battle._advance_projectiles = mock.Mock()
+
+        with contextlib.redirect_stdout(io.StringIO()):
+            battle._frame()
+
+        update.assert_called_once()
+        battle._fail.assert_called_once_with(error)
+        battle._enqueue_bot_message.assert_not_called()
+        battle._advance_projectiles.assert_not_called()
+        battle._schedule.assert_not_called()
+
     def test_a_failing_target_lock_validation_does_not_end_the_round(self):
         """Releasing a stale stock lock is presentation hygiene, not authority."""
         runtime = _runtime()


### PR DESCRIPTION
## Summary

`_frame` wraps about 300 lines in one `try` whose handler calls `self._fail()`, cancelling the round. The existing `_run_optional_feature` boundary can contain failures that are truly presentation-only or diagnostic, but authority and state transitions must remain loud.

## What moved, and what deliberately did not

I audited all 39 top-level statements in that `try` and moved exactly the presentation and diagnostic pulls behind the guard:

| moved behind the guard | why | `disable` |
|---|---|---|
| visible-client bot pose presentation | pulled fresh every frame and retried after a transient display failure | `False` |
| spotting | pulled fresh every frame | `False` |
| target-lock validation | releases a stale stock lock; presentation hygiene | `False` |
| authority worker probe | opt-in diagnostics | `True` |

Worker bot pose application deliberately does **not** use the optional guard. On the hidden worker the same call also commits native destructible queries and canonical projectile collision poses. If that call fails, the frame must reach `_fail()` before publishing the newly advanced Bot state or advancing projectiles against stale or partial collision poses.

Everything else stays loud deliberately. Entity flushing, the event journal, bot manifest retry, worker fire authority, `_begin_battle`, the bot authority advance, outgoing bot messages, projectile advancement, worker bot pose application, and `_drive_local` are authority or state transitions. A silently skipped authority step with no reported error is worse than a clean round failure.

The two countdown prewarm blocks (`prewarm_world_receipts`, `_prewarm_player_tree_registries`) already carry their own guards with the right comments and are unchanged.

## `_run_optional_feature` gains `disable` and `kwargs`

It previously always called `_warn_optional_failure` with the default `disable=True`, retiring the feature for the whole round. That suits a boundary whose native resources cannot be trusted again, but it would turn one transient visible-client pose or vision failure into frozen Bots or permanent blindness for the rest of the round. The three non-worker per-frame pulls use `disable=False` and are retried on the next frame.

`kwargs` keeps the exact existing call shape `self._update_spotting(now, hud_only=True)`, which a test pins deliberately.

## What this does NOT do

This does not remove `_fail()` from the frame. Transient native failures inside authority steps, including worker bot pose application, still reach it. Containing failures inside `_drive_local`, `_advance_projectiles`, or the bot authority advance would require operation-specific recovery and is outside this PR.

The honest scope correction is that most of the 300-line `try` is authority, not presentation. Four pulls qualified, and one of those qualifies only outside worker mode.

## Validation

- 3 containment tests + 2 authority regression guards.
- The new worker regression fails on the previous PR head because the pose exception is swallowed; it now proves that `_fail()` runs and that Bot-state enqueue, projectile advancement, and frame rescheduling do not continue.
- Focused `battle_runtime` boundary tests: 5 tests, OK.
- CPython 2.7.18 source compile: 88 client files, OK.
- `git diff --check`: OK.
- GitHub Actions is running for exact head `6a788946`.
- Branch is based on current `main` (`5f91147c`).

No package, tag, release, or merge is included.

## Exact-client evidence boundary

These are pure-Python containment proofs with injected exceptions. They prove the frame control-flow boundary, not how the #1513 client looks when a real native query fails. Windows acceptance remains necessary to judge the presentation of a degraded visible-client frame.
