### PR TITLE
Reduce admitted player fire latency

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -125,7 +125,7 @@ jobs:
                                'lean_snapshot_manifest_v1',
                                'ram_contact_ledger_v2',
                                'human_ram_timeline_v1',
-                               'player_fire_intent_v5',
+                               'player_fire_intent_v6',
                                'player_environment_v2',
                                'effective_params_v1',
                                'ricochet_continuation_v1'],

--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -1171,7 +1171,7 @@ queueing a frame, normalizing periodic yaw instead of clipping it, so normal
 #1513 values never produce an avoidable rejection.
 
 A human trigger is a space-time claim, so the fire intent carries both halves
-of it. `player_fire_intent_v5` adds a bounded presentation ledger to the
+of it. `player_fire_intent_v6` carries a bounded presentation ledger in the
 intent: one `(bot_id, bot_state_revision, presentation_time_us)` entry per
 timed Bot record the shooter was displaying, taken from the same
 `SnapshotSync` confirmed-only cursor that positioned the rendered hull. The
@@ -1208,11 +1208,29 @@ the typed terminal `trigger_clock_stale`, a claim beyond the future tolerance
 gets `trigger_clock_future`, and a missing or malformed claim gets
 `trigger_clock_invalid`. The positive tolerance covers clock and RTT
 quantization only: the canonical launch instant is `min(trigger, receipt)`,
-so an admitted projectile never starts in the server's future. That instant
-lives in the pending intent, so transport delay, worker mailbox delay,
-scheduling delay, motion-clock catch-up and an exact retry cannot reinterpret
-it; the authority catches up from it the way a Bot launch already catches up
-from `bot_launch_clock_offset_us`. Bot launch timing is unchanged.
+so an admitted projectile never starts in the server's future. That same
+server-validated instant is frozen in both the worker relay and the pending
+intent. The worker can therefore start the admitted trajectory before its
+canonical echo without letting transport delay, worker mailbox delay,
+scheduling delay, motion-clock catch-up or an exact retry reinterpret it; the
+authority catches up from it the way a Bot launch already catches up from
+`bot_launch_clock_offset_us`. Bot launch timing is unchanged.
+
+The worker resolves admitted human fire at the tail of the current LAN poll,
+after every snapshot and event in that receive batch is coherent, and retains
+the ordinary frame path for native-entity readiness retries. After publishing
+the launch it installs the same deterministic projectile identity and
+six-decimal wire fields locally. The six-decimal operation is an explicit
+integer-rational half-even rule because Python 2.7 and Python 3 builtin
+`round` disagree at exact half values. A matching canonical echo is therefore
+idempotent; a changed echo atomically replaces the provisional manager state,
+and a rejection rolls it back without weakening the ordinary duplicate fence.
+An older snapshot cannot retire a provisional launch or its terminal proposal
+before either outcome arrives. Bot launches remain canonical-echo gated:
+their server launch instant depends on the private admission-time
+`bot_launch_clock_offset_us`, so guessing it in the worker would break exact
+echo identity. This preserves the existing Bot timing path while testing it
+alongside the new human path.
 
 The fire-intent envelope remains exact and closed. Once the current player,
 round, `fire_intent` type and exact next `intent_seq` can be identified safely,

--- a/launcher/core.py
+++ b/launcher/core.py
@@ -110,11 +110,11 @@ _SERVER_PROBES = {
         "capabilities": (
             "projectile_ledger_v2", "destructible_catalog_v5",
             "ram_contact_ledger_v2", "human_ram_timeline_v1",
-            "player_fire_intent_v5", "player_environment_v2",
+            "player_fire_intent_v6", "player_environment_v2",
             "effective_params_v1", "ricochet_continuation_v1"),
         "server_capabilities": (
             "destructible_catalog_v5", "ram_contact_ledger_v2",
-            "human_ram_timeline_v1", "player_fire_intent_v5",
+            "human_ram_timeline_v1", "player_fire_intent_v6",
             "player_environment_v2", "effective_params_v1",
             "ricochet_continuation_v1"),
     },

--- a/launcher/tests/test_launcher_core.py
+++ b/launcher/tests/test_launcher_core.py
@@ -1625,7 +1625,7 @@ class ListenerTest(unittest.TestCase):
                 "capabilities": hello.get("capabilities", []),
                 "server_capabilities": [
                     "destructible_catalog_v5", "ram_contact_ledger_v2",
-                    "human_ram_timeline_v1", "player_fire_intent_v5",
+                    "human_ram_timeline_v1", "player_fire_intent_v6",
                     "player_environment_v2", "effective_params_v1",
                     "ricochet_continuation_v1"],
             }

--- a/server/lan_battle_server.py
+++ b/server/lan_battle_server.py
@@ -246,7 +246,7 @@ DESTRUCTIBLE_CATALOG_V5_CAPABILITY = "destructible_catalog_v5"
 LEAN_SNAPSHOT_MANIFEST_CAPABILITY = "lean_snapshot_manifest_v1"
 RAM_CONTACT_LEDGER_CAPABILITY = "ram_contact_ledger_v2"
 HUMAN_RAM_TIMELINE_CAPABILITY = "human_ram_timeline_v1"
-PLAYER_FIRE_INTENT_CAPABILITY = "player_fire_intent_v5"
+PLAYER_FIRE_INTENT_CAPABILITY = "player_fire_intent_v6"
 PLAYER_ENVIRONMENT_CAPABILITY = "player_environment_v2"
 EFFECTIVE_PARAMS_CAPABILITY = effective_params_wire.CAPABILITY
 VEHICLE_OVERLAY_CAPABILITY = "vehicle_overlay_v1"
@@ -761,6 +761,37 @@ def _bounded_float(value, low, high, inclusive_low=True):
     return value
 
 
+def _projectile_wire_round(value):
+    """Round one binary float to the six-decimal projectile wire grid.
+
+    Python 2.7 and Python 3 disagree on builtin ``round`` at exact half
+    values. This integer-rational half-even operation has identical semantics
+    in both runtimes and preserves the sign of a rounded negative zero.
+    """
+    number = float(value)
+    numerator, denominator = number.as_integer_ratio()
+    negative = math.copysign(1.0, number) < 0.0
+    scaled = abs(numerator) * 1000000
+    quotient, remainder = divmod(scaled, denominator)
+    twice_remainder = remainder * 2
+    if (twice_remainder > denominator or
+            (twice_remainder == denominator and quotient % 2)):
+        quotient += 1
+    if quotient == 0:
+        return -0.0 if negative else 0.0
+    if negative:
+        quotient = -quotient
+    return float(quotient) / 1000000.0
+
+
+def _projectile_bounded_vector(value, lows, highs):
+    if not isinstance(value, list) or len(value) != 3:
+        raise ValueError("expected three-vector")
+    return [_projectile_wire_round(_bounded_float(
+        component, lows[index], highs[index]))
+        for index, component in enumerate(value)]
+
+
 def _bot_lineup_allowed_names(catalog):
     """Return selectable catalog identities without hidden test vehicles."""
     excluded_tags = {
@@ -818,42 +849,44 @@ def _projectile_source_shot(value):
             not isinstance(damage, list) or len(damage) != 2):
         raise ValueError("invalid source shell data")
     result = {
-        "speed": round(_bounded_float(
-            value.get("speed"), 0.000001, PROJECTILE_MAX_VELOCITY), 6),
-        "gravity": round(_bounded_float(
-            value.get("gravity"), 0.000001, PROJECTILE_MAX_GRAVITY), 6),
-        "maxDistance": round(_bounded_float(
+        "speed": _projectile_wire_round(_bounded_float(
+            value.get("speed"), 0.000001, PROJECTILE_MAX_VELOCITY)),
+        "gravity": _projectile_wire_round(_bounded_float(
+            value.get("gravity"), 0.000001, PROJECTILE_MAX_GRAVITY)),
+        "maxDistance": _projectile_wire_round(_bounded_float(
             value.get("maxDistance"), 0.000001,
-            PROJECTILE_MAX_DISTANCE), 6),
-        "piercingPower": [round(_bounded_float(
-            component, 0.0, 10000.0), 6) for component in piercing],
+            PROJECTILE_MAX_DISTANCE)),
+        "piercingPower": [_projectile_wire_round(_bounded_float(
+            component, 0.0, 10000.0)) for component in piercing],
         "deadeye": deadeye,
         "shell": {
             "kind": kind,
-            "caliber": round(_bounded_float(
-                shell.get("caliber"), 0.000001, 1000.0), 6),
+            "caliber": _projectile_wire_round(_bounded_float(
+                shell.get("caliber"), 0.000001, 1000.0)),
             "damage": [
-                round(_bounded_float(
-                    damage[0], 0.000001, 10000.0), 6),
-                round(_bounded_float(
-                    damage[1], 0.0, MAX_CRITICAL_DEVICE_HP), 6),
+                _projectile_wire_round(_bounded_float(
+                    damage[0], 0.000001, 10000.0)),
+                _projectile_wire_round(_bounded_float(
+                    damage[1], 0.0, MAX_CRITICAL_DEVICE_HP)),
             ],
-            "explosionRadius": round(_bounded_float(
+            "explosionRadius": _projectile_wire_round(_bounded_float(
                 shell.get("explosionRadius"), 0.0,
-                PROJECTILE_MAX_SPLASH_RADIUS), 6),
+                PROJECTILE_MAX_SPLASH_RADIUS)),
         },
     }
     if he_factor_fields.issubset(shell_fields):
         result["shell"].update({
-            "explosionDamageFactor": round(_bounded_float(
+            "explosionDamageFactor": _projectile_wire_round(_bounded_float(
                 shell.get("explosionDamageFactor"), 0.000001,
-                10000.0), 6),
-            "explosionDamageAbsorptionFactor": round(_bounded_float(
-                shell.get("explosionDamageAbsorptionFactor"),
-                0.000001, 10000.0), 6),
-            "explosionEdgeDamageFactor": round(_bounded_float(
-                shell.get("explosionEdgeDamageFactor"),
-                0.000001, 1.0), 6),
+                10000.0)),
+            "explosionDamageAbsorptionFactor": _projectile_wire_round(
+                _bounded_float(
+                    shell.get("explosionDamageAbsorptionFactor"),
+                    0.000001, 10000.0)),
+            "explosionEdgeDamageFactor": _projectile_wire_round(
+                _bounded_float(
+                    shell.get("explosionEdgeDamageFactor"),
+                    0.000001, 1.0)),
         })
     return result
 
@@ -6180,6 +6213,7 @@ class BattleState:
                 "shot_seq": int(player.fire_seq) + 1,
                 "input_seq": input_seq,
                 "pose_time_us": int(player.pose_time_us),
+                "trigger_launch_time_ms": trigger_launch_time_ms,
                 "presentation_ledger": [
                     dict(entry) for entry in presentation_ledger],
                 "shell_index": shell_index,
@@ -6204,14 +6238,12 @@ class BattleState:
             }
             player.fire_intent_seq = intent_seq
             player.fire_intent_fingerprints[intent_seq] = fingerprint
-            # The visible client freezes this value in the same round-clock
-            # domain used by projectile events. Keeping the validated value in
-            # the pending intent makes retries and delayed canonical launches
-            # reuse the trigger instant without consulting a jumping motion
-            # clock or a later server tick.
-            player.pending_fire_intents[intent_seq] = dict(
-                relay,
-                trigger_launch_time_ms=trigger_launch_time_ms)
+            # The visible client supplies a trigger claim in the round-clock
+            # domain used by projectile events. The worker relay and pending
+            # intent share the one server-validated and clamped value, so eager
+            # simulation, retries and delayed canonical launches cannot
+            # reinterpret it from a jumping motion clock or a later server tick.
+            player.pending_fire_intents[intent_seq] = dict(relay)
             while (len(player.fire_intent_fingerprints) >
                    PLAYER_FIRE_INTENT_HISTORY):
                 player.fire_intent_fingerprints.popitem(last=False)
@@ -6389,10 +6421,10 @@ class BattleState:
                     message.get("shot_seq"), 1, PROJECTILE_MAX_ID)
                 burst = self._projectile_burst(message, shot_seq)
                 shell_index = _exact_int(message.get("shell_index"), 0, 9)
-                origin = _bounded_vector(
+                origin = _projectile_bounded_vector(
                     message.get("origin"), (-5000.0, -1000.0, -5000.0),
                     (5000.0, 3000.0, 5000.0))
-                velocity = _bounded_vector(
+                velocity = _projectile_bounded_vector(
                     message.get("velocity"),
                     (-PROJECTILE_MAX_VELOCITY,) * 3,
                     (PROJECTILE_MAX_VELOCITY,) * 3)
@@ -6400,23 +6432,23 @@ class BattleState:
                                       for component in velocity))
                 if speed <= 0.001 or speed > PROJECTILE_MAX_VELOCITY:
                     raise ValueError("invalid launch speed")
-                gravity = round(_bounded_float(
+                gravity = _projectile_wire_round(_bounded_float(
                     message.get("gravity"), 0.0,
-                    PROJECTILE_MAX_GRAVITY, False), 6)
-                max_distance = round(_bounded_float(
+                    PROJECTILE_MAX_GRAVITY, False))
+                max_distance = _projectile_wire_round(_bounded_float(
                     message.get("max_distance"), 0.0,
-                    PROJECTILE_MAX_DISTANCE, False), 6)
+                    PROJECTILE_MAX_DISTANCE, False))
                 max_time_ms = _exact_int(
                     message.get("max_time_ms"), 1,
                     PROJECTILE_MAX_LIFETIME_MS)
                 if not isinstance(message.get("is_he"), bool):
                     raise ValueError("invalid HE flag")
                 is_he = message["is_he"]
