### PR TITLE
Close the presentation an unspotted enemy still drew

### DIFF
--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -1084,7 +1084,11 @@ are exactly what the unproven `visibleAttachments` flag would have covered.
 through the decal's own `__attached` flag; `__attach` resolves the hull node as
 `compoundModel.node(TankPartNames.HULL)`, which is the same node
 `__attachSplodge` used, so the runtime reads it from the decal before detaching
-and re-attaches the splodge to it on the reveal edge. Which of these layers
+and re-attaches the splodge to it on the reveal edge. `VehicleDecal.__reattach`
+restores every decal when `onSettingsChanged` sees a new `SHADOWS_QUALITY`,
+which is outside any spotting edge, so the wrapped `__updateEffectsLOD` re-
+asserts the decal gate on the same bounded cadence; both stock calls are
+idempotent, so the steady-state cost is a flag read. Which of these layers
 draws the artefact a tester photographs is still an exact-Windows question; all
 of them are now closed together.
 

--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -1051,10 +1051,61 @@ its projectile model, while the fire extra attaches through
 native compound exposes it as writable, stops the fire extra on the hide edge,
 settles native belt speed immediately, and stops feeding later belt/engine
 presentation while hidden. Static package inspection does not prove that
-`PyCompoundModel` inherits the plain model's `visibleAttachments` property or
-identify the native dust emitter, so those two surfaces still require exact
-Windows runtime acceptance; the runtime logs once when the attachment gate is
-absent or read-only.
+`PyCompoundModel` inherits the plain model's `visibleAttachments` property, so
+that one flag still requires exact Windows runtime acceptance; the runtime logs
+once when the attachment gate is absent or read-only.
+
+Windows playtesting in an SPG aiming camera then reported a ground shadow and
+exhaust under an unspotted enemy, and exact #1513 bytecode names both owners.
+`CompoundAppearance.__onPeriodicTimer` runs every `_PERIODIC_TIME` (0.25 s) for
+a living vehicle and calls `__updateEffectsLOD`, which enables the
+`CustomEffectManager` dust selector within `_LOD_DISTANCE_TRAIL_PARTICLES`
+(100 m) and the exhaust selector within `_LOD_DISTANCE_EXHAUST` (200 m) of
+`BigWorld.camera()`. Neither test reads a draw flag, and the distance is
+measured from the camera rather than the player, so a strategic or arty camera
+parked over its aim point enables both effects for every hidden enemy beneath
+it. `CustomEffectManager.deactivate` is not a usable hide because it also
+clears the manager's vehicle; its selector loop is, and
+`MainSelectorBase.update` returns immediately once a selector is stopped. The
+port therefore stops both selectors on the hide edge and wraps
+`__updateEffectsLOD` in the existing compat install/uninstall discipline so the
+periodic timer cannot restart them for an undrawn LAN remote. Only two selector
+classes override `settingsFlags`, `MainCustomSelector` for `SETTING_DUST` and
+`ExhaustMainSelector` for `SETTING_EXHAUST`, so stopping every selector is the
+complete gate.
+
+The second owner is the ground occlusion geometry. `CompoundAppearance.activate`
+attaches its `VehicleDecal` to the compound root, hull and turret nodes, and
+`__setupModels` attaches a `BigWorld.Splodge` built from `chassis.AODecals[0]`
+to the hull node whenever `MAX_DISTANCE` (500) is positive. Both are node
+attachments carrying `maps/spots/TankOcclusion/TankOcclusionMap.dds`, so they
+are exactly what the unproven `visibleAttachments` flag would have covered.
+`VehicleDecal.attach`/`detach` are the exact stock pair and both are idempotent
+through the decal's own `__attached` flag; `__attach` resolves the hull node as
+`compoundModel.node(TankPartNames.HULL)`, which is the same node
+`__attachSplodge` used, so the runtime reads it from the decal before detaching
+and re-attaches the splodge to it on the reveal edge. Which of these layers
+draws the artefact a tester photographs is still an exact-Windows question; all
+of them are now closed together.
+
+The stock shoot extra is the same kind of surface. Exact #1513
+`Vehicle.showShooting` for a remote is only `extra.stopFor` followed by
+`extra.startFor`, guarded by `isStarted` and the siege state and by nothing
+about visibility; the `isPlayerVehicle` branches around it are the local
+waiting-for-shot handshake. Retail never delivers that event for a vehicle the
+client cannot see, while this runtime receives every LAN shot, so the runtime
+skips the muzzle presentation for a remote whose draw pass is closed. The
+projectile keeps its own owner, so a blind shot still flies, still resolves and
+still damages; this matches the impact-effect gate the runtime already applies
+to a terminal event on an unspotted target.
+
+The entity AOI that owns the world model follows the observed vehicle, not the
+player's own hull. The local integrator stops the moment the player dies, so
+`_local_position` freezes at the wreck; centring the 565 m AOI there hid the
+ally the postmortem camera had just switched to, and every vehicle around it,
+whenever the wreck was far away. The runtime resolves the AOI origin from the
+currently spectated entity instead and re-evaluates spotting on the next frame
+after a viewpoint switch.
 
 Authority Bot snapshots also retain the retired predecessor's no-rewind rule:
 the client that integrates a Bot never reapplies its older server echo pose,

--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -1092,16 +1092,28 @@ idempotent, so the steady-state cost is a flag read. Which of these layers
 draws the artefact a tester photographs is still an exact-Windows question; all
 of them are now closed together.
 
-The stock shoot extra is the same kind of surface. Exact #1513
-`Vehicle.showShooting` for a remote is only `extra.stopFor` followed by
-`extra.startFor`, guarded by `isStarted` and the siege state and by nothing
-about visibility; the `isPlayerVehicle` branches around it are the local
-waiting-for-shot handshake. Retail never delivers that event for a vehicle the
-client cannot see, while this runtime receives every LAN shot, so the runtime
-skips the muzzle presentation for a remote whose draw pass is closed. The
-projectile keeps its own owner, so a blind shot still flies, still resolves and
-still damages; this matches the impact-effect gate the runtime already applies
-to a terminal event on an unspotted target.
+The muzzle effect is the same class of leak, and the entity definitions say
+why. `scripts/entity_defs/Vehicle.def` declares `showShooting` under
+`ClientMethods`, so it is a cell-to-client RPC on the Vehicle entity, and that
+entity carries `IsManualAoI` together with the `receiveVisibilityUpdate`,
+`onDetectedByEnemy` and `onConcealedFromEnemy` cell methods that drive its
+membership. A retail client that has not spotted an enemy is not in that AoI
+and never receives the call. `Vehicle.showShooting` itself guards only on
+`isStarted` and the siege state - the `isPlayerVehicle` branches around it are
+the local waiting-for-shot handshake - and the `shoot` extra it starts is
+`ShowShooting`, whose `_start` plays `gunDescr.effects` through
+`EffectsListPlayer` bound to the vehicle's own compound model: the muzzle
+flash, its smoke and the gun sound. This runtime receives every LAN shot
+instead, so the runtime skips that presentation for a remote whose draw pass is
+closed, which reproduces the retail delivery rule.
+
+The tracer is a different entity and must not follow it. `Avatar.def` declares
+`showTracer` and `stopTracer` under its own `ClientMethods`, and the player's
+Avatar is always inside its own AoI, so retail still draws the tracer of a shot
+fired by a vehicle the client cannot see. The runtime's projectile keeps its own
+owner, so a blind shot still draws its tracer, still resolves and still damages;
+this also matches the impact-effect gate the runtime already applies to a
+terminal event on an unspotted target.
 
 The entity AOI that owns the world model follows the observed vehicle, not the
 player's own hull. The local integrator stops the moment the player dies, so

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -9810,17 +9810,28 @@ class BattleRuntime(object):
     def _shot_muzzle_drawn(self, record):
         """Whether the stock muzzle effect belongs to a drawable shooter.
 
-        Exact #1513 ``Vehicle.showShooting`` for a remote is only
-        ``extra.stopFor`` followed by ``extra.startFor``: it starts the shoot
-        extra on ``appearance.boundEffects`` and guards on ``isStarted`` and
-        the siege state alone.  Retail never delivers that event for a vehicle
-        the client cannot see, while this runtime receives every LAN shot, so
-        an unspotted enemy fired a visible muzzle flash and its shot sound
-        over a hidden hull.  This is the same node-bound surface the fire
-        extra already closes on the hide edge.
+        Exact #1513 ``scripts/entity_defs/Vehicle.def`` declares
+        ``showShooting`` under ``ClientMethods``: it is a cell-to-client RPC
+        on the Vehicle entity, and that entity carries ``IsManualAoI`` with
+        the ``receiveVisibilityUpdate``/``onDetectedByEnemy``/
+        ``onConcealedFromEnemy`` cell methods that drive its membership.  A
+        retail client that has not spotted an enemy is not in that AoI and
+        never receives the call at all.  ``Vehicle.showShooting`` itself
+        guards only on ``isStarted`` and the siege state, and its ``shoot``
+        extra is ``ShowShooting``, whose ``_start`` plays ``gunDescr.effects``
+        through ``EffectsListPlayer`` bound to the vehicle's own compound
+        model - the muzzle flash, its smoke and the gun sound.
 
-        The projectile keeps its own owner, so the tracer of a blind shot
-        still flies and still resolves.
+        This runtime receives every LAN shot instead, so an unspotted enemy
+        was firing that whole effect list over a hidden hull. Skip it, which
+        reproduces the retail delivery rule.
+
+        The tracer is a different entity: ``Avatar.def`` declares
+        ``showTracer``/``stopTracer`` under its own ``ClientMethods``, and the
+        player's Avatar is always in its own AoI, which is why retail still
+        draws the tracer of a shot from a vehicle it cannot see. The runtime's
+        projectile keeps its own owner and is untouched here, so a blind shot
+        still draws its tracer, still resolves and still damages.
         """
         if record.get('local'):
             return True

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -3581,6 +3581,11 @@ class BattleRuntime(object):
                     previous, '_offlineLANPresentation', False)):
                 previous._postmortem_visible = False
         self._spectated_engine_id = int(engine_id)
+        # The entity AOI is now centred on a different vehicle.  Re-evaluate
+        # the retained spotting memory on the next frame instead of leaving
+        # the new viewpoint's neighbourhood hidden for the rest of the current
+        # 0.10 s HUD period.
+        self._next_spotting_time = 0.0
         return True
 
     def _fallback_postmortem_viewpoint(self, excluded_engine_id):
@@ -9802,6 +9807,25 @@ class BattleRuntime(object):
             # camera must fall back to the immutable canonical launch point.
             return None
 
+    def _shot_muzzle_drawn(self, record):
+        """Whether the stock muzzle effect belongs to a drawable shooter.
+
+        Exact #1513 ``Vehicle.showShooting`` for a remote is only
+        ``extra.stopFor`` followed by ``extra.startFor``: it starts the shoot
+        extra on ``appearance.boundEffects`` and guards on ``isStarted`` and
+        the siege state alone.  Retail never delivers that event for a vehicle
+        the client cannot see, while this runtime receives every LAN shot, so
+        an unspotted enemy fired a visible muzzle flash and its shot sound
+        over a hidden hull.  This is the same node-bound surface the fire
+        extra already closes on the hide edge.
+
+        The projectile keeps its own owner, so the tracer of a blind shot
+        still flies and still resolves.
+        """
+        if record.get('local'):
+            return True
+        return bool(record.get('spot_visible', True))
+
     def _show_shot(self, event, update_state=True):
         key = self._event_entity_key(event, 'attacker')
         if key is None:
@@ -9891,7 +9915,8 @@ class BattleRuntime(object):
                     burst_count = 1
                 burst_count = max(1, burst_count)
                 if (visual_admitted and self._optional_feature_enabled(
-                        'shot muzzle presentation')):
+                        'shot muzzle presentation') and
+                        self._shot_muzzle_drawn(record)):
                     self._run_optional_feature(
                         'shot muzzle presentation', entity.showShooting,
                         args=(burst_count, False))
@@ -19853,25 +19878,50 @@ class BattleRuntime(object):
         # should be guessed through a fallback.
         return current in (modes.STRATEGIC, modes.ARTY)
 
