### PR TITLE
Fix delayed projectile visual origins

### DIFF
--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -31,7 +31,8 @@ from gui.mods.offline_lan_0922.entities.bigworld_binding import \
 from gui.mods.offline_lan_0922.entities.native_remote_vehicle import \
     NativeRemoteVehicleFactory, set_draw_visibility
 from gui.mods.offline_lan_0922.entities.remote_vehicle import (
-    RemoteVehicleFactory, _collide_vehicle_evidence_at_matrix,
+    PROJECTILE_VISUAL_START_MAX_DIFF, RemoteVehicleFactory,
+    _collide_vehicle_evidence_at_matrix,
     _component_aim_angles, _pose_components, collide_vehicle_at_matrix,
     encode_damage_sticker, pose_animation_writes,
     reset_pose_animation_writes)
@@ -1179,6 +1180,7 @@ def _load_runtime():
     import nations
     from Avatar import ClientVisibilityFlags
     from OfflineMapCreator import g_offlineMapCreator
+    from AvatarInputHandler import cameras
     from AvatarInputHandler import aih_constants
     from AvatarInputHandler import gun_marker_ctrl
     from helpers import EffectMaterialCalculation
@@ -1203,6 +1205,7 @@ def _load_runtime():
     runtime.area_destructibles = AreaDestructibles
     runtime.aih_constants = aih_constants
     runtime.avatar_input_handler = AvatarInputHandler
+    runtime.cameras = cameras
     runtime.gun_marker_ctrl = gun_marker_ctrl
     runtime.app_loader = g_appLoader
     runtime.arena_cache = ArenaType.g_cache
@@ -7412,10 +7415,26 @@ class BattleRuntime(object):
         # Missing native entities remain queued for the ordinary frame path.
         started = _PROFILE_CLOCK()
         try:
-            return self._advance_player_fire_authority(
-                0.0, self._clock(),
+            now = self._clock()
+            pending_before = set(
+                pending.get('projectile_id') for pending in
+                self._player_fire_launch_pending.values())
+            changed = self._advance_player_fire_authority(
+                0.0, now,
                 intent_keys=tuple(self._player_fire_intents),
                 defer_missing_player=True)
+            # A click-time launch may already be older than this poll because
+            # its frozen client trigger clock crossed the LAN first.  Advance
+            # a newly preinstalled projectile here so its first canonical
+            # cursor does not wait for the next, possibly late, Bot frame.
+            # The normal collision budget and terminal barriers still apply.
+            if (self._projectiles is not None and any(
+                    pending.get('projectile_id') not in pending_before and
+                    self._projectiles.contains(pending.get('projectile_id'))
+                    for pending in
+                    self._player_fire_launch_pending.values())):
+                self._advance_projectiles(now, force_progress=True)
+            return changed
         finally:
             # PERF subtracts this mod-owned callback work from the engine's
             # outside time and reports it through the existing off-frame lane.
@@ -9716,6 +9735,44 @@ class BattleRuntime(object):
         finally:
             extras['shoot'] = original
 
+    def _projectile_visual_start(self, entity, normalized):
+        """Return #1513's current on-screen HP_gunFire visual start."""
+        if (entity is None or not bool(getattr(entity, 'isStarted', False)) or
+                not isinstance(normalized, dict) or
+                normalized.get('ricochet_count') != 0 or
+                self._projectile_visual_age(normalized) > 0.0):
+            return None
+        cameras = getattr(self._runtime, 'cameras', None)
+        is_point_on_screen = getattr(cameras, 'isPointOnScreen', None)
+        if not callable(is_point_on_screen):
+            return None
+        try:
+            appearance = entity.appearance
+            compound = appearance.compoundModel
+            node = compound.node('HP_gunFire')
+            matrix = self._runtime.math.Matrix(node)
+            native_point = matrix.translation
+            point = tuple(float(native_point[index]) for index in range(3))
+            if any(math.isnan(value) or math.isinf(value)
+                   for value in point):
+                return None
+            if not bool(is_point_on_screen(native_point)):
+                return None
+            reference = tuple(float(value) for value in
+                              normalized['segment_origin'])
+            offset_sq = sum((point[index] - reference[index]) ** 2
+                            for index in range(3))
+            if offset_sq > PROJECTILE_VISUAL_START_MAX_DIFF ** 2:
+                # Mirror ProjectileMover.add here as well as in the final
+                # presenter so the frontier bridge records the start point
+                # the native-compatible presenter will actually accept.
+                return None
+            return point
+        except Exception:
+            # The stock visual start is optional. A changing compound or
+            # camera must fall back to the immutable canonical launch point.
+            return None
+
     def _show_shot(self, event, update_state=True):
         key = self._event_entity_key(event, 'attacker')
         if key is None:
@@ -9766,7 +9823,10 @@ class BattleRuntime(object):
                 velocity = event.get('velocity')
                 gravity = _number(event.get('gravity'))
                 if normalized is not None:
-                    self._ensure_projectile_visual(normalized, self._clock())
+                    visual_start = self._projectile_visual_start(
+                        entity, normalized)
+                    self._ensure_projectile_visual(
+                        normalized, self._clock(), visual_start=visual_start)
                     visual = self._projectile_visual_meta.get(
                         normalized['projectile_id'])
                     visual_admitted = bool(
@@ -10815,7 +10875,8 @@ class BattleRuntime(object):
             return False
         return True
 
-    def _ensure_projectile_visual(self, normalized, now):
+    def _ensure_projectile_visual(self, normalized, now,
+                                  visual_start=None):
         """Create one tracer and monotonically extend its confirmed frontier."""
         if self._worker_mode:
             return False
@@ -10865,6 +10926,12 @@ class BattleRuntime(object):
                         float(existing_visual.get(
                             'display_elapsed', 0.0)) * 1000.0,
                         max(0.0, wall - timeline['trigger']) * 1000.0))
+            if (existing_visual.get('active', False) and
+                    existing_visual.get('first_frontier_pending', False)):
+                if existing_visual['confirmed_elapsed'] <= 0.0:
+                    return True
+                return self._catch_up_first_projectile_frontier(
+                    projectile_id, existing_visual, now)
             if (existing_visual.get('active', False) or
                     not existing_visual.get('admitted', True) or
                     not existing_visual.get('launch_retryable', False)):
@@ -10888,6 +10955,21 @@ class BattleRuntime(object):
                 'last_frame': float(now),
                 'active': False,
                 'launch_retryable': True,
