### PR TITLE
Orient bot routes against the decoded arena bases

### DIFF
--- a/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/0.9.22/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -2171,18 +2171,49 @@ class BotRuntime(object):
                             'navigation graph route waypoint is invalid')
         return routes
 
+    def _baked_objective_bases(self):
+        """Return this map's decoded CTF bases from the baked graph.
+
+        ``bake_navigation_0922`` stores the exact ``teamBasePositions`` it
+        decoded from the arena definition, and ``SpawnPlanner`` already reads
+        the same field.  The static tactical tables carry a hand-written copy
+        of those two points which is only as good as whoever typed it, so the
+        graph shipped with the map is the source the director must orient a
+        route against.
+        """
+        points = (self.baked_graph or {}).get('objective_bases')
+        if not isinstance(points, (list, tuple)) or len(points) != 2:
+            return None
+        bases = {}
+        for team, point in enumerate(points, 1):
+            if not isinstance(point, (list, tuple)) or len(point) != 2:
+                return None
+            try:
+                values = (float(point[0]), float(point[1]))
+            except (TypeError, ValueError):
+                return None
+            if any(math.isnan(value) or math.isinf(value)
+                   for value in values):
+                return None
+            bases[team] = values
+        return bases
+
     def _new_adapter(self, map_name, round_id):
         """Keep custom two-argument factories compatible with the graph seam."""
+        seam = {}
         baked_routes = (self.baked_graph or {}).get('routes')