+    def _presentation_origin(self):
+        """Return the position the client's entity AOI is centred on.
+
+        Retail centres the vehicle AOI on the vehicle the player is attached
+        to, and a dead player is attached to whichever ally the postmortem
+        camera currently observes.  This runtime stops integrating the local
+        tank the moment it dies, so ``_local_position`` freezes at the wreck.
+        Keeping the AOI there hid the observed ally itself, and every vehicle
+        near it, whenever the wreck was more than 565 m away.
+        """
+        engine_id = self._spectated_engine_id
+        if engine_id is None:
+            return self._local_position
+        local_id = (int(self._server.vehicle_id)
+                    if self._server is not None else 0)
+        if int(engine_id) == local_id:
+            return self._local_position
+        try:
+            entity = self._server_entity(engine_id)
+        except ReferenceError:
+            entity = None
+        if entity is None:
+            return self._local_position
+        return _xyz(entity.position)
+
     def _spot_presentation_visibility(
             self, entity, remembered, was_model_visible=False):
         """Return ``(model, team knowledge)`` for one spotted enemy.
 
         The minimap follows team spotting memory.  The ordinary world model
-        and 3D marker remain bounded by the 565 m entity AOI, except that an
-        SPG in either of its aiming cameras must be able to aim at every
-        team-spotted target in its shell range.  The exemption covers the
-        whole aiming slice so switching between those cameras cannot make an
-        engaged target disappear.  Exact #1513 keeps an already-present entity
-        for the additional five-metre ``CIRCULAR_AOI_MARGIN`` to prevent
-        boundary flicker.
+        and 3D marker remain bounded by the 565 m entity AOI around the
+        currently observed vehicle, except that an SPG in either of its aiming
+        cameras must be able to aim at every team-spotted target in its shell
+        range.  The exemption covers the whole aiming slice so switching
+        between those cameras cannot make an engaged target disappear.  Exact
+        #1513 keeps an already-present entity for the additional five-metre
+        ``CIRCULAR_AOI_MARGIN`` to prevent boundary flicker.
         """
         remembered = bool(remembered)
         aoi_radius = spotting.VEHICLE_AOI_RADIUS
         if was_model_visible:
             aoi_radius += spotting.VEHICLE_AOI_HYSTERESIS_MARGIN
         within_aoi = _distance_2d(
-            self._local_position, _xyz(entity.position)) <= aoi_radius
+            self._presentation_origin(), _xyz(entity.position)) <= aoi_radius
         model_visible = remembered and (
             within_aoi or self._spg_aiming_view_active())
         return model_visible, remembered

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/compat.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/compat.py
@@ -8,6 +8,9 @@ try:
 except ImportError:
     import pickle as _pickle
 
+from gui.mods.offline_lan_0922.entities.remote_vehicle import (
+    close_stock_presentation_extras, stop_ground_effects)
+
 
 OFFLINE_SERVER_ADDRESS = 'offline-lan.local:0'
 _OFFLINE_ACCOUNT_NAME = 'offline_account'
@@ -561,6 +564,7 @@ class OfflineCompatibility(object):
         self._original_compound_getattribute = None
         self._original_compound_deactivate = None
         self._original_compound_models_refresh = None
+        self._original_compound_effects_lod = None
         self._compound_models_refresh_code = None
         self._original_connect = None
         self._original_disconnect = None
@@ -603,6 +607,7 @@ class OfflineCompatibility(object):
         self._compound_getattribute_wrapper = None
         self._compound_deactivate_wrapper = None
         self._compound_models_refresh_wrapper = None
+        self._compound_effects_lod_wrapper = None
         self._vehicle_starting_visual = None
         self._vehicle_starting_wg_physics = None
         self._vehicle_syncing_gun_angles = None
@@ -977,6 +982,12 @@ class OfflineCompatibility(object):
                     'func_code', getattr(
                         self._original_compound_models_refresh,
                         '__code__', None))
+            self._original_compound_effects_lod = (
+                compound_type.__dict__.get(
+                    '_CompoundAppearance__updateEffectsLOD',
+                    getattr(
+                        compound_type,
+                        '_CompoundAppearance__updateEffectsLOD', None)))
         self._original_connect = runtime.bigworld.connect
         self._original_disconnect = runtime.bigworld.disconnect
         self._original_server_time = runtime.bigworld.serverTime
@@ -1418,6 +1429,12 @@ class OfflineCompatibility(object):
             show(False)
             if change_visibility is not None:
                 change_visibility(False)
+            # startVisual has just run activate(), which attached the ground
+            # occlusion decals and started the dust/exhaust selectors.  Close
+            # those two stock surfaces on the same edge; neither follows the
+            # compound draw flags.
+            if appearance is not None:
+                close_stock_presentation_extras(appearance, False)
             stop_visual(int(vehicle.id), False)
             return True
 
@@ -2138,6 +2155,33 @@ class OfflineCompatibility(object):
                     else:
                         delattr(runtime.bigworld, 'player')
 
+        def compound_effects_lod(appearance, distance_from_player):
+            """Keep an undrawn LAN remote out of the stock effects LOD.
+
+            Exact #1513 ``CompoundAppearance.__updateEffectsLOD`` enables
+            ground dust within 100 m and exhaust within 200 m of
+            ``BigWorld.camera()`` and reads no draw flag, so a hidden enemy
+            keeps emitting both.  ``__onPeriodicTimer`` calls it every 0.25 s
+            for every living vehicle, which is why stopping the selectors once
+            on the runtime's hide edge is not sufficient on its own.
+
+            An SPG aiming camera makes the leak obvious: it sits over the aim
+            point rather than over the player, so unspotted enemies anywhere
+            near that point fall inside both LOD radii.
+            """
+            original = compatibility._original_compound_effects_lod
+            if not compatibility._battle_active:
+                return original(appearance, distance_from_player)
+            try:
+                vehicle = compatibility._original_compound_getattribute(
+                    appearance, '_CompoundAppearance__vehicle')
+            except (AttributeError, ReferenceError):
+                vehicle = None
+            if vehicle is not None and undrawn_lan_remote(vehicle):
+                stop_ground_effects(appearance)
+                return None
+            return original(appearance, distance_from_player)
+
         def compound_models_refresh(appearance, model_state, resource_list):
             original = compatibility._original_compound_models_refresh
             if not compatibility._battle_active:
@@ -2395,6 +2439,7 @@ class OfflineCompatibility(object):
         self._compound_getattribute_wrapper = compound_getattribute
         self._compound_deactivate_wrapper = compound_deactivate
         self._compound_models_refresh_wrapper = compound_models_refresh
+        self._compound_effects_lod_wrapper = compound_effects_lod
         self._connect_wrapper = connect
         self._disconnect_wrapper = disconnect
         self._server_time_wrapper = server_time
@@ -2468,6 +2513,9 @@ class OfflineCompatibility(object):
                 if self._original_compound_models_refresh is not None:
                     compound_type._CompoundAppearance__onModelsRefresh = (
                         compound_models_refresh)
+                if self._original_compound_effects_lod is not None:
+                    compound_type._CompoundAppearance__updateEffectsLOD = (
+                        compound_effects_lod)
             runtime.bigworld.connect = connect
             runtime.bigworld.disconnect = disconnect
             runtime.bigworld.serverTime = server_time
@@ -2715,6 +2763,13 @@ class OfflineCompatibility(object):
                 self._compound_models_refresh_wrapper):
             compound_type._CompoundAppearance__onModelsRefresh = (
                 self._original_compound_models_refresh)
+        if (compound_type is not None and
+                self._original_compound_effects_lod is not None and
+                compound_type.__dict__.get(
+                    '_CompoundAppearance__updateEffectsLOD') is
+                self._compound_effects_lod_wrapper):
+            compound_type._CompoundAppearance__updateEffectsLOD = (
+                self._original_compound_effects_lod)
         if (compound_type is not None and
                 self._original_compound_deactivate is not None and
                 compound_type.__dict__.get('deactivate') is

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/compat.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/compat.py
@@ -9,7 +9,8 @@ except ImportError:
     import pickle as _pickle
 
 from gui.mods.offline_lan_0922.entities.remote_vehicle import (
-    close_stock_presentation_extras, stop_ground_effects)
+    close_stock_presentation_extras, set_ground_decal_visibility,
+    stop_ground_effects)
 
 
 OFFLINE_SERVER_ADDRESS = 'offline-lan.local:0'
@@ -2168,6 +2169,13 @@ class OfflineCompatibility(object):
             An SPG aiming camera makes the leak obvious: it sits over the aim
             point rather than over the player, so unspotted enemies anywhere
             near that point fall inside both LOD radii.
