### PR TITLE
Restore the blocked-damage roll on worker terminals

### DIFF
--- a/0.9.22/server/lan_battle_server.py
+++ b/0.9.22/server/lan_battle_server.py
@@ -7088,6 +7088,8 @@ class BattleState:
         if (not isinstance(raw, dict) or set(raw) - allowed or
                 not required.issubset(raw)):
             raise ValueError("invalid effect shape")
+        if splash and "potential_damage" in raw:
+            raise ValueError("splash effect cannot carry potential damage")
         target_kind = raw.get("target_kind")
         if target_kind not in ("player", "bot"):
             raise ValueError("invalid target kind")

--- a/0.9.22/server/lan_battle_server.py
+++ b/0.9.22/server/lan_battle_server.py
@@ -7189,10 +7189,14 @@ class BattleState:
                 direct_fields = {
                     "target_kind", "target_id", "damage", "shot_result",
                     "x", "y", "z"}
+                # A bounce is the archetypal blocked-damage contact, so the
+                # harmless direct effect keeps the worker's potential-damage
+                # roll along with its decal identity.  Critical, stun and
+                # splash tokens stay forbidden on a continuing shell.
+                direct_optional = {"damage_sticker", "potential_damage"}
                 if (not isinstance(raw_direct, dict) or
-                        set(raw_direct) not in (
-                            direct_fields,
-                            direct_fields | {"damage_sticker"})):
+                        not direct_fields.issubset(raw_direct) or
+                        set(raw_direct) - (direct_fields | direct_optional)):
                     raise ValueError(
                         "ricochet direct effect has optional terminal fields")
                 direct = self._normalize_projectile_effect(

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -11883,7 +11883,8 @@ class BattleRuntime(object):
 
     def _projectile_effect(self, record, damage, result, impact,
                            critical, hull_damage, critical_delta,
-                           target_position=None, damage_sticker=None):
+                           target_position=None, damage_sticker=None,
+                           potential_damage=None):
         target_kind = record.get('kind')
         if target_kind == 'human':
             target_kind = 'player'
@@ -11897,6 +11898,12 @@ class BattleRuntime(object):
             'x': float(impact[0]), 'y': float(impact[1]),
             'z': float(impact[2]),
         }
+        if potential_damage is not None:
+            # The armour ledger needs the roll the damage law already made,
+            # before armour and modules reduced it.  Splash carries no roll:
+            # its own law rolls a different quantity and the server excludes
+            # splash from blocked damage.
+            effect['potential_damage'] = max(0, int(potential_damage))
         if target_position is not None:
             effect.update({
                 'target_x': float(target_position[0]),
@@ -11977,8 +11984,16 @@ class BattleRuntime(object):
             record, critical_target, shot, trace_start, trace_end,
             collisions, result,
             historic=isinstance(collision_pose, dict))
+        damage_rolls = []
+
+        def capture_damage_roll(low, high):
+            """Record the exact roll the damage law is about to consume."""
+            rolled = random.uniform(low, high)
+            damage_rolls.append(rolled)
+            return rolled
+
         damage = combat_rules.damage(
-            shot, result, armor,
+            shot, result, armor, random_uniform=capture_damage_roll,
             spall_coefficient=tank_collision.descriptor_spall_coefficient(
                 getattr(critical_target, 'typeDescriptor', None)))
         hull_damage = damage
@@ -12025,7 +12040,8 @@ class BattleRuntime(object):
         return self._projectile_effect(
             record, damage, result, terminal_data['impact'],
             critical, hull_damage, critical_delta,
-            damage_sticker=damage_sticker)
+            damage_sticker=damage_sticker,
+            potential_damage=(int(damage_rolls[0]) if damage_rolls else 0))
 
     def _projectile_splash_effects(self, meta, impact, direct_key):
         source = self._projectile_source_entity(meta)

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -12193,11 +12193,14 @@ class BattleRuntime(object):
                     collision_evidence))
         critical = self._critical_with_crew_roster(
             critical_target, critical)
+        potential_damage = None
+        if contact is not None:
+            potential_damage = int(damage_rolls[0]) if damage_rolls else 0
         return self._projectile_effect(
             record, damage, result, terminal_data['impact'],
             critical, hull_damage, critical_delta,
             damage_sticker=damage_sticker,
-            potential_damage=(int(damage_rolls[0]) if damage_rolls else 0))
+            potential_damage=potential_damage)
 
     def _projectile_splash_effects(self, meta, impact, direct_key):
         source = self._projectile_source_entity(meta)

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -11902,8 +11902,12 @@ class BattleRuntime(object):
             # The armour ledger needs the roll the damage law already made,
             # before armour and modules reduced it.  Splash carries no roll:
             # its own law rolls a different quantity and the server excludes
