### PR TITLE
Relink the player's stock body swinging to the copied pose

### DIFF
--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -1125,6 +1125,25 @@ killing or dead-target hit. Retail's companion `inputHandler.onVehicleShaken`
 camera shake is not ported. Whether the resulting rocking magnitude matches
 retail still needs exact Windows acceptance.
 
+The same animator needs that rebind on the player's own tank.
+`CompoundAppearance.activate` is the only stock writer of
+`swingingAnimator.placingCompensationMatrix` and `swingingAnimator.worldMatrix`
+in the pinned package: it copies the compensation off the native vehicle filter
+and links the animator to the compound root's matrix provider object that
+exists at that moment. This port replaces that root with the copied pose after
+the native lifecycle completes, so both stock links go stale on the player
+vehicle exactly as they do on a native remote. The port repeats the same two
+writes against the live provider, with an identity compensation because the
+copied pose already carries authoritative terrain pitch and roll, restores the
+stock pair when it detaches, and re-asserts the pair only when the animator
+object itself changed. `__prepareSystemsForDamagedVehicle` clears
+`swingingAnimator`, so a missing animator is a normal damaged-model state and
+is recorded rather than raised. No stock Python code in the package writes
+`accelSwingingDirection`, and this build's `changeEngineMode` no longer arms
+acceleration swing; `stopSwinging` is the only remaining Python writer of
+`accelSwingingPeriod`. Which owner arms that swing in #1513 is unresolved and
+is not ported here.
+
 Critical-hit calculation follows the same proposal/commit boundary. The
 firing client runs a device law derived from the retired predecessor against an
 explicit detached snapshot of the target descriptor, pose, collision

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -1556,6 +1556,10 @@ class BattleRuntime(object):
         self._local_siege_aim_world_matrix = None
         self._local_siege_aim_pitch = 0.0
         self._local_model = None
+        self._local_swinging_animator = None
+        self._local_swinging_restore = None
+        self._local_placing_compensation = None
+        self._local_swinging_report = None
         self._local_native_matrix = None
         self._local_native_stabilised_matrix = None
         self._local_camera_velocity = None
@@ -1840,6 +1844,10 @@ class BattleRuntime(object):
         self._local_siege_aim_world_matrix = None
         self._local_siege_aim_pitch = 0.0
         self._local_model = None
+        self._local_swinging_animator = None
+        self._local_swinging_restore = None
+        self._local_placing_compensation = None
+        self._local_swinging_report = None
         self._local_native_matrix = None
         self._local_native_stabilised_matrix = None
         self._local_camera_velocity = None
@@ -5555,9 +5563,99 @@ class BattleRuntime(object):
         if model is None:
             raise RuntimeError('player compound model is unavailable')
         model.matrix = self._local_body_pose()
+        self._bind_local_body_swinging(entity, model)
         self._runtime.compatibility.bind_vehicle_pose_sources(
             self._avatar, entity)
         self._local_model = model
