### PR TITLE
Present retail hull impulse and make stock presentation bindings observable

### DIFF
--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -1092,6 +1092,31 @@ then cancels the local Avatar's shot-wait callback; zero is not a single-shot
 sentinel and leaves the native firing extra unbounded. Remote events use the
 same finite presentation without claiming prediction.
 
+A hit vehicle also receives retail's hull shot impulse. Exact #1513
+`Vehicle.showDamageFromShot` builds the first decoded hit point's world-space
+axis from `compoundModel.node(componentName)` and calls
+`appearance.receiveShotImpulse(dir, shotEffects[effectsIndex]['targetImpulse'])`
+only inside the decoded direct-hit branch, so an HE near miss presents
+`armorSplashHit` with no hull reaction; the impulse is scaled by neither damage
+nor calibre. `CompoundAppearance.receiveShotImpulse` skips a damaged model,
+forwards to `swingingAnimator.receiveShotImpulse` without a `None` guard, and
+also forwards to `CrashedTracksController.receiveShotImpulse`, which is
+`return None` in this build. `model_assembler.createSwingingAnimator` calls
+`setupShotSwinging(hull.swinging.sensitivityToImpulse)`, and
+`vehicle_assembler._assembleSwinging` installs the animator as the HULL node's
+provider while `CompoundAppearance.__linkCompound` keeps the compound root on
+the entity matrix; this port's pose-provider swap therefore leaves the animator
+in the transform chain, and its `worldMatrix` rebind supplies the same input
+retail passes. Disassembly of the exact executable shows the native animator
+method accumulating `dir * impulse` into three floats of the animator object
+itself, reading no filter, physics body, node or model, so the only live
+requirement is a stock animator. The port keeps the engine-ownership and
+proven-rebind gates, rejects an absent animator instead of raising inside stock
+code, normalises its contact direction, and presents no impulse for a splash,
+killing or dead-target hit. Retail's companion `inputHandler.onVehicleShaken`
+camera shake is not ported. Whether the resulting rocking magnitude matches
+retail still needs exact Windows acceptance.
+
 Critical-hit calculation follows the same proposal/commit boundary. The
 firing client runs a device law derived from the retired predecessor against an
 explicit detached snapshot of the target descriptor, pose, collision

--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -1104,7 +1104,12 @@ also forwards to `CrashedTracksController.receiveShotImpulse`, which is
 `return None` in this build. `model_assembler.createSwingingAnimator` calls
 `setupShotSwinging(hull.swinging.sensitivityToImpulse)`, and
 `vehicle_assembler._assembleSwinging` installs the animator as the HULL node's
-provider while `CompoundAppearance.__linkCompound` keeps the compound root on
+provider. That assembly runs from `__assembleNonDamagedOnly` for every vehicle
+that starts a non-damaged visual, alongside `createWheelsAnimator`,
+`assembleSuspensionIfNeed`/`assembleLeveredSuspensionIfNeed` and
+`assembleSuspensionController`, so it is not limited to the player's tank and
+the port checks both suspension variants. The animator's provider role keeps it
+live while `CompoundAppearance.__linkCompound` keeps the compound root on
 the entity matrix; this port's pose-provider swap therefore leaves the animator
 in the transform chain, and its `worldMatrix` rebind supplies the same input
 retail passes. Disassembly of the exact executable shows the native animator

--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -1110,7 +1110,10 @@ in the transform chain, and its `worldMatrix` rebind supplies the same input
 retail passes. Disassembly of the exact executable shows the native animator
 method accumulating `dir * impulse` into three floats of the animator object
 itself, reading no filter, physics body, node or model, so the only live
-requirement is a stock animator. The port keeps the engine-ownership and
+requirement is a stock animator. Every vehicle definition in the pinned
+package carries `sensitivityToImpulse`, and `vehicles/common/shot_effects.xml`
+carries `targetImpulse`, so both inputs come from shipped client data rather
+than a substituted constant. The port keeps the engine-ownership and
 proven-rebind gates, rejects an absent animator instead of raising inside stock
 code, normalises its contact direction, and presents no impulse for a splash,
 killing or dead-target hit. Retail's companion `inputHandler.onVehicleShaken`

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -8534,8 +8534,44 @@ class BattleRuntime(object):
             return None
         return getattr(vehicle, 'appearance', None)
 
-    def _present_hit_impulse(self, event, target_record, direction,
-                             effects_descr):
+    def _decoded_hit_impulse_direction(self, event, target_record):
+        """Return retail's decoded armour-segment direction in world space."""
+        if 'damage_sticker' not in event:
+            return None
+        target = self._server_entity(target_record.get('engine_id'))
+        appearance = getattr(target, 'appearance', None)
+        descriptor = getattr(target, 'typeDescriptor', None)
+        compound = getattr(appearance, 'compoundModel', None)
+        if (target is None or not getattr(target, 'isStarted', False) or
+                descriptor is None or compound is None):
+            return None
+        try:
+            from VehicleEffects import DamageFromShotDecoder
+            component_name, unused_sticker, segment_start, segment_end = \
+                DamageFromShotDecoder.decodeSegment(
+                    event['damage_sticker'], descriptor)
+            if (not component_name or segment_start is None or
+                    segment_end is None or segment_start == segment_end):
+                return None
+            component_node = compound.node(component_name)
+            if component_node is None:
+                return None
+            local_direction = segment_end - segment_start
+            if local_direction.length <= 0.001:
+                return None
+            direction = self._runtime.math.Matrix(
+                component_node).applyVector(local_direction)
+            direction = self._runtime.math.Vector3(direction)
+            if direction.length <= 0.001:
+                return None
+            direction.normalise()
+            return direction
+        except Exception as error:
+            self._warn_optional_failure(
+                'vehicle hit impulse', error, disable=False)
+            return None
+
+    def _present_hit_impulse(self, event, target_record, effects_descr):
         """Present retail's hull shot impulse on one vehicle this shot hit.
 
         Retail reaches ``CompoundAppearance.receiveShotImpulse`` only inside
@@ -8553,13 +8589,24 @@ class BattleRuntime(object):
         impulse = _number(_field(effects_descr, 'targetImpulse', 0.0))
         if impulse <= 0.0:
             return False
+        direction = self._decoded_hit_impulse_direction(
+            event, target_record)
+        if direction is None:
+            return False
         if target_record.get('local'):
-            # The player's own tank is a fully stock, filter-attached entity,
-            # but nothing in this runtime routes retail's server-side
-            # showDamageFromShot to it, so it needs the same presentation.
+            # The matching local stock-animator rebind owns this capability.
+            # Until it is proven, receiveShotImpulse can write through an
+            # unrelated or stale native animator.
+            appearance = self._local_vehicle_appearance()
+            animator = getattr(self, '_local_swinging_animator', None)
+            if (animator is None or
+                    not self._optional_feature_enabled(
+                        'local body swinging') or
+                    getattr(appearance, 'swingingAnimator', None) is not
+                    animator):
+                return False
             presented = present_shot_impulse(
-                self._runtime.math, self._local_vehicle_appearance(),
-                direction, impulse)
+                self._runtime.math, appearance, direction, impulse)
         elif target_record.get('native_remote'):
             present = getattr(
                 self._remote_factory, 'present_hit_impulse', None)
@@ -8659,7 +8706,7 @@ class BattleRuntime(object):
         # failed terrain effect must not swallow the hull reaction.
         self._run_optional_feature(
             'vehicle hit impulse', self._present_hit_impulse,
-            (event, target_record, direction, effects_descr))
+            (event, target_record, effects_descr))
         # Retail presents an HE near-miss through
         # Vehicle.showDamageFromExplosion/armorSplashHit.  Direct hits keep
         # the three protocol outcomes: ricochet, resisted and pierced.

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -18143,20 +18143,29 @@ class BattleRuntime(object):
     def _report_bot_tracks(self, vehicle, left, right, mode, now):
         """Log what the scroll controller actually holds.
 