-            # splash from blocked damage.
-            effect['potential_damage'] = max(0, int(potential_damage))
+            # splash from blocked damage.  An overlay-edited shell can roll
+            # past 5000, the exact ceiling the wire validator and the battle
+            # server enforce, so saturate the statistic instead of letting
+            # the validator drop the whole terminal.
+            effect['potential_damage'] = max(
+                0, min(5000, int(potential_damage)))
         if target_position is not None:
             effect.update({
                 'target_x': float(target_position[0]),

--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
@@ -1023,10 +1023,11 @@ def _strict_projectile_effect(value):
     stun_fields = frozenset(('stun_end_server_time_ms',))
     target_pose_fields = frozenset(('target_x', 'target_y', 'target_z'))
     damage_sticker_fields = frozenset(('damage_sticker',))
+    potential_fields = frozenset(('potential_damage',))
     keys = set(value)
     if not required.issubset(keys) or not keys.issubset(
             required | critical_fields | stun_fields | target_pose_fields |
-            damage_sticker_fields):
+            damage_sticker_fields | potential_fields):
         return None
     kind = value.get('target_kind')
     target_id = _projectile_int_range(
@@ -1043,16 +1044,19 @@ def _strict_projectile_effect(value):
     has_stun = 'stun_end_server_time_ms' in value
     has_target_pose = bool(keys & target_pose_fields)
     has_damage_sticker = 'damage_sticker' in value
+    has_potential_damage = 'potential_damage' in value
     expected = (required |
                 (critical_fields if has_critical else frozenset()) |
                 (stun_fields if has_stun else frozenset()) |
                 (target_pose_fields if has_target_pose else frozenset()) |
                 (damage_sticker_fields if has_damage_sticker else
-                 frozenset()))
+                 frozenset()) |
+                (potential_fields if has_potential_damage else frozenset()))
     if (kind not in ('player', 'bot') or target_id is None or
             damage is None or shot_result is None or
             any(component is None for component in position) or
             (has_target_pose and has_damage_sticker) or
+            (has_target_pose and has_potential_damage) or
             keys != expected):
         return None
     result = {
@@ -1097,6 +1101,14 @@ def _strict_projectile_effect(value):
         if damage_sticker is None:
             return None
         result['damage_sticker'] = damage_sticker
+    if has_potential_damage:
+        # The armour ledger's un-reduced roll shares the damage bound the
+        # server enforces; a splash proposal never carries one.
+        potential_damage = _projectile_int_range(
+            value.get('potential_damage'), 0, 5000)
+        if potential_damage is None:
+            return None
+        result['potential_damage'] = potential_damage
     if has_target_pose:
         target_position = []
         for axis in ('x', 'y', 'z'):
@@ -2801,6 +2813,10 @@ class LANClient(object):
         direct_fields = {
             'target_kind', 'target_id', 'damage', 'shot_result',
             'x', 'y', 'z'}
+        # A bounce is the archetypal blocked-damage contact, so a continuing
+        # shell still publishes its potential-damage roll and decal identity.
+        # Critical, stun and splash tokens stay forbidden on this wire.
+        direct_optional = {'damage_sticker', 'potential_damage'}
         if (parsed_epoch is None or parsed_epoch != _exact_int(
                 self.authority_epoch) or parsed_projectile_id is None or
                 parsed_base is None or parsed_time is None or
@@ -2811,8 +2827,8 @@ class LANClient(object):
                 parsed_factor is None or parsed_direct is None or
                 parsed_direct['damage'] != 0 or
                 parsed_direct['shot_result'] != 0 or
-                set(parsed_direct) not in (
-                    direct_fields, direct_fields | {'damage_sticker'})):
+                not direct_fields.issubset(parsed_direct) or
+                set(parsed_direct) - (direct_fields | direct_optional)):
             return False
         if math.sqrt(sum(
                 (parsed_origin[index] - parsed_impact[index]) ** 2

--- a/0.9.22/tests/test_port_0922_battle_projectiles.py
+++ b/0.9.22/tests/test_port_0922_battle_projectiles.py
@@ -18,6 +18,7 @@ from gui.mods.offline_lan_0922.entities.native_remote_vehicle import \
     NativeRemoteVehicleFactory
 from gui.mods.offline_lan_0922.projectile_manager import InFlightProjectiles
 from gui.mods.offline_lan_0922 import combat_rules, critical_damage
+from gui.mods.offline_lan_0922 import lan_client
 
 
 class _Vector(object):
@@ -3900,6 +3901,47 @@ class BattleProjectileTests(unittest.TestCase):
                 self.assertEqual(312, effect['potential_damage'])
                 self.assertEqual(
                     (390.0 * 0.75, 390.0 * 1.25), uniform.call_args.args)
+
+    def test_overlay_edited_shell_saturates_instead_of_losing_the_shot(self):
+        battle, unused_bigworld = _battle()
+        source = battle._server_entity(41)
+        target = types.SimpleNamespace(
+            id=55, isStarted=True, typeDescriptor=types.SimpleNamespace(),
+            position=_Vector((10.0, 0.0, 0.0)), isAlive=lambda: True)
+        battle._records['bot:17'] = {
+            'engine_id': 55, 'network_id': 17, 'kind': 'bot',
+            'local': False, 'ready': True,
+            'state': {'health': 1000, 'alive': True}}
+        battle._server_entity = lambda entity_id: (
+            source if entity_id == 41 else target if entity_id == 55 else None)
+        meta = battle._projectile_wire_meta(_event())
+        collision = types.SimpleNamespace(
+            dist=10.0, hitAngleCos=1.0, matInfo=object(), compName='hull')
+        terminal = {
+            'target_key': 'bot:17', 'collisions': [collision],
+            'query': (_Vector((0.0, 1.0, 0.0)),
+                      _Vector((12.0, 1.0, 0.0))),
+            'impact': (10.0, 1.0, 0.0),
+            'piercing_loss': 0.0, 'penetration_factor': 1.0,
+        }
+
+        with mock.patch.object(
+                combat_rules, 'resolve_armor_contact',
+                return_value={'result': 0}), \
+                mock.patch.object(
+                    combat_rules, 'he_nominal_armor', return_value=100.0), \
+                mock.patch.object(
+                    combat_rules.random, 'uniform', return_value=9000.0):
+            effect = battle._projectile_direct_effect(
+                meta, {'start': (0.0, 1.0, 0.0), 'distance': 10.0},
+                terminal)
+
+        # The launcher's vehicle overlay can raise shell damage without an
+        # upper bound.  Saturating the statistic keeps the bounce on the
+        # wire; an unclamped roll would fail the validator and lose the
+        # whole terminal along with its reload and ammunition bookkeeping.
+        self.assertEqual(5000, effect['potential_damage'])
+        self.assertIsNotNone(lan_client._strict_projectile_effect(effect))
 
     def test_splash_effect_carries_no_potential_damage(self):
         battle, unused_bigworld = _battle()

--- a/0.9.22/tests/test_port_0922_battle_projectiles.py
+++ b/0.9.22/tests/test_port_0922_battle_projectiles.py
@@ -3847,6 +3847,94 @@ class BattleProjectileTests(unittest.TestCase):
         self.assertGreater(cone.call_args.args[3].length, 0.0)
         self.assertTrue(cone.call_args.kwargs['deadeye'])
 
+    def test_direct_effect_publishes_the_exact_damage_roll(self):
+        battle, unused_bigworld = _battle()
+        source = battle._server_entity(41)
+        target = types.SimpleNamespace(
+            id=55, isStarted=True, typeDescriptor=types.SimpleNamespace(),
+            position=_Vector((10.0, 0.0, 0.0)), isAlive=lambda: True)
+        battle._records['bot:17'] = {
+            'engine_id': 55, 'network_id': 17, 'kind': 'bot',
+            'local': False, 'ready': True,
+            'state': {'health': 1000, 'alive': True}}
+        battle._server_entity = lambda entity_id: (
+            source if entity_id == 41 else target if entity_id == 55 else None)
+        meta = battle._projectile_wire_meta(_event())
+        collision = types.SimpleNamespace(
+            dist=10.0, hitAngleCos=1.0, matInfo=object(), compName='hull')
+        terminal = {
+            'target_key': 'bot:17', 'collisions': [collision],
+            'query': (_Vector((0.0, 1.0, 0.0)),
+                      _Vector((12.0, 1.0, 0.0))),
+            'impact': (10.0, 1.0, 0.0),
+            'piercing_loss': 0.0, 'penetration_factor': 1.0,
+        }
+
+        # The armour ledger needs the one roll the damage law consumed,
+        # truncated exactly as the law truncates it, for every verdict. A
+        # ricochet forces damage to zero afterwards and still owes the full
+        # roll, because that is the damage the armour actually stopped.
+        for result, damage in ((0, 0), (1, 0), (2, 312)):
+            with self.subTest(shot_result=result):
+                with mock.patch.object(
+                        combat_rules, 'resolve_armor_contact',
+                        return_value={'result': result}), \
+                        mock.patch.object(
+                            combat_rules, 'he_nominal_armor',
+                            return_value=100.0), \
+                        mock.patch.object(
+                            combat_rules.random, 'uniform',
+                            return_value=312.7) as uniform, \
+                        mock.patch.object(
+                            critical_damage, 'propose_direct',
+                            side_effect=lambda unused_target,
+                            unused_collisions, unused_start, unused_end,
+                            rolled, unused_shell, unused_attacker,
+                            **unused_kwargs: (rolled, None, None)):
+                    effect = battle._projectile_direct_effect(
+                        meta, {'start': (0.0, 1.0, 0.0), 'distance': 10.0},
+                        terminal)
+
+                self.assertEqual(result, effect['shot_result'])
+                self.assertEqual(damage, effect['damage'])
+                self.assertEqual(312, effect['potential_damage'])
+                self.assertEqual(
+                    (390.0 * 0.75, 390.0 * 1.25), uniform.call_args.args)
+
+    def test_splash_effect_carries_no_potential_damage(self):
+        battle, unused_bigworld = _battle()
+        source = battle._server_entity(41)
+        target = types.SimpleNamespace(
+            id=55, isStarted=True, typeDescriptor=types.SimpleNamespace(),
+            position=_Vector((10.0, 0.0, 0.0)), isAlive=lambda: True,
+            collideSegmentExt=mock.Mock(return_value=()))
+        battle._records['bot:17'] = {
+            'engine_id': 55, 'network_id': 17, 'kind': 'bot',
+            'local': False, 'ready': True,
+            'state': {'health': 1000, 'alive': True}}
+        battle._server_entity = lambda entity_id: (
+            source if entity_id == 41 else target if entity_id == 55 else None)
+        event = _event()
+        event['source_shot']['shell'].update({
+            'kind': 'HIGH_EXPLOSIVE', 'explosionRadius': 20.0})
+        event['is_he'] = True
+        event['splash_radius'] = 20.0
+        meta = battle._projectile_wire_meta(event)
+
+        with mock.patch.object(
+                combat_rules, 'he_splash_damage', return_value=90), \
+                mock.patch.object(
+                    critical_damage, 'propose_explosion',
+                    return_value=(90, None, None)):
+            effects = battle._projectile_splash_effects(
+                meta, (9.0, 1.0, 0.0), 'player:7')
+
+        # Splash rolls its own distance-attenuated quantity and the server
+        # excludes splash from blocked damage, so it publishes no roll.
+        self.assertEqual(1, len(effects))
+        self.assertEqual(90, effects[0]['damage'])
+        self.assertNotIn('potential_damage', effects[0])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/0.9.22/tests/test_port_0922_battle_projectiles.py
+++ b/0.9.22/tests/test_port_0922_battle_projectiles.py
@@ -4174,12 +4174,18 @@ class BattleProjectileTests(unittest.TestCase):
         # The armour ledger needs the one roll the damage law consumed,
         # truncated exactly as the law truncates it, for every verdict. A
         # ricochet forces damage to zero afterwards and still owes the full
-        # roll, because that is the damage the armour actually stopped.
-        for result, damage in ((0, 0), (1, 0), (2, 312)):
-            with self.subTest(shot_result=result):
+        # roll, because that is the damage the armour actually stopped. A
+        # broad vehicle hit with no resolved armour contact remains terminal,
+        # but cannot claim that armour stopped its roll.
+        for contact, result, damage, potential in (
+                ({'result': 0}, 0, 0, 312),
+                ({'result': 1}, 1, 0, 312),
+                ({'result': 2}, 2, 312, 312),
+                (None, 1, 0, None)):
+            with self.subTest(contact=contact):
                 with mock.patch.object(
                         combat_rules, 'resolve_armor_contact',
-                        return_value={'result': result}), \
+                        return_value=contact), \
                         mock.patch.object(
                             combat_rules, 'he_nominal_armor',
                             return_value=100.0), \
@@ -4198,7 +4204,10 @@ class BattleProjectileTests(unittest.TestCase):
 
                 self.assertEqual(result, effect['shot_result'])
                 self.assertEqual(damage, effect['damage'])
-                self.assertEqual(312, effect['potential_damage'])
+                if potential is None:
+                    self.assertNotIn('potential_damage', effect)
+                else:
+                    self.assertEqual(potential, effect['potential_damage'])
                 self.assertEqual(
                     (390.0 * 0.75, 390.0 * 1.25), uniform.call_args.args)
 

--- a/0.9.22/tests/test_port_0922_lan_client_projectiles.py
+++ b/0.9.22/tests/test_port_0922_lan_client_projectiles.py
@@ -728,6 +728,58 @@ class ProjectileWireTests(unittest.TestCase):
                     [11.0, 2.0, 3.0], [11.002, 2.0, 3.0],
                     [-100.0, 20.0, 0.0], 0.75, proposal))
 