+
+            This is also the only stock callback that runs at a bounded
+            cadence for one hidden vehicle, so re-assert the ground decal gate
+            here.  ``VehicleDecal.onSettingsChanged`` re-attaches every decal
+            when the shadow quality changes, and the runtime's own gate runs
+            only on a spotting edge.  Both calls are idempotent, so the
+            steady-state cost is two flag reads.
             """
             original = compatibility._original_compound_effects_lod
             if not compatibility._battle_active:
@@ -2179,6 +2187,7 @@ class OfflineCompatibility(object):
                 vehicle = None
             if vehicle is not None and undrawn_lan_remote(vehicle):
                 stop_ground_effects(appearance)
+                set_ground_decal_visibility(appearance, False)
                 return None
             return original(appearance, distance_from_player)
 

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/compat.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/compat.py
@@ -9,8 +9,8 @@ except ImportError:
     import pickle as _pickle
 
 from gui.mods.offline_lan_0922.entities.remote_vehicle import (
-    close_stock_presentation_extras, set_ground_decal_visibility,
-    stop_ground_effects)
+    clear_ground_decal_visibility_state, close_stock_presentation_extras,
+    set_ground_decal_visibility, stop_ground_effects)
 
 
 OFFLINE_SERVER_ADDRESS = 'offline-lan.local:0'
@@ -2101,8 +2101,18 @@ class OfflineCompatibility(object):
 
         def compound_deactivate(appearance, stopEffects=True):
             original = compatibility._original_compound_deactivate
+            def call_original():
+                try:
+                    return original(appearance, stopEffects)
+                finally:
+                    # A nested model refresh needs the old generation token
+                    # so its retained Splodge cannot be mistaken for a child
+                    # of the replacement compound.  Final teardown does not.
+                    if (compatibility._compound_refreshing_models is not
+                            appearance):
+                        clear_ground_decal_visibility_state(appearance)
             if not compatibility._battle_active:
-                return original(appearance, stopEffects)
+                return call_original()
             try:
                 player = runtime.bigworld.player()
             except ReferenceError:
@@ -2114,7 +2124,7 @@ class OfflineCompatibility(object):
                 except ReferenceError:
                     handler = None
             if handler is not None:
-                return original(appearance, stopEffects)
+                return call_original()
 
             # PlayerAvatar.__destroyGUI clears inputHandler before its later
             # Vehicle.stopVisual loop.  CompoundAppearance.deactivate still
@@ -2127,9 +2137,9 @@ class OfflineCompatibility(object):
                 try:
                     player.inputHandler = fallback
                 except Exception:
-                    return original(appearance, stopEffects)
+                    return call_original()
                 try:
-                    return original(appearance, stopEffects)
+                    return call_original()
                 finally:
                     if getattr(player, 'inputHandler', None) is fallback:
                         player.inputHandler = None
@@ -2148,7 +2158,7 @@ class OfflineCompatibility(object):
 
             runtime.bigworld.player = collider_owner
             try:
-                return original(appearance, stopEffects)
+                return call_original()
             finally:
                 if runtime.bigworld.player is collider_owner:
                     if had_player:

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/entities/native_remote_vehicle.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/entities/native_remote_vehicle.py
@@ -14,7 +14,7 @@ import math
 
 from gui.mods.offline_lan_0922.entities.remote_vehicle import (
     _RemoteShotPresenter, _blend_angle, _component_aim_angles,
-    set_model_attachment_visibility)
+    close_stock_presentation_extras, set_model_attachment_visibility)
 
 
 _MINIMUM_KEYFRAME_SECONDS = 0.001
@@ -42,6 +42,10 @@ def set_draw_visibility(entity, visible):
     # keeps drawing over a hidden tank.  Gate the attachments too.
     set_model_attachment_visibility(
         getattr(appearance, 'compoundModel', None), visible)
+    # That flag is one unproven native property.  Close the two stock owners
+    # it would have covered directly as well: the ground occlusion decals and
+    # the camera-distance dust/exhaust selectors.
+    close_stock_presentation_extras(appearance, visible)
     return True
 
 

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/entities/native_remote_vehicle.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/entities/native_remote_vehicle.py
@@ -14,7 +14,8 @@ import math
 
 from gui.mods.offline_lan_0922.entities.remote_vehicle import (
     _RemoteShotPresenter, _blend_angle, _component_aim_angles,
-    close_stock_presentation_extras, set_model_attachment_visibility)
+    clear_ground_decal_visibility_state, close_stock_presentation_extras,
+    set_model_attachment_visibility)
 
 
 _MINIMUM_KEYFRAME_SECONDS = 0.001
@@ -728,6 +729,7 @@ class _NativeRemoteState(object):
     def detach(self):
         entity = self.entity
         engine_owned = self._engine_owns_entity()
+        appearance = None
         if entity is None:
             return False
         if engine_owned:
@@ -742,6 +744,7 @@ class _NativeRemoteState(object):
         # The overlay clear is the last native-facing operation.  Preserve the
         # entity and callback owners if it raises so factory teardown can retry
         # rather than forgetting a still-linked presentation.
+        clear_ground_decal_visibility_state(appearance)
         self.model_changed = None
         self.entity = None
         return True

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/entities/remote_vehicle.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/entities/remote_vehicle.py
@@ -81,6 +81,29 @@ def set_model_attachment_visibility(model, visible):
 # One line per process for each stock surface the runtime could not reach.
 _ground_effect_gate_reported = False
 _ground_decal_gate_reported = False
+_ground_effect_failure_reported = False
+_ground_decal_failure_reported = False
+
+
+def _report_ground_gate_failure(kind, error):
+    """Log one bounded failure for an optional stock presentation owner."""
+    global _ground_effect_failure_reported, _ground_decal_failure_reported
+    if kind == 'effects':
+        if _ground_effect_failure_reported:
+            return False
+        _ground_effect_failure_reported = True
+    else:
+        if _ground_decal_failure_reported:
+            return False
+        _ground_decal_failure_reported = True
+    try:
+        message = ' '.join(str(error).split())[:240]
+    except Exception:
+        message = error.__class__.__name__
+    sys.stdout.write(
+        '[Offline LAN 0.9.22] hidden vehicle ground %s gate degraded: %s\n' %
+        (kind, message or error.__class__.__name__))
+    return True
 
 
 def stop_ground_effects(appearance):
@@ -118,10 +141,24 @@ def stop_ground_effects(appearance):
                 'selector list; hidden vehicle dust and exhaust may still '
                 'draw\n')
         return False
+    reached = False
+    try:
+        selectors = tuple(selectors)
+    except Exception as error:
+        _report_ground_gate_failure('effects', error)
+        return False
     for selector in selectors:
-        if getattr(selector, '_enabled', True):
+        try:
+            if not getattr(selector, '_enabled', True):
+                reached = True
+                continue
             selector.stop()
-    return True
+            reached = True
+        except Exception as error:
+            # One broken native selector must not leave the other selector,
+            # the decal gate or the whole visibility edge unprocessed.
+            _report_ground_gate_failure('effects', error)
+    return reached
 
 
 def set_ground_decal_visibility(appearance, visible):
@@ -146,29 +183,127 @@ def set_ground_decal_visibility(appearance, visible):
         return False
     visible = bool(visible)
     reached = False
-    decal = getattr(appearance, '_CompoundAppearance__chassisDecal', None)
-    hull_node = getattr(decal, '_VehicleDecal__hullParent', None)
-    splodge = getattr(appearance, '_CompoundAppearance__splodge', None)
-    detached_from = getattr(appearance, '_offlineSplodgeParent', None)
-    if splodge is not None:
-        if visible and detached_from is not None:
-            detached_from.attach(splodge)
-            appearance._offlineSplodgeParent = None
+    attempted = False
+    try:
+        model = getattr(appearance, 'compoundModel', None)
+        decal = getattr(
+            appearance, '_CompoundAppearance__chassisDecal', None)
+        hull_node = getattr(decal, '_VehicleDecal__hullParent', None)
+        splodge = getattr(
+            appearance, '_CompoundAppearance__splodge', None)
+        detached = getattr(appearance, '_offlineSplodgeDetach', None)
+        disabled = getattr(appearance, '_offlineSplodgeDisabled', None)
+    except Exception as error:
+        _report_ground_gate_failure('decal', error)
+        return False
+
+    if disabled is not None:
+        try:
+            disabled_matches = (
+                disabled[0] is model and disabled[1] is splodge)
+            reused_disabled_splodge = (
+                not disabled_matches and disabled[1] is splodge)
+        except (IndexError, TypeError):
+            disabled_matches = False
+            reused_disabled_splodge = False
+        if not disabled_matches:
+            if (reused_disabled_splodge and model is not None and
+                    splodge is not None):
+                # A failed native operation can have partially committed.
+                # Replacing the compound does not make the retained Splodge's
+                # owner knowable again, so carry the fence into this model
+                # generation until stock supplies a new Splodge object.
+                disabled = (model, splodge)
+                appearance._offlineSplodgeDisabled = disabled
+            else:
+                appearance._offlineSplodgeDisabled = None
+                disabled = None
+
+    if detached is not None:
+        try:
+            detached_matches = (
+                detached[0] is model and detached[1] is splodge and
+                (hull_node is None or detached[2] is hull_node))
+            reused_splodge = (
+                not detached_matches and detached[1] is splodge)
+        except (IndexError, TypeError):
+            detached_matches = False
+            reused_splodge = False
+        if not detached_matches:
+            # Never dereference the retired hull node after a compound model
+            # refresh.  #1513 can retain the same Splodge while replacing its
+            # compound, in which case its ownership in the new generation is
+            # unknowable and native attach/detach must stay disabled.
+            appearance._offlineSplodgeDetach = None
+            detached = None
+            if reused_splodge and model is not None and splodge is not None:
+                disabled = (model, splodge)
+                appearance._offlineSplodgeDisabled = disabled
+
+    splodge_disabled = disabled is not None
+    if not splodge_disabled and splodge is not None:
+        if visible and detached is not None:
+            attempted = True
+            # Publish the unknown state before a native call that may
+            # synchronously re-enter Python or mutate before raising.
+            appearance._offlineSplodgeDetach = None
+            appearance._offlineSplodgeDisabled = (model, splodge)
+            try:
+                detached[2].attach(splodge)
+            except Exception as error:
+                # A native attach may have partially committed.  Do not retry
+                # an operation whose idempotence cannot be proved.
+                _report_ground_gate_failure('decal', error)
+            else:
+                appearance._offlineSplodgeDisabled = None
+                reached = True
+        elif not visible and detached is None and hull_node is not None:
+            attempted = True
+            appearance._offlineSplodgeDisabled = (model, splodge)
+            try:
+                hull_node.detach(splodge)
+            except Exception as error:
+                _report_ground_gate_failure('decal', error)
+            else:
+                appearance._offlineSplodgeDisabled = None
+                appearance._offlineSplodgeDetach = (
+                    model, splodge, hull_node)
+                reached = True
+        elif detached is not None:
             reached = True
-        elif not visible and detached_from is None and hull_node is not None:
-            hull_node.detach(splodge)
-            appearance._offlineSplodgeParent = hull_node
+    elif splodge_disabled:
+        attempted = True
+
+    try:
+        change = getattr(decal, 'attach' if visible else 'detach', None)
+        if callable(change):
+            attempted = True
+            change()
             reached = True
-    change = getattr(decal, 'attach' if visible else 'detach', None)
-    if callable(change):
-        change()
-        reached = True
-    if not reached and not _ground_decal_gate_reported:
+    except Exception as error:
+        _report_ground_gate_failure('decal', error)
+    if not reached and not attempted and not _ground_decal_gate_reported:
         _ground_decal_gate_reported = True
         sys.stdout.write(
             '[Offline LAN 0.9.22] compound appearance exposes no ground '
             'decal owner; a hidden vehicle may still cast its occlusion '
             'decal\n')
+    return reached
+
+
+def clear_ground_decal_visibility_state(appearance):
+    """Release cached node wrappers when one appearance is retired."""
+    if appearance is None:
+        return False
+    reached = False
+    for name in ('_offlineSplodgeDetach', '_offlineSplodgeDisabled'):
+        try:
+            if getattr(appearance, name, None) is not None:
+                setattr(appearance, name, None)
+                reached = True
+        except Exception:
+            # Teardown must not dereference or recover a retired native node.
+            pass
     return reached
 
 

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/entities/remote_vehicle.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/entities/remote_vehicle.py
@@ -78,6 +78,117 @@ def set_model_attachment_visibility(model, visible):
     return True
 
 
+# One line per process for each stock surface the runtime could not reach.
+_ground_effect_gate_reported = False
+_ground_decal_gate_reported = False
+
+
+def stop_ground_effects(appearance):
+    """Stop the stock #1513 dust and exhaust selectors for one appearance.
+
+    ``CompoundAppearance.__onPeriodicTimer`` runs every 0.25 s for a living
+    vehicle and asks ``__updateEffectsLOD`` to enable ground dust within 100 m
+    and exhaust within 200 m of ``BigWorld.camera()``.  Neither threshold
+    reads the compound draw flags, so an unspotted enemy keeps emitting both
+    over a hidden hull.  The camera is what makes this visible first in an SPG
+    aiming view: it flies to the aim point, hundreds of metres from the SPG.
+
+    ``CustomEffectManager.deactivate`` is not usable as a hide because it also
+    clears the manager's vehicle.  Its selector loop is: stock ``deactivate``
+    is exactly ``for selector in __selectors: selector.stop()``, and
+    ``MainSelectorBase.update`` returns immediately once a selector is
+    stopped.  Reveal needs no counterpart; stock restarts each selector from
+    its own distance test on the next periodic tick.
+
+    ``stop`` deactivates every effect node it owns, so re-running it four
+    times a second for every hidden enemy would be real per-frame native
+    work.  ``MainSelectorBase`` keeps ``_enabled`` as its own started flag;
+    read it so a repeated gate is a comparison rather than a teardown.
+    """
+    global _ground_effect_gate_reported
+    manager = getattr(appearance, 'customEffectManager', None)
+    if manager is None:
+        return False
+    selectors = getattr(manager, '_CustomEffectManager__selectors', None)
+    if selectors is None:
+        if not _ground_effect_gate_reported:
+            _ground_effect_gate_reported = True
+            sys.stdout.write(
+                '[Offline LAN 0.9.22] custom effect manager exposes no '
+                'selector list; hidden vehicle dust and exhaust may still '
+                'draw\n')
+        return False
+    for selector in selectors:
+        if getattr(selector, '_enabled', True):
+            selector.stop()
+    return True
+
+
+def set_ground_decal_visibility(appearance, visible):
+    """Detach the ground decals a hidden #1513 compound would still draw.
+
+    Exact #1513 ``CompoundAppearance.activate`` attaches its ``VehicleDecal``
+    to the compound root, hull and turret nodes, and ``__setupModels``
+    attaches a ``BigWorld.Splodge`` built from ``chassis.AODecals[0]`` to the
+    hull node.  Both carry the tank-shaped ground occlusion texture as node
+    attachments, and this build keeps ``visible`` and ``visibleAttachments``
+    as independent model draw flags, so closing the compound alone can leave
+    that shadow on the ground under an unspotted enemy.
+
+    ``VehicleDecal.attach``/``detach`` are the exact stock pair and both are
+    idempotent through the decal's own ``__attached`` flag.  The splodge has
+    no stock pair, so use the hull node the decal already resolved through
+    ``model.node(TankPartNames.HULL)`` - the same node ``__attachSplodge``
+    used - and read it before detaching the decal clears it.
+    """
+    global _ground_decal_gate_reported
+    if appearance is None:
+        return False
+    visible = bool(visible)
+    reached = False
+    decal = getattr(appearance, '_CompoundAppearance__chassisDecal', None)
+    hull_node = getattr(decal, '_VehicleDecal__hullParent', None)
+    splodge = getattr(appearance, '_CompoundAppearance__splodge', None)
+    detached_from = getattr(appearance, '_offlineSplodgeParent', None)
+    if splodge is not None:
+        if visible and detached_from is not None:
+            detached_from.attach(splodge)
+            appearance._offlineSplodgeParent = None
+            reached = True
+        elif not visible and detached_from is None and hull_node is not None:
+            hull_node.detach(splodge)
+            appearance._offlineSplodgeParent = hull_node
+            reached = True
+    change = getattr(decal, 'attach' if visible else 'detach', None)
+    if callable(change):
+        change()
+        reached = True
+    if not reached and not _ground_decal_gate_reported:
+        _ground_decal_gate_reported = True
+        sys.stdout.write(
+            '[Offline LAN 0.9.22] compound appearance exposes no ground '
+            'decal owner; a hidden vehicle may still cast its occlusion '
+            'decal\n')
+    return reached
+
+
+def close_stock_presentation_extras(appearance, visible):
+    """Apply every draw gate the stock compound flags do not cover.
+
+    ``changeVisibility`` writes ``compoundModel.visible``, the stickers and
+    the crashed-track controller.  It reaches neither the node attachments nor
+    the camera-distance effect selectors, and both keep drawing over a hidden
+    enemy.  Each surface is optional on its own: a build that does not expose
+    one logs a single line and the round continues.
+    """
+    if appearance is None:
+        return False
+    reached = set_ground_decal_visibility(appearance, visible)
+    if not visible:
+        reached = stop_ground_effects(appearance) or reached
+    return reached
+
+
 from gui.mods.offline_lan_0922 import tank_collision
 from gui.mods.offline_lan_0922 import track_damage
 

--- a/tests/test_port_0922.py
+++ b/tests/test_port_0922.py
@@ -2002,6 +2002,90 @@ class OfflineCompatibilityTests(unittest.TestCase):
         self.assertIs(stock_start_visual,
                       vehicle_type.__dict__['startVisual'])
 
+    def test_stock_effects_lod_cannot_restart_a_hidden_lan_remote(self):
+        """The 0.25 s effects timer must not undo the spotting gate.
+
+        Exact #1513 ``CompoundAppearance.__onPeriodicTimer`` calls
+        ``__updateEffectsLOD`` every 0.25 s for every living vehicle, and that
+        method enables ground dust within 100 m and exhaust within 200 m of
+        ``BigWorld.camera()`` without reading any draw flag.  An SPG aiming
+        camera sits over its aim point rather than over the player, so an
+        unspotted enemy under that camera kept both effects running.
+        """
+        compatibility_module = _load_port_source('compat')
+        runtime, operations = self._runtime()
+        appearance_type = (
+            runtime.compound_appearance_module.CompoundAppearance)
+        method_name = '_CompoundAppearance__updateEffectsLOD'
+        original = appearance_type.__dict__[method_name]
+        vehicle_type = runtime.vehicle_module.Vehicle
+
+        class Selector(object):
+            def __init__(self, flags):
+                self.flags = flags
+                self.enabled = False
+
+            def settingsFlags(self):
+                return self.flags
+
+            def start(self):
+                self.enabled = True
+
+            def stop(self):
+                self.enabled = False
+
+        class EffectManager(object):
+            def __init__(self):
+                self._CustomEffectManager__selectors = [
+                    Selector(appearance_type.SETTING_DUST),
+                    Selector(appearance_type.SETTING_EXHAUST)]
+
+            def enable(self, enable, flags):
+                for selector in self._CustomEffectManager__selectors:
+                    if selector.settingsFlags() == flags:
+                        if enable:
+                            selector.start()
+                        else:
+                            selector.stop()
+
+            def running(self):
+                return [selector.flags
+                        for selector in self._CustomEffectManager__selectors
+                        if selector.enabled]
+
+        manager = EffectManager()
+        enemy = vehicle_type()
+        enemy.id = 11
+        enemy._offlineNativeRemote = True
+        enemy._offlineNativeDrawVisible = False
+        appearance = appearance_type(None)
+        appearance.customEffectManager = manager
+        appearance._CompoundAppearance__vehicle = enemy
+
+        compatibility = compatibility_module.OfflineCompatibility(runtime)
+        compatibility.install()
+
+        # Outside a battle the stock LOD owns the decision unchanged.
+        getattr(appearance, method_name)(10.0)
+        self.assertIn(('compound_effects_lod', 10.0), operations)
+        self.assertEqual([1, 2], manager.running())
+
+        compatibility.configure_battle(player_team=1)
+        operations[:] = []
+        getattr(appearance, method_name)(10.0)
+        self.assertEqual([], operations)
+        self.assertEqual([], manager.running())
+
+        # A drawn remote keeps the exact stock behaviour, including the
+        # ceiling that leaves dust off and exhaust on between 100 and 200 m.
+        enemy._offlineNativeDrawVisible = True
+        getattr(appearance, method_name)(150.0)
+        self.assertEqual([('compound_effects_lod', 150.0)], operations)
+        self.assertEqual([2], manager.running())
+
+        compatibility.fini()
+        self.assertIs(original, appearance_type.__dict__[method_name])
+
     def test_compatibility_does_not_replace_stock_vehicle_filters(self):
         compatibility_module = _load_port_source('compat')
         runtime, operations = self._runtime()
@@ -2876,10 +2960,31 @@ class OfflineCompatibilityTests(unittest.TestCase):
                     start_point, end_point, False, False)
 
         class CompoundAppearance(object):
+            # Exact #1513 ``EffectSettings`` selector flags.
+            SETTING_DUST = 1
+            SETTING_EXHAUST = 2
+            # Exact #1513 ``__updateEffectsLOD`` camera-distance ceilings.
+            LOD_DISTANCE_EXHAUST = 200.0
+            LOD_DISTANCE_TRAIL_PARTICLES = 100.0
+
             def __init__(self, vehicle_filter):
                 self._CompoundAppearance__filter = vehicle_filter
+                self._CompoundAppearance__vehicle = None
+                self.customEffectManager = None
                 self._arena_callback = lambda *unused: None
                 self._camera_callback = lambda *unused: None
+
+            def __updateEffectsLOD(self, distanceFromPlayer):
+                operations.append(
+                    ('compound_effects_lod', distanceFromPlayer))
+                if not self.customEffectManager:
+                    return
+                self.customEffectManager.enable(
+                    distanceFromPlayer <=
+                    self.LOD_DISTANCE_TRAIL_PARTICLES, self.SETTING_DUST)
+                self.customEffectManager.enable(
+                    distanceFromPlayer <= self.LOD_DISTANCE_EXHAUST,
+                    self.SETTING_EXHAUST)
 
             def __onModelsRefresh(self, model_state, resource_list):
                 operations.append(

--- a/tests/test_port_0922.py
+++ b/tests/test_port_0922.py
@@ -3021,6 +3021,8 @@ class OfflineCompatibilityTests(unittest.TestCase):
             def __onModelsRefresh(self, model_state, resource_list):
                 operations.append(
                     ('compound_refresh_before', model_state, resource_list))
+                if getattr(self, 'deactivate_during_refresh', False):
+                    self.deactivate(False)
                 replacement = getattr(self, 'replacement_filter', None)
                 if replacement is not None:
                     self._CompoundAppearance__filter = replacement
@@ -4409,12 +4411,20 @@ class OfflineCompatibilityTests(unittest.TestCase):
         operations[:] = []
         replacement = VehicleFilter('replacement')
         appearance.replacement_filter = replacement
+        detached = object()
+        disabled = object()
+        appearance._offlineSplodgeDetach = detached
+        appearance._offlineSplodgeDisabled = disabled
+        appearance.deactivate_during_refresh = True
         getattr(appearance, method_name)('offline', {'offline': True})
         self.assertEqual(
             [('compound_refresh_before', 'offline', {'offline': True}),
+             ('compound_deactivate', False),
              ('compound_refresh_after',)],
             operations)
         self.assertIsNone(compatibility._compound_refreshing_models)
+        self.assertIs(detached, appearance._offlineSplodgeDetach)
+        self.assertIs(disabled, appearance._offlineSplodgeDisabled)
         self.assertIs(replacement, appearance.nested_filter)
         self.assertIs(
             replacement,
@@ -4483,11 +4493,15 @@ class OfflineCompatibilityTests(unittest.TestCase):
         runtime.bigworld._player = None
         appearance = appearance_type(object())
         appearance.fail_deactivate = True
+        appearance._offlineSplodgeDetach = object()
+        appearance._offlineSplodgeDisabled = object()
 
         with self.assertRaisesRegex(
                 RuntimeError, 'compound deactivate failed'):
             appearance.deactivate(False)
 
+        self.assertIsNone(appearance._offlineSplodgeDetach)
+        self.assertIsNone(appearance._offlineSplodgeDisabled)
         self.assertNotIn('player', runtime.bigworld.__dict__)
         self.assertIs(original_player,
                       runtime.bigworld.__class__.__dict__['player'])

--- a/tests/test_port_0922.py
+++ b/tests/test_port_0922.py
@@ -2053,13 +2053,31 @@ class OfflineCompatibilityTests(unittest.TestCase):
                         for selector in self._CustomEffectManager__selectors
                         if selector.enabled]
 
+        class Decal(object):
+            def __init__(self):
+                self._VehicleDecal__attached = True
+                self._VehicleDecal__hullParent = object()
+                self.detaches = 0
+
+            def attach(self):
+                self._VehicleDecal__attached = True
+
+            def detach(self):
+                if not self._VehicleDecal__attached:
+                    return
+                self.detaches += 1
+                self._VehicleDecal__attached = False
+                self._VehicleDecal__hullParent = None
+
         manager = EffectManager()
+        decal = Decal()
         enemy = vehicle_type()
         enemy.id = 11
         enemy._offlineNativeRemote = True
         enemy._offlineNativeDrawVisible = False
         appearance = appearance_type(None)
         appearance.customEffectManager = manager
+        appearance._CompoundAppearance__chassisDecal = decal
         appearance._CompoundAppearance__vehicle = enemy
 
         compatibility = compatibility_module.OfflineCompatibility(runtime)
@@ -2075,6 +2093,18 @@ class OfflineCompatibilityTests(unittest.TestCase):
         getattr(appearance, method_name)(10.0)
         self.assertEqual([], operations)
         self.assertEqual([], manager.running())
+        self.assertFalse(decal._VehicleDecal__attached)
+
+        # ``VehicleDecal.onSettingsChanged`` re-attaches every decal when the
+        # shadow quality changes.  This bounded callback is what makes the
+        # ground gate self-healing, and it must not detach twice.
+        self.assertEqual(1, decal.detaches)
+        getattr(appearance, method_name)(10.0)
+        self.assertEqual(1, decal.detaches)
+        decal.attach()
+        getattr(appearance, method_name)(10.0)
+        self.assertFalse(decal._VehicleDecal__attached)
+        self.assertEqual(2, decal.detaches)
 
         # A drawn remote keeps the exact stock behaviour, including the
         # ceiling that leaves dust off and exhaust on between 100 and 200 m.
@@ -2970,6 +3000,8 @@ class OfflineCompatibilityTests(unittest.TestCase):
             def __init__(self, vehicle_filter):
                 self._CompoundAppearance__filter = vehicle_filter
                 self._CompoundAppearance__vehicle = None
+                self._CompoundAppearance__chassisDecal = None
+                self._CompoundAppearance__splodge = None
                 self.customEffectManager = None
                 self._arena_callback = lambda *unused: None
                 self._camera_callback = lambda *unused: None

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -34,7 +34,7 @@ from gui.mods.offline_lan_0922.entities import remote_vehicle as \
 from gui.mods.offline_lan_0922.entities.bigworld_binding import \
     BigWorldVehicleBinding
 from gui.mods.offline_lan_0922.entities.native_remote_vehicle import \
-    NativeRemoteVehicleFactory, _NativeRemoteState
+    NativeRemoteVehicleFactory, _NativeRemoteState, set_draw_visibility
 
 
 class _Vector(object):
@@ -554,6 +554,109 @@ class _VehicleDescr(object):
             typeName or compactDescr or 'ussr:R11_MS-1', loaded=False)
 
 
+class _EffectSelector(object):
+    """Reproduce exact #1513 ``MainSelectorBase`` start/stop enablement.
+
+    Stock ``stop`` deactivates every effect node it owns, so the count of
+    stops is the native work a repeated hide edge would cost.
+    """
+
+    def __init__(self, settings_flags):
+        self.settings_flags = int(settings_flags)
+        self._enabled = True
+        self.stops = 0
+
+    @property
+    def enabled(self):
+        return self._enabled
+
+    def settingsFlags(self):
+        return self.settings_flags
+
+    def start(self):
+        self._enabled = True
+
+    def stop(self):
+        self.stops += 1
+        self._enabled = False
+
+
+class _CustomEffectManager(object):
+    """Reproduce the exact #1513 dust and exhaust selector container."""
+
+    SETTING_DUST = 1
+    SETTING_EXHAUST = 2
+
+    def __init__(self):
+        self._CustomEffectManager__selectors = [
+            _EffectSelector(self.SETTING_DUST),
+            _EffectSelector(self.SETTING_EXHAUST)]
+
+    def enable(self, enable, settings_flags):
+        for selector in self._CustomEffectManager__selectors:
+            if selector.settingsFlags() == settings_flags:
+                if enable:
+                    selector.start()
+                else:
+                    selector.stop()
+
+    def deactivate(self):
+        for selector in self._CustomEffectManager__selectors:
+            selector.stop()
+        self._CustomEffectManager__vehicle = None
+
+    def running(self):
+        return [selector.settingsFlags()
+                for selector in self._CustomEffectManager__selectors
+                if selector.enabled]
+
+
+class _ModelNode(object):
+    """A compound node that rejects a double attach or a stale detach."""
+
+    def __init__(self):
+        self.attachments = []
+
+    def attach(self, attachment):
+        if attachment in self.attachments:
+            raise RuntimeError('attachment is already attached')
+        self.attachments.append(attachment)
+
+    def detach(self, attachment):
+        if attachment not in self.attachments:
+            raise RuntimeError('attachment is not attached')
+        self.attachments.remove(attachment)
+
+
+class _VehicleDecal(object):
+    """Reproduce exact #1513 ``VehicleDecal`` attach/detach idempotence."""
+
+    def __init__(self, hull_node):
+        self.hull_node = hull_node
+        self._VehicleDecal__attached = True
+        self._VehicleDecal__hullParent = hull_node
+        self.decal = object()
+        hull_node.attach(self.decal)
+
+    @property
+    def attached(self):
+        return self._VehicleDecal__attached
+
+    def attach(self):
+        if self._VehicleDecal__attached:
+            return
+        self._VehicleDecal__attached = True
+        self._VehicleDecal__hullParent = self.hull_node
+        self.hull_node.attach(self.decal)
+
+    def detach(self):
+        if not self._VehicleDecal__attached:
+            return
+        self._VehicleDecal__attached = False
+        self._VehicleDecal__hullParent = None
+        self.hull_node.detach(self.decal)
+
+
 class _Vehicle(object):
     def __init__(self, entity_id, descriptor, position, rotation, properties):
         self.id = entity_id
