### PR TITLE
Clear native target before battle teardown

### DIFF
--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -887,6 +887,17 @@ synthetic entity to native lookup and invokes the stock viewpoint callback. It
 is deliberately limited to an active postmortem control after the delay;
 enemy, dead, absent and not-ready vehicles fail closed.
 
+Exact `#1513` destroys the battle GUI before its late
+`BigWorld.target.clear()` in `PlayerAvatar.onBecomeNonPlayer()`. That clear
+synchronously enters `PlayerAvatar.targetBlur()`, which removes the target
+edge and unconditionally reads `TriggersManager.g_manager`. A hidden native
+target may already be absent from the callable `PyTarget` result while its
+pending blur still retains the entity. The shared presentation-quiesce boundary
+therefore clears native target focus once per battle before postmortem, local
+pose, outline or remote-entity owners are retired. ABI and lifecycle audits pin
+the target-blur signature and this stock teardown order; only Windows `#1513`
+acceptance can prove the native result-screen behavior.
+
 Local Vehicle creation is gated by the complete pinned `Vehicle.def` SHA-256
 `e585c59235ebb2cfbb7857645878ed095360a8efe5df666c055e59a74e6a55c5`,
 uses all of its client properties, and publishes the exact

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -20760,9 +20760,17 @@ class BattleRuntime(object):
         """Release battle-scoped native visuals before Hangar takes over."""
         cleanup_error = None
         try:
-            self._release_postmortem_visibility()
+            # BigWorld.target.clear() synchronously reaches stock targetBlur.
+            # Run it before any GUI, trigger, edge or remote-entity owner can
+            # be retired; PlayerAvatar.onBecomeNonPlayer clears it too late.
+            self._runtime.compatibility.clear_target_focus()
         except Exception as error:
             cleanup_error = error
+        try:
+            self._release_postmortem_visibility()
+        except Exception as error:
+            if cleanup_error is None:
+                cleanup_error = error
         if self._local_matrix is not None or self._local_model is not None:
             try:
                 self._detach_local_presentation()

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/compat.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/compat.py
@@ -623,6 +623,7 @@ class OfflineCompatibility(object):
         self._target_lock_candidate = None
         self._target_lock_input_pending = False
         self._target_lock_input_avatar = None
+        self._target_focus_clear_attempted = False
 
     def install(self):
         if self._installed:
@@ -2778,6 +2779,7 @@ class OfflineCompatibility(object):
         self._target_lock_candidate = None
         self._target_lock_input_pending = False
         self._target_lock_input_avatar = None
+        self._target_focus_clear_attempted = False
         self._installed = False
 
     def garage_state(self):
@@ -3017,6 +3019,7 @@ class OfflineCompatibility(object):
         self._battle_player_vehicle_id = 0
         self._postmortem_vehicle_id = 0
         self._target_lock_candidate = None
+        self._target_focus_clear_attempted = False
         self._native_battle = True
         self._battle_gui_type = gui_type
         self._battle_bonus_type = bonus_type
@@ -3174,6 +3177,34 @@ class OfflineCompatibility(object):
                 raise ValueError(
                     'target-lock candidate has no visual entity')
         self._target_lock_candidate = vehicle
+        return True
+
+    def clear_target_focus(self):
+        """Release the native mouse target while its battle owners are live.
+
+        Exact #1513 synchronously calls ``PlayerAvatar.targetBlur`` from
+        ``BigWorld.target.clear()``.  That callback owns the target edge and
+        reads the battle Trigger manager, so it must run before Avatar GUI
+        teardown rather than from stock ``onBecomeNonPlayer`` afterwards.
+        """
+        if (not self._battle_active or
+                self._target_focus_clear_attempted):
+            return False
+        self._target_lock_candidate = None
+        target = self._original_target
+        if not callable(target):
+            raise RuntimeError('#1513 BigWorld.target is unavailable')
+        clear = getattr(target, 'clear', None)
+        if not callable(clear):
+            raise RuntimeError(
+                '#1513 BigWorld target-clear boundary is unavailable')
+        # PyTarget.__call__ hides an internally retained hidden target, so a
+        # None result cannot prove that clear is unnecessary.  Install the
+        # idempotence token before the native call because clear synchronously
+        # re-enters PlayerAvatar.targetBlur and may raise after releasing the
+        # engine pointer.
+        self._target_focus_clear_attempted = True
+        clear()
         return True
 
     def _target_lock_holds(self, current_id):

--- a/tests/test_port_0922.py
+++ b/tests/test_port_0922.py
@@ -3703,6 +3703,60 @@ class OfflineCompatibilityTests(unittest.TestCase):
             original_auto_aim,
             runtime.avatar_module.PlayerAvatar.__dict__['autoAim'])
 