-        ``leftContact``/``rightContact`` still reading the constructor's
-        ``True`` and ``leftScroll``/``rightScroll`` still reading ``0.0`` mean
-        the controller's 20 Hz updater never ran, which is what a filter with
-        no owning entity looks like from Python.
+        ``fed`` is the authoritative belt speed this runtime computed, which
+        is not always what reaches the controller: a hidden compound is
+        settled to zero on its hide edge and an unchanged feed is
+        deduplicated.  ``wrote`` and ``outcome`` name the effective write, so
+        ``leftScroll``/``rightScroll`` reading ``0.0`` stays attributable
+        rather than looking like a native failure.  A zero readback with
+        ``outcome=engine and python`` and the constructor's ``True`` contacts
+        is the real defect: the controller's 20 Hz updater never ran, which is
+        what a filter with no owning entity looks like from Python.
         """
         if self._track_report_time is not None and (
                 now - self._track_report_time) < TRACK_REPORT_SECONDS:
             return False
         self._track_report_time = now
+        feed_state = getattr(vehicle, 'track_feed_state', None)
+        written, outcome, hidden, engine_owned = (
+            feed_state() if callable(feed_state)
+            else (None, 'unavailable', None, None))
         sys.stdout.write(
             '[Offline LAN 0.9.22] bot tracks id=%s mode=%r fed=(%.3f, %.3f) '
-            'scroll=%r error=%r\n' % (
-                vehicle.bw_entity_id, mode, left, right,
-                vehicle.track_scroll_readback(),
+            'wrote=%r outcome=%s hidden=%s engine=%s scroll=%r error=%r\n' % (
+                vehicle.bw_entity_id, mode, left, right, written, outcome,
+                hidden, engine_owned, vehicle.track_scroll_readback(),
                 self._remote_factory.track_animation_error))
         return True
 

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -29,7 +29,7 @@ from gui.mods.offline_lan_0922.entities.avatar_server import AvatarServerBridge
 from gui.mods.offline_lan_0922.entities.bigworld_binding import \
     BigWorldVehicleBinding
 from gui.mods.offline_lan_0922.entities.native_remote_vehicle import \
-    NativeRemoteVehicleFactory, set_draw_visibility
+    NativeRemoteVehicleFactory, present_shot_impulse, set_draw_visibility
 from gui.mods.offline_lan_0922.entities.remote_vehicle import (
     PROJECTILE_VISUAL_START_MAX_DIFF, RemoteVehicleFactory,
     _collide_vehicle_evidence_at_matrix,
@@ -1512,6 +1512,7 @@ class BattleRuntime(object):
         self._bot_pose_times = {}
         self._bot_yaw_rates = {}
         self._track_report_time = None
+        self._hit_impulse_reports = 0
         self._local_speed = 0.0
         self._local_turn_speed = 0.0
         self._local_drive_turn = 0.0
@@ -1799,6 +1800,7 @@ class BattleRuntime(object):
         self._bot_pose_times = {}
         self._bot_yaw_rates = {}
         self._track_report_time = None
+        self._hit_impulse_reports = 0
         self._local_speed = 0.0
         self._local_turn_speed = 0.0
         self._local_drive_turn = 0.0
@@ -8520,6 +8522,74 @@ class BattleRuntime(object):
             return False
         return True
 
+    _HIT_IMPULSE_REPORT_LIMIT = 16
+
+    def _local_vehicle_appearance(self):
+        """Return the player's own stock appearance while it is still live."""
+        lookup = getattr(self._runtime.bigworld, 'entity', None)
+        if not callable(lookup):
+            return None
+        vehicle = lookup(int(getattr(self._avatar, 'playerVehicleID', 0) or 0))
+        if vehicle is None or not bool(getattr(vehicle, 'isStarted', False)):
+            return None
+        return getattr(vehicle, 'appearance', None)
+
+    def _present_hit_impulse(self, event, target_record, direction,
+                             effects_descr):
+        """Present retail's hull shot impulse on one vehicle this shot hit.
+
+        Retail reaches ``CompoundAppearance.receiveShotImpulse`` only inside
+        ``Vehicle.showDamageFromShot``'s decoded direct-hit branch, so an HE
+        near miss presents ``armorSplashHit`` with no hull reaction at all.
+        The impulse is the shot effect group's own ``targetImpulse``: retail
+        scales it by neither damage nor calibre.
+        """
+        state = target_record.get('state') or {}
+        if event.get('splash', False) or event.get('dead', False):
+            return False
+        if not bool(state.get('alive', True)) or int(
+                state.get('health', 1) or 0) <= 0:
+            return False
+        impulse = _number(_field(effects_descr, 'targetImpulse', 0.0))
+        if impulse <= 0.0:
+            return False
+        if target_record.get('local'):
+            # The player's own tank is a fully stock, filter-attached entity,
+            # but nothing in this runtime routes retail's server-side
+            # showDamageFromShot to it, so it needs the same presentation.
+            presented = present_shot_impulse(
+                self._runtime.math, self._local_vehicle_appearance(),
+                direction, impulse)
+        elif target_record.get('native_remote'):
+            present = getattr(
+                self._remote_factory, 'present_hit_impulse', None)
+            if not callable(present):
+                return False
+            presented = present(
+                int(target_record['engine_id']), direction, impulse)
+        else:
+            # The compound-only fallback owns no stock swinging animator.
+            return False
+        self._report_hit_impulse(target_record, direction, impulse, presented)
+        return bool(presented)
+
+    def _report_hit_impulse(self, target_record, direction, impulse,
+                            presented):
+        """Log the first hull impulses of the round and their arguments."""
+        if self._hit_impulse_reports >= self._HIT_IMPULSE_REPORT_LIMIT:
+            return False
+        self._hit_impulse_reports += 1
+        sys.stdout.write(
+            '[Offline LAN 0.9.22] IMPULSE id=%s local=%s dir=(%.3f, %.3f, '
+            '%.3f) impulse=%.1f presented=%s\n' % (
+                target_record.get('engine_id'),
+                bool(target_record.get('local')),
+                _number(getattr(direction, 'x', 0.0)),
+                _number(getattr(direction, 'y', 0.0)),
+                _number(getattr(direction, 'z', 0.0)),
+                impulse, bool(presented)))
+        return True
+
     def _present_combat_hit(self, event, target_record, attacker_record,
                             attacker_id):
         """Port the mature 0.8.2 hit feedback through exact #1513 APIs."""
@@ -8585,6 +8655,11 @@ class BattleRuntime(object):
             raise RuntimeError('combat shell effects index is unavailable')
         effects_descr = self._runtime.vehicles.g_cache.shotEffects[
             effects_index]
+        # Retail rocks the hull before it spawns the armour effect, and a
+        # failed terrain effect must not swallow the hull reaction.
+        self._run_optional_feature(
+            'vehicle hit impulse', self._present_hit_impulse,
+            (event, target_record, direction, effects_descr))
         # Retail presents an HE near-miss through
         # Vehicle.showDamageFromExplosion/armorSplashHit.  Direct hits keep
         # the three protocol outcomes: ricochet, resisted and pierced.
@@ -21583,6 +21658,7 @@ class BattleRuntime(object):
         self._bot_pose_times = {}
         self._bot_yaw_rates = {}
         self._track_report_time = None
