### PR TITLE
Keep bot spawn traffic moving

### DIFF
--- a/src/res/scripts/client/gui/mods/offline_lan_0922/ai/adapter.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/ai/adapter.py
@@ -52,13 +52,14 @@ class BotAdapter(object):
     def decide(self, state, direction_clear):
         """Return a deterministic, serializable command for one bot.
 
-        ``state`` needs ``id``, ``position``, ``yaw``, ``speed``, ``dt``,
-        ``now`` and optionally ``health``, ``max_health``, ``contacts`` and
-        ``neighbours``.  ``direction_clear(yaw)`` is the sole runtime probe.
+        ``state`` needs ``id``, ``slot``, ``position``, ``yaw``, ``speed``,
+        ``dt``, ``now`` and optionally ``health``, ``max_health``, ``contacts``
+        and ``neighbours``.  ``direction_clear(yaw)`` is the sole runtime probe.
         """
         state = state if isinstance(state, dict) else {}
         bot_id = int(state.get('id', 0))
         position = _position(state.get('position'))
+        speed = float(state['speed'])
         contacts = [_contact(item) for item in state.get('contacts', ())]
         contacts = [item for item in contacts if item is not None]
         team = self.director.agents[bot_id]['team']
@@ -72,6 +73,7 @@ class BotAdapter(object):
                 contact.get('speed', 0.0))
         strategic = self.director.order_for(
             bot_id, position, float(state.get('yaw', 0.0)),
+            speed,
             state.get('health', 1.0), state.get('max_health', 1.0), now)
         return self._drive_order(
             bot_id, state, position, strategic, direction_clear)