-                splash_radius = round(_bounded_float(
+                splash_radius = _projectile_wire_round(_bounded_float(
                     message.get("splash_radius"), 0.0,
-                    PROJECTILE_MAX_SPLASH_RADIUS), 6)
-                penetration_factor = round(_bounded_float(
-                    message.get("penetration_factor"), 0.0, 100.0), 6)
+                    PROJECTILE_MAX_SPLASH_RADIUS))
+                penetration_factor = _projectile_wire_round(_bounded_float(
+                    message.get("penetration_factor"), 0.0, 100.0))
                 source_shot = _projectile_source_shot(
                     message.get("source_shot"))
                 fire_intent_seq = (
@@ -6592,7 +6624,7 @@ class BattleState:
                 return self._set_protocol_reject(
                     reject_kind, "identity", "source vehicle is invalid")
             try:
-                range_origin = _bounded_vector(
+                range_origin = _projectile_bounded_vector(
                     shooter_position,
                     (-5000.0, -1000.0, -5000.0),
                     (5000.0, 3000.0, 5000.0))

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/authority_worker.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/authority_worker.py
@@ -256,6 +256,14 @@ class AuthorityWorkerLANClient(LANClient):
         self.spawn = {
             'x': 0.0, 'y': WORKER_DUMMY_Y, 'z': 0.0, 'yaw': 0.0}
         self._worker_avatar = None
+        self.on_batch_drained = None
+
+    def _poll(self):
+        """Drain one wire batch before running worker-only urgent work."""
+        LANClient._poll(self)
+        callback = self.on_batch_drained
+        if callable(callback):
+            callback(self)
 
     def is_bot_authority(self):
         """Only the dedicated worker identity may own bot simulation."""
@@ -752,6 +760,7 @@ class WorkerSession(object):
         self._probe_sample = None
         self._process_sample_time = None
         self._process_cpu_seconds = None
+        self._urgent_player_fire = False
 
     def _ensure_runtime_boundaries(self):
         if self._bigworld is None:
@@ -786,10 +795,21 @@ class WorkerSession(object):
                     # LAN poll callback and leave a connected zombie worker.
                     self._worker_failure(error)
 
-        self.client = self._client_factory(
+        client = self._client_factory(
             self._config.get('host', '127.0.0.1'),
             self._config.get('port', 28782), on_event=on_event,
             bigworld=self._bigworld)
+
+        def on_batch_drained(source_client):
+            if (not self._stopped and generation == self._generation and
+                    self.client is source_client):
+                try:
+                    self._on_batch_drained()
+                except Exception as error:
+                    self._worker_failure(error)
+
+        client.on_batch_drained = on_batch_drained
+        self.client = client
         self.state = 'connecting'
         try:
             if not self.client.start():
@@ -1045,6 +1065,7 @@ class WorkerSession(object):
         # a later stop can therefore retry instead of abandoning a live map.
         if self.runtime is runtime:
             self.runtime = None
+        self._urgent_player_fire = False
         self._active_round_id = None
         self._last_progress_frame = 0
         self._next_progress_time = 0.0
@@ -1090,6 +1111,7 @@ class WorkerSession(object):
         if client is not None:
             try:
                 client.on_event = None
+                client.on_batch_drained = None
                 client.stop()
             except Exception as cleanup_error:
                 cleanup_failed = True
@@ -1170,7 +1192,8 @@ class WorkerSession(object):
             elif kind == 'battle_live':
                 self.runtime.on_battle_live(message)
             elif kind == 'fire_intent':
-                self.runtime.on_fire_intent(message)
+                if self.runtime.on_fire_intent(message):
+                    self._urgent_player_fire = True
             elif kind == 'player_destructible_contact':
                 self.runtime.on_player_destructible_contact(message)
             elif kind == 'fire_intent_result':
@@ -1184,6 +1207,24 @@ class WorkerSession(object):
             self._worker_failure(RuntimeError(
                 message.get('message') or 'worker transport lost'))
         self._write_status()
+
+    def _on_batch_drained(self):
+        """Resolve admitted player fire after this wire batch is coherent."""
+        if not self._urgent_player_fire:
+            return False
+        self._urgent_player_fire = False
+        runtime = self.runtime
+        client = self.client
+        if (runtime is None or client is None or
+                not client.is_bot_authority() or
+                self._active_round_id is None):
+            return False
+        flush = getattr(
+            runtime, 'flush_admitted_player_fire_intents', None)
+        if not callable(flush):
+            raise RuntimeError(
+                'worker player-fire fast path is unavailable')
+        return bool(flush())
 
     def _write_status(self, force=False):
         now = time.time()
@@ -1479,6 +1520,7 @@ class WorkerSession(object):
             if client is not None:
                 try:
                     client.on_event = None
+                    client.on_batch_drained = None
                     client.stop()
                 except Exception as error:
                     if cleanup_error is None:
@@ -1487,6 +1529,7 @@ class WorkerSession(object):
                     if self.client is client:
                         self.client = None
         self._active_round_id = None
+        self._urgent_player_fire = False
         self._pending_start = None
         self._pending_start_deadline = None
         self._last_progress_frame = 0

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -155,6 +155,13 @@ EXPERT_DEVICE_DELAY_SECONDS = 4.0
 PROJECTILE_PROGRESS_SECONDS = 0.10
 PROJECTILE_MAX_TIME_MS = 20000
 PROJECTILE_MAX_ACTIVE = 128
+_PROJECTILE_IMMUTABLE_FIELDS = (
+    'projectile_id', 'shooter_kind', 'shooter_id', 'source_vehicle',
+    'source_shot', 'shot_seq', 'shell_index',
+    'burst_group_seq', 'burst_index', 'burst_count',
+    'origin', 'velocity', 'range_origin', 'gravity', 'max_distance',
+    'max_time_ms', 'is_he', 'splash_radius', 'penetration_factor',
+    'launch_server_time_ms', 'fire_intent_seq', 'fire_input_seq')
 PROJECTILE_CHORDS_PER_FRAME = 32
 PROJECTILE_MAX_CHORDS_PER_FRAME = 256
 # A rotating target traces a curve in component-local space. Subdivide until
@@ -1587,6 +1594,7 @@ class BattleRuntime(object):
         self._player_fire_intents = collections.OrderedDict()
         self._player_fire_intent_history = collections.OrderedDict()
         self._player_fire_launch_pending = {}
+        self._fire_timeline = collections.OrderedDict()
         self._local_fire_intent = None
         self._fire_intent_reject_round = None
         self._fire_intent_reject_counts = {}
@@ -1870,6 +1878,7 @@ class BattleRuntime(object):
         self._player_fire_intents = collections.OrderedDict()
         self._player_fire_intent_history = collections.OrderedDict()
         self._player_fire_launch_pending = {}
+        self._fire_timeline = collections.OrderedDict()
         self._local_fire_intent = None
         self._fire_intent_reject_round = None
         self._fire_intent_reject_counts = {}
@@ -7299,6 +7308,7 @@ class BattleRuntime(object):
         required = {
             'type', 'round_id', 'authority_epoch', 'player_id', 'intent_seq',
             'shot_seq', 'input_seq', 'pose_time_us', 'shell_index',
+            'trigger_launch_time_ms',
             'next_shell_index', 'shell_change_pending',
             'gun_checkpoint_seq', 'gun_checkpoint',
             'aim_yaw', 'gun_pitch', 'x', 'y', 'z', 'yaw', 'pitch', 'roll',
@@ -7316,6 +7326,7 @@ class BattleRuntime(object):
             shot_seq = int(message['shot_seq'])
             input_seq = int(message['input_seq'])
             pose_time_us = int(message['pose_time_us'])
+            trigger_launch_time_ms = int(message['trigger_launch_time_ms'])
             shell_index = int(message['shell_index'])
             next_shell_index = int(message['next_shell_index'])
             gun_checkpoint_seq = int(message['gun_checkpoint_seq'])
@@ -7344,6 +7355,12 @@ class BattleRuntime(object):
                 authority_epoch != int(self.client.authority_epoch) or
                 player_id <= 0 or intent_seq <= 0 or shot_seq <= 0 or
                 input_seq <= 0 or pose_time_us < 0 or
+                isinstance(message['trigger_launch_time_ms'], bool) or
+                not isinstance(message['trigger_launch_time_ms'],
+                               _INTEGER_TYPES) or
+                trigger_launch_time_ms < 0 or
+                trigger_launch_time_ms >
+                lan_protocol.MAX_MOTION_TIME_US // 1000 or
                 gun_checkpoint_seq != input_seq or
                 gun_checkpoint is None or
                 presentation_ledger is None or
@@ -7378,6 +7395,16 @@ class BattleRuntime(object):
                for value in self._player_fire_intents.values()):
             raise RuntimeError('worker received overlapping fire intents')
         self._player_fire_intents[key] = frozen
+        poll_delay = _number(message.get('_client_dispatch_delay'), 0.0)
+        self._remember_fire_timeline(key, {
+            'received_wall': _PROFILE_CLOCK(),
+            'poll_delay': max(0.0, poll_delay),
+        })
+        sys.stdout.write(
+            '[Offline LAN 0.9.22] FIRE INTENT RECEIVED player=%d intent=%d '
+            'shot_seq=%d poll_delay_ms=%.0f\n' % (
+                player_id, intent_seq, shot_seq,
+                max(0.0, poll_delay) * 1000.0))
         return True
 
     def flush_admitted_player_fire_intents(self):
@@ -7499,6 +7526,20 @@ class BattleRuntime(object):
                     not isinstance(pending, dict) or
                     sequence != int(pending.get('intent_seq', 0))):
                 return False
+            projectile_id = pending.get('projectile_id')
+            meta = self._projectile_meta.get(projectile_id)
+            if meta is not None and meta.get('local_launch_pending'):
+                manager_key = meta.get('manager_key', projectile_id)
+                rolled_back = (self._projectiles is not None and
+                               self._projectiles.rollback_provisional(
+                                   manager_key))
+                self._report_projectile_terminal_failure(
+                    meta, {}, 'fire_intent_result', 'server_rejected')
+                self._projectile_meta.pop(projectile_id, None)
+                self._projectile_terminal_data.pop(projectile_id, None)
+                if not rolled_back:
+                    self._report_projectile_terminal_failure(
+                        meta, {}, 'fire_intent_result', 'rollback_failed')
             self._player_fire_launch_pending.pop(player_id, None)
             return True
         pending = self._local_fire_intent
@@ -9577,6 +9618,13 @@ class BattleRuntime(object):
                 raise RuntimeError(
                     'canonical player shot violates worker gun state')
             self._player_fire_launch_pending.pop(player_id, None)
+            commit_wall = _PROFILE_CLOCK()
+            launch_wall = float(pending.get('sent_wall', commit_wall))
+            sys.stdout.write(
+                '[Offline LAN 0.9.22] FIRE COMMIT player=%d intent=%d '
+                'shot_seq=%d launch_to_commit_ms=%.0f\n' % (
+                    player_id, intent_seq, shot_seq,
+                    max(0.0, commit_wall - launch_wall) * 1000.0))
             return True
         if not record.get('local'):
             return False
@@ -9608,6 +9656,15 @@ class BattleRuntime(object):
                 gun.reload_time, gun.reload_duration, force=True)
             if self._sender is not None:
                 self._sender.send_current()
+        projectile_id = event.get('projectile_id')
+        if projectile_id is not None:
+            now_wall = _PROFILE_CLOCK()
+            self._remember_fire_timeline(str(projectile_id), {
+                'trigger': float(pending.get('sent_wall', now_wall)),
+                'shown': None,
+                'cursor_logs': 0,
+                'moving_logged': False,
+            })
         self._local_fire_intent = None
         return True
 
@@ -9767,6 +9824,17 @@ class BattleRuntime(object):
                     delattr(entity, name)
                 except Exception:
                     pass
+        projectile_id = event.get('projectile_id')
+        timeline = self._fire_timeline.get(str(projectile_id))
+        if timeline is not None and timeline.get('shown') is None:
+            shown_wall = _PROFILE_CLOCK()
+            timeline['shown'] = shown_wall
+            sys.stdout.write(
+                '[Offline LAN 0.9.22] FIRE SHOWN intent=%d shot_seq=%d '
+                'projectile=%s since_trigger_ms=%.0f\n' % (
+                    int(event.get('fire_intent_seq', 0) or 0),
+                    int(event.get('shot_seq', 0) or 0), projectile_id,
+                    max(0.0, shown_wall - timeline['trigger']) * 1000.0))
         return True
 
     def _projectile_is_authority(self):
@@ -9901,11 +9969,10 @@ class BattleRuntime(object):
     def _projectile_local_launch_time(self, launch_server_time_ms, now):
         estimated = self._projectile_estimated_server_time(now)
         if estimated is None:
-            return min(float(now), self._projectiles.now)
+            return max(0.0, float(now))
         age = max(
             0.0, float(estimated - int(launch_server_time_ms)) / 1000.0)
-        return max(
-            0.0, min(self._projectiles.now, float(now) - age))
+        return max(0.0, float(now) - age)
 
     @staticmethod
     def _projectile_visual_age(raw):
@@ -10076,6 +10143,122 @@ class BattleRuntime(object):
             return None
         return result
 
+    @staticmethod
+    def _projectile_source_shot_for_server(source_shot):
+        """Mirror the server's six-decimal mounted-shot wire contract."""
+        normalized = lan_protocol._strict_projectile_source_shot(source_shot)
+        if normalized is None:
+            return None
+        shell = normalized['shell']
+        frozen_shell = {
+            'kind': shell['kind'],
+            'caliber': lan_protocol._projectile_wire_round(shell['caliber']),
+            'damage': [lan_protocol._projectile_wire_round(value)
+                       for value in shell['damage']],
+            'explosionRadius': lan_protocol._projectile_wire_round(
+                shell['explosionRadius']),
+        }
+        for name in lan_protocol.PROJECTILE_HE_FACTOR_FIELDS:
+            if name in shell:
+                frozen_shell[name] = lan_protocol._projectile_wire_round(
+                    shell[name])
+        return {
+            'speed': lan_protocol._projectile_wire_round(
+                normalized['speed']),
+            'gravity': lan_protocol._projectile_wire_round(
+                normalized['gravity']),
+            'maxDistance': lan_protocol._projectile_wire_round(
+                normalized['maxDistance']),
+            'piercingPower': [lan_protocol._projectile_wire_round(value)
+                              for value in normalized['piercingPower']],
+            'deadeye': bool(normalized['deadeye']),
+            'shell': frozen_shell,
+        }
+
+    @staticmethod
+    def _projectile_id_for_round(
+            round_id, shooter_kind, shooter_id, shot_seq):
+        """Return the deterministic identity used by the LAN server."""
+        marker = {'player': 'p', 'bot': 'b'}.get(shooter_kind)
+        if marker is None:
+            return None
+        values = (round_id, shooter_id, shot_seq)
+        if any(isinstance(value, bool) or
+               not isinstance(value, _INTEGER_TYPES) for value in values):
+            return None
+        if any(value <= 0 for value in values):
+            return None
+        return '%d:%s:%d:%d' % (
+            values[0], marker, values[1], values[2])
+
+    def _local_player_projectile_meta(
+            self, intent, record, origin, velocity, gravity, maximum,
+            max_time_ms, is_he, splash_radius, penetration_factor,
+            source_shot):
+        """Build exactly the launch record the server will echo."""
+        state = record.get('state') or {}
+        projectile_id = self._projectile_id_for_round(
+            (self._start_message or {}).get('round_id'), 'player',
+            intent.get('player_id'), intent.get('shot_seq'))
+        source_vehicle = state.get('vehicle')
+        frozen_shot = self._projectile_source_shot_for_server(source_shot)
+        if (projectile_id is None or
+                not isinstance(source_vehicle, _STRING_TYPES) or
+                not source_vehicle or len(source_vehicle) > 128 or
+                frozen_shot is None):
+            return None
+
+        def vector(values):
+            return [lan_protocol._projectile_wire_round(value)
+                    for value in values]
+
+        try:
+            shot_seq = int(intent['shot_seq'])
+            raw = {
+                'projectile_id': projectile_id,
+                'shooter_kind': 'player',
+                'shooter_id': int(intent['player_id']),
+                'source_vehicle': str(source_vehicle),
+                'source_shot': frozen_shot,
+                'shot_seq': shot_seq,
+                'burst_group_seq': shot_seq,
+                'burst_index': 0,
+                'burst_count': 1,
+                'shell_index': int(intent['shell_index']),
+                'fire_intent_seq': int(intent['intent_seq']),
+                'fire_input_seq': int(intent['input_seq']),
+                'origin': vector(origin),
+                'velocity': vector(velocity),
+                'range_origin': vector((
+                    intent['x'], intent['y'], intent['z'])),
+                'segment_origin': vector(origin),
+                'segment_velocity': vector(velocity),
+                'segment_start_time_ms': 0,
+                'ricochet_count': 0,
+                'base_penetration_multiplier': 1.0,
+                'gravity': lan_protocol._projectile_wire_round(gravity),
+                'max_distance': lan_protocol._projectile_wire_round(maximum),
+                'max_time_ms': int(max_time_ms),
+                'is_he': bool(is_he),
+                'splash_radius': lan_protocol._projectile_wire_round(
+                    splash_radius),
+                'penetration_factor': lan_protocol._projectile_wire_round(
+                    penetration_factor),
+                'launch_server_time_ms': int(
+                    intent['trigger_launch_time_ms']),
+                'checked_through_ms': 0,
+                'checked_distance': 0.0,
+                'piercing_loss': 0.0,
+            }
+        except (KeyError, TypeError, ValueError, OverflowError):
+            return None
+        return self._projectile_wire_meta(raw)
+
+    @staticmethod
+    def _projectile_launch_mismatches(current, canonical):
+        return tuple(name for name in _PROJECTILE_IMMUTABLE_FIELDS
+                     if current.get(name) != canonical.get(name))
+
     def _projectile_presentation_offsets(self, normalized):
         """Bind one admitted shot to the target timelines its shooter saw.
 
@@ -10115,17 +10298,22 @@ class BattleRuntime(object):
             offsets['bot:%d' % bot_id] = float(lag_us) / 1000000.0
         return offsets
 
+    def _new_projectile_meta(self, normalized):
+        projectile_id = normalized['projectile_id']
+        meta = dict(normalized)
+        meta['manager_key'] = (
+            projectile_id if normalized['ricochet_count'] == 0 else
+            (projectile_id, normalized['ricochet_count']))
+        meta['destructibles_pending'] = []
+        meta['presentation_offsets'] = (
+            self._projectile_presentation_offsets(normalized))
+        return meta
+
     def _install_projectile_meta(self, normalized):
         projectile_id = normalized['projectile_id']
         meta = self._projectile_meta.get(projectile_id)
         if meta is None:
-            meta = dict(normalized)
-            meta['manager_key'] = (
-                projectile_id if normalized['ricochet_count'] == 0 else
-                (projectile_id, normalized['ricochet_count']))
-            meta['destructibles_pending'] = []
-            meta['presentation_offsets'] = (
-                self._projectile_presentation_offsets(normalized))
+            meta = self._new_projectile_meta(normalized)
             self._projectile_meta[projectile_id] = meta
             self._report_player_shot_timing(meta)
         else:
@@ -10135,17 +10323,8 @@ class BattleRuntime(object):
             meta.setdefault(
                 'manager_key', projectile_id if current_count == 0 else
                 (projectile_id, current_count))
-            frozen = (
-                'shooter_kind', 'shooter_id', 'source_vehicle',
-                'source_shot', 'shot_seq', 'shell_index',
-                'burst_group_seq', 'burst_index', 'burst_count',
-                'origin', 'velocity', 'range_origin',
-                'gravity', 'max_distance',
-                'max_time_ms', 'is_he', 'splash_radius',
-                'penetration_factor', 'launch_server_time_ms',
-                'fire_intent_seq', 'fire_input_seq')
             if any(meta.get(name) != normalized.get(name)
-                   for name in frozen):
+                   for name in _PROJECTILE_IMMUTABLE_FIELDS):
                 raise RuntimeError('canonical projectile launch changed')
             incoming_count = normalized['ricochet_count']
             if incoming_count < current_count or incoming_count > (
@@ -10202,6 +10381,178 @@ class BattleRuntime(object):
         self._confirm_bot_projectile_launch(normalized)
         return meta
 
+    def _projectile_manager_snapshot(self, normalized, now):
+        launch_time = self._projectile_local_launch_time(
+            normalized['launch_server_time_ms'] +
+            normalized['segment_start_time_ms'], now)
+        cursor_time = min(
+            float(now),
+            launch_time + max(
+                0, normalized['base_checked_ms'] -
+                normalized['segment_start_time_ms']) / 1000.0)
+        return {
+            'key': (normalized['projectile_id']
+                    if normalized['ricochet_count'] == 0 else
+                    (normalized['projectile_id'],
+                     normalized['ricochet_count'])),
+            'start': normalized['segment_origin'],
+            'velocity': normalized['segment_velocity'],
+            'gravity': (0.0, -normalized['gravity'], 0.0),
+            'launch_time': launch_time,
+            'max_time': max(
+                0.001, float(
+                    normalized['max_time_ms'] -
+                    normalized['segment_start_time_ms']) / 1000.0),
+            'max_distance': normalized['max_distance'],
+            'payload': {
+                'shooter_kind': normalized['shooter_kind'],
+                'shooter_id': normalized['shooter_id'],
+                'shot_seq': normalized['shot_seq'],
+                'shell_index': normalized['shell_index'],
+                'range_origin': normalized['range_origin'],
+                'base_penetration_multiplier': normalized[
+                    'base_penetration_multiplier'],
+                'ricochet_count': normalized['ricochet_count'],
+                'segment_start_time_ms': normalized[
+                    'segment_start_time_ms'],
+            },
+            'cursor_time': max(launch_time, cursor_time),
+            'distance': normalized['checked_distance'],
+        }
+
+    def _admit_projectile_manager_state(
+            self, normalized, now, replacement_key=None):
+        snapshot = self._projectile_manager_snapshot(normalized, now)
+        if replacement_key is not None:
+            return bool(self._projectiles.replace_authoritative(
+                snapshot, provisional_key=replacement_key,
+                admission_time=now))
+        if normalized['ricochet_count'] != 0:
+            return bool(self._projectiles.restore(
+                snapshot, admission_time=now))
+        return bool(self._projectiles.launch(
+            snapshot['key'], snapshot['start'], snapshot['velocity'],
+            snapshot['gravity'], snapshot['launch_time'],
+            snapshot['max_time'], snapshot['max_distance'],
+            payload=snapshot['payload'], admission_time=now))
+
+    def _find_provisional_projectile(self, normalized):
+        direct = self._projectile_meta.get(normalized['projectile_id'])
+        if direct is not None and direct.get('local_launch_pending'):
+            return direct
+        identity = (
+            normalized.get('shooter_kind'), normalized.get('shooter_id'),
+            normalized.get('shot_seq'), normalized.get('fire_intent_seq'))
+        for meta in self._projectile_meta.values():
+            if (meta.get('local_launch_pending') and
+                    (meta.get('shooter_kind'), meta.get('shooter_id'),
+                     meta.get('shot_seq'), meta.get('fire_intent_seq')) ==
+                    identity):
+                return meta
+        return None
+
+    def _reconcile_provisional_projectile(
+            self, normalized, now, authoritative_snapshot=False):
+        """Confirm or atomically correct one locally launched player shell."""
+        provisional = self._find_provisional_projectile(normalized)
+        if provisional is None:
+            return None
+        mismatch = self._projectile_launch_mismatches(
+            provisional, normalized)
+        if not mismatch:
+            old_key = provisional.get(
+                'manager_key', provisional['projectile_id'])
+            state = (self._projectiles.get(old_key)
+                     if self._projectiles is not None else None)
+            if authoritative_snapshot and state is not None:
+                snapshot = self._projectile_manager_snapshot(
+                    normalized, now)
+                if snapshot['cursor_time'] > state['cursor_time'] + 1e-9:
+                    accepted = self._projectiles.replace_authoritative(
+                        snapshot, provisional_key=old_key,
+                        admission_time=now)
+                    if not accepted:
+                        diagnostic = {
+                            'projectile_id': provisional.get(
+                                'projectile_id'),
+                            'terminal_failure_boundary': provisional.get(
+                                'terminal_failure_boundary'),
+                        }
+                        self._report_projectile_terminal_failure(
+                            diagnostic, state, 'canonical_snapshot',
+                            'takeover_rejected')
+                        return False
+            meta = self._install_projectile_meta(normalized)
+            meta.pop('local_launch_pending', None)
+            return meta
+
+        old_id = provisional['projectile_id']
+        old_key = provisional.get('manager_key', old_id)
+        state = (self._projectiles.get(old_key)
+                 if self._projectiles is not None else None)
+        replacement = self._new_projectile_meta(normalized)
+        accepted = self._admit_projectile_manager_state(
+            normalized, now, replacement_key=old_key)
+        if not accepted:
+            diagnostic = {
+                'projectile_id': provisional.get('projectile_id'),
+                'terminal_failure_boundary': provisional.get(
+                    'terminal_failure_boundary'),
+            }
+            self._report_projectile_terminal_failure(
+                diagnostic, state or {}, 'canonical_echo',
+                'replacement_rejected', ','.join(mismatch))
+            return False
+
+        self._report_projectile_terminal_failure(
+            provisional, state or {}, 'canonical_echo',
+            'launch_mismatch', ','.join(mismatch))
+        if self._projectile_meta.get(old_id) is provisional:
+            self._projectile_meta.pop(old_id, None)
+        self._projectile_terminal_data.pop(old_id, None)
+        self._projectile_meta[normalized['projectile_id']] = replacement
+        return replacement
+
+    def _preinstall_player_projectile(
+            self, intent, record, origin, velocity, gravity, maximum,
+            max_time_ms, is_he, splash_radius, penetration_factor,
+            source_shot, now):
+        """Start one server-admitted human shell before its canonical echo."""
+        projectile_id = self._projectile_id_for_round(
+            (self._start_message or {}).get('round_id'), 'player',
+            intent.get('player_id'), intent.get('shot_seq'))
+        diagnostic = {'projectile_id': projectile_id or 'unknown'}
+        if (not self._projectile_is_authority() or
+                self._projectiles is None or
+                not self._set_projectile_epoch(
+                    getattr(self.client, 'authority_epoch', None), now)):
+            self._report_projectile_terminal_failure(
+                diagnostic, {}, 'local_preinstall', 'authority_unavailable')
+            return None
+        normalized = self._local_player_projectile_meta(
+            intent, record, origin, velocity, gravity, maximum,
+            max_time_ms, is_he, splash_radius, penetration_factor,
+            source_shot)
+        if normalized is None:
+            self._report_projectile_terminal_failure(
+                diagnostic, {}, 'local_preinstall', 'normalization_failed')
+            return None
+        meta = self._install_projectile_meta(normalized)
+        meta['local_launch_pending'] = True
+        if not self._admit_projectile_manager_state(normalized, now):
+            self._projectile_meta.pop(normalized['projectile_id'], None)
+            self._report_projectile_terminal_failure(
+                meta, {}, 'local_preinstall', 'manager_rejected')
+            return None
+        if not self._projectile_position_history:
+            poses = self._projectile_record_poses()
+            self._sample_projectile_positions(now, poses)
+            self._projectile_target_positions = dict(
+                (key, _xyz(pose)) for key, pose in poses.items())
+        meta['awaiting_resolution'] = False
+        meta['awaiting_ricochet'] = False
+        return normalized['projectile_id']
+
     def _accept_projectile_event(self, event):
         """Register one server-admitted launch on the elected simulator."""
         if not self._projectile_is_authority() or self._projectiles is None:
@@ -10213,55 +10564,27 @@ class BattleRuntime(object):
         normalized = self._projectile_wire_meta(event)
         if normalized is None:
             raise RuntimeError('canonical projectile event is malformed')
-        meta = self._install_projectile_meta(normalized)
+        now = self._clock()
+        meta = self._reconcile_provisional_projectile(normalized, now)
+        if meta is False:
+            return False
+        if meta is None:
+            meta = self._install_projectile_meta(normalized)
         projectile_id = normalized['projectile_id']
         manager_key = meta['manager_key']
         if self._projectiles.contains(manager_key):
             return True
-        now = self._clock()
-        launch_time = self._projectile_local_launch_time(
-            normalized['launch_server_time_ms'] +
-            normalized['segment_start_time_ms'], now)
-        payload = {
-                'shooter_kind': normalized['shooter_kind'],
-                'shooter_id': normalized['shooter_id'],
-                'shot_seq': normalized['shot_seq'],
-                'shell_index': normalized['shell_index'],
-                'range_origin': normalized['range_origin'],
-                'base_penetration_multiplier': normalized[
-                    'base_penetration_multiplier'],
-                'ricochet_count': normalized['ricochet_count'],
-                'segment_start_time_ms': normalized[
-                    'segment_start_time_ms'],
-            }
-        if normalized['ricochet_count'] == 0:
-            accepted = self._projectiles.launch(
-                manager_key, normalized['segment_origin'],
-                normalized['segment_velocity'],
-                (0.0, -normalized['gravity'], 0.0), launch_time,
-                float(normalized['max_time_ms']) / 1000.0,
-                normalized['max_distance'], payload=payload)
-        else:
-            cursor_time = min(
-                self._projectiles.now,
-                launch_time + max(
-                    0, normalized['base_checked_ms'] -
-                    normalized['segment_start_time_ms']) / 1000.0)
-            accepted = self._projectiles.restore({
-                'key': manager_key,
-                'start': normalized['segment_origin'],
-                'velocity': normalized['segment_velocity'],
-                'gravity': (0.0, -normalized['gravity'], 0.0),
-                'launch_time': launch_time,
-                'max_time': max(
-                    0.001, float(
-                        normalized['max_time_ms'] -
-                        normalized['segment_start_time_ms']) / 1000.0),
-                'max_distance': normalized['max_distance'],
-                'payload': payload,
-                'cursor_time': max(launch_time, cursor_time),
-                'distance': normalized['checked_distance'],
-            })
+        if (meta.get('pending_resolution') is not None or
+                meta.get('pending_ricochet') is not None or
+                meta.get('awaiting_resolution') or
+                meta.get('awaiting_ricochet')):
+            # A provisional projectile may terminal before its canonical echo.
+            # The terminal proposal stayed behind the echo barrier; never
+            # manufacture a second launch for the retired manager identity.
+            self._submit_projectile_ricochet(meta)
+            self._submit_projectile_resolution(meta)
+            return True
+        accepted = self._admit_projectile_manager_state(normalized, now)
         if not accepted:
             self._projectile_meta.pop(projectile_id, None)
             raise RuntimeError('canonical projectile launch was not admitted')
@@ -10295,8 +10618,13 @@ class BattleRuntime(object):
                 # metadata or an authority simulator entry.
                 continue
             active_ids.add(projectile_id)
+            installed = self._reconcile_provisional_projectile(
+                normalized, now, authoritative_snapshot=True)
+            if installed is False:
+                continue
+            if installed is None:
+                installed = self._install_projectile_meta(normalized)
             normalized_rows.append(normalized)
-            installed = self._install_projectile_meta(normalized)
             self._ensure_projectile_visual(installed, now)
         if not self._projectile_is_authority():
             return True
@@ -10331,44 +10659,14 @@ class BattleRuntime(object):
                 # shooter that disconnected after firing remains resolvable;
                 # only wait when even that canonical descriptor is unavailable.
                 continue
-            launch_time = self._projectile_local_launch_time(
-                normalized['launch_server_time_ms'] +
-                normalized['segment_start_time_ms'], now)
-            cursor_time = min(
-                self._projectiles.now,
-                launch_time + max(
-                    0, normalized['base_checked_ms'] -
-                    normalized['segment_start_time_ms']) / 1000.0)
-            restored = self._projectiles.restore({
-                'key': meta['manager_key'],
-                'start': normalized['segment_origin'],
-                'velocity': normalized['segment_velocity'],
-                'gravity': (0.0, -normalized['gravity'], 0.0),
-                'launch_time': launch_time,
-                'max_time': max(
-                    0.001, float(
-                        normalized['max_time_ms'] -
-                        normalized['segment_start_time_ms']) / 1000.0),
-                'max_distance': normalized['max_distance'],
-                'payload': {
-                    'shooter_kind': normalized['shooter_kind'],
-                    'shooter_id': normalized['shooter_id'],
-                    'shot_seq': normalized['shot_seq'],
-                    'shell_index': normalized['shell_index'],
-                    'range_origin': normalized['range_origin'],
-                    'base_penetration_multiplier': normalized[
-                        'base_penetration_multiplier'],
-                    'ricochet_count': normalized['ricochet_count'],
-                    'segment_start_time_ms': normalized[
-                        'segment_start_time_ms'],
-                },
-                'cursor_time': max(launch_time, cursor_time),
-                'distance': normalized['checked_distance'],
-            })
+            restored = self._projectiles.restore(
+                self._projectile_manager_snapshot(normalized, now),
+                admission_time=now)
             if not restored:
                 raise RuntimeError('active projectile restore failed')
         for projectile_id, meta in tuple(self._projectile_meta.items()):
             if (projectile_id not in active_ids and
+                    not meta.get('local_launch_pending') and
                     (meta.get('awaiting_resolution') or
                      meta.get('pending_resolution') is not None or
                      meta.get('awaiting_ricochet') or
@@ -10557,6 +10855,22 @@ class BattleRuntime(object):
             existing_visual['confirmed_elapsed'] = max(
                 float(existing_visual.get('confirmed_elapsed', 0.0)),
                 confirmed_elapsed)
+            timeline = self._fire_timeline.get(str(projectile_id))
+            if (timeline is not None and
+                    timeline.get('shown') is not None and
+                    int(timeline.get('cursor_logs', 0)) < 8):
+                timeline['cursor_logs'] = int(
+                    timeline.get('cursor_logs', 0)) + 1
+                wall = _PROFILE_CLOCK()
+                sys.stdout.write(
+                    '[Offline LAN 0.9.22] FIRE CURSOR projectile=%s '
+                    'confirmed_ms=%.0f display_ms=%.0f '
+                    'since_trigger_ms=%.0f\n' % (
+                        projectile_id,
+                        existing_visual['confirmed_elapsed'] * 1000.0,
+                        float(existing_visual.get(
+                            'display_elapsed', 0.0)) * 1000.0,
+                        max(0.0, wall - timeline['trigger']) * 1000.0))
             if (existing_visual.get('active', False) or
                     not existing_visual.get('admitted', True) or
                     not existing_visual.get('launch_retryable', False)):
@@ -10688,6 +11002,21 @@ class BattleRuntime(object):
                 visual['active'] = False
                 visual['launch_retryable'] = False
                 continue
+            if display_elapsed > previous_elapsed:
+                timeline = self._fire_timeline.get(str(projectile_id))
+                if (timeline is not None and
+                        timeline.get('shown') is not None and
+                        not timeline.get('moving_logged', False)):
+                    timeline['moving_logged'] = True
+                    wall = _PROFILE_CLOCK()
+                    sys.stdout.write(
+                        '[Offline LAN 0.9.22] FIRE TRACER MOVING '
+                        'projectile=%s since_trigger_ms=%.0f '
+                        'since_shown_ms=%.0f confirmed_ms=%.0f\n' % (
+                            projectile_id,
+                            max(0.0, wall - timeline['trigger']) * 1000.0,
+                            max(0.0, wall - timeline['shown']) * 1000.0,
+                            confirmed_elapsed * 1000.0))
             advanced = advanced or display_elapsed > previous_elapsed
         return advanced
 
@@ -12561,7 +12890,8 @@ class BattleRuntime(object):
 
     def _submit_projectile_ricochet(self, meta):
         pending = meta.get('pending_ricochet')
-        if (pending is None or meta.get('progress_pending') is not None or
+        if (pending is None or meta.get('local_launch_pending') or
+                meta.get('progress_pending') is not None or
                 meta.get('awaiting_ricochet') or
                 not self._projectile_is_authority()):
             return False
@@ -12623,7 +12953,8 @@ class BattleRuntime(object):
 
     def _submit_projectile_resolution(self, meta):
         pending = meta.get('pending_resolution')
-        if (pending is None or meta.get('progress_pending') is not None or
+        if (pending is None or meta.get('local_launch_pending') or
+                meta.get('progress_pending') is not None or
                 meta.get('awaiting_resolution') or
                 not self._projectile_is_authority()):
             return False
@@ -18161,6 +18492,13 @@ class BattleRuntime(object):
             self._bot_fire_confirmations.pop(bot_id, None)
         return True
 
+    def _remember_fire_timeline(self, key, value):
+        """Keep bounded monotonic timestamps for per-shot diagnostics."""
+        self._fire_timeline.pop(key, None)
+        self._fire_timeline[key] = value
+        while len(self._fire_timeline) > 64:
+            self._fire_timeline.popitem(last=False)
+
     def _remember_player_fire_intent(self, key, intent):
         frozen = dict(intent)
         previous = self._player_fire_intent_history.get(key)
@@ -18184,6 +18522,7 @@ class BattleRuntime(object):
             'reason=%s reload=%.3f\n' % (
                 int(intent['player_id']), int(intent['intent_seq']),
                 str(reason), remaining))
+        self._fire_timeline.pop(key, None)
         self._remember_player_fire_intent(key, intent)
         self._player_fire_intents.pop(key, None)
         return True
@@ -18226,6 +18565,116 @@ class BattleRuntime(object):
         gun.load_started = True
         gun._client_checkpoint_seq = input_seq
         return gun.can_fire(True)
+
+    def _launch_player_fire_intent(
+            self, key, intent, now, defer_missing_player=False,
+            path='frame_retry'):
+        """Freeze, publish and provisionally start one admitted human shot."""
+        player_id = int(intent['player_id'])
+        if player_id in self._player_fire_launch_pending:
+            return False
+        record = self._records.get('player:%s' % player_id)
+        if record is None and defer_missing_player:
+            return False
+        if record is None or record.get('tombstone'):
+            return self._reject_player_fire_intent(
+                key, 'player_unavailable')
+        entity = self._server_entity(record.get('engine_id'))
+        if (entity is None or not getattr(entity, 'isStarted', False) or
+                getattr(entity, 'typeDescriptor', None) is None):
+            return False
+        state = record.get('state') or {}
+        if not bool(state.get('alive', True)):
+            return self._reject_player_fire_intent(key, 'player_dead')
+        gun = self._player_authority_guns.get(player_id)
+        if gun is None:
+            return False
+        effective = gun._effective_params
+        shell_index = int(intent['shell_index'])
+        if not self._apply_player_gun_checkpoint(gun, intent):
+            return self._reject_player_fire_intent(key, 'gun_not_ready')
+        try:
+            source_shot = dict(effective['gun']['shots'][
+                shell_index]['source_shot'])
+            # A shot freezes the perk state of its physical gunner at the
+            # accepted fire edge. The immutable round snapshot owns skill
+            # affiliation; current critical state owns consciousness.
+            source_shot['deadeye'] = bool(
+                effective_params.living_skill_count(
+                    effective, 'gunner_sniper',
+                    state.get('critical') or {}))
+            speed = float(source_shot['speed'])
+            gravity = float(source_shot['gravity'])
+            maximum = float(source_shot['maxDistance'])
+        except (IndexError, KeyError, TypeError, ValueError):
+            raise RuntimeError(
+                'worker player mounted shot contract is invalid')
+        if speed <= 0.0 or gravity <= 0.0 or maximum <= 0.0:
+            raise RuntimeError(
+                'worker player gun has invalid projectile parameters')
+        try:
+            origin = tuple(float(value) for value in intent['shot_origin'])
+            direction = self._vector(tuple(
+                float(value) for value in intent['shot_direction']))
+            dispersion_angle = float(intent['dispersion_angle'])
+        except (KeyError, TypeError, ValueError, OverflowError):
+            raise RuntimeError('worker player trigger ray is unavailable')
+        direction.normalise()
+        if direction.length <= 0.0:
+            raise RuntimeError('worker player muzzle direction is empty')
+        gun.scatter(
+            direction,
+            bool(self._config and self._config.get(
+                'perfect_accuracy', False)),
+            dispersion_angle=dispersion_angle)
+        velocity = tuple(value * speed for value in _xyz(direction))
+        shot_seq = int(intent['shot_seq'])
+        is_he = combat_rules.is_he(source_shot)
+        splash_radius = (
+            combat_rules.he_radius(source_shot) if is_he else 0.0)
+        penetration_factor = combat_rules.sample_penetration_factor()
+        accepted = self.client.send_projectile_launch(
+            'player', player_id, shot_seq, shell_index,
+            list(origin), list(velocity), gravity, maximum,
+            PROJECTILE_MAX_TIME_MS, is_he, splash_radius,
+            authority_epoch=self.client.authority_epoch,
+            penetration_factor=penetration_factor,
+            source_shot=source_shot,
+            fire_intent_seq=int(intent['intent_seq']),
+            fire_input_seq=int(intent['input_seq']))
+        if accepted != shot_seq:
+            raise RuntimeError(
+                'worker could not publish a canonical player launch')
+
+        launch_wall = _PROFILE_CLOCK()
+        projectile_id = self._projectile_id_for_round(
+            (self._start_message or {}).get('round_id'), 'player',
+            player_id, shot_seq)
+        self._player_fire_launch_pending[player_id] = {
+            'intent_seq': int(intent['intent_seq']),
+            'input_seq': int(intent['input_seq']),
+            'shot_seq': shot_seq,
+            'projectile_id': projectile_id,
+            'sent_at': float(now),
+            'sent_wall': launch_wall,
+        }
+        self._remember_player_fire_intent(key, intent)
+        self._preinstall_player_projectile(
+            intent, record, origin, velocity, gravity, maximum,
+            PROJECTILE_MAX_TIME_MS, is_he, splash_radius,
+            penetration_factor, source_shot, now)
+        received = self._fire_timeline.pop(key, None)
+        sys.stdout.write(
+            '[Offline LAN 0.9.22] FIRE LAUNCH player=%d intent=%d '
+            'shot_seq=%d wait_ms=%s poll_delay_ms=%s path=%s\n' % (
+                player_id, int(intent['intent_seq']), shot_seq,
+                ('%.0f' % (max(
+                    0.0, launch_wall - received['received_wall']) * 1000.0)
+                 if received is not None else '-'),
+                ('%.0f' % (received['poll_delay'] * 1000.0)
+                 if received is not None else '-'), str(path)))
+        self._player_fire_intents.pop(key, None)
+        return True
 
     def _advance_player_fire_authority(
             self, dt, now, intent_keys=None, defer_missing_player=False):
@@ -18289,93 +18738,11 @@ class BattleRuntime(object):
             for player_id in tuple(self._player_authority_guns):
                 if player_id not in live_players:
                     self._player_authority_guns.pop(player_id, None)
+        path = 'poll' if intent_keys is not None else 'frame_retry'
         for key, intent in pending_intents:
-            player_id = int(intent['player_id'])
-            if player_id in self._player_fire_launch_pending:
-                continue
-            record = self._records.get('player:%s' % player_id)
-            if record is None and defer_missing_player:
-                continue
-            if record is None or record.get('tombstone'):
-                self._reject_player_fire_intent(key, 'player_unavailable')
-                continue
-            entity = self._server_entity(record.get('engine_id'))
-            if (entity is None or not getattr(entity, 'isStarted', False) or
-                    getattr(entity, 'typeDescriptor', None) is None):
-                continue
-            state = record.get('state') or {}
-            if not bool(state.get('alive', True)):
-                self._reject_player_fire_intent(key, 'player_dead')
-                continue
-            gun = self._player_authority_guns.get(player_id)
-            if gun is None:
-                continue
-            effective = gun._effective_params
-            shell_index = int(intent['shell_index'])
-            if not self._apply_player_gun_checkpoint(gun, intent):
-                self._reject_player_fire_intent(key, 'gun_not_ready')
-                continue
-            try:
-                source_shot = dict(effective['gun']['shots'][
-                    shell_index]['source_shot'])
-                # A shot freezes the perk state of its physical gunner at
-                # the accepted fire edge.  The immutable round snapshot owns
-                # skill affiliation; the current critical state owns whether
-                # that carrier is conscious for this shot.
-                source_shot['deadeye'] = bool(
-                    effective_params.living_skill_count(
-                        effective, 'gunner_sniper',
-                        state.get('critical') or {}))
-                speed = float(source_shot['speed'])
-                gravity = float(source_shot['gravity'])
-                maximum = float(source_shot['maxDistance'])
-            except (IndexError, KeyError, TypeError, ValueError):
-                raise RuntimeError(
-                    'worker player mounted shot contract is invalid')
-            if speed <= 0.0 or gravity <= 0.0 or maximum <= 0.0:
-                raise RuntimeError(
-                    'worker player gun has invalid projectile parameters')
-            try:
-                origin = tuple(float(value) for value in
-                               intent['shot_origin'])
-                direction = self._vector(tuple(
-                    float(value) for value in intent['shot_direction']))
-                dispersion_angle = float(intent['dispersion_angle'])
-            except (KeyError, TypeError, ValueError, OverflowError):
-                raise RuntimeError(
-                    'worker player trigger ray is unavailable')
-            direction.normalise()
-            if direction.length <= 0.0:
-                raise RuntimeError('worker player muzzle direction is empty')
-            gun.scatter(
-                direction,
-                bool(self._config and self._config.get(
-                    'perfect_accuracy', False)),
-                dispersion_angle=dispersion_angle)
-            velocity = tuple(
-                value * speed for value in _xyz(direction))
-            shot_seq = int(intent['shot_seq'])
-            is_he = combat_rules.is_he(source_shot)
-            accepted = self.client.send_projectile_launch(
-                'player', player_id, shot_seq, shell_index,
-                list(origin), list(velocity), gravity, maximum,
-                PROJECTILE_MAX_TIME_MS, is_he,
-                combat_rules.he_radius(source_shot) if is_he else 0.0,
-                authority_epoch=self.client.authority_epoch,
-                penetration_factor=combat_rules.sample_penetration_factor(),
-                source_shot=source_shot,
-                fire_intent_seq=int(intent['intent_seq']),
-                fire_input_seq=int(intent['input_seq']))
-            if accepted != shot_seq:
-                raise RuntimeError(
-                    'worker could not publish a canonical player launch')
-            self._player_fire_launch_pending[player_id] = {
-                'intent_seq': int(intent['intent_seq']),
-                'input_seq': int(intent['input_seq']),
-                'shot_seq': shot_seq, 'sent_at': float(now),
-            }
-            self._remember_player_fire_intent(key, intent)
-            self._player_fire_intents.pop(key, None)
+            self._launch_player_fire_intent(
+                key, intent, now,
+                defer_missing_player=defer_missing_player, path=path)
         return True
 
     def _launch_bot_projectile(self, state, shot_seq):
@@ -20441,6 +20808,7 @@ class BattleRuntime(object):
         trigger_server_time_ms = self._projectile_estimated_server_time(now)
         if trigger_server_time_ms is None:
             return self._reject_local_fire('trigger_clock_unavailable')
+        trigger_wall = _PROFILE_CLOCK()
         if not self._sender.send_current():
             return self._reject_local_fire('input_send_failed')
         intent_seq = sender(
@@ -20453,7 +20821,14 @@ class BattleRuntime(object):
             'intent_seq': int(intent_seq),
             'input_seq': int(getattr(self.client, '_input_seq', 0)),
             'sent_at': float(now),
+            'sent_wall': trigger_wall,
         }
+        sys.stdout.write(
+            '[Offline LAN 0.9.22] FIRE TRIGGER intent=%d input=%d '
+            'shell=%d\n' % (
+                int(intent_seq),
+                int(getattr(self.client, '_input_seq', 0)),
+                int(shell_index)))
         return True
 
     @staticmethod
@@ -21084,6 +21459,7 @@ class BattleRuntime(object):
         self._player_fire_intents = collections.OrderedDict()
         self._player_fire_intent_history = collections.OrderedDict()
         self._player_fire_launch_pending = {}
+        self._fire_timeline = collections.OrderedDict()
         self._local_fire_intent = None
         self._fire_intent_reject_round = None
         self._fire_intent_reject_counts = {}

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -7380,6 +7380,26 @@ class BattleRuntime(object):
         self._player_fire_intents[key] = frozen
         return True
 
+    def flush_admitted_player_fire_intents(self):
+        """Resolve a drained LAN batch before the next full Bot frame."""
+        if not self._battle_live or not self._player_fire_intents:
+            return False
+        # WorkerSession calls this at the tail of AuthorityWorkerLANClient's
+        # BigWorld-thread poll.  Every snapshot/event already received in the
+        # same batch is therefore applied before shot-relevant state is read.
+        # Missing native entities remain queued for the ordinary frame path.
+        started = _PROFILE_CLOCK()
+        try:
+            return self._advance_player_fire_authority(
+                0.0, self._clock(),
+                intent_keys=tuple(self._player_fire_intents),
+                defer_missing_player=True)
+        finally:
+            # PERF subtracts this mod-owned callback work from the engine's
+            # outside time and reports it through the existing off-frame lane.
+            self._offframe_seconds += max(
+                0.0, _PROFILE_CLOCK() - started)
+
     def on_player_destructible_contact(self, message):
         """Resolve one server-admitted player hull contact immediately."""
         if not self._worker_mode or self.state != 'running':
@@ -18207,10 +18227,22 @@ class BattleRuntime(object):
         gun._client_checkpoint_seq = input_seq
         return gun.can_fire(True)
 
-    def _advance_player_fire_authority(self, dt, now):
+    def _advance_player_fire_authority(
+            self, dt, now, intent_keys=None, defer_missing_player=False):
         """Resolve visible triggers from their input-bound client gun edge."""
         if not self._worker_mode or not self._projectile_is_authority():
             return False
+        if intent_keys is None:
+            pending_intents = tuple(self._player_fire_intents.items())
+            target_player_ids = None
+        else:
+            pending_intents = tuple(
+                (key, self._player_fire_intents[key])
+                for key in tuple(intent_keys)
+                if key in self._player_fire_intents)
+            target_player_ids = set(
+                int(intent['player_id'])
+                for unused_key, intent in pending_intents)
         live_players = set()
         for record in tuple(self._records.values()):
             if record.get('kind') != 'player':
@@ -18218,6 +18250,9 @@ class BattleRuntime(object):
             try:
                 player_id = int(record.get('network_id'))
             except (TypeError, ValueError, OverflowError):
+                continue
+            if (target_player_ids is not None and
+                    player_id not in target_player_ids):
                 continue
             if player_id <= 0 or record.get('tombstone'):
                 continue
@@ -18250,15 +18285,17 @@ class BattleRuntime(object):
                 if getattr(gun, '_effective_params', None) != effective:
                     raise RuntimeError(
                         'worker player effective parameters changed in battle')
-        for player_id in tuple(self._player_authority_guns):
-            if player_id not in live_players:
-                self._player_authority_guns.pop(player_id, None)
-
-        for key, intent in tuple(self._player_fire_intents.items()):
+        if target_player_ids is None:
+            for player_id in tuple(self._player_authority_guns):
+                if player_id not in live_players:
+                    self._player_authority_guns.pop(player_id, None)
+        for key, intent in pending_intents:
             player_id = int(intent['player_id'])
             if player_id in self._player_fire_launch_pending:
                 continue
             record = self._records.get('player:%s' % player_id)
+            if record is None and defer_missing_player:
+                continue
             if record is None or record.get('tombstone'):
                 self._reject_player_fire_intent(key, 'player_unavailable')
                 continue

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
@@ -29,7 +29,7 @@ DESTRUCTIBLE_CATALOG_V5_CAPABILITY = 'destructible_catalog_v5'
 LEAN_SNAPSHOT_MANIFEST_CAPABILITY = 'lean_snapshot_manifest_v1'
 RAM_CONTACT_LEDGER_CAPABILITY = 'ram_contact_ledger_v2'
 HUMAN_RAM_TIMELINE_CAPABILITY = 'human_ram_timeline_v1'
-PLAYER_FIRE_INTENT_CAPABILITY = 'player_fire_intent_v5'
+PLAYER_FIRE_INTENT_CAPABILITY = 'player_fire_intent_v6'
 PLAYER_ENVIRONMENT_CAPABILITY = 'player_environment_v2'
 EFFECTIVE_PARAMS_CAPABILITY = effective_params_wire.CAPABILITY
 SIMULATION_WORKER_CAPABILITY = 'simulation_worker_v1'
@@ -751,6 +751,24 @@ def _projectile_float_range(value, minimum, maximum):
     if parsed < minimum or parsed > maximum:
         return None
     return parsed
+
+
+def _projectile_wire_round(value):
+    """Round identically on the shipped Python 2.7 and Python 3 server."""
+    number = float(value)
+    numerator, denominator = number.as_integer_ratio()
+    negative = math.copysign(1.0, number) < 0.0
+    scaled = abs(numerator) * 1000000
+    quotient, remainder = divmod(scaled, denominator)
+    twice_remainder = remainder * 2
+    if (twice_remainder > denominator or
+            (twice_remainder == denominator and quotient % 2)):
+        quotient += 1
+    if quotient == 0:
+        return -0.0 if negative else 0.0
+    if negative:
+        quotient = -quotient
+    return float(quotient) / 1000000.0
 
 
 def _valid_visible_authority_id(value):

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/projectile_manager.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/projectile_manager.py
@@ -223,8 +223,13 @@ class InFlightProjectiles(object):
         return total
 
     def launch(self, key, start, velocity, gravity, launch_time, max_time,
-               max_distance, payload=None):
-        """Freeze and register one unique launch, returning acceptance."""
+               max_distance, payload=None, admission_time=None):
+        """Freeze and register one unique launch, returning acceptance.
+
+        ``admission_time`` is an optional caller-owned clock horizon. It lets
+        an event received between two manager advances retain its exact launch
+        instant without advancing or skipping older projectiles first.
+        """
         try:
             frozen_key = _freeze_key(key)
             hash(frozen_key)
@@ -235,11 +240,14 @@ class InFlightProjectiles(object):
             frozen_max_time = _finite_number(max_time)
             frozen_max_distance = _finite_number(max_distance)
             frozen_payload = _safe_copy(payload)
+            horizon = self._admission_horizon(admission_time)
         except Exception:
+            return False
+        if horizon is None:
             return False
         if frozen_launch_time < 0.0:
             return False
-        if frozen_launch_time > self._now + _EPSILON:
+        if frozen_launch_time > horizon + _EPSILON:
             return False
         if frozen_max_time <= 0.0 or frozen_max_distance <= 0.0:
             return False
@@ -259,15 +267,116 @@ class InFlightProjectiles(object):
             self._install(state)
         return True
 
-    def restore(self, snapshot):
+    def restore(self, snapshot, admission_time=None):
         """Restore one active cursor from a detached takeover snapshot.
 
         The launch trajectory remains authoritative.  Any supplied ``position``
         or ``elapsed`` value is ignored and recomputed from ``cursor_time`` so a
         takeover cannot introduce a discontinuity or rescan an elapsed chord.
+        ``admission_time`` has the same bounded clock meaning as it does for
+        ``launch``.
         """
-        if self._advancing or not isinstance(snapshot, dict):
+        if self._advancing:
             return False
+        state = self._state_from_snapshot(snapshot, admission_time)
+        if state is None:
+            return False
+        if state.key in self._known_keys:
+            return False
+        if len(self) >= self._maximum_active:
+            return False
+
+        self._known_keys.add(state.key)
+        self._install(state)
+        return True
+
+    def rollback_provisional(self, key):
+        """Explicitly forget one locally provisional launch identity.
+
+        Unlike ``remove``, this releases the duplicate-launch fence so a
+        rejected provisional launch may reuse its server-assigned identity.
+        The operation also succeeds after the local projectile has already
+        reached a terminal state.  Callers must invoke this only while
+        reconciling a provisional launch with an authoritative rejection.
+        """
+        if self._advancing:
+            return False
+        try:
+            frozen_key = _freeze_key(key)
+            hash(frozen_key)
+        except Exception:
+            return False
+        if frozen_key not in self._known_keys:
+            return False
+
+        self._remove_active(frozen_key)
+        self._known_keys.discard(frozen_key)
+        return True
+
+    def replace_authoritative(self, snapshot, provisional_key=None,
+                              admission_time=None):
+        """Atomically replace a known provisional launch from a snapshot.
+
+        The entire detached snapshot is validated before the current active
+        state is touched. ``provisional_key`` may identify a different local
+        key when the canonical authority corrected the identity. A locally
+        terminal known identity may be restored, while an active replacement
+        retains its scheduling position. This is an explicit reconciliation
+        escape hatch and never releases the canonical duplicate-launch fence.
+        """
+        if self._advancing:
+            return False
+        state = self._state_from_snapshot(snapshot, admission_time)
+        if state is None:
+            return False
+        try:
+            old_key = _freeze_key(
+                state.key if provisional_key is None else provisional_key)
+            hash(old_key)
+        except Exception:
+            return False
+        if old_key not in self._known_keys:
+            return False
+        if state.key != old_key and state.key in self._known_keys:
+            return False
+        replacing_active = old_key in self._states
+        if not replacing_active and len(self) >= self._maximum_active:
+            return False
+
+        if replacing_active and state.key == old_key:
+            self._states[state.key] = state
+        elif replacing_active:
+            try:
+                order_index = self._order.index(old_key)
+            except ValueError:
+                return False
+            if old_key not in self._round_robin:
+                return False
+            replacement_queue = deque(
+                state.key if key == old_key else key
+                for key in self._round_robin)
+            del self._states[old_key]
+            self._states[state.key] = state
+            self._order[order_index] = state.key
+            self._round_robin = replacement_queue
+        else:
+            self._install(state)
+        self._known_keys.discard(old_key)
+        self._known_keys.add(state.key)
+        return True
+
+    def _admission_horizon(self, admission_time):
+        if admission_time is None:
+            return self._now
+        horizon = _finite_number(admission_time)
+        if horizon + _EPSILON < self._now:
+            return None
+        return horizon
+
+    def _state_from_snapshot(self, snapshot, admission_time=None):
+        """Validate and detach a restore/replace snapshot without mutation."""
+        if not isinstance(snapshot, dict):
+            return None
         try:
             frozen_key = _freeze_key(snapshot['key'])
             hash(frozen_key)
@@ -280,37 +389,37 @@ class InFlightProjectiles(object):
             frozen_cursor_time = _finite_number(snapshot['cursor_time'])
             frozen_distance = _finite_number(snapshot['distance'])
             frozen_payload = _safe_copy(snapshot.get('payload'))
+            horizon = self._admission_horizon(admission_time)
         except Exception:
-            return False
+            return None
+        if horizon is None:
+            return None
         if frozen_launch_time < 0.0:
-            return False
+            return None
         if frozen_max_time <= 0.0 or frozen_max_distance <= 0.0:
-            return False
+            return None
         if frozen_cursor_time < frozen_launch_time:
-            return False
-        if frozen_cursor_time > self._now:
-            return False
+            return None
+        if frozen_cursor_time > horizon:
+            return None
         if frozen_cursor_time > frozen_launch_time + frozen_max_time:
-            return False
+            return None
         if frozen_distance < 0.0 or frozen_distance > frozen_max_distance:
-            return False
-        if frozen_key in self._known_keys:
-            return False
-        if len(self) >= self._maximum_active:
-            return False
+            return None
 
-        state = _ProjectileState(
-            frozen_key, frozen_start, frozen_velocity, frozen_gravity,
-            frozen_launch_time, frozen_max_time, frozen_max_distance,
-            frozen_payload, self._maximum_substep)
-        state.cursor_time = frozen_cursor_time
-        state.position = trajectory_position(
-            state.start, state.velocity, state.gravity,
-            state.cursor_time - state.launch_time)
-        state.distance = frozen_distance
-        self._known_keys.add(frozen_key)
-        self._install(state)
-        return True
+        try:
+            state = _ProjectileState(
+                frozen_key, frozen_start, frozen_velocity, frozen_gravity,
+                frozen_launch_time, frozen_max_time, frozen_max_distance,
+                frozen_payload, self._maximum_substep)
+            state.cursor_time = frozen_cursor_time
+            state.position = trajectory_position(
+                state.start, state.velocity, state.gravity,
+                state.cursor_time - state.launch_time)
+            state.distance = frozen_distance
+        except Exception:
+            return None
+        return state
 
     def remove(self, key):
         """Retire a projectile without a terminal callback."""

--- a/tests/test_port_0922_authority_worker_client.py
+++ b/tests/test_port_0922_authority_worker_client.py
@@ -3,6 +3,7 @@ import json
 from pathlib import Path
 import sys
 import tempfile
+import threading
 import types
 import unittest
 from unittest import mock
@@ -1352,6 +1353,76 @@ class AuthorityWorkerClientTests(unittest.TestCase):
             session._on_event('fire_intent_result', message)
 
         self.assertEqual([message], runtime.fire_intent_results)
+
+    def test_bigworld_poll_flushes_fire_intent_at_batch_tail(self):
+        scheduled = []
+
+        def callback(delay, function):
+            scheduled.append((delay, function))
+            return len(scheduled)
+
+        world = types.SimpleNamespace(callback=callback)
+        client = AuthorityWorkerLANClient(
+            '127.0.0.1', 28782, bigworld=world)
+        client.running = True
+        client.ready = True
+        client.phase = 'battle'
+        client.round_id = 7
+        client.authority_epoch = 4
+        client.bot_authority_id = WORKER_AUTHORITY_ID
+        runtime = _WorkerRuntime(client, world)
+        calls = []
+
+        def on_fire_intent(message):
+            calls.append((
+                'intent', threading.current_thread(), dict(message)))
+            return True
+
+        def on_fire_intent_result(message):
+            calls.append((
+                'result', threading.current_thread(), dict(message)))
+            return True
+
+        def flush_admitted_player_fire_intents():
+            calls.append(('flush', threading.current_thread(), None))
+            return True
+
+        runtime.on_fire_intent = on_fire_intent
+        runtime.on_fire_intent_result = on_fire_intent_result
+        runtime.flush_admitted_player_fire_intents = (
+            flush_admitted_player_fire_intents)
+        message = {
+            'type': 'fire_intent', 'round_id': 7,
+            'authority_epoch': 4, 'player_id': 2, 'intent_seq': 3,
+        }
+        result = {
+            'type': 'fire_intent_result', 'round_id': 7,
+            'player_id': 3, 'intent_seq': 4, 'accepted': False,
+            'reason': 'projectile_launch_rejected',
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            session = WorkerSession(
+                {}, bigworld=world,
+                status_path=str(Path(directory) / 'status.json'))
+            session.client = client
+            session.runtime = runtime
+            session._active_round_id = 7
+            client.on_event = session._on_event
+            client.on_batch_drained = (
+                lambda source: session._on_batch_drained())
+
+            client._queue_message(message)
+            client._queue_message(result)
+            client._schedule_poll()
+            self.assertEqual(1, len(scheduled))
+            scheduled[0][1]()
+
+        self.assertEqual(['intent', 'result', 'flush'], [
+            call[0] for call in calls])
+        self.assertTrue(all(
+            threading.current_thread() is call[1] for call in calls))
+        self.assertEqual(message, calls[0][2])
+        self.assertEqual(result, calls[1][2])
 
     def test_worker_routes_player_destructible_contact_to_runtime(self):
         world = _DrawWorld()

--- a/tests/test_port_0922_authority_worker_client.py
+++ b/tests/test_port_0922_authority_worker_client.py
@@ -1394,6 +1394,7 @@ class AuthorityWorkerClientTests(unittest.TestCase):
         message = {
             'type': 'fire_intent', 'round_id': 7,
             'authority_epoch': 4, 'player_id': 2, 'intent_seq': 3,
+            'trigger_launch_time_ms': 900,
         }
         result = {
             'type': 'fire_intent_result', 'round_id': 7,

--- a/tests/test_port_0922_battle_projectiles.py
+++ b/tests/test_port_0922_battle_projectiles.py
@@ -10,6 +10,8 @@ from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 CLIENT_SCRIPTS = ROOT / 'src' / 'res' / 'scripts' / 'client'
+SERVER_SCRIPTS = ROOT / 'server'
+sys.path.insert(0, str(SERVER_SCRIPTS))
 sys.path.insert(0, str(CLIENT_SCRIPTS))
 
 from gui.mods.offline_lan_0922.battle_runtime import (
@@ -19,6 +21,7 @@ from gui.mods.offline_lan_0922.entities.native_remote_vehicle import \
 from gui.mods.offline_lan_0922.projectile_manager import InFlightProjectiles
 from gui.mods.offline_lan_0922 import combat_rules, critical_damage
 from gui.mods.offline_lan_0922 import lan_client
+import lan_battle_server as server_runtime
 
 
 class _Vector(object):
@@ -287,6 +290,90 @@ def _event():
 
 
 class BattleProjectileTests(unittest.TestCase):
+    def _preinstalled_high_precision_player_projectile(self):
+        battle, unused_bigworld = _battle(now=10.0)
+        battle._worker_mode = True
+        battle._start_message = {'round_id': 9}
+        battle._projectile_server_time_ms = 5000
+        battle._projectile_server_local_time = 10.0
+        record = battle._records['player:7']
+        record['state']['vehicle'] = 'ussr:R11_MS-1'
+        intent = {
+            'player_id': 7, 'intent_seq': 5, 'shot_seq': 3,
+            'input_seq': 11, 'shell_index': 2,
+            'x': 10.123456789, 'y': 20.234567891, 'z': 30.345678912,
+            'trigger_launch_time_ms': 5000,
+        }
+        origin = (1.123456789, 2.234567891, 3.345678912)
+        velocity = (0.0, 0.0, 100.123456789)
+        source_shot = {
+            'speed': 100.123456789,
+            'gravity': 9.876543219,
+            'maxDistance': 720.123456789,
+            'piercingPower': [201.123456789, 189.987654321],
+            'deadeye': True,
+            'shell': {
+                'kind': 'ARMOR_PIERCING',
+                'caliber': 75.123456789,
+                'damage': [110.123456789, 45.987654321],
+                'explosionRadius': 0.0,
+            },
+        }
+        projectile_id = battle._preinstall_player_projectile(
+            intent, record, origin, velocity,
+            9.876543219, 720.123456789, 20000, False, 0.0,
+            1.234567891, source_shot, 10.0)
+        self.assertEqual('9:p:7:3', projectile_id)
+
+        # This is the event shape produced after the server applies its
+        # six-decimal vector, projectile-law and scalar wire contract.
+        echo = _event()
+        echo.update({
+            'projectile_id': '9:p:7:3',
+            'shooter_kind': 'player',
+            'shooter_id': 7,
+            'source_vehicle': 'ussr:R11_MS-1',
+            'source_shot': {
+                'speed': 100.123457,
+                'gravity': 9.876543,
+                'maxDistance': 720.123457,
+                'piercingPower': [201.123457, 189.987654],
+                'deadeye': True,
+                'shell': {
+                    'kind': 'ARMOR_PIERCING',
+                    'caliber': 75.123457,
+                    'damage': [110.123457, 45.987654],
+                    'explosionRadius': 0.0,
+                },
+            },
+            'shot_seq': 3,
+            'burst_group_seq': 3,
+            'burst_index': 0,
+            'burst_count': 1,
+            'shell_index': 2,
+            'fire_intent_seq': 5,
+            'fire_input_seq': 11,
+            'origin': [1.123457, 2.234568, 3.345679],
+            'velocity': [0.0, 0.0, 100.123457],
+            'range_origin': [10.123457, 20.234568, 30.345679],
+            'segment_origin': [1.123457, 2.234568, 3.345679],
+            'segment_velocity': [0.0, 0.0, 100.123457],
+            'segment_start_time_ms': 0,
+            'ricochet_count': 0,
+            'base_penetration_multiplier': 1.0,
+            'gravity': 9.876543,
+            'maxDistance': 720.123457,
+            'max_time_ms': 20000,
+            'is_he': False,
+            'splash_radius': 0.0,
+            'penetration_factor': 1.234568,
+            'launch_server_time_ms': 5000,
+            'authority_epoch': 1,
+        })
+        canonical = battle._projectile_wire_meta(echo)
+        self.assertIsNotNone(canonical)
+        return battle, echo, canonical
+
     def _vehicle_chord_battle(self, shooter_kind='player', target_kind='bot',
                               shell_kind='ARMOR_PIERCING'):
         battle, bigworld = _battle()
@@ -335,6 +422,565 @@ class BattleProjectileTests(unittest.TestCase):
                      '_send_splash_hit', '_critical_hit', '_shell_damage'):
             with self.subTest(name=name):
                 self.assertFalse(hasattr(BattleRuntime, name))
+
+    def test_round_projectile_ids_match_server_player_and_bot_formats(self):
+        self.assertEqual(
+            '12:p:34:56',
+            BattleRuntime._projectile_id_for_round(
+                12, 'player', 34, 56))
+        self.assertEqual(
+            '12:b:34:56',
+            BattleRuntime._projectile_id_for_round(
+                12, 'bot', 34, 56))
+
+    def test_provisional_launch_between_manager_and_now_keeps_true_age(self):
+        battle, unused_bigworld = _battle(now=10.0)
+        battle._worker_mode = True
+        battle._start_message = {'round_id': 9}
+        battle._projectile_server_time_ms = 5000
+        battle._projectile_server_local_time = 10.0
+        battle._records['player:7']['state']['vehicle'] = 'ussr:R11_MS-1'
+        intent = {
+            'player_id': 7, 'intent_seq': 1, 'shot_seq': 1,
+            'input_seq': 1, 'shell_index': 0,
+            'x': 0.0, 'y': 0.0, 'z': 0.0,
+            'trigger_launch_time_ms': 5062,
+        }
+        event = _event()
+        admission_now = 10.125
+        expected_launch = battle._projectile_local_launch_time(
+            intent['trigger_launch_time_ms'], admission_now)
+
+        self.assertGreater(expected_launch, battle._projectiles.now)
+        self.assertLess(expected_launch, admission_now)
+        projectile_id = battle._preinstall_player_projectile(
+            intent, battle._records['player:7'], event['origin'],
+            event['velocity'], event['gravity'], event['maxDistance'],
+            event['max_time_ms'], event['is_he'], event['splash_radius'],
+            event['penetration_factor'], event['source_shot'], admission_now)
+
+        state = battle._projectiles.get(projectile_id)
+        self.assertAlmostEqual(expected_launch, state['launch_time'])
+        self.assertAlmostEqual(expected_launch, state['cursor_time'])
+        self.assertAlmostEqual(10.0, battle._projectiles.now)
+
+        chords = []
+        terminal = mock.Mock()
+        self.assertTrue(battle._projectiles.advance(
+            admission_now,
+            lambda unused_state, unused_start, unused_end,
+            absolute_start, absolute_end: chords.append(
+                (absolute_start, absolute_end)),
+            terminal))
+
+        self.assertTrue(chords)
+        self.assertAlmostEqual(expected_launch, chords[0][0])
+        self.assertAlmostEqual(admission_now, chords[-1][1])
+        self.assertAlmostEqual(
+            admission_now - expected_launch,
+            sum(end - start for start, end in chords))
+        state = battle._projectiles.get(projectile_id)
+        self.assertAlmostEqual(
+            admission_now - expected_launch, state['elapsed'])
+        terminal.assert_not_called()
+
+    def test_half_even_player_preinstall_matches_real_server_echo(self):
+        half_even_edge = 0.0078125
+        launch_server_time_ms = 15000
+        source_shot = {
+            'speed': 100.0,
+            'gravity': 9.81,
+            'maxDistance': 1000.0,
+            'piercingPower': [220.0, 200.0],
+            'deadeye': False,
+            'shell': {
+                'kind': 'ARMOR_PIERCING',
+                'caliber': 105.0,
+                'damage': [390.0, 150.0],
+                'explosionRadius': 0.0,
+            },
+        }
+        intent = {
+            'player_id': 7, 'intent_seq': 5, 'shot_seq': 3,
+            'input_seq': 11, 'shell_index': 0,
+            'x': half_even_edge, 'y': 0.0, 'z': 0.0,
+            'trigger_launch_time_ms': launch_server_time_ms,
+        }
+        origin = (half_even_edge, 1.0, 0.0)
+        velocity = (100.0, 0.0, 0.0)
+        battle, unused_bigworld = _battle(now=10.0)
+        battle._worker_mode = True
+        battle._start_message = {'round_id': 9}
+        battle._projectile_server_time_ms = launch_server_time_ms
+        battle._projectile_server_local_time = 10.0
+        battle._records['player:7']['state']['vehicle'] = 'ussr:R11_MS-1'
+
+        projectile_id = battle._preinstall_player_projectile(
+            intent, battle._records['player:7'], origin, velocity,
+            source_shot['gravity'], source_shot['maxDistance'], 10000,
+            False, 0.0, 1.0, source_shot, 10.0)
+        self.assertEqual('9:p:7:3', projectile_id)
+
+        server = server_runtime.BattleState(map_name='04_himmelsdorf')
+        server.client_build = server_runtime.CLIENT_BUILD_0922
+        server.phase = 'battle'
+        server.tick = int(round(
+            server_runtime.PREBATTLE_SECONDS * server_runtime.TICK_HZ))
+        server.round_id = 9
+        server.authority_epoch = 1
+        server.bot_authority_id = (
+            server_runtime.SIMULATION_WORKER_AUTHORITY_ID)
+        server.simulation_worker = server_runtime.SimulationWorker(
+            mock.Mock(), ('127.0.0.1', 28782))
+        player = server_runtime.Player(
+            7, mock.Mock(), ('127.0.0.1', 7),
+            vehicle='ussr:R11_MS-1', team=1)
+        player.fire_seq = 2
+        player.pending_fire_intents[5] = {
+            'shot_seq': 3, 'input_seq': 11,
+            'trigger_launch_time_ms': launch_server_time_ms,
+            'x': half_even_edge, 'y': 0.0, 'z': 0.0,
+        }
+        server.players[7] = player
+        launch = {
+            'type': 'projectile_launch', 'round_id': 9,
+            'authority_epoch': 1,
+            'shooter_kind': 'player', 'shooter_id': 7,
+            'shot_seq': 3, 'shell_index': 0,
+            'fire_intent_seq': 5, 'fire_input_seq': 11,
+            'burst_group_seq': 3, 'burst_index': 0, 'burst_count': 1,
+            'origin': list(origin), 'velocity': list(velocity),
+            'gravity': source_shot['gravity'],
+            'max_distance': source_shot['maxDistance'],
+            'max_time_ms': 10000, 'is_he': False,
+            'splash_radius': 0.0, 'penetration_factor': 1.0,
+            'source_shot': source_shot,
+        }
+
+        self.assertTrue(server.launch_projectile(
+            server_runtime.SIMULATION_WORKER_AUTHORITY_ID, launch))
+        echo = server.pending_events[-1]
+        self.assertEqual(0.007812, echo['origin'][0])
+        self.assertEqual(0.007812, echo['range_origin'][0])
+        canonical = battle._projectile_wire_meta(echo)
+        provisional = battle._projectile_meta[projectile_id]
+        self.assertEqual(
+            canonical,
+            dict((name, provisional[name]) for name in canonical))
+        self.assertEqual(
+            (), battle._projectile_launch_mismatches(
+                provisional, canonical))
+
+    def test_empty_snapshot_preserves_terminal_provisional_until_echo(self):
+        battle, echo, canonical = (
+            self._preinstalled_high_precision_player_projectile())
+        projectile_id = canonical['projectile_id']
+        self.assertTrue(battle._projectiles.advance(
+            10.05,
+            lambda unused_state, unused_start, unused_end,
+            unused_absolute_start, unused_absolute_end: {
+                'reason': 'max_distance', 'fraction': 1.0},
+            battle._projectile_terminal))
+        pending = battle._projectile_meta[projectile_id][
+            'pending_resolution']
+
+        self.assertTrue(battle._reconcile_projectile_snapshot({
+            'projectiles': [], 'projectile_revision': 1,
+        }))
+
+        self.assertIs(
+            pending,
+            battle._projectile_meta[projectile_id]['pending_resolution'])
+        self.assertTrue(
+            battle._projectile_meta[projectile_id][
+                'local_launch_pending'])
+        self.assertEqual([], battle.client.resolutions)
+
+        self.assertTrue(battle._accept_projectile_event(echo))
+        self.assertTrue(battle._accept_projectile_event(dict(echo)))
+        self.assertEqual(1, len(battle.client.resolutions))
+        self.assertNotIn(
+            'local_launch_pending', battle._projectile_meta[projectile_id])
+
+    def test_rejected_terminal_provisional_releases_snapshot_reuse_fence(self):
+        battle, echo, canonical = (
+            self._preinstalled_high_precision_player_projectile())
+        projectile_id = canonical['projectile_id']
+        battle._player_fire_launch_pending[7] = {
+            'intent_seq': 5, 'projectile_id': projectile_id,
+        }
+        self.assertTrue(battle._projectiles.advance(
+            10.05,
+            lambda unused_state, unused_start, unused_end,
+            unused_absolute_start, unused_absolute_end: {
+                'reason': 'max_distance', 'fraction': 1.0},
+            battle._projectile_terminal))
+        self.assertTrue(battle._reconcile_projectile_snapshot({
+            'projectiles': [], 'projectile_revision': 1,
+        }))
+        self.assertIn(projectile_id, battle._projectile_meta)
+
+        with mock.patch.object(sys, 'stdout', io.StringIO()):
+            self.assertTrue(battle.on_fire_intent_result({
+                'type': 'fire_intent_result', 'round_id': 9,
+                'player_id': 7, 'intent_seq': 5,
+                'accepted': False, 'reason': 'projectile_launch_rejected',
+            }))
+
+        self.assertNotIn(projectile_id, battle._projectile_meta)
+        self.assertNotIn(7, battle._player_fire_launch_pending)
+        self.assertFalse(battle._projectiles.contains(projectile_id))
+        range_origin = echo['range_origin']
+        retry_intent = {
+            'player_id': 7,
+            'intent_seq': echo['fire_intent_seq'],
+            'shot_seq': echo['shot_seq'],
+            'input_seq': echo['fire_input_seq'],
+            'shell_index': echo['shell_index'],
+            'x': range_origin[0], 'y': range_origin[1],
+            'z': range_origin[2],
+            'trigger_launch_time_ms': echo['launch_server_time_ms'],
+        }
+        reused_id = battle._preinstall_player_projectile(
+            retry_intent, battle._records['player:7'], echo['origin'],
+            echo['velocity'], echo['gravity'], echo['maxDistance'],
+            echo['max_time_ms'], echo['is_he'], echo['splash_radius'],
+            echo['penetration_factor'], echo['source_shot'], 10.05)
+
+        self.assertEqual(projectile_id, reused_id)
+        self.assertTrue(battle._projectiles.contains(projectile_id))
+        self.assertTrue(
+            battle._projectile_meta[projectile_id][
+                'local_launch_pending'])
+
+    def test_high_precision_player_preinstall_matches_canonical_echo(self):
+        battle, echo, canonical = (
+            self._preinstalled_high_precision_player_projectile())
+        projectile_id = canonical['projectile_id']
+        provisional = battle._projectile_meta[projectile_id]
+
+        self.assertEqual(
+            canonical,
+            dict((name, provisional[name]) for name in canonical))
+        self.assertEqual(
+            (), battle._projectile_launch_mismatches(
+                provisional, canonical))
+        manager_before = battle._projectiles.get(projectile_id)
+        self.assertIsNotNone(manager_before)
+
+        with mock.patch.object(
+                battle._projectiles, 'launch',
+                wraps=battle._projectiles.launch) as launch:
+            self.assertTrue(battle._accept_projectile_event(echo))
+            self.assertTrue(battle._accept_projectile_event(dict(echo)))
+
+        launch.assert_not_called()
+        self.assertEqual(1, len(battle._projectiles))
+        self.assertEqual(
+            manager_before, battle._projectiles.get(projectile_id))
+        self.assertNotIn(
+            'local_launch_pending', battle._projectile_meta[projectile_id])
+
+    def test_matching_snapshot_advances_provisional_manager_cursor(self):
+        battle, echo, unused_canonical = (
+            self._preinstalled_high_precision_player_projectile())
+        projectile_id = echo['projectile_id']
+        echo.update({
+            'checked_through_ms': 100,
+            'checked_distance': 10.0,
+        })
+        battle._runtime.bigworld.now = 10.1
+
+        self.assertTrue(battle._reconcile_projectile_snapshot({
+            'projectiles': [echo], 'projectile_revision': 1,
+        }))
+
+        state = battle._projectiles.get(projectile_id)
+        self.assertAlmostEqual(10.1, state['cursor_time'])
+        self.assertEqual(10.0, state['distance'])
+        meta = battle._projectile_meta[projectile_id]
+        self.assertEqual(100, meta['base_checked_ms'])
+        self.assertNotIn('local_launch_pending', meta)
+
+    def test_matching_older_snapshot_does_not_rewind_provisional_cursor(self):
+        battle, echo, unused_canonical = (
+            self._preinstalled_high_precision_player_projectile())
+        projectile_id = echo['projectile_id']
+        self.assertTrue(battle._projectiles.advance(
+            10.15,
+            lambda unused_state, unused_start, unused_end,
+            unused_absolute_start, unused_absolute_end: None,
+            mock.Mock()))
+        before = battle._projectiles.get(projectile_id)
+        echo.update({
+            'checked_through_ms': 100,
+            'checked_distance': 10.0,
+        })
+        battle._runtime.bigworld.now = 10.2
+
+        with mock.patch.object(
+                battle._projectiles, 'replace_authoritative',
+                wraps=battle._projectiles.replace_authoritative) as replace:
+            self.assertTrue(battle._reconcile_projectile_snapshot({
+                'projectiles': [echo], 'projectile_revision': 1,
+            }))
+
+        replace.assert_not_called()
+        self.assertEqual(before, battle._projectiles.get(projectile_id))
+        self.assertNotIn(
+            'local_launch_pending', battle._projectile_meta[projectile_id])
+
+    def test_invalid_matching_snapshot_preserves_provisional_state(self):
+        battle, echo, unused_canonical = (
+            self._preinstalled_high_precision_player_projectile())
+        projectile_id = echo['projectile_id']
+        before_manager = battle._projectiles.get(projectile_id)
+        before_meta = dict(battle._projectile_meta[projectile_id])
+        echo.update({
+            'checked_through_ms': 100,
+            'checked_distance': echo['maxDistance'] + 1.0,
+        })
+        battle._runtime.bigworld.now = 10.1
+
+        output = io.StringIO()
+        with mock.patch.object(sys, 'stdout', output):
+            self.assertTrue(battle._reconcile_projectile_snapshot({
+                'projectiles': [echo], 'projectile_revision': 1,
+            }))
+
+        self.assertEqual(
+            before_manager, battle._projectiles.get(projectile_id))
+        self.assertEqual(before_meta, battle._projectile_meta[projectile_id])
+        self.assertIn(
+            'stage=canonical_snapshot reason=takeover_rejected',
+            output.getvalue())
+
+    def test_canonical_echo_replaces_mismatched_provisional_launch(self):
+        replacements = (
+            ('origin', {
+                'origin': [4.123457, 5.234568, 6.345679],
+                'segment_origin': [4.123457, 5.234568, 6.345679],
+            }),
+            ('velocity', {
+                'velocity': [100.123457, 0.0, 0.0],
+                'segment_velocity': [100.123457, 0.0, 0.0],
+            }),
+            ('launch_server_time_ms', {
+                'launch_server_time_ms': 4900,
+            }),
+        )
+        for mismatch_name, replacement in replacements:
+            with self.subTest(field=mismatch_name):
+                battle, echo, unused_canonical = (
+                    self._preinstalled_high_precision_player_projectile())
+                projectile_id = echo['projectile_id']
+                previous = battle._projectiles.get(projectile_id)
+                echo.update(replacement)
+                canonical = battle._projectile_wire_meta(echo)
+                self.assertIsNotNone(canonical)
+                written = []
+
+                with mock.patch.object(sys, 'stdout') as stdout:
+                    stdout.write = written.append
+                    self.assertTrue(battle._accept_projectile_event(echo))
+
+                current = battle._projectiles.get(projectile_id)
+                self.assertIsNotNone(current)
+                self.assertEqual(1, len(battle._projectiles))
+                self.assertNotEqual(previous, current)
+                self.assertEqual(
+                    canonical,
+                    dict((name, battle._projectile_meta[
+                        projectile_id][name]) for name in canonical))
+                if mismatch_name == 'origin':
+                    self.assertEqual(tuple(echo['origin']), current['start'])
+                elif mismatch_name == 'velocity':
+                    self.assertEqual(
+                        tuple(echo['velocity']), current['velocity'])
+                else:
+                    self.assertEqual(4900, battle._projectile_meta[
+                        projectile_id]['launch_server_time_ms'])
+                    self.assertAlmostEqual(9.9, current['launch_time'])
+                failure = ''.join(written)
+                self.assertIn('PROJECTILE FAILURE', failure)
+                self.assertIn(
+                    'stage=canonical_echo reason=launch_mismatch', failure)
+                self.assertIn('error=%s' % mismatch_name, failure)
+
+    def test_invalid_canonical_replacement_preserves_provisional_state(self):
+        battle, echo, unused_canonical = (
+            self._preinstalled_high_precision_player_projectile())
+        projectile_id = echo['projectile_id']
+        before_manager = battle._projectiles.get(projectile_id)
+        before_meta = dict(battle._projectile_meta[projectile_id])
+        before_terminal = dict(battle._projectile_terminal_data)
+        echo.update({
+            'origin': [4.123457, 5.234568, 6.345679],
+            'segment_origin': [4.123457, 5.234568, 6.345679],
+            'checked_distance': echo['maxDistance'] + 1.0,
+        })
+
+        output = io.StringIO()
+        with mock.patch.object(sys, 'stdout', output):
+            self.assertFalse(battle._accept_projectile_event(echo))
+
+        self.assertEqual(
+            before_manager, battle._projectiles.get(projectile_id))
+        self.assertEqual(
+            before_meta, battle._projectile_meta[projectile_id])
+        self.assertEqual(before_terminal, battle._projectile_terminal_data)
+        self.assertIn(
+            'stage=canonical_echo reason=replacement_rejected',
+            output.getvalue())
+
+    def test_mismatched_echo_replaces_terminal_provisional_without_submission(self):
+        battle, echo, unused_canonical = (
+            self._preinstalled_high_precision_player_projectile())
+        projectile_id = echo['projectile_id']
+        self.assertTrue(battle._projectiles.advance(
+            10.05,
+            lambda unused_state, unused_start, unused_end,
+            unused_absolute_start, unused_absolute_end: {
+                'reason': 'max_distance', 'fraction': 1.0},
+            battle._projectile_terminal))
+        self.assertIsNotNone(
+            battle._projectile_meta[projectile_id].get(
+                'pending_resolution'))
+        echo.update({
+            'origin': [4.123457, 5.234568, 6.345679],
+            'segment_origin': [4.123457, 5.234568, 6.345679],
+        })
+        battle._runtime.bigworld.now = 10.05
+
+        output = io.StringIO()
+        with mock.patch.object(sys, 'stdout', output):
+            self.assertTrue(battle._accept_projectile_event(echo))
+
+        state = battle._projectiles.get(projectile_id)
+        self.assertIsNotNone(state)
+        self.assertEqual(tuple(echo['origin']), state['start'])
+        meta = battle._projectile_meta[projectile_id]
+        self.assertNotIn('local_launch_pending', meta)
+        self.assertNotIn('pending_resolution', meta)
+        self.assertEqual([], battle.client.resolutions)
+        self.assertIn(
+            'stage=canonical_echo reason=launch_mismatch',
+            output.getvalue())
+
+    def test_provisional_terminal_waits_for_matching_canonical_echo(self):
+        battle, echo, canonical = (
+            self._preinstalled_high_precision_player_projectile())
+        projectile_id = canonical['projectile_id']
+
+        self.assertTrue(battle._projectiles.advance(
+            10.05,
+            lambda unused_state, unused_start, unused_end,
+            unused_absolute_start, unused_absolute_end: {
+                'reason': 'max_distance', 'fraction': 1.0},
+            battle._projectile_terminal))
+
+        self.assertFalse(battle._projectiles.contains(projectile_id))
+        self.assertEqual([], battle.client.resolutions)
+        provisional = battle._projectile_meta[projectile_id]
+        self.assertTrue(provisional['local_launch_pending'])
+        self.assertIsNotNone(provisional.get('pending_resolution'))
+
+        with mock.patch.object(
+                battle._projectiles, 'launch',
+                wraps=battle._projectiles.launch) as launch:
+            self.assertTrue(battle._accept_projectile_event(echo))
+            self.assertEqual(1, len(battle.client.resolutions))
+            self.assertTrue(battle._accept_projectile_event(dict(echo)))
+
+        launch.assert_not_called()
+        self.assertFalse(battle._projectiles.contains(projectile_id))
+        self.assertEqual(1, len(battle.client.resolutions))
+        self.assertNotIn(
+            'local_launch_pending', battle._projectile_meta[projectile_id])
+
+    def test_bot_launch_waits_for_canonical_echo_before_manager_install(self):
+        battle, unused_bigworld = _battle(now=0.0)
+        battle._worker_mode = True
+        battle._start_message = {'round_id': 9}
+        shell = types.SimpleNamespace(
+            kind='ARMOR_PIERCING', caliber=75.0,
+            damage=(110.0, 45.0), explosionRadius=0.0)
+        shot = types.SimpleNamespace(
+            speed=100.0, gravity=9.8, maxDistance=720.0,
+            piercingPower=(200.0, 180.0), shell=shell)
+        source = types.SimpleNamespace(
+            id=77, isStarted=True,
+            typeDescriptor=types.SimpleNamespace(
+                gun=types.SimpleNamespace(shots=(shot,))))
+        battle._records = {'bot:11': {
+            'engine_id': 77, 'network_id': 11, 'kind': 'bot',
+            'local': False, 'ready': True,
+            'state': {
+                'vehicle': 'ussr:R11_MS-1',
+                'health': 100, 'alive': True,
+            },
+        }}
+        battle._server_entity = lambda entity_id: (
+            source if entity_id == 77 else None)
+        state = {
+            'id': 11, 'shell_index': 0,
+            'shot_yaw': 0.0, 'shot_pitch': 0.0,
+            'shot_origin': (1.0, 3.0, 3.0),
+            'burst_group_seq': 1, 'burst_index': 0, 'burst_count': 1,
+            'launch_time_us': 0,
+            'launch_pose': (1.0, 2.0, 3.0, 0.0, 0.0, 0.0),
+            'profile': {'class_tag': 'mediumTank'},
+        }
+        projectile_id = '9:b:11:1'
+
+        with mock.patch.object(
+                battle._projectiles, 'launch',
+                wraps=battle._projectiles.launch) as launch:
+            self.assertTrue(battle._launch_bot_projectile(state, 1))
+            launch.assert_not_called()
+            self.assertNotIn(projectile_id, battle._projectile_meta)
+            self.assertFalse(battle._projectiles.contains(projectile_id))
+
+            args, kwargs = battle.client.launches[-1]
+            echo = _event()
+            echo.update({
+                'kind': 'bot_shot',
+                'attacker_bot': 11,
+                'projectile_id': projectile_id,
+                'shooter_kind': 'bot',
+                'shooter_id': 11,
+                'source_vehicle': 'ussr:R11_MS-1',
+                'source_shot': kwargs['source_shot'],
+                'shot_seq': 1,
+                'burst_group_seq': 1,
+                'burst_index': 0,
+                'burst_count': 1,
+                'shell_index': 0,
+                'origin': args[4],
+                'velocity': args[5],
+                'range_origin': [1.0, 2.0, 3.0],
+                'segment_origin': args[4],
+                'segment_velocity': args[5],
+                'gravity': args[6],
+                'maxDistance': args[7],
+                'max_time_ms': args[8],
+                'is_he': args[9],
+                'splash_radius': args[10],
+                'penetration_factor': kwargs['penetration_factor'],
+                'launch_server_time_ms': 0,
+                'authority_epoch': 1,
+            })
+            echo.pop('attacker', None)
+            echo.pop('fire_intent_seq', None)
+            echo.pop('fire_input_seq', None)
+
+            self.assertTrue(battle._accept_projectile_event(echo))
+
+        self.assertEqual(1, launch.call_count)
+        self.assertTrue(battle._projectiles.contains(projectile_id))
+        self.assertIn(projectile_id, battle._projectile_meta)
+        self.assertNotIn(
+            'local_launch_pending', battle._projectile_meta[projectile_id])
 
     def test_all_shooter_target_pairs_cap_destructibles_at_the_vehicle(self):
         for shooter_kind in ('player', 'bot'):

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -20743,6 +20743,8 @@ class BattleRuntimeContractTests(unittest.TestCase):
         battle = BattleRuntime(_runtime())
         battle._worker_mode = True
         battle.state = 'running'
+        battle._battle_live = True
+        battle._projectile_is_authority = lambda: True
         battle.client = _Client()
         battle.client.authority_epoch = 4
         battle._start_message = {'round_id': 7}
@@ -20778,6 +20780,112 @@ class BattleRuntimeContractTests(unittest.TestCase):
         with self.assertRaisesRegex(
                 RuntimeError, 'worker fire intent is malformed'):
             battle.on_fire_intent(dict(intent, unexpected='wire field'))
+
+    def test_worker_fire_fast_path_revisits_older_intents_in_order(self):
+        battle = BattleRuntime(_runtime())
+        battle._worker_mode = True
+        battle.state = 'running'
+        battle._battle_live = True
+        battle.client = _Client()
+        battle.client.authority_epoch = 4
+        battle._start_message = {'round_id': 7}
+        battle._clock = mock.Mock(return_value=12.5)
+        older_key = (1, 2)
+        battle._player_fire_intents[older_key] = {'player_id': 1}
+        battle._advance_player_fire_authority = mock.Mock(return_value=True)
+        intent = {
+            'type': 'fire_intent', 'round_id': 7,
+            'authority_epoch': 4, 'player_id': 2, 'intent_seq': 3,
+            'shot_seq': 5, 'input_seq': 8, 'pose_time_us': 1000,
+            'shell_index': 0, 'next_shell_index': 0,
+            'shell_change_pending': False,
+            'gun_checkpoint_seq': 8,
+            'gun_checkpoint': _human_gun_checkpoint(),
+            'aim_yaw': 0.2, 'gun_pitch': -0.1,
+            'x': 1.0, 'y': 2.0, 'z': 3.0, 'yaw': 0.0,
+            'pitch': 0.0, 'roll': 0.0, 'speed': 4.0,
+            'shot_origin': [1.0, 3.0, 3.0],
+            'shot_direction': [0.0, 0.0, 1.0],
+            'dispersion_angle': 0.02,
+            'presentation_ledger': [],
+        }
+
+        self.assertTrue(battle.on_fire_intent(intent))
+        battle._advance_player_fire_authority.assert_not_called()
+        self.assertTrue(battle.flush_admitted_player_fire_intents())
+
+        battle._advance_player_fire_authority.assert_called_once_with(
+            0.0, 12.5, intent_keys=(older_key, (2, 3)),
+            defer_missing_player=True)
+
+    def test_worker_fire_fast_path_retries_player_missing_at_dispatch(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._worker_mode = True
+        battle.state = 'running'
+        battle._battle_live = True
+        battle._start_message = {'round_id': 7}
+        battle._projectile_is_authority = lambda: True
+        battle._config = {'perfect_accuracy': True}
+        client = _Client()
+        client.authority_epoch = 4
+        client.send_projectile_launch = mock.Mock(
+            side_effect=lambda *args, **unused_kwargs: args[2])
+        client.send_fire_intent_result = mock.Mock(return_value=True)
+        battle.client = client
+        intent = {
+            'type': 'fire_intent', 'round_id': 7,
+            'authority_epoch': 4, 'player_id': 2, 'intent_seq': 3,
+            'shot_seq': 5, 'input_seq': 8, 'pose_time_us': 1000,
+            'shell_index': 0, 'next_shell_index': 0,
+            'shell_change_pending': False,
+            'gun_checkpoint_seq': 8,
+            'gun_checkpoint': _human_gun_checkpoint(),
+            'aim_yaw': 0.2, 'gun_pitch': -0.1,
+            'x': 50.0, 'y': 0.0, 'z': 50.0, 'yaw': 0.0,
+            'pitch': 0.0, 'roll': 0.0, 'speed': 0.0,
+            'shot_origin': [4.0, 2.0, 8.0],
+            'shot_direction': [0.0, 0.0, 1.0],
+            'dispersion_angle': 0.02,
+            'presentation_ledger': [],
+        }
+        key = (2, 3)
+
+        # The transport can beat the snapshot/native entity lifecycle.  The
+        # fast path must not turn that harmless ordering into a terminal
+        # rejection or lose the admitted shot.
+        self.assertTrue(battle.on_fire_intent(intent))
+        self.assertTrue(battle.flush_admitted_player_fire_intents())
+        self.assertIn(key, battle._player_fire_intents)
+        self.assertNotIn(key, battle._player_fire_intent_history)
+        client.send_projectile_launch.assert_not_called()
+        client.send_fire_intent_result.assert_not_called()
+
+        descriptor = _Descriptor()
+        entity = _Vehicle(
+            11, descriptor, _Vector(50.0, 0.0, 50.0), (0, 0, 0),
+            {'health': 500})
+        runtime.bigworld.entities[11] = entity
+        effective = _effective_params_snapshot(ammo=[[101, 40]])
+        battle._records = {'player:2': {
+            'engine_id': 11, 'network_id': 2, 'kind': 'player',
+            'local': False, 'ready': True, 'tombstone': False,
+            'state': {
+                'alive': True, 'shell_index': 0, 'speed': 0.0,
+                'turn': 0.0, 'effective_params': effective,
+            },
+        }}
+
+        self.assertTrue(battle._advance_player_fire_authority(0.1, 10.0))
+        self.assertNotIn(key, battle._player_fire_intents)
+        self.assertIn(key, battle._player_fire_intent_history)
+        self.assertEqual(1, client.send_projectile_launch.call_count)
+
+        # The ordinary frame remains safe to call after the deferred intent
+        # has been launched: no second canonical projectile is emitted.
+        self.assertTrue(battle._advance_player_fire_authority(0.1, 10.1))
+        self.assertEqual(1, client.send_projectile_launch.call_count)
+        client.send_fire_intent_result.assert_not_called()
 
     def test_worker_resolves_immediate_player_destructible_contact(self):
         battle = BattleRuntime(_runtime())
@@ -21734,6 +21842,12 @@ class BattleRuntimeContractTests(unittest.TestCase):
                 side_effect=AssertionError(
                     'stale model node must not be read')) as node:
             self.assertTrue(battle.on_fire_intent(intent))
+            client.send_projectile_launch.assert_not_called()
+            # WorkerSession invokes this after the current LAN batch is fully
+            # applied but before the next full Bot frame.
+            self.assertTrue(battle.flush_admitted_player_fire_intents())
+            self.assertEqual(1, client.send_projectile_launch.call_count)
+            self.assertNotIn((2, 3), battle._player_fire_intents)
             self.assertTrue(
                 battle._advance_player_fire_authority(0.1, 10.0))
             node.assert_not_called()

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -20492,7 +20492,11 @@ class BattleRuntimeContractTests(unittest.TestCase):
 
         entity.showShooting = stock_show_shooting
 
-        self.assertTrue(battle.shoot(0.2, -0.1))
+        fire_output = io.StringIO()
+        with contextlib.redirect_stdout(fire_output):
+            self.assertTrue(battle.shoot(0.2, -0.1))
+        self.assertEqual(1, fire_output.getvalue().count(
+            'FIRE TRIGGER intent=1 input=1 shell=0'))
         self.assertEqual([], battle._avatar.dispersion_queries)
         self.assertEqual(1, battle._gun_state.clip)
         intent = next(item for item in client.sent
@@ -20616,7 +20620,10 @@ class BattleRuntimeContractTests(unittest.TestCase):
         battle._avatar.gunRotator.turretYaw = 0.2
         battle._avatar.gunRotator.gunPitch = -0.1
 
-        self.assertFalse(battle.shoot(0.2, -0.1))
+        fire_output = io.StringIO()
+        with contextlib.redirect_stdout(fire_output):
+            self.assertFalse(battle.shoot(0.2, -0.1))
+        self.assertNotIn('FIRE TRIGGER', fire_output.getvalue())
         self.assertEqual([], battle._avatar.dispersion_queries)
         client.send_fire_intent.assert_called_once_with(
             0, [0.0, 2.0, 0.0], [0.0, 0.0, 1.0], 0.25, [], 0)
@@ -20752,6 +20759,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
             'type': 'fire_intent', 'round_id': 7,
             'authority_epoch': 4, 'player_id': 2, 'intent_seq': 3,
             'shot_seq': 5, 'input_seq': 8, 'pose_time_us': 1000,
+            'trigger_launch_time_ms': 900,
             'shell_index': 0, 'next_shell_index': 0,
             'shell_change_pending': False,
             'gun_checkpoint_seq': 8,
@@ -20767,19 +20775,36 @@ class BattleRuntimeContractTests(unittest.TestCase):
             '_client_dispatch_delay': 0.01,
         }
 
-        self.assertTrue(battle.on_fire_intent(intent))
-        retry = dict(
-            intent, _client_received_time=10.5,
-            _client_dispatch_delay=0.02)
-        self.assertTrue(battle.on_fire_intent(retry))
+        output = io.StringIO()
+        with mock.patch.object(
+                battle_runtime_module, '_PROFILE_CLOCK', return_value=20.0), \
+                contextlib.redirect_stdout(output):
+            self.assertTrue(battle.on_fire_intent(intent))
+            retry = dict(
+                intent, _client_received_time=10.5,
+                _client_dispatch_delay=0.02)
+            self.assertTrue(battle.on_fire_intent(retry))
 
         stored = battle._player_fire_intents[(2, 3)]
         self.assertNotIn('_client_received_time', stored)
         self.assertNotIn('_client_dispatch_delay', stored)
         self.assertEqual(1, len(battle._player_fire_intents))
+        self.assertEqual(
+            20.0, battle._fire_timeline[(2, 3)]['received_wall'])
+        self.assertEqual(1, output.getvalue().count(
+            'FIRE INTENT RECEIVED player=2 intent=3'))
         with self.assertRaisesRegex(
                 RuntimeError, 'worker fire intent is malformed'):
             battle.on_fire_intent(dict(intent, unexpected='wire field'))
+        for invalid in (True, 1.0, -1,
+                        battle_runtime_module.lan_protocol.MAX_MOTION_TIME_US //
+                        1000 + 1):
+            with self.subTest(trigger_launch_time_ms=invalid), \
+                    self.assertRaisesRegex(
+                        RuntimeError, 'violates its contract'):
+                battle.on_fire_intent(dict(
+                    intent, intent_seq=4,
+                    trigger_launch_time_ms=invalid))
 
     def test_worker_fire_fast_path_revisits_older_intents_in_order(self):
         battle = BattleRuntime(_runtime())
@@ -20797,6 +20822,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
             'type': 'fire_intent', 'round_id': 7,
             'authority_epoch': 4, 'player_id': 2, 'intent_seq': 3,
             'shot_seq': 5, 'input_seq': 8, 'pose_time_us': 1000,
+            'trigger_launch_time_ms': 900,
             'shell_index': 0, 'next_shell_index': 0,
             'shell_change_pending': False,
             'gun_checkpoint_seq': 8,
@@ -20837,6 +20863,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
             'type': 'fire_intent', 'round_id': 7,
             'authority_epoch': 4, 'player_id': 2, 'intent_seq': 3,
             'shot_seq': 5, 'input_seq': 8, 'pose_time_us': 1000,
+            'trigger_launch_time_ms': 900,
             'shell_index': 0, 'next_shell_index': 0,
             'shell_change_pending': False,
             'gun_checkpoint_seq': 8,
@@ -20876,16 +20903,105 @@ class BattleRuntimeContractTests(unittest.TestCase):
             },
         }}
 
-        self.assertTrue(battle._advance_player_fire_authority(0.1, 10.0))
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            self.assertTrue(
+                battle._advance_player_fire_authority(0.1, 10.0))
         self.assertNotIn(key, battle._player_fire_intents)
         self.assertIn(key, battle._player_fire_intent_history)
         self.assertEqual(1, client.send_projectile_launch.call_count)
+        self.assertEqual(1, output.getvalue().count('FIRE LAUNCH'))
+        self.assertIn('path=frame_retry', output.getvalue())
 
         # The ordinary frame remains safe to call after the deferred intent
         # has been launched: no second canonical projectile is emitted.
         self.assertTrue(battle._advance_player_fire_authority(0.1, 10.1))
         self.assertEqual(1, client.send_projectile_launch.call_count)
         client.send_fire_intent_result.assert_not_called()
+
+    def test_worker_fast_path_preinstalls_and_advances_before_echo(self):
+        runtime = _runtime()
+        runtime.bigworld.now = 10.0
+        battle = BattleRuntime(runtime)
+        battle._worker_mode = True
+        battle.state = 'running'
+        battle._battle_live = True
+        battle._start_message = {'round_id': 7}
+        battle._config = {'perfect_accuracy': True}
+        client = _Client()
+        client.authority_epoch = 4
+        client.is_bot_authority = lambda: True
+        client.send_projectile_launch = mock.Mock(
+            side_effect=lambda *args, **unused_kwargs: args[2])
+        client.send_projectile_progress = mock.Mock(return_value=True)
+        battle.client = client
+        battle._projectiles = battle_runtime_module.InFlightProjectiles(
+            initial_time=10.0)
+        battle._projectile_epoch = 4
+        battle._projectile_server_time_ms = 1000
+        battle._projectile_server_local_time = 10.0
+        battle._next_projectile_progress_time = 10.0
+        descriptor = _Descriptor()
+        entity = _Vehicle(
+            11, descriptor, _Vector(50.0, 0.0, 50.0), (0, 0, 0),
+            {'health': 500})
+        runtime.bigworld.entities[11] = entity
+        battle._records = {'player:2': {
+            'engine_id': 11, 'network_id': 2, 'kind': 'player',
+            'local': False, 'ready': True, 'tombstone': False,
+            'state': {
+                'vehicle': 'ussr:R11_MS-1',
+                'alive': True, 'shell_index': 0,
+                'speed': 0.0, 'turn': 0.0,
+                'effective_params': _effective_params_snapshot(
+                    ammo=[[101, 40]]),
+            },
+        }}
+        intent = {
+            'type': 'fire_intent', 'round_id': 7,
+            'authority_epoch': 4, 'player_id': 2, 'intent_seq': 3,
+            'shot_seq': 5, 'input_seq': 8, 'pose_time_us': 1000,
+            'trigger_launch_time_ms': 900,
+            'shell_index': 0, 'next_shell_index': 0,
+            'shell_change_pending': False,
+            'gun_checkpoint_seq': 8,
+            'gun_checkpoint': _human_gun_checkpoint(),
+            'aim_yaw': 0.2, 'gun_pitch': -0.1,
+            'x': 50.0, 'y': 0.0, 'z': 50.0, 'yaw': 0.0,
+            'pitch': 0.0, 'roll': 0.0, 'speed': 0.0,
+            'shot_origin': [4.0, 2.0, 8.0],
+            'shot_direction': [0.0, 0.0, 1.0],
+            'dispersion_angle': 0.02,
+            'presentation_ledger': [],
+        }
+        output = io.StringIO()
+
+        with contextlib.redirect_stdout(output):
+            self.assertTrue(battle.on_fire_intent(intent))
+            client.send_projectile_launch.assert_not_called()
+            self.assertTrue(battle.flush_admitted_player_fire_intents())
+
+        projectile_id = '7:p:2:5'
+        self.assertTrue(battle._projectiles.contains(projectile_id))
+        self.assertTrue(battle._projectile_meta[
+            projectile_id]['local_launch_pending'])
+        self.assertEqual(1, client.send_projectile_launch.call_count)
+        self.assertIn('path=poll', output.getvalue())
+
+        battle._projectile_record_poses = mock.Mock(return_value={})
+        battle._sample_projectile_positions = mock.Mock()
+        battle._prune_projectile_position_history = mock.Mock()
+        battle._build_projectile_spatial_bins = mock.Mock()
+        battle._clear_projectile_spatial_index = mock.Mock()
+        battle._projectile_chord = mock.Mock(return_value=None)
+        battle._projectile_terminal = mock.Mock(return_value=None)
+
+        self.assertTrue(battle._advance_projectiles(10.05))
+
+        client.send_projectile_progress.assert_called_once()
+        cursor = client.send_projectile_progress.call_args.args[1][0]
+        self.assertEqual(projectile_id, cursor['projectile_id'])
+        self.assertGreater(cursor['checked_through_ms'], 0)
 
     def test_worker_resolves_immediate_player_destructible_contact(self):
         battle = BattleRuntime(_runtime())
@@ -21822,6 +21938,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
             'type': 'fire_intent', 'round_id': 7,
             'authority_epoch': 4, 'player_id': 2, 'intent_seq': 3,
             'shot_seq': 5, 'input_seq': 8, 'pose_time_us': 1000,
+            'trigger_launch_time_ms': 900,
             'shell_index': 0, 'next_shell_index': 0,
             'shell_change_pending': False,
             'gun_checkpoint_seq': 8,
@@ -21928,6 +22045,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
             'type': 'fire_intent', 'round_id': 7,
             'authority_epoch': 4, 'player_id': 2, 'intent_seq': 3,
             'shot_seq': 5, 'input_seq': 8, 'pose_time_us': 1000,
+            'trigger_launch_time_ms': 900,
             'shell_index': 0, 'next_shell_index': 1,
             'shell_change_pending': True,
             'gun_checkpoint_seq': 8,
@@ -22013,6 +22131,66 @@ class BattleRuntimeContractTests(unittest.TestCase):
 
         self.assertEqual({}, battle._player_fire_launch_pending)
         self.assertTrue(battle._advance_player_fire_authority(0.1, 10.0))
+
+    def test_worker_fire_rejection_rolls_back_provisional_projectile(self):
+        battle = BattleRuntime(_runtime())
+        battle._worker_mode = True
+        battle._start_message = {'round_id': 7}
+        battle._projectiles = battle_runtime_module.InFlightProjectiles()
+        projectile_id = '7:p:2:5'
+        self.assertTrue(battle._projectiles.launch(
+            projectile_id, (0.0, 1.0, 0.0), (10.0, 0.0, 0.0),
+            (0.0, -9.81, 0.0), 0.0, 10.0, 500.0))
+        battle._projectile_meta = {projectile_id: {
+            'projectile_id': projectile_id,
+            'manager_key': projectile_id,
+            'local_launch_pending': True,
+        }}
+        battle._player_fire_launch_pending = {2: {
+            'intent_seq': 3, 'input_seq': 4, 'shot_seq': 5,
+            'projectile_id': projectile_id,
+            'sent_at': 1.0, 'sent_wall': 2.0,
+        }}
+
+        self.assertTrue(battle.on_fire_intent_result({
+            'type': 'fire_intent_result', 'round_id': 7,
+            'player_id': 2, 'intent_seq': 3, 'accepted': False,
+            'reason': 'projectile_launch_rejected',
+        }))
+
+        self.assertFalse(battle._projectiles.contains(projectile_id))
+        self.assertNotIn(projectile_id, battle._projectile_meta)
+        self.assertEqual({}, battle._player_fire_launch_pending)
+        self.assertTrue(battle._projectiles.launch(
+            projectile_id, (0.0, 1.0, 0.0), (10.0, 0.0, 0.0),
+            (0.0, -9.81, 0.0), 0.0, 10.0, 500.0))
+
+    def test_worker_commit_timeline_uses_monotonic_process_clock(self):
+        battle = BattleRuntime(_runtime())
+        battle._worker_mode = True
+        battle._clock = mock.Mock(return_value=999.0)
+        gun = types.SimpleNamespace(
+            shot_index=0, commit_fire=mock.Mock(return_value=True))
+        battle._player_authority_guns = {2: gun}
+        battle._player_fire_launch_pending = {2: {
+            'intent_seq': 3, 'input_seq': 4, 'shot_seq': 5,
+            'sent_at': 999.0, 'sent_wall': 10.0,
+        }}
+        output = io.StringIO()
+
+        with mock.patch.object(
+                battle_runtime_module, '_PROFILE_CLOCK', return_value=10.125), \
+                contextlib.redirect_stdout(output):
+            self.assertTrue(battle._accept_player_fire_commit({
+                'shooter_kind': 'player', 'shooter_id': 2,
+                'fire_intent_seq': 3, 'fire_input_seq': 4,
+                'shot_seq': 5, 'shell_index': 0,
+            }, {'engine_id': None}))
+
+        self.assertIn(
+            'FIRE COMMIT player=2 intent=3 shot_seq=5 '
+            'launch_to_commit_ms=125', output.getvalue())
+        battle._clock.assert_not_called()
 
     def test_server_shot_event_confirms_local_after_mailbox_returns(self):
         runtime = _runtime()

--- a/tests/test_port_0922_lan_protocol.py
+++ b/tests/test_port_0922_lan_protocol.py
@@ -15,7 +15,8 @@ sys.path.insert(0, str(ROOT / 'server'))
 from gui.mods.offline_lan_0922.lan_client import (
     HUMAN_RAM_TIMELINE_CAPABILITY, LANClient,
     LEAN_SNAPSHOT_MANIFEST_CAPABILITY, MAX_PROJECTILE_ID,
-    _strict_projectile_effect, _valid_player_environment_contract,
+    _projectile_wire_round, _strict_projectile_effect,
+    _valid_player_environment_contract,
     project_bot_state)
 from gui.mods.offline_lan_0922.authority_worker import (
     AuthorityWorkerLANClient)
@@ -88,6 +89,13 @@ class LanProtocolTests(unittest.TestCase):
         worker.bot_authority_id = worker.player_id
         worker._send = self.client._send
         return worker
+
+    def test_projectile_wire_round_uses_cross_runtime_half_even_grid(self):
+        self.assertEqual(0.007812, _projectile_wire_round(0.0078125))
+        self.assertEqual(-0.007812, _projectile_wire_round(-0.0078125))
+        self.assertEqual(0.000002, _projectile_wire_round(0.0000015))
+        self.assertEqual(
+            -1.0, math.copysign(1.0, _projectile_wire_round(-0.0000001)))
 
     def test_v5_explicit_control_messages(self):
         self.assertTrue(self.client.leave_battle())

--- a/tests/test_port_0922_projectile_manager.py
+++ b/tests/test_port_0922_projectile_manager.py
@@ -41,6 +41,23 @@ def _launch(manager, key='shot', **overrides):
         values['payload'])
 
 
+def _authoritative_snapshot(key='shot', **overrides):
+    values = {
+        'key': key,
+        'start': (1.0, 2.0, 3.0),
+        'velocity': (20.0, 0.0, 0.0),
+        'gravity': (0.0, 0.0, 0.0),
+        'launch_time': 0.0,
+        'max_time': 10.0,
+        'max_distance': 5000.0,
+        'cursor_time': 0.0,
+        'distance': 0.0,
+        'payload': {'authority': 'server'},
+    }
+    values.update(overrides)
+    return values
+
+
 class ProjectileManagerTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -205,6 +222,217 @@ class ProjectileManagerTests(unittest.TestCase):
         self.assertTrue(manager.reset())
         self.assertAlmostEqual(0.01, manager.now)
         self.assertTrue(_launch(manager, launch_time=0.01))
+
+    def test_remove_keeps_identity_fence_and_duplicate_launch_is_rejected(self):
+        manager = self.module.InFlightProjectiles()
+        self.assertTrue(_launch(manager))
+        self.assertFalse(_launch(manager))
+        self.assertTrue(manager.remove('shot'))
+        self.assertFalse(manager.contains('shot'))
+        self.assertFalse(_launch(manager))
+
+    def test_active_provisional_rollback_releases_identity_for_relaunch(self):
+        manager = self.module.InFlightProjectiles()
+        self.assertTrue(_launch(manager))
+
+        self.assertTrue(manager.rollback_provisional('shot'))
+
+        self.assertFalse(manager.contains('shot'))
+        self.assertEqual([], manager.snapshot())
+        self.assertFalse(manager.rollback_provisional('shot'))
+        self.assertTrue(_launch(manager))
+
+    def test_terminal_provisional_rollback_releases_identity_for_relaunch(self):
+        manager = self.module.InFlightProjectiles()
+        self.assertTrue(_launch(manager, max_time=0.01))
+        callback_results = []
+
+        def terminal(_state, _result):
+            callback_results.append(
+                manager.rollback_provisional('shot'))
+            callback_results.append(manager.replace_authoritative(
+                _authoritative_snapshot(
+                    cursor_time=0.01, distance=1.0)))
+
+        self.assertTrue(manager.advance(
+            0.01, lambda *_args: None, terminal))
+
+        self.assertEqual([False, False], callback_results)
+        self.assertFalse(manager.contains('shot'))
+        self.assertFalse(_launch(manager, launch_time=0.01))
+        self.assertTrue(manager.rollback_provisional('shot'))
+        self.assertTrue(_launch(manager, launch_time=0.01))
+
+    def test_active_authoritative_replace_is_atomic_and_keeps_order(self):
+        manager = self.module.InFlightProjectiles(initial_time=0.5)
+        self.assertTrue(_launch(manager, key='shot'))
+        self.assertTrue(_launch(manager, key='peer'))
+        replacement = _authoritative_snapshot(
+            start=(5.0, 4.0, 3.0),
+            velocity=(20.0, 2.0, -4.0),
+            launch_time=0.1,
+            cursor_time=0.4,
+            distance=6.5,
+            payload={'authority': 'canonical'})
+
+        self.assertTrue(manager.replace_authoritative(replacement))
+
+        self.assertEqual(
+            ['shot', 'peer'],
+            [state['key'] for state in manager.snapshot()])
+        state = manager.get('shot')
+        self.assertEqual((5.0, 4.0, 3.0), state['start'])
+        for expected, actual in zip(
+                (11.0, 4.6, 1.8), state['position']):
+            self.assertAlmostEqual(expected, actual)
+        self.assertAlmostEqual(0.4, state['cursor_time'])
+        self.assertAlmostEqual(6.5, state['distance'])
+        self.assertEqual('canonical', state['payload']['authority'])
+
+    def test_admission_horizon_preserves_launch_between_manager_advances(self):
+        manager = self.module.InFlightProjectiles(initial_time=10.0)
+
+        self.assertTrue(manager.launch(
+            'shot', (0.0, 0.0, 0.0), (100.0, 0.0, 0.0),
+            (0.0, 0.0, 0.0), 10.04, 10.0, 5000.0,
+            admission_time=10.06))
+
+        self.assertAlmostEqual(10.0, manager.now)
+        self.assertAlmostEqual(10.04, manager.get('shot')['launch_time'])
+        self.assertTrue(manager.advance(
+            10.02, lambda *_args: None,
+            lambda _state, _terminal: None))
+        self.assertAlmostEqual(0.0, manager.get('shot')['elapsed'])
+        chords = []
+        self.assertTrue(manager.advance(
+            10.06,
+            lambda _state, _start, _end, first, last:
+            chords.append((first, last)),
+            lambda _state, _terminal: None))
+        self.assertAlmostEqual(0.02, manager.get('shot')['elapsed'])
+        self.assertAlmostEqual(10.04, chords[0][0])
+        self.assertAlmostEqual(10.06, chords[-1][1])
+
+    def test_admission_horizon_rejects_unadmitted_future_without_mutation(self):
+        manager = self.module.InFlightProjectiles(initial_time=10.0)
+
+        self.assertFalse(manager.launch(
+            'future', (0.0, 0.0, 0.0), (100.0, 0.0, 0.0),
+            (0.0, 0.0, 0.0), 10.07, 10.0, 5000.0,
+            admission_time=10.06))
+        self.assertFalse(manager.launch(
+            'stale-horizon', (0.0, 0.0, 0.0), (100.0, 0.0, 0.0),
+            (0.0, 0.0, 0.0), 9.9, 10.0, 5000.0,
+            admission_time=9.99))
+
+        self.assertEqual([], manager.snapshot())
+
+    def test_terminal_identity_accepts_inactive_authoritative_replace(self):
+        manager = self.module.InFlightProjectiles(initial_time=0.5)
+        self.assertTrue(_launch(manager, max_time=0.1))
+        self.assertTrue(manager.advance(
+            0.5, lambda *_args: None,
+            lambda _state, _terminal: None))
+        self.assertFalse(manager.contains('shot'))
+
+        self.assertTrue(manager.replace_authoritative(
+            _authoritative_snapshot(
+                start=(2.0, 0.0, 0.0),
+                velocity=(10.0, 0.0, 0.0),
+                cursor_time=0.25,
+                distance=2.5)))
+
+        state = manager.get('shot')
+        self.assertIsNotNone(state)
+        self.assertEqual((4.5, 0.0, 0.0), state['position'])
+        self.assertAlmostEqual(0.25, state['cursor_time'])
+        self.assertAlmostEqual(2.5, state['distance'])
+
+    def test_authoritative_replace_changes_key_atomically_and_keeps_order(self):
+        manager = self.module.InFlightProjectiles(initial_time=0.5)
+        self.assertTrue(_launch(manager, key='provisional'))
+        self.assertTrue(_launch(manager, key='peer'))
+
+        self.assertTrue(manager.replace_authoritative(
+            _authoritative_snapshot(
+                key='canonical', cursor_time=0.25, distance=5.0),
+            provisional_key='provisional'))
+
+        self.assertFalse(manager.contains('provisional'))
+        self.assertTrue(manager.contains('canonical'))
+        self.assertEqual(
+            ['canonical', 'peer'],
+            [state['key'] for state in manager.snapshot()])
+        self.assertFalse(_launch(manager, key='canonical'))
+        self.assertTrue(_launch(manager, key='provisional'))
+
+    def test_invalid_cross_key_replace_preserves_provisional_state_and_fence(self):
+        manager = self.module.InFlightProjectiles(initial_time=0.5)
+        self.assertTrue(_launch(manager, key='provisional'))
+        before = manager.get('provisional')
+
+        self.assertFalse(manager.replace_authoritative(
+            _authoritative_snapshot(
+                key='canonical', cursor_time=0.6),
+            provisional_key='provisional'))
+
+        self.assertEqual(before, manager.get('provisional'))
+        self.assertFalse(manager.contains('canonical'))
+        self.assertFalse(_launch(manager, key='provisional'))
+        self.assertTrue(_launch(manager, key='canonical'))
+
+    def test_invalid_authoritative_replace_preserves_active_state(self):
+        manager = self.module.InFlightProjectiles(initial_time=0.5)
+        self.assertTrue(_launch(manager))
+        before = manager.get('shot')
+
+        self.assertFalse(manager.replace_authoritative(
+            _authoritative_snapshot(cursor_time=0.6)))
+
+        self.assertEqual(before, manager.get('shot'))
+        self.assertFalse(_launch(manager))
+
+        class Uncopyable(object):
+            def __deepcopy__(self, _memo):
+                raise RuntimeError('payload cannot be detached')
+
+        self.assertFalse(manager.replace_authoritative(
+            _authoritative_snapshot(payload=Uncopyable())))
+        self.assertEqual(before, manager.get('shot'))
+
+    def test_invalid_inactive_replace_preserves_terminal_identity_fence(self):
+        manager = self.module.InFlightProjectiles(initial_time=0.5)
+        self.assertTrue(_launch(manager, max_time=0.1))
+        self.assertTrue(manager.advance(
+            0.5, lambda *_args: None,
+            lambda _state, _terminal: None))
+
+        self.assertFalse(manager.replace_authoritative(
+            _authoritative_snapshot(cursor_time=0.6)))
+
+        self.assertFalse(manager.contains('shot'))
+        self.assertFalse(_launch(manager))
+        self.assertTrue(manager.rollback_provisional('shot'))
+
+    def test_provisional_reconciliation_is_rejected_during_advance(self):
+        manager = self.module.InFlightProjectiles()
+        self.assertTrue(_launch(manager))
+        replacement = _authoritative_snapshot()
+        callback_results = []
+
+        def observe(_state, _start, _end, _first, _last):
+            if not callback_results:
+                callback_results.append(
+                    manager.rollback_provisional('shot'))
+                callback_results.append(
+                    manager.replace_authoritative(replacement))
+
+        self.assertTrue(manager.advance(
+            0.01, observe, lambda _state, _terminal: None))
+
+        self.assertEqual([False, False], callback_results)
+        self.assertTrue(manager.contains('shot'))
+        self.assertAlmostEqual(0.01, manager.get('shot')['cursor_time'])
 
     def test_future_launch_stale_advance_and_invalid_inputs_fail_closed(self):
         manager = self.module.InFlightProjectiles()

--- a/tests/test_port_0922_server_projectiles.py
+++ b/tests/test_port_0922_server_projectiles.py
@@ -24,10 +24,12 @@ from lan_battle_server import (  # noqa: E402
     PROJECTILE_MAX_ID,
     RICOCHET_CONTINUATION_CAPABILITY, SERVER_CAPABILITIES,
     Player, SimulationWorker, SIMULATION_WORKER_AUTHORITY_ID,
+    SIMULATION_WORKER_CAPABILITY,
     SIMULATION_WORKER_ADVANCEMENT_TYPES,
     SIEGE_DISABLED, SIEGE_ENABLED, SIEGE_SWITCHING_OFF,
     SIEGE_SWITCHING_ON, SIEGE_VEHICLE_PARAMS, TICK_HZ,
     _critical_damage_delta, _critical_payload, _projectile_source_shot,
+    _projectile_wire_round,
 )
 from gui.mods.offline_lan_0922 import vehicle_physics
 from effective_params_fixture import effective_params
@@ -344,6 +346,13 @@ def _player_destructible_contact(seq=1, **changes):
 
 
 class ServerProjectileLedgerTests(unittest.TestCase):
+    def test_projectile_wire_round_is_cross_runtime_half_even(self):
+        self.assertEqual(0.007812, _projectile_wire_round(0.0078125))
+        self.assertEqual(-0.007812, _projectile_wire_round(-0.0078125))
+        self.assertEqual(0.000002, _projectile_wire_round(0.0000015))
+        self.assertEqual(
+            -1.0, math.copysign(1.0, _projectile_wire_round(-0.0000001)))
+
     def _assert_rejected_terminal_retired(self, state, projectile_id,
                                           record=None):
         """Assert a refused live terminal retired its shot silently.
@@ -1439,6 +1448,9 @@ class ServerProjectileLedgerTests(unittest.TestCase):
         self.assertEqual(1, relay['shot_seq'])
         self.assertEqual(player.input_seq, relay['input_seq'])
         self.assertEqual(player.pose_time_us, relay['pose_time_us'])
+        self.assertEqual(message['trigger_server_time_ms'],
+                         relay['trigger_launch_time_ms'])
+        self.assertEqual(relay, player.pending_fire_intents[1])
         self.assertEqual((3.25, 1.5, -4.75),
                          (relay['x'], relay['y'], relay['z']))
         self.assertEqual((-0.5, 0.125),
@@ -1598,6 +1610,9 @@ class ServerProjectileLedgerTests(unittest.TestCase):
             ('dispersion_bounds', {'dispersion_angle': 0.5001}, None,
              'fire_intent_field_invalid'),
             ('missing_origin', {}, 'shot_origin',
+             'fire_intent_wire_shape'),
+            ('canonical_launch_clock_injection',
+             {'trigger_launch_time_ms': 1}, None,
              'fire_intent_wire_shape'),
             ('extra_field', {'unexpected': True}, None,
              'fire_intent_wire_shape'),
@@ -1923,12 +1938,18 @@ class ServerProjectileLedgerTests(unittest.TestCase):
         player = state.players[1]
         state.tick += 30
         self.assertTrue(_update_player_input(state, 1))
+        relayed = []
+        state.simulation_worker.offer_reliable = lambda message: (
+            relayed.append(dict(message)) or True)
         receipt_time_ms = state._server_time_ms()
         self.assertTrue(state.submit_fire_intent(1, _fire_intent(
             state, trigger_server_time_ms=receipt_time_ms + 250)))
         self.assertEqual(
             receipt_time_ms,
             int(player.pending_fire_intents[1]['trigger_launch_time_ms']))
+        self.assertEqual(
+            receipt_time_ms, relayed[-1]['trigger_launch_time_ms'])
+        self.assertEqual(relayed[-1], player.pending_fire_intents[1])
 
         state = _state()
         player = state.players[1]
@@ -1993,6 +2014,36 @@ class ServerProjectileLedgerTests(unittest.TestCase):
                 times[-1], state.projectiles['1:p:1:1'][
                     'launch_server_time_ms'])
         self.assertEqual(1, len(set(times)))
+
+    def test_player_launch_cannot_override_the_frozen_trigger_clock(self):
+        state = _state()
+        player = state.players[1]
+        self.assertTrue(_update_player_input(state, 1))
+        relayed = []
+        state.simulation_worker.offer_reliable = lambda message: (
+            relayed.append(dict(message)) or True)
+        self.assertTrue(state.submit_fire_intent(1, _fire_intent(state)))
+        relay = relayed[-1]
+        launch = _launch(
+            authority_epoch=state.authority_epoch,
+            fire_intent_seq=relay['intent_seq'],
+            fire_input_seq=relay['input_seq'],
+            shot_seq=relay['shot_seq'],
+            trigger_launch_time_ms=relay['trigger_launch_time_ms'] + 1)
+
+        self.assertFalse(state.launch_projectile(
+            SIMULATION_WORKER_AUTHORITY_ID, launch))
+        self.assertEqual('shape', state.last_projectile_launch_reject_code)
+        self.assertEqual([relay['intent_seq']],
+                         list(player.pending_fire_intents))
+        self.assertFalse(state.projectiles)
+
+        launch.pop('trigger_launch_time_ms')
+        self.assertTrue(state.launch_projectile(
+            SIMULATION_WORKER_AUTHORITY_ID, launch))
+        self.assertEqual(
+            relay['trigger_launch_time_ms'],
+            state.pending_events[-1]['launch_server_time_ms'])
 
     def test_bot_launch_timing_is_unchanged_by_the_player_mapping(self):
         state = _state()
@@ -3844,8 +3895,46 @@ class ServerProjectileLedgerTests(unittest.TestCase):
                 'update_spotted_targets', '_apply_reported_health'):
             self.assertFalse(hasattr(BattleState, method_name))
 