+        self._hit_impulse_reports = 0
         self._local_speed = 0.0
         self._local_turn_speed = 0.0
         self._local_drive_turn = 0.0

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/config.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/config.py
@@ -69,9 +69,11 @@ DEFAULT_CONFIG = {
     'physics_tuning': {},
     'he_tuning': {},
     'perfect_accuracy': False,
-    # Native belt animation for bots.  Off: a client-only vehicle gets no
-    # engine-owned filter, so the belts cannot turn.  See
-    # COMPATIBILITY_REVIEW.md.
+    # Belt animation for the compound-only fallback below.  Off: a
+    # client-created compound owns no engine filter, so WGVehicleFilter
+    # cannot turn its belts.  This flag does not reach the default
+    # native_remote_vehicles path, whose stock Vehicle entities always feed
+    # belt speed and engine mode.  See COMPATIBILITY_REVIEW.md.
     'bot_track_animation': False,
     # Stock remote Vehicle entities provide native wheels, suspension,
     # acceleration swing and engine audio. Copied LAN physics remains

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/entities/native_remote_vehicle.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/entities/native_remote_vehicle.py
@@ -490,7 +490,11 @@ class _NativeRemoteState(object):
 
         swinging = getattr(appearance, 'swingingAnimator', None)
         if swinging is not None:
+            restore = None
             try:
+                restore = (
+                    swinging.placingCompensationMatrix,
+                    swinging.worldMatrix)
                 # CompoundAppearance initially binds this to the entity's
                 # native filter matrices.  Our model is driven by a copied
                 # LAN MatrixAnimation whose root already contains the
@@ -502,6 +506,19 @@ class _NativeRemoteState(object):
                 swinging.worldMatrix = self.provider
                 self._record_capability('body_swinging', True)
             except Exception as error:
+                rollback_errors = []
+                if restore is not None:
+                    for name, value in (
+                            ('placingCompensationMatrix', restore[0]),
+                            ('worldMatrix', restore[1])):
+                        try:
+                            setattr(swinging, name, value)
+                        except Exception as rollback_error:
+                            rollback_errors.append('%s: %s' % (
+                                name, rollback_error))
+                if rollback_errors:
+                    error = RuntimeError('%s; rollback failed: %s' % (
+                        error, '; '.join(rollback_errors)))
                 self._record_capability('body_swinging', False, error)
         else:
             self._record_capability(

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/entities/native_remote_vehicle.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/entities/native_remote_vehicle.py
@@ -442,7 +442,15 @@ class _NativeRemoteState(object):
         self._capabilities_changed = False
         if not callable(self._capability_report):
             return False
-        return bool(self._capability_report(self))
+        try:
+            return bool(self._capability_report(self))
+        except Exception:
+            # update_tracks runs under an optional-feature guard that retires
+            # belt animation for the whole round on an exception.  A failed
+            # diagnostic write must never cost the presentation, and it
+            # cannot report its own failure, so stop reporting instead.
+            self._capability_report = None
+            return False
 
     def _read_vehicle_speed(self):
         return float(self.speed)

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/entities/native_remote_vehicle.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/entities/native_remote_vehicle.py
@@ -11,6 +11,7 @@ fallback for diagnostics and clients that cannot provide the pinned ABI.
 from __future__ import print_function
 
 import math
+import sys
 
 from gui.mods.offline_lan_0922.entities.remote_vehicle import (
     _RemoteShotPresenter, _blend_angle, _component_aim_angles,
@@ -104,8 +105,9 @@ class _NativeRemoteState(object):
 
     def __init__(self, bigworld, math_module, compatibility, data_links,
                  position, rotation, interpolate_motion=True,
-                 authority_geometry=False):
+                 authority_geometry=False, capability_report=None):
         self._bigworld = bigworld
+        self._capability_report = capability_report
         self._math = math_module
         self._compatibility = compatibility
         self._data_links = data_links
@@ -156,8 +158,11 @@ class _NativeRemoteState(object):
         self.track_mode = None
         self._track_feed = None
         self._track_feed_hidden = False
+        self.track_outcome = 'never fed'
+        self.track_written = None
         self.presentation_capabilities = {}
         self.presentation_errors = {}
+        self._capabilities_changed = False
 
     def _write_matrix(self, matrix):
         matrix.setRotateYPR((self.yaw, self.pitch, self.roll))
@@ -408,6 +413,8 @@ class _NativeRemoteState(object):
             return False
 
     def _record_capability(self, name, available, error=None):
+        if self.presentation_capabilities.get(name) is not bool(available):
+            self._capabilities_changed = True
         self.presentation_capabilities[name] = bool(available)
         if error is None:
             self.presentation_errors.pop(name, None)
@@ -419,6 +426,23 @@ class _NativeRemoteState(object):
                 self.presentation_capabilities
             entity._offlinePresentationErrors = self.presentation_errors
         return bool(available)
+
+    def _publish_capabilities(self):
+        """Report the binding outcome once each set of records is complete.
+
+        ``_bind_stock_motion`` fills five records one at a time, so reporting
+        every write would publish partial sets.  Call this at the two stable
+        points instead: after the initial rebind and after the first belt
+        write settles the engine-owned record.
+        """
+        # update_tracks reaches this on every belt write, so the steady
+        # state must cost one boolean test rather than a dict sort.
+        if not self._capabilities_changed:
+            return False
+        self._capabilities_changed = False
+        if not callable(self._capability_report):
+            return False
+        return bool(self._capability_report(self))
 
     def _read_vehicle_speed(self):
         return float(self.speed)
@@ -515,6 +539,7 @@ class _NativeRemoteState(object):
             'stock_suspension', suspension is not None,
             None if suspension is not None else
             'stock suspension is unavailable')
+        self._publish_capabilities()
         return bool(engine_ready or swinging is not None or
                     wheels is not None or suspension is not None)
 
@@ -582,6 +607,7 @@ class _NativeRemoteState(object):
         entity.settle_motion = self.settle_motion
         entity.update_tracks = self.update_tracks
         entity.track_scroll_readback = self.track_scroll_readback
+        entity.track_feed_state = self.track_feed_state
         entity.model.matrix = self.provider
         self._publish_pose()
         appearance = entity.appearance
@@ -691,6 +717,7 @@ class _NativeRemoteState(object):
     def update_tracks(self, left, right, mode):
         entity = self.entity
         if entity is None:
+            self.track_outcome = 'detached'
             return False
         if not self._engine_owns_entity():
             # Once BigWorld releases the PyEntity, even reading a component
@@ -701,9 +728,11 @@ class _NativeRemoteState(object):
             self.presentation_errors.setdefault(
                 'engine_owned_track_motion',
                 'BigWorld no longer owns the Vehicle entity')
+            self.track_outcome = 'not engine owned'
             return False
         appearance = getattr(entity, 'appearance', None)
         if appearance is None:
+            self.track_outcome = 'no appearance'
             return False
         left = float(left)
         right = float(right)
@@ -715,6 +744,9 @@ class _NativeRemoteState(object):
         hidden = not bool(getattr(entity, '_offlineNativeDrawVisible', True))
         if hidden:
             if self._track_feed_hidden:
+                # The belts are already settled behind a hidden compound, so
+                # the caller's authoritative speed is deliberately not fed.
+                self.track_outcome = 'hidden and settled'
                 return False
             self._track_feed_hidden = True
             left = 0.0
@@ -734,6 +766,7 @@ class _NativeRemoteState(object):
         feed = (round(left, 3), round(right, 3), tuple(mode),
                 left_contact, right_contact)
         if feed == self._track_feed:
+            self.track_outcome = 'deduplicated'
             return bool(self.presentation_capabilities.get(
                 'engine_owned_track_motion'))
         native_updated = False
@@ -758,6 +791,7 @@ class _NativeRemoteState(object):
             self._record_capability(
                 'engine_owned_track_motion', False,
                 'Appearance/filter ownership or movementInfo is unavailable')
+        self._publish_capabilities()
         if not hidden and mode != self.track_mode:
             appearance.changeEngineMode(mode, True)
             self.track_mode = mode
@@ -770,7 +804,24 @@ class _NativeRemoteState(object):
         # allowed to retry instead of becoming a permanent false success.
         if native_updated:
             self._track_feed = feed
+        self.track_written = (left, right)
+        self.track_outcome = ('hidden and settling' if hidden else
+                              ('engine and python' if native_updated
+                               else 'python only'))
         return bool(native_updated)
+
+    def track_feed_state(self):
+        """Report what the last belt update actually wrote, and why.
+
+        ``_update_bot_tracks`` logs the authoritative feed it computed, which
+        is not what reaches the controller on a hide edge or a deduplicated
+        sample.  Publishing the effective write and its outcome keeps a zero
+        readback attributable instead of looking like a native failure.
+        """
+        return (self.track_written, self.track_outcome,
+                bool(self._track_feed_hidden),
+                self.presentation_capabilities.get(
+                    'engine_owned_track_motion'))
 
     def track_scroll_readback(self):
         if self.track_scroll is None:
@@ -826,9 +877,32 @@ class NativeRemoteVehicleFactory(object):
         self._failed_creates = set()
         self._descriptors = {}
         self._hit_testers = {}
+        self._reported_capabilities = set()
         self.track_animation_error = None
         self._shot_presenter = _RemoteShotPresenter(
             bigworld, math_module, model_assembler, self._space_id)
+
+    def report_capabilities(self, state):
+        """Log each distinct stock presentation binding result once a round.
+
+        ``_bind_stock_motion`` records whether the stock engine audition,
+        swinging animator, LOD position, wheels animator and suspension were
+        rebound to the copied LAN pose, and ``update_tracks`` adds the
+        engine-owned belt write.  Nothing consumed those records, so a real
+        battle could not show which stock components were live.  One line per
+        distinct outcome keeps a full lineup readable.
+        """
+        capabilities = state.presentation_capabilities
+        signature = tuple(sorted(capabilities.items()))
+        if not signature or signature in self._reported_capabilities:
+            return False
+        self._reported_capabilities.add(signature)
+        errors = dict(state.presentation_errors)
+        sys.stdout.write(
+            '[Offline LAN 0.9.22] PRESENTATION %s%s\n' % (
+                ' '.join('%s=%s' % (name, value) for name, value in signature),
+                '' if not errors else ' errors=%r' % (errors,)))
+        return True
 
     def prepare_descriptor(self, descriptor):
         # Stock Vehicle.prerequisites/CompoundAppearance own BSP references.
@@ -853,7 +927,8 @@ class NativeRemoteVehicleFactory(object):
             self._bigworld, self._math, self._compatibility,
             self._data_links, position, rotation,
             interpolate_motion=self._interpolate_motion,
-            authority_geometry=self._authority_geometry)
+            authority_geometry=self._authority_geometry,
+            capability_report=self.report_capabilities)
         self._vehicles[int(entity_id)] = None
         try:
             self._binding.arena_vehicle_added(entity_id, {

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/entities/native_remote_vehicle.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/entities/native_remote_vehicle.py
@@ -45,6 +45,52 @@ def set_draw_visibility(entity, visible):
     return True
 
 
+def present_shot_impulse(math_module, appearance, direction, impulse):
+    """Feed one retail hull shot impulse through a stock CompoundAppearance.
+
+    Exact #1513 ``Vehicle.showDamageFromShot`` passes the first decoded hit
+    point's world-space axis and ``shotEffects[effectsIndex]['targetImpulse']``
+    to ``CompoundAppearance.receiveShotImpulse(dir, impulse)``.  That method
+    skips a damaged model, forwards to ``swingingAnimator.receiveShotImpulse``
+    and to ``CrashedTracksController.receiveShotImpulse``, which is a no-op in
+    this build.  The native animator method only accumulates ``dir * impulse``
+    into its own shot-swinging vector, so a live stock animator is the whole
+    requirement: it reads no filter, physics body, node or model.  Stock
+    dereferences ``swingingAnimator`` without a guard, so a missing animator
+    must be rejected here instead of raising inside stock code.
+    """
+    if appearance is None or getattr(
+            appearance, 'swingingAnimator', None) is None:
+        return False
+    receive = getattr(appearance, 'receiveShotImpulse', None)
+    if not callable(receive):
+        return False
+    try:
+        impulse = float(impulse)
+        if hasattr(direction, 'x'):
+            values = [float(direction.x), float(direction.y),
+                      float(direction.z)]
+        else:
+            values = [float(direction[index]) for index in range(3)]
+    except (AttributeError, IndexError, KeyError, TypeError, ValueError,
+            OverflowError):
+        return False
+    if impulse <= 0.0 or math.isnan(impulse) or math.isinf(impulse):
+        return False
+    if any(math.isnan(value) or math.isinf(value) for value in values):
+        return False
+    length = math.sqrt(sum(value * value for value in values))
+    if length <= 1.0e-6:
+        return False
+    # Retail's direction is a hit component's transformed unit axis and the
+    # native accumulator scales it by the impulse.  Normalise this runtime's
+    # contact direction rather than rejecting a denormalised one, so the
+    # rocking magnitude stays the retail impulse.
+    receive(math_module.Vector3(values[0] / length, values[1] / length,
+                                values[2] / length), impulse)
+    return True
+
+
 class _AimTarget(object):
 
     def __init__(self, math_module):
@@ -627,6 +673,21 @@ class _NativeRemoteState(object):
             entity._gun_pitch = raw_gun_pitch
         return True
 
+    def present_hit_impulse(self, direction, impulse):
+        """Rock the hull like retail, only while stock still owns the model."""
+        if not self._engine_owns_entity():
+            # Once BigWorld releases the PyEntity, reading ``appearance`` can
+            # already dereference freed native memory.
+            return False
+        if self.presentation_capabilities.get('body_swinging') is not True:
+            # This runtime rebinds the stock animator's world matrix to the
+            # copied LAN provider.  Without that proven rebind the animator
+            # is either absent or still swinging around a stale spawn pose.
+            return False
+        return present_shot_impulse(
+            self._math, getattr(self.entity, 'appearance', None),
+            direction, impulse)
+
     def update_tracks(self, left, right, mode):
         entity = self.entity
         if entity is None:
@@ -878,6 +939,12 @@ class NativeRemoteVehicleFactory(object):
         if state is None or state.entity is None:
             return False
         return state.update_siege_pose()
+
+    def present_hit_impulse(self, entity_id, direction, impulse):
+        state = self._states.get(int(entity_id))
+        if state is None or state.entity is None:
+            return False
+        return state.present_hit_impulse(direction, impulse)
 
     def request_wreck(self, unused_entity_id):
         # Vehicle.onHealthChanged owns stock damaged-model replacement.

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -2740,6 +2740,24 @@ class RemoteVehicleFactoryTests(unittest.TestCase):
         vehicle.appearance.receiveShotImpulse = mock.Mock()
         return runtime, factory, binding, vehicle_id, vehicle
 
+    def test_failed_capability_log_never_retires_belt_animation(self):
+        """update_tracks retires belts for the round on any exception."""
+        runtime, factory, unused_binding, vehicle_id, vehicle = \
+            self._ready_native_factory()
+        state = factory._states[vehicle_id]
+        state._capability_report = mock.Mock(
+            side_effect=IOError('python.log is unavailable'))
+        state._capabilities_changed = True
+
+        self.assertFalse(state._publish_capabilities())
+        self.assertIsNone(state._capability_report)
+        # The belt write itself still completes rather than raising into the
+        # optional-feature guard that would retire it for the round.
+        state._capability_report = mock.Mock(
+            side_effect=IOError('python.log is unavailable'))
+        vehicle.update_tracks(2.0, 3.0, (ENGINE_MODE_RUNNING, 1))
+        self.assertEqual('python only', vehicle.track_feed_state()[1])
+
     def test_bot_track_report_names_the_effective_write(self):
         runtime, factory, unused_binding, vehicle_id, vehicle = \
             self._ready_native_factory()

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -35,6 +35,8 @@ from gui.mods.offline_lan_0922.entities.bigworld_binding import \
     BigWorldVehicleBinding
 from gui.mods.offline_lan_0922.entities.native_remote_vehicle import \
     NativeRemoteVehicleFactory, _NativeRemoteState, present_shot_impulse
+from gui.mods.offline_lan_0922.entities import native_remote_vehicle as \
+    native_remote_vehicle_module
 
 
 class _Vector(object):
@@ -2518,6 +2520,65 @@ class NativeRemoteVehicleFactoryTests(unittest.TestCase):
         self.assertEqual([moving, moving], vehicle.engine_modes)
         self.assertTrue(factory.destroy(vehicle_id))
 
+    def test_hidden_belt_settle_is_reported_as_a_deliberate_zero(self):
+        """A zero readback must be attributable, not look like a failure.
+
+        The runtime logs the authoritative belt speed it computed, which is
+        not what reaches the controller once a hidden compound has been
+        settled.  Real client logs therefore showed a non-zero ``fed`` beside
+        a ``0.0`` scroll readback with no recorded cause.
+        """
+        runtime = _runtime()
+        holder = {}
+        binding = BigWorldVehicleBinding(
+            runtime.bigworld, runtime.bigworld.avatar, runtime.constants,
+            _VehicleDescr, runtime.encode_gun_angles,
+            outfit_provider=lambda unused_descriptor: '',
+            authority_entity_resolver=lambda entity_id:
+            holder['factory'].get(entity_id))
+        factory = NativeRemoteVehicleFactory(
+            runtime.bigworld, runtime.math, runtime.model_assembler, 7,
+            binding=binding, compatibility=runtime.compatibility)
+        holder['factory'] = factory
+        properties = binding.properties_from_compact_descr(
+            'ussr:R11_MS-1', 2, 'Native remote')
+        vehicle_id = factory.create(
+            _Descriptor(), properties, _Vector(), (0.0, 0.0, 0.0))
+        pending = runtime.bigworld.pending_entities[vehicle_id]
+        pending.filter.movementInfo = object()
+        pending.filter.setTracksSpeed = mock.Mock()
+        pending.appearance.filter = pending.filter
+        pending.appearance.flyingInfoProvider = types.SimpleNamespace(
+            isLeftSideFlying=False, isRightSideFlying=False)
+        runtime.bigworld.enter_pending_vehicle(vehicle_id)
+        self.assertTrue(factory.is_ready(vehicle_id))
+        vehicle = factory.get(vehicle_id)
+        moving = (ENGINE_MODE_RUNNING, 1)
+
+        self.assertTrue(vehicle.update_tracks(2.0, 3.0, moving))
+        self.assertEqual(
+            ((2.0, 3.0), 'engine and python', False, True),
+            vehicle.track_feed_state())
+        # An unchanged feed keeps reporting the engine-owned write it made.
+        self.assertTrue(vehicle.update_tracks(2.0, 3.0, moving))
+        self.assertEqual('deduplicated', vehicle.track_feed_state()[1])
+
+        vehicle._offlineNativeDrawVisible = False
+        self.assertTrue(vehicle.update_tracks(9.4, 9.4, moving))
+        self.assertEqual(
+            ((0.0, 0.0), 'hidden and settling', True, True),
+            vehicle.track_feed_state())
+        # This is the shape the real client logged: a live authoritative feed
+        # whose effective write is the deliberate hide-edge zero.
+        self.assertFalse(vehicle.update_tracks(9.4, 9.4, moving))
+        self.assertEqual(
+            ((0.0, 0.0), 'hidden and settled', True, True),
+            vehicle.track_feed_state())
+
+        runtime.bigworld.entities.pop(vehicle_id)
+        self.assertFalse(vehicle.update_tracks(9.4, 9.4, moving))
+        self.assertEqual('not engine owned', vehicle.track_feed_state()[1])
+
     def test_guest_native_vehicle_uses_one_stable_pose_matrix(self):
         runtime = _runtime()
         holder = {}
@@ -2678,6 +2739,84 @@ class RemoteVehicleFactoryTests(unittest.TestCase):
         vehicle.appearance.swingingAnimator = types.SimpleNamespace()
         vehicle.appearance.receiveShotImpulse = mock.Mock()
         return runtime, factory, binding, vehicle_id, vehicle
+
+    def test_bot_track_report_names_the_effective_write(self):
+        runtime, factory, unused_binding, vehicle_id, vehicle = \
+            self._ready_native_factory()
+        battle = BattleRuntime(runtime)
+        battle._remote_factory = factory
+        vehicle.update_tracks(2.0, 3.0, (ENGINE_MODE_RUNNING, 1))
+        stream = io.StringIO()
+
+        with mock.patch.object(battle_runtime_module.sys, 'stdout', stream):
+            self.assertTrue(battle._report_bot_tracks(
+                vehicle, 9.4, 9.4, (ENGINE_MODE_RUNNING, 1), 1.0))
+            self.assertFalse(battle._report_bot_tracks(
+                vehicle, 9.4, 9.4, (ENGINE_MODE_RUNNING, 1), 2.0))
+
+        line = stream.getvalue()
+        self.assertIn('fed=(9.400, 9.400)', line)
+        self.assertIn('wrote=(2.0, 3.0)', line)
+        self.assertIn('outcome=python only', line)
+        self.assertIn('hidden=False', line)
+
+    def test_stock_presentation_bindings_are_reported_once_per_outcome(self):
+        """One battle must show which stock components were actually bound.
+
+        ``_bind_stock_motion`` recorded the engine audition, swinging
+        animator, LOD position, wheels and suspension results and nothing
+        consumed them, so a real client log could not distinguish a rebound
+        stock component from a missing one.
+        """
+        runtime = _runtime()
+        holder = {}
+        binding = BigWorldVehicleBinding(
+            runtime.bigworld, runtime.bigworld.avatar, runtime.constants,
+            _VehicleDescr, runtime.encode_gun_angles,
+            outfit_provider=lambda unused_descriptor: '',
+            authority_entity_resolver=lambda entity_id:
+            holder['factory'].get(entity_id))
+        factory = NativeRemoteVehicleFactory(
+            runtime.bigworld, runtime.math, runtime.model_assembler, 7,
+            binding=binding, compatibility=runtime.compatibility)
+        holder['factory'] = factory
+        properties = binding.properties_from_compact_descr(
+            'ussr:R11_MS-1', 2, 'Native remote')
+        identifiers = []
+        for unused_index in range(2):
+            vehicle_id = factory.create(
+                _Descriptor(), properties, _Vector(), (0.0, 0.0, 0.0))
+            pending = runtime.bigworld.pending_entities[vehicle_id]
+            pending.filter.movementInfo = object()
+            pending.filter.setTracksSpeed = mock.Mock()
+            pending.appearance.filter = pending.filter
+            pending.appearance.flyingInfoProvider = types.SimpleNamespace(
+                isLeftSideFlying=False, isRightSideFlying=False)
+            pending.appearance.swingingAnimator = types.SimpleNamespace(
+                worldMatrix=None, placingCompensationMatrix=None)
+            runtime.bigworld.enter_pending_vehicle(vehicle_id)
+            identifiers.append(vehicle_id)
+        stream = io.StringIO()
+
+        with mock.patch.object(
+                native_remote_vehicle_module.sys, 'stdout', stream):
+            for vehicle_id in identifiers:
+                self.assertTrue(factory.is_ready(vehicle_id))
+            # The engine-owned belt record only exists after the first write,
+            # so it is the second stable reporting point.
+            self.assertTrue(factory.get(identifiers[0]).update_tracks(
+                2.0, 3.0, (ENGINE_MODE_RUNNING, 1)))
+            self.assertTrue(factory.get(identifiers[1]).update_tracks(
+                2.0, 3.0, (ENGINE_MODE_RUNNING, 1)))
+
+        lines = stream.getvalue().strip().splitlines()
+        # Two Bots with one shared outcome publish one line per stable point.
+        self.assertEqual(2, len(lines))
+        self.assertIn('body_swinging=True', lines[0])
+        self.assertIn('stock_wheels=False', lines[0])
+        self.assertNotIn('engine_owned_track_motion', lines[0])
+        self.assertIn('WheelsAnimator is unavailable', lines[0])
+        self.assertIn('engine_owned_track_motion=True', lines[1])
 
     def test_shot_impulse_normalises_direction_and_keeps_retail_impulse(self):
         appearance = types.SimpleNamespace(

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -2910,6 +2910,34 @@ class RemoteVehicleFactoryTests(unittest.TestCase):
             vehicle_id, _Vector(0.0, 0.0, 1.0), 350.0))
         self.assertEqual(1, vehicle.appearance.receiveShotImpulse.call_count)
 
+    def test_remote_swinging_second_setter_failure_rolls_back_first(self):
+        runtime, factory, unused_binding, vehicle_id, vehicle = \
+            self._ready_native_factory()
+        state = factory._states[vehicle_id]
+        native_compensation = object()
+        native_world = object()
+
+        class _FailingWorldAnimator(object):
+            def __init__(self):
+                object.__setattr__(
+                    self, 'placingCompensationMatrix', native_compensation)
+                object.__setattr__(self, 'worldMatrix', native_world)
+
+            def __setattr__(self, name, value):
+                if name == 'worldMatrix' and value is state.provider:
+                    raise RuntimeError('world provider rejected')
+                object.__setattr__(self, name, value)
+
+        swinging = _FailingWorldAnimator()
+        vehicle.appearance.swingingAnimator = swinging
+
+        state._bind_stock_motion()
+
+        self.assertIs(
+            native_compensation, swinging.placingCompensationMatrix)
+        self.assertIs(native_world, swinging.worldMatrix)
+        self.assertFalse(state.presentation_capabilities['body_swinging'])
+
     def test_direct_hit_uses_decoded_armour_axis_for_remote_impulse(self):
         runtime, factory, unused_binding, vehicle_id, vehicle = \
             self._swinging_native_factory()

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -34,7 +34,7 @@ from gui.mods.offline_lan_0922.entities import remote_vehicle as \
 from gui.mods.offline_lan_0922.entities.bigworld_binding import \
     BigWorldVehicleBinding
 from gui.mods.offline_lan_0922.entities.native_remote_vehicle import \
-    NativeRemoteVehicleFactory, _NativeRemoteState
+    NativeRemoteVehicleFactory, _NativeRemoteState, present_shot_impulse
 
 
 class _Vector(object):
@@ -2669,6 +2669,215 @@ class RemoteVehicleFactoryTests(unittest.TestCase):
         runtime.bigworld.enter_pending_vehicle(vehicle_id)
         self.assertTrue(factory.is_ready(vehicle_id))
         return runtime, factory, binding, vehicle_id, factory.get(vehicle_id)
+
+    def _swinging_native_factory(self):
+        runtime, factory, binding, vehicle_id, vehicle = \
+            self._ready_native_factory()
+        state = factory._states[vehicle_id]
+        state.presentation_capabilities['body_swinging'] = True
+        vehicle.appearance.swingingAnimator = types.SimpleNamespace()
+        vehicle.appearance.receiveShotImpulse = mock.Mock()
+        return runtime, factory, binding, vehicle_id, vehicle
+
+    def test_shot_impulse_normalises_direction_and_keeps_retail_impulse(self):
+        appearance = types.SimpleNamespace(
+            swingingAnimator=types.SimpleNamespace(),
+            receiveShotImpulse=mock.Mock())
+
+        self.assertTrue(present_shot_impulse(
+            types.SimpleNamespace(Vector3=_Vector), appearance,
+            _Vector(0.0, 0.0, 4.0), 350.0))
+
+        direction, impulse = appearance.receiveShotImpulse.call_args.args
+        self.assertEqual((0.0, 0.0, 1.0), tuple(direction))
+        self.assertEqual(350.0, impulse)
+
+    def test_shot_impulse_rejects_every_unusable_native_argument(self):
+        animator = types.SimpleNamespace()
+        math_module = types.SimpleNamespace(Vector3=_Vector)
+        receive = mock.Mock()
+        appearance = types.SimpleNamespace(
+            swingingAnimator=animator, receiveShotImpulse=receive)
+
+        self.assertFalse(present_shot_impulse(
+            math_module, None, _Vector(0.0, 0.0, 1.0), 350.0))
+        # Stock receiveShotImpulse dereferences swingingAnimator without a
+        # guard, so a missing animator must never reach it.
+        self.assertFalse(present_shot_impulse(
+            math_module, types.SimpleNamespace(
+                swingingAnimator=None, receiveShotImpulse=receive),
+            _Vector(0.0, 0.0, 1.0), 350.0))
+        self.assertFalse(present_shot_impulse(
+            math_module, types.SimpleNamespace(swingingAnimator=animator),
+            _Vector(0.0, 0.0, 1.0), 350.0))
+        for impulse in (0.0, -1.0, float('nan'), float('inf'), 'x'):
+            self.assertFalse(present_shot_impulse(
+                math_module, appearance, _Vector(0.0, 0.0, 1.0), impulse))
+        for direction in (_Vector(0.0, 0.0, 0.0),
+                          _Vector(float('nan'), 0.0, 1.0),
+                          _Vector(float('inf'), 0.0, 1.0),
+                          (0.0, 1.0), None):
+            self.assertFalse(present_shot_impulse(
+                math_module, appearance, direction, 350.0))
+        receive.assert_not_called()
+
+        # A plain three-element sequence is accepted for callers that never
+        # built a Math.Vector3.
+        self.assertTrue(present_shot_impulse(
+            math_module, appearance, (0.0, 3.0, 0.0), 120.0))
+        self.assertEqual(
+            (0.0, 1.0, 0.0),
+            tuple(receive.call_args.args[0]))
+
+    def test_native_hit_impulse_needs_proven_swinging_and_live_owner(self):
+        runtime, factory, unused_binding, vehicle_id, vehicle = \
+            self._ready_native_factory()
+        state = factory._states[vehicle_id]
+        vehicle.appearance.swingingAnimator = types.SimpleNamespace()
+        vehicle.appearance.receiveShotImpulse = mock.Mock()
+
+        # _bind_stock_motion never proved the rebind for this fake appearance.
+        self.assertFalse(factory.present_hit_impulse(
+            vehicle_id, _Vector(0.0, 0.0, 1.0), 350.0))
+        state.presentation_capabilities['body_swinging'] = True
+        self.assertTrue(factory.present_hit_impulse(
+            vehicle_id, _Vector(0.0, 0.0, 1.0), 350.0))
+        self.assertFalse(factory.present_hit_impulse(
+            vehicle_id + 5000, _Vector(0.0, 0.0, 1.0), 350.0))
+
+        runtime.bigworld.entities.pop(vehicle_id)
+        self.assertFalse(factory.present_hit_impulse(
+            vehicle_id, _Vector(0.0, 0.0, 1.0), 350.0))
+        self.assertEqual(1, vehicle.appearance.receiveShotImpulse.call_count)
+
+    def test_direct_hit_rocks_the_native_remote_hull_before_the_effect(self):
+        runtime, factory, unused_binding, vehicle_id, vehicle = \
+            self._swinging_native_factory()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        battle._remote_factory = factory
+        battle._local_position = (0.0, 0.0, 0.0)
+        runtime.vehicles.g_cache.shotEffects[3]['targetImpulse'] = 350.0
+        attacker = _Vehicle(11, _Descriptor(), _Vector(0.0, 0.0, 0.0),
+                            (0, 0, 0), {'health': 500})
+        runtime.bigworld.entities[11] = attacker
+        target_record = {
+            'engine_id': vehicle_id, 'local': False, 'native_remote': True,
+            'spot_visible': True, 'kind': 'bot', 'network_id': 2,
+            'state': {'team': 2, 'health': 500, 'alive': True,
+                      'x': 0.0, 'y': 0.0, 'z': 30.0}}
+        attacker_record = {
+            'engine_id': 11, 'local': True, 'kind': 'player',
+            'network_id': 1,
+            'state': {'team': 1, 'health': 500,
+                      'x': 0.0, 'y': 0.0, 'z': 0.0}}
+        event = {
+            'kind': 'bot_hit', 'world_pose': True, 'source': 'shot',
+            'x': 0.0, 'y': 1.0, 'z': 29.0, 'shell_index': 0,
+            'shot_result': 2, 'damage': 144}
+
+        self.assertTrue(battle._present_combat_hit(
+            event, target_record, attacker_record, 11))
+
+        direction, impulse = \
+            vehicle.appearance.receiveShotImpulse.call_args.args
+        self.assertEqual(350.0, impulse)
+        # Retail's direction points from the shooter into the armour plate.
+        self.assertAlmostEqual(1.0, direction.z)
+        self.assertAlmostEqual(0.0, direction.x)
+
+    def test_hull_impulse_survives_a_failed_terrain_effect(self):
+        runtime, factory, unused_binding, vehicle_id, vehicle = \
+            self._swinging_native_factory()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        battle._remote_factory = factory
+        battle._local_position = (0.0, 0.0, 0.0)
+        runtime.vehicles.g_cache.shotEffects[3]['targetImpulse'] = 350.0
+        runtime.bigworld.entities[11] = _Vehicle(
+            11, _Descriptor(), _Vector(), (0, 0, 0), {'health': 500})
+        battle._avatar.terrainEffects.addNew.side_effect = RuntimeError(
+            'native impact failed')
+        target_record = {
+            'engine_id': vehicle_id, 'local': False, 'native_remote': True,
+            'spot_visible': True, 'kind': 'bot', 'network_id': 2,
+            'state': {'team': 2, 'health': 500, 'alive': True,
+                      'x': 0.0, 'y': 0.0, 'z': 30.0}}
+        attacker_record = {
+            'engine_id': 11, 'local': True, 'kind': 'player',
+            'network_id': 1,
+            'state': {'team': 1, 'health': 500,
+                      'x': 0.0, 'y': 0.0, 'z': 0.0}}
+        event = {
+            'kind': 'bot_hit', 'world_pose': True, 'source': 'shot',
+            'x': 0.0, 'y': 1.0, 'z': 29.0, 'shell_index': 0,
+            'shot_result': 2, 'damage': 144}
+
+        self.assertFalse(battle._present_combat_hit(
+            event, target_record, attacker_record, 11))
+
+        vehicle.appearance.receiveShotImpulse.assert_called_once()
+        self.assertIn(
+            'projectile impact presentation',
+            battle._disabled_optional_features)
+        self.assertNotIn(
+            'vehicle hit impulse', battle._disabled_optional_features)
+
+    def test_splash_and_killing_hits_present_no_retail_hull_impulse(self):
+        runtime, factory, unused_binding, vehicle_id, vehicle = \
+            self._swinging_native_factory()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        battle._remote_factory = factory
+        runtime.vehicles.g_cache.shotEffects[3]['targetImpulse'] = 350.0
+        target_record = {
+            'engine_id': vehicle_id, 'local': False, 'native_remote': True,
+            'spot_visible': True, 'state': {'health': 500, 'alive': True}}
+        effects_descr = runtime.vehicles.g_cache.shotEffects[3]
+        direction = _Vector(0.0, 0.0, 1.0)
+
+        self.assertFalse(battle._present_hit_impulse(
+            {'splash': True}, target_record, direction, effects_descr))
+        self.assertFalse(battle._present_hit_impulse(
+            {'dead': True}, target_record, direction, effects_descr))
+        self.assertFalse(battle._present_hit_impulse(
+            {}, dict(target_record, state={'health': 0, 'alive': False}),
+            direction, effects_descr))
+        self.assertFalse(battle._present_hit_impulse(
+            {}, dict(target_record, native_remote=False),
+            direction, effects_descr))
+        self.assertFalse(battle._present_hit_impulse(
+            {}, target_record, direction, {}))
+        vehicle.appearance.receiveShotImpulse.assert_not_called()
+
+        self.assertTrue(battle._present_hit_impulse(
+            {}, target_record, direction, effects_descr))
+
+    def test_local_victim_hull_receives_the_same_retail_impulse(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        runtime.vehicles.g_cache.shotEffects[3]['targetImpulse'] = 350.0
+        target = _Vehicle(10, _Descriptor(), _Vector(), (0, 0, 0),
+                          {'health': 500})
+        target.appearance.swingingAnimator = types.SimpleNamespace()
+        target.appearance.receiveShotImpulse = mock.Mock()
+        runtime.bigworld.entities[10] = target
+        battle._avatar.playerVehicleID = 10
+        target_record = {
+            'engine_id': 10, 'local': True,
+            'state': {'health': 500, 'alive': True}}
+        effects_descr = runtime.vehicles.g_cache.shotEffects[3]
+
+        self.assertTrue(battle._present_hit_impulse(
+            {}, target_record, _Vector(0.0, 0.0, 1.0), effects_descr))
+
+        target.appearance.receiveShotImpulse.assert_called_once()
+        target.isStarted = False
+        self.assertFalse(battle._present_hit_impulse(
+            {}, target_record, _Vector(0.0, 0.0, 1.0), effects_descr))
+        self.assertEqual(
+            1, target.appearance.receiveShotImpulse.call_count)
 
     def test_sticker_owner_survives_failed_native_detach(self):
         runtime = _runtime()

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -163,6 +163,9 @@ class _Matrix(object):
         value = _Vector(value)
         return value + self.translation
 
+    def applyVector(self, value):
+        return _Vector(value)
+
 
 class _YawMatrix(_Matrix):
     """Rigid yaw transform for visible-pose collision regression tests."""
@@ -2907,7 +2910,7 @@ class RemoteVehicleFactoryTests(unittest.TestCase):
             vehicle_id, _Vector(0.0, 0.0, 1.0), 350.0))
         self.assertEqual(1, vehicle.appearance.receiveShotImpulse.call_count)
 