+        return True
+
+    def _report_local_body_swinging(self, available, error=None):
+        """Publish one line per distinct player body-swinging outcome."""
+        record = (bool(available), None if error is None else str(error))
+        if record == self._local_swinging_report:
+            return False
+        self._local_swinging_report = record
+        sys.stdout.write(
+            '[Offline LAN 0.9.22] PRESENTATION local_body_swinging=%s%s\n' % (
+                record[0],
+                '' if record[1] is None else ' error=%r' % (record[1],)))
+        return True
+
+    def _bind_local_body_swinging(self, entity, model):
+        """Rebind the player's stock SwingingAnimator to the copied pose.
+
+        Exact #1513 ``CompoundAppearance.activate`` is the only stock writer of
+        ``swingingAnimator.placingCompensationMatrix`` and ``worldMatrix``: it
+        copies the compensation off the native vehicle filter and links the
+        animator to the compound root's matrix *provider object* that exists at
+        that moment.  This port swaps that root onto the copied LAN pose after
+        the native lifecycle completes, so the animator keeps swinging around a
+        filter placement this vehicle no longer follows and reads a provider
+        the compound no longer uses.  Repeat the same two stock writes against
+        the live provider, with an identity compensation because the copied
+        pose already carries authoritative terrain pitch and roll.
+
+        ``CompoundAppearance.__prepareSystemsForDamagedVehicle`` drops the
+        animator, so a missing one is a normal state rather than a failure.
+        This is presentation only: it never feeds authoritative motion.
+        """
+        appearance = getattr(entity, 'appearance', None)
+        swinging = getattr(appearance, 'swingingAnimator', None)
+        if swinging is None:
+            self._local_swinging_animator = None
+            self._local_swinging_restore = None
+            self._report_local_body_swinging(
+                False, 'stock SwingingAnimator is unavailable')
+            return False
+        if swinging is self._local_swinging_animator:
+            return True
+        # Only a rebind reads the compound provider, so the steady state costs
+        # the two attribute reads above and one identity test.
+        provider = getattr(model, 'matrix', None)
+        if provider is None:
+            self._local_swinging_animator = None
+            self._local_swinging_restore = None
+            self._report_local_body_swinging(
+                False, 'player compound model has no matrix provider')
+            return False
+        if self._local_placing_compensation is None:
+            compensation = self._runtime.math.Matrix()
+            compensation.setIdentity()
+            self._local_placing_compensation = compensation
+        try:
+            restore = (
+                swinging,
+                getattr(swinging, 'placingCompensationMatrix', None),
+                getattr(swinging, 'worldMatrix', None))
+            swinging.placingCompensationMatrix = \
+                self._local_placing_compensation
+            swinging.worldMatrix = provider
+        except Exception as error:
+            self._local_swinging_animator = None
+            self._local_swinging_restore = None
+            self._report_local_body_swinging(False, error)
+            return False
+        self._local_swinging_animator = swinging
+        self._local_swinging_restore = restore
+        self._report_local_body_swinging(True)
+        return True
+
+    def _restore_local_body_swinging(self):
+        """Return the animator to the stock bindings this port replaced."""
+        restore = self._local_swinging_restore
+        self._local_swinging_animator = None
+        self._local_swinging_restore = None
+        if restore is None:
+            return False
+        swinging, compensation, world = restore
+        try:
+            if compensation is not None:
+                swinging.placingCompensationMatrix = compensation
+            if world is not None:
+                swinging.worldMatrix = world
+        except Exception as error:
+            self._report_local_body_swinging(False, error)
+            return False
         return True
 
     def _update_local_presentation(self, entity, dt=0.0):
@@ -5600,6 +5698,12 @@ class BattleRuntime(object):
             stabilised_matrix=self._local_stabilised_pose())
         self._reset_full_turret_sniper_aim(previous_yaw)
         self._local_camera_velocity = velocity
+        # A stock compound refresh rebuilds the appearance and its animator,
+        # which would silently drop this port's rebind for the rest of the
+        # round. Re-assert it here; an unchanged animator costs one test.
+        self._run_optional_feature(
+            'local body swinging', self._bind_local_body_swinging,
+            (entity, self._local_model))
         self._run_optional_feature(
             'local track animation', self._update_local_tracks, (entity,))
         return position
@@ -5703,6 +5807,7 @@ class BattleRuntime(object):
         if entity is None:
             return False
         self._sync_fire_effect(entity, False)
+        self._restore_local_body_swinging()
         if self._local_model is not None and self._local_native_matrix is not None:
             self._local_model.matrix = self._local_native_matrix
         clear = getattr(
@@ -5725,6 +5830,10 @@ class BattleRuntime(object):
         self._local_siege_aim_world_matrix = None
         self._local_siege_aim_pitch = 0.0
         self._local_model = None
+        self._local_swinging_animator = None
+        self._local_swinging_restore = None
+        self._local_placing_compensation = None
+        self._local_swinging_report = None
         self._local_native_matrix = None
         self._local_native_stabilised_matrix = None
         self._local_camera_velocity = None
@@ -21688,6 +21797,10 @@ class BattleRuntime(object):
         self._local_siege_aim_world_matrix = None
         self._local_siege_aim_pitch = 0.0
         self._local_model = None
+        self._local_swinging_animator = None
+        self._local_swinging_restore = None
+        self._local_placing_compensation = None
+        self._local_swinging_report = None
         self._local_native_matrix = None
         self._local_native_stabilised_matrix = None
         self._local_camera_velocity = None

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -5563,7 +5563,9 @@ class BattleRuntime(object):
         if model is None:
             raise RuntimeError('player compound model is unavailable')
         model.matrix = self._local_body_pose()
-        self._bind_local_body_swinging(entity, model)
+        self._run_optional_feature(
+            'local body swinging', self._bind_local_body_swinging,
+            (entity, model))
         self._runtime.compatibility.bind_vehicle_pose_sources(
             self._avatar, entity)
         self._local_model = model
@@ -5625,37 +5627,68 @@ class BattleRuntime(object):
         try:
             restore = (
                 swinging,
-                getattr(swinging, 'placingCompensationMatrix', None),
-                getattr(swinging, 'worldMatrix', None))
-            swinging.placingCompensationMatrix = \
-                self._local_placing_compensation
-            swinging.worldMatrix = provider
+                swinging.placingCompensationMatrix,
+                swinging.worldMatrix)
         except Exception as error:
             self._local_swinging_animator = None
             self._local_swinging_restore = None
             self._report_local_body_swinging(False, error)