@@ -577,6 +680,13 @@ class _Vehicle(object):
             self.visibility_changes.append(bool(visible))
             self.model.visible = bool(visible)
 
+        self.hull_node = _ModelNode()
+        self.splodge = object()
+        self.hull_node.attach(self.splodge)
+        self.chassis_decal = _VehicleDecal(self.hull_node)
+        self.custom_effects = _CustomEffectManager()
+        self.custom_effects.enable(True, _CustomEffectManager.SETTING_DUST)
+        self.custom_effects.enable(True, _CustomEffectManager.SETTING_EXHAUST)
         self.appearance = types.SimpleNamespace(
             compoundModel=self.model, turretMatrix=_Matrix(),
             gunMatrix=_Matrix(),
@@ -591,6 +701,12 @@ class _Vehicle(object):
                 self.track_scrolls.append((left, right)),
             changeEngineMode=lambda mode, forceSwinging=False:
                 self.engine_modes.append(tuple(mode)))
+        # Exact #1513 keeps the ground occlusion decals and the camera
+        # distance effect selectors outside every compound draw flag.
+        setattr(self.appearance, 'customEffectManager', self.custom_effects)
+        setattr(self.appearance, '_CompoundAppearance__chassisDecal',
+                self.chassis_decal)
+        setattr(self.appearance, '_CompoundAppearance__splodge', self.splodge)
         self.health = properties['health']
         self.isCrewActive = True
         self.gunAnglesPacked = properties.get('gunAnglesPacked', 0)