-    def test_direct_hit_rocks_the_native_remote_hull_before_the_effect(self):
+    def test_direct_hit_uses_decoded_armour_axis_for_remote_impulse(self):
         runtime, factory, unused_binding, vehicle_id, vehicle = \
             self._swinging_native_factory()
         battle = BattleRuntime(runtime)
@@ -2931,17 +2934,24 @@ class RemoteVehicleFactoryTests(unittest.TestCase):
         event = {
             'kind': 'bot_hit', 'world_pose': True, 'source': 'shot',
             'x': 0.0, 'y': 1.0, 'z': 29.0, 'shell_index': 0,
-            'shot_result': 2, 'damage': 144}
+            'shot_result': 2, 'damage': 144, 'damage_sticker': 123}
+        decoder = types.SimpleNamespace(decodeSegment=mock.Mock(
+            return_value=(
+                'hull', 29, _Vector(-2.0, 0.0, 0.0),
+                _Vector(2.0, 0.0, 0.0))))
 
-        self.assertTrue(battle._present_combat_hit(
-            event, target_record, attacker_record, 11))
+        with mock.patch.dict(sys.modules, {
+                'VehicleEffects': types.SimpleNamespace(
+                    DamageFromShotDecoder=decoder)}):
+            self.assertTrue(battle._present_combat_hit(
+                event, target_record, attacker_record, 11))
 
         direction, impulse = \
             vehicle.appearance.receiveShotImpulse.call_args.args
         self.assertEqual(350.0, impulse)