-            return False
+            raise
+        try:
+            swinging.placingCompensationMatrix = \
+                self._local_placing_compensation
+            swinging.worldMatrix = provider
+        except Exception as error:
+            rollback_errors = []
+            for name, value in (
+                    ('placingCompensationMatrix', restore[1]),
+                    ('worldMatrix', restore[2])):
+                try:
+                    setattr(swinging, name, value)
+                except Exception as rollback_error:
+                    rollback_errors.append('%s: %s' % (
+                        name, rollback_error))
+            if rollback_errors:
+                # Preserve the exact owner and stock values so teardown can
+                # retry after a transient native setter failure.
+                self._local_swinging_animator = swinging
+                self._local_swinging_restore = restore
+                error = RuntimeError('%s; rollback failed: %s' % (
+                    error, '; '.join(rollback_errors)))
+            else:
+                self._local_swinging_animator = None
+                self._local_swinging_restore = None
+            self._report_local_body_swinging(False, error)
+            raise error
         self._local_swinging_animator = swinging
         self._local_swinging_restore = restore
         self._report_local_body_swinging(True)
         return True
 
-    def _restore_local_body_swinging(self):
+    def _restore_local_body_swinging(self, entity):
         """Return the animator to the stock bindings this port replaced."""
         restore = self._local_swinging_restore
-        self._local_swinging_animator = None
-        self._local_swinging_restore = None
         if restore is None:
             return False
         swinging, compensation, world = restore
+        appearance = getattr(entity, 'appearance', None)
+        if (not getattr(entity, 'isStarted', False) or
+                getattr(appearance, 'swingingAnimator', None) is not
+                swinging):
+            # A stock appearance refresh retired this animator.  Never write
+            # cached providers into the replacement that now owns the model.
+            self._local_swinging_animator = None
+            self._local_swinging_restore = None
+            return False
         try:
-            if compensation is not None:
-                swinging.placingCompensationMatrix = compensation
-            if world is not None:
-                swinging.worldMatrix = world
+            swinging.placingCompensationMatrix = compensation
+            swinging.worldMatrix = world
         except Exception as error:
             self._report_local_body_swinging(False, error)
-            return False
+            # Keep the owner and original providers for a later cleanup retry.
+            raise
+        self._local_swinging_animator = None
+        self._local_swinging_restore = None
         return True
 
     def _update_local_presentation(self, entity, dt=0.0):
@@ -5807,7 +5840,7 @@ class BattleRuntime(object):
         if entity is None:
             return False
         self._sync_fire_effect(entity, False)