-        if (not isinstance(baked_routes, dict) or not any(
+        if (isinstance(baked_routes, dict) and any(
                 baked_routes.get(key) for key in (1, 2, '1', '2'))):
+            seam['baked_routes'] = baked_routes
+        bases = self._baked_objective_bases()
+        if bases is not None:
+            seam['bases'] = bases
+        if not seam:
             return self.adapter_factory(map_name, round_id)
         if self.adapter_factory is BotAdapter:
-            return self.adapter_factory(map_name, round_id,
-                                        baked_routes=baked_routes)
+            return self.adapter_factory(map_name, round_id, **seam)
         try:
-            return self.adapter_factory(map_name, round_id,
-                                        baked_routes=baked_routes)
+            return self.adapter_factory(map_name, round_id, **seam)
         except TypeError:
             return self.adapter_factory(map_name, round_id)
 

--- a/0.9.22/tests/test_port_0922_bot_runtime.py
+++ b/0.9.22/tests/test_port_0922_bot_runtime.py
@@ -11115,6 +11115,71 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertTrue(driver._reverse_blocked_by_vehicle(
             (0.0, 0.0, 0.0), 0.0, neighbours, 2.0, 1.0))
 
+    def test_the_baked_graph_owns_the_tactical_bases(self):
+        """The decoded arena bases must beat the hand-written tactical copy.
+
+        01_karelia is the case that proves it: its static table holds the two
+        team bases the other way round from the arena definition the
+        navigation graph was baked from, so orienting a route against the
+        static copy sends a team at its own base.
+        """
+        runtime = self.module.BotRuntime(
+            1, descriptor_resolver=lambda unused: _combat_descriptor(),
+            adapter_factory=self.module.BotAdapter,
+            direction_probe=lambda *unused: {'clear': True, 'slope': 0.2},
+            ground_probe=lambda *unused: 0.0,
+            physics_ground_probe=lambda *unused: 0.0,
+            spawn_resolver=_spawn_resolver, baked_graph=_graph())
+        runtime.baked_graph = _graph()
+
+        adapter = runtime._new_adapter('01_karelia', 5)
+        static = self.module.tactical_maps.get_tactical_map(
+            '01_karelia').get('bases')
+        self.assertEqual({1: (8.0, 0.0), 2: (0.0, 0.0)},
+                         adapter.director.bases)
+        # The static copy is still reachable as the no-graph fallback, and it
+        # is exactly what must not have won here.
+        self.assertNotEqual(static, adapter.director.bases)
+        self.assertEqual(
+            {1: (8.0, 0.0), 2: (0.0, 0.0)},
+            runtime._baked_objective_bases())
+
+    def test_a_graphless_round_keeps_the_static_tactical_bases(self):
+        """Without a baked graph the static table remains the only source."""
+        runtime = self.module.BotRuntime(
+            1, descriptor_resolver=lambda unused: _combat_descriptor(),
+            adapter_factory=self.module.BotAdapter,
+            direction_probe=lambda *unused: {'clear': True, 'slope': 0.2},
+            ground_probe=lambda *unused: 0.0,
+            physics_ground_probe=lambda *unused: 0.0,
+            spawn_resolver=_spawn_resolver, baked_graph=_graph())
+        runtime.baked_graph = None
+
+        self.assertIsNone(runtime._baked_objective_bases())
+        adapter = runtime._new_adapter('01_karelia', 5)
+        static = self.module.tactical_maps.get_tactical_map(
+            '01_karelia').get('bases')
+        self.assertEqual(static, adapter.director.bases)
+
+    def test_a_malformed_graph_base_is_refused_not_half_applied(self):
+        """A partial base pair must fall back whole, never mix two sources."""
+        runtime = self.module.BotRuntime(
+            1, descriptor_resolver=lambda unused: _combat_descriptor(),
+            adapter_factory=self.module.BotAdapter,
+            direction_probe=lambda *unused: {'clear': True, 'slope': 0.2},
+            ground_probe=lambda *unused: 0.0,
+            physics_ground_probe=lambda *unused: 0.0,
+            spawn_resolver=_spawn_resolver, baked_graph=_graph())
+        for broken in (((8.0, 0.0),), ((8.0, 0.0), (0.0,)),
+                       ((8.0, 0.0), (float('nan'), 0.0)),
+                       ((8.0, 0.0), ('x', 0.0)), 'not-a-sequence', None):
+            graph = _graph()
+            graph['objective_bases'] = broken
+            runtime.baked_graph = graph
+            self.assertIsNone(
+                runtime._baked_objective_bases(),
+                'accepted a malformed objective base: %r' % (broken,))
+
     def test_production_adapter_exposes_a_lease_capable_driver(self):
         """The wiring above must reach the shipped adapter, not a double."""
         adapter = self.module.BotAdapter('01_karelia', 5)


### PR DESCRIPTION
## The bug

`BattleDirector.__init__` reads:

```python
self.bases.update(self.map_data.get("bases", {}))   # static tactical table
# The live arena definition is authoritative. Static tactical data only
# supplies a fallback for tests or incomplete legacy DataSections.
self.bases.update(dict(bases or {}))                # live
```

**Nothing ever passed `bases`.** `BotRuntime._new_adapter` built every adapter as `adapter_factory(map_name, round_id, baked_routes=...)`, so the second `update` was a no-op and the hand-written copy in the tactical tables *was* the live value. That comment described an intent, not the code.

## Those copies are wrong

Comparing every tactical map against the `objective_bases` its navigation graph was baked from — trying both team orderings, taking the better:

| map | error |
|---|---|
| `84_winter` | **995 m** (on a 1000 m map) |
| `73_asia_korea` | 906 m |
| `22_slough` | 806 m |
| `114_czech` | 743 m |
| `59_asia_great_wall` | 741 m |
| `103_ruinberg_winter` | 720 m |
| `95_lost_city` | 646 m |
| `13_erlenberg` | 504 m |
| `92_stalingrad` | 855 m |
| `63_tundra` | 436 m |
| `34_redshire` | 402 m |
| `86_himmelsdorf_winter` | 353 m |
| `112_eiffel_tower_ctf` | 323 m |
| `11_murovanka` | 285 m |
| `83_kharkiv` | 136 m |

**11 of the 13 maps in `ai/maps_0922_extra.py` are out by more than 100 m** — that module documents its own coordinates as coarse minimap guesses. `01_karelia` matches *exactly* but with **the two teams the other way round**.

19 maps match to 0–4 m, which is what identifies `objective_bases` as the right field and `[team1, team2]` as the right ordering.

## Why it matters

The director uses these two points in:

- `planner.py:467` `route_toward_enemy()` — decides **which end of a lane belongs to which team**, reversing the waypoints when the far end is closer to our own base;
- `planner.py:1107` `_route_position()` — drives a bot **straight at the enemy base** when it holds no route.

Wrong bases therefore reverse a lane, or send a team at its own base.

## The fix

Pass the graph's `objective_bases` instead of correcting thirteen sets of numbers:

- `bake_navigation_0922.py:2393` stores the exact `teamBasePositions` decoded from the arena definition;
- `spawn_planner.py:53` **already reads that same field**, with the same `enumerate(..., 1)` team ordering;
- `navigation_graph_schema.py:144` already validates it as team points.

So this removes a hand-written duplicate of data the mod already ships, and fixes **every map with a baked graph**, not only the guessed ones. It also makes the existing `BattleDirector` comment true.

The static table stays as the documented no-graph fallback. A malformed or partial `objective_bases` pair is refused **whole**, so the two sources can never be mixed.

## Validation

- 3 new tests. **Verified all three fail without the production change.**
  - the graph beats the static copy, using `01_karelia` — the swapped-team case;
  - a graphless round still keeps the static table;
  - six malformed `objective_bases` shapes (short pair, short point, NaN, non-numeric, non-sequence, `None`) are each refused whole.
- `bot_runtime` suite: 374 tests, OK.
- Full 0.9.22 suite: 3338 tests, OK.
- CPython 2.7.18 compile of the changed module.
- Branch is based on current `main` (`8e334f1`).

No package, tag, or release is included.

## Exact-client evidence boundary

This is a pure-data comparison against the baked graphs plus injected-fixture tests. It proves which coordinates the director now receives; **it does not prove how bots visibly behave on #1513.** This changes bot lane orientation and the no-route objective on many maps, so it wants Windows acceptance before it is trusted — in particular `01_karelia`, whose teams flip, and `84_winter`, which moves the furthest.