@@ -131,7 +133,8 @@ class BotAdapter(object):
             }
         else:
             local = self.driver.drive(
-                bot_id, position, float(state.get('yaw', 0.0)),
+                bot_id, int(state['slot']), position,
+                float(state.get('yaw', 0.0)),
                 float(state.get('speed', 0.0)), float(state.get('dt', 0.0)),
                 target, state.get('neighbours', ()), direction_clear,
                 velocity=state.get('velocity'),

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/ai/driver.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/ai/driver.py
@@ -15,6 +15,13 @@ TRAFFIC_WAIT_LEASE_SECONDS = 1.5
 FIRST_CANDIDATE_OFFSET = 0.42
 # Fifteen-degree circular buckets centre both the +/-pi seam and cardinal yaws.
 FAILED_YAW_BUCKET_COUNT = 24
+# Bot slots are team-local and the LAN roster has exactly fifteen per team.
+BOT_TEAM_SLOT_COUNT = 15
+# Seven is coprime with fifteen, so consecutive formation slots visit every
+# timing bucket without clustering adjacent tanks at one end of the window.
+RECOVERY_TIMING_STRIDE = 7
+RECOVERY_YAW_OFFSET = 0.85
+RECOVERY_SWEEP_FRACTIONS = (0.25, 0.50, 0.75, 1.0)
 
 
 def _angle_delta(target, current):
@@ -37,13 +44,22 @@ def _distance(first, second):
 	return math.sqrt(dx * dx + dz * dz)
 
 
-def _identity_phase(bot_id):
-	"""Stable 0..1 value without Python's randomized string hash."""
-	text = str(bot_id)
-	value = 0
-	for char in text:
-		value = (value * 33 + ord(char)) & 0x7fffffff
-	return float(value % 997) / 997.0
+def _team_slot(value):
+	"""Return one explicit stable team-local formation slot."""
+	try:
+		slot = int(value)
+	except (TypeError, ValueError, OverflowError):
+		raise ValueError('bot team slot is invalid')
+	if slot < 0 or slot >= BOT_TEAM_SLOT_COUNT:
+		raise ValueError('bot team slot is outside 0..14')
+	return slot
+
+
+def _recovery_timing_phase(team_slot):
+	"""Uniform per-team recovery timing independent of steering side."""
+	slot = _team_slot(team_slot)
+	bucket = (slot * RECOVERY_TIMING_STRIDE) % BOT_TEAM_SLOT_COUNT
+	return (float(bucket) + 0.5) / float(BOT_TEAM_SLOT_COUNT)
 
 
 def _component_value(component, name, default=None):
@@ -115,7 +131,7 @@ def barrel_direction(yaw, pitch):
 
 
 class LocalDriver(object):
-	"""Stateful local steering, keyed only by bot id.
+	"""Stateful local steering keyed by bot id and a stable team-local slot.
 
 	``direction_clear(absolute_yaw)`` must return whether a short vehicle-length
 	segment in that direction is drivable.  It may raise; a failed probe is
@@ -173,22 +189,25 @@ class LocalDriver(object):
 		if state['traffic_wait_time'] <= TRAFFIC_WAIT_LEASE_SECONDS:
 			state['stuck_time'] = 0.0
 			state['recovery_time'] = 0.0
+			state['recovery_side'] = 0.0
 		return True
 
-	def _state(self, bot_id, position):
+	def _state(self, bot_id, team_slot, position):
+		team_slot = _team_slot(team_slot)
 		state = self.states.get(bot_id)
 		if state is None:
-			phase = _identity_phase(bot_id)
 			state = {
+				'team_slot': team_slot,
 				'last_position': (float(position[0]), float(position[2])),
 				'stuck_time': 0.0,
 				'recovery_time': 0.0,
 				'recovery_count': 0,
+				'recovery_side': 0.0,
 				'steering_yaw': None,
 				'steering_reason': 'route',
 				'steering_age': 999.0,
 				'plan_age': 999.0,
-				'phase': phase,
+				'recovery_timing_phase': _recovery_timing_phase(team_slot),
 				'clock': 0.0,
 				'failed_yaws': {},
 				'escape_side': 0.0,
@@ -201,7 +220,13 @@ class LocalDriver(object):
 				'braking_target': None,
 			}
 			self.states[bot_id] = state
+		elif state['team_slot'] != team_slot:
+			raise ValueError('bot team slot changed during battle')
 		return state
+
+	def _fallback_recovery_side(self, state):
+		parity = int(state['team_slot']) + int(state['recovery_count'])
+		return 1.0 if parity & 1 else -1.0
 
 	def _yaw_key(self, yaw):
 		turn = math.pi * 2.0
@@ -228,10 +253,10 @@ class LocalDriver(object):
 		if abs(offset) >= 0.10:
 			side = 1.0 if offset > 0.0 else -1.0
 		else:
-			# Adjacent ids choose opposite initial sides, then keep that side while
-			# widening the escape angle. This avoids left/right grinding at a broad
-			# obstacle without turning the finite failure TTL into a permanent bias.
-			side = 1.0 if (int(state['phase'] * 997.0 + 0.5) & 1) else -1.0
+			# Adjacent formation slots choose opposite initial sides, then keep it
+			# while widening the escape angle. This avoids left/right grinding at a
+			# broad obstacle without making a finite failure TTL a permanent bias.
+			side = self._fallback_recovery_side(state)
 		state['escape_side'] = side
 		state['escape_side_until'] = (
 			state['clock'] + min(2.0, max(0.8, ttl)))
@@ -459,6 +484,58 @@ class LocalDriver(object):
 				continue
 		return False
 
+	def _recovery_occupancy(self, position, yaw, direction, neighbours,
+			half_length, half_width):
+		"""Count occupied sampled poses in one in-place recovery turn."""
+		occupied = 0
+		for neighbour in neighbours or ():
+			other = self._neighbour_position(neighbour)
+			if other is None:
+				continue
+			try:
+				if abs(float(other[1]) - float(position[1])) > 5.0:
+					continue
+			except Exception:
+				pass
+			other_yaw = 0.0
+			other_length = half_length
+			other_width = half_width
+			if isinstance(neighbour, dict):
+				try:
+					other_yaw = float(neighbour.get('yaw', 0.0) or 0.0)
+					other_length = float(
+						neighbour.get('half_length', half_length) or half_length)
+					other_width = float(
+						neighbour.get('half_width', half_width) or half_width)
+				except (TypeError, ValueError, OverflowError):
+					continue
+			for fraction in RECOVERY_SWEEP_FRACTIONS:
+				candidate_yaw = (
+					float(yaw) + float(direction) *
+					RECOVERY_YAW_OFFSET * fraction)
+				try:
+					if self._obb_overlap(
+							position, candidate_yaw,
+							half_length, half_width,
+							other, other_yaw, other_length, other_width):
+						occupied += 1
+				except Exception:
+					continue
+		return occupied
+
+	def _select_recovery_side(self, state, position, yaw, neighbours,
+			half_length, half_width):
+		"""Prefer the less occupied pivot arc, then use stable slot parity."""
+		negative = self._recovery_occupancy(
+			position, yaw, -1.0, neighbours, half_length, half_width)
+		positive = self._recovery_occupancy(
+			position, yaw, 1.0, neighbours, half_length, half_width)
+		if negative < positive:
+			return -1.0
+		if positive < negative:
+			return 1.0
+		return self._fallback_recovery_side(state)
+
 	def _choose_yaw(self, state, desired_yaw, current_yaw, position, speed,
 			velocity, neighbours, direction_clear, half_length, half_width):
 		separation = self._separation_yaw(
@@ -489,18 +566,21 @@ class LocalDriver(object):
 				return candidate
 		return None
 
-	def drive(self, bot_id, position, yaw, speed, dt, target, neighbours,
-			direction_clear, velocity=None, half_length=3.5, half_width=1.7,
+	def drive(self, bot_id, team_slot, position, yaw, speed, dt, target,
+			neighbours, direction_clear, velocity=None,
+			half_length=3.5, half_width=1.7,
 			movement_intent=True, stopping_distance=None,
 			stop_at_target=True, decision_horizon=0.0):
 		"""Return ``throttle``, ``turn``, ``target_yaw`` and ``recovery_mode``.
 
+		``team_slot`` is the explicit stable 0..14 formation slot. It must not be
+		inferred from a network entity id because those numbering schemes differ.
 		All timing uses the complete supplied interval.  The authority caller
 		already advances vehicle physics in bounded substeps; throwing away the
 		planner's remaining wall time would leave recovery and route leases
 		permanently behind after every slow callback.
 		"""
-		state = self._state(bot_id, position)
+		state = self._state(bot_id, team_slot, position)
 		step = max(0.0, float(dt))
 		if not state.pop('traffic_waiting', False):
 			state['traffic_wait_time'] = 0.0
@@ -527,6 +607,7 @@ class LocalDriver(object):
 			# reinterpret that commanded hold as a stuck tank 1.8 seconds later.
 			state['stuck_time'] = 0.0
 			state['recovery_time'] = 0.0
+			state['recovery_side'] = 0.0
 			state['steering_yaw'] = None
 			state['braking_target'] = None
 			return {
@@ -545,6 +626,7 @@ class LocalDriver(object):
 			# is zero and previously produced full throttle until the next order tick.
 			state['stuck_time'] = 0.0
 			state['recovery_time'] = 0.0
+			state['recovery_side'] = 0.0
 			state['steering_yaw'] = None
 			state['last_position'] = (
 				float(position[0]), float(position[2]))
@@ -570,26 +652,37 @@ class LocalDriver(object):
 		else:
 			state['stuck_time'] += step
 
-		threshold = self.stuck_seconds + state['phase'] * 0.42
+		timing_phase = state['recovery_timing_phase']
+		threshold = self.stuck_seconds + timing_phase * 0.42
 		if state['recovery_time'] > 0.0:
 			state['recovery_time'] = max(0.0, state['recovery_time'] - step)
 			if state['recovery_time'] == 0.0:
 				state['recovery_count'] += 1
+				state['recovery_side'] = 0.0
 				state['stuck_time'] = 0.0
 		else:
 			if state['stuck_time'] >= threshold:
 				if state.get('last_clear_yaw') is not None:
 					state['failed_yaws'][self._yaw_key(state['last_clear_yaw'])] = (
 						state['clock'] + self.failure_ttl)
-				state['recovery_time'] = self.recovery_seconds + state['phase'] * 0.28
+				state['recovery_time'] = (
+					self.recovery_seconds + timing_phase * 0.28)
+				state['recovery_side'] = self._select_recovery_side(
+					state, position, yaw, neighbours,
+					own_half_length, own_half_width)
 
 		if state['recovery_time'] > 0.0:
-			# Alternate the turn direction each recovery so a bot does not grind a
-			# wall forever.  Phase makes adjacent ids leave a traffic jam apart. Never
-			# reverse blindly: at a cliff or shoreline the space behind the hull can be
-			# the unsafe side that caused the stall in the first place.
-			direction = 1.0 if ((state['recovery_count'] + int(state['phase'] * 10)) % 2) else -1.0
-			recovery_yaw = float(yaw) + direction * 0.85
+			# Keep one side for the whole episode. Geometry separates an asymmetric
+			# local jam; team-local slot parity breaks an exact tie without coupling
+			# steering to the timing phase. Never reverse blindly: at a cliff or
+			# shoreline the space behind can be the unsafe side that caused the stall.
+			direction = state.get('recovery_side', 0.0)
+			if direction not in (-1.0, 1.0):
+				direction = self._select_recovery_side(
+					state, position, yaw, neighbours,
+					own_half_length, own_half_width)
+				state['recovery_side'] = direction
+			recovery_yaw = float(yaw) + direction * RECOVERY_YAW_OFFSET
 			if (not self._clear(direction_clear, float(yaw) + math.pi) or
 					self._reverse_blocked_by_vehicle(
 						position, yaw, neighbours,

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/ai/planner.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/ai/planner.py
@@ -1100,7 +1100,7 @@ class BattleDirector(object):
 		agent['target_id'] = best.get('id') if best is not None else None
 		return best
 
-	def _route_position(self, agent, position, now, hull_yaw=None):
+	def _route_position(self, agent, position, now, speed, hull_yaw=None):
 		route = agent.get('route')
 		if route is None:
 			enemy_base = self.bases.get(2 if agent['team'] == 1 else 1)
@@ -1126,10 +1126,12 @@ class BattleDirector(object):
 					position[1], float(waypoints[nearest][1]))) < 30.0):
 				nearest += 1
 			# A deployed formation can be closer to a connector that it has already
-			# passed than to the next lane point. Joining that connector makes every
-			# hull turn back toward its own flag before it may leave spawn. Only skip
-			# a genuinely rear-facing point and preserve lateral lane openings.
-			if hull_yaw is not None:
+			# passed than to the next lane point. Once a hull is moving forward its
+			# yaw proves the current travel direction, so skip only a genuinely
+			# rear-facing connector and preserve lateral lane openings. A parked
+			# hull's yaw is merely its parking orientation, and negative speed is a
+			# temporary reverse recovery; neither may discard the authored egress.
+			if hull_yaw is not None and _number(speed) > 0.5:
 				while nearest + 1 < len(waypoints):
 					waypoint = waypoints[nearest]
 					bearing = math.atan2(
@@ -1211,13 +1213,15 @@ class BattleDirector(object):
 		angle = 12.0 + agent['personality']['caution'] * 18.0
 		return -angle if (agent['seed'] & 1) == 0 else angle
 
-	def order_for(self, bot_id, position, hull_yaw, health, max_health, now):
+	def order_for(self, bot_id, position, hull_yaw, speed, health, max_health,
+	              now):
 		agent = self.agents[int(bot_id)]
 		agent['position'] = tuple(position)
 		agent['health_fraction'] = (
 			_number(health, 1.0) / max(_number(max_health, 1.0), 1.0))
 		contact = self._choose_contact(agent, position, hull_yaw, now)
-		route_position = self._route_position(agent, position, now, hull_yaw)
+		route_position = self._route_position(
+			agent, position, now, speed, hull_yaw)
 		profile = agent['profile']
 		personality = agent['personality']
 		order = {

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -185,8 +185,14 @@ BOT_OVERTURN_DEATH_REASON = 7
 
 # Route groups lease these lateral lanes without moving an existing member.
 # A safety rejection may narrow a lane toward zero for one macro route leg,
-# but never crosses sides or upgrades again inside that leg.
+# but never crosses sides or upgrades again inside that leg.  The server owns
+# macro-route progress and accepts a waypoint at 13 metres.  Leave the local
+# driver's final 1.5-metre arrival tolerance inside that contract instead of
+# allowing an offset target to park just outside the server gate.
 ROUTE_LANE_OFFSETS = (0.0, 5.0, -5.0, 10.0, -10.0)
+ROUTE_LANE_ORDER = (-10.0, -5.0, 0.0, 5.0, 10.0)
+ROUTE_JOIN_ARRIVAL_RADIUS = 13.0
+ROUTE_JOIN_ROW_LIMIT = 4.0
 
 
 def _route_lane_fallbacks(offset):
@@ -201,6 +207,60 @@ def _route_lane_fallbacks(offset):
     if offset < 0.0:
         return (-5.0, 0.0)
     return (0.0,)
+
+
+def _route_lane_layout(count):
+    """Return centred, monotonically ordered lanes for one cohort."""
+    count = max(1, int(count))
+    if count == 1:
+        return (0.0,)
+    if count == 2:
+        return (-5.0, 5.0)
+    if count == 3:
+        return (-5.0, 0.0, 5.0)
+    if count == 4:
+        return (-10.0, -5.0, 5.0, 10.0)
+    if count == 5:
+        return ROUTE_LANE_ORDER
+    # Quantise equal-width rank bins across all five lanes. Centred samples
+    # keep six and seven symmetric while a full 15-Bot team divides 3/3/3/3/3
+    # instead of overloading the inner lanes.
+    return tuple(
+        ROUTE_LANE_ORDER[
+            ((2 * index + 1) * len(ROUTE_LANE_ORDER)) // (2 * count)]
+        for index in range(count))
+
+
+def _route_row_layout(count):
+    """Return bounded convoy rows, reusing them deterministically if needed."""
+    count = max(1, int(count))
+    if count == 1:
+        return (0.0,)
+    row_count = min(5, count)
+    rows = tuple(
+        -ROUTE_JOIN_ROW_LIMIT +
+        (2.0 * ROUTE_JOIN_ROW_LIMIT * index / float(row_count - 1))
+        for index in range(row_count))
+    if count == row_count:
+        return rows
+    # Keep unexpected oversized test/input cohorts deterministic too. More
+    # lateral spread would violate the server's arrival circle, so stable row
+    # reuse is safer than silently widening the gate.
+    result = []
+    for index in range(count):
+        row_index = int(round(
+            index * float(row_count - 1) / float(count - 1)))
+        result.append(rows[row_index])
+    return tuple(result)
+
+
+def _route_row_fallbacks(offset):
+    """Narrow a longitudinal join row toward the authored waypoint."""
+    offset = float(offset)
+    if abs(offset) < 1.0e-9:
+        return (0.0,)
+    middle = offset * 0.5
+    return (offset, middle, 0.0)
 
 
 def _cache_deadline(now, entity_id, interval, salt=0, stagger=False):
@@ -3782,6 +3842,20 @@ class BotRuntime(object):
             if _server_order_signature(previous.get(bot_id)) !=
             _server_order_signature(accepted.get(bot_id)))
         for bot_id in changed_ids:
+            previous_route_id = (previous.get(bot_id) or {}).get('route_id')
+            accepted_route_id = (accepted.get(bot_id) or {}).get('route_id')
+            if previous_route_id != accepted_route_id:
+                lane_state = self.states.get(bot_id)
+                if lane_state is not None:
+                    for name in (
+                            '_route_lane_group', '_route_lane_gate',
+                            '_route_lane_origin',
+                            '_route_lane_desired',
+                            '_route_lane_row_desired',
+                            '_route_lane_forward', '_route_lane_segment',
+                            '_route_lane_offset', '_route_lane_row',
+                            '_route_lane_goal'):
+                        lane_state.pop(name, None)
             self._server_order_tokens[bot_id] = (
                 int(self._server_order_tokens.get(bot_id, 0)) + 1)
             self._decision_cache.pop(bot_id, None)
@@ -5664,31 +5738,419 @@ class BotRuntime(object):
         return all(after[index] <= before[index] + 1.0e-6
                    for index in range(4))
 
-    def _route_lane_binding(self, bot_state, group_key):
-        """Lease the least-used stable lane without moving existing peers."""
-        if bot_state.get('_route_lane_group') == group_key:
-            return _number(bot_state.get('_route_lane_desired'))
-        counts = dict((offset, 0) for offset in ROUTE_LANE_OFFSETS)
-        for peer in self.states.values():
-            if (peer is bot_state or not peer.get('alive', True) or
-                    peer.get('_route_lane_group') != group_key):
+    def _route_lane_cohort(self, bot_id, group_key, gate_key):
+        """Return one authoritative live route-gate cohort.
+
+        A route may have several spawn connectors.  The server publishes a
+        complete atomic order snapshot, so production peers are grouped by
+        their initial route index as well as the persistent team/route lease.
+        An already-bound peer retains its original gate identity after it
+        advances; this keeps a late rebalance from moving existing leases.
+        """
+        bot_id = int(bot_id)
+        team, route_id = group_key
+        result = []
+        for peer_id in sorted(self.states):
+            peer = self.states[peer_id]
+            if (not peer.get('alive', True) or
+                    int(peer.get('team', 0)) != int(team)):
                 continue
-            offset = _number(peer.get('_route_lane_desired'))
-            if offset in counts:
-                counts[offset] += 1
-        desired = min(
-            ROUTE_LANE_OFFSETS,
-            key=lambda offset: (counts[offset],
-                                ROUTE_LANE_OFFSETS.index(offset)))
-        bot_state['_route_lane_group'] = group_key
-        bot_state['_route_lane_desired'] = desired
-        bot_state.pop('_route_lane_segment', None)
-        bot_state.pop('_route_lane_offset', None)
-        return desired
+            peer_route_id = None
+            peer_gate = None
+            previous_group = peer.get('_route_lane_group')
+            previous_gate = peer.get('_route_lane_gate')
+            if previous_group == group_key and isinstance(
+                    previous_gate, tuple) and len(previous_gate) == 2:
+                peer_route_id = previous_group[1]
+                peer_gate = (
+                    int(_number(previous_gate[0])), bool(previous_gate[1]))
+            else:
+                # A current server order is the strategic authority.  The
+                # route retained on the local agent is only a conservative
+                # seam before any complete order snapshot exists.
+                order = self._server_orders.get(int(peer_id))
+                if isinstance(order, dict):
+                    peer_route_id = order.get('route_id')
+                    if (order.get('route_index') is not None and
+                            'route_join' in order):
+                        peer_gate = (
+                            int(_number(order.get('route_index'))),
+                            bool(order.get('route_join')))
+                elif self._server_orders:
+                    # Production snapshots are complete and replaced
+                    # atomically.  Never guess a missing peer into a known
+                    # gate from its older local route.
+                    continue
+
+            if peer_route_id is None and not self._server_orders:
+                route = peer.get('route') or {}
+                peer_route_id = (
+                    route.get('id') if isinstance(route, dict) else None)
+                if (peer.get('route_index') is not None and
+                        peer.get('route_join') is not None):
+                    peer_gate = (
+                        int(_number(peer.get('route_index'))),
+                        bool(peer.get('route_join')))
+                elif int(peer_id) == bot_id:
+                    peer_gate = gate_key
+            if (str(peer_route_id) != route_id or peer_gate != gate_key):
+                continue
+            result.append(peer)
+        bot_state = self.states.get(bot_id)
+        if bot_state is not None and bot_state not in result:
+            result.append(bot_state)
+        return sorted(result, key=lambda peer: (
+            int(peer.get('slot', 0)), int(peer.get('id', 0))))
+
+    @staticmethod
+    def _route_waypoint_xz(raw):
+        if isinstance(raw, dict):
+            return (_number(raw.get('x')), _number(raw.get('z')))
+        try:
+            return (_number(raw[0]), _number(raw[1]))
+        except (TypeError, IndexError):
+            return None
+
+    def _route_lane_forward(self, bot_state, goal, strategic):
+        """Resolve one authored direction shared by the complete cohort."""
+        route = bot_state.get('route') or {}
+        strategic_route_id = str(strategic.get('route_id', 'direct'))
+        local_route_id = (route.get('id')
+                          if isinstance(route, dict) else None)
+        waypoints = ()
+        if (local_route_id is not None and
+                str(local_route_id) == strategic_route_id):
+            waypoints = route.get('waypoints', ()) or ()
+        route_index = int(_number(strategic.get('route_index'), 0))
+        if waypoints:
+            if route_index > 0 and route_index < len(waypoints):
+                first = self._route_waypoint_xz(waypoints[route_index - 1])
+                second = self._route_waypoint_xz(waypoints[route_index])
+            elif len(waypoints) > 1:
+                first = self._route_waypoint_xz(waypoints[0])
+                second = self._route_waypoint_xz(waypoints[1])
+            else:
+                first = None
+                second = None
+            if first is not None and second is not None:
+                dx = second[0] - first[0]
+                dz = second[1] - first[1]
+                length = math.hypot(dx, dz)
+                if length >= 0.25:
+                    return (dx / length, dz / length)
+        anchor = strategic.get('route_anchor')
+        try:
+            anchor_x = _number(anchor[0])
+            anchor_z = _number(anchor[2])
+        except (TypeError, IndexError, KeyError):
+            anchor_x = _number(_value(anchor, 'x', bot_state.get('x')))
+            anchor_z = _number(_value(anchor, 'z', bot_state.get('z')))
+        dx = _number(goal[0]) - anchor_x
+        dz = _number(goal[2]) - anchor_z
+        length = math.hypot(dx, dz)
+        if length < 0.25:
+            yaw = _number(bot_state.get('yaw'))
+            return (math.sin(yaw), math.cos(yaw))
+        return (dx / length, dz / length)
+
+    def _route_lane_binding(self, bot_id, group_key, goal, strategic):
+        """Bind one spawn-gate cohort by lateral projection, once and stably."""
+        bot_id = int(bot_id)
+        bot_state = self.states.get(bot_id)
+        if bot_state is None:
+            return (0.0, 0.0)
+        order = self._server_orders.get(bot_id)
+        if (isinstance(order, dict) and
+                str(order.get('route_id')) == group_key[1] and
+                order.get('route_index') is not None and
+                'route_join' in order):
+            gate_key = (
+                int(_number(order.get('route_index'))),
+                bool(order.get('route_join')))
+        else:
+            gate_key = (
+                int(_number(strategic.get('route_index'), 0)),
+                bool(strategic.get('route_join')))
+        if bot_state.get('_route_lane_group') == group_key:
+            # Normal non-join progress keeps the spawn lease and lets the
+            # current macro leg derive its own direction.  A fresh join on a
+            # different authoritative gate is different: preserve the leased
+            # lane/row, but rotate this Bot's private join goal to the new
+            # segment without reassigning any peer.
+            if (gate_key[1] and
+                    bot_state.get('_route_lane_gate') != gate_key):
+                bot_state['_route_lane_gate'] = gate_key
+                bot_state['_route_lane_forward'] = self._route_lane_forward(
+                    bot_state, goal, strategic)
+                for name in (
+                        '_route_lane_segment', '_route_lane_offset',
+                        '_route_lane_row', '_route_lane_goal'):
+                    bot_state.pop(name, None)
+            return (
+                _number(bot_state.get('_route_lane_desired')),
+                _number(bot_state.get('_route_lane_row_desired')),
+            )
+        cohort = self._route_lane_cohort(bot_id, group_key, gate_key)
+        if not cohort:
+            return (0.0, 0.0)
+        for peer in cohort:
+            if (peer.get('_route_lane_group') != group_key or
+                    peer.get('_route_lane_gate') != gate_key or
+                    peer.get('_route_lane_origin') is None):
+                peer['_route_lane_origin'] = _position(peer)
+        forward_x, forward_z = self._route_lane_forward(
+            bot_state, goal, strategic)
+        lateral_x = -forward_z
+        lateral_z = forward_x
+        lateral_order = sorted(cohort, key=lambda peer: (
+            _number(peer['_route_lane_origin'][0]) * lateral_x +
+            _number(peer['_route_lane_origin'][2]) * lateral_z,
+            int(peer.get('slot', 0)), int(peer.get('id', 0))))
+        count = len(lateral_order)
+        assignments = {}
+        lane_members = {}
+        layout = _route_lane_layout(count)
+        for index, peer in enumerate(lateral_order):
+            lane_members.setdefault(layout[index], []).append(peer)
+        for lane in ROUTE_LANE_ORDER:
+            members = lane_members.get(lane, ())
+            members = sorted(members, key=lambda peer: (
+                _number(peer['_route_lane_origin'][0]) * forward_x +
+                _number(peer['_route_lane_origin'][2]) * forward_z,
+                int(peer.get('slot', 0)), int(peer.get('id', 0))))
+            rows = _route_row_layout(len(members)) if members else ()
+            for index, peer in enumerate(members):
+                assignments[int(peer.get('id', 0))] = (lane, rows[index])
+        bound = [peer for peer in cohort
+                 if (peer.get('_route_lane_group') == group_key and
+                     peer.get('_route_lane_gate') == gate_key)]
+        if bound:
+            occupied = set((
+                _number(peer.get('_route_lane_desired')),
+                _number(peer.get('_route_lane_row_desired')),
+            ) for peer in bound)
+            row_choices = (-4.0, -2.0, 0.0, 2.0, 4.0)
+            for peer in lateral_order:
+                if peer.get('_route_lane_group') == group_key:
+                    continue
+                peer_id = int(peer.get('id', 0))
+                expected_lane, expected_row = assignments.get(
+                    peer_id, (0.0, 0.0))
+                occupied_lanes = set(value[0] for value in occupied)
+                available = [
+                    (lane, 0.0) for lane in ROUTE_LANE_ORDER
+                    if lane not in occupied_lanes]
+                if available:
+                    desired = min(available, key=lambda value: (
+                        (value[0] - expected_lane) ** 2 +
+                        (value[1] - expected_row) ** 2,
+                        abs(value[0] - expected_lane),
+                        abs(value[1] - expected_row),
+                        ROUTE_LANE_ORDER.index(value[0]),
+                        row_choices.index(value[1])))
+                else:
+                    reused = [
+                        (lane, row) for lane in ROUTE_LANE_ORDER
+                        for row in row_choices
+                        if (lane, row) not in occupied]
+                    if reused:
+                        # A distinct tuple can still overlap another hull: a
+                        # two-metre row delta is worse than the bounded four
+                        # metres available at the same lane. Maximise the
+                        # nearest occupied-pair separation first, then stay as
+                        # close as possible to the full-cohort geometry.
+                        desired = min(reused, key=lambda value: (
+                            -min((value[0] - used[0]) ** 2 +
+                                 (value[1] - used[1]) ** 2
+                                 for used in occupied),
+                            (value[0] - expected_lane) ** 2 +
+                            (value[1] - expected_row) ** 2,
+                            abs(value[0] - expected_lane),
+                            abs(value[1] - expected_row),
+                            ROUTE_LANE_ORDER.index(value[0]),
+                            row_choices.index(value[1])))
+                    else:
+                        # The supported team-local roster cannot exhaust all
+                        # 25 bounded pairs. Keep a deterministic centre
+                        # fallback for malformed state without widening.
+                        desired = (0.0, 0.0)
+                assignments[peer_id] = desired
+                occupied.add(desired)
+        for peer in cohort:
+            if peer.get('_route_lane_group') == group_key:
+                continue
+            desired, row = assignments.get(
+                int(peer.get('id', 0)), (0.0, 0.0))
+            peer['_route_lane_group'] = group_key
+            peer['_route_lane_gate'] = gate_key
+            peer['_route_lane_desired'] = desired
+            peer['_route_lane_row_desired'] = row
+            peer['_route_lane_forward'] = (forward_x, forward_z)
+            peer.pop('_route_lane_segment', None)
+            peer.pop('_route_lane_offset', None)
+            peer.pop('_route_lane_row', None)
+            peer.pop('_route_lane_goal', None)
+        return (
+            _number(bot_state.get('_route_lane_desired')),
+            _number(bot_state.get('_route_lane_row_desired')),
+        )
+
+    def _route_lane_leg_forward(
+            self, bot_state, position, goal, strategic, joining):
+        if joining:
+            stored = bot_state.get('_route_lane_forward')
+            try:
+                forward_x = _number(stored[0])
+                forward_z = _number(stored[1])
+                length = math.hypot(forward_x, forward_z)
+                if length >= 0.25:
+                    return (forward_x / length, forward_z / length)
+            except (TypeError, IndexError):
+                pass
+        anchor = strategic.get('route_anchor')
+        try:
+            anchor_x = _number(anchor[0])
+            anchor_z = _number(anchor[2])
+        except (TypeError, IndexError, KeyError):
+            anchor_x = _number(_value(anchor, 'x', position[0]))
+            anchor_z = _number(_value(anchor, 'z', position[2]))
+        forward_x = _number(goal[0]) - anchor_x
+        forward_z = _number(goal[2]) - anchor_z
+        length = math.hypot(forward_x, forward_z)
+        if length < 0.25:
+            forward_x = _number(goal[0]) - _number(position[0])
+            forward_z = _number(goal[2]) - _number(position[2])
+            length = math.hypot(forward_x, forward_z)
+        if length < 0.25:
+            return None
+        return (forward_x / length, forward_z / length)
+
+    def _safe_route_lane_goal(
+            self, bot_state, goal, forward, lateral, row, now):
+        """Validate one offset macro goal before it enters navigation A*."""
+        if abs(lateral) < 1.0e-9 and abs(row) < 1.0e-9:
+            return tuple(goal)
+        grid = getattr(self.navigator, 'grid', None)
+        ground = getattr(grid, '_ground', None)
+        segment_hazard = getattr(grid, 'segment_has_baked_hazard', None)
+        point_hazard = getattr(grid, 'point_has_baked_hazard', None)
+        dry_segment = getattr(grid, 'dry_segment_clear', None)
+        if not all(callable(value) for value in (
+                ground, segment_hazard, point_hazard, dry_segment)):
+            return None
+        forward_x, forward_z = forward
+        lateral_x = -forward_z
+        lateral_z = forward_x
+        candidate_x = (_number(goal[0]) + lateral_x * lateral +
+                       forward_x * row)
+        candidate_z = (_number(goal[2]) + lateral_z * lateral +
+                       forward_z * row)
+        offset_distance = math.hypot(
+            candidate_x - _number(goal[0]),
+            candidate_z - _number(goal[2]))
+        if (offset_distance + ai_driver.WAYPOINT_ARRIVAL_RADIUS >
+                ROUTE_JOIN_ARRIVAL_RADIUS + 1.0e-9):
+            return None
+        candidate_y = ground(candidate_x, candidate_z, _number(goal[1]))
+        if candidate_y is None:
+            return None
+        candidate = (candidate_x, candidate_y, candidate_z)
+        hazard_mask = BAKED_FATAL_HAZARDS | BAKED_SHALLOW_WATER
+        try:
+            # An authored ford remains centred.  Offset endpoints and the
+            # short cross-lane chord around a dry macro gate must both remain
+            # outside fatal and shallow cells; A* then proves the complete
+            # spawn-to-offset route rather than inheriting this local chord.
+            if (point_hazard(goal, hazard_mask) or
+                    point_hazard(candidate, hazard_mask) or
+                    segment_hazard(goal, candidate, hazard_mask) or
+                    not dry_segment(goal, candidate, now)):
+                return None
+        except Exception:
+            return None
+        travel_yaw = math.atan2(forward_x, forward_z)
+        overflow = self._baked_boundary_overflow(
+            bot_state, candidate, travel_yaw)
+        if (overflow is None or
+                any(value > 1.0e-6 for value in overflow)):
+            return None
+        return candidate
+
+    def _route_lane_goal(
+            self, bot_id, position, goal, strategic, now, joining):
+        """Return a stable safe macro lane goal for navigation to prove."""
+        bot_id = int(bot_id)
+        bot_state = self.states.get(bot_id)
+        if bot_state is None:
+            return (tuple(goal), (0, 0))
+        group_key = (
+            int(bot_state.get('team', 0)),
+            str(strategic.get('route_id', 'direct')),
+        )
+        desired, desired_row = self._route_lane_binding(
+            bot_id, group_key, goal, strategic)
+        route_index = int(_number(strategic.get('route_index'), 0))
+        segment_key = group_key + (route_index, bool(joining))
+        if bot_state.get('_route_lane_segment') != segment_key:
+            bot_state['_route_lane_segment'] = segment_key
+            bot_state['_route_lane_offset'] = desired
+            bot_state['_route_lane_row'] = desired_row if joining else 0.0
+            bot_state.pop('_route_lane_goal', None)
+        forward = self._route_lane_leg_forward(
+            bot_state, position, goal, strategic, joining)
+        if forward is None:
+            bot_state['_route_lane_offset'] = 0.0
+            bot_state['_route_lane_row'] = 0.0
+            bot_state['_route_lane_goal'] = tuple(goal)
+            return (tuple(goal), (0, 0))
+
+        current_offset = _number(bot_state.get('_route_lane_offset'))
+        current_row = _number(bot_state.get('_route_lane_row'))
+        reject_current = False
+        navigator_states = getattr(self.navigator, 'bot_states', {})
+        navigator_state = (
+            navigator_states.get(bot_id, {})
+            if isinstance(navigator_states, dict) else {})
+        planned_goal = navigator_state.get('planned_goal')
+        previous_goal = bot_state.get('_route_lane_goal')
+        try:
+            reject_current = bool(
+                navigator_state.get('navigation_status') == 'blocked' and
+                previous_goal is not None and planned_goal is not None and
+                _distance(previous_goal, planned_goal) < 0.25)
+        except (TypeError, IndexError):
+            reject_current = False
+
+        first = True
+        seen = set()
+        for row in _route_row_fallbacks(current_row):
+            for offset in _route_lane_fallbacks(current_offset):
+                identity = (round(offset, 6), round(row, 6))
+                if identity in seen:
+                    continue
+                seen.add(identity)
+                if reject_current and first:
+                    first = False
+                    continue
+                first = False
+                candidate = self._safe_route_lane_goal(
+                    bot_state, goal, forward, offset, row, now)
+                if candidate is None:
+                    continue
+                bot_state['_route_lane_offset'] = offset
+                bot_state['_route_lane_row'] = row
+                bot_state['_route_lane_goal'] = candidate
+                return (candidate, (
+                    int(round(offset * 1000.0)),
+                    int(round(row * 1000.0))))
+        bot_state['_route_lane_offset'] = 0.0
+        bot_state['_route_lane_row'] = 0.0
+        bot_state['_route_lane_goal'] = tuple(goal)
+        return (tuple(goal), (0, 0))
 
     def _route_lane_target(
             self, bot_id, position, goal, selected, strategic, now):
-        """Offset one proved shared-route target through a stable safe lane."""
+        """Offset one proved non-join route target through its stable lane."""
         bot_state = self.states.get(int(bot_id))
         grid = getattr(self.navigator, 'grid', None)
         selected = tuple(selected)
@@ -5702,7 +6164,8 @@ class BotRuntime(object):
             int(bot_state.get('team', 0)),
             str(strategic.get('route_id', 'direct')),
         )
-        desired = self._route_lane_binding(bot_state, group_key)
+        desired, unused_row = self._route_lane_binding(
+            bot_id, group_key, goal, strategic)
         segment_key = group_key + (
             int(_number(strategic.get('route_index'), 0)),)
         if bot_state.get('_route_lane_segment') != segment_key:
@@ -5732,7 +6195,6 @@ class BotRuntime(object):
             route_length = math.hypot(route_dx, route_dz)
         if route_length < 0.25:
             return selected
-        # Positive offsets are left of the authored route direction.
         lateral_x = -route_dz / route_length
         lateral_z = route_dx / route_length
 
@@ -5755,10 +6217,6 @@ class BotRuntime(object):
             candidate_z = _number(selected[2]) + lateral_z * offset
             candidate_dx = candidate_x - _number(position[0])
             candidate_dz = candidate_z - _number(position[2])
-            # A short local A* target can sit closer than the requested lane
-            # offset. Never turn that proved forward step into a point behind
-            # the hull or inside LocalDriver's arrival radius: either result
-            # would convert a distant macro route into a persistent nav_wait.
             if (math.hypot(candidate_dx, candidate_dz) <=
                     ai_driver.WAYPOINT_ARRIVAL_RADIUS + 1.0e-9 or
                     dx * candidate_dx + dz * candidate_dz <= 1.0e-9):
@@ -5797,6 +6255,8 @@ class BotRuntime(object):
         if self.navigator is None:
             state['navigation_stop_at_target'] = stop_at_goal
             return goal
+        grid = getattr(self.navigator, 'grid', None)
+        now = state.get('now', 0.0)
         route_index = int(_number(strategic.get('route_index'), 0))
         if mode == 'base_defense':
             path_key = (
@@ -5806,16 +6266,21 @@ class BotRuntime(object):
         elif mode in ('route', 'advance', 'hold'):
             anchor = (strategic.get('route_anchor')
                       if bool(strategic.get('route_join')) else None)
+            lane_identity = (0, 0)
+            if mode in ('route', 'advance') and anchor is not None:
+                goal, lane_identity = self._route_lane_goal(
+                    bot_id, position, goal, strategic, now,
+                    True)
             if anchor is not None:
-                # A route's first shared path used to be cached from whichever
-                # spawn slot requested it first. Every following tank then
-                # converged onto that one hull's egress line. Keep the strategic
-                # destination shared, but join it from each real slot through a
-                # bot-scoped terrain path. Later route segments remain shared.
+                # Lane offsets are macro goals, never post-A* translations of
+                # a locally proved point.  Each offset route remains private so
+                # neither its spawn anchor nor its narrowed goal can leak into
+                # another hull's cached path.
                 path_key = (
                     'route_join', int(bot_id),
                     int(self.states[bot_id].get('team', 0)),
-                    strategic.get('route_id', 'direct'), route_index)
+                    strategic.get('route_id', 'direct'), route_index,
+                    lane_identity[0], lane_identity[1])
             else:
                 path_key = (
                     'route', int(self.states[bot_id].get('team', 0)),
@@ -5830,14 +6295,12 @@ class BotRuntime(object):
         # teammate repeatedly change the selected waypoint and produced visible
         # drive/stop cycles, especially for slow heavy tanks.
         avoid = None
-        grid = getattr(self.navigator, 'grid', None)
         cell_size = max(1.0, _number(getattr(grid, 'cell_size', 1.0), 1.0))
         lookahead_distance = max(
             cell_size * 2.0,
             abs(_number(state.get('speed'))) *
             BAKED_MOTION_LOOKAHEAD_SECONDS)
         direct = getattr(grid, 'dry_segment_clear', None)
-        now = state.get('now', 0.0)
         direct_close = _distance(position, goal) <= 15.0
         bot_edges_penalized = getattr(
             self.navigator, 'bot_segment_penalized', None)
@@ -5864,8 +6327,7 @@ class BotRuntime(object):
              (callable(terminal) and terminal(bot_id))))
         if mode in ('route', 'advance') and anchor is None:
             target = self._route_lane_target(
-                bot_id, position, goal, target, strategic,
-                now)
+                bot_id, position, goal, target, strategic, now)
         return target
 
     def _player_neighbours(self, players):
@@ -9003,9 +9465,15 @@ class BotRuntime(object):
                     stopping_distance = self._cached_traffic_stopping_distance(
                         state, previous_command, physics_params)
                 decision_state = {
-                    'id': state['id'], 'position': position,
+                    'id': state['id'],
+                    'slot': int(state.get('slot', 0)),
+                    'position': position,
                     'yaw': state['yaw'],
-                    'speed': abs(_number(state.get('speed'))),
+                    # Connector selection distinguishes parked/forward motion
+                    # from a deliberate reverse.  Preserve the authoritative
+                    # sign here; LocalDriver applies abs only where magnitude
+                    # is the physical quantity being consumed.
+                    'speed': _number(state.get('speed')),
                     'dt': decision_step, 'now': now,
                     'health': state['health'],
                     'max_health': state['max_health'],

--- a/tests/test_port_0922_ai.py
+++ b/tests/test_port_0922_ai.py
@@ -252,13 +252,37 @@ class BotAiPortTests(unittest.TestCase):
         adapter = BotAdapter('01_karelia', 7)
         adapter.register(1, 1, descriptor)
         order = adapter.decide({
-            'id': 1, 'position': (0, 0, 0), 'yaw': 0, 'speed': 0,
+            'id': 1, 'slot': 0, 'position': (0, 0, 0),
+            'yaw': 0, 'speed': 0,
             'dt': 0.05, 'now': 1, 'health': 100, 'max_health': 100,
             'contacts': (), 'neighbours': (),
         }, lambda yaw: True)
         self.assertEqual(1, order['bot_id'])
         self.assertIn('throttle', order)
         self.assertIsInstance(order['move_position'], tuple)
+
+    def test_adapter_passes_signed_speed_to_the_route_planner(self):
+        descriptor = {'type': {'name': 'MS-1', 'tags': ('mediumTank',)},
+                      'physics': {'speedLimits': (18.0,)}, 'hull': {},
+                      'turret': {}, 'gun': {'shots': ()}}
+        adapter = BotAdapter('01_karelia', 7)
+        adapter.register(1, 1, descriptor)
+        observed = []
+        original_order_for = adapter.director.order_for
+
+        def order_for(*args, **kwargs):
+            observed.append(args[3])
+            return original_order_for(*args, **kwargs)
+
+        adapter.director.order_for = order_for
+        adapter.decide({
+            'id': 1, 'slot': 0, 'position': (0, 0, 0),
+            'yaw': 0, 'speed': -3.5,
+            'dt': 0.05, 'now': 1, 'health': 100, 'max_health': 100,
+            'contacts': (), 'neighbours': (),
+        }, lambda unused_yaw: True)
+
+        self.assertEqual([-3.5], observed)
 
     def test_vehicle_profile_reads_native_1513_components_as_attributes(self):
         descriptor = _StrictNoLegacyStuff(
@@ -428,7 +452,8 @@ class BotAiPortTests(unittest.TestCase):
         adapter = BotAdapter('01_karelia', 7)
         adapter.register(1, 1, descriptor)
         order = adapter.decide_with_order({
-            'id': 1, 'position': (0.0, 0.0, 0.0), 'yaw': 0.0,
+            'id': 1, 'slot': 0,
+            'position': (0.0, 0.0, 0.0), 'yaw': 0.0,
             'speed': 0.0, 'dt': 0.05, 'now': 1.0,
             'neighbours': (),
         }, {
@@ -457,7 +482,8 @@ class BotAiPortTests(unittest.TestCase):
         adapter.register(1, 1, descriptor)
 
         order = adapter.decide_with_order({
-            'id': 1, 'position': (0.0, 0.0, 0.0), 'yaw': 0.25,
+            'id': 1, 'slot': 0,
+            'position': (0.0, 0.0, 0.0), 'yaw': 0.25,
             'speed': 0.0, 'dt': 0.05, 'now': 1.0,
             'neighbours': (),
         }, {
@@ -499,7 +525,7 @@ class BotAiPortTests(unittest.TestCase):
                 1, 402, 2, target, 1000, 1000,
                 'heavyTank', True, now)
             order = director.order_for(
-                401, position, 0.0, 1000, 1000, now)
+                401, position, 0.0, 0.0, 1000, 1000, now)
             modes.add(order['combat_mode'])
             throttle_values.add(order['throttle_override'])
 
@@ -519,7 +545,7 @@ class BotAiPortTests(unittest.TestCase):
             'SPG', True, 1.0, shootable_by_ids=(401,))
 
         order = director.order_for(
-            401, (0.0, 0.0, 0.0), 0.0, 1000, 1000, 1.0)
+            401, (0.0, 0.0, 0.0), 0.0, 0.0, 1000, 1000, 1.0)
 
         self.assertEqual(403, order['target_id'])
 
@@ -535,7 +561,7 @@ class BotAiPortTests(unittest.TestCase):
             'SPG', False, 1.0, shootable_by_ids=(401,))
 
         order = director.order_for(
-            401, (0.0, 0.0, 0.0), 0.0, 1000, 1000, 1.0)
+            401, (0.0, 0.0, 0.0), 0.0, 0.0, 1000, 1000, 1.0)
 
         self.assertEqual(402, order['target_id'])
 
@@ -1144,7 +1170,7 @@ class BotAiPortTests(unittest.TestCase):
             if position[0] < 22.0 and mode in ('safe_local', 'reactive'):
                 near_bank_fallbacks.add(mode)
             command = driver.drive(
-                9, tuple(position), yaw[0], 0.0, 0.1, target, (),
+                9, 0, tuple(position), yaw[0], 0.0, 0.1, target, (),
                 direction_clear)
             yaw[0] = float(command['target_yaw'])
             throttle = float(command['throttle'])
@@ -1427,40 +1453,50 @@ class BotAiPortTests(unittest.TestCase):
         agent['route_started'] = True
         agent['waypoint_index'] = 1
 
-        target = director._route_position(agent, (0.0, 0.0, -20.0), 3.0)
+        target = director._route_position(
+            agent, (0.0, 0.0, -20.0), 3.0, 0.0)
 
         self.assertEqual((0.0, 0.0, 80.0), target)
         self.assertEqual(2, agent['waypoint_index'])
 
-    def test_spawn_skips_rear_connector_and_anchors_navigation_at_hull(self):
-        director = BattleDirector('07_lakeville', 'forward-join')
+    def test_only_a_forward_moving_spawn_skips_its_rear_connector(self):
         descriptor = {
             'type': {'name': 'medium', 'tags': ('mediumTank',)},
             'physics': {'speedLimits': (18.0,)}, 'hull': {},
             'turret': {}, 'gun': {'shots': ()}}
-        agent = director.register(
-            93, 1, descriptor, 'Forward join bot')
-        agent['route'] = {
-            'waypoints': (
-                (0.0, -40.0, False),
-                (0.0, -65.0, False),
-                (40.0, 40.0, False),
-            )}
-        agent['route_started'] = False
+        cases = (
+            (0.0, (0.0, 0.0, -65.0), 1),
+            (-2.0, (0.0, 0.0, -65.0), 1),
+            (2.0, (40.0, 0.0, 40.0), 2),
+        )
+        for speed, expected, waypoint_index in cases:
+            director = BattleDirector('07_lakeville', 'forward-join')
+            agent = director.register(
+                93, 1, descriptor, 'Forward join bot')
+            agent['route'] = {
+                'waypoints': (
+                    (0.0, -40.0, False),
+                    (0.0, -65.0, False),
+                    (40.0, 40.0, False),
+                )}
+            agent['route_started'] = False
 
-        order = director.order_for(
-            93, (0.0, 0.0, -20.0), 0.0, 1000, 1000, 0.0)
+            order = director.order_for(
+                93, (0.0, 0.0, -20.0), 0.0, speed,
+                1000, 1000, 0.0)
 
-        self.assertEqual((40.0, 0.0, 40.0), order['move_position'])
-        self.assertEqual(2, agent['waypoint_index'])
-        self.assertEqual((0.0, 0.0, -20.0), order['route_anchor'])
-        self.assertTrue(order['route_join'])
+            with self.subTest(speed=speed):
+                self.assertEqual(expected, order['move_position'])
+                self.assertEqual(waypoint_index, agent['waypoint_index'])
+                self.assertEqual(
+                    (0.0, 0.0, -20.0), order['route_anchor'])
+                self.assertTrue(order['route_join'])
 
     def test_normal_route_turn_keeps_full_throttle(self):
         driver = LocalDriver()
         target_yaw = 0.9
         order = driver.drive(
-            2, (0.0, 0.0, 0.0), 0.0, 0.0, 0.1,
+            2, 0, (0.0, 0.0, 0.0), 0.0, 0.0, 0.1,
             (math.sin(target_yaw) * 50.0, 0.0,
              math.cos(target_yaw) * 50.0),
             (), lambda unused_angle: True)
@@ -1480,7 +1516,7 @@ class BotAiPortTests(unittest.TestCase):
         }
 
         order = driver.drive(
-            133, (0.0, 0.0, 0.0), 0.0, 8.0, 0.1,
+            133, 0, (0.0, 0.0, 0.0), 0.0, 8.0, 0.1,
             (0.0, 0.0, 50.0), (neighbour,),
             lambda unused_yaw: True,
             velocity=(0.0, 0.0, 8.0),
@@ -1508,7 +1544,7 @@ class BotAiPortTests(unittest.TestCase):
             neighbour['position'], 0.0, 3.7, 1.9))
 
         order = driver.drive(
-            134, position, 0.0, 0.0, 0.1,
+            134, 0, position, 0.0, 0.0, 0.1,
             (50.0, 0.0, 0.0), (neighbour,),
             lambda unused_yaw: True,
             half_length=3.5, half_width=1.7)