+    def test_potential_damage_survives_the_terminal_normalizer(self):
+        client = self.active_worker_client()
+        direct = self.effect('player', 8)
+        direct['potential_damage'] = 480
+
+        self.assertTrue(client.send_projectile_resolve(
+            4, 'player:7:1', 150, 'impact', 180,
+            [11.0, 2.0, 3.0], direct, []))
+        message = wire_copy(client._outbound_queue[-1][1])
+        # The normalizer rebuilds the effect from a fixed key set, so the
+        # armour roll only reaches the server if it is copied explicitly.
+        self.assertEqual(480, message['direct']['potential_damage'])
+        self.assertEqual(120, message['direct']['damage'])
+
+        for invalid in (True, 1.0, -1, 5001, '480', None):
+            with self.subTest(potential_damage=invalid):
+                self.assertFalse(client.send_projectile_resolve(
+                    4, 'player:7:2', 0, 'impact', 10,
+                    [0.0, 0.0, 0.0],
+                    dict(direct, potential_damage=invalid), []))
+
+        # Splash rolls a different quantity and the server excludes it from
+        # blocked damage, so a splash proposal must never carry a roll.
+        splash = self.effect('bot', 17, 12.0, target_pose=(12.0, 2.0, 3.0))
+        splash['potential_damage'] = 480
+        self.assertFalse(client.send_projectile_resolve(
+            4, 'player:7:3', 0, 'impact', 10,
+            [0.0, 0.0, 0.0], self.effect('player', 8), [splash]))
+
+    def test_first_ricochet_wire_keeps_the_blocked_damage_roll(self):
+        client = self.active_worker_client()
+        direct = self.effect('bot', 17, 11.0)
+        direct['damage'] = 0
+        direct['shot_result'] = 0
+        direct['potential_damage'] = 5000
+
+        self.assertTrue(client.send_projectile_ricochet(
+            4, 'player:7:1', 150, 180,
+            [11.0, 2.0, 3.0], [11.002, 2.0, 3.0],
+            [-100.0, 20.0, 0.0], 0.75, direct))
+        message = wire_copy(client._outbound_queue[-1][1])
+        self.assertEqual(5000, message['direct']['potential_damage'])
+        self.assertEqual(0, message['direct']['damage'])
+
+        for invalid in (True, -1, 5001, 1.0):
+            with self.subTest(potential_damage=invalid):
+                self.assertFalse(client.send_projectile_ricochet(
+                    4, 'player:7:2', 150, 180,
+                    [11.0, 2.0, 3.0], [11.002, 2.0, 3.0],
+                    [-100.0, 20.0, 0.0], 0.75,
+                    dict(direct, potential_damage=invalid)))
+
     def test_optional_terminal_field_is_omitted_without_server_support(self):
         client = self.active_worker_client()
         client.server_capabilities = [

--- a/0.9.22/tests/test_port_0922_postbattle.py
+++ b/0.9.22/tests/test_port_0922_postbattle.py
@@ -393,6 +393,53 @@ class PostBattleContractTests(unittest.TestCase):
                             'goldReplay', 'crystalReplay'):
             self.assertTrue(vehicle_fields[replay_name])
 