+    def test_target_focus_clear_runs_stock_blur_while_triggers_are_live(self):
+        compatibility_module = _load_port_source('compat')
+        runtime, operations = self._runtime()
+        compatibility = compatibility_module.OfflineCompatibility(runtime)
+        compatibility.configure_battle()
+        lifecycle = {
+            'focused': True,
+            'trigger_owner_live': True,
+        }
+
+        def clear():
+            operations.append(('native_target_clear',))
+            if not lifecycle['focused']:
+                return
+            operations.append(('stock_target_blur',))
+            lifecycle['focused'] = False
+            if not lifecycle['trigger_owner_live']:
+                raise AttributeError(
+                    "'NoneType' object has no attribute "
+                    "'deactivateTrigger'")
+
+        # PyTarget.__call__ reports None for a hidden entity even while its
+        # internal target pointer remains live and still needs targetBlur.
+        runtime.bigworld._target = None
+        runtime.bigworld.target.clear = clear
+        compatibility._target_lock_candidate = object()
+
+        self.assertTrue(compatibility.clear_target_focus())
+        self.assertFalse(lifecycle['focused'])
+        self.assertIsNone(compatibility._target_lock_candidate)
+        self.assertEqual([
+            ('native_target_clear',),
+            ('stock_target_blur',),
+        ], operations[-2:])
+
+        self.assertFalse(compatibility.clear_target_focus())
+        self.assertEqual(1, operations.count(('native_target_clear',)))
+
+        compatibility.deactivate_map()
+        runtime.bigworld._target = object()
+        self.assertFalse(compatibility.clear_target_focus())
+        self.assertEqual(1, operations.count(('native_target_clear',)))
+
+        compatibility.configure_battle()
+        lifecycle['focused'] = True
+        lifecycle['trigger_owner_live'] = False
+        with self.assertRaisesRegex(
+                AttributeError, "deactivateTrigger"):
+            compatibility.clear_target_focus()
+        self.assertFalse(lifecycle['focused'])
+        self.assertFalse(compatibility.clear_target_focus())
+        self.assertEqual(2, operations.count(('native_target_clear',)))
+        compatibility.fini()
+
     def test_target_lock_input_scope_clears_on_consume_and_failure(self):
         compatibility_module = _load_port_source('compat')
         runtime, unused_operations = self._runtime()

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -990,6 +990,7 @@ class _Compatibility(object):
         self.target_lock_validations = []
         self.account_int_commands = []
         self.postmortem_vehicle_id = 0
+        self.target_focus_clears = 0
 
     def dispatch_account_int_command(self, command, values):
         self.account_int_commands.append((command, values))
@@ -1021,6 +1022,10 @@ class _Compatibility(object):
 
     def set_target_lock_candidate(self, vehicle):
         self.target_lock_candidate = vehicle
+        return True
+
+    def clear_target_focus(self):
+        self.target_focus_clears += 1
         return True
 
     def set_postmortem_vehicle(self, vehicle_id):
@@ -11521,6 +11526,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
         runtime = _runtime()
         battle = BattleRuntime(runtime)
         battle._avatar = runtime.bigworld.avatar
+        battle.state = 'running'
         battle._binding = mock.Mock()
         battle._avatar.playerVehicleID = 10
         battle._synchronise_player_identity(10)
@@ -11535,7 +11541,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
         target_record = {
             'engine_id': 11, 'local': False, 'kind': 'bot',
             'network_id': 2, 'presentation': True, 'native_remote': True,
-            'ready': True, 'visual_started': False,
+            'ready': True, 'arena_added': True, 'visual_started': False,
             'spot_visible': False, 'spot_marker_visible': False,
             'state': {'team': 2, 'health': 500, 'alive': True,
                       'x': 0.0, 'y': 0.0, 'z': 10.0}}
@@ -11547,23 +11553,48 @@ class BattleRuntimeContractTests(unittest.TestCase):
                           'frags': 0}},
             'bot:2': target_record,
         }
-        request_wreck = mock.Mock(return_value=True)
+        request_wreck = mock.Mock(return_value=False)
         battle._remote_factory = types.SimpleNamespace(
             get=lambda engine_id: target if engine_id == 11 else None,
             request_wreck=request_wreck)
         event = {
+            'event_id': '1:1:0',
             'kind': 'bot_hit', 'attacker': 1, 'target_bot': 2,
             'health': 0, 'dead': True, 'attack_reason': 0,
             'death_reason': 0, 'source': 'shot', 'world_pose': True,
             'x': 0.0, 'y': 1.0, 'z': 10.0, 'shell_index': 0,
             'shot_result': 2, 'damage': 500}