@@ -1535,7 +1571,7 @@ class BotAiPortTests(unittest.TestCase):
             neighbour['position'], 0.0, 3.7, 1.9))
 
         order = driver.drive(
-            135, position, 0.0, 0.0, 0.1,
+            135, 0, position, 0.0, 0.0, 0.1,
             (50.0, 0.0, 0.0), (neighbour,),
             lambda unused_yaw: True,
             half_length=3.5, half_width=1.7)
@@ -1547,14 +1583,14 @@ class BotAiPortTests(unittest.TestCase):
         driver = LocalDriver()
         target = (0.0, 0.0, 10.0)
         driver.drive(
-            137, (0.0, 0.0, 0.0), 0.0, 4.0, 0.1,
+            137, 0, (0.0, 0.0, 0.0), 0.0, 4.0, 0.1,
             target, (), lambda unused_yaw: True)
 
         held = driver.drive(
-            137, (1.0, 0.0, 1.0), 0.0, 4.0, 0.1,
+            137, 0, (1.0, 0.0, 1.0), 0.0, 4.0, 0.1,
             target, (), lambda unused_yaw: True)
         refreshed = driver.drive(
-            137, (1.0, 0.0, 2.0), 0.0, 4.0, 0.3,
+            137, 0, (1.0, 0.0, 2.0), 0.0, 4.0, 0.3,
             target, (), lambda unused_yaw: True)
 
         self.assertEqual('drive', held['recovery_mode'])