@@ -609,6 +725,10 @@ class _Vehicle(object):
 
     def show(self, visible):
         self.shows.append(bool(visible))
+        # Exact #1513 ``Vehicle.show`` reaches the appearance only once
+        # ``startVisual`` has set ``isStarted``.
+        if not self.isStarted:
+            return
         self.draw_pass_visible = bool(visible)
 
     def drawEdge(self, force_simple_edge):
@@ -19969,6 +20089,142 @@ class BattleRuntimeContractTests(unittest.TestCase):
         battle._binding.start_vehicle_marker.assert_called_once_with(1000)
         battle._binding.start_vehicle_minimap.assert_not_called()
 
+    def test_hidden_remote_stops_drawing_its_ground_decals_and_effects(self):
+        """Closing the compound is not enough for an unspotted enemy.
+
+        Exact #1513 ``CompoundAppearance.changeVisibility`` writes only
+        ``compoundModel.visible``, ``showStickers`` and the crashed-track
+        controller, and ``Vehicle.show`` only swaps the draw-pass mask.  The
+        occlusion decals and the ``BigWorld.Splodge`` are node attachments,
+        and ``customEffectManager`` runs its dust and exhaust selectors from
+        ``BigWorld.camera()`` distance alone, so an unspotted tank kept its
+        ground shadow and kept emitting exhaust.
+        """
+        vehicle = _Vehicle(
+            1000, _Descriptor(), _Vector(), (0.0, 0.0, 0.0),
+            {'health': 500, 'publicInfo': {'team': 2}})
+        appearance = vehicle.appearance
+        self.assertEqual([1, 2], vehicle.custom_effects.running())
+        self.assertIn(vehicle.splodge, vehicle.hull_node.attachments)
+        self.assertTrue(vehicle.chassis_decal.attached)
+
+        self.assertTrue(set_draw_visibility(vehicle, False))
+
+        self.assertFalse(vehicle.model.visible)
+        self.assertEqual([], vehicle.custom_effects.running())
+        self.assertNotIn(vehicle.splodge, vehicle.hull_node.attachments)
+        self.assertFalse(vehicle.chassis_decal.attached)
+        self.assertIs(
+            vehicle.hull_node,
+            getattr(appearance, '_offlineSplodgeParent'))
+
+        # A repeated hide edge must not detach an already detached decal or
+        # tear the effect nodes down again.
+        stops = [selector.stops for selector
+                 in vehicle.custom_effects._CustomEffectManager__selectors]
+        self.assertTrue(set_draw_visibility(vehicle, False))
+        self.assertNotIn(vehicle.splodge, vehicle.hull_node.attachments)
+        self.assertEqual(stops, [
+            selector.stops for selector
+            in vehicle.custom_effects._CustomEffectManager__selectors])
+
+        self.assertTrue(set_draw_visibility(vehicle, True))
+
+        self.assertTrue(vehicle.model.visible)
+        self.assertIn(vehicle.splodge, vehicle.hull_node.attachments)
+        self.assertTrue(vehicle.chassis_decal.attached)
+        self.assertIsNone(getattr(appearance, '_offlineSplodgeParent'))
+        # Reveal never starts an effect selector: stock owns that decision
+        # through its own camera-distance test on the next periodic tick.
+        self.assertEqual([], vehicle.custom_effects.running())
+        self.assertTrue(set_draw_visibility(vehicle, True))
+        self.assertIn(vehicle.splodge, vehicle.hull_node.attachments)
+
+    def test_hidden_remote_gate_survives_a_client_without_those_owners(self):
+        """A build that exposes neither owner still runs the round."""
+        vehicle = _Vehicle(
+            1000, _Descriptor(), _Vector(), (0.0, 0.0, 0.0),
+            {'health': 500, 'publicInfo': {'team': 2}})
+        delattr(vehicle.appearance, '_CompoundAppearance__chassisDecal')
+        delattr(vehicle.appearance, '_CompoundAppearance__splodge')
+        delattr(vehicle.appearance, 'customEffectManager')
+
+        self.assertTrue(set_draw_visibility(vehicle, False))
+        self.assertFalse(vehicle.model.visible)
+
+    def test_spectated_ally_beyond_the_wreck_aoi_is_still_drawn(self):
+        """A dead player's AOI follows the vehicle the camera observes.
+
+        The local integrator stops the moment the player dies, so
+        ``_local_position`` freezes at the wreck.  Centring the 565 m vehicle
+        AOI there hid the observed ally itself, and every vehicle around it,
+        as soon as the wreck was far away.
+        """
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle.client = _Client()
+        battle._avatar = runtime.bigworld.avatar
+        battle._binding = mock.Mock()
+        battle._local_position = (0.0, 0.0, 0.0)
+        battle._server = types.SimpleNamespace(vehicle_id=10)
+        ally = RemoteVehicle(
+            1000, _Descriptor(), {
+                'publicInfo': {'team': 1, 'name': 'Ally'},
+                'health': 500, 'isCrewActive': True,
+                'gunAnglesPacked': 0},
+            _Vector(900.0, 0.0, 0.0), (0.0, 0.0, 0.0), runtime.math)
+        enemy = RemoteVehicle(
+            1001, _Descriptor(), {
+                'publicInfo': {'team': 2, 'name': 'Enemy'},
+                'health': 500, 'isCrewActive': True,
+                'gunAnglesPacked': 0},
+            _Vector(940.0, 0.0, 0.0), (0.0, 0.0, 0.0), runtime.math)
+        for vehicle in (ally, enemy):
+            vehicle.model = _Model()
+            vehicle.appearance.attach(vehicle.model)
+            vehicle.isStarted = True
+            vehicle.inWorld = True
+        entities = {1000: ally, 1001: enemy}
+        runtime.bigworld.entities.update(entities)
+        battle._remote_factory = types.SimpleNamespace(
+            get=lambda entity_id: entities.get(entity_id))
+        battle._spotting_observers = lambda: ()
+        ally_record = {
+            'engine_id': 1000, 'kind': 'bot', 'network_id': 17,
+            'ready': True, 'local': False, 'presentation': True,
+            'tombstone': False, 'native_remote': False,
+            'world_marker_started': True, 'minimap_started': True,
+            'spot_visible': True, 'spot_marker_visible': True,
+            'state': {'team': 1, 'health': 500, 'alive': True}}
+        enemy_record = {
+            'engine_id': 1001, 'kind': 'bot', 'network_id': 18,
+            'ready': True, 'local': False, 'presentation': True,
+            'tombstone': False, 'native_remote': False,
+            'world_marker_started': True, 'minimap_started': True,
+            'spot_visible': True, 'spot_marker_visible': True,
+            'spot_until': 99.0, 'spot_next': 999.0,
+            'state': {'team': 2, 'health': 500, 'alive': True}}
+        battle._records = {'bot:17': ally_record, 'bot:18': enemy_record}
+
+        # The wreck is still the viewpoint: both are outside its AOI.
+        battle._spectated_engine_id = 10
+        self.assertTrue(battle._update_spotting(10.0))
+        self.assertFalse(ally_record['spot_visible'])
+        self.assertFalse(enemy_record['spot_visible'])
+
+        # Observing the ally recentres the AOI on it, which draws the ally
+        # and the enemy the team still remembers next to it.
+        battle._spectated_engine_id = 1000
+        battle._next_spotting_time = 0.0
+        self.assertTrue(battle._update_spotting(10.1))
+        self.assertTrue(ally_record['spot_visible'])
+        self.assertTrue(enemy_record['spot_visible'])
+        self.assertEqual((900.0, 0.0, 0.0), battle._presentation_origin())
+
+        # Leaving postmortem returns the AOI to the local vehicle.
+        battle._spectated_engine_id = None
+        self.assertEqual((0.0, 0.0, 0.0), battle._presentation_origin())
+
     def test_strategic_spg_view_draws_team_spotted_target_beyond_aoi(self):
         runtime = _runtime()
         battle = BattleRuntime(runtime)
@@ -22258,6 +22514,43 @@ class BattleRuntimeContractTests(unittest.TestCase):
                          battle._records['player:1']['shot_penalty_until'])
         self.assertEqual(10.75,
                          battle._records['player:2']['shot_penalty_until'])