-        # Retail's direction points from the shooter into the armour plate.
-        self.assertAlmostEqual(1.0, direction.z)
-        self.assertAlmostEqual(0.0, direction.x)
+        # The decoded plate ray is independent of the centre-to-centre line.
+        self.assertAlmostEqual(0.0, direction.z)
+        self.assertAlmostEqual(1.0, direction.x)
 
     def test_hull_impulse_survives_a_failed_terrain_effect(self):
         runtime, factory, unused_binding, vehicle_id, vehicle = \
@@ -2968,10 +2978,17 @@ class RemoteVehicleFactoryTests(unittest.TestCase):
         event = {
             'kind': 'bot_hit', 'world_pose': True, 'source': 'shot',
             'x': 0.0, 'y': 1.0, 'z': 29.0, 'shell_index': 0,
-            'shot_result': 2, 'damage': 144}
+            'shot_result': 2, 'damage': 144, 'damage_sticker': 123}
+        decoder = types.SimpleNamespace(decodeSegment=mock.Mock(
+            return_value=(
+                'hull', 29, _Vector(0.0, 0.0, -1.0),
+                _Vector(0.0, 0.0, 1.0))))
 
-        self.assertFalse(battle._present_combat_hit(
-            event, target_record, attacker_record, 11))
+        with mock.patch.dict(sys.modules, {
+                'VehicleEffects': types.SimpleNamespace(
+                    DamageFromShotDecoder=decoder)}):
+            self.assertFalse(battle._present_combat_hit(
+                event, target_record, attacker_record, 11))
 
         vehicle.appearance.receiveShotImpulse.assert_called_once()
         self.assertIn(
@@ -2991,24 +3008,34 @@ class RemoteVehicleFactoryTests(unittest.TestCase):
             'engine_id': vehicle_id, 'local': False, 'native_remote': True,
             'spot_visible': True, 'state': {'health': 500, 'alive': True}}
         effects_descr = runtime.vehicles.g_cache.shotEffects[3]