@@ -1568,13 +1604,13 @@ class BotAiPortTests(unittest.TestCase):
                      'half_length': 3.5, 'half_width': 1.5}
         target = (0.0, 0.0, 8.0)
         first = driver.drive(
-            138, (0.0, 0.0, 0.0), 0.0, 1.0, 0.1,
+            138, 0, (0.0, 0.0, 0.0), 0.0, 1.0, 0.1,
             target, (neighbour,), lambda unused_yaw: True,
             half_length=3.5, half_width=1.5)
         # The other hull moves away before the former 1.2-second lease ends.
         neighbour['position'] = (10.0, 0.0, 0.0)
         released = driver.drive(
-            138, (0.0, 0.0, 0.1), 0.0, 1.0, 0.1,
+            138, 0, (0.0, 0.0, 0.1), 0.0, 1.0, 0.1,
             target, (neighbour,), lambda unused_yaw: True,
             half_length=3.5, half_width=1.5)
 
@@ -1585,7 +1621,7 @@ class BotAiPortTests(unittest.TestCase):
     def test_separation_behind_hull_turns_before_driving_into_overlap(self):
         driver = LocalDriver()
         order = driver.drive(
-            139, (0.0, 0.0, 0.0), 0.0, 0.0, 0.1,
+            139, 0, (0.0, 0.0, 0.0), 0.0, 0.0, 0.1,
             (50.0, 0.0, 0.0), ({
                 'position': (0.0, 0.0, 6.0), 'yaw': 0.0,
                 'half_length': 3.5, 'half_width': 1.7,
@@ -1600,10 +1636,10 @@ class BotAiPortTests(unittest.TestCase):
         driver = LocalDriver()
         target = (50.0, 0.0, 0.0)
         first = driver.drive(
-            140, (0.0, 0.0, 0.0), 0.0, 4.0, 0.1,
+            140, 0, (0.0, 0.0, 0.0), 0.0, 4.0, 0.1,
             target, (), lambda unused_yaw: True)
         second = driver.drive(
-            140, (0.0, 0.0, 3.0), 0.0, 4.0, 0.1,
+            140, 0, (0.0, 0.0, 3.0), 0.0, 4.0, 0.1,
             target, (), lambda unused_yaw: True)
 
         self.assertEqual(1.0, first['throttle'])
@@ -1613,7 +1649,7 @@ class BotAiPortTests(unittest.TestCase):
 
     def test_failed_yaw_cache_uses_circular_buckets(self):
         driver = LocalDriver()
-        state = driver._state(136, (0.0, 0.0, 0.0))
+        state = driver._state(136, 0, (0.0, 0.0, 0.0))
         turn = math.pi * 2.0
         for yaw in (-math.pi, -2.70, -0.51, 0.13, 1.73,
                     math.pi - 0.11):
@@ -1658,7 +1694,7 @@ class BotAiPortTests(unittest.TestCase):
         driver = LocalDriver()
 
         driver.drive(
-            3, (0.0, 0.0, 0.0), 0.0, 0.0, 1.0,
+            3, 0, (0.0, 0.0, 0.0), 0.0, 0.0, 1.0,
             (0.0, 0.0, 50.0), (), lambda unused_yaw: True)
 
         state = driver.states[3]
@@ -1674,7 +1710,7 @@ class BotAiPortTests(unittest.TestCase):
         throttles = set()
         for unused in range(150):
             order = driver.drive(
-                7, (0.0, 0.0, 0.0), yaw, 0.0, 1.0 / 30.0,
+                7, 0, (0.0, 0.0, 0.0), yaw, 0.0, 1.0 / 30.0,
                 (0.0, 0.0, -50.0), (), lambda unused_yaw: True)
             modes.add(order['recovery_mode'])
             throttles.add(order['throttle'])
@@ -1695,7 +1731,7 @@ class BotAiPortTests(unittest.TestCase):
             target = (math.sin(target_yaw) * 50.0, 0.0,
                       math.cos(target_yaw) * 50.0)
             order = driver.drive(
-                70, (0.0, 0.0, 0.0), yaw, 0.0, 1.0 / 30.0,
+                70, 0, (0.0, 0.0, 0.0), yaw, 0.0, 1.0 / 30.0,
                 target, (), lambda unused_yaw: True)
             if order['recovery_mode'] in ('reverse_turn', 'pivot_recovery'):
                 recovery = order
@@ -1708,12 +1744,12 @@ class BotAiPortTests(unittest.TestCase):
     def test_terminal_target_coasts_inside_copied_stopping_distance(self):
         driver = LocalDriver()
         terminal = driver.drive(
-            71, (0.0, 0.0, 0.0), 0.0, 14.0, 0.15,
+            71, 0, (0.0, 0.0, 0.0), 0.0, 14.0, 0.15,
             (0.0, 0.0, 8.0), (), lambda unused_yaw: True,
             stopping_distance=6.0, stop_at_target=True,
             decision_horizon=0.15)
         corridor = driver.drive(
-            72, (0.0, 0.0, 0.0), 0.0, 14.0, 0.15,
+            72, 1, (0.0, 0.0, 0.0), 0.0, 14.0, 0.15,
             (0.0, 0.0, 8.0), (), lambda unused_yaw: True,
             stopping_distance=6.0, stop_at_target=False,
             decision_horizon=0.15)
@@ -1738,7 +1774,7 @@ class BotAiPortTests(unittest.TestCase):
             float(corner[1]) - float(first[1]))
 
         order = driver.drive(
-            121, (corner[0], 0.0, corner[1]), incoming_yaw, 0.0, 0.1,
+            121, 0, (corner[0], 0.0, corner[1]), incoming_yaw, 0.0, 0.1,
             (target[0], 0.0, target[1]),
             (), lambda unused_yaw: True)
 
@@ -1751,7 +1787,7 @@ class BotAiPortTests(unittest.TestCase):
         modes = set()
         for unused in range(150):
             order = driver.drive(
-                8, (0.0, 0.0, 0.0), 0.0, 0.0, 1.0 / 30.0,
+                8, 0, (0.0, 0.0, 0.0), 0.0, 0.0, 1.0 / 30.0,
                 (0.0, 0.0, 50.0), (), lambda unused_yaw: True)
             modes.add(order['recovery_mode'])
 
@@ -1762,11 +1798,156 @@ class BotAiPortTests(unittest.TestCase):
         modes = set()
         for unused in range(150):
             order = driver.drive(
-                82, (0.0, 0.0, 0.0), 0.0, 0.0, 1.0 / 30.0,
+                82, 0, (0.0, 0.0, 0.0), 0.0, 0.0, 1.0 / 30.0,
                 (0.0, 0.0, 2.0), (), lambda unused_yaw: True)
             modes.add(order['recovery_mode'])
 
         self.assertTrue(modes & set(('reverse_turn', 'pivot_recovery')))
+
+    def test_canonical_team_slots_have_uniform_timing_and_split_ties(self):
+        """Recovery timing and side depend on explicit slots, not network ids."""
+        driver = LocalDriver()
+
+        def recovery_profile(bot_id, team_slot):
+            state = driver._state(bot_id, team_slot, (0.0, 0.0, 0.0))
+            state['stuck_time'] = 10.0
+            order = driver.drive(
+                bot_id, team_slot, (0.0, 0.0, 0.0),
+                0.0, 0.0, 0.0, (0.0, 0.0, 50.0), (),
+                lambda unused_yaw: True)
+            side = 1 if order['target_yaw'] > 0.0 else -1
+            return state['recovery_timing_phase'], side
+
+        team_one = [recovery_profile(slot + 1, slot)
+                    for slot in range(15)]
+        team_two = [recovery_profile(slot + 16, slot)
+                    for slot in range(15)]
+
+        # Both formations use the same team-local law. The threshold offsets
+        # cover all fifteen uniform buckets, while an actual planner callback
+        # may still coalesce multiple crossings at its own cadence.
+        self.assertEqual(team_one, team_two)
+        phases = [phase for phase, unused in team_one]
+        self.assertEqual(
+            [(bucket + 0.5) / 15.0 for bucket in range(15)],
+            sorted(phases))
+        sides = [side for unused, side in team_one]
+        self.assertEqual({-1, 1}, set(sides))
+        self.assertEqual([8, 7], [sides.count(-1), sides.count(1)])
+
+    def test_recovery_prefers_clear_pivot_arc_and_latches_the_episode(self):
+        right_front = {
+            'position': (4.0, 0.0, 4.0), 'yaw': 0.0,
+            'half_length': 3.5, 'half_width': 1.7,
+        }
+        left_front = dict(right_front, position=(-4.0, 0.0, 4.0))
+
+        def force(bot_id, team_slot, neighbour):
+            driver = LocalDriver()
+            driver.drive(
+                bot_id, team_slot, (0.0, 0.0, 0.0),
+                0.0, 0.0, 0.0, (0.0, 0.0, 50.0), (),
+                lambda unused_yaw: True)
+            driver.states[bot_id]['stuck_time'] = 10.0
+            order = driver.drive(
+                bot_id, team_slot, (0.0, 0.0, 0.0),
+                0.0, 0.0, 0.0, (0.0, 0.0, 50.0), (neighbour,),
+                lambda unused_yaw: True)
+            return driver, order
+
+        # Slot one would choose positive on a tie, so a negative result proves
+        # that the occupied right arc loses to geometry rather than identity.
+        driver, first = force(201, 1, right_front)
+        self.assertLess(first['target_yaw'], 0.0)
+        self.assertEqual('reverse_turn', first['recovery_mode'])
+
+        # Changing the snapshot to the opposite obstruction cannot make an
+        # active recovery wag left/right. The chosen side belongs to the edge.
+        latched = driver.drive(
+            201, 1, (0.0, 0.0, 0.0),
+            0.0, 0.0, 0.05, (0.0, 0.0, 50.0), (left_front,),
+            lambda unused_yaw: True)
+        self.assertLess(latched['target_yaw'], 0.0)
+        self.assertEqual(first['target_yaw'], latched['target_yaw'])
+
+        # Mirroring the physical obstruction mirrors the selected escape even
+        # when slot zero's parity fallback points the other way.
+        unused_driver, mirrored = force(202, 0, left_front)
+        self.assertGreater(mirrored['target_yaw'], 0.0)
+
+    def test_recovery_geometry_is_independent_of_neighbour_order(self):
+        driver = LocalDriver()
+        state = driver._state(205, 1, (0.0, 0.0, 0.0))
+        right_front = {
+            'position': (4.0, 0.0, 4.0), 'yaw': 0.0,
+            'half_length': 3.5, 'half_width': 1.7,
+        }
+        far_left = {
+            'position': (-20.0, 0.0, 15.0), 'yaw': 0.0,
+            'half_length': 3.5, 'half_width': 1.7,
+        }
+
+        first = driver._select_recovery_side(
+            state, (0.0, 0.0, 0.0), 0.0,
+            (right_front, far_left), 3.5, 1.7)
+        reordered = driver._select_recovery_side(
+            state, (0.0, 0.0, 0.0), 0.0,
+            (far_left, right_front), 3.5, 1.7)
+
+        self.assertEqual(-1.0, first)
+        self.assertEqual(first, reordered)
+
+    def test_recovery_entry_is_not_skipped_by_a_large_elapsed_step(self):
+        driver = LocalDriver()
+        order = driver.drive(
+            206, 0, (0.0, 0.0, 0.0),
+            0.0, 0.0, 10.0, (0.0, 0.0, 50.0), (),
+            lambda unused_yaw: True)
+        state = driver.states[206]
+
+        self.assertIn(order['recovery_mode'],
+                      ('reverse_turn', 'pivot_recovery'))
+        self.assertEqual(-1.0, state['recovery_side'])
+        self.assertEqual(0, state['recovery_count'])
+
+    def test_tied_recovery_side_flips_only_between_episodes(self):
+        driver = LocalDriver()
+        driver.drive(
+            203, 0, (0.0, 0.0, 0.0),
+            0.0, 0.0, 0.0, (0.0, 0.0, 50.0), (),
+            lambda unused_yaw: True)
+        state = driver.states[203]
+        state['stuck_time'] = 10.0
+        first = driver.drive(
+            203, 0, (0.0, 0.0, 0.0),
+            0.0, 0.0, 0.0, (0.0, 0.0, 50.0), (),
+            lambda unused_yaw: True)
+
+        driver.drive(
+            203, 0, (0.0, 0.0, 0.0),
+            0.0, 0.0, state['recovery_time'],
+            (0.0, 0.0, 50.0), (), lambda unused_yaw: True)
+        self.assertEqual(1, state['recovery_count'])
+        state['stuck_time'] = 10.0
+        second = driver.drive(
+            203, 0, (0.0, 0.0, 0.0),
+            0.0, 0.0, 0.0, (0.0, 0.0, 50.0), (),
+            lambda unused_yaw: True)
+
+        self.assertLess(first['target_yaw'] * second['target_yaw'], 0.0)
+
+    def test_driver_rejects_a_changed_team_slot(self):
+        driver = LocalDriver()
+        driver.drive(
+            204, 0, (0.0, 0.0, 0.0),
+            0.0, 0.0, 0.0, (0.0, 0.0, 50.0), (),
+            lambda unused_yaw: True)
+
+        with self.assertRaisesRegex(ValueError, 'slot changed'):
+            driver.drive(
+                204, 1, (0.0, 0.0, 0.0),
+                0.0, 0.0, 0.0, (0.0, 0.0, 50.0), (),
+                lambda unused_yaw: True)
 
     def test_traffic_lease_uses_explicit_time_not_decision_steps(self):
         """An external lease producer must supply its physical interval.
@@ -1777,7 +1958,7 @@ class BotAiPortTests(unittest.TestCase):
         """
         driver = LocalDriver()
         driver.drive(
-            41, (0.0, 0.0, 0.0), 0.0, 0.0, 0.15,
+            41, 0, (0.0, 0.0, 0.0), 0.0, 0.0, 0.15,
             (0.0, 0.0, 50.0), (), lambda unused_yaw: True)
         state = driver.states[41]
         self.assertAlmostEqual(0.15, state['last_step'])
@@ -1802,7 +1983,7 @@ class BotAiPortTests(unittest.TestCase):
         modes = set()
         for unused in range(150):
             order = driver.drive(
-                9, (0.0, 0.0, 0.0), 0.0, 0.0, 1.0 / 30.0,
+                9, 0, (0.0, 0.0, 0.0), 0.0, 0.0, 1.0 / 30.0,
                 (0.0, 0.0, 50.0), behind, lambda unused_yaw: True)
             modes.add(order['recovery_mode'])
 
@@ -1838,7 +2019,7 @@ class BotAiPortTests(unittest.TestCase):
         modes = set()
         for unused in range(150):
             order = driver.drive(
-                10, (0.0, 0.0, 0.0), 0.0, 0.0, 1.0 / 30.0,
+                10, 0, (0.0, 0.0, 0.0), 0.0, 0.0, 1.0 / 30.0,
                 (0.0, 0.0, 50.0), far, lambda unused_yaw: True)
             modes.add(order['recovery_mode'])
 
@@ -1849,7 +2030,7 @@ class BotAiPortTests(unittest.TestCase):
         order = None
         for unused in range(10):
             order = driver.drive(
-                130, (0.0, 0.0, 0.0), 0.0, 0.0, 0.1,
+                130, 0, (0.0, 0.0, 0.0), 0.0, 0.0, 0.1,
                 (0.0, 0.0, 50.0), (), lambda unused_yaw: True)
             driver.wait_for_traffic(130)
 
@@ -1863,7 +2044,7 @@ class BotAiPortTests(unittest.TestCase):
         recovery = None
         for unused in range(80):
             order = driver.drive(
-                131, (0.0, 0.0, 0.0), 0.0, 0.0, 0.1,
+                131, 0, (0.0, 0.0, 0.0), 0.0, 0.0, 0.1,
                 (0.0, 0.0, 50.0), (), lambda unused_yaw: True)
             if order['recovery_mode'] in (
                     'reverse_turn', 'pivot_recovery'):
@@ -1879,15 +2060,15 @@ class BotAiPortTests(unittest.TestCase):
         driver = LocalDriver()
         for unused in range(10):
             driver.drive(
-                132, (0.0, 0.0, 0.0), 0.0, 0.0, 0.1,
+                132, 0, (0.0, 0.0, 0.0), 0.0, 0.0, 0.1,
                 (0.0, 0.0, 50.0), (), lambda unused_yaw: True)
             driver.wait_for_traffic(132)
 
         driver.drive(
-            132, (1.0, 0.0, 0.0), 0.0, 2.0, 0.1,
+            132, 0, (1.0, 0.0, 0.0), 0.0, 2.0, 0.1,
             (0.0, 0.0, 50.0), (), lambda unused_yaw: True)
         order = driver.drive(
-            132, (1.2, 0.0, 0.0), 0.0, 2.0, 0.1,
+            132, 0, (1.2, 0.0, 0.0), 0.0, 2.0, 0.1,
             (0.0, 0.0, 50.0), (), lambda unused_yaw: True)
         driver.wait_for_traffic(132)
 
@@ -1902,11 +2083,11 @@ class BotAiPortTests(unittest.TestCase):
             return abs(yaw) > 0.20
 
         first = driver.drive(
-            81, (0.0, 0.0, 0.0), 0.0, 3.0, 0.05,
+            81, 0, (0.0, 0.0, 0.0), 0.0, 3.0, 0.05,
             (0.0, 0.0, 50.0), (), clear)
         shifted_yaw = 1.30
         second = driver.drive(
-            81, (0.0, 0.0, 0.1), 0.1, 3.0, 0.05,
+            81, 0, (0.0, 0.0, 0.1), 0.1, 3.0, 0.05,
             (math.sin(shifted_yaw) * 50.0, 0.0,
              math.cos(shifted_yaw) * 50.0), (), clear)
 
@@ -1917,15 +2098,15 @@ class BotAiPortTests(unittest.TestCase):
     def test_repeated_obstacle_failures_widen_on_one_side(self):
         driver = LocalDriver(failure_ttl=5.0)
         first = driver.drive(
-            17, (0.0, 0.0, 0.0), 0.0, 2.0, 0.1,
+            17, 0, (0.0, 0.0, 0.0), 0.0, 2.0, 0.1,
             (0.0, 0.0, 50.0), (), lambda unused_yaw: True)
         driver.remember_failure(17, first['target_yaw'], ttl=5.0)
         second = driver.drive(
-            17, (0.0, 0.0, 0.0), 0.0, 2.0, 0.1,
+            17, 0, (0.0, 0.0, 0.0), 0.0, 2.0, 0.1,
             (0.0, 0.0, 50.0), (), lambda unused_yaw: True)
         driver.remember_failure(17, second['target_yaw'], ttl=5.0)
         third = driver.drive(
-            17, (0.0, 0.0, 0.0), 0.0, 2.0, 0.1,
+            17, 0, (0.0, 0.0, 0.0), 0.0, 2.0, 0.1,
             (0.0, 0.0, 50.0), (), lambda unused_yaw: True)
 
         self.assertEqual('avoid', second['recovery_mode'])
@@ -1937,14 +2118,14 @@ class BotAiPortTests(unittest.TestCase):
     def test_adjacent_bots_choose_opposite_initial_escape_sides(self):
         driver = LocalDriver(failure_ttl=5.0)
         escaped = []
-        for bot_id in (20, 21):
+        for team_slot, bot_id in enumerate((20, 21)):
             straight = driver.drive(
-                bot_id, (0.0, 0.0, 0.0), 0.0, 2.0, 0.1,
+                bot_id, team_slot, (0.0, 0.0, 0.0), 0.0, 2.0, 0.1,
                 (0.0, 0.0, 50.0), (), lambda unused_yaw: True)
             driver.remember_failure(
                 bot_id, straight['target_yaw'], ttl=5.0)
             escaped.append(driver.drive(
-                bot_id, (0.0, 0.0, 0.0), 0.0, 2.0, 0.1,
+                bot_id, team_slot, (0.0, 0.0, 0.0), 0.0, 2.0, 0.1,
                 (0.0, 0.0, 50.0), (),
                 lambda unused_yaw: True)['target_yaw'])
 
@@ -1953,10 +2134,10 @@ class BotAiPortTests(unittest.TestCase):
     def test_uphill_route_turn_aligns_before_drive_torque(self):
         driver = LocalDriver()
         uphill = driver.drive(
-            120, (0.0, 0.0, 0.0), 0.0, 0.0, 0.1,
+            120, 0, (0.0, 0.0, 0.0), 0.0, 0.0, 0.1,
             (20.0, 6.0, 20.0), (), lambda unused_yaw: True)
         flat = driver.drive(
-            121, (0.0, 0.0, 0.0), 0.0, 0.0, 0.1,
+            121, 1, (0.0, 0.0, 0.0), 0.0, 0.0, 0.1,
             (20.0, 0.0, 20.0), (), lambda unused_yaw: True)
 
         self.assertEqual(0.0, uphill['throttle'])

--- a/tests/test_port_0922_bot_runtime.py
+++ b/tests/test_port_0922_bot_runtime.py
@@ -4357,7 +4357,7 @@ class BotRuntimeTests(unittest.TestCase):
     def test_traffic_wait_does_not_enter_reverse_recovery(self):
         from gui.mods.offline_lan_0922.ai.driver import LocalDriver
         driver = LocalDriver()
-        driver_state = driver._state(11, (0.0, 0.0, 0.0))
+        driver_state = driver._state(11, 0, (0.0, 0.0, 0.0))
         driver_state['stuck_time'] = 10.0
         driver_state['recovery_time'] = 0.5
 
@@ -10876,7 +10876,7 @@ class BotRuntimeTests(unittest.TestCase):
             x=16.0, y=0.0, z=16.0, yaw=math.pi * 0.5,
             speed=0.0, grounded_once=True)
         runtime.adapter.driver = self.module.ai_driver.LocalDriver()
-        runtime.adapter.driver._state(11, (16.0, 0.0, 16.0))[
+        runtime.adapter.driver._state(11, 0, (16.0, 0.0, 16.0))[
             'steering_yaw'] = command['target_yaw']
         return runtime
 
@@ -13400,48 +13400,19 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertEqual('human', self.runtime.states[11]['target_kind'])
         self.assertEqual(2, self.runtime.states[11]['target_id'])
 
-    def test_spawn_route_join_paths_are_scoped_to_each_bot(self):
+    def test_driver_decision_receives_slot_and_signed_reverse_speed(self):
+        self.runtime.battle_start(self.start)
+        self.runtime.states[11]['speed'] = -2.0
+
+        self.runtime.update(.04, 1.0, players=[])
+
+        decision = self.adapters[0].calls[0][0]
+        self.assertEqual(0, decision['slot'])
+        self.assertEqual(-2.0, decision['speed'])
+
+    def test_spawn_route_join_offsets_macro_goal_before_private_astar(self):
         calls = []
 
-        class Navigator(object):
-            def next_target(self, bot_id, position, goal, path_key, now,
-                            anchor, avoid, lookahead_distance=None):
-                calls.append((bot_id, path_key, anchor))
-                return goal
-
-        runtime = self.module.BotRuntime(1)
-        runtime.navigator = Navigator()
-        runtime.states = {
-            11: {'team': 2},
-            12: {'team': 2},
-        }
-        strategic = {
-            'combat_mode': 'route', 'route_id': 'forest', 'route_index': 1,
-            'route_join': True,
-        }
-        runtime._navigation_target(
-            11, (-12.0, 0.0, 0.0), (0.0, 0.0, 80.0),
-            dict(strategic, route_anchor=(-12.0, 0.0, 0.0)),
-            {'now': 1.0, 'neighbours': ()})
-        runtime._navigation_target(
-            12, (12.0, 0.0, 0.0), (0.0, 0.0, 80.0),
-            dict(strategic, route_anchor=(12.0, 0.0, 0.0)),
-            {'now': 1.0, 'neighbours': ()})
-
-        self.assertEqual(('route_join', 11, 2, 'forest', 1), calls[0][1])
-        self.assertEqual(('route_join', 12, 2, 'forest', 1), calls[1][1])
-        self.assertNotEqual(calls[0][1], calls[1][1])
-        self.assertNotEqual(calls[0][2], calls[1][2])
-
-        runtime._navigation_target(
-            11, (0.0, 0.0, 40.0), (0.0, 0.0, 80.0),
-            dict(strategic, route_join=False,
-                 route_anchor=(0.0, 0.0, 20.0)),
-            {'now': 2.0, 'neighbours': ()})
-        self.assertEqual(('route', 2, 'forest', 1), calls[2][1])
-        self.assertIsNone(calls[2][2])
-
-    def test_shared_route_lanes_are_unique_stable_and_keep_their_side(self):
         class Grid(object):
             cell_size = 4.0
 
@@ -13461,64 +13432,725 @@ class BotRuntimeTests(unittest.TestCase):
             def dry_segment_clear(*unused):
                 return True
 
+        class Navigator(object):
+            grid = Grid()
+            bot_states = {}
+
+            def next_target(self, bot_id, position, goal, path_key, now,
+                            anchor, avoid, lookahead_distance=None):
+                calls.append((bot_id, goal, path_key, anchor))
+                # The navigation result is deliberately unrelated to the
+                # macro goal. A post-A* translation would change this tuple.
+                return (1.0, 0.0, 24.0)
+
         runtime = self.module.BotRuntime(1)
-        runtime.navigator = types.SimpleNamespace(
-            grid=Grid(), bot_states={})
-        runtime.baked_graph = {'bounds': (-100.0, -100.0, 100.0, 100.0)}
+        runtime.navigator = Navigator()
+        runtime.baked_graph = {
+            'bounds': (-100.0, -100.0, 100.0, 120.0)}
+        route = {
+            'id': 'forest',
+            'waypoints': ((0.0, 0.0, False),
+                          (0.0, 80.0, False)),
+        }
+        # Slots are intentionally unrelated to lateral position. Cohort
+        # projection, not slot order or first update order, owns the lanes.
+        positions = {
+            11: (-20.0, 0.0, 0.0), 12: (20.0, 0.0, 0.0),
+            13: (0.0, 0.0, 0.0), 14: (10.0, 0.0, 0.0),
+            15: (-10.0, 0.0, 0.0),
+        }
+        slots = {11: 9, 12: 1, 13: 14, 14: 0, 15: 7}
         runtime.states = dict((bot_id, {
-            'id': bot_id, 'team': 1, 'slot': slot,
-            'half_length': 3.5, 'half_width': 1.7,
-        }) for slot, bot_id in enumerate(range(11, 16)))
-        position = (0.0, 0.0, 0.0)
-        selected = (0.0, 0.0, 40.0)
-        goal = (0.0, 0.0, 80.0)
+            'id': bot_id, 'team': 2, 'slot': slots[bot_id],
+            'x': position[0], 'y': position[1], 'z': position[2],
+            'yaw': 0.0, 'half_length': 3.5, 'half_width': 1.7,
+            'route': route,
+        }) for bot_id, position in positions.items())
+        runtime._server_orders = dict((bot_id, {
+            'route_id': 'forest', 'route_index': 1, 'route_join': True,
+            'move_position': (0.0, 0.0, 80.0),
+            'route_anchor': position,
+        }) for bot_id, position in positions.items())
         strategic = {
             'combat_mode': 'route', 'route_id': 'forest', 'route_index': 1,
-            'route_anchor': (0.0, 0.0, 0.0),
+            'route_join': True,
+        }
+        results = {}
+        for bot_id in (14, 11, 15, 12, 13):
+            results[bot_id] = runtime._navigation_target(
+                bot_id, positions[bot_id], (0.0, 0.0, 80.0),
+                dict(strategic, route_anchor=positions[bot_id]),
+                {'now': 1.0, 'neighbours': ()})
+
+        self.assertEqual({(1.0, 0.0, 24.0)}, set(results.values()))
+        self.assertEqual(5, len(set(call[2] for call in calls)))
+        self.assertEqual([bot_id for bot_id in (14, 11, 15, 12, 13)],
+                         [call[0] for call in calls])
+        for bot_id, astar_goal, path_key, anchor in calls:
+            self.assertEqual('route_join', path_key[0])
+            self.assertEqual(bot_id, path_key[1])
+            self.assertEqual(2, path_key[2])
+            self.assertEqual('forest', path_key[3])
+            self.assertEqual(1, path_key[4])
+            self.assertEqual(positions[bot_id], anchor)
+            self.assertAlmostEqual(positions[bot_id][0] * 0.5,
+                                   astar_goal[0])
+            self.assertEqual(80.0, astar_goal[2])
+
+        runtime._navigation_target(
+            11, (0.0, 0.0, 40.0), (0.0, 0.0, 80.0),
+            dict(strategic, route_join=False,
+                 route_anchor=(0.0, 0.0, 20.0)),
+            {'now': 2.0, 'neighbours': ()})
+        self.assertEqual(('route', 2, 'forest', 1), calls[-1][2])
+        self.assertIsNone(calls[-1][3])
+
+    def test_route_lane_binding_uses_full_cohort_not_first_update_order(self):
+        route = {
+            'id': 'forest',
+            'waypoints': ((0.0, 0.0, False),
+                          (0.0, 80.0, False)),
+        }
+        positions = {
+            11: (-20.0, 0.0, 0.0), 12: (20.0, 0.0, 0.0),
+            13: (0.0, 0.0, 0.0), 14: (10.0, 0.0, 0.0),
+            15: (-10.0, 0.0, 0.0),
+        }
+        slots = {11: 9, 12: 1, 13: 14, 14: 0, 15: 7}
+        strategic = {
+            'route_id': 'forest', 'route_index': 1,
+            'route_anchor': positions[13], 'route_join': True,
         }
 