+
+    def test_an_unspotted_shooter_fires_without_a_visible_muzzle(self):
+        """The stock shoot extra is a node-bound effect like the fire extra.
+
+        Exact #1513 ``Vehicle.showShooting`` for a remote is exactly
+        ``extra.stopFor`` then ``extra.startFor``, guarded only by
+        ``isStarted`` and the siege state.  Retail never delivers that event
+        for a vehicle the client cannot see, so an unspotted enemy must not
+        flash its muzzle or play its gun sound over a hidden hull.  The
+        camouflage penalty, the shot bookkeeping and the projectile itself are
+        unaffected.
+        """
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        local = _Vehicle(10, _Descriptor(), _Vector(), (0, 0, 0),
+                         {'health': 500})
+        hidden = _Vehicle(11, _Descriptor(), _Vector(), (0, 0, 0),
+                          {'health': 500})
+        runtime.bigworld.entities.update({10: local, 11: hidden})
+        battle._records = {
+            'player:1': {'engine_id': 10, 'local': True},
+            'bot:1': {'engine_id': 11, 'local': False,
+                      'spot_visible': False}}
+
+        battle._show_shot({'attacker_bot': 1})
+
+        self.assertFalse(hasattr(hidden, 'last_shot'))
+        self.assertEqual(10.75,
+                         battle._records['bot:1']['shot_penalty_until'])
+
+        battle._records['bot:1']['spot_visible'] = True
+        battle._show_shot({'attacker_bot': 1})
+        self.assertEqual((1, False), hidden.last_shot)
+
+        # The local player is never gated by the spotting record.
+        battle._show_shot({'attacker': 1})
+        self.assertEqual((1, False), local.last_shot)
 
     def test_bot_shot_camouflage_penalty_does_not_mark_same_id_player(self):
         runtime = _runtime()

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -616,13 +616,23 @@ class _ModelNode(object):
 
     def __init__(self):
         self.attachments = []
+        self.attach_calls = []
+        self.detach_calls = []
+        self.attach_error = None
+        self.detach_error = None
 
     def attach(self, attachment):
+        self.attach_calls.append(attachment)
+        if self.attach_error is not None:
+            raise self.attach_error
         if attachment in self.attachments:
             raise RuntimeError('attachment is already attached')
         self.attachments.append(attachment)
 
     def detach(self, attachment):
+        self.detach_calls.append(attachment)
+        if self.detach_error is not None:
+            raise self.detach_error
         if attachment not in self.attachments:
             raise RuntimeError('attachment is not attached')
         self.attachments.remove(attachment)
@@ -2248,9 +2258,13 @@ class NativeRemoteVehicleFactoryTests(unittest.TestCase):
 
     def test_native_state_detach_retains_owner_until_overlay_cleanup_succeeds(self):
         runtime = _runtime()