-        self._restore_local_body_swinging()
+        self._restore_local_body_swinging(entity)
         if self._local_model is not None and self._local_native_matrix is not None:
             self._local_model.matrix = self._local_native_matrix
         clear = getattr(

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -25891,6 +25891,75 @@ class LocalBodySwingingTests(unittest.TestCase):
 
         self.assertEqual([], writes)
 
+    def test_second_bind_setter_failure_rolls_back_and_disables_feature(self):
+        battle, entity = self._battle()
+        native_compensation = _Matrix()
+        native_world = entity.matrix
+
+        class _FailingWorldAnimator(object):
+            def __init__(self):
+                object.__setattr__(
+                    self, 'placingCompensationMatrix', native_compensation)
+                object.__setattr__(self, 'worldMatrix', native_world)
+
+            def __setattr__(self, name, value):
+                if (name == 'worldMatrix' and
+                        value is battle._local_matrix):
+                    raise RuntimeError('world provider rejected')
+                object.__setattr__(self, name, value)
+
+        swinging = _FailingWorldAnimator()
+        entity.appearance.swingingAnimator = swinging
+
+        self.assertTrue(battle._attach_local_presentation())
+
+        self.assertIs(
+            native_compensation, swinging.placingCompensationMatrix)
+        self.assertIs(native_world, swinging.worldMatrix)
+        self.assertIsNone(battle._local_swinging_animator)
+        self.assertIsNone(battle._local_swinging_restore)
+        self.assertIn(
+            'local body swinging', battle._disabled_optional_features)
+
+    def test_failed_bind_rollback_retains_owner_for_cleanup_retry(self):
+        battle, entity = self._battle()
+        native_compensation = _Matrix()
+        native_world = entity.matrix
+
+        class _FailingRollbackAnimator(object):
+            def __init__(self):
+                object.__setattr__(self, 'fail_bind', True)
+                object.__setattr__(self, 'fail_rollback', True)
+                object.__setattr__(
+                    self, 'placingCompensationMatrix', native_compensation)
+                object.__setattr__(self, 'worldMatrix', native_world)
+
+            def __setattr__(self, name, value):
+                if (name == 'worldMatrix' and self.fail_bind and
+                        value is battle._local_matrix):
+                    raise RuntimeError('world provider rejected')
+                if (name == 'placingCompensationMatrix' and
+                        self.fail_rollback and
+                        value is native_compensation):
+                    raise RuntimeError('compensation rollback rejected')
+                object.__setattr__(self, name, value)
+
+        swinging = _FailingRollbackAnimator()
+        entity.appearance.swingingAnimator = swinging
+
+        self.assertTrue(battle._attach_local_presentation())
+
+        self.assertIs(swinging, battle._local_swinging_animator)
+        self.assertIsNotNone(battle._local_swinging_restore)
+        swinging.fail_bind = False
+        swinging.fail_rollback = False
+        self.assertTrue(battle._restore_local_body_swinging(entity))
+        self.assertIs(
+            native_compensation, swinging.placingCompensationMatrix)
+        self.assertIs(native_world, swinging.worldMatrix)
+        self.assertIsNone(battle._local_swinging_animator)
+        self.assertIsNone(battle._local_swinging_restore)
+
     def test_a_missing_animator_is_reported_without_failing_the_battle(self):
         battle, entity = self._battle(animator=False)
         stream = io.StringIO()
@@ -25928,3 +25997,51 @@ class LocalBodySwingingTests(unittest.TestCase):
         self.assertIs(native_compensation, swinging.placingCompensationMatrix)
         self.assertIs(native_world, swinging.worldMatrix)
         self.assertIsNone(battle._local_swinging_animator)
+
+    def test_detach_does_not_write_a_retired_animator_after_refresh(self):
+        battle, entity = self._battle()
+        writes = []
+
+        class _CountingAnimator(object):
+            def __setattr__(self, name, value):
+                writes.append(name)
+                object.__setattr__(self, name, value)
+
+        swinging = _CountingAnimator()
+        swinging.placingCompensationMatrix = _Matrix()
+        swinging.worldMatrix = entity.matrix
+        entity.appearance.swingingAnimator = swinging
+        battle._attach_local_presentation()
+        del writes[:]
+        entity.appearance.swingingAnimator = types.SimpleNamespace(
+            placingCompensationMatrix=_Matrix(), worldMatrix=entity.matrix)
+        battle._local_native_matrix = entity.matrix
+
+        self.assertTrue(battle._detach_local_presentation())
+
+        self.assertEqual([], writes)
+        self.assertIsNone(battle._local_swinging_animator)
+        self.assertIsNone(battle._local_swinging_restore)
+
+    def test_detach_does_not_write_an_animator_after_entity_exit(self):
+        battle, entity = self._battle()
+        writes = []
+
+        class _CountingAnimator(object):
+            def __setattr__(self, name, value):
+                writes.append(name)
+                object.__setattr__(self, name, value)
+
+        swinging = _CountingAnimator()
+        swinging.placingCompensationMatrix = _Matrix()
+        swinging.worldMatrix = entity.matrix
+        entity.appearance.swingingAnimator = swinging
+        battle._attach_local_presentation()
+        del writes[:]
+        entity.isStarted = False
+
+        self.assertFalse(battle._restore_local_body_swinging(entity))
+
+        self.assertEqual([], writes)
+        self.assertIsNone(battle._local_swinging_animator)
+        self.assertIsNone(battle._local_swinging_restore)

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -25759,3 +25759,127 @@ class LocalBattleDescriptorTests(unittest.TestCase):
         with self.assertRaisesRegex(
                 RuntimeError, 'does not match ussr:T-34'):
             runtime._local_battle_descriptor('ussr:T-34')
+
+
+class LocalBodySwingingTests(unittest.TestCase):
+    """The player's stock SwingingAnimator follows the copied LAN pose.
+
+    Exact #1513 ``CompoundAppearance.activate`` is the only stock writer of
+    ``swingingAnimator.placingCompensationMatrix`` and ``worldMatrix``.  It
+    runs before this port swaps the compound root onto the copied pose, so
+    without a rebind the animator swings around a filter placement the
+    vehicle no longer follows.
+    """
+
+    def _battle(self, animator=True):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle.client = _Client()
+        battle._avatar = runtime.bigworld.avatar
+        entity = _Vehicle(10, _Descriptor(), _Vector(2, 3, 4), (0, 0, 0),
+                          {'health': 500})
+        if animator:
+            entity.appearance.swingingAnimator = types.SimpleNamespace(
+                placingCompensationMatrix=_Matrix(),
+                worldMatrix=entity.matrix)
+        runtime.bigworld.entities[10] = entity
+        battle._server = types.SimpleNamespace(vehicle_id=10)
+        battle._sender = types.SimpleNamespace(
+            forward=0.0, turn=0.0, handbrake=False,
+            send_current=lambda: True)
+        battle._local_position = (2.0, 3.0, 4.0)
+        battle._local_descriptor = entity.typeDescriptor
+        return battle, entity
+
+    def test_the_animator_is_relinked_to_the_copied_compound_provider(self):
+        battle, entity = self._battle()
+        native_compensation = \
+            entity.appearance.swingingAnimator.placingCompensationMatrix
+
+        battle._attach_local_presentation()
+
+        swinging = entity.appearance.swingingAnimator
+        self.assertIs(entity.model.matrix, swinging.worldMatrix)
+        self.assertIs(battle._local_matrix, swinging.worldMatrix)
+        # The copied pose already carries authoritative terrain pitch and
+        # roll, so the native filter's placement must not be applied twice.
+        self.assertIsNot(native_compensation,
+                         swinging.placingCompensationMatrix)
+        self.assertIs(battle._local_placing_compensation,
+                      swinging.placingCompensationMatrix)
+        self.assertEqual(0.0, swinging.placingCompensationMatrix.pitch)
+        self.assertEqual(0.0, swinging.placingCompensationMatrix.roll)
+
+    def test_a_stock_appearance_refresh_does_not_drop_the_rebind(self):
+        battle, entity = self._battle()
+        battle._attach_local_presentation()
+
+        # __prepareSystemsForDamagedVehicle and a compound refresh rebuild
+        # the animator, which would otherwise keep the stale stock link.
+        rebuilt = types.SimpleNamespace(
+            placingCompensationMatrix=_Matrix(), worldMatrix=entity.matrix)
+        entity.appearance.swingingAnimator = rebuilt
+
+        battle._update_local_presentation(entity, 0.1)
+
+        self.assertIs(entity.model.matrix, rebuilt.worldMatrix)
+        self.assertIs(rebuilt, battle._local_swinging_animator)
+
+    def test_an_unchanged_animator_is_not_rewritten_every_frame(self):
+        battle, entity = self._battle()
+        battle._attach_local_presentation()
+        writes = []
+
+        class _CountingAnimator(object):
+            def __setattr__(self, name, value):
+                writes.append(name)
+                object.__setattr__(self, name, value)
+
+        counting = _CountingAnimator()
+        counting.placingCompensationMatrix = _Matrix()
+        counting.worldMatrix = entity.matrix
+        entity.appearance.swingingAnimator = counting
+        battle._update_local_presentation(entity, 0.1)
+        del writes[:]
+
+        battle._update_local_presentation(entity, 0.1)
+
+        self.assertEqual([], writes)
+
+    def test_a_missing_animator_is_reported_without_failing_the_battle(self):
+        battle, entity = self._battle(animator=False)
+        stream = io.StringIO()
+
+        with mock.patch('sys.stdout', stream):
+            self.assertTrue(battle._attach_local_presentation())
+
+        self.assertIn('local_body_swinging=False', stream.getvalue())
+        self.assertIn('SwingingAnimator is unavailable', stream.getvalue())
+        self.assertIsNone(battle._local_swinging_animator)
+        self.assertIs(entity.model.matrix, battle._local_matrix)
+
+    def test_one_line_reports_each_distinct_binding_outcome(self):
+        battle, entity = self._battle()
+        stream = io.StringIO()
+
+        with mock.patch('sys.stdout', stream):
+            battle._attach_local_presentation()
+            battle._update_local_presentation(entity, 0.1)
+            battle._update_local_presentation(entity, 0.1)
+
+        self.assertEqual(
+            1, stream.getvalue().count('local_body_swinging=True'))
+
+    def test_detaching_returns_the_animator_to_its_stock_bindings(self):
+        battle, entity = self._battle()
+        swinging = entity.appearance.swingingAnimator
+        native_compensation = swinging.placingCompensationMatrix
+        native_world = swinging.worldMatrix
+        battle._attach_local_presentation()
+        battle._local_native_matrix = entity.matrix
+
+        self.assertTrue(battle._detach_local_presentation())
+
+        self.assertIs(native_compensation, swinging.placingCompensationMatrix)
+        self.assertIs(native_world, swinging.worldMatrix)
+        self.assertIsNone(battle._local_swinging_animator)


### PR DESCRIPTION
## Source

Mined from `~/contrib.zip` (contributor build of `0.6.0-alpha.6`, 8 changed
files). Contrib applies the same two writes to the player's animator; this PR
ports only that binding into the current architecture, with the stock contract
verified against the pinned package and the exact executable.

## Summary

- rebind the player vehicle's stock `SwingingAnimator` to the copied LAN pose:
  `placingCompensationMatrix` to an identity matrix this port owns, and
  `worldMatrix` to the compound root provider the port actually installed
- re-assert the pair when a stock compound refresh rebuilds the animator, and
  restore the stock pair on detach
- record a missing animator instead of raising, and publish one
  `PRESENTATION local_body_swinging=` line per distinct outcome

## Why

`CompoundAppearance.activate` is the only stock writer of those two attributes
in the pinned `scripts.pkg`. It copies the compensation off the native vehicle
filter and links the animator to the compound root's matrix provider object
that exists at that moment. `_attach_local_presentation` replaces that root
with the copied pose *after* the native lifecycle completes, so on the player's
own tank the animator kept swinging around a filter placement the vehicle no
longer follows and kept reading a provider the compound no longer uses. Native
remote vehicles already got this rebind; the local vehicle did not.

## Exact-client evidence

Disassembled from `res/packages/scripts.pkg` of the pinned Chinese HD
`0.9.22.0.1 #1513` build with CPython 2.7.18:

- `CompoundAppearance.activate` writes `placingCompensationMatrix` and
  `worldMatrix`; no other method in the package writes either.
- `CompoundAppearance.__prepareSystemsForDamagedVehicle` sets
  `swingingAnimator = None`, so a missing animator is a normal damaged-model
  state.
- `CompoundAppearance.stopSwinging` is the only Python writer of
  `accelSwingingPeriod`; `changeEngineMode` in this build touches only
  `detailedEngineState.mode` and `__trackScrollCtl.setMode`, and nothing in the
  package writes `accelSwingingDirection`.

Because of that last point, acceleration swing is **not** armed here. Both
attribute names exist in the exact executable, but which owner arms the swing
in #1513 is unresolved, and a second writer is the jitter class this repository
already avoids.

## Cost

Steady state is two attribute reads and one identity test per local
presentation update. Only an actual rebind reads the compound provider and
writes the two attributes.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -p 'test_*.py'` — 3492 passed
- `tests/test_port_0922_battle_runtime.py` — 720 passed (6 new)
- CPython 2.7.18 source compile: 89 client files
- `git diff --check` clean

## What this does not prove

Whether the resulting body rocking looks right, and whether the animator's
native update reads anything beyond `worldMatrix`, still need acceptance on the
exact #1513 Windows client.

## Base

Stacked on `feature/0922-presentation-fidelity` (PR #45), which edits the same
swinging block for native remotes. Retarget to `main` after that merges.