-        first = [runtime._route_lane_target(
-            bot_id, position, goal, selected, strategic, 1.0)
-                 for bot_id in range(11, 16)]
-        repeated = [runtime._route_lane_target(
-            bot_id, position, goal, selected, strategic, 1.1)
-                    for bot_id in range(11, 16)]
-        desired = [runtime.states[bot_id]['_route_lane_desired']
-                   for bot_id in range(11, 16)]
+        def bindings(insertion_order, first_bot):
+            runtime = self.module.BotRuntime(1)
+            runtime.states = {}
+            for bot_id in insertion_order:
+                position = positions[bot_id]
+                runtime.states[bot_id] = {
+                    'id': bot_id, 'team': 1, 'slot': slots[bot_id],
+                    'x': position[0], 'y': position[1], 'z': position[2],
+                    'yaw': 0.0, 'route': route,
+                }
+            runtime._server_orders = dict((bot_id, {
+                'route_id': 'forest', 'route_index': 1,
+                'route_join': True,
+            }) for bot_id in positions)
+            runtime._route_lane_binding(
+                first_bot, (1, 'forest'), (0.0, 0.0, 80.0), strategic)
+            return dict((bot_id, (
+                runtime.states[bot_id]['_route_lane_desired'],
+                runtime.states[bot_id]['_route_lane_row_desired']))
+                for bot_id in positions)
 