+    def test_blocked_damage_reaches_the_native_result_and_dossier(self):
+        state = BattleState(map_name='01_karelia', team_size=1)
+        state.client_build = CLIENT_BUILD_0922
+        state.phase = 'battle'
+        first = Player(1, _Socket(), ('127.0.0.1', 1), name='Alice',
+                       vehicle='ussr:R11_MS-1', team=1,
+                       account_key='a' * 32)
+        second = Player(2, _Socket(), ('127.0.0.1', 2), name='Bob',
+                        vehicle='germany:G04_PzVI_Tiger_I', team=2,
+                        account_key='b' * 32)
+        state.players = {1: first, 2: second}
+        state._freeze_round_participants((first, second))
+        # One enemy shot that the armour stopped, as the projectile ledger
+        # records it on the vehicle that bounced it.
+        state._statistics_row('player', 2)['damage_blocked'] = 420
+
+        self.assertTrue(state._finish_battle(1, 'team_eliminated'))
+
+        receipt = _latest_receipt(state, second.account_key)
+        self.assertEqual(420, receipt['stats']['damage_blocked'])
+        rows = dict(((row['actor_kind'], row['actor_id']), row)
+                    for row in receipt['public_results'])
+        self.assertEqual(
+            420, rows['player', 2]['stats']['damage_blocked'])
+
+        packers = _Packers()
+        original_vehicle = postbattle_store._vehicle_type_compact_descr
+        original_arena = postbattle_store._arena_type_id
+        try:
+            postbattle_store._vehicle_type_compact_descr = lambda unused: 50001
+            postbattle_store._arena_type_id = lambda unused: 70001
+            postbattle_store.pack_battle_result(
+                receipt, packers=packers,
+                replay_types=(_Replay, _ReplayConnector))
+        finally:
+            postbattle_store._vehicle_type_compact_descr = original_vehicle
+            postbattle_store._arena_type_id = original_arena
+        vehicle_fields = dict(packers.calls)['VEH_FULL_RESULTS']
+        self.assertEqual(420, vehicle_fields['damageBlockedByArmor'])
+
+        store = postbattle_store.PostBattleStore(path=None)
+        receipt['account_key'] = store.account_key
+        self.assertTrue(store.accept(receipt))
+        self.assertEqual(
+            420, store.progress()['vehicles'][
+                receipt['vehicle']]['damageBlockedByArmor'])
+
     def test_native_vehicle_details_keep_each_enemy_interaction(self):
         receipt = _receipt()
         enemy_stats = dict((name, 0) for name in receipt['stats'])