-        direction = _Vector(0.0, 0.0, 1.0)
 
         self.assertFalse(battle._present_hit_impulse(
-            {'splash': True}, target_record, direction, effects_descr))
+            {'splash': True}, target_record, effects_descr))
         self.assertFalse(battle._present_hit_impulse(
-            {'dead': True}, target_record, direction, effects_descr))
+            {'dead': True}, target_record, effects_descr))
         self.assertFalse(battle._present_hit_impulse(
             {}, dict(target_record, state={'health': 0, 'alive': False}),
-            direction, effects_descr))
+            effects_descr))
         self.assertFalse(battle._present_hit_impulse(
             {}, dict(target_record, native_remote=False),
-            direction, effects_descr))
+            effects_descr))
         self.assertFalse(battle._present_hit_impulse(
-            {}, target_record, direction, {}))
+            {}, target_record, {}))
         vehicle.appearance.receiveShotImpulse.assert_not_called()
 
-        self.assertTrue(battle._present_hit_impulse(
-            {}, target_record, direction, effects_descr))
+        # A hit without the exact decoded direct-hit segment must not invent
+        # an impulse direction from vehicle centres.
+        self.assertFalse(battle._present_hit_impulse(
+            {}, target_record, effects_descr))
+        decoder = types.SimpleNamespace(decodeSegment=mock.Mock(
+            return_value=(
+                'hull', 29, _Vector(0.0, 0.0, -1.0),
+                _Vector(0.0, 0.0, 1.0))))
+        with mock.patch.dict(sys.modules, {
+                'VehicleEffects': types.SimpleNamespace(
+                    DamageFromShotDecoder=decoder)}):
+            self.assertTrue(battle._present_hit_impulse(
+                {'damage_sticker': 123}, target_record, effects_descr))
 
     def test_local_victim_hull_receives_the_same_retail_impulse(self):
         runtime = _runtime()