+        statistics = {
+            'event_id': '1:1:1', 'kind': 'vehicle_statistics',
+            'actor_kind': 'player', 'actor_id': 1, 'frags': 1,
+            'team_killer': False}
+        result = {
+            'event_id': '1:1:2', 'kind': 'battle_result', 'winner': 1,
+            'reason': 'team_eliminated'}
+
+        def on_round_finished(winner, reason):
+            # The last-shot event batch must finish the blind death edge and
+            # frag publication before entering the native result lifecycle.
+            self.assertEqual(0, target.health)
+            self.assertTrue(target.model.visible)
+            request_wreck.assert_called_once_with(11)
+            battle._binding.arena_vehicle_killed.assert_called_once_with(
+                11, 10, 0)
+            battle._binding.arena_vehicle_statistics.assert_called_once_with(
+                10, 1)
+            battle._avatar.round_finished.append((winner, reason))
+
+        battle._avatar.onRoundFinished = mock.Mock(
+            side_effect=on_round_finished)
 
         with mock.patch.object(
                 critical_damage, 'apply_death',
                 return_value=None) as apply_death:
-            self.assertTrue(battle._apply_combat_event(event))
-            # An ordered replay must not repeat native death/effect callbacks.
-            self.assertTrue(battle._apply_combat_event(event))
+            events = {'events': [event, statistics, result]}
+            self.assertTrue(battle.on_events(events))
+            # An ordered replay must not repeat native death, frag or result
+            # callbacks.
+            self.assertTrue(battle.on_events(events))
 
         self.assertEqual(0, target.health)
         self.assertEqual(0, target_record['state']['health'])
@@ -11585,17 +11616,13 @@ class BattleRuntimeContractTests(unittest.TestCase):
             setVehicleState.assert_not_called()
         battle._binding.arena_vehicle_killed.assert_called_once_with(
             11, 10, 0)
+        battle._binding.arena_vehicle_statistics.assert_called_once_with(
+            10, 1)
+        battle._avatar.onRoundFinished.assert_called_once_with(
+            1, runtime.constants.FINISH_REASON.EXTERMINATION)
         battle._avatar.terrainEffects.addNew.assert_not_called()
         self.assertEqual([], battle._avatar.shot_results)
         self.assertEqual([], battle._avatar.battle_events)
-
-        statistics = {
-            'kind': 'vehicle_statistics', 'actor_kind': 'player',
-            'actor_id': 1, 'frags': 1, 'team_killer': False}
-        self.assertTrue(battle._apply_vehicle_statistics_event(statistics))
-        self.assertFalse(battle._apply_vehicle_statistics_event(statistics))
-        battle._binding.arena_vehicle_statistics.assert_called_once_with(
-            10, 1)
 
     def test_blind_critical_state_has_no_remote_vehicle_effect(self):
         runtime = _runtime()
@@ -23641,6 +23668,63 @@ class BattleRuntimeContractTests(unittest.TestCase):
         runtime.bigworld.callbacks.pop()()
         self.assertEqual('stopped', battle.state)
         self.assertIsNone(battle._server)