--- a/0.9.22/tests/test_port_0922_server_projectiles.py
+++ b/0.9.22/tests/test_port_0922_server_projectiles.py
@@ -2925,7 +2925,6 @@ class ServerProjectileLedgerTests(unittest.TestCase):
                                     potential_damage=390),
                      splash=[_effect(
                          target_id=4, damage=0, shot_result=1,
-                         potential_damage=390,
                          target_pose=(30.0, 1.0, 0.0))])))
 
         self.assertEqual(
@@ -2937,6 +2936,24 @@ class ServerProjectileLedgerTests(unittest.TestCase):
                       if event.get('kind') == 'hit' and event.get('splash')]
         self.assertEqual([0], [
             event['blocked_damage'] for event in splash_hit])
+
+    def test_splash_rejects_a_direct_contact_damage_roll(self):
+        state = _state(players=3)
+        self.assertTrue(_launch_authority(state, _launch(
+            is_he=True, splash_radius=20.0)))
+        record = state.projectiles['1:p:1:1']
+
+        self.assertFalse(state.resolve_projectile(
+            SIMULATION_WORKER_AUTHORITY_ID,
+            _resolve('1:p:1:1', direct=None, splash=[_effect(
+                target_id=3, damage=0, shot_result=1,
+                potential_damage=390,
+                target_pose=(30.0, 1.0, 0.0))])))
+
+        self.assertEqual(1000, state.players[3].health)
+        self.assertEqual(
+            0, state._statistics_row('player', 3)['damage_blocked'])
+        self._assert_rejected_terminal_retired(state, '1:p:1:1', record)
 
     def test_ricochet_keeps_wire_and_order_boundaries(self):
         mutations = (

--- a/0.9.22/tests/test_port_0922_server_projectiles.py
+++ b/0.9.22/tests/test_port_0922_server_projectiles.py
@@ -2450,12 +2450,116 @@ class ServerProjectileLedgerTests(unittest.TestCase):
             SIMULATION_WORKER_AUTHORITY_ID, second))
         self.assertEqual(1, record['ricochet_count'])
 