@@ -3026,13 +3053,31 @@ class RemoteVehicleFactoryTests(unittest.TestCase):
             'state': {'health': 500, 'alive': True}}
         effects_descr = runtime.vehicles.g_cache.shotEffects[3]
 
-        self.assertTrue(battle._present_hit_impulse(
-            {}, target_record, _Vector(0.0, 0.0, 1.0), effects_descr))
+        event = {'damage_sticker': 123}
+        decoder = types.SimpleNamespace(decodeSegment=mock.Mock(
+            return_value=(
+                'hull', 29, _Vector(0.0, 0.0, -1.0),
+                _Vector(0.0, 0.0, 1.0))))
+
+        # PR #45 alone has not rebound the local stock animator and must skip
+        # the native call.  PR #46 establishes this exact ownership proof.
+        with mock.patch.dict(sys.modules, {
+                'VehicleEffects': types.SimpleNamespace(
+                    DamageFromShotDecoder=decoder)}):
+            self.assertFalse(battle._present_hit_impulse(
+                event, target_record, effects_descr))
+            battle._local_swinging_animator = \
+                target.appearance.swingingAnimator
+            self.assertTrue(battle._present_hit_impulse(
+                event, target_record, effects_descr))
 
         target.appearance.receiveShotImpulse.assert_called_once()
         target.isStarted = False