-        self.assertEqual(list(self.module.ROUTE_LANE_OFFSETS), desired)
-        self.assertEqual(5, len(set(point[0] for point in first)))
-        self.assertEqual(first, repeated)
-        self.assertEqual([0.0, -5.0, 5.0, -10.0, 10.0],
-                         [point[0] for point in first])
+        forward = bindings((11, 12, 13, 14, 15), 11)
+        reversed_first = bindings((15, 14, 13, 12, 11), 12)
+        self.assertEqual(forward, reversed_first)
+        self.assertEqual(5, len(set(value[0] for value in forward.values())))
+        ordered_by_spawn_x = sorted(positions, key=lambda bot_id:
+                                    positions[bot_id][0])
+        target_x = [-forward[bot_id][0] for bot_id in ordered_by_spawn_x]
+        self.assertEqual(sorted(target_x), target_x)
+        self.assertEqual({0.0}, set(value[1] for value in forward.values()))
 
-        advanced = dict(strategic, route_index=2)
-        second_segment = [runtime._route_lane_target(
-            bot_id, position, goal, selected, advanced, 2.0)
-                          for bot_id in range(11, 16)]
-        self.assertEqual(first, second_segment)
-        self.assertEqual(desired, [
-            runtime.states[bot_id]['_route_lane_desired']
-            for bot_id in range(11, 16)])
+    def test_route_lane_cohort_prefers_authoritative_server_route(self):
+        runtime = self.module.BotRuntime(1)
+        local_route = {'id': 'old-local-route', 'waypoints': (
+            (0.0, 0.0, False), (80.0, 0.0, False))}
+        runtime.states = {
+            11: {'id': 11, 'team': 1, 'slot': 0,
+                 'x': -10.0, 'y': 0.0, 'z': 0.0, 'yaw': 0.0,
+                 'route': local_route},
+            12: {'id': 12, 'team': 1, 'slot': 1,
+                 'x': 0.0, 'y': 0.0, 'z': 0.0, 'yaw': 0.0,
+                 'route': local_route},
+            13: {'id': 13, 'team': 1, 'slot': 2,
+                 'x': 10.0, 'y': 0.0, 'z': 0.0, 'yaw': 0.0,
+                 'route': local_route},
+        }
+        runtime._server_orders = {
+            11: {'route_id': 'server-west', 'route_index': 1,
+                 'route_join': True},
+            12: {'route_id': 'server-east', 'route_index': 1,
+                 'route_join': True},
+            13: {'route_id': 'server-west', 'route_index': 1,
+                 'route_join': True},
+        }
+        strategic = {
+            'route_id': 'server-west', 'route_index': 1,
+            'route_join': True, 'route_anchor': (0.0, 0.0, 0.0),
+        }
 
-        # Moving one member to another route preserves every remaining lease;
-        # a newly joining member receives the now-unoccupied centre lane.
-        runtime._route_lane_target(
-            11, position, goal, selected,
-            dict(strategic, route_id='hill'), 3.0)
-        retained = [runtime.states[bot_id]['_route_lane_desired']
-                    for bot_id in range(12, 16)]
+        runtime._route_lane_binding(
+            11, (1, 'server-west'), (0.0, 0.0, 80.0), strategic)
+
+        self.assertEqual((1, 'server-west'),
+                         runtime.states[11]['_route_lane_group'])
+        self.assertEqual((1, 'server-west'),
+                         runtime.states[13]['_route_lane_group'])
+        self.assertNotIn('_route_lane_group', runtime.states[12])
+        self.assertEqual(
+            {-5.0, 5.0},
+            {runtime.states[11]['_route_lane_desired'],
+             runtime.states[13]['_route_lane_desired']})
+        # The stale local route points east; the authoritative anchor and goal
+        # point north. Both orientation and lateral ordering must follow the
+        # server order, or the two spawn sides cross on their way to the gate.
+        self.assertEqual((0.0, 1.0),
+                         runtime.states[11]['_route_lane_forward'])
+        self.assertEqual(5.0,
+                         runtime.states[11]['_route_lane_desired'])
+        self.assertEqual(-5.0,
+                         runtime.states[13]['_route_lane_desired'])
+
+    def test_route_lane_binding_separates_authoritative_spawn_gates(self):
+        route = {'id': 'city', 'waypoints': (
+            (0.0, 0.0, False), (0.0, 80.0, False),
+            (80.0, 80.0, False))}
+        positions = {
+            11: (-10.0, 0.0, 0.0), 12: (10.0, 0.0, 0.0),
+            13: (0.0, 0.0, 70.0), 14: (0.0, 0.0, 90.0),
+        }
+        orders = {
+            11: {'route_id': 'city', 'route_index': 1,
+                 'route_join': True, 'route_anchor': positions[11],
+                 'move_position': (0.0, 0.0, 80.0)},
+            12: {'route_id': 'city', 'route_index': 1,
+                 'route_join': True, 'route_anchor': positions[12],
+                 'move_position': (0.0, 0.0, 80.0)},
+            13: {'route_id': 'city', 'route_index': 2,
+                 'route_join': True, 'route_anchor': positions[13],
+                 'move_position': (80.0, 0.0, 80.0)},
+            14: {'route_id': 'city', 'route_index': 2,
+                 'route_join': True, 'route_anchor': positions[14],
+                 'move_position': (80.0, 0.0, 80.0)},
+        }
+
+        def bind(first_gate_order):
+            runtime = self.module.BotRuntime(1)
+            runtime.states = dict((bot_id, {
+                'id': bot_id, 'team': 1, 'slot': bot_id - 11,
+                'x': position[0], 'y': position[1], 'z': position[2],
+                'yaw': 0.0, 'route': route,
+            }) for bot_id, position in positions.items())
+            runtime._server_orders = dict(
+                (bot_id, dict(order)) for bot_id, order in orders.items())
+            for bot_id in first_gate_order:
+                order = runtime._server_orders[bot_id]
+                runtime._route_lane_binding(
+                    bot_id, (1, 'city'), order['move_position'], order)
+            result = dict((bot_id, (
+                runtime.states[bot_id]['_route_lane_desired'],
+                runtime.states[bot_id]['_route_lane_row_desired'],
+                runtime.states[bot_id]['_route_lane_gate'],
+                runtime.states[bot_id]['_route_lane_forward']))
+                for bot_id in positions)
+            return runtime, result
+
+        runtime, forward = bind((11, 13))
+        unused_runtime, reversed_first = bind((14, 12))
+        self.assertEqual(forward, reversed_first)
+        self.assertEqual({-5.0, 5.0},
+                         {forward[11][0], forward[12][0]})
+        self.assertEqual({-5.0, 5.0},
+                         {forward[13][0], forward[14][0]})
+        self.assertEqual({(1, True)},
+                         {forward[11][2], forward[12][2]})
+        self.assertEqual({(2, True)},
+                         {forward[13][2], forward[14][2]})
+        self.assertEqual({(0.0, 1.0)},
+                         {forward[11][3], forward[12][3]})
+        self.assertEqual({(1.0, 0.0)},
+                         {forward[13][3], forward[14][3]})
+
+        # Route progress changes the segment direction, but never the
+        # persistent team/route lane lease assigned at the spawn gate.
+        retained = dict((bot_id, forward[bot_id][:3]) for bot_id in positions)
+        for bot_id in positions:
+            runtime._server_orders[bot_id].update(
+                route_index=2, route_join=False,
+                route_anchor=(0.0, 0.0, 80.0),
+                move_position=(80.0, 0.0, 80.0))
+            runtime._route_lane_binding(
+                bot_id, (1, 'city'), (80.0, 0.0, 80.0),
+                runtime._server_orders[bot_id])
+        self.assertEqual(retained, dict((bot_id, (
+            runtime.states[bot_id]['_route_lane_desired'],
+            runtime.states[bot_id]['_route_lane_row_desired'],
+            runtime.states[bot_id]['_route_lane_gate']))
+            for bot_id in positions))
+
+    def test_route_rebalance_keeps_leases_and_gives_newcomer_unique_pair(self):
+        class Grid(object):
+            @staticmethod
+            def _ground(unused_x, unused_z, unused_hint):
+                return 0.0
+
+            @staticmethod
+            def segment_has_baked_hazard(*unused):
+                return False
+
+            @staticmethod
+            def point_has_baked_hazard(*unused):
+                return False
+
+            @staticmethod
+            def dry_segment_clear(*unused):
+                return True
+
+        runtime = self.module.BotRuntime(1)
+        runtime.navigator = types.SimpleNamespace(grid=Grid(), bot_states={})
+        runtime.baked_graph = {
+            'bounds': (-100.0, -100.0, 100.0, 120.0)}
+        route = {'id': 'forest', 'waypoints': (
+            (0.0, 0.0, False), (0.0, 80.0, False))}
+        positions = (-20.0, -10.0, 0.0, 10.0, 20.0)
+        runtime.states = dict((11 + index, {
+            'id': 11 + index, 'team': 1, 'slot': index,
+            'x': x, 'y': 0.0, 'z': 0.0, 'yaw': 0.0,
+            'half_length': 3.5, 'half_width': 1.7,
+            'route': route,
+        }) for index, x in enumerate(positions))
+        runtime._server_orders = dict((11 + index, {
+            'route_id': 'forest', 'route_index': 1, 'route_join': True,
+        }) for index in range(len(positions)))
+        strategic = {
+            'route_id': 'forest', 'route_index': 1,
+            'route_join': True, 'route_anchor': (0.0, 0.0, 0.0),
+        }
+        runtime._route_lane_binding(
+            11, (1, 'forest'), (0.0, 0.0, 80.0), strategic)
+        retained = dict((bot_id, (
+            state['_route_lane_desired'],
+            state['_route_lane_row_desired']))
+            for bot_id, state in runtime.states.items())
+
         runtime.states[16] = {
             'id': 16, 'team': 1, 'slot': 5,
+            'x': -30.0, 'y': 0.0, 'z': 0.0, 'yaw': 0.0,
             'half_length': 3.5, 'half_width': 1.7,
+            'route': route,
         }