+    def test_worker_roll_becomes_the_victim_blocked_damage_ledger(self):
+        for shot_result, damage, blocked in (
+                (1, 0, 390), (1, 200, 190), (2, 300, 0)):
+            with self.subTest(shot_result=shot_result, damage=damage):
+                state = _state()
+                self.assertTrue(_launch_authority(state, _launch()))
+                victim = state.players[2]
+                health = victim.health
+
+                self.assertTrue(state.resolve_projectile(
+                    SIMULATION_WORKER_AUTHORITY_ID,
+                    _resolve('1:p:1:1', direct=_effect(
+                        damage=damage, shot_result=shot_result,
+                        potential_damage=390))))
+
+                hit = [event for event in state.pending_events
+                       if event.get('kind') == 'hit'][-1]
+                self.assertEqual(blocked, hit['blocked_damage'])
+                self.assertEqual(damage, hit['damage'])
+                self.assertEqual(health - damage, victim.health)
+                self.assertEqual(
+                    blocked,
+                    state._statistics_row('player', 2)['damage_blocked'])
+                # The shooter never blocks his own shot.
+                self.assertEqual(
+                    0, state._statistics_row('player', 1)['damage_blocked'])
+                self.assertEqual(
+                    blocked, state.vehicle_interactions[
+                        ('player', 2)]['player:1']['damage_blocked'])
+
+    def test_first_ricochet_credits_one_bounce_and_no_penetration(self):
+        state = _state()
+        self.assertTrue(_launch_authority(state, _launch()))
+        victim = state.players[2]
+
+        self.assertTrue(state.ricochet_projectile(
+            SIMULATION_WORKER_AUTHORITY_ID,
+            _ricochet('1:p:1:1', direct=_effect(
+                damage=0, shot_result=0, potential_damage=420))))
+
+        # A bounce is the archetypal blocked hit: the whole roll counts for
+        # the vehicle whose armour stopped it, and the shell keeps flying.
+        bounce = [event for event in state.pending_events
+                  if event.get('kind') == 'hit'][-1]
+        self.assertEqual(0, bounce['shot_result'])
+        self.assertEqual(420, bounce['blocked_damage'])
+        self.assertEqual(0, bounce['damage'])
+        self.assertEqual(1000, victim.health)
+        self.assertEqual(
+            420, state._statistics_row('player', 2)['damage_blocked'])
+        self.assertEqual(
+            1, state.vehicle_interactions[
+                ('player', 2)]['player:1']['ricochets_received'])
+
+        # The continued shell that finally penetrates adds no second credit.
+        self.assertTrue(state.resolve_projectile(
+            SIMULATION_WORKER_AUTHORITY_ID,
+            _resolve('1:p:1:1', base_checked_ms=100,
+                     resolved_time_ms=150, checked_distance=20.0,
+                     impact=[20.0, 1.0, 0.0],
+                     direct=_effect(damage=100, shot_result=2, x=20.0,
+                                    potential_damage=390))))
+
+        penetration = [event for event in state.pending_events
+                       if event.get('kind') == 'hit'][-1]
+        self.assertEqual(2, penetration['shot_result'])
+        self.assertEqual(0, penetration['blocked_damage'])
+        self.assertEqual(900, victim.health)
+        self.assertEqual(
+            420, state._statistics_row('player', 2)['damage_blocked'])
+
+    def test_splash_never_credits_blocked_damage(self):
+        # Player 4 shares team 2 with the direct victim, so only the splash
+        # exclusion can keep its blocked-damage row at zero.
+        state = _state(players=4)
+        self.assertTrue(_launch_authority(state, _launch(
+            is_he=True, splash_radius=20.0)))
+
+        self.assertTrue(state.resolve_projectile(
+            SIMULATION_WORKER_AUTHORITY_ID,
+            _resolve('1:p:1:1',
+                     direct=_effect(damage=0, shot_result=1,
+                                    potential_damage=390),
+                     splash=[_effect(
+                         target_id=4, damage=0, shot_result=1,
+                         potential_damage=390,
+                         target_pose=(30.0, 1.0, 0.0))])))
+
+        self.assertEqual(
+            390, state._statistics_row('player', 2)['damage_blocked'])
+        self.assertEqual(2, state.players[4].team)
+        self.assertEqual(
+            0, state._statistics_row('player', 4)['damage_blocked'])
+        splash_hit = [event for event in state.pending_events
+                      if event.get('kind') == 'hit' and event.get('splash')]
+        self.assertEqual([0], [
+            event['blocked_damage'] for event in splash_hit])
+
     def test_ricochet_keeps_wire_and_order_boundaries(self):
         mutations = (
             {'direct': _effect(damage=1, shot_result=0)},
             {'direct': _effect(damage=0, shot_result=1)},
             {'direct': dict(
-                _effect(damage=0, shot_result=0), potential_damage=5000)},
+                _effect(damage=0, shot_result=0), potential_damage=5001)},
+            {'direct': dict(
+                _effect(damage=0, shot_result=0), potential_damage=-1)},
+            {'direct': dict(
+                _effect(damage=0, shot_result=0), potential_damage=True)},
+            {'direct': dict(
+                _effect(damage=0, shot_result=0), potential_damage=100.0)},
             {'direct': _effect(
                 damage=0, shot_result=0, damage_sticker=True)},
             {'direct': _effect(


### PR DESCRIPTION
## Symptom

A tester edited the Maus's armour through the launcher vehicle overlay and
reported that the "blocked by armour" statistic disappeared entirely: even a
hit that dealt no damage was not counted as blocked damage.

The overlay edit is a red herring. `damageBlockedByArmor` has been zero for
**every vehicle** since the worker became the sole simulation authority; the
tester only noticed it because he was deliberately bouncing shots. The
in-battle TANKING ribbon was silent for the same reason.

## Root cause

`potential_damage` had no producer anywhere in the repository. Commit
`77ae79a` ("Remove visible and server authority fallbacks") deleted
`0.9.22/server/server_battle_authority.py`, whose `_direct_effect` builder was
the only one:

```python
damage = combat_rules.damage(shot, result, armor, random_uniform=roll)
...
# The same roll the damage law used, before armor and modules.
'potential_damage': int(rolls[0]) if rolls else 0,
```

The mandatory hidden worker rebuilds the terminal effect in
`battle_runtime._projectile_effect` / `_projectile_direct_effect` and never set
the key. The server still parses it, defaulting to `0`, so

```python
blocked_damage = max(0, proposal["potential_damage"] - damage)
```

was always `max(0, 0 - damage) == 0`. `_statistics_row(victim)["damage_blocked"]`
never grew, and the value reached the post-battle screen as zero through
`account_rpc/postbattle_store.py`.

## Fix

`_projectile_direct_effect` passes a capturing hook into
`combat_rules.damage()` again and publishes the roll it consumed only
when `resolve_armor_contact()` returned a real plate. A broad vehicle
terminal with no resolved armour contact keeps its existing terminal
result but carries no blocked-damage claim.
`combat_rules.damage()` rolls `int(uniform(average * 0.75, average * 1.25))`
*before* it branches on the armour verdict, so the hook yields a roll for
ricochet (0), no-penetration (1) and penetration (2) alike. A ricochet forces
`damage = 0` after the call and therefore still reports the full roll, which is
exactly the damage its target's armour stopped.

The value survives the whole wire:

- producer: `battle_runtime._projectile_effect` takes an optional
  `potential_damage`; `_projectile_direct_effect` supplies the captured roll.
- client normalizer: `lan_client._strict_projectile_effect` rebuilds the effect
  from a fixed key set, so an uncopied key is silently dropped. It now copies
  `potential_damage` with the same `0..5000` bound the server enforces.
- server: `_normalize_projectile_effect` already allowed the key; only the
  ricochet handler's strict field set needed widening.
- consumer: the ordered-combat-event validator's existing
  `0 <= blocked_damage <= 5000` and `shot_result != 2` checks accept real
  values, because the server only emits `blocked_damage` for a non-splash
  enemy contact with `shot_result != 2` and `potential_damage <= 5000`.

### Rules chosen

**Ricochet.** Credit is per resolved armour contact, to the vehicle that
stopped it. A first ricochet keeps publishing the roll on its harmless direct
effect, so the archetypal blocked hit counts while the shell continues; both
`send_projectile_ricochet` and the server's `ricochet_projectile` widen their
strict field sets by that one optional key, and critical, stun and splash
tokens stay forbidden on a continuing shell. Because the server excludes
`shot_result == 2`, a shell that bounces and then penetrates is credited
exactly once — for the bounce. Each contact is committed once behind the
existing `ricochet_count` and tombstone compare-and-swap fences, so no contact
can be double-counted.

**HE direct.** A direct HE hit carries the roll like any other direct contact,
so a non-penetration credits the part of the shell's damage the armour
absorbed.

**Splash.** No roll. `he_splash_damage()` rolls a different,
distance-attenuated quantity, and the server already excludes splash from
`blocked_damage`. Both the client normalizer and battle server reject a splash proposal
that carries one, so the exclusion is enforced at both wire boundaries
rather than implied.

**Overlay-edited shells.** The launcher's vehicle overlay editor accepts any
positive `shells/<name>/damage/armor`, so an edited shell can roll past 5000 —
the exact ceiling both the client wire validator and the battle server enforce
for a damage field. The producer saturates the statistic at that ceiling rather
than publishing a roll the validator would reject, which would cost the shot
its whole terminal, reload and ammunition bookkeeping. That failure would land
on exactly the overlay-editing player who reported this bug.

**Capability gate.** None. The launcher installs and starts the matching
server and worker together, so the widened ricochet wire is not a combination
it ever creates.

## Evidence layer

Layers 1 and 3 only: current repository source, pure-data tests and
producer/consumer contract tests.

- worker: a resolved direct armour contact carries the truncated roll for
  `shot_result` 0, 1 and 2 and uses the exact
  `average * 0.75 .. average * 1.25` interval; a broad hit without a resolved
  armour contact and all splash effects carry none.
- wire: the `lan_client` normalizer round-trips the key and rejects
  out-of-range, negative, boolean, float, string and splash spellings, on both
  the resolution and the ricochet senders.
- server: a bounce, a non-penetration and a partial HE hit credit the victim's
  `damage_blocked` row, the event's `blocked_damage` and the interaction
  counter; a penetration and a splash credit nothing; splash carrying the
  direct-contact roll is rejected atomically, and the ricochet boundary test
  still rejects every invalid `potential_damage` spelling.
- post-battle: the blocked row reaches the receipt, the native
  `VEH_FULL_RESULTS` `damageBlockedByArmor` field and the vehicle dossier.
- the existing client tests already prove that a real `blocked_damage` event
  passes the ordered-event validator and produces exactly one TANKING ribbon.

Commands run: the full `0.9.22` suite (`python3 -m unittest discover -s tests`,
3288 tests, OK) before the rebase; after merging current `main` and the review
fixes, the eight related `test_port_0922_*` suites (1114 tests, OK),
`python2.7` source compilation of both changed client files, and
`git diff --check`.

## Windows acceptance (unproved here)

Nothing in this PR proves #1513 runtime behaviour. On the exact client:

1. Bounce a shot off a thick target — the Maus's upper front plate at a steep
   angle is the tester's own case, and an unedited vehicle should be checked
   too, since the defect was never Maus-specific.
2. Watch for the in-battle TANKING ribbon at the moment of the bounce.
3. End the round and read 抵挡伤害 / `damageBlockedByArmor` in the results
   screen; it must equal the sum of the stopped rolls, not zero.
4. Also confirm that a shell which bounces and then penetrates a second
   vehicle credits the bounce once and the penetration not at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)