+    def test_player_fire_intent_v5_cannot_join_the_v6_room(self):
+        legacy_capabilities = [
+            PROJECTILE_CAPABILITY,
+            DESTRUCTIBLE_CATALOG_V5_CAPABILITY,
+            RAM_CONTACT_LEDGER_CAPABILITY,
+            HUMAN_RAM_TIMELINE_CAPABILITY,
+            'player_fire_intent_v5',
+            PLAYER_ENVIRONMENT_CAPABILITY,
+            EFFECTIVE_PARAMS_CAPABILITY,
+            RICOCHET_CONTINUATION_CAPABILITY,
+        ]
+        state = BattleState(map_name='04_himmelsdorf')
+
+        player, error = state.add_player(
+            _Socket(), ('127.0.0.1', 1), {
+                'client_build': CLIENT_BUILD_0922,
+                'name': 'Legacy',
+                'capabilities': legacy_capabilities,
+            })
+
+        self.assertIsNone(player)
+        self.assertEqual('unsupported_capabilities', error)
+
+        worker, error = state.add_simulation_worker(
+            _Socket(), ('127.0.0.1', 2), {
+                'role': 'simulation_worker',
+                'client_build': CLIENT_BUILD_0922,
+                'capabilities': legacy_capabilities + [
+                    SIMULATION_WORKER_CAPABILITY],
+            })
+
+        self.assertIsNone(worker)
+        self.assertEqual('unsupported_capabilities', error)
+
     def test_capability_and_active_snapshot_wire_bound(self):
         self.assertEqual('projectile_ledger_v2', PROJECTILE_CAPABILITY)
