### PR TITLE
Prioritize admitted player fire intents

### DIFF
--- a/src/res/scripts/client/gui/mods/offline_lan_0922/authority_worker.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/authority_worker.py
@@ -256,6 +256,14 @@ class AuthorityWorkerLANClient(LANClient):
         self.spawn = {
             'x': 0.0, 'y': WORKER_DUMMY_Y, 'z': 0.0, 'yaw': 0.0}
         self._worker_avatar = None
+        self.on_batch_drained = None
+
+    def _poll(self):
+        """Drain one wire batch before running worker-only urgent work."""
+        LANClient._poll(self)
+        callback = self.on_batch_drained
+        if callable(callback):
+            callback(self)
 
     def is_bot_authority(self):
         """Only the dedicated worker identity may own bot simulation."""
@@ -752,6 +760,7 @@ class WorkerSession(object):
         self._probe_sample = None
         self._process_sample_time = None
         self._process_cpu_seconds = None
+        self._urgent_player_fire = False
 
     def _ensure_runtime_boundaries(self):
         if self._bigworld is None:
@@ -786,10 +795,21 @@ class WorkerSession(object):
                     # LAN poll callback and leave a connected zombie worker.
                     self._worker_failure(error)
 
-        self.client = self._client_factory(
+        client = self._client_factory(
             self._config.get('host', '127.0.0.1'),
             self._config.get('port', 28782), on_event=on_event,
             bigworld=self._bigworld)
+
+        def on_batch_drained(source_client):
+            if (not self._stopped and generation == self._generation and
+                    self.client is source_client):
+                try:
+                    self._on_batch_drained()
+                except Exception as error:
+                    self._worker_failure(error)
+
+        client.on_batch_drained = on_batch_drained
+        self.client = client
         self.state = 'connecting'
         try:
             if not self.client.start():
@@ -1045,6 +1065,7 @@ class WorkerSession(object):
         # a later stop can therefore retry instead of abandoning a live map.
         if self.runtime is runtime:
             self.runtime = None
+        self._urgent_player_fire = False
         self._active_round_id = None
         self._last_progress_frame = 0
         self._next_progress_time = 0.0
@@ -1090,6 +1111,7 @@ class WorkerSession(object):
         if client is not None:
             try:
                 client.on_event = None
+                client.on_batch_drained = None
                 client.stop()
             except Exception as cleanup_error:
                 cleanup_failed = True
@@ -1170,7 +1192,8 @@ class WorkerSession(object):
             elif kind == 'battle_live':
                 self.runtime.on_battle_live(message)
             elif kind == 'fire_intent':
-                self.runtime.on_fire_intent(message)
+                if self.runtime.on_fire_intent(message):
+                    self._urgent_player_fire = True
             elif kind == 'player_destructible_contact':
                 self.runtime.on_player_destructible_contact(message)
             elif kind == 'fire_intent_result':
@@ -1184,6 +1207,24 @@ class WorkerSession(object):
             self._worker_failure(RuntimeError(
                 message.get('message') or 'worker transport lost'))
         self._write_status()
+
+    def _on_batch_drained(self):
+        """Resolve admitted player fire after this wire batch is coherent."""
+        if not self._urgent_player_fire:
+            return False
+        self._urgent_player_fire = False
+        runtime = self.runtime
+        client = self.client
+        if (runtime is None or client is None or
+                not client.is_bot_authority() or
+                self._active_round_id is None):
+            return False
+        flush = getattr(
+            runtime, 'flush_admitted_player_fire_intents', None)
+        if not callable(flush):
+            raise RuntimeError(
+                'worker player-fire fast path is unavailable')
+        return bool(flush())
 
     def _write_status(self, force=False):
         now = time.time()
@@ -1479,6 +1520,7 @@ class WorkerSession(object):
             if client is not None:
                 try:
                     client.on_event = None
+                    client.on_batch_drained = None
                     client.stop()
                 except Exception as error:
                     if cleanup_error is None:
@@ -1487,6 +1529,7 @@ class WorkerSession(object):
                     if self.client is client:
                         self.client = None
         self._active_round_id = None
+        self._urgent_player_fire = False
         self._pending_start = None
         self._pending_start_deadline = None
         self._last_progress_frame = 0

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -7380,6 +7380,26 @@ class BattleRuntime(object):
         self._player_fire_intents[key] = frozen
         return True
 
+    def flush_admitted_player_fire_intents(self):
+        """Resolve a drained LAN batch before the next full Bot frame."""
+        if not self._battle_live or not self._player_fire_intents:
+            return False
+        # WorkerSession calls this at the tail of AuthorityWorkerLANClient's
+        # BigWorld-thread poll.  Every snapshot/event already received in the
+        # same batch is therefore applied before shot-relevant state is read.
+        # Missing native entities remain queued for the ordinary frame path.
+        started = _PROFILE_CLOCK()
+        try:
+            return self._advance_player_fire_authority(
+                0.0, self._clock(),
+                intent_keys=tuple(self._player_fire_intents),
+                defer_missing_player=True)
+        finally:
+            # PERF subtracts this mod-owned callback work from the engine's
+            # outside time and reports it through the existing off-frame lane.
+            self._offframe_seconds += max(
+                0.0, _PROFILE_CLOCK() - started)
+
     def on_player_destructible_contact(self, message):
         """Resolve one server-admitted player hull contact immediately."""
         if not self._worker_mode or self.state != 'running':
@@ -18207,10 +18227,22 @@ class BattleRuntime(object):
         gun._client_checkpoint_seq = input_seq
         return gun.can_fire(True)
 
-    def _advance_player_fire_authority(self, dt, now):
+    def _advance_player_fire_authority(
+            self, dt, now, intent_keys=None, defer_missing_player=False):
         """Resolve visible triggers from their input-bound client gun edge."""
         if not self._worker_mode or not self._projectile_is_authority():
             return False
+        if intent_keys is None:
+            pending_intents = tuple(self._player_fire_intents.items())
+            target_player_ids = None
+        else:
+            pending_intents = tuple(
+                (key, self._player_fire_intents[key])
+                for key in tuple(intent_keys)
+                if key in self._player_fire_intents)
+            target_player_ids = set(
+                int(intent['player_id'])
+                for unused_key, intent in pending_intents)
         live_players = set()
         for record in tuple(self._records.values()):
             if record.get('kind') != 'player':
@@ -18218,6 +18250,9 @@ class BattleRuntime(object):
             try:
                 player_id = int(record.get('network_id'))
             except (TypeError, ValueError, OverflowError):
+                continue
+            if (target_player_ids is not None and
+                    player_id not in target_player_ids):
                 continue
             if player_id <= 0 or record.get('tombstone'):
                 continue
@@ -18250,15 +18285,17 @@ class BattleRuntime(object):
                 if getattr(gun, '_effective_params', None) != effective:
                     raise RuntimeError(
                         'worker player effective parameters changed in battle')
-        for player_id in tuple(self._player_authority_guns):
-            if player_id not in live_players:
-                self._player_authority_guns.pop(player_id, None)
-
-        for key, intent in tuple(self._player_fire_intents.items()):
+        if target_player_ids is None:
+            for player_id in tuple(self._player_authority_guns):
+                if player_id not in live_players:
+                    self._player_authority_guns.pop(player_id, None)
+        for key, intent in pending_intents:
             player_id = int(intent['player_id'])
             if player_id in self._player_fire_launch_pending:
                 continue
             record = self._records.get('player:%s' % player_id)
+            if record is None and defer_missing_player:
+                continue
             if record is None or record.get('tombstone'):
                 self._reject_player_fire_intent(key, 'player_unavailable')
                 continue

--- a/tests/test_port_0922_authority_worker_client.py
+++ b/tests/test_port_0922_authority_worker_client.py
@@ -3,6 +3,7 @@ import json
 from pathlib import Path
 import sys
 import tempfile
+import threading
 import types
 import unittest
 from unittest import mock
@@ -1352,6 +1353,76 @@ class AuthorityWorkerClientTests(unittest.TestCase):
             session._on_event('fire_intent_result', message)
 
         self.assertEqual([message], runtime.fire_intent_results)
+
+    def test_bigworld_poll_flushes_fire_intent_at_batch_tail(self):
+        scheduled = []
+
+        def callback(delay, function):
+            scheduled.append((delay, function))
+            return len(scheduled)
+
+        world = types.SimpleNamespace(callback=callback)
+        client = AuthorityWorkerLANClient(
+            '127.0.0.1', 28782, bigworld=world)
+        client.running = True
+        client.ready = True
+        client.phase = 'battle'
+        client.round_id = 7
+        client.authority_epoch = 4
+        client.bot_authority_id = WORKER_AUTHORITY_ID
+        runtime = _WorkerRuntime(client, world)
+        calls = []
+
+        def on_fire_intent(message):
+            calls.append((
+                'intent', threading.current_thread(), dict(message)))
+            return True
+
+        def on_fire_intent_result(message):
+            calls.append((
+                'result', threading.current_thread(), dict(message)))
+            return True
+
+        def flush_admitted_player_fire_intents():
+            calls.append(('flush', threading.current_thread(), None))
+            return True
+
+        runtime.on_fire_intent = on_fire_intent
+        runtime.on_fire_intent_result = on_fire_intent_result
+        runtime.flush_admitted_player_fire_intents = (
+            flush_admitted_player_fire_intents)
+        message = {
+            'type': 'fire_intent', 'round_id': 7,
+            'authority_epoch': 4, 'player_id': 2, 'intent_seq': 3,
+        }
+        result = {
+            'type': 'fire_intent_result', 'round_id': 7,
+            'player_id': 3, 'intent_seq': 4, 'accepted': False,
+            'reason': 'projectile_launch_rejected',
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            session = WorkerSession(
+                {}, bigworld=world,
+                status_path=str(Path(directory) / 'status.json'))
+            session.client = client
+            session.runtime = runtime
+            session._active_round_id = 7
+            client.on_event = session._on_event
+            client.on_batch_drained = (
+                lambda source: session._on_batch_drained())
+
+            client._queue_message(message)
+            client._queue_message(result)
+            client._schedule_poll()
+            self.assertEqual(1, len(scheduled))
+            scheduled[0][1]()
+
+        self.assertEqual(['intent', 'result', 'flush'], [
+            call[0] for call in calls])
+        self.assertTrue(all(
+            threading.current_thread() is call[1] for call in calls))
+        self.assertEqual(message, calls[0][2])
+        self.assertEqual(result, calls[1][2])
 
     def test_worker_routes_player_destructible_contact_to_runtime(self):
         world = _DrawWorld()

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -20743,6 +20743,8 @@ class BattleRuntimeContractTests(unittest.TestCase):
         battle = BattleRuntime(_runtime())
         battle._worker_mode = True
         battle.state = 'running'
+        battle._battle_live = True
+        battle._projectile_is_authority = lambda: True
         battle.client = _Client()
         battle.client.authority_epoch = 4
         battle._start_message = {'round_id': 7}
@@ -20778,6 +20780,112 @@ class BattleRuntimeContractTests(unittest.TestCase):
         with self.assertRaisesRegex(
                 RuntimeError, 'worker fire intent is malformed'):
             battle.on_fire_intent(dict(intent, unexpected='wire field'))
+
+    def test_worker_fire_fast_path_revisits_older_intents_in_order(self):
+        battle = BattleRuntime(_runtime())
+        battle._worker_mode = True
+        battle.state = 'running'
+        battle._battle_live = True
+        battle.client = _Client()
+        battle.client.authority_epoch = 4
+        battle._start_message = {'round_id': 7}
+        battle._clock = mock.Mock(return_value=12.5)
+        older_key = (1, 2)
+        battle._player_fire_intents[older_key] = {'player_id': 1}
+        battle._advance_player_fire_authority = mock.Mock(return_value=True)
+        intent = {
+            'type': 'fire_intent', 'round_id': 7,
+            'authority_epoch': 4, 'player_id': 2, 'intent_seq': 3,
+            'shot_seq': 5, 'input_seq': 8, 'pose_time_us': 1000,
+            'shell_index': 0, 'next_shell_index': 0,
+            'shell_change_pending': False,
+            'gun_checkpoint_seq': 8,
+            'gun_checkpoint': _human_gun_checkpoint(),
+            'aim_yaw': 0.2, 'gun_pitch': -0.1,
+            'x': 1.0, 'y': 2.0, 'z': 3.0, 'yaw': 0.0,
+            'pitch': 0.0, 'roll': 0.0, 'speed': 4.0,
+            'shot_origin': [1.0, 3.0, 3.0],
+            'shot_direction': [0.0, 0.0, 1.0],
+            'dispersion_angle': 0.02,
+            'presentation_ledger': [],
+        }
+
+        self.assertTrue(battle.on_fire_intent(intent))
+        battle._advance_player_fire_authority.assert_not_called()
+        self.assertTrue(battle.flush_admitted_player_fire_intents())
+
+        battle._advance_player_fire_authority.assert_called_once_with(
+            0.0, 12.5, intent_keys=(older_key, (2, 3)),
+            defer_missing_player=True)
+
+    def test_worker_fire_fast_path_retries_player_missing_at_dispatch(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._worker_mode = True
+        battle.state = 'running'
+        battle._battle_live = True
+        battle._start_message = {'round_id': 7}
+        battle._projectile_is_authority = lambda: True
+        battle._config = {'perfect_accuracy': True}
+        client = _Client()
+        client.authority_epoch = 4
+        client.send_projectile_launch = mock.Mock(
+            side_effect=lambda *args, **unused_kwargs: args[2])
+        client.send_fire_intent_result = mock.Mock(return_value=True)
+        battle.client = client
+        intent = {
+            'type': 'fire_intent', 'round_id': 7,
+            'authority_epoch': 4, 'player_id': 2, 'intent_seq': 3,
+            'shot_seq': 5, 'input_seq': 8, 'pose_time_us': 1000,
+            'shell_index': 0, 'next_shell_index': 0,
+            'shell_change_pending': False,
+            'gun_checkpoint_seq': 8,
+            'gun_checkpoint': _human_gun_checkpoint(),
+            'aim_yaw': 0.2, 'gun_pitch': -0.1,
+            'x': 50.0, 'y': 0.0, 'z': 50.0, 'yaw': 0.0,
+            'pitch': 0.0, 'roll': 0.0, 'speed': 0.0,
+            'shot_origin': [4.0, 2.0, 8.0],
+            'shot_direction': [0.0, 0.0, 1.0],
+            'dispersion_angle': 0.02,
+            'presentation_ledger': [],
+        }
+        key = (2, 3)
+
+        # The transport can beat the snapshot/native entity lifecycle.  The
+        # fast path must not turn that harmless ordering into a terminal
+        # rejection or lose the admitted shot.
+        self.assertTrue(battle.on_fire_intent(intent))
+        self.assertTrue(battle.flush_admitted_player_fire_intents())
+        self.assertIn(key, battle._player_fire_intents)
+        self.assertNotIn(key, battle._player_fire_intent_history)
+        client.send_projectile_launch.assert_not_called()
+        client.send_fire_intent_result.assert_not_called()
+
+        descriptor = _Descriptor()
+        entity = _Vehicle(
+            11, descriptor, _Vector(50.0, 0.0, 50.0), (0, 0, 0),
+            {'health': 500})
+        runtime.bigworld.entities[11] = entity
+        effective = _effective_params_snapshot(ammo=[[101, 40]])
+        battle._records = {'player:2': {
+            'engine_id': 11, 'network_id': 2, 'kind': 'player',
+            'local': False, 'ready': True, 'tombstone': False,
+            'state': {
+                'alive': True, 'shell_index': 0, 'speed': 0.0,
+                'turn': 0.0, 'effective_params': effective,
+            },
+        }}
+
+        self.assertTrue(battle._advance_player_fire_authority(0.1, 10.0))
+        self.assertNotIn(key, battle._player_fire_intents)
+        self.assertIn(key, battle._player_fire_intent_history)
+        self.assertEqual(1, client.send_projectile_launch.call_count)
+
+        # The ordinary frame remains safe to call after the deferred intent
+        # has been launched: no second canonical projectile is emitted.
+        self.assertTrue(battle._advance_player_fire_authority(0.1, 10.1))
+        self.assertEqual(1, client.send_projectile_launch.call_count)
+        client.send_fire_intent_result.assert_not_called()
 
     def test_worker_resolves_immediate_player_destructible_contact(self):
         battle = BattleRuntime(_runtime())
@@ -21734,6 +21842,12 @@ class BattleRuntimeContractTests(unittest.TestCase):
                 side_effect=AssertionError(
                     'stale model node must not be read')) as node:
             self.assertTrue(battle.on_fire_intent(intent))
+            client.send_projectile_launch.assert_not_called()
+            # WorkerSession invokes this after the current LAN batch is fully
+            # applied but before the next full Bot frame.
+            self.assertTrue(battle.flush_admitted_player_fire_intents())
+            self.assertEqual(1, client.send_projectile_launch.call_count)
+            self.assertNotIn((2, 3), battle._player_fire_intents)
             self.assertTrue(
                 battle._advance_player_fire_authority(0.1, 10.0))
             node.assert_not_called()


### PR DESCRIPTION
## Summary

- Process admitted player fire intents at the tail of the same worker LAN poll batch.
- Preserve message ordering, authority/round lifecycle fences, pending intent order, and duplicate suppression.
- Leave intents without a native player entity pending for the normal frame path.
- Account fast-path work as off-frame worker time without bypassing server admission or projectile authority.

## Why

A fire intent previously waited for the next complete simulation frame after worker admission. Under long worker callbacks, that added up to another full slow tick before launch. This change removes that avoidable wait; it does not claim to make the underlying slow frame faster or preempt an already-running BigWorld callback.

## Validation

- 49 authority worker tests passed
- 699 battle runtime tests passed
- All 89 Python 2.7 client source files compiled
- Full GitHub Actions client, server, package, and Windows launcher workflow passed for the identical patch before it was reverted from main

## Native-client boundary

Only testing on the exact Windows 0.9.22.0.1 #1513 client can prove the user-visible latency improvement and BigWorld timing behavior.