-        self.assertFalse(battle._present_hit_impulse(
-            {}, target_record, _Vector(0.0, 0.0, 1.0), effects_descr))
+        with mock.patch.dict(sys.modules, {
+                'VehicleEffects': types.SimpleNamespace(
+                    DamageFromShotDecoder=decoder)}):
+            self.assertFalse(battle._present_hit_impulse(
+                event, target_record, effects_descr))
         self.assertEqual(
             1, target.appearance.receiveShotImpulse.call_count)
 


### PR DESCRIPTION
## Summary

Roadmap item #4 (visible-client presentation fidelity). Three of its four questions turned out to be answerable from Peng's existing Windows logs plus the pinned `scripts.pkg` and `WorldOfTanks.exe`, so this branch fixes what the evidence showed and instruments what still needs one battle.

- **Hull shot impulse.** A vehicle hit by a shot showed no hull reaction. Retail rocks it, for Bots and for the player's own tank, and nothing in this runtime reached that call. Added behind the engine-ownership and proven-rebind gates, running before the terrain effect so a failed effect cannot swallow the reaction.
- **Presentation bindings are now observable.** `_bind_stock_motion` recorded whether the stock engine audition, swinging animator, LOD position, wheels animator and suspension were rebound to the copied LAN pose. Nothing read those records, so a real battle could not show which stock components were live. One `PRESENTATION` line per distinct outcome, at the two points where a record set is complete.
- **Truthful belt reporting.** The belt report logged the authoritative feed, not the effective write, so 123 of 1777 samples in real logs showed a live feed beside a `0.0` scroll readback with no recorded cause. That shape is the deliberate hide-edge settle. The report now names the effective write and its outcome.
- **Stale config comment.** `bot_track_animation` claimed belts cannot turn while it is off. It only reaches the compound-only fallback factory; native remote Vehicle entities always feed belts, which the real logs confirm at the shipped `False`.

## #1513 evidence for the new native boundary

Read from the pinned `scripts.pkg` and `WorldOfTanks.exe`:

- `Vehicle.showDamageFromShot` builds the first decoded hit point's world-space axis from `compoundModel.node(componentName)` and calls `appearance.receiveShotImpulse(dir, shotEffects[effectsIndex]['targetImpulse'])`, scaled by neither damage nor calibre, only inside the decoded direct-hit branch.
- `CompoundAppearance.receiveShotImpulse` skips a damaged model, forwards to `swingingAnimator.receiveShotImpulse` with no `None` guard, and also to `CrashedTracksController.receiveShotImpulse`, which is `return None` in this build.
- `vehicle_assembler.__assembleNonDamagedOnly` assembles the swinging animator, wheels animator, either suspension variant and the suspension controller for every vehicle that starts a non-damaged visual, so this is not limited to the player's tank.
- `_assembleSwinging` installs the animator as the HULL node's provider while `CompoundAppearance.__linkCompound` keeps the compound root on the entity matrix, so this port's pose-provider swap leaves the animator in the transform chain and its `worldMatrix` rebind supplies the same input retail passes.
- The native animator method accumulates `dir * impulse` into three floats of the animator object itself. It reads no filter, physics body, node or model, so a live stock animator is the whole requirement.
- Every vehicle definition in the package carries `sensitivityToImpulse` and `vehicles/common/shot_effects.xml` carries `targetImpulse`, so both inputs come from shipped client data.

This supersedes draft #12, whose native-risk note predates the disassembly and whose branch predates the flattened layout.

## Validation

- CPython 2.7 source compile: 89 client files
- `tests/test_port_0922_battle_runtime.py`: 714 passed
- full client suite: 3485 passed; launcher suite: 480 passed
- `git diff --check`

## What still needs one Windows battle

- Whether `body_swinging`, `stock_wheels` and `stock_suspension` read `True` in the new `PRESENTATION` line.
- Whether the rocking magnitude feels retail. The bounded `IMPULSE` report names the direction and impulse of the first calls of the round.
- Whether wheels conform on slopes. No log can answer that one.

Retail's companion `inputHandler.onVehicleShaken` camera shake is not ported: it is a different ABI surface across the arcade, sniper, strategic and postmortem control modes, and keeping one new mechanism per battle keeps attribution clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)