+        self.assertEqual('player_fire_intent_v6',
+                         PLAYER_FIRE_INTENT_CAPABILITY)
+        self.assertIn(PLAYER_FIRE_INTENT_CAPABILITY, SERVER_CAPABILITIES)
+        self.assertNotIn('player_fire_intent_v5', SERVER_CAPABILITIES)
         self.assertEqual('ricochet_continuation_v1',
                          RICOCHET_CONTINUATION_CAPABILITY)
         self.assertIn(RICOCHET_CONTINUATION_CAPABILITY, SERVER_CAPABILITIES)

--- a/tests/test_port_0922_vehicle_overlay.py
+++ b/tests/test_port_0922_vehicle_overlay.py
@@ -261,7 +261,7 @@ class VehicleOverlayProbeExchangeTest(unittest.TestCase):
         capabilities = [
             "projectile_ledger_v2", "destructible_catalog_v5",
             "ram_contact_ledger_v2", "human_ram_timeline_v1",
-            "player_fire_intent_v5", "player_environment_v2",
+            "player_fire_intent_v6", "player_environment_v2",
             "effective_params_v1", "ricochet_continuation_v1",
         ]
         return {


### PR DESCRIPTION
## Summary

- Resolve server-admitted human fire at the tail of the current LAN poll, after the complete receive batch is coherent, while retaining the ordinary frame path for readiness retries.
- Upgrade the paired fire-intent contract to `player_fire_intent_v6`, relay the server-clamped launch time, and provisionally install the worker-owned player projectile immediately after its canonical launch is queued.
- Make the provisional launch byte-for-byte compatible across the Python 2.7 client and Python 3 server, then reconcile canonical echoes and snapshots idempotently or atomically replace mismatches with the server state.
- Fence terminal proposals until canonical admission, roll rejected provisionals back without weakening normal duplicate protection, and keep stale snapshots from retiring them prematurely.
- Keep Bot launches on their existing canonical-echo path because their exact launch time uses a server-private admission offset; add explicit no-regression coverage.
- Retain bounded, high-resolution `FIRE TRIGGER / INTENT RECEIVED / LAUNCH / COMMIT / SHOWN / CURSOR / TRACER MOVING` diagnostics for Windows acceptance.

## Authority and scope

The hidden worker remains the only projectile simulator. Visible clients still submit intent and render canonical state; they gain no projectile authority. The server still validates and commits every launch, progress update, and terminal result.

The fast path runs at the same BigWorld poll tail rather than inside an individual message callback so snapshots and ordered events already present in that receive batch are applied before shot-relevant state is read. Optional visible-client tracer run-ahead and trigger-time local muzzle presentation are not included; they should only be considered after this change is measured on the exact client.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=tests python3 -m unittest discover -s tests -p 'test_*.py' -q`: 3,421 tests passed.
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -p 'test_*.py' -q` from `launcher/`: 480 tests passed, 2 skipped.
- Required fire/projectile/protocol focused suite: 1,152 tests passed.
- CPython 2.7 compiled all 89 client source files and executed the exact half-even wire-rounding edge cases.
- The Python 2.7 build produced the `.wotmod`; `tools/validate_wotmod.py` validated all 103 archive members and its SHA-256 sidecar matched.
- `git diff --check` passed.

A complete desktop overlay cannot be assembled locally because the Windows CI server executable is intentionally absent. CI remains responsible for producing that matching executable and assembling the paired v6 payload.

## Windows acceptance boundary

Only a 15-v-15 run on Chinese HD client `0.9.22.0.1 #1513` can prove A1/A2 and native presentation behavior. Capture the permanent `FIRE *` lines for multiple shots and evaluate `TRIGGER -> SHOWN` and `SHOWN -> TRACER MOVING`; the unit and package checks above do not claim those runtime thresholds.

The historical diagnostic needs one correction before comparison: its logged worker `wait_ms` mixed the BigWorld frame clock with receipt time. Comparing the actual log prefixes in `hidden-worker-profile-20260904T080309Z.zip` gives approximately 7-29 ms from `FIRE INTENT RECEIVED` to `FIRE LAUNCH` (median about 15 ms), rather than the logged 9-264 ms. This change removes that remaining poll-to-frame interval and, more importantly for tracer freeze, removes the worker's canonical-echo gate; exact #1513 logs are still required to quantify the result.