+                'first_frontier_pending': bool(
+                    normalized['ricochet_count'] == 0 and
+                    confirmed_elapsed <= 0.0),
+                'visual_start': (
+                    tuple(visual_start) if
+                    normalized['ricochet_count'] == 0 and
+                    confirmed_elapsed <= 0.0 and
+                    visual_start is not None else None),
+                'first_frontier_min_distance_sq': (
+                    sum((float(visual_start[index]) -
+                         float(normalized['segment_origin'][index])) ** 2
+                        for index in range(3)) if
+                    normalized['ricochet_count'] == 0 and
+                    confirmed_elapsed <= 0.0 and
+                    visual_start is not None else 0.0),
             }
             self._projectile_visual_meta[projectile_id] = visual
             record = self._records.get('%s:%s' % (
@@ -10907,10 +10989,17 @@ class BattleRuntime(object):
             visual['display_elapsed'] = display_elapsed
             visual['last_frame'] = float(now)
             attacker_id = int(visual['attacker_id'])
+            if display_elapsed > 0.0:
+                # A failed zero-age creation owns no native tracer. Retry at
+                # the confirmed trajectory pose instead of a stale muzzle.
+                visual['first_frontier_pending'] = False
+                visual['visual_start'] = None
+                visual['first_frontier_min_distance_sq'] = 0.0
 
         admitted = bool(visual.get('admitted', True))
-        if not admitted or not self._optional_feature_enabled(
-                'projectile visual launch'):
+        if not admitted:
+            return False
+        if not self._optional_feature_enabled('projectile visual launch'):
             return False
         reference_origin = trajectory_position(
             normalized['segment_origin'], normalized['segment_velocity'],
@@ -10929,13 +11018,77 @@ class BattleRuntime(object):
                     normalized['checked_distance']),
                 attacker_id, projectile_id, reference_origin,
                 reference_velocity,
-                is_ricochet=bool(normalized['ricochet_count'])))
+                is_ricochet=bool(normalized['ricochet_count']),
+                visual_start=visual.get('visual_start')))
             visual['launch_retryable'] = not visual['active']
             return visual['active']
         except Exception as error:
             self._warn_optional_failure(
                 'projectile visual launch', error)
             return False
+
+    def _catch_up_first_projectile_frontier(self, projectile_id, visual,
+                                             now):
+        """Move a muzzle-started tracer once its safe cursor clears the bridge."""
+        if (not visual.get('active', False) or
+                not visual.get('first_frontier_pending', False)):
+            return bool(visual.get('active', False))
+        confirmed_elapsed = max(
+            0.0, float(visual.get('confirmed_elapsed', 0.0)))
+        if confirmed_elapsed <= 0.0:
+            visual['last_frame'] = max(
+                float(visual.get('last_frame', now)), float(now))
+            return True
+        callback = getattr(
+            self._remote_factory, 'update_projectile_visual', None)
+        if (not callable(callback) or not self._optional_feature_enabled(
+                'projectile visual update')):
+            return True
+        position, velocity = self._projectile_visual_pose(
+            visual, confirmed_elapsed)
+        origin = visual['origin']
+        confirmed_distance_sq = sum(
+            (float(position[index]) - float(origin[index])) ** 2
+            for index in range(3))
+        if (confirmed_distance_sq + 1.0e-9 < float(visual.get(
+                'first_frontier_min_distance_sq', 0.0))):
+            # A very fast tank and a very early worker receipt can put the
+            # first safe cursor behind the current-muzzle bridge. Keep the
+            # tracer at that muzzle until the canonical path is at least as
+            # far from the stale launch origin; never visibly snap back to it.
+            visual['last_frame'] = max(
+                float(visual.get('last_frame', now)), float(now))
+            return True
+        try:
+            visible = bool(callback(
+                projectile_id, position, velocity=velocity))
+        except Exception as error:
+            self._warn_optional_failure(
+                'projectile visual update', error)
+            visible = False
+        if not visible:
+            visual['active'] = False
+            visual['launch_retryable'] = False
+            return False
+        visual['display_elapsed'] = confirmed_elapsed
+        visual['last_frame'] = float(now)
+        visual['first_frontier_pending'] = False
+        visual['visual_start'] = None
+        visual['first_frontier_min_distance_sq'] = 0.0
+        timeline = self._fire_timeline.get(str(projectile_id))
+        if (timeline is not None and timeline.get('shown') is not None and
+                not timeline.get('moving_logged', False)):
+            timeline['moving_logged'] = True
+            wall = _PROFILE_CLOCK()
+            sys.stdout.write(
+                '[Offline LAN 0.9.22] FIRE TRACER MOVING '
+                'projectile=%s since_trigger_ms=%.0f '
+                'since_shown_ms=%.0f confirmed_ms=%.0f\n' % (
+                    projectile_id,
+                    max(0.0, wall - timeline['trigger']) * 1000.0,
+                    max(0.0, wall - timeline['shown']) * 1000.0,
+                    confirmed_elapsed * 1000.0))
+        return True
 
     @staticmethod
     def _projectile_visual_pose(visual, elapsed=None):
@@ -10971,6 +11124,12 @@ class BattleRuntime(object):
                     not visual.get('admitted', True)):
                 continue
             previous_frame = float(visual.get('last_frame', frame))
+            if visual.get('first_frontier_pending', False):
+                if self._catch_up_first_projectile_frontier(
+                        projectile_id, visual, frame):
+                    advanced = advanced or not visual.get(
+                        'first_frontier_pending', False)
+                continue
             dt = max(0.0, frame - previous_frame)
             visual['last_frame'] = max(previous_frame, frame)
             previous_elapsed = max(
@@ -11635,7 +11794,8 @@ class BattleRuntime(object):
             key=lambda key: order[key])
         return tuple((key, records[key]) for key in ordered)
 
-    def _advance_projectiles(self, now):
+    def _advance_projectiles(self, now, force_progress=False):
+        """Advance collision cursors and optionally publish an extra barrier."""
         self._projectile_perf = {}
         self._projectile_scan_count = 0
         self._projectile_candidate_count = 0
@@ -11691,22 +11851,21 @@ class BattleRuntime(object):
         }
         self._prune_projectile_position_history()
         self._projectile_target_positions = current
-        if now >= self._next_projectile_progress_time:
-            # Advance the deadline along the fixed cadence grid instead of
-            # restarting a whole interval from this frame.  A late worker
-            # frame otherwise pushes every following publication out by its
-            # own overshoot, so the confirmed cursor that gates tracer
-            # advancement and terminal submission degrades with worker frame
-            # time rather than staying at the intended rate.  Missed
-            # intervals are skipped, never replayed as a burst.
-            if self._next_projectile_progress_time <= 0.0:
-                self._next_projectile_progress_time = float(now)
-            overshoot = max(
-                0.0, float(now) - self._next_projectile_progress_time)
-            intervals = int(math.floor(
-                (overshoot + 1e-9) / PROJECTILE_PROGRESS_SECONDS)) + 1
-            self._next_projectile_progress_time += (
-                intervals * PROJECTILE_PROGRESS_SECONDS)
+        if force_progress or now >= self._next_projectile_progress_time:
+            if now >= self._next_projectile_progress_time:
+                # Advance the deadline along the fixed cadence grid instead of
+                # restarting a whole interval from this frame.  A late worker
+                # frame otherwise pushes every following publication out by
+                # its own overshoot.  A forced fire-edge publication before
+                # this deadline deliberately leaves that grid unchanged.
+                if self._next_projectile_progress_time <= 0.0:
+                    self._next_projectile_progress_time = float(now)
+                overshoot = max(
+                    0.0, float(now) - self._next_projectile_progress_time)
+                intervals = int(math.floor(
+                    (overshoot + 1e-9) / PROJECTILE_PROGRESS_SECONDS)) + 1
+                self._next_projectile_progress_time += (
+                    intervals * PROJECTILE_PROGRESS_SECONDS)
             self._publish_projectile_progress()
         return advanced
 

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/entities/native_remote_vehicle.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/entities/native_remote_vehicle.py
@@ -887,11 +887,12 @@ class NativeRemoteVehicleFactory(object):
                                velocity, gravity, max_distance, attacker_id,
                                projectile_id=None, reference_position=None,
                                reference_velocity=None,