-        runtime._route_lane_target(
-            16, position, goal, selected, strategic, 3.1)
-        self.assertEqual([5.0, -5.0, 10.0, -10.0], retained)
-        self.assertEqual(0.0, runtime.states[16]['_route_lane_desired'])
-        self.assertEqual(retained, [
-            runtime.states[bot_id]['_route_lane_desired']
-            for bot_id in range(12, 16)])
+        runtime._server_orders[16] = {
+            'route_id': 'forest', 'route_index': 1, 'route_join': True}
+        runtime._route_lane_binding(
+            16, (1, 'forest'), (0.0, 0.0, 80.0), strategic)
+
+        self.assertEqual(retained, dict((bot_id, (
+            runtime.states[bot_id]['_route_lane_desired'],
+            runtime.states[bot_id]['_route_lane_row_desired']))
+            for bot_id in retained))
+        occupied = set(retained.values())
+        newcomer = (
+            runtime.states[16]['_route_lane_desired'],
+            runtime.states[16]['_route_lane_row_desired'])
+        self.assertNotIn(newcomer, occupied)
+        self.assertEqual(10.0, newcomer[0])
+        self.assertEqual(4.0, abs(newcomer[1]))
+        lane_goal, unused_identity = runtime._route_lane_goal(
+            16, (-30.0, 0.0, 0.0), (0.0, 0.0, 80.0),
+            dict(strategic, route_anchor=(-30.0, 0.0, 0.0)),
+            1.0, True)
+        self.assertLessEqual(
+            math.hypot(lane_goal[0], lane_goal[2] - 80.0) +
+            self.module.ai_driver.WAYPOINT_ARRIVAL_RADIUS,
+            self.module.ROUTE_JOIN_ARRIVAL_RADIUS)
+
+        # A dead member releases its pair; an outer newcomer uses that empty
+        # lane without disturbing any surviving lease.
+        released_id = next(bot_id for bot_id, pair in retained.items()
+                           if pair == (-10.0, 0.0))
+        runtime.states[released_id]['alive'] = False
+        runtime.states[17] = {
+            'id': 17, 'team': 1, 'slot': 6,
+            'x': 30.0, 'y': 0.0, 'z': 0.0, 'yaw': 0.0,
+            'half_length': 3.5, 'half_width': 1.7,
+            'route': route,
+        }
+        runtime._server_orders[17] = {
+            'route_id': 'forest', 'route_index': 1, 'route_join': True}
+        runtime._route_lane_binding(
+            17, (1, 'forest'), (0.0, 0.0, 80.0), strategic)
+        self.assertEqual(
+            (-10.0, 0.0),
+            (runtime.states[17]['_route_lane_desired'],
+             runtime.states[17]['_route_lane_row_desired']))
+
+    def test_same_route_rejoin_rotates_goal_without_reassigning_lease(self):
+        class Grid(object):
+            @staticmethod
+            def _ground(unused_x, unused_z, unused_hint):
+                return 0.0
+
+            @staticmethod
+            def segment_has_baked_hazard(*unused):
+                return False
+
+            @staticmethod
+            def point_has_baked_hazard(*unused):
+                return False
+
+            @staticmethod
+            def dry_segment_clear(*unused):
+                return True
+
+        runtime = self.module.BotRuntime(1)
+        runtime.navigator = types.SimpleNamespace(grid=Grid(), bot_states={})
+        runtime.baked_graph = {
+            'bounds': (-100.0, -100.0, 120.0, 120.0)}
+        runtime.states = {11: {
+            'id': 11, 'team': 1, 'slot': 0,
+            'x': 0.0, 'y': 0.0, 'z': 0.0, 'yaw': 0.0,
+            'half_length': 3.5, 'half_width': 1.7,
+            'route': {'id': 'city', 'waypoints': (
+                (0.0, 0.0, False), (0.0, 80.0, False),
+                (80.0, 80.0, False))},
+            '_route_lane_group': (1, 'city'),
+            '_route_lane_gate': (1, True),
+            '_route_lane_desired': 5.0,
+            '_route_lane_row_desired': 0.0,
+            '_route_lane_forward': (0.0, 1.0),
+            '_route_lane_segment': (1, 'city', 1, True),
+            '_route_lane_offset': 5.0,
+            '_route_lane_row': 0.0,
+            '_route_lane_goal': (-5.0, 0.0, 80.0),
+        }}
+        runtime._server_orders = {11: {
+            'id': 11, 'route_id': 'city', 'route_index': 1,
+            'route_join': True,
+            'route_anchor': (0.0, 0.0, 0.0),
+            'move_position': (0.0, 0.0, 80.0),
+        }}
+        self.assertTrue(runtime._apply_orders({
+            'bot_order_revision': 1,
+            'bot_orders': [{
+                'id': 11, 'route_id': 'city', 'route_index': 2,
+                'route_join': True,
+                'route_anchor': {'x': 0.0, 'y': 0.0, 'z': 80.0},
+                'move_position': {'x': 80.0, 'y': 0.0, 'z': 80.0},
+            }],
+        }))
+        strategic = runtime._server_orders[11]
+
+        desired = runtime._route_lane_binding(
+            11, (1, 'city'), (80.0, 0.0, 80.0), strategic)
+
+        self.assertEqual((5.0, 0.0), desired)
+        self.assertEqual((2, True),
+                         runtime.states[11]['_route_lane_gate'])
+        self.assertEqual((1.0, 0.0),
+                         runtime.states[11]['_route_lane_forward'])
+        for name in ('_route_lane_segment', '_route_lane_offset',
+                     '_route_lane_row', '_route_lane_goal'):
+            self.assertNotIn(name, runtime.states[11])
+
+        lane_goal, unused_identity = runtime._route_lane_goal(
+            11, (0.0, 0.0, 80.0), (80.0, 0.0, 80.0),
+            strategic, 2.0, True)
+        self.assertEqual((80.0, 0.0, 85.0), lane_goal)
+        self.assertEqual(5.0,
+                         runtime.states[11]['_route_lane_desired'])
+        self.assertEqual(0.0,
+                         runtime.states[11]['_route_lane_row_desired'])
+
+    def test_route_join_lane_narrows_for_every_static_safety_boundary(self):
+        module = self.module
+
+        class Grid(object):
+            cell_size = 4.0
+
+            def __init__(self, mode):
+                self.mode = mode
+
+            def _ground(self, x, unused_z, unused_hint):
+                if self.mode == 'ground' and x < -8.0:
+                    return None
+                return 0.0
+
+            def point_has_baked_hazard(self, point, mask):
+                return bool(
+                    self.mode == 'shallow' and point[0] < -8.0 and
+                    mask & module.BAKED_SHALLOW_WATER)
+
+            def segment_has_baked_hazard(
+                    self, unused_start, end, mask):
+                return bool(
+                    self.mode == 'fatal' and end[0] < -8.0 and
+                    mask & module.BAKED_FATAL_HAZARDS)
+
+            def dry_segment_clear(self, unused_start, end, unused_now):
+                return not (self.mode == 'segment' and end[0] < -8.0)
+
+        route = {
+            'id': 'city',
+            'waypoints': ((0.0, 0.0, False),
+                          (0.0, 80.0, False)),
+        }
+        strategic = {
+            'combat_mode': 'route', 'route_id': 'city', 'route_index': 1,
+            'route_join': True, 'route_anchor': (0.0, 0.0, 0.0),
+        }
+        for mode in ('ground', 'shallow', 'fatal', 'segment', 'bounds'):
+            with self.subTest(mode=mode):
+                grid = Grid(mode)
+                runtime = module.BotRuntime(1)
+                runtime.navigator = types.SimpleNamespace(
+                    grid=grid, bot_states={})
+                runtime.baked_graph = {
+                    'bounds': ((-8.0 if mode == 'bounds' else -100.0),
+                               -100.0, 100.0, 100.0)}
+                runtime.states = {14: {
+                    'id': 14, 'team': 1, 'slot': 3,
+                    'x': 0.0, 'y': 0.0, 'z': 0.0, 'yaw': 0.0,
+                    'half_length': 3.5, 'half_width': 1.7,
+                    'route': route,
+                    '_route_lane_group': (1, 'city'),
+                    '_route_lane_desired': 10.0,
+                    '_route_lane_row_desired': 0.0,
+                    '_route_lane_forward': (0.0, 1.0),
+                }}
+
+                candidate, unused_identity = runtime._route_lane_goal(
+                    14, (0.0, 0.0, 0.0), (0.0, 0.0, 80.0),
+                    strategic, 1.0, True)
+
+                self.assertEqual(-5.0, candidate[0])
+                self.assertEqual(5.0,
+                                 runtime.states[14]['_route_lane_offset'])
+                self.assertLessEqual(
+                    math.hypot(candidate[0], candidate[2] - 80.0) +
+                    module.ai_driver.WAYPOINT_ARRIVAL_RADIUS,
+                    module.ROUTE_JOIN_ARRIVAL_RADIUS)
+                # Once narrowed, a changing probe result cannot make the same
+                # join leg oscillate back to its wider preferred lane.
+                grid.mode = 'clear'
+                repeated, unused_identity = runtime._route_lane_goal(
+                    14, (0.0, 0.0, 0.0), (0.0, 0.0, 80.0),
+                    strategic, 1.1, True)
+                self.assertEqual(candidate, repeated)
+
+    def test_route_join_conclusive_astar_failure_narrows_on_next_request(self):
+        calls = []
+
+        class Grid(object):
+            cell_size = 4.0
+
+            @staticmethod
+            def _ground(unused_x, unused_z, unused_hint):
+                return 0.0
+
+            @staticmethod
+            def segment_has_baked_hazard(*unused):
+                return False
+
+            @staticmethod
+            def point_has_baked_hazard(*unused):
+                return False
+
+            @staticmethod
+            def dry_segment_clear(*unused):
+                return True
+
+        class Navigator(object):
+            def __init__(self):
+                self.grid = Grid()
+                self.bot_states = {}
+
+            def next_target(self, bot_id, position, goal, path_key, now,
+                            anchor, avoid, lookahead_distance=None):
+                calls.append((goal, path_key))
+                self.bot_states[bot_id] = {
+                    'navigation_status': 'blocked',
+                    'planned_goal': tuple(goal),
+                }
+                return tuple(goal)
+
+        runtime = self.module.BotRuntime(1)
+        runtime.navigator = Navigator()
+        runtime.baked_graph = {
+            'bounds': (-100.0, -100.0, 100.0, 100.0)}
+        runtime.states = {14: {
+            'id': 14, 'team': 1, 'slot': 3,
+            'x': 0.0, 'y': 0.0, 'z': 0.0, 'yaw': 0.0,
+            'half_length': 3.5, 'half_width': 1.7,
+            'route': {'id': 'city', 'waypoints': (
+                (0.0, 0.0, False), (0.0, 80.0, False))},
+            '_route_lane_group': (1, 'city'),
+            '_route_lane_desired': 10.0,
+            '_route_lane_row_desired': 0.0,
+            '_route_lane_forward': (0.0, 1.0),
+        }}
+        strategic = {
+            'combat_mode': 'route', 'route_id': 'city', 'route_index': 1,
+            'route_join': True, 'route_anchor': (0.0, 0.0, 0.0),
+        }
+
+        runtime._navigation_target(
+            14, (0.0, 0.0, 0.0), (0.0, 0.0, 80.0), strategic,
+            {'now': 1.0, 'speed': 0.0})
+        runtime._navigation_target(
+            14, (0.0, 0.0, 0.0), (0.0, 0.0, 80.0), strategic,
+            {'now': 1.2, 'speed': 0.0})
+
+        self.assertEqual([-10.0, -5.0], [call[0][0] for call in calls])
+        self.assertEqual([10000, 5000], [call[1][5] for call in calls])
+        self.assertNotEqual(calls[0][1], calls[1][1])
+
+    def test_full_team_route_join_cohort_uses_bounded_longitudinal_rows(self):
+        class Grid(object):
+            @staticmethod
+            def _ground(unused_x, unused_z, unused_hint):
+                return 0.0
+
+            @staticmethod
+            def segment_has_baked_hazard(*unused):
+                return False
+
+            @staticmethod
+            def point_has_baked_hazard(*unused):
+                return False
+
+            @staticmethod
+            def dry_segment_clear(*unused):
+                return True
+
+        runtime = self.module.BotRuntime(1)
+        runtime.navigator = types.SimpleNamespace(grid=Grid(), bot_states={})
+        runtime.baked_graph = {
+            'bounds': (-500.0, -100.0, 500.0, 300.0)}
+        route = {'id': 'overflow', 'waypoints': (
+            (0.0, 0.0, False), (0.0, 200.0, False))}
+        runtime.states = {}
+        for index in range(15):
+            bot_id = 100 + index
+            runtime.states[bot_id] = {
+                'id': bot_id, 'team': 1, 'slot': (index * 7) % 15,
+                'x': -70.0 + index * 10.0,
+                'y': 0.0, 'z': float(index % 3), 'yaw': 0.0,
+                'half_length': 3.5, 'half_width': 1.7,
+                'route': route,
+            }
+        runtime._server_orders = dict((100 + index, {
+            'route_id': 'overflow', 'route_index': 1,
+            'route_join': True,
+        }) for index in range(15))
+        strategic = {
+            'route_id': 'overflow', 'route_index': 1,
+            'route_join': True, 'route_anchor': (0.0, 0.0, 0.0),
+        }
+
+        self.assertEqual(
+            (-10.0, -5.0, 0.0, 0.0, 5.0, 10.0),
+            self.module._route_lane_layout(6))
+        self.assertEqual(
+            (-10.0, -5.0, -5.0, 0.0, 5.0, 5.0, 10.0),
+            self.module._route_lane_layout(7))
+        runtime._route_lane_binding(
+            107, (1, 'overflow'), (0.0, 0.0, 200.0), strategic)
+        lateral_order = sorted(
+            runtime.states.values(), key=lambda state: -state['x'])
+        lanes = [state['_route_lane_desired'] for state in lateral_order]
+        self.assertEqual(sorted(lanes), lanes)
+        self.assertEqual([3, 3, 3, 3, 3],
+                         [lanes.count(offset)
+                          for offset in self.module.ROUTE_LANE_ORDER])
+        for offset in self.module.ROUTE_LANE_ORDER:
+            rows = [state['_route_lane_row_desired']
+                    for state in runtime.states.values()
+                    if state['_route_lane_desired'] == offset]
+            self.assertEqual(len(set(rows)), len(rows))
+            self.assertLessEqual(max(abs(value) for value in rows), 4.0)
+        for bot_id, bot_state in runtime.states.items():
+            position = (bot_state['x'], bot_state['y'], bot_state['z'])
+            goal, unused_identity = runtime._route_lane_goal(
+                bot_id, position, (0.0, 0.0, 200.0),
+                dict(strategic, route_anchor=position), 1.0, True)
+            self.assertLessEqual(
+                math.hypot(goal[0], goal[2] - 200.0) +
+                self.module.ai_driver.WAYPOINT_ARRIVAL_RADIUS,
+                self.module.ROUTE_JOIN_ARRIVAL_RADIUS + 1.0e-9)
+
+    def test_winter_himmelsdorf_spawn_cohorts_have_reachable_lane_goals(self):
+        graph = json.loads(
+            (PORT_ROOT / 'navgraphs' /
+             '86_himmelsdorf_winter.json').read_text())
+        runtime = self.module.BotRuntime(1)
+        runtime.navigator = self.module.TerrainNavigator(
+            lambda *unused: None, baked_graph=graph)
+        runtime.baked_graph = graph
+        routes = graph['routes']['1']
+        spawns = graph['spawn_formations']['1']
+        runtime.states = {}
+        # The report has no per-Bot route/profile rows. Partitioning the 15
+        # exact team-1 spawn poses into three capacity-five route cohorts is a
+        # deterministic geometry seam, not a claim about that random lineup.
+        for route_number, route in enumerate(routes):
+            for slot in range(route_number * 5, route_number * 5 + 5):
+                point = spawns[slot]
+                bot_id = slot + 1
+                runtime.states[bot_id] = {
+                    'id': bot_id, 'team': 1, 'slot': slot,
+                    'x': point[0], 'y': point[1], 'z': point[2],
+                    'yaw': point[3],
+                    'half_length': 3.5, 'half_width': 1.7,
+                    'route': route,
+                }
+                runtime._server_orders[bot_id] = {
+                    'route_id': route['id'], 'route_index': 1,
+                    'route_join': True,
+                }
+
+        offset_goals = 0
+        for route_number, route in enumerate(routes):
+            bot_ids = range(route_number * 5 + 1,
+                            route_number * 5 + 6)
+            waypoint = route['waypoints'][1]
+            goal_y = runtime.navigator.grid._ground(
+                waypoint[0], waypoint[1], 0.0)
+            goal = (waypoint[0], goal_y, waypoint[1])
+            first = runtime.states[bot_ids[0]]
+            first_position = (first['x'], first['y'], first['z'])
+            strategic = {
+                'combat_mode': 'route', 'route_id': route['id'],
+                'route_index': 1, 'route_join': True,
+                'route_anchor': first_position,
+            }
+            runtime._route_lane_binding(
+                bot_ids[0], (1, route['id']), goal, strategic)
+            for bot_id in bot_ids:
+                state = runtime.states[bot_id]
+                position = (state['x'], state['y'], state['z'])
+                lane_goal, unused_identity = runtime._route_lane_goal(
+                    bot_id, position, goal,
+                    dict(strategic, route_anchor=position),
+                    1.0, True)
+                offset_distance = math.hypot(
+                    lane_goal[0] - goal[0], lane_goal[2] - goal[2])
+                self.assertLessEqual(
+                    offset_distance +
+                    self.module.ai_driver.WAYPOINT_ARRIVAL_RADIUS,
+                    self.module.ROUTE_JOIN_ARRIVAL_RADIUS + 1.0e-9)
+                self.assertFalse(
+                    runtime.navigator.grid.point_has_baked_hazard(
+                        lane_goal,
+                        self.module.BAKED_FATAL_HAZARDS |
+                        self.module.BAKED_SHALLOW_WATER))
+                overflow = runtime._baked_boundary_overflow(
+                    state, lane_goal,
+                    math.atan2(
+                        state['_route_lane_forward'][0],
+                        state['_route_lane_forward'][1]))
+                self.assertFalse(any(value > 1.0e-6 for value in overflow))
+                path = runtime.navigator.grid.plan(
+                    position, lane_goal, max_expansions=20000, now=1.0,
+                    prefer_clearance=False)
+                self.assertTrue(path)
+                self.assertLessEqual(
+                    math.hypot(path[-1][0] - lane_goal[0],
+                               path[-1][2] - lane_goal[2]),
+                    self.module.ROUTE_JOIN_ARRIVAL_RADIUS)
+                offset_goals += int(offset_distance > 1.0e-6)
+        self.assertGreater(offset_goals, 0)
 
     def test_route_lane_collision_and_hull_bounds_narrow_without_oscillation(self):
         class Grid(object):

--- a/tests/test_port_0922_fjord_departure.py
+++ b/tests/test_port_0922_fjord_departure.py
@@ -210,7 +210,7 @@ class SpawnDepartureTests(unittest.TestCase):
                 def drive(*args, **kwargs):
                     order = original_drive(*args, **kwargs)
                     bot_id = int(args[0])