+
+    def test_avatar_leave_clears_target_before_trigger_teardown(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        client = _Client()
+        start = {
+            'round_id': 1, 'map': '01_karelia', 'bot_authority_id': 1,
+            'players': [{
+                'id': 1, 'team': 1, 'slot': 0, 'name': 'Player',
+                'vehicle': 'ussr:R11_MS-1', 'health': 500}],
+            'bots': []}
+        self.assertTrue(battle.start({
+            'map': '01_karelia', 'vehicle': 'ussr:R11_MS-1',
+            'name': 'Player'}, start, client))
+        runtime.bigworld.callbacks.pop(0)()
+        runtime.bigworld.callbacks.pop(0)()
+        server = battle._server
+        lifecycle = {
+            'focused': True,
+            'trigger_owner_live': True,
+        }
+        calls = []
+
+        def clear_target_focus():
+            calls.append('clear_target_focus')
+            if not lifecycle['focused']:
+                return False
+            if not lifecycle['trigger_owner_live']:
+                raise AttributeError(
+                    "'NoneType' object has no attribute "
+                    "'deactivateTrigger'")
+            lifecycle['focused'] = False
+            return True
+
+        original_retire = runtime.compatibility.retire_current_player
+
+        def retire_current_player():
+            calls.append('retire_current_player')
+            lifecycle['trigger_owner_live'] = False
+            if lifecycle['focused']:
+                raise AttributeError(
+                    "'NoneType' object has no attribute "
+                    "'deactivateTrigger'")
+            return original_retire()
+
+        runtime.compatibility.clear_target_focus = clear_target_focus
+        runtime.compatibility.retire_current_player = retire_current_player
+
+        server.leaveArena({})
+
+        self.assertFalse(lifecycle['focused'])
+        self.assertEqual(['clear_target_focus'], calls)
+        runtime.bigworld.callbacks.pop()()
+        self.assertEqual(
+            ['clear_target_focus', 'clear_target_focus',
+             'retire_current_player'], calls)
+        self.assertEqual('stopped', battle.state)
 
     def test_avatar_leave_delegates_session_ownership_after_mailbox_returns(self):
         runtime = _runtime()

--- a/tools/audit_client_abi.py
+++ b/tools/audit_client_abi.py
@@ -463,6 +463,7 @@ EXPECTED_ABI = {
         'PlayerAvatar.enableOwnVehicleAutorotation': ('self', 'enable'),
         'PlayerAvatar.autoAim': ('self', 'target'),
         'PlayerAvatar.targetFocus': ('self', 'entity'),
+        'PlayerAvatar.targetBlur': ('self', 'prevEntity'),
         'PlayerAvatar.shoot': ('self', 'isRepeat'),
         'PlayerAvatar.__isOwnVehicleSwitchingSiegeMode': ('self',),
         'PlayerAvatar.cancelWaitingForShot': ('self',),
@@ -1148,6 +1149,11 @@ EXPECTED_CODE_NAMES = {
         'PlayerAvatar.targetFocus': (
             '_PlayerAvatar__vehicles', 'guiSessionProvider',
             'setTargetInFocus', 'drawEdge'),
+        'PlayerAvatar.targetBlur': (
+            '_PlayerAvatar__vehicles', 'guiSessionProvider',
+            'setTargetInFocus', 'removeEdge', 'target',
+            'TriggersManager', 'g_manager', 'deactivateTrigger',
+            'TRIGGER_TYPE', 'AIM_AT_VEHICLE'),
         'PlayerAvatar.shoot': (
             'base', 'vehicle_shoot', '_PlayerAvatar__startWaitingForShot',
             '_PlayerAvatar__isOwnVehicleSwitchingSiegeMode'),

--- a/tools/audit_client_lifecycle.py
+++ b/tools/audit_client_lifecycle.py
@@ -332,6 +332,19 @@ ORDERED_USES = (
         'native Avatar closes the arena music and ambience lifecycle',
     ),
     (
+        'scripts/client/Avatar.pyc',
+        'PlayerAvatar.onBecomeNonPlayer',
+        ('_PlayerAvatar__destroyGUI', 'BigWorld', 'target', 'clear'),
+        'Avatar destroys battle GUI before its late native target clear',
+    ),
+    (
+        'scripts/client/Avatar.pyc',
+        'PlayerAvatar.targetBlur',
+        ('removeEdge', 'target', 'TriggersManager', 'g_manager',
+         'deactivateTrigger', 'TRIGGER_TYPE', 'AIM_AT_VEHICLE'),
+        'target blur releases the edge before reading the Trigger owner',
+    ),
+    (
         'scripts/client/account_helpers/AccountSyncData.pyc',
         'AccountSyncData.setAccount',
         ('_AccountSyncData__account',


### PR DESCRIPTION
## Summary

- clear the exact #1513 native PyTarget at the shared presentation-quiesce boundary, before GUI, trigger, edge, and remote-entity owners retire
- keep blind lethal hit, wreck, frag statistics, and battle-result delivery ordered in one replay-safe event batch
- pin the targetBlur ABI and stock teardown ordering in exact-client audits

## Evidence

- An exact Chinese HD #1513 session records PostProcessing teardown followed by Avatar.py targetBlur raising because TriggersManager.g_manager is None at the result/leave boundary.
- Pinned bytecode shows PlayerAvatar.onBecomeNonPlayer destroys battle GUI before its late BigWorld.target.clear; targetBlur removes the target edge and then calls the Trigger manager.
- Server elimination/result logic is independent of spotting state, so this is fixed at the common client teardown owner rather than with a blind-kill special case.
- No actionable exception dump was captured. The traceback is confirmed, but this PR does not claim it is statically proven to be the sole cause of process exit.

## Validation

- 3 focused blind-kill/target-teardown regressions passed
- 853 relevant client compatibility/runtime tests passed after final assertion tightening
- 3387 repository tests passed against the production change
- all 89 client Python sources compile with CPython 2.7.18
- exact #1513 ABI audit passed: 461 signatures plus reviewed code-name contracts
- exact #1513 lifecycle audit passed, including GUI-before-target-clear and targetBlur edge/trigger ordering
- staged diff check passed

## Remaining acceptance boundary

Exact Windows #1513 playtesting is still required to prove that blind-killing the final enemy, an ordinary round ending, and player-death ending all enter and leave the result screen without the traceback or a client exit.