-                               is_ricochet=False):
+                               is_ricochet=False, visual_start=None):
         return self._shot_presenter.play_canonical(
             descriptor, shell_index, origin, velocity, gravity,
             max_distance, attacker_id, projectile_id,
-            reference_position, reference_velocity, is_ricochet)
+            reference_position, reference_velocity, is_ricochet,
+            visual_start)
 
     def admit_projectile_visual(self, attacker_id, projectile_id, now=None):
         """Reserve one bounded cosmetic slot for a canonical projectile."""

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/entities/remote_vehicle.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/entities/remote_vehicle.py
@@ -87,6 +87,10 @@ except NameError:
     _STRING_TYPES = (str,)
 
 
+# Exact #1513 ProjectileMover.add guard between startPoint and refStartPoint.
+PROJECTILE_VISUAL_START_MAX_DIFF = 20.0
+
+
 # Exact value contract returned by #1513 ``Vehicle.collideSegment``.  The
 # stock ProjectileMover uses both tuple indexing and these named fields.
 _SegmentCollisionResult = namedtuple(
@@ -326,6 +330,7 @@ class _RemoteShotPresenter(object):
     are outside the standard-battle catalog and fail closed on this ledger.
     """
 
+    _STOCK_VISUAL_START_MAX_DIFF = PROJECTILE_VISUAL_START_MAX_DIFF
     # A stock gun can emit a short autocannon burst, so keep a generous
     # immediate allowance.  Sustained edited reloads are presentation-only
     # load and refill more slowly than they can create native particles.
@@ -542,7 +547,8 @@ class _RemoteShotPresenter(object):
     def play_canonical(self, descriptor, shell_index, origin, velocity,
                        gravity, max_distance, attacker_id,
                        projectile_id=None, reference_position=None,
-                       reference_velocity=None, is_ricochet=False):
+                       reference_velocity=None, is_ricochet=False,
+                       visual_start=None):
         """Create one tracer whose pose is owned by authoritative updates.
 
         The origin and velocity belong to the authoritative launch event.
@@ -552,6 +558,9 @@ class _RemoteShotPresenter(object):
         hidden-worker-confirmed cursor when a launch arrives late.  No
         ballistic motor is created here, so the tracer cannot run ahead of
         that cursor while the next collision receipt is pending.
+        ``visual_start`` is the separate current-muzzle pose used by stock
+        #1513 presentation; its exact 20 m guard never changes the launch or
+        confirmed-reference trajectory.
         """
         if self._closed or not self._launches_enabled:
             return False
@@ -561,8 +570,24 @@ class _RemoteShotPresenter(object):
         if shot is None or shell is None or effects_index is None:
             return False
         launch_start = self._finite_vector(origin)
-        visual_start = (launch_start if reference_position is None else
-                        self._finite_vector(reference_position))
+        reference_start = (
+            launch_start if reference_position is None else
+            self._finite_vector(reference_position))
+        requested_visual_start = self._finite_vector(visual_start)
+        if requested_visual_start is not None and reference_start is not None:
+            try:
+                offset_sq = sum(
+                    (getattr(requested_visual_start, name) -
+                     getattr(reference_start, name)) ** 2
+                    for name in ('x', 'y', 'z'))
+                if offset_sq > self._STOCK_VISUAL_START_MAX_DIFF ** 2:
+                    # Exact #1513 ProjectileMover.add falls all the way back
+                    # to refStartPoint; it does not clamp the offset to 20 m.
+                    requested_visual_start = reference_start
+            except Exception:
+                requested_visual_start = reference_start
+        initial_position = (reference_start if requested_visual_start is None
+                            else requested_visual_start)
         visual_velocity = self._finite_vector(
             velocity if reference_velocity is None else reference_velocity)
         gravity = self._finite_float(gravity)
@@ -592,7 +617,8 @@ class _RemoteShotPresenter(object):
             if not released:
                 return False
             self._remove_projectile_mapping(projectile_id)
-        if (launch_start is None or visual_start is None or
+        if (launch_start is None or reference_start is None or
+                initial_position is None or
                 visual_velocity is None or gravity is None or
                 maximum is None or gravity < 0.0 or maximum <= 0.0 or
                 attacker_id <= 0):
@@ -653,7 +679,7 @@ class _RemoteShotPresenter(object):
             self._next_shot_id += 1
             pose = self._math.Matrix()
             self._write_projectile_pose(
-                pose, visual_start, visual_velocity)
+                pose, initial_position, visual_velocity)
             model = model_factory(selected_name)
             servo = servo_factory(pose)
             entry = {
@@ -665,7 +691,7 @@ class _RemoteShotPresenter(object):
                 'projectile_effects': projectile_effects,
                 'effects_data': {},
                 'attacker_id': attacker_id,
-                'position': visual_start,
+                'position': initial_position,
                 'velocity': visual_velocity,
                 'in_scene': False,
                 'motor_attached': False,
@@ -695,7 +721,7 @@ class _RemoteShotPresenter(object):
             entry['flying_attached'] = True
             self._projectile_shots[projectile_id] = entry
             self._projectile_order.append(projectile_id)
-            self._notify_projectile_launch(launch_start)
+            self._notify_projectile_launch(initial_position)
             return visual_id
         except Exception as error:
             if entry is not None:
@@ -2949,12 +2975,13 @@ class RemoteVehicleFactory(object):
                                velocity, gravity, max_distance, attacker_id,
                                projectile_id=None, reference_position=None,
                                reference_velocity=None,
-                               is_ricochet=False):
+                               is_ricochet=False, visual_start=None):
         """Play one authoritative launch without consulting a vehicle pose."""
         return self._shot_presenter.play_canonical(
             descriptor, shell_index, origin, velocity, gravity,
             max_distance, attacker_id, projectile_id,
-            reference_position, reference_velocity, is_ricochet)
+            reference_position, reference_velocity, is_ricochet,
+            visual_start)
 
     def admit_projectile_visual(self, attacker_id, projectile_id, now=None):
         """Reserve one bounded cosmetic slot for a canonical projectile."""

--- a/tests/test_port_0922_battle_projectiles.py
+++ b/tests/test_port_0922_battle_projectiles.py
@@ -135,17 +135,24 @@ class _ControlledTracerFactory(object):
             self, descriptor, shell_index, origin, velocity, gravity,
             max_distance, attacker_id, projectile_id=None,
             reference_position=None, reference_velocity=None,
-            is_ricochet=False):
+            is_ricochet=False, visual_start=None):
         self.play_attempts.append(projectile_id)
         if self.fail_plays > 0:
             self.fail_plays -= 1
             return False
         if projectile_id in self.active:
             raise AssertionError('controlled tracer was rebuilt')
-        position = origin if reference_position is None else reference_position
+        reference = (origin if reference_position is None else
+                     reference_position)
+        position = reference if visual_start is None else visual_start
         current_velocity = (velocity if reference_velocity is None else
                             reference_velocity)
         row = {
+            'origin': tuple(float(value) for value in origin),
+            'reference_position': tuple(
+                float(value) for value in reference),
+            'visual_start': (None if visual_start is None else tuple(
+                float(value) for value in visual_start)),
             'position': tuple(float(value) for value in position),
             'velocity': tuple(float(value) for value in current_velocity),
             'visible': True,
@@ -187,7 +194,9 @@ def _battle(now=0.0):
     bigworld.now = now
     runtime = types.SimpleNamespace(
         bigworld=bigworld,
-        math=types.SimpleNamespace(Vector3=_Vector))
+        math=types.SimpleNamespace(Vector3=_Vector),
+        cameras=types.SimpleNamespace(
+            isPointOnScreen=lambda unused_point: False))
     battle = BattleRuntime(runtime)
     battle.client = _Client()
     battle._avatar = types.SimpleNamespace(spaceID=1)
@@ -1530,11 +1539,19 @@ class BattleProjectileTests(unittest.TestCase):
             battle._projectile_visual_meta['bot:11:1']['active'])
         source.showShooting.assert_called_once_with(1, False)
 
-    def test_controlled_tracer_never_crosses_confirmed_frontier_after_stall(self):
+    def test_zero_cursor_tracer_bridges_muzzle_to_confirmed_frontier(self):
         battle, unused_bigworld = _battle(now=0.0)
         battle.client.is_bot_authority = lambda: False
         source = battle._server_entity(41)
         source.showShooting = mock.Mock(return_value=True)
+        muzzle = _Vector((15.0, 1.0, 0.0))
+        source.appearance = types.SimpleNamespace(
+            compoundModel=types.SimpleNamespace(
+                node=mock.Mock(return_value=types.SimpleNamespace(
+                    translation=muzzle))))
+        battle._runtime.math.Matrix = lambda value: value
+        battle._runtime.cameras = types.SimpleNamespace(
+            isPointOnScreen=mock.Mock(return_value=True))
         factory = _ControlledTracerFactory()
         battle._remote_factory = factory
         source_shot = dict(_event()['source_shot'])
@@ -1551,17 +1568,54 @@ class BattleProjectileTests(unittest.TestCase):
             launch_server_time_ms=0)
 
         self.assertTrue(battle._show_shot(event))
-        self.assertTrue(factory.active['player:7:1']['visible'])
-        self.assertEqual((0.0, 1.0, 0.0),
+        visual = battle._projectile_visual_meta['player:7:1']
+        self.assertEqual(1, len(factory.play_calls))
+        self.assertEqual((15.0, 1.0, 0.0),
                          factory.active['player:7:1']['position'])
+        self.assertEqual((0.0, 1.0, 0.0),
+                         factory.play_calls[0][1]['origin'])
+        self.assertEqual((0.0, 1.0, 0.0),
+                         factory.play_calls[0][1]['reference_position'])
+        self.assertEqual((15.0, 1.0, 0.0),
+                         factory.play_calls[0][1]['visual_start'])
+        self.assertTrue(visual['active'])
+        self.assertTrue(visual['first_frontier_pending'])
+        self.assertTrue(visual['admitted'])
+        self.assertEqual(0.0, visual['display_elapsed'])
+        self.assertEqual(0.0, visual['confirmed_elapsed'])
+        source.showShooting.assert_called_once_with(1, False)
+
+        for frame in (0.01, 0.02):
+            self.assertFalse(battle._advance_projectiles(frame))
+        self.assertEqual([], factory.update_calls)
+        self.assertEqual((15.0, 1.0, 0.0),
+                         factory.active['player:7:1']['position'])
+
+        early_progress = dict(event, checked_through_ms=10,
+                              checked_distance=1.0, piercing_loss=0.0)
+        early_normalized = battle._projectile_wire_meta(early_progress)
+        early_normalized['source_descriptor'] = source.typeDescriptor
+        battle._install_projectile_meta(early_normalized)
+        self.assertTrue(battle._ensure_projectile_visual(
+            early_normalized, 0.02))
+        self.assertEqual([], factory.update_calls)
+        self.assertEqual((15.0, 1.0, 0.0),
+                         factory.active['player:7:1']['position'])
+        self.assertTrue(visual['first_frontier_pending'])
 
         progress = dict(event, checked_through_ms=400,
                         checked_distance=40.0, piercing_loss=0.0)
         normalized = battle._projectile_wire_meta(progress)
         normalized['source_descriptor'] = source.typeDescriptor
         battle._install_projectile_meta(normalized)
-        self.assertTrue(battle._ensure_projectile_visual(normalized, 0.0))
+        self.assertTrue(battle._ensure_projectile_visual(normalized, 0.02))
         self.assertEqual(1, len(factory.play_calls))
+        tracer = factory.active['player:7:1']
+        self.assertEqual((40.0, 8.2, 0.0), tracer['position'])
+        self.assertEqual((40.0, 8.2, 0.0),
+                         factory.update_calls[0][1]['position'])
+        self.assertFalse(visual['first_frontier_pending'])
+        self.assertEqual(0.4, visual['display_elapsed'])
 
         self.assertFalse(battle._advance_projectiles(0.1))
         visual = battle._projectile_visual_meta['player:7:1']
@@ -1570,8 +1624,11 @@ class BattleProjectileTests(unittest.TestCase):
         self.assertTrue(tracer['visible'])
         self.assertLessEqual(
             visual['display_elapsed'], visual['confirmed_elapsed'])
-        self.assertEqual(0.1, visual['display_elapsed'])
-        self.assertAlmostEqual(10.0, tracer['position'][0])
+        self.assertFalse(visual['first_frontier_pending'])
+        self.assertEqual(0.4, visual['display_elapsed'])
+        self.assertAlmostEqual(40.0, tracer['position'][0])
+        self.assertTrue(all(
+            row[1]['position'][0] >= 15.0 for row in factory.update_calls))
 
         # A duplicate and then a regressing snapshot neither rebuilds the
         # visible tracer nor lowers the already confirmed frontier.
@@ -1592,6 +1649,43 @@ class BattleProjectileTests(unittest.TestCase):
         self.assertLessEqual(
             visual['display_elapsed'], visual['confirmed_elapsed'])
         self.assertAlmostEqual(40.0, tracer['position'][0])
+
+    def test_zero_cursor_visual_start_requires_onscreen_muzzle(self):
+        cases = (
+            ('offscreen', 3.0, False),
+            ('beyond-stock-guard', 21.0, True),
+            ('screen-check-failed', 3.0,
+             RuntimeError('camera unavailable')),
+        )
+        for label, muzzle_x, screen_result in cases:
+            with self.subTest(label=label):
+                battle, unused_bigworld = _battle(now=0.0)
+                battle.client.is_bot_authority = lambda: False
+                source = battle._server_entity(41)
+                source.showShooting = mock.Mock(return_value=True)
+                source.appearance = types.SimpleNamespace(
+                    compoundModel=types.SimpleNamespace(
+                        node=mock.Mock(return_value=types.SimpleNamespace(
+                            translation=_Vector((muzzle_x, 1.0, 0.0))))))
+                battle._runtime.math.Matrix = lambda value: value
+                if isinstance(screen_result, Exception):
+                    screen_check = mock.Mock(side_effect=screen_result)
+                else:
+                    screen_check = mock.Mock(return_value=screen_result)
+                battle._runtime.cameras = types.SimpleNamespace(
+                    isPointOnScreen=screen_check)
+                factory = _ControlledTracerFactory()
+                battle._remote_factory = factory
+
+                self.assertTrue(battle._show_shot(_event()))
+
+                self.assertEqual((0.0, 1.0, 0.0),
+                                 factory.play_calls[0][1]['position'])
+                self.assertIsNone(
+                    factory.play_calls[0][1]['visual_start'])
+                self.assertTrue(
+                    battle._projectile_visual_meta[
+                        'player:7:1']['first_frontier_pending'])
 
     def test_failed_launch_stays_inactive_and_retries_under_runtime_ownership(self):
         battle, unused_bigworld = _battle(now=1.0)
@@ -1650,9 +1744,10 @@ class BattleProjectileTests(unittest.TestCase):
         factory = _ControlledTracerFactory()
         battle._remote_factory = factory
 
-        self.assertTrue(battle._show_shot(_event()))
+        first = _event()
+        self.assertTrue(battle._show_shot(first))
         second = dict(
-            _event(), projectile_id='player:7:2', shot_seq=2,
+            first, projectile_id='player:7:2', shot_seq=2,
             burst_group_seq=2)
         self.assertTrue(battle._show_shot(second))
 
@@ -1669,9 +1764,10 @@ class BattleProjectileTests(unittest.TestCase):
         source.showShooting = mock.Mock(return_value=True)
         factory = _ControlledTracerFactory()
         battle._remote_factory = factory
-        self.assertTrue(battle._show_shot(_event()))
+        launch = _event()
+        self.assertTrue(battle._show_shot(launch))
         self.assertTrue(factory.active['player:7:1']['visible'])
-        self.assertTrue(battle._accept_projectile_event(_event()))
+        self.assertTrue(battle._accept_projectile_event(launch))
         event = {
             'kind': 'projectile_impact',
             'projectile_id': 'player:7:1',
@@ -1697,7 +1793,9 @@ class BattleProjectileTests(unittest.TestCase):
                 source.showShooting = mock.Mock(return_value=True)
                 factory = _ControlledTracerFactory()
                 battle._remote_factory = factory
-                self.assertTrue(battle._show_shot(_event()))
+                launch = _event()
+                self.assertTrue(battle._show_shot(launch))
+                self.assertIn('player:7:1', factory.active)
 
                 self.assertTrue(battle._apply_projectile_terminal_event({
                     'kind': 'projectile_impact',
@@ -1718,7 +1816,8 @@ class BattleProjectileTests(unittest.TestCase):
         source.showShooting = mock.Mock(return_value=True)
         factory = _ControlledTracerFactory(order=order)
         battle._remote_factory = factory
-        self.assertTrue(battle._show_shot(_event()))
+        launch = _event()
+        self.assertTrue(battle._show_shot(launch))
         battle._apply_combat_event = lambda event, update_state=False: (
             order.append(('combat', event['kind'])))
 
@@ -1774,10 +1873,20 @@ class BattleProjectileTests(unittest.TestCase):
         battle, unused_bigworld = _battle()
         source = battle._server_entity(41)
         source.showShooting = mock.Mock(return_value=True)
+        source.appearance = types.SimpleNamespace(
+            compoundModel=types.SimpleNamespace(
+                node=mock.Mock(return_value=types.SimpleNamespace(
+                    translation=_Vector((15.0, 1.0, 0.0))))))
+        battle._runtime.math.Matrix = lambda value: value
+        battle._runtime.cameras = types.SimpleNamespace(
+            isPointOnScreen=mock.Mock(return_value=True))
         factory = _ControlledTracerFactory()
         battle._remote_factory = factory
         launch = _event()
         self.assertTrue(battle._show_shot(launch))
+        self.assertEqual(
+            (15.0, 1.0, 0.0),
+            factory.play_calls[0][1]['visual_start'])
         self.assertTrue(battle._accept_projectile_event(launch))
         ricochet = dict(launch)
         ricochet['max_distance'] = ricochet.pop('maxDistance')
@@ -1804,6 +1913,7 @@ class BattleProjectileTests(unittest.TestCase):
         tracer = factory.active['player:7:1']
         self.assertTrue(tracer['visible'])
         self.assertTrue(tracer['ricochet'])
+        self.assertIsNone(factory.play_calls[1][1]['visual_start'])
         self.assertEqual((5.0, 1.0, 0.0), tracer['position'])
         visual = battle._projectile_visual_meta['player:7:1']
         self.assertTrue(visual['active'])
@@ -1817,7 +1927,8 @@ class BattleProjectileTests(unittest.TestCase):
         source.showShooting = mock.Mock(return_value=True)
         factory = _ControlledTracerFactory()
         battle._remote_factory = factory
-        self.assertTrue(battle._show_shot(_event()))
+        launch = _event()
+        self.assertTrue(battle._show_shot(launch))
         self.assertTrue(factory.active['player:7:1']['visible'])
 
         self.assertTrue(battle._set_projectile_epoch(2, 0.5))

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -1,5 +1,6 @@
 import contextlib
 import copy
+import dis
 import io
 import math
 from pathlib import Path
@@ -1956,6 +1957,8 @@ def _runtime():
                 ARCADE='arcade', SNIPER='sniper',
                 STRATEGIC='strategic', ARTY='arty',
                 POSTMORTEM='postmortem')),
+        cameras=types.SimpleNamespace(
+            isPointOnScreen=lambda unused_point: False),
         aih_constants=types.SimpleNamespace(
             GUN_MARKER_FLAG=types.SimpleNamespace(
                 UNDEFINED=0, CONTROL_ENABLED=1, CLIENT_MODE_ENABLED=2,
@@ -5155,6 +5158,20 @@ class BattleRuntimeContractTests(unittest.TestCase):
             side_effect=_plain_bot_factors)
         self._bot_factors_patch.start()
         self.addCleanup(self._bot_factors_patch.stop)
+
+    def test_production_runtime_wires_stock_camera_visibility_module(self):
+        instructions = [
+            (instruction.opname, instruction.argval)
+            for instruction in dis.get_instructions(
+                battle_runtime_module._load_runtime)]
+
+        self.assertIn(('IMPORT_FROM', 'cameras'), instructions)
+        self.assertTrue(any(
+            instructions[index:index + 3] == [
+                ('LOAD_FAST', 'cameras'),
+                ('LOAD_FAST', 'runtime'),
+                ('STORE_ATTR', 'cameras')]
+            for index in range(len(instructions) - 2)))
 
     def test_local_state_falls_back_before_roster_publishes_the_player(self):
         battle = BattleRuntime(_runtime())
@@ -20794,6 +20811,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
             'presentation_ledger': [],
         }
         key = (2, 3)
+        battle._advance_projectiles = mock.Mock(return_value=True)
 
         # The transport can beat the snapshot/native entity lifecycle.  The
         # fast path must not turn that harmless ordering into a terminal
@@ -20804,6 +20822,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertNotIn(key, battle._player_fire_intent_history)
         client.send_projectile_launch.assert_not_called()
         client.send_fire_intent_result.assert_not_called()
+        battle._advance_projectiles.assert_not_called()
 
         descriptor = _Descriptor()
         entity = _Vehicle(
@@ -20857,7 +20876,9 @@ class BattleRuntimeContractTests(unittest.TestCase):
         battle._projectile_epoch = 4
         battle._projectile_server_time_ms = 1000
         battle._projectile_server_local_time = 10.0
-        battle._next_projectile_progress_time = 10.0
+        # A newly admitted click must publish its first safe cursor even when
+        # the ordinary 10 Hz progress deadline is still in the future.
+        battle._next_projectile_progress_time = 11.0
         descriptor = _Descriptor()
         entity = _Vehicle(
             11, descriptor, _Vector(50.0, 0.0, 50.0), (0, 0, 0),
@@ -20891,6 +20912,13 @@ class BattleRuntimeContractTests(unittest.TestCase):
             'dispersion_angle': 0.02,
             'presentation_ledger': [],
         }
+        battle._projectile_record_poses = mock.Mock(return_value={})
+        battle._sample_projectile_positions = mock.Mock()
+        battle._prune_projectile_position_history = mock.Mock()
+        battle._build_projectile_spatial_bins = mock.Mock()
+        battle._clear_projectile_spatial_index = mock.Mock()
+        battle._projectile_chord = mock.Mock(return_value=None)
+        battle._projectile_terminal = mock.Mock(return_value=None)
         output = io.StringIO()
 
         with contextlib.redirect_stdout(output):
@@ -20905,20 +20933,11 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertEqual(1, client.send_projectile_launch.call_count)
         self.assertIn('path=poll', output.getvalue())
 
-        battle._projectile_record_poses = mock.Mock(return_value={})
-        battle._sample_projectile_positions = mock.Mock()
-        battle._prune_projectile_position_history = mock.Mock()
-        battle._build_projectile_spatial_bins = mock.Mock()
-        battle._clear_projectile_spatial_index = mock.Mock()
-        battle._projectile_chord = mock.Mock(return_value=None)
-        battle._projectile_terminal = mock.Mock(return_value=None)
-
-        self.assertTrue(battle._advance_projectiles(10.05))
-
         client.send_projectile_progress.assert_called_once()
         cursor = client.send_projectile_progress.call_args.args[1][0]
         self.assertEqual(projectile_id, cursor['projectile_id'])
         self.assertGreater(cursor['checked_through_ms'], 0)
+        self.assertEqual(11.0, battle._next_projectile_progress_time)
 
     def test_worker_resolves_immediate_player_destructible_contact(self):
         battle = BattleRuntime(_runtime())

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -1,6 +1,5 @@
 import contextlib
 import copy
-import dis
 import io
 import math
 from pathlib import Path
@@ -5160,18 +5159,19 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.addCleanup(self._bot_factors_patch.stop)
 
     def test_production_runtime_wires_stock_camera_visibility_module(self):
-        instructions = [
-            (instruction.opname, instruction.argval)
-            for instruction in dis.get_instructions(
-                battle_runtime_module._load_runtime)]
+        cameras = types.SimpleNamespace(isPointOnScreen=mock.Mock())
+        modules = {'AvatarInputHandler': mock.Mock(cameras=cameras)}
 
-        self.assertIn(('IMPORT_FROM', 'cameras'), instructions)
-        self.assertTrue(any(
-            instructions[index:index + 3] == [
-                ('LOAD_FAST', 'cameras'),
-                ('LOAD_FAST', 'runtime'),
-                ('STORE_ATTR', 'cameras')]
-            for index in range(len(instructions) - 2)))
+        def import_runtime_module(name, *unused_args, **unused_kwargs):
+            if name not in modules:
+                modules[name] = mock.Mock(name=name)
+            return modules[name]
+
+        with mock.patch('builtins.__import__',
+                        side_effect=import_runtime_module):
+            runtime = battle_runtime_module._load_runtime()
+
+        self.assertIs(cameras, runtime.cameras)
 
     def test_local_state_falls_back_before_roster_publishes_the_player(self):
         battle = BattleRuntime(_runtime())

--- a/tests/test_port_0922_client_abi_audit.py
+++ b/tests/test_port_0922_client_abi_audit.py
@@ -101,6 +101,28 @@ class ClientAbiProjectileAuditTests(unittest.TestCase):
         self.assertEqual('arty', modes['ARTY'])
 
     def test_controlled_tracer_dependencies_are_pinned(self):
+        self.assertEqual(
+            ('point',),
+            AUDIT.EXPECTED_ABI[
+                'scripts/client/AvatarInputHandler/cameras.pyc'][
+                    'isPointOnScreen'])
+        avatar = AUDIT.EXPECTED_ABI['scripts/client/Avatar.pyc']
+        self.assertEqual(
+            ('self', 'shooterID', 'shotID', 'isRicochet', 'effectsIndex',
+             'refStartPoint', 'velocity', 'gravity', 'maxShotDist'),
+            avatar['PlayerAvatar.showTracer'])
+        avatar_names = AUDIT.EXPECTED_CODE_NAMES[
+            'scripts/client/Avatar.pyc']['PlayerAvatar.showTracer']
+        self.assertTrue({
+            'BigWorld', 'entity', 'isStarted', 'Math', 'Matrix',
+            'cameras', 'isPointOnScreen', 'appearance', 'compoundModel',
+            'node', 'translation', '_PlayerAvatar__projectileMover', 'add',
+        }.issubset(avatar_names))
+        self.assertIn(
+            'HP_gunFire',
+            AUDIT.EXPECTED_CODE_LITERALS[
+                'scripts/client/Avatar.pyc']['PlayerAvatar.showTracer'])
+
         effects = AUDIT.EXPECTED_ABI[
             'scripts/client/helpers/EffectsList.pyc']
         self.assertEqual(
@@ -185,6 +207,12 @@ class ClientAbiProjectileAuditTests(unittest.TestCase):
             'fireMissedTrigger', 'TriggersManager', 'g_manager',
             'fireTrigger', 'TRIGGER_TYPE', 'PLAYER_SHOT_MISSED',
         }.isdisjoint(mover_names['ProjectileMover.__delProjectile']))
+        self.assertEqual(
+            20,
+            AUDIT.EXPECTED_CLASS_CONSTANTS[
+                'scripts/client/ProjectileMover.pyc'][
+                    'ProjectileMover'][
+                        '_ProjectileMover__START_POINT_MAX_DIFF'])
         self.assertEqual(
             2.0,
             AUDIT.EXPECTED_CLASS_CONSTANTS[

--- a/tests/test_port_0922_projectile_visual_presenter.py
+++ b/tests/test_port_0922_projectile_visual_presenter.py
@@ -302,16 +302,17 @@ class ProjectileVisualPresenterTests(unittest.TestCase):
             self.bigworld, self.math, types.SimpleNamespace(), 7)
 
     def _launch(self, factory, projectile_id='round:shot', attacker_id=42,
+                origin=(1.0, 2.0, 3.0),
                 reference_position=(3.0, 4.0, 5.0),
                 reference_velocity=(100.0, 10.0, 0.0),
-                effects=None, is_ricochet=False):
+                effects=None, is_ricochet=False, visual_start=None):
         effects = self.effects if effects is None else effects
         with mock.patch.dict(sys.modules, _modules(effects)):
             return factory.play_projectile_tracer(
-                _descriptor(), 0, (1.0, 2.0, 3.0),
+                _descriptor(), 0, origin,
                 (120.0, 20.0, 0.0), 9.81, 640.0, attacker_id,
                 projectile_id, reference_position, reference_velocity,
-                is_ricochet)
+                is_ricochet, visual_start)
 
     def test_player_and_bot_use_visible_stock_effects_on_controlled_servos(self):
         factory = self._factory()
@@ -382,6 +383,30 @@ class ProjectileVisualPresenterTests(unittest.TestCase):
         self.assertEqual(1, len(self.bigworld._player.models))
         self.assertEqual(1, len(self.projectile_effects.attach_calls))
         self.assertEqual([], _ProjectileMover.instances)
+
+    def test_visual_start_uses_stock_twenty_metre_guard(self):
+        factory = self._factory()
+        origin = (1.0, 2.0, 3.0)
+        reference = (51.0, 2.0, 3.0)
+
+        self.assertTrue(self._launch(
+            factory, projectile_id='edge:accepted', origin=origin,
+            reference_position=reference,
+            visual_start=(71.0, 2.0, 3.0)))
+        self.assertTrue(self._launch(
+            factory, projectile_id='edge:rejected', origin=origin,
+            reference_position=reference,
+            visual_start=(71.001, 2.0, 3.0)))
+
+        presenter = factory._shot_presenter
+        accepted = presenter._projectile_shots['edge:accepted']
+        rejected = presenter._projectile_shots['edge:rejected']
+        self.assertEqual(
+            (71.0, 2.0, 3.0), _xyz(accepted['pose'].translation))
+        self.assertEqual(reference, _xyz(rejected['pose'].translation))
+        self.assertEqual(
+            [(71.0, 2.0, 3.0), reference],
+            [_xyz(position) for position in self.flock.positions])
 
     def test_terminal_pins_then_keeps_stock_tail_before_owner_cleanup(self):
         factory = self._factory()
@@ -700,6 +725,25 @@ class ProjectileVisualPresenterTests(unittest.TestCase):
                 factory_type, 'update_projectile_visual', None)))
             self.assertTrue(callable(getattr(
                 factory_type, 'reset_projectile_visuals', None)))
+
+    def test_both_factory_implementations_forward_visual_start(self):
+        visual_start = (7.0, 8.0, 9.0)
+        for factory_type in (RemoteVehicleFactory,
+                             NativeRemoteVehicleFactory):
+            with self.subTest(factory=factory_type.__name__):
+                factory = factory_type.__new__(factory_type)
+                factory._shot_presenter = mock.Mock()
+                factory._shot_presenter.play_canonical.return_value = 17
+
+                self.assertEqual(17, factory.play_projectile_tracer(
+                    _descriptor(), 0, (1.0, 2.0, 3.0),
+                    (120.0, 20.0, 0.0), 9.81, 640.0, 42,
+                    'forwarded:1', (3.0, 4.0, 5.0),
+                    (100.0, 10.0, 0.0), False, visual_start))
+
+                self.assertEqual(
+                    visual_start,
+                    factory._shot_presenter.play_canonical.call_args.args[-1])
 
 
 if __name__ == '__main__':

--- a/tools/audit_client_abi.py
+++ b/tools/audit_client_abi.py
@@ -464,6 +464,9 @@ EXPECTED_ABI = {
         'PlayerAvatar.autoAim': ('self', 'target'),
         'PlayerAvatar.targetFocus': ('self', 'entity'),
         'PlayerAvatar.targetBlur': ('self', 'prevEntity'),
+        'PlayerAvatar.showTracer': (
+            'self', 'shooterID', 'shotID', 'isRicochet', 'effectsIndex',
+            'refStartPoint', 'velocity', 'gravity', 'maxShotDist'),
         'PlayerAvatar.shoot': ('self', 'isRepeat'),
         'PlayerAvatar.__isOwnVehicleSwitchingSiegeMode': ('self',),
         'PlayerAvatar.cancelWaitingForShot': ('self',),
@@ -534,6 +537,9 @@ EXPECTED_ABI = {
         '_Targeting.getTargetEntity': ('self',),
         '_Targeting.enable': ('self', 'flag'),
         '_Targeting.onRecreateDevice': ('self',),
+    },
+    'scripts/client/AvatarInputHandler/cameras.pyc': {
+        'isPointOnScreen': ('point',),
     },
     'scripts/client/AvatarInputHandler/commands/siege_mode_control.pyc': {
         'SiegeModeControl.handleKeyEvent': (
@@ -945,6 +951,7 @@ EXPECTED_CODE_LITERALS = {
     'scripts/client/Avatar.pyc': {
         'PlayerAvatar.__onSetOwnVehicleAuxPhysicsData': (
             'syncStabilisedYPR',),
+        'PlayerAvatar.showTracer': ('HP_gunFire',),
     },
     'scripts/client/gui/Scaleform/daapi/view/battle/shared/markers2d/'
     'plugins.pyc': {
@@ -1154,6 +1161,10 @@ EXPECTED_CODE_NAMES = {
             'setTargetInFocus', 'removeEdge', 'target',
             'TriggersManager', 'g_manager', 'deactivateTrigger',
             'TRIGGER_TYPE', 'AIM_AT_VEHICLE'),
+        'PlayerAvatar.showTracer': (
+            'BigWorld', 'entity', 'isStarted', 'Math', 'Matrix',
+            'cameras', 'isPointOnScreen', 'appearance', 'compoundModel',
+            'node', 'translation', '_PlayerAvatar__projectileMover', 'add'),
         'PlayerAvatar.shoot': (
             'base', 'vehicle_shoot', '_PlayerAvatar__startWaitingForShot',
             '_PlayerAvatar__isOwnVehicleSwitchingSiegeMode'),
@@ -1354,9 +1365,10 @@ EXPECTED_CODE_NAMES = {
     },
     'scripts/client/ProjectileMover.pyc': {
         'ProjectileMover.add': (
-            'salvo', 'addProjectile', '_ProjectileMover__ballistics', 'BigWorld',
-            'Model', 'player', 'addModel', 'addMotor', 'visible',
-            'visibleAttachments', 'attachTo', 'FlockManager',
+            'distTo', '_ProjectileMover__START_POINT_MAX_DIFF',
+            'salvo', 'addProjectile', '_ProjectileMover__ballistics',
+            'BigWorld', 'Model', 'player', 'addModel', 'addMotor',
+            'visible', 'visibleAttachments', 'attachTo', 'FlockManager',
             'getManager', 'onProjectile'),
         'ProjectileMover.explode': (
             'TriggersManager', 'g_manager', 'fireTrigger', 'TRIGGER_TYPE',
@@ -1957,6 +1969,7 @@ EXPECTED_CLASS_CONSTANTS = {
     },
     'scripts/client/ProjectileMover.pyc': {
         'ProjectileMover': {
+            '_ProjectileMover__START_POINT_MAX_DIFF': 20,
             '_ProjectileMover__PROJECTILE_TIME_AFTER_DEATH': 2.0,
         },
     },
@@ -2152,6 +2165,41 @@ EXPECTED_ORDERED_INSTRUCTION_PATTERNS = {
             )),
     },
     'scripts/client/Avatar.pyc': {
+        'PlayerAvatar.showTracer': (
+            'visible non-ricochet uses the current on-screen muzzle', 10, (
+                ('LOAD_FAST', 'value', 'refStartPoint'),
+                ('STORE_FAST', 'value', 'startPoint'),
+                ('LOAD_FAST', 'value', 'isRicochet'),
+                ('UNARY_NOT', None, None),
+                ('POP_JUMP_IF_FALSE', None, None),
+                ('LOAD_FAST', 'value', 'shooter'),
+                ('LOAD_CONST', 'value', None),
+                ('COMPARE_OP', 'argument', 9),
+                ('POP_JUMP_IF_FALSE', None, None),
+                ('LOAD_FAST', 'value', 'shooter'),
+                ('LOAD_ATTR', 'value', 'isStarted'),
+                ('POP_JUMP_IF_FALSE', None, None),
+                ('LOAD_GLOBAL', 'value', 'Math'),
+                ('LOAD_ATTR', 'value', 'Matrix'),
+                ('LOAD_FAST', 'value', 'shooter'),
+                ('LOAD_ATTR', 'value', 'appearance'),
+                ('LOAD_ATTR', 'value', 'compoundModel'),
+                ('LOAD_ATTR', 'value', 'node'),
+                ('LOAD_CONST', 'value', 'HP_gunFire'),
+                ('CALL_FUNCTION', 'argument', 1),
+                ('CALL_FUNCTION', 'argument', 1),
+                ('STORE_FAST', 'value', 'gunMatrix'),
+                ('LOAD_FAST', 'value', 'gunMatrix'),
+                ('LOAD_ATTR', 'value', 'translation'),
+                ('STORE_FAST', 'value', 'gunFirePos'),
+                ('LOAD_GLOBAL', 'value', 'cameras'),
+                ('LOAD_ATTR', 'value', 'isPointOnScreen'),
+                ('LOAD_FAST', 'value', 'gunFirePos'),
+                ('CALL_FUNCTION', 'argument', 1),
+                ('POP_JUMP_IF_FALSE', None, None),
+                ('LOAD_FAST', 'value', 'gunFirePos'),
+                ('STORE_FAST', 'value', 'startPoint'),
+            )),
         'PlayerAvatar.handleVehicleCollidedVehicle': (
             'vehicle collision uses full relative Vector3 speed', 5, (
                 ('LOAD_CONST', 'value', 0.2),
@@ -2166,6 +2214,22 @@ EXPECTED_ORDERED_INSTRUCTION_PATTERNS = {
                 ('BINARY_SUBTRACT', None, None),
                 ('LOAD_ATTR', 'value', 'length'),
                 ('STORE_FAST', 'value', 'vehSpeedSum'),
+            )),
+    },
+    'scripts/client/ProjectileMover.pyc': {
+        'ProjectileMover.add': (
+            'visual start falls back to the reference beyond 20 metres', 2, (
+                ('LOAD_FAST', 'value', 'startPoint'),
+                ('LOAD_ATTR', 'value', 'distTo'),
+                ('LOAD_FAST', 'value', 'refStartPoint'),
+                ('CALL_FUNCTION', 'argument', 1),
+                ('LOAD_GLOBAL', 'value', 'ProjectileMover'),
+                ('LOAD_ATTR', 'value',
+                 '_ProjectileMover__START_POINT_MAX_DIFF'),
+                ('COMPARE_OP', 'argument', 4),
+                ('POP_JUMP_IF_FALSE', None, None),
+                ('LOAD_FAST', 'value', 'refStartPoint'),
+                ('STORE_FAST', 'value', 'startPoint'),
             )),
     },
     'scripts/client/AreaDestructibles.pyc': {


### PR DESCRIPTION
## Summary

- preserve click-time muzzle, direction, dispersion, and timing as the canonical worker trajectory
- start a delayed controlled-player tracer at the current on-screen HP_gunFire muzzle, matching the reviewed 0.9.22 client contract and its 20 metre fallback
- hold the visual bridge until the confirmed worker frontier catches up, then continue with the same tracer without restoring visible-client authority
- force one immediate safe projectile-progress publication after an admitted player fire intent
- pin the exact #1513 showTracer and ProjectileMover bytecode contracts in the ABI audit

## Validation

- PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -p test_*.py: 3472 tests passed
- CPython 2.7.18 source compile: 89 client files passed
- exact #1513 client ABI audit: 463 signatures, 1001 code names, 77 literals, 80 class constants, and 8 instruction patterns passed
- GitHub Actions run 33868985817 passed for the identical source tree before the direct main push was reverted

## Runtime boundary

Static validation proves the reviewed Python contract and local lifecycle. Exact Windows CN HD 0.9.22.0.1 #1513 acceptance is still required to judge the native BigWorld projectile ribbon during moving fire.