+        splodge_owner = object()
         entity = types.SimpleNamespace(
             id=44, inWorld=True, isStarted=True,
-            appearance=types.SimpleNamespace(onModelChanged=None))
+            appearance=types.SimpleNamespace(
+                onModelChanged=None,
+                _offlineSplodgeDetach=splodge_owner,
+                _offlineSplodgeDisabled=splodge_owner))
         bigworld = types.SimpleNamespace(entities={44: entity})
         compatibility = mock.Mock()
         compatibility.clear_vehicle_pose_overlay.side_effect = RuntimeError(
@@ -2267,11 +2281,42 @@ class NativeRemoteVehicleFactoryTests(unittest.TestCase):
 
         self.assertIs(entity, state.entity)
         self.assertIs(callback, state.model_changed)
+        self.assertIs(
+            splodge_owner, entity.appearance._offlineSplodgeDetach)
+        self.assertIs(
+            splodge_owner, entity.appearance._offlineSplodgeDisabled)
 
         compatibility.clear_vehicle_pose_overlay.side_effect = None
         self.assertTrue(state.detach())
         self.assertIsNone(state.entity)
         self.assertIsNone(state.model_changed)
+        self.assertIsNone(entity.appearance._offlineSplodgeDetach)
+        self.assertIsNone(entity.appearance._offlineSplodgeDisabled)
+
+    def test_native_state_detach_does_not_read_retired_appearance(self):
+        runtime = _runtime()
+
+        class RetiredEntity(object):
+            id = 44
+            inWorld = False
+            isStarted = False
+
+            @property
+            def appearance(self):
+                raise ReferenceError('retired native appearance')
+
+        entity = RetiredEntity()
+        compatibility = mock.Mock()
+        state = _NativeRemoteState(
+            types.SimpleNamespace(entities={}), runtime.math,
+            compatibility, None, _Vector(), (0.0, 0.0, 0.0))
+        state.entity = entity
+
+        self.assertTrue(state.detach())
+
+        compatibility.clear_vehicle_pose_overlay.assert_called_once_with(
+            entity)
+        self.assertIsNone(state.entity)
 
     def test_native_siege_authority_uses_hydraulic_body_and_ground_chassis(self):
         runtime = _runtime()
@@ -2675,13 +2720,33 @@ class NativeRemoteVehicleFactoryTests(unittest.TestCase):
 
         vehicle._offlineNativeDrawVisible = False
         vehicle._spot_visible = False
+        self.assertTrue(set_draw_visibility(vehicle, False))
+        old_hull = vehicle.hull_node
+        old_splodge = vehicle.splodge
+        old_attach_count = len(old_hull.attach_calls)
         vehicle.model = _Model()
         vehicle.appearance.compoundModel = vehicle.model
+        refreshed_hull = _ModelNode()
+        refreshed_decal = _VehicleDecal(refreshed_hull)
+        setattr(
+            vehicle.appearance, '_CompoundAppearance__chassisDecal',
+            refreshed_decal)
+        # #1513 retains __splodge across this compound replacement, so it is
+        # still detached from the retired hull and has no proven new owner.
+        setattr(
+            vehicle.appearance, '_CompoundAppearance__splodge',
+            old_splodge)
         for handler in tuple(vehicle.appearance.onModelChanged.handlers):
             handler()
         self.assertIs(provider, vehicle.model.matrix)
         self.assertFalse(vehicle.model.visible)
         self.assertEqual([], vehicle.targetCaps)
+        self.assertEqual(old_attach_count, len(old_hull.attach_calls))
+        self.assertNotIn(old_splodge, refreshed_hull.detach_calls)
+        disabled = getattr(
+            vehicle.appearance, '_offlineSplodgeDisabled')
+        self.assertIs(vehicle.model, disabled[0])
+        self.assertIs(old_splodge, disabled[1])
 
         # A late stock wreck-model relink must preserve world visibility while
         # never turning the dead vehicle back into a spotting-gated target.
@@ -20114,9 +20179,10 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertEqual([], vehicle.custom_effects.running())
         self.assertNotIn(vehicle.splodge, vehicle.hull_node.attachments)
         self.assertFalse(vehicle.chassis_decal.attached)
-        self.assertIs(
-            vehicle.hull_node,
-            getattr(appearance, '_offlineSplodgeParent'))
+        detached = getattr(appearance, '_offlineSplodgeDetach')
+        self.assertIs(vehicle.model, detached[0])
+        self.assertIs(vehicle.splodge, detached[1])
+        self.assertIs(vehicle.hull_node, detached[2])
 
         # A repeated hide edge must not detach an already detached decal or
         # tear the effect nodes down again.
@@ -20133,12 +20199,175 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertTrue(vehicle.model.visible)
         self.assertIn(vehicle.splodge, vehicle.hull_node.attachments)
         self.assertTrue(vehicle.chassis_decal.attached)
-        self.assertIsNone(getattr(appearance, '_offlineSplodgeParent'))
+        self.assertIsNone(getattr(appearance, '_offlineSplodgeDetach'))
         # Reveal never starts an effect selector: stock owns that decision
         # through its own camera-distance test on the next periodic tick.
         self.assertEqual([], vehicle.custom_effects.running())
         self.assertTrue(set_draw_visibility(vehicle, True))
         self.assertIn(vehicle.splodge, vehicle.hull_node.attachments)
+
+    def test_ground_splodge_rebind_uses_only_the_current_model_generation(self):
+        vehicle = _Vehicle(
+            1000, _Descriptor(), _Vector(), (0.0, 0.0, 0.0),
+            {'health': 500, 'publicInfo': {'team': 2}})
+        appearance = vehicle.appearance
+        old_hull = vehicle.hull_node
+        old_splodge = vehicle.splodge
+
+        self.assertTrue(set_draw_visibility(vehicle, False))
+        old_attach_count = len(old_hull.attach_calls)
+
+        new_model = _Model()
+        new_hull = _ModelNode()
+        new_splodge = object()
+        new_hull.attach(new_splodge)
+        new_decal = _VehicleDecal(new_hull)
+        appearance.compoundModel = new_model
+        setattr(appearance, '_CompoundAppearance__splodge', new_splodge)
+        setattr(appearance, '_CompoundAppearance__chassisDecal', new_decal)
+
+        self.assertTrue(set_draw_visibility(vehicle, False))
+
+        self.assertEqual(old_attach_count, len(old_hull.attach_calls))
+        self.assertNotIn(old_splodge, old_hull.attachments)
+        self.assertIn(new_splodge, new_hull.detach_calls)
+        self.assertNotIn(new_splodge, new_hull.attachments)
+        self.assertTrue(set_draw_visibility(vehicle, True))
+        self.assertIn(new_splodge, new_hull.attachments)
+        self.assertIsNone(getattr(appearance, '_offlineSplodgeDetach'))
+        self.assertIsNone(getattr(
+            appearance, '_offlineSplodgeDisabled', None))
+
+    def test_reused_splodge_is_disabled_when_the_compound_changes(self):
+        vehicle = _Vehicle(
+            1000, _Descriptor(), _Vector(), (0.0, 0.0, 0.0),
+            {'health': 500, 'publicInfo': {'team': 2}})
+        appearance = vehicle.appearance
+        old_hull = vehicle.hull_node
+        splodge = vehicle.splodge
+        self.assertTrue(set_draw_visibility(vehicle, False))
+        old_attach_count = len(old_hull.attach_calls)
+
+        new_model = _Model()
+        new_hull = _ModelNode()
+        new_decal = _VehicleDecal(new_hull)
+        appearance.compoundModel = new_model
+        setattr(appearance, '_CompoundAppearance__chassisDecal', new_decal)
+        # Exact #1513 can retain __splodge while replacing the compound.  The
+        # retained object is detached from the old hull and was never attached
+        # to this new hull, so neither node is a safe owner now.
+        setattr(appearance, '_CompoundAppearance__splodge', splodge)
+
+        self.assertTrue(set_draw_visibility(vehicle, False))
+        self.assertTrue(set_draw_visibility(vehicle, True))
+
+        self.assertEqual(old_attach_count, len(old_hull.attach_calls))
+        self.assertNotIn(splodge, new_hull.detach_calls)
+        self.assertNotIn(splodge, new_hull.attach_calls)
+        self.assertIsNone(getattr(appearance, '_offlineSplodgeDetach'))
+        self.assertEqual(
+            (new_model, splodge),
+            getattr(appearance, '_offlineSplodgeDisabled'))
+        self.assertTrue(new_decal.attached)
+
+        # A later stock generation with a new Splodge gets a fresh gate; the
+        # disabled token must never outlive the exact model/object pair.
+        latest_model = _Model()
+        latest_hull = _ModelNode()
+        latest_splodge = object()
+        latest_hull.attach(latest_splodge)
+        latest_decal = _VehicleDecal(latest_hull)
+        appearance.compoundModel = latest_model
+        setattr(
+            appearance, '_CompoundAppearance__splodge', latest_splodge)
+        setattr(
+            appearance, '_CompoundAppearance__chassisDecal', latest_decal)
+        self.assertTrue(set_draw_visibility(vehicle, False))
+        self.assertIn(latest_splodge, latest_hull.detach_calls)
+        self.assertTrue(set_draw_visibility(vehicle, True))
+        self.assertIn(latest_splodge, latest_hull.attachments)
+
+    def test_ground_owner_failures_do_not_abort_the_other_visibility_gates(self):
+        vehicle = _Vehicle(
+            1000, _Descriptor(), _Vector(), (0.0, 0.0, 0.0),
+            {'health': 500, 'publicInfo': {'team': 2}})
+        appearance = vehicle.appearance
+        selectors = vehicle.custom_effects._CustomEffectManager__selectors
+        selectors[0].stop = mock.Mock(
+            side_effect=RuntimeError('dust stop failed'))
+        original_detach = vehicle.hull_node.detach
+        splodge_detach = mock.Mock()
+
+        def selective_detach(attachment):
+            if attachment is vehicle.splodge:
+                splodge_detach(attachment)
+                original_detach(attachment)
+                raise ReferenceError('splodge parent expired')
+            return original_detach(attachment)
+
+        vehicle.hull_node.detach = selective_detach
+
+        self.assertTrue(set_draw_visibility(vehicle, False))
+
+        self.assertFalse(vehicle.model.visible)
+        self.assertTrue(vehicle.chassis_decal.attached is False)
+        self.assertTrue(selectors[0].enabled)
+        self.assertFalse(selectors[1].enabled)
+        self.assertEqual(1, splodge_detach.call_count)
+        disabled = getattr(appearance, '_offlineSplodgeDisabled')
+        self.assertIs(vehicle.model, disabled[0])
+        self.assertIs(vehicle.splodge, disabled[1])
+
+        # The unsafe native owner stays disabled for this generation while
+        # the idempotent stock decal may still follow later visibility edges.
+        self.assertTrue(set_draw_visibility(vehicle, False))
+        self.assertTrue(set_draw_visibility(vehicle, True))
+        self.assertEqual(1, splodge_detach.call_count)
+        self.assertTrue(vehicle.chassis_decal.attached)
+
+        # A compound replacement does not make a retained Splodge safe again:
+        # the failed detach may already have changed native ownership.
+        new_model = _Model()
+        new_hull = _ModelNode()
+        new_decal = _VehicleDecal(new_hull)
+        appearance.compoundModel = new_model
+        setattr(appearance, '_CompoundAppearance__chassisDecal', new_decal)
+        self.assertTrue(set_draw_visibility(vehicle, False))
+        self.assertTrue(set_draw_visibility(vehicle, True))
+        self.assertNotIn(vehicle.splodge, new_hull.detach_calls)
+        self.assertNotIn(vehicle.splodge, new_hull.attach_calls)
+        disabled = getattr(appearance, '_offlineSplodgeDisabled')
+        self.assertIs(new_model, disabled[0])
+        self.assertIs(vehicle.splodge, disabled[1])
+
+    def test_failed_splodge_attach_is_not_retried_for_the_same_generation(self):
+        vehicle = _Vehicle(
+            1000, _Descriptor(), _Vector(), (0.0, 0.0, 0.0),
+            {'health': 500, 'publicInfo': {'team': 2}})
+        appearance = vehicle.appearance
+        self.assertTrue(set_draw_visibility(vehicle, False))
+        original_attach = vehicle.hull_node.attach
+        splodge_attach = mock.Mock()
+
+        def selective_attach(attachment):
+            if attachment is vehicle.splodge:
+                splodge_attach(attachment)
+                original_attach(attachment)
+                raise ReferenceError('splodge parent expired')
+            return original_attach(attachment)
+
+        vehicle.hull_node.attach = selective_attach
+
+        self.assertTrue(set_draw_visibility(vehicle, True))
+        self.assertTrue(set_draw_visibility(vehicle, True))
+
+        self.assertEqual(1, splodge_attach.call_count)
+        self.assertIn(vehicle.splodge, vehicle.hull_node.attachments)
+        self.assertTrue(vehicle.chassis_decal.attached)
+        self.assertIsNone(getattr(appearance, '_offlineSplodgeDetach'))
+        disabled = getattr(appearance, '_offlineSplodgeDisabled')
+        self.assertIs(vehicle.model, disabled[0])
+        self.assertIs(vehicle.splodge, disabled[1])
 
     def test_reveal_before_start_visual_leaves_the_draw_pass_to_stock(self):
         """``Vehicle.show`` is a silent no-op until ``startVisual`` runs.

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -20140,6 +20140,29 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertTrue(set_draw_visibility(vehicle, True))
         self.assertIn(vehicle.splodge, vehicle.hull_node.attachments)
 
+    def test_reveal_before_start_visual_leaves_the_draw_pass_to_stock(self):
+        """``Vehicle.show`` is a silent no-op until ``startVisual`` runs.
+
+        Exact #1513 ``show`` reaches ``changeDrawPassVisibility`` only while
+        ``isStarted`` is set, and ``changeVisibility`` alone never clears
+        ``skipColorPass``, so a reveal inside that window cannot restore the
+        colour pass by itself.  Stock ``startVisual`` sets ``isStarted`` and
+        then calls ``show(True)``, which is the owner of that restore; the
+        runtime re-asserts its own gate after that call returns.
+        """
+        vehicle = _Vehicle(
+            1000, _Descriptor(), _Vector(), (0.0, 0.0, 0.0),
+            {'health': 500, 'publicInfo': {'team': 2}})
+        self.assertTrue(set_draw_visibility(vehicle, False))
+        vehicle.isStarted = False
+
+        self.assertTrue(set_draw_visibility(vehicle, True))
+
+        self.assertEqual([False, True], vehicle.shows)
+        self.assertFalse(vehicle.draw_pass_visible)
+        self.assertTrue(vehicle.model.visible)
+        self.assertTrue(vehicle.chassis_decal.attached)
+
     def test_hidden_remote_gate_survives_a_client_without_those_owners(self):
         """A build that exposes neither owner still runs the round."""
         vehicle = _Vehicle(

--- a/tests/test_port_0922_client_abi_audit.py
+++ b/tests/test_port_0922_client_abi_audit.py
@@ -1,4 +1,6 @@
+import ast
 import importlib.util
+import io
 import os
 import unittest
 
@@ -255,6 +257,51 @@ class ClientAbiProjectileAuditTests(unittest.TestCase):
 
         self.assertFalse(
             AUDIT._matches_unknown_projectile_explosion_branch(instructions))
+
+
+class ClientAbiAuditTableTests(unittest.TestCase):
+    """The expectation tables are dict literals: a repeated key is silent.
+
+    A duplicated member or member entry keeps only the last value, so an
+    earlier expectation stops being checked without any error.  That has
+    already dropped real #1513 contract coverage once, so assert it here
+    instead of noticing it as a changed ``checked*`` count.
+    """
+
+    @staticmethod
+    def _duplicate_keys():
+        source = io.open(TOOL_PATH, encoding='utf-8').read()
+        duplicates = []
+        for node in ast.parse(source).body:
+            if (not isinstance(node, ast.Assign) or
+                    not isinstance(node.value, ast.Dict) or
+                    not isinstance(node.targets[0], ast.Name)):
+                continue
+            table = node.targets[0].id
+            if not table.startswith('EXPECTED_'):
+                continue
+            for prefix, mapping in [((), node.value)] + [
+                    ((key,), value)
+                    for key, value in zip(node.value.keys, node.value.values)
+                    if isinstance(value, ast.Dict)]:
+                seen = {}
+                for key_node in mapping.keys:
+                    try:
+                        key = ast.literal_eval(key_node)
+                    except ValueError:
+                        continue
+                    label = '.'.join(
+                        [table] +
+                        [ast.literal_eval(item) for item in prefix] + [str(key)])
+                    if key in seen:
+                        duplicates.append(
+                            '%s (lines %d and %d)' %
+                            (label, seen[key], key_node.lineno))
+                    seen[key] = key_node.lineno
+        return duplicates
+
+    def test_expectation_tables_have_no_shadowed_keys(self):
+        self.assertEqual([], self._duplicate_keys())
 
 
 if __name__ == '__main__':

--- a/tools/audit_client_abi.py
+++ b/tools/audit_client_abi.py
@@ -702,6 +702,28 @@ EXPECTED_ABI = {
         'CompoundAppearance.addDamageSticker': (
             'self', 'code', 'componentName', 'stickerID',
             'segStart', 'segEnd'),
+        'CompoundAppearance.__onPeriodicTimer': ('self',),
+        'CompoundAppearance.__updateEffectsLOD': (
+            'self', 'distanceFromPlayer'),
+        'CompoundAppearance.__attachSplodge': ('self', 'splodge'),
+    },
+    'scripts/client/CustomEffectManager.pyc': {
+        'CustomEffectManager.enable': ('self', 'enable', 'settingsFlags'),
+        'CustomEffectManager.activate': ('self',),
+        'CustomEffectManager.deactivate': ('self',),
+    },
+    'scripts/client/CustomEffect.pyc': {
+        'MainSelectorBase.settingsFlags': ('self',),
+        'MainSelectorBase.start': ('self',),
+        'MainSelectorBase.stop': ('self',),
+        'MainSelectorBase.update': ('self', 'args'),
+        'MainCustomSelector.settingsFlags': ('self',),
+        'ExhaustMainSelector.settingsFlags': ('self',),
+    },
+    'scripts/client/vehicle_systems/components/vehicleDecal.pyc': {
+        'VehicleDecal.attach': ('self',),
+        'VehicleDecal.detach': ('self',),
+        'VehicleDecal.__attach': ('self',),
     },
     'scripts/client/vehicle_systems/components/highlighter.pyc': {
         'Highlighter.deactivate': ('self',),
@@ -1655,6 +1677,58 @@ EXPECTED_CODE_NAMES = {
             'BigWorld', 'player', 'inputHandler',
             'removeVehicleFromCameraCollider', 'arena',
             'onPeriodChange', 'onCameraChanged'),
+        # The periodic timer is the only stock owner of the effects LOD, and
+        # it neither reads a draw flag nor stops for an undrawn vehicle.
+        'CompoundAppearance.__onPeriodicTimer': (
+            'BigWorld', 'camera', 'position', 'isAlive',
+            '_CompoundAppearance__updateEffectsLOD',
+            'customEffectManager', 'update'),
+        'CompoundAppearance.__updateEffectsLOD': (
+            'customEffectManager', 'isUnderwater', 'BigWorld',
+            'wg_isVehicleDustEnabled', 'enable', 'EffectSettings',
+            'SETTING_DUST', 'SETTING_EXHAUST'),
+        'CompoundAppearance.__attachSplodge': (
+            '_CompoundAppearance__compoundModel', 'node', 'TankPartNames',
+            'HULL', '_CompoundAppearance__splodge', 'attach'),
+    },
+    'scripts/client/CustomEffectManager.pyc': {
+        'CustomEffectManager.enable': (
+            '_CustomEffectManager__selectors', 'settingsFlags', 'start',
+            'stop'),
+        # deactivate also clears the manager's vehicle, so it is a teardown
+        # rather than a reversible hide for one unspotted enemy.
+        'CustomEffectManager.deactivate': (
+            '_CustomEffectManager__selectors', 'stop',
+            '_CustomEffectManager__vehicle'),
+    },
+    'scripts/client/CustomEffect.pyc': {
+        'MainSelectorBase.start': ('_enabled',),
+        'MainSelectorBase.stop': (
+            '_enabled', '_activeEffectId', 'enable', '_effectNodes',
+            'values', 'deactivate'),
+        'MainSelectorBase.update': ('_enabled', '_effectSelector'),
+        'MainCustomSelector.settingsFlags': (
+            'EffectSettings', 'SETTING_DUST'),
+        'ExhaustMainSelector.settingsFlags': (
+            'EffectSettings', 'SETTING_EXHAUST'),
+    },
+    'scripts/client/vehicle_systems/components/vehicleDecal.pyc': {
+        'VehicleDecal.attach': (
+            '_VehicleDecal__attached', '_VehicleDecal__appearance',
+            '_VehicleDecal__attach'),
+        'VehicleDecal.detach': (
+            '_VehicleDecal__attached', '_VehicleDecal__chassisDecals',
+            '_VehicleDecal__chassisParent', 'detach',
+            '_VehicleDecal__hullDecals', '_VehicleDecal__hullParent',
+            '_VehicleDecal__turretDecals', '_VehicleDecal__turretParent'),
+        # __attach resolves the same hull node __attachSplodge uses, which is
+        # how the runtime finds it again after closing the draw pass.
+        'VehicleDecal.__attach': (
+            '_VehicleDecal__appearance', 'compoundModel', 'root',
+            '_VehicleDecal__chassisParent', 'node', 'TankPartNames', 'HULL',
+            '_VehicleDecal__hullParent', 'TURRET',
+            '_VehicleDecal__turretParent', 'attach',
+            '_VehicleDecal__attached'),
     },
     'scripts/client/vehicle_systems/components/highlighter.pyc': {
         'Highlighter.deactivate': (
@@ -1942,6 +2016,15 @@ EXPECTED_GLOBALS = {
     'scripts/common/physics_shared.pyc': {
         'WEIGHT_SCALE': 0.001,
     },
+    'scripts/client/vehicle_systems/CompoundAppearance.pyc': {
+        # The effects LOD runs on this cadence and measures the camera, not
+        # the player, so an SPG aiming camera enables both effects around its
+        # aim point regardless of spotting.
+        '_PERIODIC_TIME': 0.25,
+        '_LOD_DISTANCE_EXHAUST': 200.0,
+        '_LOD_DISTANCE_TRAIL_PARTICLES': 100.0,
+        'MAX_DISTANCE': 500,
+    },
     'scripts/common/AccountCommands.pyc': {
         'RES_FAILURE': -1,
         'RES_SUCCESS': 0,
@@ -1961,6 +2044,21 @@ EXPECTED_GLOBALS = {
 
 
 EXPECTED_CLASS_CONSTANTS = {
+    'scripts/client/CustomEffect.pyc': {
+        'EffectSettings': {
+            'SETTINGS_NO': 0,
+            'SETTING_DUST': 1,
+            'SETTING_EXHAUST': 2,
+        },
+    },
+    'scripts/client/vehicle_systems/tankStructure.pyc': {
+        'TankPartNames': {
+            'CHASSIS': 'chassis',
+            'HULL': 'hull',
+            'TURRET': 'turret',
+            'GUN': 'gun',
+        },
+    },
     'scripts/client/AvatarInputHandler/aih_constants.pyc': {
         'CTRL_MODE_NAME': {
             'STRATEGIC': 'strategic',

--- a/tools/audit_client_abi.py
+++ b/tools/audit_client_abi.py
@@ -720,6 +720,10 @@ EXPECTED_ABI = {
         'MainCustomSelector.settingsFlags': ('self',),
         'ExhaustMainSelector.settingsFlags': ('self',),
     },
+    'scripts/client/vehicle_extras.pyc': {
+        'ShowShooting._start': ('self', 'data', 'burstCount'),
+        'ShowShooting._cleanup': ('self', 'data'),
+    },
     'scripts/client/vehicle_systems/components/vehicleDecal.pyc': {
         'VehicleDecal.attach': ('self',),
         'VehicleDecal.detach': ('self',),
@@ -1281,11 +1285,6 @@ EXPECTED_CODE_NAMES = {
         'CombatSelectedArea.relocate': (
             '_CombatSelectedArea__matrix', 'setRotateYPR', 'translation'),
     },
-    'scripts/client/AvatarPositionControl.pyc': {
-        'AvatarPositionControl.switchViewpoint': (
-            '_AvatarPositionControl__avatar', 'cell',
-            'switchViewPointOrBindToVehicle'),
-    },
     'scripts/client/AvatarInputHandler/PostmortemDelay.pyc': {
         'PostmortemDelay.start': (
             'BigWorld', 'player', 'playerVehicleID',
@@ -1416,6 +1415,11 @@ EXPECTED_CODE_NAMES = {
             'segmentMayHitEntity'),
     },
     'scripts/client/vehicle_extras.pyc': {
+        # The shoot extra is the muzzle effect list: it plays gunDescr.effects
+        # through EffectsListPlayer bound to the vehicle's own compound model.
+        'ShowShooting._start': (
+            'typeDescriptor', 'gun', 'effects', 'EffectsListPlayer',
+            'appearance', 'compoundModel', '_ShowShooting__doShot'),
         'Fire._start': (
             'appearance', 'isUnderwater', '_Fire__playEffect',
             'switchFireVibrations'),
@@ -1509,6 +1513,9 @@ EXPECTED_CODE_NAMES = {
         'VehicleMarker.isAlive': ('isAlive',),
     },
     'scripts/client/AvatarPositionControl.pyc': {
+        'AvatarPositionControl.switchViewpoint': (
+            '_AvatarPositionControl__avatar', 'cell',
+            'switchViewPointOrBindToVehicle'),
         'ConsistentMatrices.__setTarget': (
             '_ConsistentMatrices__attachedVehicleMatrix', 'target',
             'onVehicleMatrixBindingChanged'),
@@ -1613,8 +1620,6 @@ EXPECTED_CODE_NAMES = {
             'getDescByFilename'),
         'DestructiblesManager.onChunkLoad': (
             '_DestructiblesManager__loadedChunkIDs',),
-        '_DestructiblesAnimator.showFall': (
-            'spaceID', 'chunkID', 'destrIndex'),
         'AreaDestructibles.set_fallenTrees': (
             'orderDestructibleDestroy', 'DESTR_TYPE_TREE'),
         'AreaDestructibles.set_fallenColumns': (
@@ -1960,8 +1965,29 @@ EXPECTED_PACKED_XML_PATH_VALUES = {
             (1, 'OBJECT_ID'), (1, 'UINT8'), (1, 'INT32'), (1, 'ARRAY')),
         ('ClientMethods', 'updateVehicleMiscStatus', 'Arg', 'of'): (
             (1, 'FLOAT32'),),
+        # The tracer is an Avatar client method, not a Vehicle one.  The
+        # player's own Avatar is always in its own AoI, so retail still draws
+        # the tracer of a shot fired by a vehicle the client cannot see.
+        ('ClientMethods', 'showTracer', 'Arg'): (
+            (1, 'OBJECT_ID'), (1, 'SHOT_ID'), (5, '\x04\xe3\x8b'),
+            (1, 'UINT8'), (1, 'VECTOR3'), (1, 'VECTOR3'), (1, 'FLOAT32'),
+            (1, 'FLOAT32')),
+        ('ClientMethods', 'stopTracer', 'Arg'): (
+            (1, 'SHOT_ID'), (1, 'VECTOR3')),
     },
     'scripts/entity_defs/Vehicle.def': {
+        # showShooting is a cell->client entity RPC on the Vehicle, and the
+        # Vehicle entity owns a manual AoI whose membership the spotting cell
+        # methods below drive.  A client that has not spotted an enemy is not
+        # in that AoI and never receives the call, which is why retail draws
+        # no muzzle effect and plays no gun sound for an unspotted shooter.
+        ('ClientMethods', 'showShooting', 'Arg'): ((1, 'UINT8'),),
+        ('IsManualAoI',): ((4, True),),
+        ('CellMethods', 'receiveVisibilityUpdate', 'Arg'): (
+            (1, 'OBJECT_ID'), (5, '\x04\xe3\x8b'), (5, '\x04\xe3\x8b')),
+        ('CellMethods', 'onDetectedByEnemy', 'Arg'): (
+            (1, 'OBJECT_ID'), (5, '\x04\xe3\x8b')),
+        ('CellMethods', 'onConcealedFromEnemy', 'Arg'): ((1, 'OBJECT_ID'),),
         ('Properties', 'damageStickers', 'Type'): (
             (1, 'ARRAY'),),
         ('Properties', 'damageStickers', 'Type', 'of'): (


### PR DESCRIPTION
## What Peng reported

- SPG aiming view: an enemy that is **not spotted** still shows a ground shadow and exhaust (screenshot).
- After dying, switching the camera to a teammate **sometimes renders only that teammate's shadow**.

## What the exact #1513 bytecode says

Read from `scripts.pkg` with CPython 2.7.18. Three separate owners sit outside every compound draw flag the runtime already writes, and one stale origin explains the spectator report.

1. **Camera-distance effect selectors.** `CompoundAppearance.__onPeriodicTimer` runs every `_PERIODIC_TIME` (0.25 s) for a living vehicle and calls `__updateEffectsLOD`, which enables the `CustomEffectManager` dust selector within `_LOD_DISTANCE_TRAIL_PARTICLES` (100 m) and the exhaust selector within `_LOD_DISTANCE_EXHAUST` (200 m) of **`BigWorld.camera()`**. Neither test reads a draw flag, and the distance is measured from the camera rather than the player — which is exactly why this shows up first in an SPG view: the strategic/arty camera sits over the aim point, hundreds of metres from the SPG, so every hidden enemy beneath it falls inside both radii.
2. **Ground occlusion geometry.** `activate()` attaches the `VehicleDecal` to the compound root/hull/turret nodes and `__setupModels` attaches a `BigWorld.Splodge` from `chassis.AODecals[0]` to the hull node (`MAX_DISTANCE` is 500, so every vehicle gets one). Both are node attachments carrying `maps/spots/TankOcclusion/TankOcclusionMap.dds` — precisely what the still-unproven `visibleAttachments` flag would have covered.
3. **Muzzle presentation.** `scripts/entity_defs/Vehicle.def` declares `showShooting` under `ClientMethods` — a cell→client RPC on the Vehicle entity — and that entity carries `IsManualAoI` together with the `receiveVisibilityUpdate` / `onDetectedByEnemy` / `onConcealedFromEnemy` cell methods that drive its membership. A retail client that has not spotted an enemy is not in that AoI and never receives the call. The `shoot` extra it starts is `ShowShooting`, whose `_start` plays `gunDescr.effects` through `EffectsListPlayer` bound to the vehicle's own compound model — the muzzle flash, its smoke and the gun sound. The tracer is a *different* entity: `Avatar.def` declares `showTracer`/`stopTracer` under its own `ClientMethods`, and the player's Avatar is always in its own AoI, which is why retail still draws the tracer of a shot from a vehicle it cannot see.
4. **Observer AOI.** The local integrator stops the moment the player dies, so `_local_position` freezes at the wreck. Centring the 565 m vehicle AOI there hid the ally the postmortem camera had just switched to — and every vehicle around it — whenever the wreck was far away. `_switch_postmortem_viewpoint` only flipped `_postmortem_visible`, which is the `BigWorld.entity` lookup, never the draw pass.

## The change

- `stop_ground_effects` / `set_ground_decal_visibility` / `close_stock_presentation_extras` in `entities/remote_vehicle.py`, driven from `set_draw_visibility` and from the initial enter-world enemy gate. `VehicleDecal.attach`/`detach` are the exact stock pair and are idempotent; the splodge moves with the hull node the decal already resolved as `compoundModel.node(TankPartNames.HULL)`.
- A compat wrap of `CompoundAppearance.__updateEffectsLOD` with the same install/uninstall discipline as the `getCollidableEntities` wrap, so the 0.25 s periodic timer cannot restart dust or exhaust for an undrawn LAN remote. It re-asserts the decal gate on the same cadence, because `VehicleDecal.onSettingsChanged` re-attaches every decal when the shadow quality changes and the runtime's own gate runs only on a spotting edge. A selector whose own `_enabled` flag is already clear is skipped, so the steady-state cost is a couple of flag reads rather than a teardown of the effect nodes.
- `_shot_muzzle_drawn` skips `showShooting` for a remote whose draw pass is closed. The projectile keeps its own owner, so a blind shot still flies, resolves and damages — the same shape as the impact-effect gate already applied to a terminal event on an unspotted target.
- `_presentation_origin` resolves the AOI origin from the currently spectated entity, and a viewpoint switch re-evaluates spotting on the next frame.
- New contracts pinned in `tools/audit_client_abi.py`, new evidence recorded in `COMPATIBILITY_REVIEW.md`. No new document.

### Note on the muzzle gate's predicate

It reads the record's `spot_visible`, which is the **model draw gate**, not team spotting memory — for a live vehicle that also folds in the 565 m AOI and the SPG aiming exemption. That is the right predicate precisely because retail gates on AoI membership, not on spotting memory: a team-spotted enemy at 700 m has a marker but is outside AoI, so retail would not have delivered `showShooting` for it either, and the same holds for an ally at 600 m. The local player is never gated. Nothing in the projectile path changes, so the tracer of a blind shot is unaffected.

### Audit-tool hazard found while pinning this

`tools/audit_client_abi.py`'s expectation tables are dict literals, so a repeated key silently keeps only the last value. Two such keys already existed and had quietly dropped real coverage — the `AvatarPositionControl.switchViewpoint` code names, and a stale `_DestructiblesAnimator.showFall` entry that listed argument names this table never checks. The first is merged, the second dropped, and the audit tests now assert that no expectation key is shadowed. Checked code names went 1065 → 1075 as a result.

## Validation

- `python -m unittest discover -s tests -p "test_*.py"` — 3496 tests, only the two failures that already fail on `origin/main` 265fb9a (`test_half_even_player_preinstall_matches_real_server_echo`, `test_observation_and_damage_memory_survive_skipped_plan_ticks`).
- CPython 2.7 source compile of `src/res/scripts/client`: 90 files.
- `tools/audit_client_abi.py` under CPython 2.7.18 against the exact #1513 `scripts.pkg`: 480 signatures, 1075 code names, 36 packed-XML paths, 18 constant globals, 87 class constants, no errors. Every constant quoted above is checked by that run.
- Each new test was confirmed to fail with its fix reverted.

## Not proved here

Which of the gated layers draws the exact dark blob in the screenshot is an exact-Windows question; they are all closed together. Engine audition on a hidden enemy is audio, not covered. `_fallback_postmortem_viewpoint` still picks the nearest replacement ally by distance from the wreck — a selection heuristic, not a rendering defect, so it is left alone. Whether `PyCompoundModel` exposes a writable `visibleAttachments` is still unproven — the runtime keeps mirroring it and logs once if it is absent, but no longer depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