-                    position = args[1]
+                    position = args[2]
                     goal = macro_goals.get(bot_id, position)
                     far_macro_goal = math.hypot(
                         float(goal[0]) - float(position[0]),

--- a/tests/test_port_0922_himmelsdorf_departure.py
+++ b/tests/test_port_0922_himmelsdorf_departure.py
@@ -1,0 +1,425 @@
+import collections
+import json
+import math
+import sys
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CLIENT_SCRIPTS = ROOT / 'src' / 'res' / 'scripts' / 'client'
+TESTS_ROOT = ROOT / 'tests'
+sys.path.insert(0, str(ROOT / 'server'))
+sys.path.insert(0, str(CLIENT_SCRIPTS))
+sys.path.insert(0, str(TESTS_ROOT))
+
+from gui.mods.offline_lan_0922.ai.planner import BattleDirector
+from server_bot_ai import BotPlanner
+import test_port_0922_bot_runtime as runtime_fixtures
+from effective_params_fixture import bot_default_crew_factors
+from test_port_0922_fjord_departure import (
+    ROLES, _EpisodeMonitor, _flat_graph,
+)
+
+
+NON_SPG_LINEUP = (
+    ('heavyTank',) * 6 + ('mediumTank',) * 5 +
+    ('AT-SPG',) * 2 + ('lightTank',) * 2)
+
+
+class HimmelsdorfDepartureTests(unittest.TestCase):
+    def setUp(self):
+        self._gui_modules = dict(
+            (key, value) for key, value in sys.modules.items()
+            if key == 'gui' or key.startswith('gui.'))
+
+    def tearDown(self):
+        for key in list(sys.modules):
+            if key == 'gui' or key.startswith('gui.'):
+                sys.modules.pop(key, None)
+        sys.modules.update(self._gui_modules)
+
+    @staticmethod
+    def _route_profile(bot_id):
+        """Return a non-SPG profile suitable for the v0.6.6 route roster."""
+        return {
+            'vehicle_name': 'departure-test:%d' % bot_id,
+            'class_tag': 'mediumTank',
+            'dominant_role': 'support',
+            'roles': {
+                'brawler': 0.5,
+                'flanker': 0.5,
+                'scout': 0.5,
+                'sniper': 0.5,
+                'support': 0.5,
+                'artillery': 0.0,
+            },
+            'shells': (),
+            'desired_range': 180.0,
+            'fire_range': 500.0,
+            'armor': 80.0,
+            'speed': 15.0,
+        }
+
+    @staticmethod
+    def _synthetic_director():
+        director = BattleDirector('07_lakeville', 'connector-motion-contract')
+        agent = director.register_profile(
+            93, 1, HimmelsdorfDepartureTests._route_profile(93),
+            'Connector contract Bot')
+        agent['route'] = {
+            'id': 'connector-contract',
+            'waypoints': (
+                (0.0, -40.0, False),
+                (0.0, -65.0, False),
+                (40.0, 40.0, False),
+            ),
+        }
+        agent['route_started'] = False
+        return director, agent
+
+    def test_local_connector_filter_requires_forward_motion(self):
+        """Parked and reversing hulls retain the authored spawn connector."""
+        cases = (
+            (0.0, (0.0, 0.0, -65.0), 1),
+            (-6.0, (0.0, 0.0, -65.0), 1),
+            (6.0, (40.0, 0.0, 40.0), 2),
+        )
+        for speed, expected_target, expected_index in cases:
+            with self.subTest(speed=speed):
+                director, agent = self._synthetic_director()
+
+                order = director.order_for(
+                    93, (0.0, 0.0, -20.0), 0.0, speed,
+                    1000, 1000, 0.0)
+
+                self.assertEqual(expected_target, order['move_position'])
+                self.assertEqual(expected_index, order['route_index'])
+                self.assertEqual((0.0, 0.0, -20.0), order['route_anchor'])
+                self.assertTrue(order['route_join'])
+                self.assertTrue(agent['route_started'])
+
+    def test_report_roster_parked_route_joins_match_server_contract(self):
+        """Rebuild the reported map, human slot, Bot slots and baked routes.
+
+        The report contains one human in team-2 slot zero, leaving all fifteen
+        team-1 Bots and fourteen team-2 Bots. The exact random vehicle roster is
+        not present in the report, so uniform non-SPG profiles isolate the
+        connector contract while retaining the real capacity allocation, spawn
+        poses and route geometry.
+        """
+        graph = json.loads(
+            (ROOT / 'navgraphs' / '86_himmelsdorf_winter.json').read_text())
+        director = BattleDirector(
+            '86_himmelsdorf_winter', 'reported-round-1',
+            bases={1: tuple(graph['bases'][0]),
+                   2: tuple(graph['bases'][1])},
+            bounds=tuple(graph['bounds']), baked_routes=graph['routes'])
+        server = BotPlanner()
+        route_counts = collections.Counter()
+        team_one_hill = []
+        bot_ids = []
+
+        for team in (1, 2):
+            for slot in range(15):
+                if team == 2 and slot == 0:
+                    continue
+                bot_id = slot + 1 if team == 1 else slot + 16
+                bot_ids.append(bot_id)
+                profile = self._route_profile(bot_id)
+                agent = director.register_profile(
+                    bot_id, team, profile, 'Bot %d' % bot_id)
+                raw_spawn = graph['spawn_formations'][str(team)][slot]
+                spawn = (float(raw_spawn[0]), float(raw_spawn[1]),
+                         float(raw_spawn[2]))
+                yaw = float(raw_spawn[3])
+
+                local_order = director.order_for(
+                    bot_id, spawn, yaw, 0.0, 1000, 1000, 0.0)
+                route = dict(agent['route'])
+                route['waypoints'] = [
+                    {'x': float(point[0]), 'y': spawn[1],
+                     'z': float(point[1])}
+                    for point in agent['route']['waypoints']
+                ]
+                server_bot = {
+                    'id': bot_id,
+                    'team': team,
+                    'slot': slot,
+                    'profile': profile,
+                    'route': route,
+                    'state': {
+                        'x': spawn[0], 'y': spawn[1], 'z': spawn[2],
+                        'yaw': yaw, 'speed': 0.0,
+                    },
+                }
+                (server_route_id, server_index, server_point,
+                 server_anchor, server_join) = server._route(server_bot, 0.0)
+
+                route_id = agent['route']['id']
+                route_counts[(team, route_id)] += 1
+                self.assertEqual(route_id, local_order['route_id'])
+                self.assertEqual(server_route_id, local_order['route_id'])
+                self.assertEqual(server_index, local_order['route_index'])
+                self.assertEqual(
+                    (server_point['x'], server_point['y'], server_point['z']),
+                    local_order['move_position'])
+                self.assertEqual(
+                    (server_anchor['x'], server_anchor['y'],
+                     server_anchor['z']),
+                    spawn)
+                self.assertEqual(spawn, local_order['route_anchor'])
+                self.assertTrue(server_join)
+                self.assertTrue(local_order['route_join'])
+
+                if team == 1 and route_id == 'hill':
+                    dx = local_order['move_position'][0] - spawn[0]
+                    dz = local_order['move_position'][2] - spawn[2]
+                    heading_error = abs(
+                        (math.atan2(dx, dz) - yaw + math.pi) %
+                        (2.0 * math.pi) - math.pi)
+                    team_one_hill.append(
+                        (bot_id, local_order['route_index'], heading_error))
+
+        self.assertEqual(29, len(bot_ids))
+        self.assertNotIn(16, bot_ids)
+        self.assertEqual(
+            [4, 5, 5],
+            sorted(route_counts[(2, route_id)]
+                   for route_id in ('banana', 'hill', 'rail')))
+        self.assertEqual(
+            [5, 5, 5],
+            sorted(route_counts[(1, route_id)]
+                   for route_id in ('banana', 'hill', 'rail')))
+        self.assertEqual(5, len(team_one_hill))
+        for unused_bot_id, route_index, heading_error in team_one_hill:
+            self.assertEqual(1, route_index)
+            self.assertGreater(heading_error, math.pi * 0.5)
+
+    def test_flat_report_roster_departs_at_15_and_24_fps(self):
+        """Exercise 30 seconds of the copied authority without native claims.
+
+        This is a pure-data regression over the production Himmelsdorf route
+        topology, formations, planner, driver, traffic law and copied vehicle
+        physics. It cannot prove #1513 BigWorld collision or presentation on
+        Windows, but it does reproduce the reported team-2 human slot zero and
+        all 29 non-SPG Bot spawn/route-join decisions at two render cadences.
+        """
+        module = runtime_fixtures._load()
+        original_factors = module.loadout.attribute_factors
+        module.loadout.attribute_factors = bot_default_crew_factors
+        self.addCleanup(
+            setattr, module.loadout, 'attribute_factors', original_factors)
+        graph = _flat_graph('86_himmelsdorf_winter')
+        bots = []
+        for team in (1, 2):
+            for slot, class_tag in enumerate(NON_SPG_LINEUP):
+                if team == 2 and slot == 0:
+                    continue
+                dominant_role, roles = ROLES[class_tag]
+                bot_id = slot + 1 if team == 1 else slot + 16
+                bots.append({
+                    'id': bot_id,
+                    'team': team,
+                    'slot': slot,
+                    'name': '%s%d' % (class_tag, bot_id),
+                    'vehicle': 'fake',
+                    'profile': {
+                        'class_tag': class_tag,
+                        'dominant_role': dominant_role,
+                        'roles': dict(roles),
+                        'shells': [],
+                        'vehicle_name': 'fake',
+                        'desired_range': 200,
+                        'fire_range': 500,
+                    },
+                })
+
+        def spawn(team, slot):
+            point = graph['spawn_formations'][str(team)][slot]
+            return ((point[0], 0.0, point[2]), point[3])
+
+        def flat_ground(unused_x, unused_z, unused_hint=0.0):
+            return 0.0
+
+        for fps in (15, 24):
+            with self.subTest(fps=fps):
+                runtime_box = {}
+
+                def baked_direction(
+                        position, yaw, speed, unused_descriptor,
+                        maximum_distance):
+                    distance = 20.0 if abs(float(speed)) > 5.0 else 15.0
+                    if maximum_distance is not None:
+                        distance = min(distance, float(maximum_distance))
+                    end = (
+                        float(position[0]) + math.sin(float(yaw)) * distance,
+                        float(position[1]),
+                        float(position[2]) + math.cos(float(yaw)) * distance,
+                    )
+                    grid = runtime_box['runtime'].navigator.grid
+                    clear = grid.segment_clear(position, end)
+                    return {
+                        'clear': clear, 'collision': not clear, 'slope': 0.0,
+                    }
+
+                def baked_receipt(
+                        position, yaw, speed, descriptor, maximum_distance):
+                    result = baked_direction(
+                        position, yaw, speed, descriptor, maximum_distance)
+                    if not result['clear']:
+                        return False
+                    distance = 15.0
+                    if maximum_distance is not None:
+                        distance = min(distance, float(maximum_distance))
+                    return {
+                        'distance': distance, 'half_width': 1.6,
+                        'leading': 3.5, 'origin': tuple(position),
+                        'yaw': float(yaw),
+                        'direction': -1 if float(speed) < 0.0 else 1,
+                    }
+
+                runtime = module.BotRuntime(
+                    1,
+                    descriptor_resolver=(
+                        lambda unused: runtime_fixtures._combat_descriptor()),
+                    direction_probe=baked_direction,
+                    world_receipt_probe=baked_receipt,
+                    spawn_resolver=spawn,
+                    ground_probe=flat_ground,
+                    physics_ground_probe=flat_ground,
+                    baked_graph=graph,
+                    visibility_probe=lambda *unused: False,
+                    firing_lane_probe=lambda *unused: False)
+                runtime_box['runtime'] = runtime
+                runtime.battle_start({
+                    'map': '86_himmelsdorf_winter',
+                    'round_id': fps,
+                    'bot_authority_id': 1,
+                    'bots': bots,
+                })
+                starts = dict(
+                    (bot_id, (state['x'], state['z']))
+                    for bot_id, state in runtime.states.items())
+                maximum_departure = dict((bot_id, 0.0) for bot_id in starts)
+                monitor = _EpisodeMonitor()
+                monitor.started['recovery'] = {}
+                monitor.maximum['recovery'] = {}
+                now = [0.0]
+                macro_goals = {}
+                peak_group = {
+                    1: {'parked': 0, 'recovery': 0},
+                    2: {'parked': 0, 'recovery': 0},
+                }
+
+                original_navigation = runtime.adapter.navigation_target
+
+                def navigation_target(
+                        bot_id, position, goal, strategic, state):
+                    macro_goals[int(bot_id)] = tuple(goal)
+                    return original_navigation(
+                        bot_id, position, goal, strategic, state)
+
+                runtime.adapter.navigation_target = navigation_target
+                original_drive = runtime.adapter.driver.drive
+
+                def drive(*args, **kwargs):
+                    order = original_drive(*args, **kwargs)
+                    bot_id = int(args[0])
+                    position = args[2]
+                    goal = macro_goals.get(bot_id, position)
+                    far_macro_goal = math.hypot(
+                        float(goal[0]) - float(position[0]),
+                        float(goal[2]) - float(position[2])) > 15.0
+                    mode = order.get('recovery_mode')
+                    monitor.record(
+                        'parked', bot_id,
+                        far_macro_goal and mode == 'arrived', now[0])
+                    monitor.record(
+                        'recovery', bot_id,
+                        mode in ('blocked', 'pivot_recovery', 'reverse_turn'),
+                        now[0])
+                    return order
+
+                runtime.adapter.driver.drive = drive
+
+                for frame in range(1, fps * 30 + 1):
+                    now[0] = frame / float(fps)
+                    runtime.update(1.0 / float(fps), now[0])
+                    group = {
+                        1: {'parked': 0, 'recovery': 0},
+                        2: {'parked': 0, 'recovery': 0},
+                    }
+                    for bot_id, state in runtime.states.items():
+                        distance = math.hypot(
+                            state['x'] - starts[bot_id][0],
+                            state['z'] - starts[bot_id][1])
+                        maximum_departure[bot_id] = max(
+                            maximum_departure[bot_id], distance)
+                        cached = runtime._decision_cache.get(bot_id)
+                        command = cached[3] if cached is not None else {}
+                        mode = command.get('recovery_mode')
+                        goal = macro_goals.get(bot_id, (state['x'], 0.0,
+                                                       state['z']))
+                        far_macro_goal = math.hypot(
+                            float(goal[0]) - float(state['x']),
+                            float(goal[2]) - float(state['z'])) > 15.0
+                        if far_macro_goal and mode == 'arrived':
+                            group[state['team']]['parked'] += 1
+                        if mode in ('blocked', 'pivot_recovery',
+                                    'reverse_turn'):
+                            group[state['team']]['recovery'] += 1
+                    for team in (1, 2):
+                        for kind in ('parked', 'recovery'):
+                            peak_group[team][kind] = max(
+                                peak_group[team][kind], group[team][kind])
+
+                bot_ids = sorted(runtime.states)
+                monitor.finish(bot_ids, now[0])
+                final_departure = dict(
+                    (bot_id, math.hypot(
+                        state['x'] - starts[bot_id][0],
+                        state['z'] - starts[bot_id][1]))
+                    for bot_id, state in runtime.states.items())
+                thresholds = dict(
+                    (bot_id, max(8.0, 2.0 * state['half_length']))
+                    for bot_id, state in runtime.states.items())
+                never_exited = [
+                    bot_id for bot_id in bot_ids
+                    if maximum_departure[bot_id] < thresholds[bot_id]
+                ]
+
+                self.assertEqual(29, len(bot_ids))
+                self.assertNotIn(16, bot_ids)
+                self.assertEqual([], sorted(
+                    (bot_id, round(maximum_departure[bot_id], 3),
+                     round(thresholds[bot_id], 3))
+                    for bot_id in never_exited))
+                self.assertEqual([], sorted(
+                    (bot_id, round(final_departure[bot_id], 3),
+                     round(thresholds[bot_id], 3))
+                    for bot_id in bot_ids
+                    if final_departure[bot_id] < thresholds[bot_id]))
+                for team in (1, 2):
+                    team_ids = [bot_id for bot_id in bot_ids
+                                if runtime.states[bot_id]['team'] == team]
+                    team_never_exited = [bot_id for bot_id in never_exited
+                                         if bot_id in team_ids]
+                    self.assertLess(
+                        len(team_never_exited), (len(team_ids) + 1) // 2)
+                    self.assertLess(
+                        peak_group[team]['parked'],
+                        (len(team_ids) + 1) // 2)
+                    self.assertLess(
+                        peak_group[team]['recovery'],
+                        (len(team_ids) + 1) // 2)
+                self.assertLessEqual(
+                    max(monitor.maximum['parked'].values() or [0.0]),
+                    0.5)
+                self.assertLessEqual(
+                    max(monitor.maximum['recovery'].values() or [0.0]),
+                    2.0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_port_0922_navigation.py
+++ b/tests/test_port_0922_navigation.py
@@ -209,9 +209,10 @@ class ClimbApproachNavigationTests(unittest.TestCase):
             self.assertGreater(selected[2], current[2])
             driver = LocalDriver()
             aligning = driver.drive(
-                7, current, 0.0, 0.0, 0.1, selected, [], lambda yaw: True)
+                7, 0, current, 0.0, 0.0, 0.1,
+                selected, [], lambda yaw: True)
             aligned = driver.drive(
-                7, current, aligning['target_yaw'], 0.0, 0.1,
+                7, 0, current, aligning['target_yaw'], 0.0, 0.1,
                 selected, [], lambda yaw: True)
             self.assertEqual(0.0, aligning['throttle'])
             self.assertGreater(aligned['throttle'], 0.0)


### PR DESCRIPTION
## Summary

- keep parked or reversing Bots on their authored spawn connector, and skip a rear-facing connector only after verified forward motion
- spread each authoritative spawn-gate cohort across stable route-join lanes with Bot-private A* paths and safe same-side narrowing back to the authored centreline
- stagger stuck recovery by the explicit team-local slot and choose the less occupied pivot arc before using deterministic parity as a tie-breaker
- cover the reported winter Himmelsdorf roster at 15 and 24 FPS, including all 29 non-SPG Bots around the team-2 slot-zero player

The route offset is deliberately best effort. Each candidate must fit the full hull inside arena bounds, remain dry and outside baked hazards, stay within the server 13 m arrival contract, and be A*-reachable. A rejected 10 m lane narrows to 5 m and then 0 m without crossing sides.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -p "test_*.py" -v` — 3442 passed
- launcher suite — 480 passed, 2 Windows-only skips
- CPython 2.7 in-memory compile — 89 client files
- 41-map real-navgraph audit — 1230/1230 route joins, zero safety, reachability, or order-stability failures

Pure-data and copied-physics coverage cannot prove native movement, collision timing, or gameplay feel in the exact Windows #1513 client.