### PR TITLE
Award #1513 post-battle achievements

### DIFF
--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -724,9 +724,27 @@ regular battles this product packs (`bonusType` 1) use the base table. Those
 numbers are copied verbatim into
 `src/res/scripts/client/gui/mods/offline_lan_0922/battle_achievements.py`; the
 predicates around them combine one exact constant with the documented shape of
-the medal. `UNAWARDED_ACHIEVEMENTS` in the same module records every medal this
-product deliberately does not award and the input it would need, so no later
-change closes a gap by inventing a coefficient.
+the medal. The full table holds 62 entries across every mode this build ever
+shipped, so `scripts/item_defs/achievements.xml` selects the subset that
+matters: each achievement there carries a `mode`, and only `mode="random"`
+belongs to the battles this product packs.
+
+`UNAWARDED_ACHIEVEMENTS` in the same module records every medal this product
+deliberately does not award and why, so no later change closes a gap by
+inventing a coefficient. Two of those reasons come straight from the pinned
+client rather than from documentation:
+
+- `gui/shared/gui_items/dossier/factories.pyc` registers `sniper` and
+  `medalWittmann` as `DeprecatedAchievement`, whose `checkIsValid` returns
+  `validators.alreadyAchieved`. The client itself treats both as historical
+  and will not accept a newly earned one.
+- `alaric` and `lumberjack` have conditions and record IDs but no entry at all
+  in `item_defs/achievements.xml`, so the client has no metadata to render
+  them. They were cancelled before release and no account has ever held one.
+
+The remaining three are product decisions, not missing data: the two platoon
+medals have no platoon to award to, and Mark of Mastery needs the per-vehicle
+experience distributions retail computes.
 
 The LAN server owns the decision. `_finish_battle` freezes the complete public
 roster first, awards from it, and stores the resulting names on every roster
@@ -748,6 +766,23 @@ Two statistics the server never recorded are now canonical round state, because
 accumulated `capturePoints`, and the `droppedCapturePoints` credited to the
 enemy whose damage reset a capture. Without them Invader and Defender could
 never be awarded and both results columns stayed at zero.
+
+`spotted` is a detection count, not a sighting count. A vehicle is detected
+when it becomes visible to a team that could not see it a moment earlier, and
+every direct observer on that team at that instant detected it. The statistic
+counts distinct enemies per observer, so re-acquiring a target that observer
+already revealed adds nothing, while an enemy that goes dark and reappears
+credits whoever finds it that time. This replaces a count of every enemy the
+vehicle had ever directly seen, which had no team fence and could never drop.
+Patrol Duty (`scout`) reads the same number, and earned experience moves with
+it.
+
+Ammunition belongs to whoever owns the gun, so Fadin's medal takes the shell
+total from the producer rather than inferring it. The visible client puts
+`shells_before_shot` on its fire intent, read before the local gun debits the
+round; the worker puts the same field on a Bot launch, computed from the
+inventory it has just debited. The server freezes the flag on the projectile
+and awards the medal only when that shot also left no living enemy.
 
 Battle-hero medals go to one actor per battle, ordered by the medal's own
 metric and broken by earned experience, which is Wargaming's documented

--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -712,6 +712,51 @@ OfflineMapCreator.destroy()
   -> if local player is room host, open the next TrainingSettingsWindow
 ```
 
+## Post-battle achievements
+
+Wargaming's battle server, not the client, decides which medals a battle
+awards, so `res/packages/scripts.pkg` ships the thresholds without the
+predicates. `scripts/common/arena_achievements.py` of `#1513` holds
+`ACHIEVEMENT_CONDITIONS`, and `getAchievementCondition` only consults
+`ACHIEVEMENT_CONDITIONS_EXT` when `ARENA_BONUS_TYPE_CAPS.checkAny` accepts the
+arena bonus type. That build answers `False` for every bonus type, so the
+regular battles this product packs (`bonusType` 1) use the base table. Those
+numbers are copied verbatim into
+`src/res/scripts/client/gui/mods/offline_lan_0922/battle_achievements.py`; the
+predicates around them combine one exact constant with the documented shape of
+the medal. `UNAWARDED_ACHIEVEMENTS` in the same module records every medal this
+product deliberately does not award and the input it would need, so no later
+change closes a gap by inventing a coefficient.
+
+The LAN server owns the decision. `_finish_battle` freezes the complete public
+roster first, awards from it, and stores the resulting names on every roster
+row, humans and Bots alike. The three consumers of that wire field — the
+server's persisted-receipt validator, the client receiver and the durable
+post-battle store — accept only names from that table, and a receipt written
+before achievements shipped still loads with an empty list.
+
+| Producer | Exact consumer contract covered |
+| --- | --- |
+| `VEH_FULL_RESULTS.achievements` / `VEH_PUBLIC_RESULTS.achievements` | Record database IDs from `dossiers2.custom.records.RECORD_DB_IDS`. `gui/battle_results/reusable/shared.py` maps each one through `DB_ID_TO_RECORD`, so a name the pinned client does not register is dropped before packing rather than raising inside the results window. |
+| `VEH_FULL_RESULTS.dossierPopUps` | `makeAchievementFromPersonal` reads `(recordDBID, value)` pairs for the personal results medals. `AchievementBlock.setRecord` renders `value` as the badge counter for every non-series achievement, so the value carried is the account's running total after the battle. |
+| `VEH_FULL_RESULTS` / `VEH_PUBLIC_RESULTS` `directHitsReceived`, `potentialDamageReceived` | The results screen shows both columns, and Steel Wall reads them. The server accumulates the hit count and each hit's `potential_damage` where it already resolves the shot. |
+| `VehicleInteractionDetails.crits` | `gui/shared/crits_mask_parser.py` reads bits 0-7 as critically damaged devices, 12-23 as destroyed devices and 24-31 as destroyed crew, indexed by `VEHICLE_DEVICE_TYPE_NAMES` and `VEHICLE_TANKMAN_TYPE_NAMES`. Both server track devices map onto the single `track` slot and each numbered crew role onto its base type. The field is a mask, so distinct modules accumulate with `or` and a repeated crit stays one bit. |
+| vehicle and account `achievements` dossier blocks | `getVehicleDossierDescr` and `getAccountDossierDescr` carry one counter per medal plus the aggregate `battleHeroes`. An unregistered name raises `KeyError` inside the native block, so the writer skips it. `StatsRequester.accountDossier` reads the `stats` cache key `dossier`, which the account snapshot and the post-battle diff now publish. |
+
+Two statistics the server never recorded are now canonical round state, because
+`#1513` displays both and the conditions read them: each vehicle's own
+accumulated `capturePoints`, and the `droppedCapturePoints` credited to the
+enemy whose damage reset a capture. Without them Invader and Defender could
+never be awarded and both results columns stayed at zero.
+
+Battle-hero medals go to one actor per battle, ordered by the medal's own
+metric and broken by earned experience, which is Wargaming's documented
+tie-break. Bots are ordinary participants and can take one.
+
+This is static and pure-data coverage. It proves which fields reach the native
+packers with which values; only acceptance on the exact Windows client can show
+the results window rendering those ribbons, counters and tooltips.
+
 ## Stock map-selection lifecycle
 
 Before the local Account creates the lobby, a chain-safe adapter intercepts the

--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -729,9 +729,26 @@ shipped, so `scripts/item_defs/achievements.xml` selects the subset that
 matters: each achievement there carries a `mode`, and only `mode="random"`
 belongs to the battles this product packs.
 
+A threshold is not an award rule. The rest of each rule is in the client's own
+description text, `res/text/LC_MESSAGES/achievements.mo`, where every medal
+carries a `<name>_descr` summary and a `<name>_condition` clause list. Those
+clauses decide the class fences, the friendly-fire exclusions, the win and
+survival requirements and the tier floors that no constant carries: Cold-Blooded
+ships only a distance and a kill count while its description also demands
+light-tank victims and a Tier IV gun, and Rock Solid's constant bounds the
+rammer's speed while its description also requires the victim to have been
+faster. Each predicate quotes the clause it enforces, so the code and the
+client cannot drift apart.
+
+The same text settles two questions a threshold cannot. Cool-Headed has no
+survival clause, so a vehicle that dies still keeps a ten-bounce run. The
+Billotte family says "击毁数将在受到所有伤害后计算" — frags are counted after
+all damage is received — which makes the final totals the rule and rules out
+any per-event ordering requirement.
+
 `UNAWARDED_ACHIEVEMENTS` in the same module records every medal this product
 deliberately does not award and why, so no later change closes a gap by
-inventing a coefficient. Two of those reasons come straight from the pinned
+inventing a coefficient. Every one of those reasons comes from the pinned
 client rather than from documentation:
 
 - `gui/shared/gui_items/dossier/factories.pyc` registers `sniper` and
@@ -739,8 +756,12 @@ client rather than from documentation:
   `validators.alreadyAchieved`. The client itself treats both as historical
   and will not accept a newly earned one.
 - `alaric` and `lumberjack` have conditions and record IDs but no entry at all
-  in `item_defs/achievements.xml`, so the client has no metadata to render
-  them. They were cancelled before release and no account has ever held one.
+  in `item_defs/achievements.xml`, and no name, description or condition in
+  `achievements.mo` either. They were cancelled before release and no account
+  has ever held one.
+
+The deprecation is stated in the text as well: Sniper reads "从0.8.11版本后将
+无法获得" and Bölter's Medal "从0.8.0版本后将无法获得".
 
 The remaining three are product decisions, not missing data: the two platoon
 medals have no platoon to award to, and Mark of Mastery needs the per-vehicle

--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -784,6 +784,15 @@ round; the worker puts the same field on a Bot launch, computed from the
 inventory it has just debited. The server freezes the flag on the projectile
 and awards the medal only when that shot also left no living enemy.
 
+That one optional field crosses four exact contracts on its way, and each had
+to be widened for it: the fire-intent key set in `submit_fire_intent`, the
+`launch_projectile` allowlist, the worker's `on_fire_intent` relay check, and
+`_local_launch_record`, the projection that decides which Bot fields reach the
+launch publisher at all. The first three reject an unknown field outright; the
+fourth drops it silently, which would have left Bots unable to earn the medal
+with nothing to show for it. Each of the three rejecting validators has a test
+that an unknown field is still refused.
+
 Battle-hero medals go to one actor per battle, ordered by the medal's own
 metric and broken by earned experience, which is Wargaming's documented
 tie-break. Bots are ordinary participants and can take one.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ whose profile changed after it started must be restarted first.
 - A LAN match is one shared battle: lineups, countdown, orders, projectiles,
   health, critical damage, destructibles, capture and results stay
   synchronized through the room's mandatory hidden simulation worker.
+- The results screen awards battle heroes and historical medals from the
+  client's own achievement thresholds, and both the vehicle and the account
+  dossier keep counting them. Medals whose award condition needs data this
+  reconstruction does not own, including Mark of Mastery, are listed in
+  `battle_achievements.py` rather than guessed.
 
 This is a reconstruction from the frozen clients and same-era mechanics, not
 Wargaming's retail server. LAN play assumes trusted clients. Native rendering,

--- a/README.md
+++ b/README.md
@@ -78,11 +78,12 @@ whose profile changed after it started must be restarted first.
 - A LAN match is one shared battle: lineups, countdown, orders, projectiles,
   health, critical damage, destructibles, capture and results stay
   synchronized through the room's mandatory hidden simulation worker.
-- The results screen awards battle heroes and historical medals from the
-  client's own achievement thresholds, and both the vehicle and the account
-  dossier keep counting them. Medals whose award condition needs data this
-  reconstruction does not own, including Mark of Mastery, are listed in
-  `battle_achievements.py` rather than guessed.
+- The results screen awards battle heroes, historical, special and
+  commemorative medals from the client's own achievement thresholds, and both
+  the vehicle and the account dossier keep counting them. Medals the client
+  itself retired, cancelled before release, or that need data this
+  reconstruction does not own, including Mark of Mastery, are listed with
+  their reason in `battle_achievements.py` rather than guessed.
 
 This is a reconstruction from the frozen clients and same-era mechanics, not
 Wargaming's retail server. LAN play assumes trusted clients. Native rendering,

--- a/server/lan_battle_server.py
+++ b/server/lan_battle_server.py
@@ -48,7 +48,8 @@ from vehicle_overlay_store import (
 )
 from gui.mods.offline_lan_0922 import tank_collision
 from gui.mods.offline_lan_0922.battle_achievements import (
-    AWARDABLE_ACHIEVEMENTS, RECEIPT_STAT_NAMES, award_battle_achievements)
+    ACHIEVEMENT_CONDITIONS, AWARDABLE_ACHIEVEMENTS, RECEIPT_STAT_NAMES,
+    award_battle_achievements)
 from gui.mods.offline_lan_0922 import burst_mechanics
 from gui.mods.offline_lan_0922 import effective_params as effective_params_wire
 from gui.mods.offline_lan_0922 import equipment_mechanics
@@ -384,6 +385,8 @@ VEHICLE_CLASS_TAGS = frozenset((
 # and ``['sturdy']['minHealth']`` of the pinned client.
 SNIPER_SHOT_DISTANCE = 300.0
 SPARTAN_HEALTH_PERCENT = 10.0
+LUCKY_DEVIL_RADIUS = ACHIEVEMENT_CONDITIONS["luckyDevil"]["radius"]
+ROCK_SOLID_MAX_SPEED = ACHIEVEMENT_CONDITIONS["monolith"]["maxSpeed_ms"]
 CRITICAL_STATES = frozenset(("normal", "critical", "destroyed"))
 CRITICAL_CAUSES = frozenset((
     "shot", "explosion", "repair", "fire", "drowning", "ramming"))
@@ -741,6 +744,21 @@ def _exact_int(value, low=None, high=None):
     if high is not None and value > high:
         raise ValueError("integer above upper bound")
     return value
+
+
+def _optional_exact_int(value, low=None, high=None):
+    """Return one exact bounded integer, or None when it is absent or bad.
+
+    An optional achievement input must never turn a legal message into a
+    protocol rejection, so an out-of-range or missing value simply means the
+    condition that reads it cannot be satisfied.
+    """
+    if value is None:
+        return None
+    try:
+        return _exact_int(value, low, high)
+    except (TypeError, ValueError, OverflowError):
+        return None
 
 
 def _team_capacity(value, name):
@@ -4489,6 +4507,7 @@ class BattleState:
                 message.get("affordances"), known_bots, known_targets, now)
             self._replace_bot_spotted(direct_bot_spots)
             self._replace_player_spotted(direct_player_spots)
+            self._commit_detections()
             if accepted_visibility:
                 return {
                     "type": "bot_observation",
@@ -4513,15 +4532,6 @@ class BattleState:
         for bot_id in sorted(direct_spots):
             spotted = frozenset(direct_spots[bot_id])
             self.bot_spotted[int(bot_id)] = spotted
-            reporter = ("bot", int(bot_id))
-            for target in spotted:
-                self._record_first_spot(reporter, target)
-                interaction = self._statistics_interaction(reporter, target)
-                if interaction["spotted"]:
-                    continue
-                interaction["spotted"] = 1
-                row = self._statistics_row(*reporter)
-                row["spotted"] = int(row.get("spotted", 0)) + 1
         return True
 
     def _replace_player_spotted(self, direct_spots):
@@ -4532,15 +4542,6 @@ class BattleState:
         for player_id in sorted(direct_spots):
             spotted = frozenset(direct_spots[player_id])
             self.player_spotted[int(player_id)] = spotted
-            reporter = ("player", int(player_id))
-            for target in spotted:
-                self._record_first_spot(reporter, target)
-                interaction = self._statistics_interaction(reporter, target)
-                if interaction["spotted"]:
-                    continue
-                interaction["spotted"] = 1
-                row = self._statistics_row(*reporter)
-                row["spotted"] = int(row.get("spotted", 0)) + 1
         return True
 
     @staticmethod
@@ -6207,20 +6208,18 @@ class BattleState:
                 return self._commit_fire_intent_rejection_locked(
                     player, intent_seq, fingerprint, reason)
 
-            expected_fields = frozenset((
+            required_fields = frozenset((
                 "type", "round_id", "intent_seq", "input_seq",
                 "shell_index", "shot_origin", "shot_direction",
-                "dispersion_angle", "presentation_ledger",
-                "trigger_server_time_ms"))
-            if set(message) not in (
-                    expected_fields,
-                    expected_fields - frozenset((
-                        "presentation_ledger",)),
-                    expected_fields - frozenset((
-                        "trigger_server_time_ms",)),
-                    expected_fields - frozenset((
-                        "presentation_ledger",
-                        "trigger_server_time_ms"))):
+                "dispersion_angle"))
+            # A client may omit any of these; the trigger is still legal and
+            # only the condition that reads the missing one goes unmet.
+            optional_fields = frozenset((
+                "presentation_ledger", "trigger_server_time_ms",
+                "shells_before_shot"))
+            fields = set(message)
+            if not required_fields <= fields <= (
+                    required_fields | optional_fields):
                 return reject("fire_intent_wire_shape")
             try:
                 input_seq = _exact_int(
@@ -6334,6 +6333,11 @@ class BattleState:
                 "pitch": round(float(player.pitch), 5),
                 "roll": round(float(player.roll), 5),
                 "speed": round(float(player.speed), 4),
+                # Optional: only a client that reported its ammunition can
+                # ever earn Fadin's medal, and a missing count is not a
+                # reason to reject a legal trigger.
+                "shells_before_shot": _optional_exact_int(
+                    message.get("shells_before_shot"), 0, 1000),
             }
             player.fire_intent_seq = intent_seq
             player.fire_intent_fingerprints[intent_seq] = fingerprint
@@ -6506,6 +6510,9 @@ class BattleState:
                 "authority_epoch", "fire_intent_seq", "fire_input_seq",
                 "burst_group_seq", "burst_index", "burst_count",
                 "launch_time_us", "launch_pose",
+                # Optional: the shell total this round was drawn from, which
+                # only the producer that owns the ammunition can report.
+                "shells_before_shot",
             }
             if set(message) - allowed:
                 return self._set_protocol_reject(
@@ -6753,6 +6760,15 @@ class BattleState:
                 "last_progress_request_fingerprint": None,
             })
             self.projectiles[projectile_id] = record
+            # Freeze whether this was the shooter's final round while the
+            # producer that owns the ammunition is still the one reporting it.
+            shells_before_shot = (
+                _optional_exact_int(intent.get("shells_before_shot"), 0, 1000)
+                if shooter_kind == "player" else
+                _optional_exact_int(message.get("shells_before_shot"), 0, 1000))
+            if shells_before_shot is not None:
+                self.last_shell_shots[str(projectile_id)] = (
+                    shells_before_shot <= 1)
             if shooter_kind == "player":
                 shooter.fire_seq = shot_seq
                 if bool(intent.get("shell_change_pending", False)):
@@ -7515,6 +7531,13 @@ class BattleState:
                 maximum = self._vehicle_max_health(victim)
                 if health * 100 <= SPARTAN_HEALTH_PERCENT * maximum:
                     victim_row["deflected_hits_at_low_health"] += 1
+                victim_row["deflection_streak"] += 1
+                victim_row["best_deflection_streak"] = max(
+                    victim_row["best_deflection_streak"],
+                    victim_row["deflection_streak"])
+            elif applied > 0:
+                # A shell that got through ends the run of bounces.
+                victim_row["deflection_streak"] = 0
         if was_alive and not alive:
             if target_kind == "player":
                 target.death_attacker_kind = record["shooter_kind"]
@@ -8272,6 +8295,7 @@ class BattleState:
                 "death_reason": record["death_reason"],
                 "distance": record["distance"],
                 "defended_base": record["defended_base"],
+                "actor_speed": record["actor_speed"],
             })
 
         actors = []
@@ -8294,10 +8318,14 @@ class BattleState:
                 "kills": kills_by_actor.get(identity, []),
                 "damaged_targets": sorted(
                     self.damaged_targets.get(identity, ())),
-                "first_spotted": int(statistics.get("first_spotted", 0)),
                 "exclusive_spot_assists": len(
                     self.exclusive_spot_assists.get(identity, ())),
                 "ever_spotted": identity in self.ever_spotted_targets,
+                "ally_damage": int(self.ally_damage.get(identity, 0)),
+                "last_shell_finisher": identity in self.last_shell_finishers,
+                "lucky_devil": identity in self.lucky_devils,
+                "best_deflection_streak": int(
+                    statistics.get("best_deflection_streak", 0)),
                 "crits_received": _popcount(
                     statistics.get("crits_received_mask", 0)),
                 "hits_received": int(statistics.get("hits_received", 0)),
@@ -10393,10 +10421,19 @@ class BattleState:
 
     def _reset_achievement_tracking(self):
         """Clear the per-round inputs #1513 achievement conditions read."""
-        # target -> the first actor that ever directly detected it.
-        self.first_spotters = {}
+        # team -> the enemies that team can currently see, so a vehicle that
+        # goes dark and reappears is a new detection for whoever finds it.
+        self.team_visible_targets = {1: set(), 2: set()}
         # every vehicle any enemy ever directly detected.
         self.ever_spotted_targets = set()
+        # actor -> damage it dealt to its own team.
+        self.ally_damage = {}
+        # actors that destroyed the last living enemy with their last shell.
+        self.last_shell_finishers = set()
+        # projectile id -> whether it was the shooter's final round.
+        self.last_shell_shots = {}
+        # actors that stood beside an enemy its own team destroyed.
+        self.lucky_devils = set()
         # actor -> targets it damaged while it was their only direct spotter.
         self.exclusive_spot_assists = {}
         # actor -> every enemy it damaged.
@@ -10413,18 +10450,44 @@ class BattleState:
         self.capture_invaders = {1: set(), 2: set()}
         self.base_captured_team = 0
 
-    def _record_first_spot(self, reporter, target):
-        """Remember the first detector and that this target was ever seen."""
-        reporter = (str(reporter[0]), int(reporter[1]))
-        target = (str(target[0]), int(target[1]))
-        reporter_team = self._vehicle_team(*reporter)
-        target_team = self._vehicle_team(*target)
-        if not target_team or reporter_team == target_team:
-            return
-        self.ever_spotted_targets.add(target)
-        if target not in self.first_spotters:
-            self.first_spotters[target] = reporter
-            self._statistics_row(*reporter)["first_spotted"] += 1
+    def _commit_detections(self):
+        """Credit a detection to every observer that revealed an enemy.
+
+        A vehicle is detected when it becomes visible to a team that could
+        not see it a moment ago; every direct observer on that team that saw
+        it at that instant detected it.  The statistic counts distinct
+        enemies, so re-acquiring a target the observer already revealed adds
+        nothing, while an enemy that goes dark and is revealed again credits
+        whoever found it that time.  This is the ``spotted`` column the
+        results screen shows and the count Patrol Duty (``scout``) reads.
+        """
+        observers = [(("bot", int(bot_id)), spotted)
+                     for bot_id, spotted in self.bot_spotted.items()]
+        observers.extend(
+            (("player", int(player_id)), spotted)
+            for player_id, spotted in self.player_spotted.items())
+        for team in (1, 2):
+            visible = {}
+            for reporter, spotted in observers:
+                if self._vehicle_team(*reporter) != team:
+                    continue
+                for target in spotted:
+                    target = (str(target[0]), int(target[1]))
+                    target_team = self._vehicle_team(*target)
+                    if not target_team or target_team == team:
+                        continue
+                    visible.setdefault(target, []).append(reporter)
+            for target in sorted(set(visible) - self.team_visible_targets[team]):
+                self.ever_spotted_targets.add(target)
+                for reporter in sorted(visible[target]):
+                    interaction = self._statistics_interaction(
+                        reporter, target)
+                    if interaction["spotted"]:
+                        continue
+                    interaction["spotted"] = 1
+                    row = self._statistics_row(*reporter)
+                    row["spotted"] = int(row.get("spotted", 0)) + 1
+            self.team_visible_targets[team] = set(visible)
 
     def _direct_spotters(self, target):
         """Return every enemy observer that directly sees ``target``.
@@ -10447,6 +10510,74 @@ class BattleState:
                 result.append(reporter)
         return result
 
+    def _vehicle_position(self, identity, alive_only=True):
+        """Return one vehicle's world position, or None.
+
+        A vehicle that has just been destroyed still has the pose it died in,
+        which is the only position a proximity condition can use, so
+        ``alive_only`` is False for the victim of a kill.
+        """
+        if identity[0] == "player":
+            player = self.players.get(int(identity[1]))
+            if player is None or (alive_only and not player.alive):
+                return None
+            return (float(player.x), float(player.y), float(player.z))
+        state = self.bot_states.get(int(identity[1]))
+        if state is None or (alive_only and not state.get("alive")):
+            return None
+        return (_finite_float(state.get("x")), _finite_float(state.get("y")),
+                _finite_float(state.get("z")))
+
+    def _record_lucky_devils(self, victim, victim_team):
+        """Credit everyone standing beside a vehicle its own team destroyed.
+
+        #1513 ships only the radius for Lucky (``luckyDevil``); the medal
+        itself goes to the enemies of the destroyed vehicle who were inside
+        that radius when its own side killed it.
+        """
+        origin = self._vehicle_position(victim, alive_only=False)
+        if origin is None:
+            return
+        for identity in self._round_actor_identities():
+            if (identity == victim or
+                    self._vehicle_team(*identity) in (0, int(victim_team))):
+                continue
+            position = self._vehicle_position(identity)
+            if position is None:
+                continue
+            offset = sum((position[axis] - origin[axis]) ** 2
+                         for axis in (0, 1, 2))
+            if offset <= LUCKY_DEVIL_RADIUS * LUCKY_DEVIL_RADIUS:
+                self.lucky_devils.add(identity)
+
+    def _round_actor_identities(self):
+        """Return every vehicle identity taking part in this round."""
+        identities = [("player", int(player_id))
+                      for player_id in self.players]
+        identities.extend(("bot", int(bot_id)) for bot_id in self.bot_states)
+        return identities
+
+    def _vehicle_speed(self, identity):
+        """Return one vehicle's current speed in metres per second."""
+        if identity[0] == "player":
+            player = self.players.get(int(identity[1]))
+            return abs(float(player.speed)) if player is not None else 0.0
+        state = self.bot_states.get(int(identity[1]))
+        return abs(_finite_float((state or {}).get("speed"))) if state else 0.0
+
+    def _living_enemies(self, team):
+        """Return how many vehicles hostile to ``team`` are still alive."""
+        alive = 0
+        for player in self.players.values():
+            if (player.connected and player.participating and player.alive and
+                    int(player.team) not in (0, int(team))):
+                alive += 1
+        for state in self.bot_states.values():
+            if (state.get("alive") and
+                    int(state.get("team", 0)) not in (0, int(team))):
+                alive += 1
+        return alive
+
     def _record_kill(self, attacker, victim, death_reason,
                      projectile_id=None, distance=None):
         """Freeze one enemy kill with the facts #1513 medals ask about."""
@@ -10462,7 +10593,16 @@ class BattleState:
             # inside the defender's own base circle.
             "defended_base": victim in self.capture_invaders.get(
                 self._vehicle_team(*attacker), set()),
+            # Rock Solid bounds the rammer's own speed at the moment of the
+            # kill, which is only knowable here.
+            "actor_speed": round(self._vehicle_speed(attacker), 4),
         })
+        # Fadin's medal wants the shot that ended the battle to have been the
+        # shooter's last round.  Both facts are only true at this instant.
+        if (projectile_id is not None and
+                self.last_shell_shots.get(str(projectile_id)) and
+                not self._living_enemies(self._vehicle_team(*attacker))):
+            self.last_shell_finishers.add(attacker)
         if projectile_id is not None:
             # Projectile identities are opaque strings, not integers.
             key = str(projectile_id)
@@ -10510,7 +10650,7 @@ class BattleState:
                 "damage_dealt": 0, "damage_received": 0,
                 "damage_blocked": 0, "damage_assisted_track": 0,
                 "damage_assisted_radio": 0, "damage_assisted_stun": 0,
-                "kills": 0,
+                "kills": 0, "spotted": 0,
                 "capture_points": 0, "dropped_capture_points": 0,
                 # Battle-result fidelity fields.  #1513 shows every one of
                 # these on the results screen and Wargaming's achievement
@@ -10519,8 +10659,11 @@ class BattleState:
                 "potential_damage_received": 0, "hits_received": 0,
                 "damaging_hits_received": 0, "deflected_hits_received": 0,
                 "crits_received_mask": 0, "hits_with_damage": 0,
-                "sniper_damage_dealt": 0, "first_spotted": 0,
+                "sniper_damage_dealt": 0,
                 "deflected_hits_at_low_health": 0,
+                # Cool-Headed (``ironMan``) wants bounces in a row, so the
+                # live streak and its best value are both round state.
+                "deflection_streak": 0, "best_deflection_streak": 0,
             }
             self.vehicle_statistics[key] = row
         elif not row["team"]:
@@ -10618,6 +10761,12 @@ class BattleState:
         else:
             attacker_team = int(attacker_team)
         if attacker_team == target_team:
+            # Gore's and Rock Solid both require a clean sheet against one's
+            # own team, so friendly damage needs an owner even though it
+            # earns the shooter nothing.
+            if attacker != target:
+                self.ally_damage[attacker] = int(
+                    self.ally_damage.get(attacker, 0)) + damage
             return
         if target[0] == "bot":
             self.bot_planner.report_damage(
@@ -10721,6 +10870,9 @@ class BattleState:
             team_killer = False
         else:
             return False
+        if delta < 0:
+            self._record_lucky_devils(
+                (str(victim_kind), int(victim_id)), int(victim_team))
         if delta > 0:
             row = self._statistics_row(attacker_kind, attacker_id)
             if not row["team"] and actor_team in (1, 2):

--- a/server/lan_battle_server.py
+++ b/server/lan_battle_server.py
@@ -5334,6 +5334,7 @@ class BattleState:
                     "worker human ram armor results are invalid")
             pending_projectile_launches = {}
             fire_deaths = []
+            fire_lineage_clears = set()
             capture_resets = set()
             stun_clears = []
             seen = set()
@@ -5459,13 +5460,20 @@ class BattleState:
                         "fire_attacker_kind"]
                     current["death_attacker_id"] = int(current[
                         "fire_attacker_id"])
+                    victim_identity = ("bot", int(bot_id))
+                    fire_attacker = (
+                        str(current["fire_attacker_kind"]),
+                        int(current["fire_attacker_id"]))
                     fire_deaths.append((
                         current["fire_attacker_kind"],
                         current["fire_attacker_id"], current,
-                        previous_health - current_health))
+                        previous_health - current_health,
+                        self.last_shell_fire_sources.get(victim_identity) ==
+                        fire_attacker))
                 if (not current.get("alive") or
                         not bool((current.get("critical") or {}).get(
                             "fire", False))):
+                    fire_lineage_clears.add(("bot", int(bot_id)))
                     current["fire_attacker_kind"] = ""
                     current["fire_attacker_id"] = 0
                 if (not source_clock_rebase and current["alive"] and
@@ -5506,12 +5514,16 @@ class BattleState:
                 pending_projectile_launches)
             self.bot_pending_projectile_metadata.update(
                 pending_projectile_launches)
+            for victim_identity in fire_lineage_clears:
+                self.last_shell_fire_sources.pop(victim_identity, None)
             for bot_id in capture_resets:
                 self._drop_capture_for_vehicle("bot", bot_id)
-            for attacker_kind, attacker_id, victim, damage in fire_deaths:
+            for (attacker_kind, attacker_id, victim, damage,
+                 last_shell_fire) in fire_deaths:
                 self._record_frag(
                     attacker_kind, attacker_id, victim["team"],
-                    "bot", victim["id"])
+                    "bot", victim["id"],
+                    last_shell_fire=last_shell_fire)
                 event = {
                     "kind": ("bot_bot_hit" if attacker_kind == "bot"
                              else "bot_hit"),
@@ -7038,6 +7050,7 @@ class BattleState:
             "stun_end_server_time_ms",
             "target_x", "target_y", "target_z",
             "damage_sticker",
+            "structural_armor_hit",
         }
         required = {
             "target_kind", "target_id", "damage", "shot_result",
@@ -7056,6 +7069,9 @@ class BattleState:
         damage = _exact_int(raw.get("damage"), 0, 5000)
         potential_damage = (_exact_int(raw["potential_damage"], 0, 5000)
                             if "potential_damage" in raw else 0)
+        # Optional achievement metadata never owns projectile admission.
+        # Unknown/malformed values are conservative external-module hits.
+        structural_armor_hit = raw.get("structural_armor_hit") is True
         shot_result = _exact_int(raw.get("shot_result"), 0, 2)
         pose = _bounded_vector(
             [raw.get("x"), raw.get("y"), raw.get("z")],
@@ -7155,6 +7171,7 @@ class BattleState:
             "target": target, "target_team": target_team,
             "target_alive": target_alive, "damage": damage,
             "potential_damage": potential_damage,
+            "structural_armor_hit": structural_armor_hit,
             "shot_result": shot_result, "pose": pose,
             "critical": critical,
             "critical_delta": critical_delta,
@@ -7274,9 +7291,11 @@ class BattleState:
                     "x", "y", "z"}
                 # A bounce is the archetypal blocked-damage contact, so the
                 # harmless direct effect keeps the worker's potential-damage
-                # roll along with its decal identity.  Critical, stun and
+                # roll, decal identity and armour layer. Critical, stun and
                 # splash tokens stay forbidden on a continuing shell.
-                direct_optional = {"damage_sticker", "potential_damage"}
+                direct_optional = {
+                    "damage_sticker", "potential_damage",
+                    "structural_armor_hit"}
                 if (not isinstance(raw_direct, dict) or
                         not direct_fields.issubset(raw_direct) or
                         set(raw_direct) - (direct_fields | direct_optional)):
@@ -7423,6 +7442,28 @@ class BattleState:
             health = int(target["health"])
             alive = bool(target["alive"])
 
+        shooter = (str(record["shooter_kind"]), int(record["shooter_id"]))
+        victim = (str(target_kind), int(target_id))
+        before_fire = bool(
+            isinstance(critical_before, dict) and
+            critical_before.get("fire", False))
+        current_critical = (target.critical if target_kind == "player"
+                            else target.get("critical"))
+        after_fire = bool(
+            isinstance(current_critical, dict) and
+            current_critical.get("fire", False))
+        if not before_fire and after_fire:
+            if self.last_shell_shots.get(str(record["projectile_id"])):
+                self.last_shell_fire_sources[victim] = shooter
+            else:
+                self.last_shell_fire_sources.pop(victim, None)
+        elif not after_fire:
+            self.last_shell_fire_sources.pop(victim, None)
+        if not alive:
+            # A direct terminal uses the killing projectile below. Fire
+            # lineage is only for a later canonical fire tick.
+            self.last_shell_fire_sources.pop(victim, None)
+
         if (applied > 0 or _critical_damage_transition(
                 critical_before, admitted_critical)):
             self._drop_capture_for_vehicle(
@@ -7474,8 +7515,6 @@ class BattleState:
                 if critical_commit:
                     event.update(critical_commit)
         self.pending_events.append(event)
-        shooter = (str(record["shooter_kind"]), int(record["shooter_id"]))
-        victim = (str(target_kind), int(target_id))
         self._record_damage(
             shooter, victim, applied, critical_before,
             attacker_team=int(record["team"]))
@@ -7542,7 +7581,9 @@ class BattleState:
                 # vehicle was already below its health threshold, so the
                 # health at this hit is the only usable moment.
                 maximum = self._vehicle_max_health(victim)
-                if health * 100 <= SPARTAN_HEALTH_PERCENT * maximum:
+                if (proposal["structural_armor_hit"] and
+                        health * 100 <=
+                        SPARTAN_HEALTH_PERCENT * maximum):
                     victim_row["deflected_hits_at_low_health"] += 1
                 victim_row["deflection_streak"] += 1
                 victim_row["best_deflection_streak"] = max(
@@ -8338,10 +8379,12 @@ class BattleState:
                 "ally_damage": int(self.ally_damage.get(identity, 0)),
                 "ally_hits": int(self.ally_hits.get(identity, 0)),
                 "team_kills": int(self.team_kills.get(identity, 0)),
+                "enemy_damage_received": int(
+                    self.enemy_damage_received.get(identity, 0)),
                 "support_targets": len(
                     self.support_targets.get(identity, ())),
                 "solo_capture": (
-                    self.capture_point_earners.get(
+                    self.capture_attempt_participants.get(
                         3 - int(row["team"]), set()) == {identity}),
                 "last_shell_finisher": identity in self.last_shell_finishers,
                 "lucky_devil": identity in self.lucky_devils,
@@ -10222,11 +10265,13 @@ class BattleState:
         changed = 0
         now = float(self.tick) / TICK_HZ
         for player in list(self.players.values()):
+            victim = ("player", int(player.player_id))
             burning = bool(
                 isinstance(player.critical, dict) and
                 player.critical.get("fire", False))
             if (not player.connected or not player.participating or
                     not player.alive or not burning):
+                self.last_shell_fire_sources.pop(victim, None)
                 if not burning:
                     player.combat_fire_elapsed = 0.0
                     player.combat_fire_timer = 0.0
@@ -10239,6 +10284,7 @@ class BattleState:
                         if attacker_kind in ("player", "bot") and
                         attacker_id > 0 else None)
             if attacker is None:
+                self.last_shell_fire_sources.pop(victim, None)
                 continue
             result = player_critical_mechanics.advance_fire(
                 player, max(0.0, float(dt)), now)
@@ -10296,14 +10342,19 @@ class BattleState:
                 if attacker is not None:
                     player.death_attacker_kind = attacker_kind
                     player.death_attacker_id = attacker_id
+                    last_shell_fire = (
+                        self.last_shell_fire_sources.pop(victim, None) ==
+                        attacker)
                     self._record_frag(
                         attacker_kind, attacker_id, player.team,
-                        "player", player.player_id)
+                        "player", player.player_id,
+                        last_shell_fire=last_shell_fire)
                 player.fire_attacker_kind = ""
                 player.fire_attacker_id = 0
                 if self._maybe_finish_battle():
                     break
             elif not bool(player.critical.get("fire", False)):
+                self.last_shell_fire_sources.pop(victim, None)
                 player.fire_attacker_kind = ""
                 player.fire_attacker_id = 0
         return changed
@@ -10451,16 +10502,24 @@ class BattleState:
         self.ally_damage = {}
         # actor -> vehicles of its own team it destroyed.
         self.team_kills = {}
+        # target -> damage received from enemies. The public result statistic
+        # also includes friendly damage, but Stark explicitly does not.
+        self.enemy_damage_received = {}
         # actor -> direct hits it landed on its own team.
         self.ally_hits = {}
         # actor -> enemies it damaged or whose track it destroyed.
         self.support_targets = {}
-        # base team -> every actor that ever earned a point capturing it.
-        self.capture_point_earners = {1: set(), 2: set()}
+        # base team -> every actor that joined the current non-zero capture
+        # attempt. A counter returning to zero starts a new attempt.
+        self.capture_attempt_participants = {1: set(), 2: set()}
         # actors that destroyed the last living enemy with their last shell.
         self.last_shell_finishers = set()
         # projectile id -> whether it was the shooter's final round.
         self.last_shell_shots = {}
+        # burning victim -> shooter when its igniting projectile was the
+        # shooter's last round. This stays private to the server until that
+        # fire ends or destroys the victim.
+        self.last_shell_fire_sources = {}
         # actors that stood beside an enemy its own team destroyed.
         self.lucky_devils = set()
         # actor -> targets it damaged while it was their only direct spotter.
@@ -10608,7 +10667,8 @@ class BattleState:
         return alive
 
     def _record_kill(self, attacker, victim, death_reason,
-                     projectile_id=None, distance=None):
+                     projectile_id=None, distance=None,
+                     last_shell_fire=False):
         """Freeze one enemy kill with the facts #1513 medals ask about."""
         attacker = (str(attacker[0]), int(attacker[1]))
         victim = (str(victim[0]), int(victim[1]))
@@ -10628,10 +10688,12 @@ class BattleState:
             "actor_speed": round(self._vehicle_speed(attacker), 4),
             "victim_speed": round(self._vehicle_speed(victim), 4),
         })
-        # Fadin's medal wants the shot that ended the battle to have been the
-        # shooter's last round.  Both facts are only true at this instant.
-        if (projectile_id is not None and
-                self.last_shell_shots.get(str(projectile_id)) and
+        # Fadin wants the final enemy destroyed either directly by the last
+        # round or by the fire that round started. Both facts are only true
+        # at this instant.
+        if (((projectile_id is not None and
+              self.last_shell_shots.get(str(projectile_id))) or
+             bool(last_shell_fire)) and
                 not self._living_enemies(self._vehicle_team(*attacker))):
             self.last_shell_finishers.add(attacker)
         if projectile_id is not None:
@@ -10799,6 +10861,9 @@ class BattleState:
                 self.ally_damage[attacker] = int(
                     self.ally_damage.get(attacker, 0)) + damage
             return
+        target = (str(target[0]), int(target[1]))
+        self.enemy_damage_received[target] = int(
+            self.enemy_damage_received.get(target, 0)) + damage
         if target[0] == "bot":
             self.bot_planner.report_damage(
                 target[1], attacker[0], attacker[1], damage,
@@ -10859,7 +10924,8 @@ class BattleState:
 
     def _record_frag(self, attacker_kind, attacker_id, victim_team,
                      victim_kind, victim_id, attacker_team=None,
-                     projectile_id=None, distance=None):
+                     projectile_id=None, distance=None,
+                     last_shell_fire=False):
         """Apply the shared +1 enemy / -1 ally frag and team-killer law."""
         if (attacker_kind == victim_kind and
                 int(attacker_id) == int(victim_id)):
@@ -10930,7 +10996,8 @@ class BattleState:
             interaction["death_reason"] = max(
                 minimum, min(maximum, int(reason)))
             self._record_kill(
-                attacker, victim, int(reason), projectile_id, distance)
+                attacker, victim, int(reason), projectile_id, distance,
+                last_shell_fire=last_shell_fire)
         self.pending_events.append({
             "kind": "vehicle_statistics",
             "actor_kind": attacker_kind,
@@ -11469,6 +11536,8 @@ class BattleState:
             state["points"] = min(100, sum(
                 max(0, int(points or 0))
                 for points in contributors.values()))
+            if state["points"] == 0:
+                self.capture_attempt_participants[base_team].clear()
             if not contributors:
                 self.capture_cursors[base_team] = 0
             rate = min(max(0, int(state.get("invaders", 0))), 3)
@@ -11563,11 +11632,19 @@ class BattleState:
             points = min(100, sum(
                 max(0, int(value or 0))
                 for value in contributors.values()))
+            if points == 0:
+                self.capture_attempt_participants[base_team].clear()
             # Standard CTF bases do not stop capture merely because an owner
             # enters its own circle. Only an invader leaving, dying, or taking
             # qualifying damage drops that vehicle's contribution.
             state['stopped'] = False
             if invader_keys and points < 100:
+                # Sneaky belongs only to an attempt made alone. Count every
+                # vehicle that joined while the counter was non-zero or was
+                # about to advance, even when the final one-point budget did
+                # not happen to select that vehicle.
+                self.capture_attempt_participants[base_team].update(
+                    _capture_key_actor(key) for key in invader_keys)
                 cursor = (self.capture_cursors[base_team] %
                           len(invader_keys))
                 budget = min(3, len(invader_keys), 100 - points)
@@ -11581,9 +11658,6 @@ class BattleState:
                     earner = _capture_key_actor(vehicle_id)
                     self._statistics_row(earner[0], earner[1])[
                         "capture_points"] += 1
-                    # The Sneaky medal is only for a base captured alone, so
-                    # remember everyone that ever moved this base's counter.
-                    self.capture_point_earners[base_team].add(earner)
                 self.capture_cursors[base_team] = (
                     cursor + budget) % len(invader_keys)
             elif not invader_keys:

--- a/server/lan_battle_server.py
+++ b/server/lan_battle_server.py
@@ -47,6 +47,8 @@ from vehicle_overlay_store import (
     VehicleOverlayStoreError,
 )
 from gui.mods.offline_lan_0922 import tank_collision
+from gui.mods.offline_lan_0922.battle_achievements import (
+    AWARDABLE_ACHIEVEMENTS, RECEIPT_STAT_NAMES, award_battle_achievements)
 from gui.mods.offline_lan_0922 import burst_mechanics
 from gui.mods.offline_lan_0922 import effective_params as effective_params_wire
 from gui.mods.offline_lan_0922 import equipment_mechanics
@@ -362,6 +364,26 @@ CRITICAL_CREW_NAMES = frozenset((
     "commander", "driver", "gunner1", "gunner2", "loader1",
     "loader2", "radioman1", "radioman2",
 ))
+# #1513 ``items.vehicles.VEHICLE_DEVICE_TYPE_NAMES`` and
+# ``VEHICLE_TANKMAN_TYPE_NAMES`` positions, which the client's crits mask
+# parser indexes.  Both server track devices map onto the single "track" slot
+# and every numbered crew role onto its base type, exactly as retail packs it.
+CRIT_DEVICE_INDICES = {
+    "engineHealth": 0, "ammoBayHealth": 1, "fuelTankHealth": 2,
+    "radioHealth": 3, "leftTrackHealth": 4, "rightTrackHealth": 4,
+    "gunHealth": 5, "turretRotatorHealth": 6, "surveyingDeviceHealth": 7,
+}
+CRIT_TANKMAN_INDICES = {
+    "commander": 0, "driver": 1, "radioman1": 2, "radioman2": 2,
+    "gunner1": 3, "gunner2": 3, "loader1": 4, "loader2": 4,
+}
+# The #1513 vehicle-class tags several historical medals restrict on.
+VEHICLE_CLASS_TAGS = frozenset((
+    "lightTank", "mediumTank", "heavyTank", "AT-SPG", "SPG"))
+# ``arena_achievements.ACHIEVEMENT_CONDITIONS['sniper2']['sniperDistance']``
+# and ``['sturdy']['minHealth']`` of the pinned client.
+SNIPER_SHOT_DISTANCE = 300.0
+SPARTAN_HEALTH_PERCENT = 10.0
 CRITICAL_STATES = frozenset(("normal", "critical", "destroyed"))
 CRITICAL_CAUSES = frozenset((
     "shot", "explosion", "repair", "fire", "drowning", "ramming"))
@@ -973,14 +995,14 @@ def _persisted_result_receipt(value):
         raise ValueError("invalid persisted battle receipt leave state")
     stats = value.get("stats")
     rewards = value.get("rewards")
-    stat_names = (
-        "shots", "direct_hits", "piercings", "damage", "damage_received",
-        "damage_blocked", "assist_track", "assist_radio", "assist_stun",
-        "kills", "spotted", "capture_points", "dropped_capture_points",
-    )
+    stat_names = RECEIPT_STAT_NAMES
     reward_names = ("credits", "xp", "free_xp", "repair_cost", "ammo_cost")
     if not isinstance(stats, dict) or not isinstance(rewards, dict):
         raise ValueError("invalid persisted battle receipt summary")
+    # A receipt persisted before a statistic existed keeps its zero default;
+    # the durable store applies the same rule.
+    for name in stat_names:
+        stats.setdefault(name, 0)
     for mapping, names in ((stats, stat_names), (rewards, reward_names)):
         if any(isinstance(mapping.get(name), bool) or
                not isinstance(mapping.get(name), int) or
@@ -1020,6 +1042,8 @@ def _persisted_result_receipt(value):
                 not isinstance(row.get("is_team_killer"), bool) or
                 not isinstance(row.get("stats"), dict)):
             raise ValueError("invalid persisted public result row")
+        for name in stat_names:
+            row["stats"].setdefault(name, 0)
         if any(isinstance(row["stats"].get(name), bool) or
                not isinstance(row["stats"].get(name), int) or
                row["stats"].get(name) < 0 for name in stat_names):
@@ -1030,6 +1054,15 @@ def _persisted_result_receipt(value):
                 isinstance(killer_id, bool) or not isinstance(killer_id, int) or
                 killer_id < 0 or bool(killer_kind) != bool(killer_id)):
             raise ValueError("invalid persisted public result killer")
+        # Receipts written before offline achievements shipped have no list.
+        achievements = row.get("achievements", [])
+        if (not isinstance(achievements, list) or
+                len(achievements) > len(AWARDABLE_ACHIEVEMENTS) or
+                len(set(achievements)) != len(achievements) or
+                any(name not in AWARDABLE_ACHIEVEMENTS
+                    for name in achievements)):
+            raise ValueError("invalid persisted public result achievements")
+        row["achievements"] = sorted(achievements)
         seen.add(identity)
         row_teams[identity] = row["team"]
         if identity == ("player", value["player_id"]):
@@ -1263,6 +1296,67 @@ def _critical_discrete_state(value):
         bool(value.get("fire", False)),
         bool(value.get("ammo_rack_death", False)),
     )
+
+
+def _popcount(mask):
+    return bin(int(mask) & 0xffffffff).count("1")
+
+
+def _crits_mask(previous, current):
+    """Return the #1513 ``crits`` bits this transition newly set.
+
+    ``scripts/client/gui/shared/crits_mask_parser.py`` of build #1513 reads
+    bits 0-7 as critically damaged devices, bits 12-23 as destroyed devices
+    and bits 24-31 as destroyed crew, indexed by ``VEHICLE_DEVICE_TYPE_NAMES``
+    and ``VEHICLE_TANKMAN_TYPE_NAMES`` from ``battle_results_shared``.
+    """
+    if not isinstance(current, dict):
+        return 0
+    previous = previous if isinstance(previous, dict) else {}
+    mask = 0
+
+    def device_states(value):
+        return dict(
+            (str(record.get("name", "")), str(record.get("state", "")))
+            for record in value.get("devices") or ()
+            if isinstance(record, dict))
+
+    old_devices = device_states(previous)
+    old_destroyed = set(str(name) for name in previous.get("destroyed") or ())
+    for name, state in device_states(current).items():
+        index = CRIT_DEVICE_INDICES.get(name)
+        if index is None:
+            continue
+        if state == "critical" and old_devices.get(name) != "critical":
+            mask |= 1 << index
+    for name in (set(str(name) for name in current.get("destroyed") or ()) -
+                 old_destroyed):
+        index = CRIT_DEVICE_INDICES.get(name)
+        if index is not None:
+            mask |= 1 << (12 + index)
+    for name in (set(str(name) for name in current.get("crew_ko") or ()) -
+                 set(str(name) for name in previous.get("crew_ko") or ())):
+        index = CRIT_TANKMAN_INDICES.get(name)
+        if index is not None:
+            mask |= 1 << (24 + index)
+    return mask
+
+
+def _capture_key_actor(key):
+    """Invert ``_capture_vehicle_key`` back into an actor identity."""
+    prefix, unused, raw_id = str(key).partition(":")
+    return ("player" if prefix == "human" else "bot", int(raw_id))
+
+
+def _shot_distance(record, proposal):
+    """Return the metres between the muzzle pose and the impact pose."""
+    origin = record.get("range_origin") or ()
+    pose = proposal.get("pose") or ()
+    if len(origin) < 3 or len(pose) < 3:
+        return 0.0
+    return math.sqrt(sum(
+        (float(pose[index]) - float(origin[index])) ** 2
+        for index in range(3)))
 
 
 def _critical_damage_transition(previous, current):
@@ -1898,6 +1992,7 @@ class BattleState:
         self.human_ram_probe_fingerprints = OrderedDict()
         self.vehicle_statistics = {}
         self.vehicle_interactions = {}
+        self._reset_achievement_tracking()
         self.round_participants = {}
         self.track_immobilisers = {}
         self.player_spotted = {}
@@ -2910,6 +3005,7 @@ class BattleState:
         self.human_ram_probe_fingerprints = OrderedDict()
         self.vehicle_statistics = {}
         self.vehicle_interactions = {}
+        self._reset_achievement_tracking()
         self.round_participants = {}
         self.track_immobilisers = {}
         self.player_spotted = {}
@@ -3177,6 +3273,7 @@ class BattleState:
                 "team": int(participant.team),
                 "alive": bool(participant.alive),
                 "health": int(participant.health),
+                "max_health": int(participant.max_health),
                 "death_reason": int(participant.death_reason),
                 "death_attacker_kind": str(
                     participant.death_attacker_kind or ""),
@@ -4418,6 +4515,7 @@ class BattleState:
             self.bot_spotted[int(bot_id)] = spotted
             reporter = ("bot", int(bot_id))
             for target in spotted:
+                self._record_first_spot(reporter, target)
                 interaction = self._statistics_interaction(reporter, target)
                 if interaction["spotted"]:
                     continue
@@ -4436,6 +4534,7 @@ class BattleState:
             self.player_spotted[int(player_id)] = spotted
             reporter = ("player", int(player_id))
             for target in spotted:
+                self._record_first_spot(reporter, target)
                 interaction = self._statistics_interaction(reporter, target)
                 if interaction["spotted"]:
                     continue
@@ -7307,7 +7406,9 @@ class BattleState:
 
         if (applied > 0 or _critical_damage_transition(
                 critical_before, admitted_critical)):
-            self._drop_capture_for_vehicle(target_kind, target_id)
+            self._drop_capture_for_vehicle(
+                target_kind, target_id,
+                attacker=(record["shooter_kind"], record["shooter_id"]))
         if record["shooter_kind"] == "player":
             event_kind = "hit" if target_kind == "player" else "bot_hit"
             attacker_key = "attacker"
@@ -7367,27 +7468,53 @@ class BattleState:
         if enemy_hit and proposal["splash"]:
             self._increment_interaction(
                 shooter, victim, "explosion_hits")
+        crits_mask = _crits_mask(critical_before, admitted_critical)
+        crits = _popcount(crits_mask)
+        if enemy_hit and crits_mask:
+            victim_state = self._statistics_row(*victim)
+            victim_state["crits_received_mask"] |= crits_mask
+            self._or_interaction(shooter, victim, "crits", crits_mask)
         if not proposal["splash"] and enemy_hit:
             self._increment_interaction(
                 shooter, victim, "direct_hits")
             row = self._statistics_row(*shooter)
             row["shots_hit"] += 1
+            victim_row = self._statistics_row(*victim)
+            victim_row["hits_received"] += 1
+            victim_row["potential_damage_received"] += max(
+                0, int(proposal["potential_damage"]))
+            if applied > 0 or crits:
+                row["hits_with_damage"] += 1
+            if _shot_distance(record, proposal) >= SNIPER_SHOT_DISTANCE:
+                row["sniper_damage_dealt"] += applied
             if proposal["shot_result"] == 2:
                 row["shots_penetrated"] += 1
                 self._increment_interaction(
                     shooter, victim, "piercings")
             elif blocked_damage:
-                self._statistics_row(*victim)[
-                    "damage_blocked"] += blocked_damage
+                victim_row["damage_blocked"] += blocked_damage
                 self._increment_interaction(
                     victim, shooter, "damage_blocked", blocked_damage)
+            if applied > 0 or blocked_damage:
+                victim_row["damaging_hits_received"] += 1
+            deflected = False
             if proposal["shot_result"] == 0:
+                deflected = True
                 self._increment_interaction(
                     victim, shooter, "ricochets_received")
             elif proposal["shot_result"] == 1 and applied <= 0:
+                deflected = True
                 self._increment_interaction(
                     victim, shooter,
                     "no_damage_direct_hits_received")
+            if deflected:
+                victim_row["deflected_hits_received"] += 1
+                # The Spartan medal asks for a bounced shot taken while the
+                # vehicle was already below its health threshold, so the
+                # health at this hit is the only usable moment.
+                maximum = self._vehicle_max_health(victim)
+                if health * 100 <= SPARTAN_HEALTH_PERCENT * maximum:
+                    victim_row["deflected_hits_at_low_health"] += 1
         if was_alive and not alive:
             if target_kind == "player":
                 target.death_attacker_kind = record["shooter_kind"]
@@ -7398,7 +7525,9 @@ class BattleState:
             self._record_frag(
                 record["shooter_kind"], record["shooter_id"],
                 proposal["target_team"], target_kind, target_id,
-                attacker_team=int(record["team"]))
+                attacker_team=int(record["team"]),
+                projectile_id=record["projectile_id"],
+                distance=_shot_distance(record, proposal))
             self._clear_vehicle_stun(victim)
         elif proposal["stun_end_server_time_ms"]:
             self._set_canonical_stun(
@@ -7902,7 +8031,9 @@ class BattleState:
                 bot_terminal = self._apply_bot_terminal_critical(bot)
             self._commit_external_bot_combat(bot, bot_combat_before)
             if applied_bot > 0:
-                self._drop_capture_for_vehicle("bot", bot_id)
+                self._drop_capture_for_vehicle(
+                    "bot", bot_id,
+                    attacker=(target_kind, target_id))
             bot_event = {
                 "kind": ("bot_bot_hit" if target_kind == "bot"
                          else "bot_hit"),
@@ -7943,7 +8074,8 @@ class BattleState:
                 self._commit_external_bot_combat(
                     target, target_combat_before)
                 if applied_target > 0:
-                    self._drop_capture_for_vehicle("bot", target_id)
+                    self._drop_capture_for_vehicle(
+                        "bot", target_id, attacker=("bot", bot_id))
                 target_event = {
                     "kind": "bot_bot_hit", "attacker_bot": bot_id,
                     "target_bot": target_id, "damage": applied_target,
@@ -7969,7 +8101,8 @@ class BattleState:
                 target.display_health = target.health
                 target.death_reason = reason if not target.alive else 0
                 if applied_target > 0:
-                    self._drop_capture_for_vehicle("player", target_id)
+                    self._drop_capture_for_vehicle(
+                        "player", target_id, attacker=("bot", bot_id))
                 target_event = {
                     "kind": "bot_human_hit", "attacker_bot": bot_id,
                     "target": target_id, "damage": applied_target,
@@ -8077,7 +8210,134 @@ class BattleState:
                 row.get("capture_points", 0))),
             "dropped_capture_points": max(0, int(
                 row.get("dropped_capture_points", 0))),
+            "hits_received": max(0, int(row.get("hits_received", 0))),
+            "potential_damage_received": max(0, int(
+                row.get("potential_damage_received", 0))),
+            "crits_received": _popcount(row.get("crits_received_mask", 0)),
         }
+
+    def _catalogued_vehicle(self, vehicle):
+        """Return one client catalog row for this vehicle name, or None."""
+        for player_id in sorted(self.vehicle_catalogs):
+            for entry in self.vehicle_catalogs.get(player_id, ()):
+                if entry.get("name") == vehicle:
+                    return entry
+        return None
+
+    def _result_vehicle_class(self, vehicle):
+        """Return the #1513 class tag of one catalogued vehicle, or ''."""
+        entry = self._catalogued_vehicle(vehicle)
+        for tag in (entry or {}).get("tags", ()):
+            if tag in VEHICLE_CLASS_TAGS:
+                return tag
+        return ""
+
+    def _achievement_vehicle_tier(self, vehicle):
+        """Return a catalogued tier, or 0 when this client never listed it.
+
+        ``_result_vehicle_tier`` defaults an unknown vehicle to tier 1 so
+        rewards stay bounded.  A medal must not read that guess as a real
+        tier, or every kill would look like a higher-tier kill.
+        """
+        entry = self._catalogued_vehicle(vehicle)
+        if entry is None:
+            return 0
+        return max(1, min(10, int(entry.get("level", 1))))
+
+    def _achievement_actor_rows(self, winner, public_results):
+        """Project frozen public rows plus round state into award inputs."""
+        kills_by_actor = {}
+        vehicles = {}
+        for row in public_results:
+            vehicles[(row["actor_kind"], row["actor_id"])] = row["vehicle"]
+        tiers = {}
+        classes = {}
+
+        def described(identity):
+            if identity not in tiers:
+                vehicle = vehicles.get(identity, "")
+                tiers[identity] = self._achievement_vehicle_tier(vehicle)
+                classes[identity] = self._result_vehicle_class(vehicle)
+            return tiers[identity], classes[identity]
+
+        for record in self.kill_records:
+            actor = (record["actor_kind"], record["actor_id"])
+            victim = (record["victim_kind"], record["victim_id"])
+            if victim not in vehicles:
+                continue
+            victim_tier, victim_class = described(victim)
+            kills_by_actor.setdefault(actor, []).append({
+                "victim_kind": victim[0], "victim_id": victim[1],
+                "victim_tier": victim_tier, "victim_class": victim_class,
+                "death_reason": record["death_reason"],
+                "distance": record["distance"],
+                "defended_base": record["defended_base"],
+            })
+
+        actors = []
+        for row in public_results:
+            identity = (row["actor_kind"], row["actor_id"])
+            statistics = self._statistics_row(*identity)
+            tier, vehicle_class = described(identity)
+            actors.append({
+                "actor_kind": identity[0], "actor_id": identity[1],
+                "team": int(row["team"]),
+                "vehicle": row["vehicle"],
+                "tier": tier,
+                "vehicle_class": vehicle_class,
+                "max_health": self._vehicle_max_health(identity),
+                "health": int(row["health"]),
+                "survived": int(row["death_reason"]) < 0,
+                "won": int(winner) == int(row["team"]),
+                "xp": int(row["xp"]),
+                "stats": dict(row["stats"]),
+                "kills": kills_by_actor.get(identity, []),
+                "damaged_targets": sorted(
+                    self.damaged_targets.get(identity, ())),
+                "first_spotted": int(statistics.get("first_spotted", 0)),
+                "exclusive_spot_assists": len(
+                    self.exclusive_spot_assists.get(identity, ())),
+                "ever_spotted": identity in self.ever_spotted_targets,
+                "crits_received": _popcount(
+                    statistics.get("crits_received_mask", 0)),
+                "hits_received": int(statistics.get("hits_received", 0)),
+                "damaging_hits_received": int(
+                    statistics.get("damaging_hits_received", 0)),
+                "deflected_hits_received": int(
+                    statistics.get("deflected_hits_received", 0)),
+                "deflected_hits_at_low_health": int(
+                    statistics.get("deflected_hits_at_low_health", 0)),
+                "potential_damage_received": int(
+                    statistics.get("potential_damage_received", 0)),
+                "sniper_damage": int(
+                    statistics.get("sniper_damage_dealt", 0)),
+                "hits_with_damage": int(
+                    statistics.get("hits_with_damage", 0)),
+                "best_multi_kill_shot": int(
+                    self.best_multi_kill_shot.get(identity, 0)),
+                "lone_stand_enemies": int(
+                    self.lone_stand_enemies.get(identity, 0)),
+                "captured_base": int(
+                    row["stats"].get("capture_points", 0)) > 0,
+            })
+        return actors
+
+    def _vehicle_max_health(self, identity):
+        if identity[0] == "player":
+            player = self.players.get(int(identity[1]))
+            if player is not None:
+                return max(1, int(player.max_health))
+            participant = self._frozen_player_participant(identity[1])
+            if participant is not None:
+                return max(1, int(participant.get("max_health", 1) or 1))
+            return 1
+        state = self.bot_states.get(int(identity[1]))
+        if state is not None:
+            return max(1, int(state.get("max_health", 1) or 1))
+        for entry in self.bot_manifest:
+            if int(entry.get("id", 0)) == int(identity[1]):
+                return max(1, int(entry.get("max_health", 1) or 1))
+        return 1
 
     def _result_vehicle_tier(self, vehicle, preferred_player_id=None):
         catalog_ids = []
@@ -8214,6 +8474,14 @@ class BattleState:
                     "team_killer": bool(player.team_killer),
                 } for player in self.players.values()]
             public_results = self._public_result_roster(winner, participants)
+            awards = award_battle_achievements({
+                "actors": self._achievement_actor_rows(
+                    winner, public_results),
+                "base_captured_team": self.base_captured_team,
+            })
+            for row in public_results:
+                row["achievements"] = sorted(awards.get(
+                    (row["actor_kind"], row["actor_id"]), ()))
             public_by_player = dict(
                 (row["actor_id"], row) for row in public_results
                 if row["actor_kind"] == "player")
@@ -8366,6 +8634,7 @@ class BattleState:
         for state in self.bot_states.values():
             if state.get("alive") and state.get("team") in (1, 2):
                 alive_teams.add(int(state["team"]))
+        self._record_lone_stands()
         if alive_teams == {1, 2}:
             return False
         winner = next(iter(alive_teams)) if len(alive_teams) == 1 else 0
@@ -9944,7 +10213,8 @@ class BattleState:
             player.display_health = player.health
             player.death_reason = 1 if not player.alive else 0
             if damage > 0:
-                self._drop_capture_for_vehicle("player", player.player_id)
+                self._drop_capture_for_vehicle(
+                    "player", player.player_id, attacker=attacker)
             self._record_damage(
                 attacker, ("player", player.player_id), damage,
                 critical_before)
@@ -10121,6 +10391,113 @@ class BattleState:
             return None
         return state["attacker_kind"], state["attacker_id"]
 
+    def _reset_achievement_tracking(self):
+        """Clear the per-round inputs #1513 achievement conditions read."""
+        # target -> the first actor that ever directly detected it.
+        self.first_spotters = {}
+        # every vehicle any enemy ever directly detected.
+        self.ever_spotted_targets = set()
+        # actor -> targets it damaged while it was their only direct spotter.
+        self.exclusive_spot_assists = {}
+        # actor -> every enemy it damaged.
+        self.damaged_targets = {}
+        # one row per enemy kill, in the order the server admitted them.
+        self.kill_records = []
+        # projectile id -> kills that single shot caused.
+        self.projectile_kill_counts = {}
+        # actor -> the largest kill count one of its shots caused.
+        self.best_multi_kill_shot = {}
+        # actor -> enemies alive when it became its team's last survivor.
+        self.lone_stand_enemies = {}
+        # base team -> the actors currently inside that team's base circle.
+        self.capture_invaders = {1: set(), 2: set()}
+        self.base_captured_team = 0
+
+    def _record_first_spot(self, reporter, target):
+        """Remember the first detector and that this target was ever seen."""
+        reporter = (str(reporter[0]), int(reporter[1]))
+        target = (str(target[0]), int(target[1]))
+        reporter_team = self._vehicle_team(*reporter)
+        target_team = self._vehicle_team(*target)
+        if not target_team or reporter_team == target_team:
+            return
+        self.ever_spotted_targets.add(target)
+        if target not in self.first_spotters:
+            self.first_spotters[target] = reporter
+            self._statistics_row(*reporter)["first_spotted"] += 1
+
+    def _direct_spotters(self, target):
+        """Return every enemy observer that directly sees ``target``.
+
+        A reported spot set can contain same-team entries, so this applies the
+        same team fence ``_radio_assisters`` uses; a teammate is not a spotter.
+        """
+        target = (str(target[0]), int(target[1]))
+        target_team = self._vehicle_team(*target)
+        result = []
+        for reporter_id, spotted in self.player_spotted.items():
+            reporter = ("player", int(reporter_id))
+            if target in spotted and self._vehicle_team(
+                    *reporter) != target_team:
+                result.append(reporter)
+        for bot_id, spotted in self.bot_spotted.items():
+            reporter = ("bot", int(bot_id))
+            if target in spotted and self._vehicle_team(
+                    *reporter) != target_team:
+                result.append(reporter)
+        return result
+
+    def _record_kill(self, attacker, victim, death_reason,
+                     projectile_id=None, distance=None):
+        """Freeze one enemy kill with the facts #1513 medals ask about."""
+        attacker = (str(attacker[0]), int(attacker[1]))
+        victim = (str(victim[0]), int(victim[1]))
+        self.kill_records.append({
+            "actor_kind": attacker[0], "actor_id": attacker[1],
+            "victim_kind": victim[0], "victim_id": victim[1],
+            "death_reason": int(death_reason),
+            "distance": (None if distance is None else
+                         round(float(distance), 3)),
+            # De Langlade's medal counts enemies destroyed while they were
+            # inside the defender's own base circle.
+            "defended_base": victim in self.capture_invaders.get(
+                self._vehicle_team(*attacker), set()),
+        })
+        if projectile_id is not None:
+            # Projectile identities are opaque strings, not integers.
+            key = str(projectile_id)
+            count = int(self.projectile_kill_counts.get(key, 0)) + 1
+            self.projectile_kill_counts[key] = count
+            self.best_multi_kill_shot[attacker] = max(
+                int(self.best_multi_kill_shot.get(attacker, 0)), count)
+
+    def _record_lone_stands(self):
+        """Capture the Kolobanov moment for each new last survivor."""
+        alive = {1: [], 2: []}
+        roster = {1: 0, 2: 0}
+        for player in self.players.values():
+            team = int(player.team)
+            if team not in alive or not player.connected:
+                continue
+            roster[team] += 1
+            if player.participating and player.alive:
+                alive[team].append(("player", int(player.player_id)))
+        for state in self.bot_states.values():
+            team = int(state.get("team", 0))
+            if team not in alive:
+                continue
+            roster[team] += 1
+            if state.get("alive"):
+                alive[team].append(("bot", int(state["id"])))
+        for team in (1, 2):
+            # A team that never had a second vehicle cannot leave one behind.
+            if len(alive[team]) != 1 or roster[team] < 2:
+                continue
+            survivor = alive[team][0]
+            enemies = len(alive[3 - team])
+            self.lone_stand_enemies[survivor] = max(
+                int(self.lone_stand_enemies.get(survivor, 0)), enemies)
+
     def _statistics_row(self, kind, vehicle_id):
         """Return this round's mutable statistics row for one vehicle."""
         key = (str(kind), int(vehicle_id))
@@ -10134,6 +10511,16 @@ class BattleState:
                 "damage_blocked": 0, "damage_assisted_track": 0,
                 "damage_assisted_radio": 0, "damage_assisted_stun": 0,
                 "kills": 0,
+                "capture_points": 0, "dropped_capture_points": 0,
+                # Battle-result fidelity fields.  #1513 shows every one of
+                # these on the results screen and Wargaming's achievement
+                # conditions read them, so they are canonical round state
+                # rather than presentation-only counters.
+                "potential_damage_received": 0, "hits_received": 0,
+                "damaging_hits_received": 0, "deflected_hits_received": 0,
+                "crits_received_mask": 0, "hits_with_damage": 0,
+                "sniper_damage_dealt": 0, "first_spotted": 0,
+                "deflected_hits_at_low_health": 0,
             }
             self.vehicle_statistics[key] = row
         elif not row["team"]:
@@ -10163,6 +10550,15 @@ class BattleState:
         interaction = self._statistics_interaction(actor, target)
         interaction[name] = max(minimum, min(
             maximum, int(interaction.get(name, 0)) + int(amount)))
+        return interaction[name]
+
+    def _or_interaction(self, actor, target, name, mask):
+        """Merge one bitmask field.  #1513 reads ``crits`` as a mask, so
+        distinct modules accumulate and a repeated crit stays one bit."""
+        minimum, maximum = RESULT_INTERACTION_LIMITS[name]
+        interaction = self._statistics_interaction(actor, target)
+        interaction[name] = max(minimum, min(
+            maximum, int(interaction.get(name, 0)) | int(mask)))
         return interaction[name]
 
     def _receipt_interactions(self, actor):
@@ -10231,10 +10627,18 @@ class BattleState:
         if not attacker_row["team"] and attacker_team in (1, 2):
             attacker_row["team"] = attacker_team
         attacker_row["damage_dealt"] += damage
+        self.damaged_targets.setdefault(attacker, set()).add(target)
         self._increment_interaction(
             attacker, target, "damage", damage)
         self._increment_interaction(
             target, attacker, "damage_received", damage)
+        # #1513's Patrol Duty (``evileye``) counts enemies damaged while the
+        # awarded vehicle was their only direct spotter.  Record that here,
+        # where the exact live spotter set is still known.
+        spotters = self._direct_spotters(target)
+        if len(spotters) == 1 and spotters[0] != attacker:
+            self.exclusive_spot_assists.setdefault(
+                spotters[0], set()).add(target)
         credits = []
         holder = self.track_immobilisers.get(target)
         if (holder is not None and holder != attacker and
@@ -10271,7 +10675,8 @@ class BattleState:
         return None
 
     def _record_frag(self, attacker_kind, attacker_id, victim_team,
-                     victim_kind, victim_id, attacker_team=None):
+                     victim_kind, victim_id, attacker_team=None,
+                     projectile_id=None, distance=None):
         """Apply the shared +1 enemy / -1 ally frag and team-killer law."""
         if (attacker_kind == victim_kind and
                 int(attacker_id) == int(victim_id)):
@@ -10335,6 +10740,8 @@ class BattleState:
             minimum, maximum = RESULT_INTERACTION_LIMITS["death_reason"]
             interaction["death_reason"] = max(
                 minimum, min(maximum, int(reason)))
+            self._record_kill(
+                attacker, victim, int(reason), projectile_id, distance)
         self.pending_events.append({
             "kind": "vehicle_statistics",
             "actor_kind": attacker_kind,
@@ -10648,9 +11055,13 @@ class BattleState:
         first.death_reason = 2 if not first.alive else 0
         second.death_reason = 2 if not second.alive else 0
         if damage_first > 0:
-            self._drop_capture_for_vehicle("player", first.player_id)
+            self._drop_capture_for_vehicle(
+                "player", first.player_id,
+                attacker=("player", second.player_id))
         if damage_second > 0:
-            self._drop_capture_for_vehicle("player", second.player_id)
+            self._drop_capture_for_vehicle(
+                "player", second.player_id,
+                attacker=("player", first.player_id))
         episode = int(self.human_ram_episode_seq.get(pair, 0)) + 1
         self.human_ram_episode_seq[pair] = episode
         operation_id = "%d:%d:%d:%d" % (
@@ -10854,8 +11265,12 @@ class BattleState:
         return "%s:%d" % ("human" if kind == "player" else "bot",
                            int(vehicle_id))
 
-    def _drop_capture_for_vehicle(self, kind, vehicle_id):
-        """Drop only one damaged vehicle's accumulated capture points."""
+    def _drop_capture_for_vehicle(self, kind, vehicle_id, attacker=None):
+        """Drop only one damaged vehicle's accumulated capture points.
+
+        ``attacker`` credits the enemy that caused the drop with #1513's
+        ``droppedCapturePoints``, which the Defender medal reads.
+        """
         key = self._capture_vehicle_key(kind, vehicle_id)
         dropped_total = 0
         for base_team in (1, 2):
@@ -10871,6 +11286,13 @@ class BattleState:
             state["time_left"] = (
                 float(max(0, 100 - state["points"])) / float(rate)
                 if rate > 0 else 0.0)
+        if dropped_total and attacker is not None:
+            attacker = (str(attacker[0]), int(attacker[1]))
+            target_team = self._vehicle_team(str(kind), int(vehicle_id))
+            if (attacker != (str(kind), int(vehicle_id)) and
+                    self._vehicle_team(*attacker) != target_team):
+                self._statistics_row(*attacker)[
+                    "dropped_capture_points"] += dropped_total
         return dropped_total
 
     def _update_capture(self):
@@ -10938,6 +11360,8 @@ class BattleState:
                 key for key, x, z in vehicles[invading_team]
                 if any((x - bx) ** 2 + (z - bz) ** 2 <= 2500.0
                        for bx, bz in normalized)))
+            self.capture_invaders[base_team] = set(
+                _capture_key_actor(key) for key in invader_keys)
             state = self.rules_state['bases'][str(base_team)]
             previous = dict(state)
             contributors = self.capture_contributors[base_team]
@@ -10963,6 +11387,11 @@ class BattleState:
                         (cursor + offset) % len(invader_keys)]
                     contributors[vehicle_id] = int(
                         contributors.get(vehicle_id, 0) or 0) + 1
+                    # #1513 reports each vehicle's own accumulated capture
+                    # points; the Invader medal reads exactly this total.
+                    self._statistics_row(
+                        *_capture_key_actor(vehicle_id))[
+                            "capture_points"] += 1
                 self.capture_cursors[base_team] = (
                     cursor + budget) % len(invader_keys)
             elif not invader_keys:
@@ -10977,6 +11406,7 @@ class BattleState:
                 if rate > 0 else 0.0)
             changed = changed or state != previous
             if state['points'] >= 100:
+                self.base_captured_team = invading_team
                 self._finish_battle(
                     invading_team, 'base captured', base_team)
                 break

--- a/server/lan_battle_server.py
+++ b/server/lan_battle_server.py
@@ -6337,7 +6337,7 @@ class BattleState:
                 # ever earn Fadin's medal, and a missing count is not a
                 # reason to reject a legal trigger.
                 "shells_before_shot": _optional_exact_int(
-                    message.get("shells_before_shot"), 0, 1000),
+                    message.get("shells_before_shot"), 1, 1000),
             }
             player.fire_intent_seq = intent_seq
             player.fire_intent_fingerprints[intent_seq] = fingerprint
@@ -6762,13 +6762,16 @@ class BattleState:
             self.projectiles[projectile_id] = record
             # Freeze whether this was the shooter's final round while the
             # producer that owns the ammunition is still the one reporting it.
+            # A shot was drawn from at least one shell, so zero is an
+            # invalid report rather than an emptier rack; Fadin's medal wants
+            # exactly the final round, which is a total of one.
             shells_before_shot = (
-                _optional_exact_int(intent.get("shells_before_shot"), 0, 1000)
+                _optional_exact_int(intent.get("shells_before_shot"), 1, 1000)
                 if shooter_kind == "player" else
-                _optional_exact_int(message.get("shells_before_shot"), 0, 1000))
+                _optional_exact_int(message.get("shells_before_shot"), 1, 1000))
             if shells_before_shot is not None:
                 self.last_shell_shots[str(projectile_id)] = (
-                    shells_before_shot <= 1)
+                    shells_before_shot == 1)
             if shooter_kind == "player":
                 shooter.fire_seq = shot_seq
                 if bool(intent.get("shell_change_pending", False)):
@@ -7479,6 +7482,10 @@ class BattleState:
         if _destroyed_tracks(admitted_critical) - _destroyed_tracks(
                 critical_before):
             self.track_immobilisers[victim] = shooter
+            if int(record["team"]) != int(proposal["target_team"]):
+                # Fire Support counts an enemy whose track this shooter
+                # destroyed even when the shot dealt no hit points.
+                self.support_targets.setdefault(shooter, set()).add(victim)
         enemy_hit = (
             int(record["team"]) != int(proposal["target_team"]))
         if enemy_hit and proposal["splash"]:
@@ -7490,6 +7497,12 @@ class BattleState:
             victim_state = self._statistics_row(*victim)
             victim_state["crits_received_mask"] |= crits_mask
             self._or_interaction(shooter, victim, "crits", crits_mask)
+        if not proposal["splash"] and not enemy_hit and shooter != victim:
+            # Top Gun and Sniper both forbid hitting a friendly vehicle at
+            # all, so a direct friendly hit needs an owner even though it
+            # earns the shooter nothing.
+            self.ally_hits[shooter] = int(
+                self.ally_hits.get(shooter, 0)) + 1
         if not proposal["splash"] and enemy_hit:
             self._increment_interaction(
                 shooter, victim, "direct_hits")
@@ -8296,6 +8309,7 @@ class BattleState:
                 "distance": record["distance"],
                 "defended_base": record["defended_base"],
                 "actor_speed": record["actor_speed"],
+                "victim_speed": record["victim_speed"],
             })
 
         actors = []
@@ -8322,6 +8336,13 @@ class BattleState:
                     self.exclusive_spot_assists.get(identity, ())),
                 "ever_spotted": identity in self.ever_spotted_targets,
                 "ally_damage": int(self.ally_damage.get(identity, 0)),
+                "ally_hits": int(self.ally_hits.get(identity, 0)),
+                "team_kills": int(self.team_kills.get(identity, 0)),
+                "support_targets": len(
+                    self.support_targets.get(identity, ())),
+                "solo_capture": (
+                    self.capture_point_earners.get(
+                        3 - int(row["team"]), set()) == {identity}),
                 "last_shell_finisher": identity in self.last_shell_finishers,
                 "lucky_devil": identity in self.lucky_devils,
                 "best_deflection_streak": int(
@@ -10428,6 +10449,14 @@ class BattleState:
         self.ever_spotted_targets = set()
         # actor -> damage it dealt to its own team.
         self.ally_damage = {}
+        # actor -> vehicles of its own team it destroyed.
+        self.team_kills = {}
+        # actor -> direct hits it landed on its own team.
+        self.ally_hits = {}
+        # actor -> enemies it damaged or whose track it destroyed.
+        self.support_targets = {}
+        # base team -> every actor that ever earned a point capturing it.
+        self.capture_point_earners = {1: set(), 2: set()}
         # actors that destroyed the last living enemy with their last shell.
         self.last_shell_finishers = set()
         # projectile id -> whether it was the shooter's final round.
@@ -10594,8 +10623,10 @@ class BattleState:
             "defended_base": victim in self.capture_invaders.get(
                 self._vehicle_team(*attacker), set()),
             # Rock Solid bounds the rammer's own speed at the moment of the
-            # kill, which is only knowable here.
+            # kill and requires the victim to have been the faster of the two,
+            # so both are only knowable here.
             "actor_speed": round(self._vehicle_speed(attacker), 4),
+            "victim_speed": round(self._vehicle_speed(victim), 4),
         })
         # Fadin's medal wants the shot that ended the battle to have been the
         # shooter's last round.  Both facts are only true at this instant.
@@ -10777,6 +10808,9 @@ class BattleState:
             attacker_row["team"] = attacker_team
         attacker_row["damage_dealt"] += damage
         self.damaged_targets.setdefault(attacker, set()).add(target)
+        # Fire Support counts distinct enemies this actor actually hurt; a
+        # ricochet or non-penetration never reaches here.
+        self.support_targets.setdefault(attacker, set()).add(target)
         self._increment_interaction(
             attacker, target, "damage", damage)
         self._increment_interaction(
@@ -10871,6 +10905,9 @@ class BattleState:
         else:
             return False
         if delta < 0:
+            actor_identity = (str(attacker_kind), int(attacker_id))
+            self.team_kills[actor_identity] = int(
+                self.team_kills.get(actor_identity, 0)) + 1
             self._record_lucky_devils(
                 (str(victim_kind), int(victim_id)), int(victim_team))
         if delta > 0:
@@ -11541,9 +11578,12 @@ class BattleState:
                         contributors.get(vehicle_id, 0) or 0) + 1
                     # #1513 reports each vehicle's own accumulated capture
                     # points; the Invader medal reads exactly this total.
-                    self._statistics_row(
-                        *_capture_key_actor(vehicle_id))[
-                            "capture_points"] += 1
+                    earner = _capture_key_actor(vehicle_id)
+                    self._statistics_row(earner[0], earner[1])[
+                        "capture_points"] += 1
+                    # The Sneaky medal is only for a base captured alone, so
+                    # remember everyone that ever moved this base's counter.
+                    self.capture_point_earners[base_team].add(earner)
                 self.capture_cursors[base_team] = (
                     cursor + budget) % len(invader_keys)
             elif not invader_keys:

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/data.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/data.py
@@ -588,8 +588,11 @@ def _write_achievements(dossier, counts):
     block = dossier['achievements']
     heroes = 0
     for name in sorted(counts):
-        value = max(0, int(counts.get(name, 0) or 0))
-        if not value:
+        value = counts.get(name)
+        # Optional persisted state reaches here, so a counter that is not a
+        # positive whole number is dropped rather than coerced.  ``bool`` is
+        # an ``int`` subclass and is not a count.
+        if isinstance(value, bool) or not isinstance(value, int) or value < 1:
             continue
         if name in BATTLE_HERO_ACHIEVEMENTS:
             heroes += value

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/data.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/data.py
@@ -25,6 +25,11 @@ OFFLINE_GOLD = 1000000
 OFFLINE_FREE_XP = 100000000
 OFFLINE_GARAGE_SLOTS = 2000
 OFFLINE_BARRACKS_BERTHS = 2000
+# #1513 counts each battle-hero medal in the vehicle dossier's aggregate
+# ``battleHeroes`` record as well as in its own counter.
+BATTLE_HERO_ACHIEVEMENTS = frozenset((
+    'warrior', 'invader', 'sniper', 'sniper2', 'mainGun', 'defender',
+    'steelwall', 'supporter', 'scout', 'evileye'))
 
 
 def _vehicle_records(vehicle):
@@ -385,6 +390,7 @@ def stats(selected_vehicle=None, postbattle_progress=None):
             # starts the stock lobby tutorial/hints lifecycle even though this
             # account cannot persist its tutorial actions on a retail server.
             'denunciationsLeft': 0, 'tutorialsCompleted': 33553532,
+            'dossier': account_dossier(progress),
             'battlesTillCaptcha': 0, 'dailyPlayHours': [0],
             # Full daily/weekly periods disable parental-control blocking in
             # the native #1513 GameSessionController.  Zero means no allowed
@@ -570,6 +576,54 @@ def _vehicle_type_compact_descr(type_name):
         'vehicle', nation_id, vehicle_type_id))
 
 
+def _write_achievements(dossier, counts):
+    """Store earned medal counters in the exact #1513 dossier block.
+
+    The block's record layout is fixed by the pinned client, so a name it
+    does not carry is skipped rather than allowed to raise inside the native
+    dossier builder.  ``battleHeroes`` mirrors stock's aggregate counter.
+    """
+    if not isinstance(counts, dict) or not counts:
+        return
+    block = dossier['achievements']
+    heroes = 0
+    for name in sorted(counts):
+        value = max(0, int(counts.get(name, 0) or 0))
+        if not value:
+            continue
+        if name in BATTLE_HERO_ACHIEVEMENTS:
+            heroes += value
+        try:
+            block[name] = value
+        except (KeyError, TypeError, ValueError):
+            continue
+    if heroes:
+        try:
+            block['battleHeroes'] = heroes
+        except (KeyError, TypeError, ValueError):
+            pass
+
+
+def account_dossier(postbattle_progress=None, dossier_factory=None):
+    """Return the account dossier compact descriptor #1513 reads.
+
+    ``StatsRequester.accountDossier`` of the pinned client reads the ``stats``
+    cache key ``dossier``; the lobby profile builds its achievements page from
+    it.  An account with no medals keeps the stock empty-string value.
+    """
+    progress = (postbattle_progress
+                if isinstance(postbattle_progress, dict) else {})
+    counts = progress.get('achievements')
+    if not isinstance(counts, dict) or not counts:
+        return ''
+    if dossier_factory is None:
+        from dossiers2.custom.builders import getAccountDossierDescr
+        dossier_factory = getAccountDossierDescr
+    dossier = dossier_factory('')
+    _write_achievements(dossier, counts)
+    return dossier.makeCompDescr()
+
+
 def dossiers(revision=0, max_change_time=0, postbattle_progress=None,
              dossier_factory=None, vehicle_type_resolver=None):
     """Return exact native-built vehicle dossier rows for #1513 cache."""
@@ -619,6 +673,7 @@ def dossiers(revision=0, max_change_time=0, postbattle_progress=None,
                 'damageAssistedStun'):
             block2[field_name] = max(
                 0, int(stats.get(field_name, 0) or 0))
+        _write_achievements(dossier, stats.get('achievements'))
         rows.append((resolver(type_name), change_time,
                      dossier.makeCompDescr()))
     # This cache version describes our dossier row schema, not battle count.

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/postbattle_store.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/postbattle_store.py
@@ -322,6 +322,25 @@ def _pack_interaction_details(receipt, vehicle_ids, vehicle_type_cds,
     return details.pack()
 
 
+def _achievement_counts(value):
+    """Return one medal-counter map safe to hand the #1513 dossier builder.
+
+    Persisted progress is optional state a player can edit or a partial write
+    can corrupt.  Only names this build awards survive, and only as positive
+    whole counts, because the native dossier block coerces with ``int`` and a
+    bad value there breaks the account snapshot the garage is built from.
+    """
+    if not isinstance(value, dict):
+        return {}
+    counts = {}
+    for name in AWARDABLE_ACHIEVEMENTS:
+        count = value.get(name)
+        if isinstance(count, bool) or not isinstance(count, int) or count < 1:
+            continue
+        counts[name] = count
+    return counts
+
+
 def _achievement_records(names, record_db_ids=None):
     """Return sorted ``(name, database id)`` pairs for awarded medals.
 
@@ -741,11 +760,13 @@ class PostBattleStore(object):
         row['kills'] += stats['kills']
         # #1513 counts every medal in both the account and the vehicle
         # dossier; the results badge renders the account total.
-        account_medals = progress.setdefault('achievements', {})
-        vehicle_medals = row.setdefault('achievements', {})
+        account_medals = _achievement_counts(progress.get('achievements'))
+        vehicle_medals = _achievement_counts(row.get('achievements'))
+        progress['achievements'] = account_medals
+        row['achievements'] = vehicle_medals
         for name in receipt['achievements']:
-            account_medals[name] = int(account_medals.get(name, 0)) + 1
-            vehicle_medals[name] = int(vehicle_medals.get(name, 0)) + 1
+            account_medals[name] = account_medals.get(name, 0) + 1
+            vehicle_medals[name] = vehicle_medals.get(name, 0) + 1
         for target_name, source_name in (
                 ('shots', 'shots'), ('directHits', 'direct_hits'),
                 ('piercings', 'piercings'), ('spotted', 'spotted'),
@@ -819,15 +840,17 @@ class PostBattleStore(object):
                               int(self._progress.get('wins', 0))))
             # Files written before offline achievements shipped have no
             # medal counters; an empty map is the correct starting total.
-            if not isinstance(self._progress.get('achievements'), dict):
-                self._progress['achievements'] = {}
+            # A corrupt or hand-edited counter must not reach the dossier
+            # builder, so only known names with positive whole counts survive.
+            self._progress['achievements'] = _achievement_counts(
+                self._progress.get('achievements'))
             for row in self._progress.get('vehicles', {}).values():
                 if isinstance(row, dict):
                     row.setdefault(
                         'losses', max(0, int(row.get('battles', 0)) -
                                       int(row.get('wins', 0))))
-                    if not isinstance(row.get('achievements'), dict):
-                        row['achievements'] = {}
+                    row['achievements'] = _achievement_counts(
+                        row.get('achievements'))
         except (IOError, OSError, TypeError, ValueError):
             # Keep a corrupt optional cache from preventing an offline login.
             self._pending = {}

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/postbattle_store.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/postbattle_store.py
@@ -20,6 +20,8 @@ except ImportError:
     import pickle as _pickle
 
 from gui.mods.offline_lan_0922 import config as port_config
+from gui.mods.offline_lan_0922.battle_achievements import (
+    AWARDABLE_ACHIEVEMENTS, RECEIPT_STAT_NAMES)
 
 
 try:
@@ -119,10 +121,8 @@ def _receipt(value):
     raw_rewards = value.get('rewards')
     if not isinstance(raw_stats, dict) or not isinstance(raw_rewards, dict):
         raise ValueError('battle receipt summary is invalid')
-    stats = dict((name, max(0, _int(raw_stats.get(name)))) for name in (
-        'shots', 'direct_hits', 'piercings', 'damage', 'damage_received',
-        'damage_blocked', 'assist_track', 'assist_radio', 'assist_stun',
-        'kills', 'spotted', 'capture_points', 'dropped_capture_points'))
+    stats = dict((name, max(0, _int(raw_stats.get(name))))
+                 for name in RECEIPT_STAT_NAMES)
     rewards = dict((name, max(0, _int(raw_rewards.get(name)))) for name in (
         'credits', 'xp', 'free_xp', 'repair_cost', 'ammo_cost'))
     # Offline battles never debit service costs.  Rejecting a positive debit
@@ -172,6 +172,14 @@ def _receipt(value):
             raise ValueError('battle receipt public row is invalid')
         row_stats = dict((name, max(0, _int(raw_row_stats.get(name))))
                          for name in stats)
+        # Receipts stored before offline achievements shipped have no list.
+        raw_achievements = raw.get('achievements', [])
+        if (not isinstance(raw_achievements, (list, tuple)) or
+                len(raw_achievements) > len(AWARDABLE_ACHIEVEMENTS) or
+                len(set(raw_achievements)) != len(raw_achievements) or
+                any(name not in AWARDABLE_ACHIEVEMENTS
+                    for name in raw_achievements)):
+            raise ValueError('battle receipt achievements are invalid')
         public_results.append({
             'actor_kind': actor_kind, 'actor_id': actor_id,
             'name': row_name, 'vehicle': row_vehicle, 'team': row_team,
@@ -179,6 +187,7 @@ def _receipt(value):
             'killer_kind': killer_kind, 'killer_id': killer_id,
             'is_team_killer': raw['is_team_killer'], 'xp': xp,
             'stats': row_stats,
+            'achievements': sorted(raw_achievements),
         })
         seen.add(identity)
     personal_rows = [row for row in public_results
@@ -245,6 +254,9 @@ def _receipt(value):
         'premature_leave': bool(value.get('premature_leave', False)),
         'stats': stats,
         'rewards': rewards,
+        # The personal row owns the medal list; mirroring it here keeps the
+        # durable progress transaction from re-deriving the roster.
+        'achievements': list(personal['achievements']),
         'public_results': public_results,
         'interactions': interactions,
     }
@@ -310,16 +322,44 @@ def _pack_interaction_details(receipt, vehicle_ids, vehicle_type_cds,
     return details.pack()
 
 
+def _achievement_records(names, record_db_ids=None):
+    """Return sorted ``(name, database id)`` pairs for awarded medals.
+
+    A name the pinned client does not register is dropped rather than packed;
+    the results window indexes ``DB_ID_TO_RECORD`` and would raise on it.
+    """
+    if not names:
+        return []
+    if record_db_ids is None:
+        from dossiers2.custom.records import RECORD_DB_IDS
+        record_db_ids = RECORD_DB_IDS
+    result = []
+    for name in sorted(names):
+        db_id = record_db_ids.get(('achievements', name))
+        if db_id is not None:
+            result.append((name, int(db_id)))
+    return sorted(result, key=lambda row: row[1])
+
+
+def _achievement_db_ids(names, record_db_ids=None):
+    return [db_id for unused_name, db_id in _achievement_records(
+        names, record_db_ids=record_db_ids)]
+
+
 def pack_battle_result(receipt, packers=None, replay_types=None,
-                       interaction_details_type=None):
+                       interaction_details_type=None, record_db_ids=None,
+                       achievement_counts=None):
     """Build the four-tuple consumed by #1513 ``BattleResultsCache``.
 
     Every compact list comes from the stock packer.  Supplying ``packers`` is
     only a test seam for proving which packer receives which stock field names.
+    ``achievement_counts`` carries the account's post-battle total for each
+    medal, which #1513 renders as the counter on the results badge.
     """
     receipt = _receipt(receipt)
     if packers is None:
         import battle_results_shared as packers
+    counts = achievement_counts if isinstance(achievement_counts, dict) else {}
     stats = receipt['stats']
     rewards = receipt['rewards']
     account_dbid = 1
@@ -342,6 +382,8 @@ def pack_battle_result(receipt, packers=None, replay_types=None,
         'spotted': stats['spotted'],
         'capturePoints': stats['capture_points'],
         'droppedCapturePoints': stats['dropped_capture_points'],
+        'directHitsReceived': stats['hits_received'],
+        'potentialDamageReceived': stats['potential_damage_received'],
         'deathReason': receipt['death_reason'],
         'killerID': 0,
         'credits': rewards['credits'],
@@ -429,6 +471,14 @@ def pack_battle_result(receipt, packers=None, replay_types=None,
     vehicle['killerID'] = identity_to_vehicle_id.get((
         personal_public['killer_kind'], personal_public['killer_id']), 0)
     vehicle['isTeamKiller'] = personal_public['is_team_killer']
+    # ``achievements`` drives the team table ribbon; ``dossierPopUps`` drives
+    # the personal results medals, and #1513 shows its value as the counter.
+    vehicle['achievements'] = _achievement_db_ids(
+        personal_public['achievements'], record_db_ids=record_db_ids)
+    vehicle['dossierPopUps'] = [
+        (db_id, max(1, _int(counts.get(name, 1), 1)))
+        for name, db_id in _achievement_records(
+            personal_public['achievements'], record_db_ids=record_db_ids)]
     vehicle_full_packed = packers.VEH_FULL_RESULTS.pack(vehicle)
 
     players = {}
@@ -459,10 +509,15 @@ def pack_battle_result(receipt, packers=None, replay_types=None,
             'spotted': row_stats['spotted'],
             'capturePoints': row_stats['capture_points'],
             'droppedCapturePoints': row_stats['dropped_capture_points'],
+            'directHitsReceived': row_stats['hits_received'],
+            'potentialDamageReceived': row_stats['potential_damage_received'],
             'deathReason': row['death_reason'],
             'killerID': identity_to_vehicle_id.get(killer_identity, 0),
             'isTeamKiller': row['is_team_killer'],
             'xp': row['xp'],
+            # #1513 renders one medal ribbon per team row from this list.
+            'achievements': _achievement_db_ids(
+                row['achievements'], record_db_ids=record_db_ids),
         }
         public_avatar = {
             # Regular offline battles have no avatar-only combat.  Team
@@ -525,7 +580,7 @@ class PostBattleStore(object):
         return {
             'credits': 0, 'freeXP': 0, 'battles': 0, 'wins': 0,
             'losses': 0,
-            'damage': 0, 'kills': 0, 'vehicles': {},
+            'damage': 0, 'kills': 0, 'achievements': {}, 'vehicles': {},
         }
 
     @property
@@ -575,7 +630,7 @@ class PostBattleStore(object):
         return True
 
     def result(self, arena_unique_id, packers=None, replay_types=None,
-               interaction_details_type=None):
+               interaction_details_type=None, record_db_ids=None):
         arena_unique_id = _int(arena_unique_id, -1)
         receipt = self._pending.get(str(arena_unique_id))
         if receipt is None:
@@ -589,7 +644,9 @@ class PostBattleStore(object):
             return None
         return pack_battle_result(
             receipt, packers=packers, replay_types=replay_types,
-            interaction_details_type=interaction_details_type)
+            interaction_details_type=interaction_details_type,
+            record_db_ids=record_db_ids,
+            achievement_counts=self._progress.get('achievements', {}))
 
     def service_message_data(self, arena_unique_id):
         """Return the exact BattleResultsFormatter input summary."""
@@ -670,7 +727,7 @@ class PostBattleStore(object):
         vehicles = progress['vehicles']
         row = vehicles.setdefault(receipt['vehicle'], {
             'xp': 0, 'battles': 0, 'wins': 0, 'losses': 0,
-            'damage': 0, 'kills': 0,
+            'damage': 0, 'kills': 0, 'achievements': {},
         })
         if vehicle_xp is None:
             vehicle_xp = rewards['xp']
@@ -682,6 +739,13 @@ class PostBattleStore(object):
             receipt['winner'] != receipt['team'])
         row['damage'] += stats['damage']
         row['kills'] += stats['kills']
+        # #1513 counts every medal in both the account and the vehicle
+        # dossier; the results badge renders the account total.
+        account_medals = progress.setdefault('achievements', {})
+        vehicle_medals = row.setdefault('achievements', {})
+        for name in receipt['achievements']:
+            account_medals[name] = int(account_medals.get(name, 0)) + 1
+            vehicle_medals[name] = int(vehicle_medals.get(name, 0)) + 1
         for target_name, source_name in (
                 ('shots', 'shots'), ('directHits', 'direct_hits'),
                 ('piercings', 'piercings'), ('spotted', 'spotted'),
@@ -753,11 +817,17 @@ class PostBattleStore(object):
             self._progress.setdefault(
                 'losses', max(0, int(self._progress.get('battles', 0)) -
                               int(self._progress.get('wins', 0))))
+            # Files written before offline achievements shipped have no
+            # medal counters; an empty map is the correct starting total.
+            if not isinstance(self._progress.get('achievements'), dict):
+                self._progress['achievements'] = {}
             for row in self._progress.get('vehicles', {}).values():
                 if isinstance(row, dict):
                     row.setdefault(
                         'losses', max(0, int(row.get('battles', 0)) -
                                       int(row.get('wins', 0))))
+                    if not isinstance(row.get('achievements'), dict):
+                        row['achievements'] = {}
         except (IOError, OSError, TypeError, ValueError):
             # Keep a corrupt optional cache from preventing an offline login.
             self._pending = {}

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/server.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/server.py
@@ -172,7 +172,7 @@ class FakeServer(object):
         # belongs exclusively to the initial full sync.
         stats = snapshot['stats']
         diff = {'stats': dict((name, stats[name]) for name in (
-            'credits', 'freeXP', 'vehTypeXP'))}
+            'credits', 'freeXP', 'vehTypeXP', 'dossier'))}
         touched = self._context.get('postbattle_touched_vehicles')
         touched = set(touched or ())
         if touched:

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_achievements.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_achievements.py
@@ -1,0 +1,460 @@
+"""Award #1513 post-battle achievements from one finished round.
+
+The thresholds below are copied verbatim from the pinned client's
+``scripts/common/arena_achievements.py`` (``ACHIEVEMENT_CONDITIONS``) inside
+``res/packages/scripts.pkg`` of World of Tanks HD ``0.9.22.0.1 #1513``.  That
+module also proves which table applies: ``getAchievementCondition`` only reads
+``ACHIEVEMENT_CONDITIONS_EXT`` when ``ARENA_BONUS_TYPE_CAPS.checkAny`` accepts
+the arena bonus type, and #1513 answers ``False`` for every bonus type,
+including the regular battles this product packs (``bonusType`` 1).
+
+The client ships the thresholds but not the retail award predicates, which run
+on Wargaming's battle server.  Each predicate below therefore combines an exact
+#1513 constant with the publicly documented shape of that medal.  Anything that
+would need a coefficient this repository cannot source is not awarded at all;
+``UNAWARDED_ACHIEVEMENTS`` records those and why.
+
+This module is pure data: it takes one finished-round summary and returns the
+achievement names for every actor.  It never touches live battle state.  It
+lives with the client mod because the exact-client packer needs the same
+awardable-name table that the LAN server awards from, and it must therefore
+parse and run on the embedded CPython 2.7.7 runtime.
+"""
+
+from __future__ import division
+
+import math
+
+
+# Every statistic one battle receipt carries for one vehicle.  #1513 shows all
+# of them on the results screen and the conditions below read them, so this is
+# the single wire contract shared by the server, the client receiver and the
+# exact-client result packer.
+RECEIPT_STAT_NAMES = (
+    "shots", "direct_hits", "piercings", "damage", "damage_received",
+    "damage_blocked", "assist_track", "assist_radio", "assist_stun",
+    "kills", "spotted", "capture_points", "dropped_capture_points",
+    "hits_received", "potential_damage_received", "crits_received",
+)
+
+# Verbatim #1513 ``arena_achievements.ACHIEVEMENT_CONDITIONS`` subset for the
+# medals this module can decide.  Names and numbers must not be edited without
+# re-reading the pinned client.
+ACHIEVEMENT_CONDITIONS = {
+    "warrior": {"minFrags": 6},
+    "invader": {"minCapturePts": 80},
+    "defender": {"minPoints": 70},
+    "sniper2": {
+        "minAccuracy": 0.85,
+        "minDamage": 1000,
+        "minHitsWithDamagePercent": 0.8,
+        "minShots": 8,
+        "sniperDistance": 300.0,
+    },
+    "mainGun": {"minDamage": 1000, "minDamageToTotalHealthRatio": 0.2},
+    "steelwall": {"minDamage": 1000, "minHits": 11},
+    "supporter": {"minAssists": 6},
+    "scout": {"minDetections": 9},
+    "evileye": {"minAssists": 6},
+    "heroesOfRassenay": {"maxKills": 255, "minKills": 14},
+    "medalLafayettePool": {"maxKills": 13, "minKills": 10, "minLevel": 5},
+    "medalRadleyWalters": {"maxKills": 9, "minKills": 8, "minLevel": 5},
+    "medalOrlik": {"minKills": 2, "minVictimLevelDelta": 1},
+    "medalOskin": {"maxKills": 3, "minKills": 3, "minVictimLevelDelta": 1},
+    "medalNikolas": {"maxKills": 255, "minKills": 4, "minVictimLevelDelta": 1},
+    "medalLehvaslaiho": {
+        "maxKills": 2, "minKills": 2, "minVictimLevelDelta": 1},
+    "medalHalonen": {"minKills": 2, "minVictimLevelDelta": 2},
+    "medalBurda": {"maxKills": 255, "minKills": 3, "minVictimLevelDelta": 1},
+    "medalPascucci": {"maxKills": 2, "minKills": 2},
+    "medalDumitru": {"maxKills": 255, "minKills": 3},
+    "medalTamadaYoshio": {
+        "maxKills": 255, "minKills": 2, "minVictimLevelDelta": 1},
+    "medalBillotte": {
+        "cmn_cnds": {"hpPercentage": 20, "minCrits": 5},
+        "maxKills": 2, "minKills": 2,
+    },
+    "medalBrunoPietro": {
+        "cmn_cnds": {"hpPercentage": 20, "minCrits": 5},
+        "maxKills": 4, "minKills": 3,
+    },
+    "medalTarczay": {
+        "cmn_cnds": {"hpPercentage": 20, "minCrits": 5},
+        "maxKills": 255, "minKills": 5,
+    },
+    "medalKolobanov": {"teamDiff": 5},
+    "medalDeLanglade": {"minKills": 4},
+    "medalGore": {"minDamage": 2000, "minDamageRate": 8},
+    "medalStark": {"hits": 2, "minKills": 2},
+    "medalCoolBlood": {"maxDistance": 100, "minKills": 2},
+    "medalAntiSpgFire": {"minKills": 2},
+    "bombardier": {"minKills": 2},
+    "kamikaze": {"levelDelta": 1},
+    "sturdy": {"minHealth": 10.0},
+    # ``raider`` carries no numeric threshold in #1513; its award is purely
+    # structural (capture the enemy base without ever being detected).
+    "raider": {},
+}
+
+# Medals #1513 knows about that this server deliberately never awards.  Keeping
+# the reason next to the name stops a later change from "fixing" one by
+# inventing the missing input.
+UNAWARDED_ACHIEVEMENTS = {
+    "sniper": "retired by Wargaming in 0.8.11; superseded by sniper2",
+    "medalWittmann": "no condition entry in #1513 arena_achievements",
+    "medalFadin": "needs remaining-ammunition state the server does not own",
+    "medalBrothersInArms": "platoon award; offline rounds have no platoons",
+    "medalCrucialContribution": "platoon award",
+    "medalMonolith": "needs the rammer's impact speed",
+    "luckyDevil": "needs splash-radius survival geometry",
+    "huntsman": "no sourced #1513 predicate for minKills 3",
+    "ironMan": "no sourced #1513 predicate for minHits 10",
+    "alaric": "needs per-vehicle monument destruction attribution",
+    "lumberjack": "needs per-vehicle felled-tree attribution",
+    "markOfMastery": "needs per-vehicle XP distributions retail computes",
+}
+
+# Every name this server can award.  The wire validators use it as an exact
+# allowlist; the client packer still maps each one through the pinned
+# ``dossiers2.custom.records.RECORD_DB_IDS`` table before it reaches #1513.
+AWARDABLE_ACHIEVEMENTS = tuple(sorted(ACHIEVEMENT_CONDITIONS))
+
+# Battle-hero medals go to exactly one actor per battle; the medal's own
+# metric also orders that winner.
+_UNIQUE_BATTLE_HEROES = (
+    "warrior", "invader", "defender", "steelwall", "mainGun",
+    "supporter", "scout", "evileye", "sniper2",
+)
+
+_LIGHT_TANK = "lightTank"
+_MEDIUM_TANK = "mediumTank"
+_TANK_DESTROYER = "AT-SPG"
+_SPG = "SPG"
+
+
+def _int(value, default=0):
+    if isinstance(value, bool):
+        return int(default)
+    try:
+        return int(value)
+    except (TypeError, ValueError, OverflowError):
+        return int(default)
+
+
+def _float(value, default=0.0):
+    if isinstance(value, bool):
+        return float(default)
+    try:
+        result = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return float(default)
+    # CPython 2.7 has no ``math.isfinite``.
+    if math.isnan(result) or math.isinf(result):
+        return float(default)
+    return result
+
+
+def _identity(actor):
+    return (str(actor.get("actor_kind", "")), _int(actor.get("actor_id")))
+
+
+def _stat(actor, name):
+    stats = actor.get("stats")
+    return max(0, _int(stats.get(name))) if isinstance(stats, dict) else 0
+
+
+def _kills(actor):
+    rows = actor.get("kills")
+    return list(rows) if isinstance(rows, (list, tuple)) else []
+
+
+def _tier_kills(actor, delta, victim_class=None):
+    """Count kills of victims at least ``delta`` tiers above the actor.
+
+    A tier of zero means the client never catalogued that vehicle, so its
+    tier is unknown and no tier-relative medal may read it.
+    """
+    tier = _int(actor.get("tier"))
+    if tier <= 0:
+        return 0
+    total = 0
+    for kill in _kills(actor):
+        if (victim_class is not None and
+                kill.get("victim_class") != victim_class):
+            continue
+        victim_tier = _int(kill.get("victim_tier"))
+        if victim_tier > 0 and victim_tier - tier >= delta:
+            total += 1
+    return total
+
+
+def _class_kills(actor, victim_class):
+    return sum(1 for kill in _kills(actor)
+               if kill.get("victim_class") == victim_class)
+
+
+def _health_percent(actor):
+    maximum = _int(actor.get("max_health"))
+    if maximum <= 0:
+        return 100.0
+    return 100.0 * float(max(0, _int(actor.get("health")))) / float(maximum)
+
+
+def _billotte_family(actor, condition):
+    """Shared Billotte/Bruno Pietro/Tarczay survival-under-fire clause."""
+    common = condition.get("cmn_cnds") or {}
+    return (actor.get("survived") and actor.get("won") and
+            _int(actor.get("crits_received")) >=
+            _int(common.get("minCrits"), 0) and
+            _health_percent(actor) <=
+            _float(common.get("hpPercentage"), 0.0))
+
+
+def _kill_band(actor, condition, delta=None, victim_class=None):
+    """Count the qualifying kills and test the medal's inclusive band."""
+    if delta is None:
+        if victim_class is None:
+            count = _stat(actor, "kills")
+        else:
+            count = _class_kills(actor, victim_class)
+    else:
+        count = _tier_kills(actor, delta, victim_class=victim_class)
+    minimum = _int(condition.get("minKills"), 0)
+    maximum = _int(condition.get("maxKills"), 255)
+    return count if minimum <= count <= maximum else 0
+
+
+def _enemy_team_health(actors, team):
+    return sum(max(0, _int(actor.get("max_health")))
+               for actor in actors if _int(actor.get("team")) != team)
+
+
+def _accuracy(actor):
+    shots = _stat(actor, "shots")
+    if shots <= 0:
+        return 0.0
+    return float(_stat(actor, "direct_hits")) / float(shots)
+
+
+def _damage_hit_ratio(actor):
+    hits = _stat(actor, "direct_hits")
+    if hits <= 0:
+        return 0.0
+    return float(_int(actor.get("hits_with_damage"))) / float(hits)
+
+
+def _unique_hero_metric(name, actor, context):
+    """Return this actor's battle-hero metric, or None when it does not
+    satisfy the medal's #1513 thresholds."""
+    condition = ACHIEVEMENT_CONDITIONS[name]
+    if name == "warrior":
+        kills = _stat(actor, "kills")
+        return kills if kills >= condition["minFrags"] else None
+    if name == "invader":
+        points = _stat(actor, "capture_points")
+        return points if points >= condition["minCapturePts"] else None
+    if name == "defender":
+        points = _stat(actor, "dropped_capture_points")
+        return points if points >= condition["minPoints"] else None
+    if name == "steelwall":
+        potential = _int(actor.get("potential_damage_received"))
+        return potential if (
+            actor.get("survived") and
+            potential >= condition["minDamage"] and
+            _int(actor.get("hits_received")) >= condition["minHits"]) else None
+    if name == "mainGun":
+        damage = _stat(actor, "damage")
+        enemy_health = context["enemy_team_health"][_int(actor.get("team"))]
+        threshold = condition["minDamageToTotalHealthRatio"] * enemy_health
+        return damage if (damage >= condition["minDamage"] and
+                          enemy_health > 0 and damage >= threshold) else None
+    if name == "supporter":
+        assists = len(context["confederate"].get(_identity(actor), ()))
+        return assists if assists >= condition["minAssists"] else None
+    if name == "scout":
+        detections = _int(actor.get("first_spotted"))
+        return (detections if detections >= condition["minDetections"]
+                else None)
+    if name == "evileye":
+        assists = _int(actor.get("exclusive_spot_assists"))
+        return assists if assists >= condition["minAssists"] else None
+    if name == "sniper2":
+        damage = _int(actor.get("sniper_damage"))
+        return damage if (
+            _stat(actor, "shots") >= condition["minShots"] and
+            _accuracy(actor) >= condition["minAccuracy"] and
+            _damage_hit_ratio(actor) >=
+            condition["minHitsWithDamagePercent"] and
+            damage >= condition["minDamage"]) else None
+    raise KeyError(name)
+
+
+def _epic_achievements(actor, context):
+    """Return every non-unique medal this actor earned."""
+    earned = []
+    vehicle_class = actor.get("vehicle_class")
+    tier = _int(actor.get("tier"))
+    kills = _stat(actor, "kills")
+    survived = bool(actor.get("survived"))
+
+    condition = ACHIEVEMENT_CONDITIONS["heroesOfRassenay"]
+    if condition["minKills"] <= kills <= condition["maxKills"]:
+        earned.append("heroesOfRassenay")
+    for name in ("medalLafayettePool", "medalRadleyWalters"):
+        condition = ACHIEVEMENT_CONDITIONS[name]
+        if (tier >= condition["minLevel"] and
+                condition["minKills"] <= kills <= condition["maxKills"]):
+            earned.append(name)
+
+    # Historical tier-delta medals.  #1513 restricts each one to the vehicle
+    # class its namesake fought in; the tier delta itself is the constant.
+    for name, required_class in (
+            ("medalOrlik", _LIGHT_TANK),
+            ("medalOskin", _MEDIUM_TANK),
+            ("medalNikolas", _MEDIUM_TANK),
+            ("medalLehvaslaiho", _MEDIUM_TANK),
+            ("medalHalonen", _TANK_DESTROYER)):
+        condition = ACHIEVEMENT_CONDITIONS[name]
+        if vehicle_class == required_class and _kill_band(
+                actor, condition, delta=condition["minVictimLevelDelta"]):
+            earned.append(name)
+
+    # Artillery-hunting medals.  A self-propelled gun cannot earn them.
+    if vehicle_class != _SPG:
+        for name, delta in (("medalBurda", 1), ("medalPascucci", None),
+                            ("medalDumitru", None)):
+            condition = ACHIEVEMENT_CONDITIONS[name]
+            if _kill_band(actor, condition, delta=delta, victim_class=_SPG):
+                earned.append(name)
+    if vehicle_class == _LIGHT_TANK and survived:
+        condition = ACHIEVEMENT_CONDITIONS["medalTamadaYoshio"]
+        if _kill_band(actor, condition,
+                      delta=condition["minVictimLevelDelta"],
+                      victim_class=_SPG):
+            earned.append("medalTamadaYoshio")
+
+    for name in ("medalBillotte", "medalBrunoPietro", "medalTarczay"):
+        condition = ACHIEVEMENT_CONDITIONS[name]
+        if (_billotte_family(actor, condition) and
+                _kill_band(actor, condition)):
+            earned.append(name)
+
+    condition = ACHIEVEMENT_CONDITIONS["medalKolobanov"]
+    if (actor.get("won") and
+            _int(actor.get("lone_stand_enemies")) >= condition["teamDiff"]):
+        earned.append("medalKolobanov")
+
+    condition = ACHIEVEMENT_CONDITIONS["medalDeLanglade"]
+    base_defence_kills = sum(1 for kill in _kills(actor)
+                             if kill.get("defended_base"))
+    if base_defence_kills >= condition["minKills"]:
+        earned.append("medalDeLanglade")
+
+    if vehicle_class == _SPG:
+        condition = ACHIEVEMENT_CONDITIONS["medalGore"]
+        damage = _stat(actor, "damage")
+        max_health = _int(actor.get("max_health"))
+        if (damage >= condition["minDamage"] and max_health > 0 and
+                damage >= condition["minDamageRate"] * max_health):
+            earned.append("medalGore")
+        condition = ACHIEVEMENT_CONDITIONS["medalStark"]
+        if (survived and kills >= condition["minKills"] and
+                _int(actor.get("damaging_hits_received")) >=
+                condition["hits"]):
+            earned.append("medalStark")
+        condition = ACHIEVEMENT_CONDITIONS["medalCoolBlood"]
+        close_kills = sum(
+            1 for kill in _kills(actor)
+            if _float(kill.get("distance"), -1.0) >= 0.0 and
+            _float(kill.get("distance")) <= condition["maxDistance"])
+        if close_kills >= condition["minKills"]:
+            earned.append("medalCoolBlood")
+        condition = ACHIEVEMENT_CONDITIONS["medalAntiSpgFire"]
+        if _class_kills(actor, _SPG) >= condition["minKills"]:
+            earned.append("medalAntiSpgFire")
+
+    condition = ACHIEVEMENT_CONDITIONS["bombardier"]
+    if _int(actor.get("best_multi_kill_shot")) >= condition["minKills"]:
+        earned.append("bombardier")
+
+    condition = ACHIEVEMENT_CONDITIONS["kamikaze"]
+    if tier > 0 and any(
+            _int(kill.get("death_reason")) == 2 and
+            _int(kill.get("victim_tier")) > 0 and
+            _int(kill.get("victim_tier")) - tier >= condition["levelDelta"]
+            for kill in _kills(actor)):
+        earned.append("kamikaze")
+
+    # #1513 stores only the health threshold; the server decides at each
+    # bounced hit whether the vehicle was already under it.
+    if survived and _int(actor.get("deflected_hits_at_low_health")) > 0:
+        earned.append("sturdy")
+
+    if (actor.get("captured_base") and not actor.get("ever_spotted") and
+            context["base_captured_team"] == _int(actor.get("team"))):
+        earned.append("raider")
+
+    return earned
+
+
+def _confederate_targets(actors):
+    """Map each actor to the enemies it damaged that another actor killed."""
+    killers = {}
+    for actor in actors:
+        identity = _identity(actor)
+        for kill in _kills(actor):
+            victim = (str(kill.get("victim_kind", "")),
+                      _int(kill.get("victim_id")))
+            killers.setdefault(victim, set()).add(identity)
+    result = {}
+    for actor in actors:
+        identity = _identity(actor)
+        damaged = actor.get("damaged_targets")
+        targets = set()
+        for raw in (damaged if isinstance(damaged, (list, tuple)) else ()):
+            victim = (str(raw[0]), _int(raw[1]))
+            if killers.get(victim, set()) - {identity}:
+                targets.add(victim)
+        result[identity] = targets
+    return result
+
+
+def award_battle_achievements(battle):
+    """Return ``{(actor_kind, actor_id): [achievement names]}``.
+
+    ``battle`` carries ``actors`` plus ``base_captured_team``.  Every actor
+    row is a plain summary; see the module docstring for the contract.
+    """
+    actors = list(battle.get("actors") or ())
+    if not actors:
+        return {}
+    context = {
+        "enemy_team_health": dict(
+            (team, _enemy_team_health(actors, team)) for team in (1, 2)),
+        "confederate": _confederate_targets(actors),
+        "base_captured_team": _int(battle.get("base_captured_team")),
+    }
+    awards = dict((_identity(actor), []) for actor in actors)
+
+    for name in _UNIQUE_BATTLE_HEROES:
+        best_identity = None
+        best_key = None
+        for actor in actors:
+            metric = _unique_hero_metric(name, actor, context)
+            if metric is None:
+                continue
+            identity = _identity(actor)
+            # Wargaming breaks a battle-hero tie by earned XP.  An exact
+            # remaining tie goes to the human, then to the lower actor id, so
+            # the same round always produces the same winner.
+            key = (metric, _int(actor.get("xp")),
+                   1 if identity[0] == "player" else 0, -identity[1])
+            if best_key is None or key > best_key:
+                best_key = key
+                best_identity = identity
+        if best_identity is not None:
+            awards[best_identity].append(name)
+
+    for actor in actors:
+        awards[_identity(actor)].extend(_epic_achievements(actor, context))
+    return awards

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_achievements.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_achievements.py
@@ -461,10 +461,13 @@ def _epic_achievements(actor, context):
                 for kill in _kills(actor))):
             earned.append("medalMonolith")
         # "受到的伤害以及装甲伤害必须是自身坦克生命值的三分之二."
+        # The description narrows both incoming hits to enemy tanks. Friendly
+        # damage still belongs in the public result row, but never in this
+        # award input, and Stark carries no friendly-kill disqualifier.
         condition = ACHIEVEMENT_CONDITIONS["medalStark"]
-        absorbed = _stat(actor, "damage_received") + _stat(
+        absorbed = _int(actor.get("enemy_damage_received")) + _stat(
             actor, "damage_blocked")
-        if (clean and survived and kills >= condition["minKills"] and
+        if (survived and kills >= condition["minKills"] and
                 _int(actor.get("damaging_hits_received")) >=
                 condition["hits"] and max_health > 0 and
                 3 * absorbed >= 2 * max_health):

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_achievements.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_achievements.py
@@ -8,6 +8,12 @@ module also proves which table applies: ``getAchievementCondition`` only reads
 the arena bonus type, and #1513 answers ``False`` for every bonus type,
 including the regular battles this product packs (``bonusType`` 1).
 
+The full #1513 table holds 62 entries covering every mode this build ever
+shipped.  ``scripts/item_defs/achievements.xml`` tags each achievement with a
+``mode``, and only ``mode="random"`` belongs to the battles this product packs;
+that file also decides which medals exist at all, since a condition without an
+entry there is one Wargaming cancelled before release.
+
 The client ships the thresholds but not the retail award predicates, which run
 on Wargaming's battle server.  Each predicate below therefore combines an exact
 #1513 constant with the publicly documented shape of that medal.  Anything that
@@ -37,9 +43,10 @@ RECEIPT_STAT_NAMES = (
     "hits_received", "potential_damage_received", "crits_received",
 )
 
-# Verbatim #1513 ``arena_achievements.ACHIEVEMENT_CONDITIONS`` subset for the
-# medals this module can decide.  Names and numbers must not be edited without
-# re-reading the pinned client.
+# The #1513 table holds 62 entries across every game mode this build ever
+# shipped.  Copied verbatim below is the subset ``item_defs/achievements.xml``
+# marks ``mode="random"`` and this server can decide; names and numbers must
+# not be edited without re-reading the pinned client.
 ACHIEVEMENT_CONDITIONS = {
     "warrior": {"minFrags": 6},
     "invader": {"minCapturePts": 80},
@@ -91,33 +98,44 @@ ACHIEVEMENT_CONDITIONS = {
     "bombardier": {"minKills": 2},
     "kamikaze": {"levelDelta": 1},
     "sturdy": {"minHealth": 10.0},
-    # ``raider`` carries no numeric threshold in #1513; its award is purely
-    # structural (capture the enemy base without ever being detected).
+    "huntsman": {"minKills": 3},
+    "ironMan": {"minHits": 10},
+    "luckyDevil": {"radius": 10.99},
+    # #1513 keys Rock Solid's condition as ``monolith`` while the dossier
+    # record and the results layout both call it ``medalMonolith``.
+    "monolith": {"maxSpeed_ms": 3.0555555555555554},
+    # ``raider`` and ``medalFadin`` carry no numeric threshold in #1513; both
+    # awards are purely structural.
     "raider": {},
+    "medalFadin": {},
 }
+
+# Condition key -> dossier record name, where #1513 disagrees with itself.
+CONDITION_RECORD_NAMES = {"monolith": "medalMonolith"}
 
 # Medals #1513 knows about that this server deliberately never awards.  Keeping
 # the reason next to the name stops a later change from "fixing" one by
 # inventing the missing input.
 UNAWARDED_ACHIEVEMENTS = {
-    "sniper": "retired by Wargaming in 0.8.11; superseded by sniper2",
-    "medalWittmann": "no condition entry in #1513 arena_achievements",
-    "medalFadin": "needs remaining-ammunition state the server does not own",
-    "medalBrothersInArms": "platoon award; offline rounds have no platoons",
-    "medalCrucialContribution": "platoon award",
-    "medalMonolith": "needs the rammer's impact speed",
-    "luckyDevil": "needs splash-radius survival geometry",
-    "huntsman": "no sourced #1513 predicate for minKills 3",
-    "ironMan": "no sourced #1513 predicate for minHits 10",
-    "alaric": "needs per-vehicle monument destruction attribution",
-    "lumberjack": "needs per-vehicle felled-tree attribution",
+    "sniper": "#1513 registers it as DeprecatedAchievement; the client itself "
+              "only accepts one already in the dossier",
+    "medalWittmann": "#1513 registers it as DeprecatedAchievement",
+    "alaric": "no entry in #1513 item_defs/achievements.xml; Wargaming "
+              "cancelled it before release",
+    "lumberjack": "no entry in #1513 item_defs/achievements.xml; Wargaming "
+                  "cancelled it before release",
+    "medalBrothersInArms": "platoon award; this product has no platoons",
+    "medalCrucialContribution": "platoon award; this product has no platoons",
     "markOfMastery": "needs per-vehicle XP distributions retail computes",
 }
 
-# Every name this server can award.  The wire validators use it as an exact
-# allowlist; the client packer still maps each one through the pinned
-# ``dossiers2.custom.records.RECORD_DB_IDS`` table before it reaches #1513.
-AWARDABLE_ACHIEVEMENTS = tuple(sorted(ACHIEVEMENT_CONDITIONS))
+# Every name this server can award, under the record name #1513 stores.  The
+# wire validators use it as an exact allowlist; the client packer still maps
+# each one through the pinned ``dossiers2.custom.records.RECORD_DB_IDS`` table
+# before it reaches #1513.
+AWARDABLE_ACHIEVEMENTS = tuple(sorted(
+    CONDITION_RECORD_NAMES.get(name, name)
+    for name in ACHIEVEMENT_CONDITIONS))
 
 # Battle-hero medals go to exactly one actor per battle; the medal's own
 # metric also orders that winner.
@@ -229,6 +247,19 @@ def _enemy_team_health(actors, team):
                for actor in actors if _int(actor.get("team")) != team)
 
 
+def _enemy_class_counts(actors, team):
+    """Return how many vehicles of each class opposed ``team``."""
+    counts = {}
+    for actor in actors:
+        if _int(actor.get("team")) == team:
+            continue
+        vehicle_class = actor.get("vehicle_class")
+        if not vehicle_class:
+            continue
+        counts[vehicle_class] = counts.get(vehicle_class, 0) + 1
+    return counts
+
+
 def _accuracy(actor):
     shots = _stat(actor, "shots")
     if shots <= 0:
@@ -272,7 +303,7 @@ def _unique_hero_metric(name, actor, context):
         assists = len(context["confederate"].get(_identity(actor), ()))
         return assists if assists >= condition["minAssists"] else None
     if name == "scout":
-        detections = _int(actor.get("first_spotted"))
+        detections = _stat(actor, "spotted")
         return (detections if detections >= condition["minDetections"]
                 else None)
     if name == "evileye":
@@ -350,13 +381,43 @@ def _epic_achievements(actor, context):
     if base_defence_kills >= condition["minKills"]:
         earned.append("medalDeLanglade")
 
+    # Naidin's medal (``huntsman``) asks for every enemy light tank, and the
+    # count only means anything when the enemy team actually fielded some.
+    condition = ACHIEVEMENT_CONDITIONS["huntsman"]
+    enemy_light_tanks = context["enemy_class_counts"][
+        _int(actor.get("team"))].get(_LIGHT_TANK, 0)
+    if (enemy_light_tanks >= condition["minKills"] and
+            _class_kills(actor, _LIGHT_TANK) >= enemy_light_tanks):
+        earned.append("huntsman")
+
+    # Cool-Headed (``ironMan``) counts bounces in a row, not bounces in total.
+    condition = ACHIEVEMENT_CONDITIONS["ironMan"]
+    if (survived and
+            _int(actor.get("best_deflection_streak")) >= condition["minHits"]):
+        earned.append("ironMan")
+
+    if actor.get("lucky_devil"):
+        earned.append("luckyDevil")
+
+    if actor.get("last_shell_finisher"):
+        earned.append("medalFadin")
+
     if vehicle_class == _SPG:
         condition = ACHIEVEMENT_CONDITIONS["medalGore"]
         damage = _stat(actor, "damage")
         max_health = _int(actor.get("max_health"))
         if (damage >= condition["minDamage"] and max_health > 0 and
-                damage >= condition["minDamageRate"] * max_health):
+                damage >= condition["minDamageRate"] * max_health and
+                not _int(actor.get("ally_damage"))):
             earned.append("medalGore")
+        # Rock Solid: ram an enemy to death from a crawl and drive away.
+        condition = ACHIEVEMENT_CONDITIONS["monolith"]
+        if (survived and not _int(actor.get("ally_damage")) and any(
+                _int(kill.get("death_reason")) == 2 and
+                _float(kill.get("actor_speed"), -1.0) >= 0.0 and
+                _float(kill.get("actor_speed")) <= condition["maxSpeed_ms"]
+                for kill in _kills(actor))):
+            earned.append("medalMonolith")
         condition = ACHIEVEMENT_CONDITIONS["medalStark"]
         if (survived and kills >= condition["minKills"] and
                 _int(actor.get("damaging_hits_received")) >=
@@ -369,8 +430,13 @@ def _epic_achievements(actor, context):
             _float(kill.get("distance")) <= condition["maxDistance"])
         if close_kills >= condition["minKills"]:
             earned.append("medalCoolBlood")
+        # Counter-battery fire wants the whole enemy battery, not a pair of
+        # artillery kills, so the roster bounds it the way Naidin's does.
         condition = ACHIEVEMENT_CONDITIONS["medalAntiSpgFire"]
-        if _class_kills(actor, _SPG) >= condition["minKills"]:
+        enemy_spgs = context["enemy_class_counts"][
+            _int(actor.get("team"))].get(_SPG, 0)
+        if (enemy_spgs >= condition["minKills"] and
+                _class_kills(actor, _SPG) >= enemy_spgs):
             earned.append("medalAntiSpgFire")
 
     condition = ACHIEVEMENT_CONDITIONS["bombardier"]
@@ -431,6 +497,8 @@ def award_battle_achievements(battle):
     context = {
         "enemy_team_health": dict(
             (team, _enemy_team_health(actors, team)) for team in (1, 2)),
+        "enemy_class_counts": dict(
+            (team, _enemy_class_counts(actors, team)) for team in (1, 2)),
         "confederate": _confederate_targets(actors),
         "base_captured_team": _int(battle.get("base_captured_team")),
     }

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_achievements.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_achievements.py
@@ -15,10 +15,15 @@ that file also decides which medals exist at all, since a condition without an
 entry there is one Wargaming cancelled before release.
 
 The client ships the thresholds but not the retail award predicates, which run
-on Wargaming's battle server.  Each predicate below therefore combines an exact
-#1513 constant with the publicly documented shape of that medal.  Anything that
-would need a coefficient this repository cannot source is not awarded at all;
-``UNAWARDED_ACHIEVEMENTS`` records those and why.
+on Wargaming's battle server.  The rest of each rule is in the client's own
+description text, ``res/text/LC_MESSAGES/achievements.mo``: every medal there
+carries a ``<name>_descr`` summary and a ``<name>_condition`` clause list, and
+those clauses are what each predicate below implements.  The clause is quoted
+in Chinese beside the code that enforces it so the two cannot drift.  A
+threshold alone is never the rule: ``medalCoolBlood`` ships only a distance and
+a kill count, while its description also demands light-tank victims and a Tier
+IV gun.  Anything that would still need a coefficient this repository cannot
+source is not awarded at all; ``UNAWARDED_ACHIEVEMENTS`` records those and why.
 
 This module is pure data: it takes one finished-round summary and returns the
 achievement names for every actor.  It never touches live battle state.  It
@@ -144,6 +149,14 @@ _UNIQUE_BATTLE_HEROES = (
     "supporter", "scout", "evileye", "sniper2",
 )
 
+# "坦克与自行反坦克炮" - every tier-delta medal counts tanks and tank
+# destroyers, never artillery.
+_DIRECT_FIRE_CLASSES = ("lightTank", "mediumTank", "heavyTank", "AT-SPG")
+
+# "使用至少为4级的自行火炮" - Cold-Blooded's only tier floor, which #1513
+# ships in the description rather than in ACHIEVEMENT_CONDITIONS.
+_COOL_BLOOD_MIN_TIER = 4
+
 _LIGHT_TANK = "lightTank"
 _MEDIUM_TANK = "mediumTank"
 _TANK_DESTROYER = "AT-SPG"
@@ -186,7 +199,7 @@ def _kills(actor):
     return list(rows) if isinstance(rows, (list, tuple)) else []
 
 
-def _tier_kills(actor, delta, victim_class=None):
+def _tier_kills(actor, delta, victim_classes=None):
     """Count kills of victims at least ``delta`` tiers above the actor.
 
     A tier of zero means the client never catalogued that vehicle, so its
@@ -197,8 +210,8 @@ def _tier_kills(actor, delta, victim_class=None):
         return 0
     total = 0
     for kill in _kills(actor):
-        if (victim_class is not None and
-                kill.get("victim_class") != victim_class):
+        if (victim_classes is not None and
+                kill.get("victim_class") not in victim_classes):
             continue
         victim_tier = _int(kill.get("victim_tier"))
         if victim_tier > 0 and victim_tier - tier >= delta:
@@ -206,9 +219,11 @@ def _tier_kills(actor, delta, victim_class=None):
     return total
 
 
-def _class_kills(actor, victim_class):
+def _class_kills(actor, victim_classes):
+    if isinstance(victim_classes, str):
+        victim_classes = (victim_classes,)
     return sum(1 for kill in _kills(actor)
-               if kill.get("victim_class") == victim_class)
+               if kill.get("victim_class") in victim_classes)
 
 
 def _health_percent(actor):
@@ -228,15 +243,15 @@ def _billotte_family(actor, condition):
             _float(common.get("hpPercentage"), 0.0))
 
 
-def _kill_band(actor, condition, delta=None, victim_class=None):
+def _kill_band(actor, condition, delta=None, victim_classes=None):
     """Count the qualifying kills and test the medal's inclusive band."""
     if delta is None:
-        if victim_class is None:
+        if victim_classes is None:
             count = _stat(actor, "kills")
         else:
-            count = _class_kills(actor, victim_class)
+            count = _class_kills(actor, victim_classes)
     else:
-        count = _tier_kills(actor, delta, victim_class=victim_class)
+        count = _tier_kills(actor, delta, victim_classes=victim_classes)
     minimum = _int(condition.get("minKills"), 0)
     maximum = _int(condition.get("maxKills"), 255)
     return count if minimum <= count <= maximum else 0
@@ -282,8 +297,11 @@ def _unique_hero_metric(name, actor, context):
         kills = _stat(actor, "kills")
         return kills if kills >= condition["minFrags"] else None
     if name == "invader":
+        # "此荣誉只颁发给成功占领基地" - only a completed capture qualifies.
         points = _stat(actor, "capture_points")
-        return points if points >= condition["minCapturePts"] else None
+        captured = context["base_captured_team"] == _int(actor.get("team"))
+        return (points if captured and points >= condition["minCapturePts"]
+                else None)
     if name == "defender":
         points = _stat(actor, "dropped_capture_points")
         return points if points >= condition["minPoints"] else None
@@ -294,29 +312,42 @@ def _unique_hero_metric(name, actor, context):
             potential >= condition["minDamage"] and
             _int(actor.get("hits_received")) >= condition["minHits"]) else None
     if name == "mainGun":
+        # "玩家不能击中盟友坦克" - one friendly hit ends it.
+        if _int(actor.get("ally_hits")):
+            return None
         damage = _stat(actor, "damage")
         enemy_health = context["enemy_team_health"][_int(actor.get("team"))]
         threshold = condition["minDamageToTotalHealthRatio"] * enemy_health
         return damage if (damage >= condition["minDamage"] and
                           enemy_health > 0 and damage >= threshold) else None
     if name == "supporter":
-        assists = len(context["confederate"].get(_identity(actor), ()))
+        # "比其它玩家击伤更多的敌方坦克或击毁他们的履带", with
+        # "跳弹未击穿不被计算在内": distinct enemies this actor actually hurt
+        # or immobilised, never a bounce and never somebody else's kill.
+        assists = _int(actor.get("support_targets"))
         return assists if assists >= condition["minAssists"] else None
     if name == "scout":
+        # "必须胜利才可以获得."
         detections = _stat(actor, "spotted")
-        return (detections if detections >= condition["minDetections"]
-                else None)
+        return (detections if actor.get("won") and
+                detections >= condition["minDetections"] else None)
     if name == "evileye":
         assists = _int(actor.get("exclusive_spot_assists"))
         return assists if assists >= condition["minAssists"] else None
     if name == "sniper2":
+        # "自行火炮无法获得", "玩家不得直接射中任何友军", and the damage from
+        # 300 m out must beat both 1000 and the shooter's own hit points.
+        if (actor.get("vehicle_class") == _SPG or
+                _int(actor.get("ally_hits"))):
+            return None
         damage = _int(actor.get("sniper_damage"))
         return damage if (
             _stat(actor, "shots") >= condition["minShots"] and
             _accuracy(actor) >= condition["minAccuracy"] and
             _damage_hit_ratio(actor) >=
             condition["minHitsWithDamagePercent"] and
-            damage >= condition["minDamage"]) else None
+            damage >= condition["minDamage"] and
+            damage > _int(actor.get("max_health"))) else None
     raise KeyError(name)
 
 
@@ -338,7 +369,8 @@ def _epic_achievements(actor, context):
             earned.append(name)
 
     # Historical tier-delta medals.  #1513 restricts each one to the vehicle
-    # class its namesake fought in; the tier delta itself is the constant.
+    # class its namesake fought in, and every one of these descriptions says
+    # "坦克与自行反坦克炮" - tanks and tank destroyers, never artillery.
     for name, required_class in (
             ("medalOrlik", _LIGHT_TANK),
             ("medalOskin", _MEDIUM_TANK),
@@ -347,7 +379,8 @@ def _epic_achievements(actor, context):
             ("medalHalonen", _TANK_DESTROYER)):
         condition = ACHIEVEMENT_CONDITIONS[name]
         if vehicle_class == required_class and _kill_band(
-                actor, condition, delta=condition["minVictimLevelDelta"]):
+                actor, condition, delta=condition["minVictimLevelDelta"],
+                victim_classes=_DIRECT_FIRE_CLASSES):
             earned.append(name)
 
     # Artillery-hunting medals.  A self-propelled gun cannot earn them.
@@ -355,13 +388,14 @@ def _epic_achievements(actor, context):
         for name, delta in (("medalBurda", 1), ("medalPascucci", None),
                             ("medalDumitru", None)):
             condition = ACHIEVEMENT_CONDITIONS[name]
-            if _kill_band(actor, condition, delta=delta, victim_class=_SPG):
+            if _kill_band(actor, condition, delta=delta,
+                          victim_classes=(_SPG,)):
                 earned.append(name)
     if vehicle_class == _LIGHT_TANK and survived:
         condition = ACHIEVEMENT_CONDITIONS["medalTamadaYoshio"]
         if _kill_band(actor, condition,
                       delta=condition["minVictimLevelDelta"],
-                      victim_class=_SPG):
+                      victim_classes=(_SPG,)):
             earned.append("medalTamadaYoshio")
 
     for name in ("medalBillotte", "medalBrunoPietro", "medalTarczay"):
@@ -381,8 +415,8 @@ def _epic_achievements(actor, context):
     if base_defence_kills >= condition["minKills"]:
         earned.append("medalDeLanglade")
 
-    # Naidin's medal (``huntsman``) asks for every enemy light tank, and the
-    # count only means anything when the enemy team actually fielded some.
+    # Naidin's medal (``huntsman``): "一场战斗中击毁敌方所有轻型坦克(至少
+    # 三辆)".  The count only means anything when the enemy fielded some.
     condition = ACHIEVEMENT_CONDITIONS["huntsman"]
     enemy_light_tanks = context["enemy_class_counts"][
         _int(actor.get("team"))].get(_LIGHT_TANK, 0)
@@ -391,9 +425,10 @@ def _epic_achievements(actor, context):
         earned.append("huntsman")
 
     # Cool-Headed (``ironMan``) counts bounces in a row, not bounces in total.
+    # "至少连续十次未被敌方击穿或被敌方坦克击中但跳弹" carries no survival
+    # clause, unlike Spartan below.
     condition = ACHIEVEMENT_CONDITIONS["ironMan"]
-    if (survived and
-            _int(actor.get("best_deflection_streak")) >= condition["minHits"]):
+    if _int(actor.get("best_deflection_streak")) >= condition["minHits"]:
         earned.append("ironMan")
 
     if actor.get("lucky_devil"):
@@ -403,39 +438,54 @@ def _epic_achievements(actor, context):
         earned.append("medalFadin")
 
     if vehicle_class == _SPG:
+        # Every artillery medal here carries "玩家不能击毁任何盟友坦克".
+        # Friendly hits simply do not count toward a total; a friendly kill
+        # ends the award outright.
+        clean = not _int(actor.get("team_kills"))
+        max_health = _int(actor.get("max_health"))
         condition = ACHIEVEMENT_CONDITIONS["medalGore"]
         damage = _stat(actor, "damage")
-        max_health = _int(actor.get("max_health"))
-        if (damage >= condition["minDamage"] and max_health > 0 and
-                damage >= condition["minDamageRate"] * max_health and
-                not _int(actor.get("ally_damage"))):
+        if (clean and damage >= condition["minDamage"] and max_health > 0 and
+                damage >= condition["minDamageRate"] * max_health):
             earned.append("medalGore")
-        # Rock Solid: ram an enemy to death from a crawl and drive away.
+        # Rock Solid: ram an enemy to death from a crawl while it was the
+        # faster of the two, and drive away.
+        # "击毁您的敌方坦克速度必须高于您的自行火炮速度."
         condition = ACHIEVEMENT_CONDITIONS["monolith"]
-        if (survived and not _int(actor.get("ally_damage")) and any(
+        if (clean and survived and any(
                 _int(kill.get("death_reason")) == 2 and
                 _float(kill.get("actor_speed"), -1.0) >= 0.0 and
-                _float(kill.get("actor_speed")) <= condition["maxSpeed_ms"]
+                _float(kill.get("actor_speed")) <= condition["maxSpeed_ms"] and
+                _float(kill.get("victim_speed"), -1.0) >
+                _float(kill.get("actor_speed"))
                 for kill in _kills(actor))):
             earned.append("medalMonolith")
+        # "受到的伤害以及装甲伤害必须是自身坦克生命值的三分之二."
         condition = ACHIEVEMENT_CONDITIONS["medalStark"]
-        if (survived and kills >= condition["minKills"] and
+        absorbed = _stat(actor, "damage_received") + _stat(
+            actor, "damage_blocked")
+        if (clean and survived and kills >= condition["minKills"] and
                 _int(actor.get("damaging_hits_received")) >=
-                condition["hits"]):
+                condition["hits"] and max_health > 0 and
+                3 * absorbed >= 2 * max_health):
             earned.append("medalStark")
+        # "在不超过100米的距离内击毁至少2辆敌方轻型坦克" with
+        # "使用至少为4级的自行火炮."
         condition = ACHIEVEMENT_CONDITIONS["medalCoolBlood"]
         close_kills = sum(
             1 for kill in _kills(actor)
-            if _float(kill.get("distance"), -1.0) >= 0.0 and
+            if kill.get("victim_class") == _LIGHT_TANK and
+            _float(kill.get("distance"), -1.0) >= 0.0 and
             _float(kill.get("distance")) <= condition["maxDistance"])
-        if close_kills >= condition["minKills"]:
+        if (clean and tier >= _COOL_BLOOD_MIN_TIER and
+                close_kills >= condition["minKills"]):
             earned.append("medalCoolBlood")
-        # Counter-battery fire wants the whole enemy battery, not a pair of
-        # artillery kills, so the roster bounds it the way Naidin's does.
+        # "使用自行火炮击毁敌方所有自行火炮(至少2辆)" - the whole enemy
+        # battery, not any two artillery kills.
         condition = ACHIEVEMENT_CONDITIONS["medalAntiSpgFire"]
         enemy_spgs = context["enemy_class_counts"][
             _int(actor.get("team"))].get(_SPG, 0)
-        if (enemy_spgs >= condition["minKills"] and
+        if (clean and enemy_spgs >= condition["minKills"] and
                 _class_kills(actor, _SPG) >= enemy_spgs):
             earned.append("medalAntiSpgFire")
 
@@ -456,7 +506,12 @@ def _epic_achievements(actor, context):
     if survived and _int(actor.get("deflected_hits_at_low_health")) > 0:
         earned.append("sturdy")
 
-    if (actor.get("captured_base") and not actor.get("ever_spotted") and
+    # "单独占领敌人基地且在整场战斗中未被敌人发现" - the capture must have
+    # completed, this actor must be the only vehicle that ever moved that
+    # base's counter, and nobody may have detected it all battle.  Taking
+    # damage does not disqualify: "如果坦克被偶然击中或受损并不取消".
+    if (actor.get("captured_base") and actor.get("solo_capture") and
+            not actor.get("ever_spotted") and
             context["base_captured_team"] == _int(actor.get("team"))):
         earned.append("raider")
 

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -7341,11 +7341,16 @@ class BattleRuntime(object):
             'aim_yaw', 'gun_pitch', 'x', 'y', 'z', 'yaw', 'pitch', 'roll',
             'speed', 'shot_origin', 'shot_direction', 'dispersion_angle',
             'presentation_ledger'}
+        # The shell total this trigger was drawn from, which the server relays
+        # untouched from the client that owns the ammunition.  A trigger that
+        # never reported one is still legal.
+        optional = {'shells_before_shot'}
         transport_fields = {
             '_client_received_time', '_client_dispatch_delay'}
         if (not isinstance(message, dict) or
                 not required.issubset(message) or
-                not set(message).issubset(required | transport_fields)):
+                not set(message).issubset(
+                    required | optional | transport_fields)):
             raise RuntimeError('worker fire intent is malformed')
         try:
             player_id = int(message['player_id'])
@@ -19073,6 +19078,7 @@ class BattleRuntime(object):
             'burst_count': state.get('burst_count'),
             'launch_time_us': launch_time_us,
             'launch_pose': launch_pose,
+            'shells_before_shot': state.get('shells_before_shot'),
         }
         self._bot_launch_payloads[(bot_id, shot_seq)] = (args, kwargs)
         accepted = sender(*args, **kwargs)
@@ -21005,10 +21011,17 @@ class BattleRuntime(object):
         trigger_wall = _PROFILE_CLOCK()
         if not self._sender.send_current():
             return self._reject_local_fire('input_send_failed')
+        # Read the ammunition before the local gun consumes this round, so
+        # the count the server freezes includes the shell being fired.
+        try:
+            shells_before_shot = sum(int(value) for value in state.ammo)
+        except (AttributeError, TypeError, ValueError):
+            shells_before_shot = None
         intent_seq = sender(
             shell_index, list(_xyz(shot_origin)),
             list(_xyz(shot_direction)), dispersion_angle,
-            presentation_ledger, trigger_server_time_ms)
+            presentation_ledger, trigger_server_time_ms,
+            shells_before_shot)
         if not intent_seq:
             return self._reject_local_fire('intent_send_failed')
         self._local_fire_intent = {

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -12599,7 +12599,8 @@ class BattleRuntime(object):
     def _projectile_effect(self, record, damage, result, impact,
                            critical, hull_damage, critical_delta,
                            target_position=None, damage_sticker=None,
-                           potential_damage=None):
+                           potential_damage=None,
+                           structural_armor_hit=None):
         target_kind = record.get('kind')
         if target_kind == 'human':
             target_kind = 'player'
@@ -12623,6 +12624,11 @@ class BattleRuntime(object):
             # the validator drop the whole terminal.
             effect['potential_damage'] = max(
                 0, min(5000, int(potential_damage)))
+        if structural_armor_hit is not None:
+            # Sturdy excludes tracks, screens and other external modules.
+            # Preserve the exact armour contact layer already chosen by the
+            # worker instead of trying to reconstruct it on the server.
+            effect['structural_armor_hit'] = bool(structural_armor_hit)
         if target_position is not None:
             effect.update({
                 'target_x': float(target_position[0]),
@@ -12763,7 +12769,10 @@ class BattleRuntime(object):
             record, damage, result, terminal_data['impact'],
             critical, hull_damage, critical_delta,
             damage_sticker=damage_sticker,
-            potential_damage=potential_damage)
+            potential_damage=potential_damage,
+            structural_armor_hit=(
+                contact is not None and
+                contact.get('layer') == 'structural'))
 
     def _projectile_splash_effects(self, meta, impact, direct_key):
         source = self._projectile_source_entity(meta)

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -8889,6 +8889,10 @@ class BotRuntime(object):
         if not ammo_state.consume_loaded(continuing):
             raise RuntimeError(
                 'bot ammunition changed during atomic burst')
+        # Fadin's medal reads the shell total this round was drawn from.
+        # ``remaining`` is already debited here, so restore the fired round
+        # rather than sampling the inventory at an unrelated moment.
+        state['shells_before_shot'] = sum(ammo_state.remaining) + 1
         if final_round and ammo_state.loaded_shell_requires_full_reload():
             gun_state.require_full_reload()
         state['fire_seq'] = shot_seq

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -885,6 +885,10 @@ def _local_launch_record(state, launch_time_us=None):
     }
     if 'shot_origin' in state:
         result['shot_origin'] = state['shot_origin']
+    if 'shells_before_shot' in state:
+        # Fadin's medal reads the shell total this round was drawn from, and
+        # only this worker knows it.
+        result['shells_before_shot'] = int(state['shells_before_shot'])
     if class_tag == 'SPG':
         for name in (
                 'shot_velocity', 'shot_gravity',

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
@@ -2600,7 +2600,7 @@ class LANClient(object):
 
     def send_fire_intent(self, shell_index, shot_origin, shot_direction,
                          dispersion_angle, presentation_ledger,
-                         trigger_server_time_ms):
+                         trigger_server_time_ms, shells_before_shot=None):
         """Queue one ordered trigger input without damage or ballistics."""
         if (not self.ready or self.phase != 'battle' or
                 self.is_bot_authority()):
@@ -2639,6 +2639,11 @@ class LANClient(object):
                 'presentation_ledger': parsed_ledger,
                 'trigger_server_time_ms': parsed_trigger_time,
             }
+            # The client owns its ammunition, so Fadin's medal needs the
+            # shell total standing at the trigger edge, this round included.
+            parsed_shells = _projectile_int_range(shells_before_shot, 0, 1000)
+            if parsed_shells is not None:
+                message['shells_before_shot'] = parsed_shells
             if not self._send(message):
                 return None
             self._fire_intent_seq = sequence
@@ -2705,7 +2710,8 @@ class LANClient(object):
             splash_radius, authority_epoch=None, penetration_factor=1.0,
             source_shot=None, fire_intent_seq=None, fire_input_seq=None,
             burst_group_seq=None, burst_index=None, burst_count=None,
-            launch_time_us=None, launch_pose=None):
+            launch_time_us=None, launch_pose=None,
+            shells_before_shot=None):
         """Enqueue one immutable projectile launch and return its shot seq."""
         if not self.ready or self.phase != 'battle':
             return None
@@ -2811,6 +2817,11 @@ class LANClient(object):
             if parsed_intent_seq is not None:
                 message['fire_intent_seq'] = parsed_intent_seq
                 message['fire_input_seq'] = parsed_input_seq
+            # The worker owns Bot ammunition, so it is the only producer that
+            # can report the shell total this shot was drawn from.
+            parsed_shells = _projectile_int_range(shells_before_shot, 0, 1000)
+            if parsed_shells is not None:
+                message['shells_before_shot'] = parsed_shells
             if not self._send(message):
                 return None
             return parsed_seq

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
@@ -1122,10 +1122,11 @@ def _strict_projectile_effect(value):
     target_pose_fields = frozenset(('target_x', 'target_y', 'target_z'))
     damage_sticker_fields = frozenset(('damage_sticker',))
     potential_fields = frozenset(('potential_damage',))
+    structural_fields = frozenset(('structural_armor_hit',))
     keys = set(value)
     if not required.issubset(keys) or not keys.issubset(
             required | critical_fields | stun_fields | target_pose_fields |
-            damage_sticker_fields | potential_fields):
+            damage_sticker_fields | potential_fields | structural_fields):
         return None
     kind = value.get('target_kind')
     target_id = _projectile_int_range(
@@ -1143,6 +1144,7 @@ def _strict_projectile_effect(value):
     has_target_pose = bool(keys & target_pose_fields)
     has_damage_sticker = 'damage_sticker' in value
     has_potential_damage = 'potential_damage' in value
+    has_structural_armor_hit = 'structural_armor_hit' in value
     expected = (required |
                 (critical_fields if has_critical else frozenset()) |
                 (stun_fields if has_stun else frozenset()) |
@@ -1150,6 +1152,8 @@ def _strict_projectile_effect(value):
                 (damage_sticker_fields if has_damage_sticker else
                  frozenset()) |
                 (potential_fields if has_potential_damage else frozenset()))
+    expected |= (structural_fields if has_structural_armor_hit else
+                 frozenset())
     if (kind not in ('player', 'bot') or target_id is None or
             damage is None or shot_result is None or
             any(component is None for component in position) or
@@ -1207,6 +1211,11 @@ def _strict_projectile_effect(value):
         if potential_damage is None:
             return None
         result['potential_damage'] = potential_damage
+    if has_structural_armor_hit:
+        # This field only affects an optional achievement counter. A missing
+        # or malformed value must not discard an otherwise valid terminal.
+        result['structural_armor_hit'] = (
+            value.get('structural_armor_hit') is True)
     if has_target_pose:
         target_position = []
         for axis in ('x', 'y', 'z'):
@@ -3058,9 +3067,10 @@ class LANClient(object):
             'target_kind', 'target_id', 'damage', 'shot_result',
             'x', 'y', 'z'}
         # A bounce is the archetypal blocked-damage contact, so a continuing
-        # shell still publishes its potential-damage roll and decal identity.
-        # Critical, stun and splash tokens stay forbidden on this wire.
-        direct_optional = {'damage_sticker', 'potential_damage'}
+        # shell still publishes its potential-damage roll, decal identity and
+        # armour layer. Critical, stun and splash tokens stay forbidden here.
+        direct_optional = {
+            'damage_sticker', 'potential_damage', 'structural_armor_hit'}
         if (parsed_epoch is None or parsed_epoch != _exact_int(
                 self.authority_epoch) or parsed_projectile_id is None or
                 parsed_base is None or parsed_time is None or

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
@@ -2641,7 +2641,9 @@ class LANClient(object):
             }
             # The client owns its ammunition, so Fadin's medal needs the
             # shell total standing at the trigger edge, this round included.
-            parsed_shells = _projectile_int_range(shells_before_shot, 0, 1000)
+            # A shot that happened was drawn from at least one shell, so
+            # zero is not a smaller count, it is an invalid report.
+            parsed_shells = _projectile_int_range(shells_before_shot, 1, 1000)
             if parsed_shells is not None:
                 message['shells_before_shot'] = parsed_shells
             if not self._send(message):
@@ -2819,7 +2821,9 @@ class LANClient(object):
                 message['fire_input_seq'] = parsed_input_seq
             # The worker owns Bot ammunition, so it is the only producer that
             # can report the shell total this shot was drawn from.
-            parsed_shells = _projectile_int_range(shells_before_shot, 0, 1000)
+            # A shot that happened was drawn from at least one shell, so
+            # zero is not a smaller count, it is an invalid report.
+            parsed_shells = _projectile_int_range(shells_before_shot, 1, 1000)
             if parsed_shells is not None:
                 message['shells_before_shot'] = parsed_shells
             if not self._send(message):

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
@@ -9,6 +9,8 @@ import time
 import uuid
 
 from gui.mods.offline_lan_0922 import effective_params as effective_params_wire
+from gui.mods.offline_lan_0922.battle_achievements import (
+    AWARDABLE_ACHIEVEMENTS, RECEIPT_STAT_NAMES)
 from gui.mods.offline_lan_0922 import burst_mechanics
 from gui.mods.offline_lan_0922 import equipment_mechanics
 from gui.mods.offline_lan_0922 import siege_mechanics
@@ -1438,15 +1440,14 @@ def _valid_battle_receipt(message):
         return False
     stats = message.get('stats')
     rewards = message.get('rewards')
-    stat_names = (
-        'shots', 'direct_hits', 'piercings', 'damage', 'damage_received',
-        'damage_blocked', 'assist_track', 'assist_radio', 'assist_stun',
-        'kills', 'spotted', 'capture_points', 'dropped_capture_points')
+    stat_names = RECEIPT_STAT_NAMES
     reward_names = ('credits', 'xp', 'free_xp', 'repair_cost', 'ammo_cost')
     if not isinstance(stats, dict) or not isinstance(rewards, dict):
         return False
-    if any(_exact_int(stats.get(name)) is None or
-           _exact_int(stats.get(name)) < 0 for name in stat_names):
+    # Statistics added after a receipt was recorded default to zero, exactly
+    # as the durable store treats them.
+    if any(_exact_int(stats.get(name, 0)) is None or
+           _exact_int(stats.get(name, 0)) < 0 for name in stat_names):
         return False
     if any(_exact_int(rewards.get(name)) is None or
            _exact_int(rewards.get(name)) < 0 for name in reward_names):
@@ -1488,9 +1489,17 @@ def _valid_battle_receipt(message):
                 bool(killer_kind) != bool(killer_id) or
                 not isinstance(row_stats, dict)):
             return False
-        if any(_exact_int(row_stats.get(stat_name)) is None or
-               _exact_int(row_stats.get(stat_name)) < 0
+        if any(_exact_int(row_stats.get(stat_name, 0)) is None or
+               _exact_int(row_stats.get(stat_name, 0)) < 0
                for stat_name in stat_names):
+            return False
+        # Receipts recorded before offline achievements shipped omit the list.
+        achievements = row.get('achievements', [])
+        if (not isinstance(achievements, list) or
+                len(achievements) > len(AWARDABLE_ACHIEVEMENTS) or
+                len(set(achievements)) != len(achievements) or
+                any(name not in AWARDABLE_ACHIEVEMENTS
+                    for name in achievements)):
             return False
         seen.add(identity)
         row_teams[identity] = row_team

--- a/tests/test_port_0922_account_rpc.py
+++ b/tests/test_port_0922_account_rpc.py
@@ -213,7 +213,8 @@ class AccountRpcTests(unittest.TestCase):
 
         update = pickle.loads(self.player.updates[-1])
         self.assertEqual(
-            {'credits', 'freeXP', 'vehTypeXP'}, set(update['stats']))
+            {'credits', 'freeXP', 'vehTypeXP', 'dossier'},
+            set(update['stats']))
         self.assertNotIn('eliteVehicles', update['stats'])
         self.assertNotIn('unlocks', update['stats'])
         self.assertEqual(account_data.OFFLINE_CREDITS + 700,

--- a/tests/test_port_0922_battle_achievements.py
+++ b/tests/test_port_0922_battle_achievements.py
@@ -85,6 +85,7 @@ def _actor(actor_kind='player', actor_id=1, team=1, **overrides):
         'damaged_targets': [],
         'exclusive_spot_assists': 0, 'ever_spotted': True,
         'ally_damage': 0, 'ally_hits': 0, 'team_kills': 0,
+        'enemy_damage_received': 0,
         'support_targets': 0, 'solo_capture': True,
         'last_shell_finisher': False,
         'lucky_devil': False, 'best_deflection_streak': 0,
@@ -453,6 +454,7 @@ class EpicMedalTests(unittest.TestCase):
                       'damage_received': 400, 'damage_blocked': 200}
         artillery = _actor(actor_id=1, vehicle_class='SPG',
                            max_health=800, stats=gore_stats,
+                           enemy_damage_received=400,
                            damaging_hits_received=2,
                            kills=[_kill(1, victim_class='SPG'),
                                   _kill(2, victim_class='SPG',
@@ -464,6 +466,7 @@ class EpicMedalTests(unittest.TestCase):
         self.assertIn('medalAntiSpgFire', awards)
         tank = _actor(actor_id=1, vehicle_class='heavyTank',
                       max_health=800, stats=gore_stats,
+                      enemy_damage_received=400,
                       damaging_hits_received=2,
                       kills=[_kill(1, victim_class='SPG'),
                              _kill(2, victim_class='SPG', distance=50.0)])
@@ -583,15 +586,29 @@ class EpicMedalTests(unittest.TestCase):
         # "受到的伤害以及装甲伤害必须是自身坦克生命值的三分之二."
         row = {
             'vehicle_class': 'SPG', 'max_health': 900,
-            'damaging_hits_received': 2, 'stats': {
+            'damaging_hits_received': 2, 'enemy_damage_received': 400,
+            'stats': {
                 'kills': 2, 'damage_received': 400, 'damage_blocked': 200},
         }
         self.assertIn(
             'medalStark', _awards([_actor(actor_id=1, **row)])[('player', 1)])
         row['stats'] = {
             'kills': 2, 'damage_received': 300, 'damage_blocked': 200}
+        row['enemy_damage_received'] = 300
         self.assertNotIn(
             'medalStark', _awards([_actor(actor_id=1, **row)])[('player', 1)])
+
+    def test_stark_ignores_friendly_damage_and_friendly_kills(self):
+        row = _actor(
+            actor_id=1, vehicle_class='SPG', max_health=900,
+            damaging_hits_received=2, enemy_damage_received=0,
+            team_kills=1,
+            stats={'kills': 2, 'damage_received': 600,
+                   'damage_blocked': 0})
+        self.assertNotIn('medalStark', _awards([row])[('player', 1)])
+
+        row['enemy_damage_received'] = 600
+        self.assertIn('medalStark', _awards([row])[('player', 1)])
 
     def test_tier_delta_medals_never_count_artillery_victims(self):
         # "击毁2辆或2辆以上的敌方坦克与自行反坦克炮."
@@ -969,6 +986,65 @@ class CaptureAndLoneStandTests(unittest.TestCase):
         self.assertEqual(
             state._statistics_row('player', 1)['capture_points'], 2)
 
+    def test_a_zero_counter_starts_a_new_solo_capture_attempt(self):
+        state, player = self._capture_battle()
+        player.x, player.z = 0.0, 0.0
+        state.bot_states[9] = {
+            'id': 9, 'team': 1, 'alive': True, 'world_pose': True,
+            'x': 100.0, 'y': 0.0, 'z': 100.0,
+        }
+        self.assertTrue(state._update_capture())
+        self.assertEqual(
+            {('bot', 9)}, state.capture_attempt_participants[2])
+
+        state.bot_states[9]['x'] = 0.0
+        state.tick += int(round(lan_server_module.TICK_HZ))
+        self.assertTrue(state._update_capture())
+        self.assertEqual(set(), state.capture_attempt_participants[2])
+
+        player.x, player.z = 100.0, 100.0
+        state.tick += int(round(lan_server_module.TICK_HZ))
+        self.assertTrue(state._update_capture())
+        self.assertEqual(
+            {('player', 1)}, state.capture_attempt_participants[2])
+
+    def test_final_capture_tick_counts_every_vehicle_in_the_circle(self):
+        state, unused_player = self._capture_battle()
+        state.bot_states[9] = {
+            'id': 9, 'team': 1, 'alive': True, 'world_pose': True,
+            'x': 100.0, 'y': 0.0, 'z': 100.0,
+        }
+        state.capture_contributors[2]['human:1'] = 99
+        # Sorted keys put the Bot first. Select the human for the final point
+        # to prove the unselected teammate still makes the attempt shared.
+        state.capture_cursors[2] = 1
+
+        self.assertTrue(state._update_capture())
+
+        self.assertEqual(100, state.rules_state['bases']['2']['points'])
+        self.assertEqual(
+            {('bot', 9), ('player', 1)},
+            state.capture_attempt_participants[2])
+        self.assertEqual(
+            0, state._statistics_row('bot', 9)['capture_points'])
+
+    def test_departed_participant_remains_while_capture_points_remain(self):
+        state, unused_player = self._capture_battle()
+        state.bot_states[9] = {
+            'id': 9, 'team': 1, 'alive': True, 'world_pose': True,
+            'x': 0.0, 'y': 0.0, 'z': 0.0,
+        }
+        state.capture_contributors[2].update(
+            {'human:1': 2, 'bot:9': 1})
+        state.capture_attempt_participants[2].update(
+            {('player', 1), ('bot', 9)})
+
+        self.assertTrue(state._update_capture())
+
+        self.assertEqual(
+            {('player', 1), ('bot', 9)},
+            state.capture_attempt_participants[2])
+
     @staticmethod
     def _capture_battle():
         state, player = ServerReceiptTests._battle()
@@ -1183,6 +1259,19 @@ class LuckyDevilTests(unittest.TestCase):
 class SupportAndFriendlyFireTests(unittest.TestCase):
     """Round state the corrected predicates read."""
 
+    def test_stark_tracks_only_enemy_damage_received(self):
+        state, unused_player = ServerReceiptTests._battle()
+        state._record_damage(('bot', 1), ('player', 1), 120, {})
+        self.assertEqual(120, state.enemy_damage_received[('player', 1)])
+        self.assertEqual(
+            120, state._statistics_row('player', 1)['damage_received'])
+
+        state.bot_states[1]['team'] = 1
+        state._record_damage(('bot', 1), ('player', 1), 80, {})
+        self.assertEqual(120, state.enemy_damage_received[('player', 1)])
+        self.assertEqual(
+            200, state._statistics_row('player', 1)['damage_received'])
+
     def test_real_damage_and_track_kills_both_count_as_support(self):
         state, unused_player = ServerReceiptTests._battle()
         state._record_damage(('player', 1), ('bot', 1), 120, {})
@@ -1240,6 +1329,19 @@ class LastShellTests(unittest.TestCase):
         state, unused_player = ServerReceiptTests._battle()
         state._record_kill(('player', 1), ('bot', 1), 0, projectile_id='p1')
         self.assertEqual(set(), state.last_shell_finishers)
+
+    def test_bot_fire_death_uses_the_same_last_shell_rule(self):
+        state, unused_player = ServerReceiptTests._battle()
+        state.bot_states[7] = {
+            'id': 7, 'team': 1, 'alive': True,
+            'vehicle': 'ussr:R11_MS-1', 'max_health': 1000,
+        }
+
+        self.assertTrue(state._record_frag(
+            'bot', 7, 2, 'bot', 1, attacker_team=1,
+            last_shell_fire=True))
+
+        self.assertIn(('bot', 7), state.last_shell_finishers)
 
 
 class _ReplayConnector(object):

--- a/tests/test_port_0922_battle_achievements.py
+++ b/tests/test_port_0922_battle_achievements.py
@@ -1,0 +1,815 @@
+"""Award and packing contracts for #1513 post-battle achievements."""
+
+import json
+import sys
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / 'src' / 'res' / 'scripts' / 'client'))
+sys.path.insert(0, str(ROOT / 'server'))
+
+from gui.mods.offline_lan_0922 import battle_achievements
+from gui.mods.offline_lan_0922.battle_achievements import (
+    ACHIEVEMENT_CONDITIONS, AWARDABLE_ACHIEVEMENTS, RECEIPT_STAT_NAMES,
+    award_battle_achievements)
+from gui.mods.offline_lan_0922.account_rpc import data, postbattle_store
+from gui.mods.offline_lan_0922 import lan_client as lan_client_module
+import lan_battle_server as lan_server_module
+from lan_battle_server import BattleState, CLIENT_BUILD_0922, Player
+
+
+# Exact ``dossiers2.custom.records.RECORD_DB_IDS[('achievements', name)]``
+# values read from ``res/packages/scripts.pkg`` of HD 0.9.22.0.1 #1513.
+RECORD_DB_IDS_0922 = {
+    ('achievements', 'warrior'): 34,
+    ('achievements', 'invader'): 35,
+    ('achievements', 'sniper'): 36,
+    ('achievements', 'defender'): 37,
+    ('achievements', 'steelwall'): 38,
+    ('achievements', 'supporter'): 39,
+    ('achievements', 'scout'): 40,
+    ('achievements', 'medalWittmann'): 49,
+    ('achievements', 'medalOrlik'): 50,
+    ('achievements', 'medalOskin'): 51,
+    ('achievements', 'medalHalonen'): 52,
+    ('achievements', 'medalBurda'): 53,
+    ('achievements', 'medalBillotte'): 54,
+    ('achievements', 'medalKolobanov'): 55,
+    ('achievements', 'medalFadin'): 56,
+    ('achievements', 'raider'): 61,
+    ('achievements', 'kamikaze'): 64,
+    ('achievements', 'lumberjack'): 65,
+    ('achievements', 'evileye'): 72,
+    ('achievements', 'medalRadleyWalters'): 73,
+    ('achievements', 'medalLafayettePool'): 74,
+    ('achievements', 'medalBrunoPietro'): 75,
+    ('achievements', 'medalTarczay'): 76,
+    ('achievements', 'medalPascucci'): 77,
+    ('achievements', 'medalDumitru'): 78,
+    ('achievements', 'markOfMastery'): 79,
+    ('achievements', 'medalLehvaslaiho'): 106,
+    ('achievements', 'medalNikolas'): 107,
+    ('achievements', 'heroesOfRassenay'): 110,
+    ('achievements', 'medalDeLanglade'): 145,
+    ('achievements', 'medalTamadaYoshio'): 146,
+    ('achievements', 'bombardier'): 147,
+    ('achievements', 'huntsman'): 148,
+    ('achievements', 'alaric'): 149,
+    ('achievements', 'sturdy'): 150,
+    ('achievements', 'ironMan'): 151,
+    ('achievements', 'luckyDevil'): 152,
+    ('achievements', 'sniper2'): 227,
+    ('achievements', 'mainGun'): 228,
+    ('achievements', 'medalMonolith'): 296,
+    ('achievements', 'medalAntiSpgFire'): 297,
+    ('achievements', 'medalGore'): 298,
+    ('achievements', 'medalCoolBlood'): 299,
+    ('achievements', 'medalStark'): 300,
+}
+
+EMPTY_STATS = dict((name, 0) for name in RECEIPT_STAT_NAMES)
+
+
+def _actor(actor_kind='player', actor_id=1, team=1, **overrides):
+    actor = {
+        'actor_kind': actor_kind, 'actor_id': actor_id, 'team': team,
+        'vehicle': 'ussr:R11_MS-1', 'tier': 5, 'vehicle_class': 'mediumTank',
+        'max_health': 1000, 'health': 1000, 'survived': True, 'won': True,
+        'xp': 500, 'stats': dict(EMPTY_STATS), 'kills': [],
+        'damaged_targets': [], 'first_spotted': 0,
+        'exclusive_spot_assists': 0, 'ever_spotted': True,
+        'crits_received': 0, 'hits_received': 0,
+        'damaging_hits_received': 0, 'deflected_hits_received': 0,
+        'deflected_hits_at_low_health': 0,
+        'potential_damage_received': 0, 'sniper_damage': 0,
+        'hits_with_damage': 0, 'best_multi_kill_shot': 0,
+        'lone_stand_enemies': 0, 'captured_base': False,
+    }
+    stats = overrides.pop('stats', None)
+    if stats:
+        actor['stats'].update(stats)
+    actor.update(overrides)
+    return actor
+
+
+def _kill(victim_id, victim_tier=5, victim_class='mediumTank',
+          victim_kind='bot', death_reason=0, distance=500.0,
+          defended_base=False):
+    return {
+        'victim_kind': victim_kind, 'victim_id': victim_id,
+        'victim_tier': victim_tier, 'victim_class': victim_class,
+        'death_reason': death_reason, 'distance': distance,
+        'defended_base': defended_base,
+    }
+
+
+def _awards(actors, base_captured_team=0):
+    return award_battle_achievements({
+        'actors': actors, 'base_captured_team': base_captured_team})
+
+
+class AchievementTableTests(unittest.TestCase):
+    def test_every_awardable_name_maps_to_an_exact_1513_record(self):
+        for name in AWARDABLE_ACHIEVEMENTS:
+            self.assertIn(
+                ('achievements', name), RECORD_DB_IDS_0922,
+                '%s is not a #1513 achievements record' % name)
+
+    def test_unawarded_names_are_documented_and_never_awarded(self):
+        for name, reason in battle_achievements.UNAWARDED_ACHIEVEMENTS.items():
+            self.assertNotIn(name, AWARDABLE_ACHIEVEMENTS)
+            self.assertTrue(reason)
+
+    def test_thresholds_match_the_pinned_client_table(self):
+        # A regression fence on the values copied out of #1513's
+        # arena_achievements.ACHIEVEMENT_CONDITIONS for bonus type 1.
+        self.assertEqual(ACHIEVEMENT_CONDITIONS['warrior'], {'minFrags': 6})
+        self.assertEqual(
+            ACHIEVEMENT_CONDITIONS['invader'], {'minCapturePts': 80})
+        self.assertEqual(ACHIEVEMENT_CONDITIONS['defender'], {'minPoints': 70})
+        self.assertEqual(
+            ACHIEVEMENT_CONDITIONS['steelwall'],
+            {'minDamage': 1000, 'minHits': 11})
+        self.assertEqual(
+            ACHIEVEMENT_CONDITIONS['mainGun'],
+            {'minDamage': 1000, 'minDamageToTotalHealthRatio': 0.2})
+        self.assertEqual(
+            ACHIEVEMENT_CONDITIONS['sniper2'], {
+                'minAccuracy': 0.85, 'minDamage': 1000,
+                'minHitsWithDamagePercent': 0.8, 'minShots': 8,
+                'sniperDistance': 300.0})
+        self.assertEqual(
+            ACHIEVEMENT_CONDITIONS['medalBillotte']['cmn_cnds'],
+            {'hpPercentage': 20, 'minCrits': 5})
+
+
+class BattleHeroTests(unittest.TestCase):
+    def test_top_gun_needs_six_kills_and_goes_to_one_actor(self):
+        weak = _actor(actor_id=1, stats={'kills': 5}, xp=900)
+        strong = _actor(actor_id=2, stats={'kills': 6}, xp=100)
+        awards = _awards([weak, strong])
+        self.assertNotIn('warrior', awards[('player', 1)])
+        self.assertIn('warrior', awards[('player', 2)])
+
+    def test_top_gun_tie_breaks_on_experience(self):
+        low = _actor(actor_id=1, stats={'kills': 7}, xp=100)
+        high = _actor(actor_id=2, stats={'kills': 7}, xp=900)
+        awards = _awards([low, high])
+        self.assertNotIn('warrior', awards[('player', 1)])
+        self.assertIn('warrior', awards[('player', 2)])
+
+    def test_invader_and_defender_use_capture_statistics(self):
+        invader = _actor(actor_id=1, stats={'capture_points': 80})
+        defender = _actor(actor_id=2, team=2,
+                          stats={'dropped_capture_points': 70})
+        short = _actor(actor_id=3, team=2,
+                       stats={'dropped_capture_points': 69})
+        awards = _awards([invader, defender, short])
+        self.assertIn('invader', awards[('player', 1)])
+        self.assertIn('defender', awards[('player', 2)])
+        self.assertEqual(awards[('player', 3)], [])
+
+    def test_steel_wall_needs_potential_damage_hits_and_survival(self):
+        survivor = _actor(actor_id=1, potential_damage_received=1200,
+                          hits_received=11)
+        dead = _actor(actor_id=2, potential_damage_received=5000,
+                      hits_received=30, survived=False, health=0)
+        awards = _awards([survivor, dead])
+        self.assertIn('steelwall', awards[('player', 1)])
+        self.assertNotIn('steelwall', awards[('player', 2)])
+
+    def test_high_calibre_needs_a_fifth_of_the_enemy_team_health(self):
+        hero = _actor(actor_id=1, team=1, stats={'damage': 1000})
+        enemy = _actor(actor_kind='bot', actor_id=1, team=2, max_health=4000)
+        self.assertIn('mainGun', _awards([hero, enemy])[('player', 1)])
+        tougher = _actor(actor_kind='bot', actor_id=1, team=2,
+                         max_health=6000)
+        self.assertNotIn('mainGun', _awards([hero, tougher])[('player', 1)])
+
+    def test_confederate_counts_enemies_finished_by_someone_else(self):
+        targets = [('bot', index) for index in range(1, 7)]
+        helper = _actor(actor_id=1, damaged_targets=targets)
+        finisher = _actor(actor_id=2, kills=[
+            _kill(index) for index in range(1, 7)])
+        awards = _awards([helper, finisher])
+        self.assertIn('supporter', awards[('player', 1)])
+        # The actor that scored the kills did not "assist" itself.
+        self.assertNotIn('supporter', awards[('player', 2)])
+
+    def test_scout_and_patrol_duty_use_distinct_spotting_inputs(self):
+        scout = _actor(actor_id=1, first_spotted=9)
+        patrol = _actor(actor_id=2, exclusive_spot_assists=6)
+        awards = _awards([scout, patrol])
+        self.assertIn('scout', awards[('player', 1)])
+        self.assertNotIn('evileye', awards[('player', 1)])
+        self.assertIn('evileye', awards[('player', 2)])
+
+    def test_tank_sniper_needs_accuracy_damaging_hits_and_range(self):
+        hero = _actor(actor_id=1, sniper_damage=1200, hits_with_damage=9,
+                      stats={'shots': 10, 'direct_hits': 9, 'damage': 1500})
+        self.assertIn('sniper2', _awards([hero])[('player', 1)])
+        inaccurate = _actor(actor_id=1, sniper_damage=1200,
+                            hits_with_damage=8,
+                            stats={'shots': 12, 'direct_hits': 8,
+                                   'damage': 1500})
+        self.assertNotIn('sniper2', _awards([inaccurate])[('player', 1)])
+        close_range = _actor(actor_id=1, sniper_damage=0, hits_with_damage=9,
+                             stats={'shots': 10, 'direct_hits': 9,
+                                    'damage': 1500})
+        self.assertNotIn('sniper2', _awards([close_range])[('player', 1)])
+
+
+class EpicMedalTests(unittest.TestCase):
+    def test_kill_count_medals_use_their_exact_bands(self):
+        walters = _actor(actor_id=1, tier=6, stats={'kills': 8})
+        pool = _actor(actor_id=2, tier=6, stats={'kills': 10})
+        rassenay = _actor(actor_id=3, tier=6, stats={'kills': 14})
+        awards = _awards([walters, pool, rassenay])
+        self.assertIn('medalRadleyWalters', awards[('player', 1)])
+        self.assertNotIn('medalLafayettePool', awards[('player', 1)])
+        self.assertIn('medalLafayettePool', awards[('player', 2)])
+        self.assertNotIn('medalRadleyWalters', awards[('player', 2)])
+        self.assertIn('heroesOfRassenay', awards[('player', 3)])
+
+    def test_low_tier_cannot_earn_the_tier_five_kill_medals(self):
+        low = _actor(actor_id=1, tier=4, stats={'kills': 8})
+        self.assertNotIn(
+            'medalRadleyWalters', _awards([low])[('player', 1)])
+
+    def test_tier_delta_medals_require_their_vehicle_class(self):
+        kills = [_kill(1, victim_tier=6), _kill(2, victim_tier=7)]
+        light = _actor(actor_id=1, tier=5, vehicle_class='lightTank',
+                       stats={'kills': 2}, kills=kills)
+        medium = _actor(actor_id=2, tier=5, vehicle_class='mediumTank',
+                        stats={'kills': 2}, kills=kills)
+        heavy = _actor(actor_id=3, tier=5, vehicle_class='heavyTank',
+                       stats={'kills': 2}, kills=kills)
+        awards = _awards([light, medium, heavy])
+        self.assertIn('medalOrlik', awards[('player', 1)])
+        self.assertNotIn('medalOrlik', awards[('player', 2)])
+        self.assertIn('medalLehvaslaiho', awards[('player', 2)])
+        self.assertEqual(awards[('player', 3)], [])
+
+    def test_same_tier_kills_do_not_satisfy_a_tier_delta_medal(self):
+        light = _actor(
+            actor_id=1, tier=5, vehicle_class='lightTank',
+            stats={'kills': 2},
+            kills=[_kill(1, victim_tier=5), _kill(2, victim_tier=5)])
+        self.assertNotIn('medalOrlik', _awards([light])[('player', 1)])
+
+    def test_artillery_hunting_medals_exclude_artillery_drivers(self):
+        kills = [_kill(index, victim_class='SPG', victim_tier=6)
+                 for index in range(1, 4)]
+        tank = _actor(actor_id=1, tier=5, vehicle_class='heavyTank',
+                      stats={'kills': 3}, kills=kills)
+        artillery = _actor(actor_id=2, tier=5, vehicle_class='SPG',
+                           stats={'kills': 3}, kills=kills)
+        awards = _awards([tank, artillery])
+        self.assertIn('medalDumitru', awards[('player', 1)])
+        self.assertIn('medalBurda', awards[('player', 1)])
+        self.assertNotIn('medalDumitru', awards[('player', 2)])
+        self.assertNotIn('medalBurda', awards[('player', 2)])
+
+    def test_billotte_family_needs_crits_low_health_survival_and_a_win(self):
+        base = dict(tier=5, vehicle_class='heavyTank', crits_received=5,
+                    health=150, max_health=1000)
+        billotte = _actor(actor_id=1, stats={'kills': 2}, **base)
+        self.assertIn('medalBillotte', _awards([billotte])[('player', 1)])
+        healthy = _actor(actor_id=1, stats={'kills': 2},
+                         **dict(base, health=900))
+        self.assertNotIn('medalBillotte', _awards([healthy])[('player', 1)])
+        few_crits = _actor(actor_id=1, stats={'kills': 2},
+                           **dict(base, crits_received=4))
+        self.assertNotIn('medalBillotte', _awards([few_crits])[('player', 1)])
+        defeated = _actor(actor_id=1, stats={'kills': 2},
+                          **dict(base, won=False))
+        self.assertNotIn('medalBillotte', _awards([defeated])[('player', 1)])
+        tarczay = _actor(actor_id=1, stats={'kills': 5}, **base)
+        self.assertIn('medalTarczay', _awards([tarczay])[('player', 1)])
+        self.assertNotIn('medalBillotte', _awards([tarczay])[('player', 1)])
+
+    def test_kolobanov_needs_a_lone_stand_and_a_win(self):
+        winner = _actor(actor_id=1, lone_stand_enemies=5)
+        self.assertIn('medalKolobanov', _awards([winner])[('player', 1)])
+        loser = _actor(actor_id=1, lone_stand_enemies=5, won=False)
+        self.assertNotIn('medalKolobanov', _awards([loser])[('player', 1)])
+        outnumbered_less = _actor(actor_id=1, lone_stand_enemies=4)
+        self.assertNotIn(
+            'medalKolobanov', _awards([outnumbered_less])[('player', 1)])
+
+    def test_de_langlade_counts_only_base_attackers(self):
+        inside = _actor(actor_id=1, stats={'kills': 4}, kills=[
+            _kill(index, defended_base=True) for index in range(1, 5)])
+        self.assertIn('medalDeLanglade', _awards([inside])[('player', 1)])
+        outside = _actor(actor_id=1, stats={'kills': 4}, kills=[
+            _kill(index) for index in range(1, 5)])
+        self.assertNotIn('medalDeLanglade', _awards([outside])[('player', 1)])
+
+    def test_artillery_medals_require_a_self_propelled_gun(self):
+        gore_stats = {'damage': 8000, 'kills': 2}
+        artillery = _actor(actor_id=1, vehicle_class='SPG',
+                           max_health=800, stats=gore_stats,
+                           damaging_hits_received=2,
+                           kills=[_kill(1, victim_class='SPG'),
+                                  _kill(2, victim_class='SPG',
+                                        distance=50.0)])
+        awards = _awards([artillery])[('player', 1)]
+        self.assertIn('medalGore', awards)
+        self.assertIn('medalStark', awards)
+        self.assertIn('medalAntiSpgFire', awards)
+        tank = _actor(actor_id=1, vehicle_class='heavyTank',
+                      max_health=800, stats=gore_stats,
+                      damaging_hits_received=2,
+                      kills=[_kill(1, victim_class='SPG'),
+                             _kill(2, victim_class='SPG', distance=50.0)])
+        for name in ('medalGore', 'medalStark', 'medalAntiSpgFire',
+                     'medalCoolBlood'):
+            self.assertNotIn(name, _awards([tank])[('player', 1)])
+
+    def test_cool_blood_counts_close_kills_only(self):
+        close = _actor(actor_id=1, vehicle_class='SPG', stats={'kills': 2},
+                       kills=[_kill(1, distance=40.0),
+                              _kill(2, distance=99.0)])
+        self.assertIn('medalCoolBlood', _awards([close])[('player', 1)])
+        far = _actor(actor_id=1, vehicle_class='SPG', stats={'kills': 2},
+                     kills=[_kill(1, distance=140.0),
+                            _kill(2, distance=99.0)])
+        self.assertNotIn('medalCoolBlood', _awards([far])[('player', 1)])
+
+    def test_bombardier_kamikaze_sturdy_and_raider(self):
+        bomber = _actor(actor_id=1, best_multi_kill_shot=2)
+        self.assertIn('bombardier', _awards([bomber])[('player', 1)])
+        rammer = _actor(actor_id=1, tier=5, stats={'kills': 1}, kills=[
+            _kill(1, victim_tier=6, death_reason=2)])
+        self.assertIn('kamikaze', _awards([rammer])[('player', 1)])
+        shot_kill = _actor(actor_id=1, tier=5, stats={'kills': 1}, kills=[
+            _kill(1, victim_tier=6, death_reason=0)])
+        self.assertNotIn('kamikaze', _awards([shot_kill])[('player', 1)])
+        spartan = _actor(actor_id=1, health=90, max_health=1000,
+                         deflected_hits_at_low_health=1)
+        self.assertIn('sturdy', _awards([spartan])[('player', 1)])
+        # A shot that bounced while the vehicle was still healthy is not it.
+        healthy_bounce = _actor(actor_id=1, health=90, max_health=1000,
+                                deflected_hits_received=3)
+        self.assertNotIn('sturdy', _awards([healthy_bounce])[('player', 1)])
+        dead = _actor(actor_id=1, health=0, max_health=1000, survived=False,
+                      deflected_hits_at_low_health=1)
+        self.assertNotIn('sturdy', _awards([dead])[('player', 1)])
+        raider = _actor(actor_id=1, team=1, captured_base=True,
+                        ever_spotted=False)
+        self.assertIn(
+            'raider', _awards([raider], base_captured_team=1)[('player', 1)])
+        seen = _actor(actor_id=1, team=1, captured_base=True,
+                      ever_spotted=True)
+        self.assertNotIn(
+            'raider', _awards([seen], base_captured_team=1)[('player', 1)])
+
+    def test_bots_earn_the_same_medals_as_human_players(self):
+        bot = _actor(actor_kind='bot', actor_id=3, stats={'kills': 6})
+        self.assertIn('warrior', _awards([bot])[('bot', 3)])
+
+    def test_an_empty_battle_awards_nothing(self):
+        self.assertEqual(_awards([]), {})
+
+
+class ResultPackingTests(unittest.TestCase):
+    """The exact #1513 fields the results window reads."""
+
+    def setUp(self):
+        self._native = (postbattle_store._vehicle_type_compact_descr,
+                        postbattle_store._arena_type_id)
+        postbattle_store._vehicle_type_compact_descr = lambda unused: 50001
+        postbattle_store._arena_type_id = lambda unused: 70001
+
+    def tearDown(self):
+        (postbattle_store._vehicle_type_compact_descr,
+         postbattle_store._arena_type_id) = self._native
+
+    @staticmethod
+    def _receipt(achievements, row_achievements=None):
+        stats = dict(EMPTY_STATS)
+        stats.update({'kills': 6, 'damage': 2000, 'hits_received': 12,
+                      'potential_damage_received': 3000})
+        row = {
+            'actor_kind': 'player', 'actor_id': 1, 'name': 'Alice',
+            'vehicle': 'ussr:R11_MS-1', 'team': 1, 'health': 100,
+            'death_reason': -1, 'killer_kind': '', 'killer_id': 0,
+            'is_team_killer': False, 'xp': 600, 'stats': dict(stats),
+            'achievements': list(achievements),
+        }
+        rows = [row]
+        if row_achievements is not None:
+            rows.append({
+                'actor_kind': 'bot', 'actor_id': 2, 'name': 'Bot',
+                'vehicle': 'ussr:R11_MS-1', 'team': 2, 'health': 0,
+                'death_reason': 0, 'killer_kind': 'player', 'killer_id': 1,
+                'is_team_killer': False, 'xp': 10,
+                'stats': dict(EMPTY_STATS),
+                'achievements': list(row_achievements),
+            })
+        return {
+            'receipt_id': 'server:7:1', 'arena_unique_id': (7 << 32) | 1,
+            'round_id': 7, 'player_id': 1,
+            'account_key': 'account-key-123456', 'player_name': 'Alice',
+            'vehicle': 'ussr:R11_MS-1', 'team': 1, 'winner': 1,
+            'map': '01_karelia', 'finish_reason': 1, 'death_reason': -1,
+            'duration': 120, 'premature_leave': False,
+            'stats': dict(stats),
+            'rewards': {'credits': 4200, 'xp': 600, 'free_xp': 30,
+                        'repair_cost': 0, 'ammo_cost': 0},
+            'public_results': rows,
+        }
+
+    def test_names_map_to_exact_record_database_ids(self):
+        records = postbattle_store._achievement_records(
+            ['warrior', 'medalKolobanov', 'sniper2'],
+            record_db_ids=RECORD_DB_IDS_0922)
+        self.assertEqual(records, [
+            ('warrior', 34), ('medalKolobanov', 55), ('sniper2', 227)])
+
+    def test_unregistered_names_are_dropped_before_they_reach_the_client(self):
+        self.assertEqual(postbattle_store._achievement_records(
+            ['warrior', 'notAMedal'],
+            record_db_ids=RECORD_DB_IDS_0922), [('warrior', 34)])
+
+    def test_pop_ups_carry_the_running_account_total(self):
+        packers = _Packers()
+        postbattle_store.pack_battle_result(
+            self._receipt(['warrior', 'medalKolobanov'],
+                          row_achievements=['scout']),
+            packers=packers, replay_types=(_Replay, _ReplayConnector),
+            record_db_ids=RECORD_DB_IDS_0922,
+            achievement_counts={'warrior': 12})
+        personal, = [value for name, value in packers.calls
+                     if name == 'VEH_FULL_RESULTS']
+        self.assertEqual(personal['achievements'], [34, 55])
+        self.assertEqual(personal['dossierPopUps'], [(34, 12), (55, 1)])
+        self.assertEqual(personal['directHitsReceived'], 12)
+        self.assertEqual(personal['potentialDamageReceived'], 3000)
+        public = [value for name, value in packers.calls
+                  if name == 'VEH_PUBLIC_RESULTS']
+        self.assertEqual(
+            sorted(row['achievements'] for row in public), [[34, 55], [40]])
+
+    def test_two_vehicles_share_one_compact_descriptor_slot(self):
+        # Both roster rows use the same vehicle here, so the public map must
+        # still address them by their distinct projected vehicle IDs.
+        packers = _Packers()
+        postbattle_store.pack_battle_result(
+            self._receipt(['warrior'], row_achievements=[]),
+            packers=packers, replay_types=(_Replay, _ReplayConnector),
+            record_db_ids=RECORD_DB_IDS_0922)
+        public = [value for name, value in packers.calls
+                  if name == 'VEH_PUBLIC_RESULTS']
+        self.assertEqual([row['achievements'] for row in public], [[34], []])
+
+    def test_a_battle_without_medals_packs_empty_lists(self):
+        packers = _Packers()
+        postbattle_store.pack_battle_result(
+            self._receipt([]), packers=packers,
+            replay_types=(_Replay, _ReplayConnector),
+            record_db_ids=RECORD_DB_IDS_0922)
+        personal, = [value for name, value in packers.calls
+                     if name == 'VEH_FULL_RESULTS']
+        self.assertEqual(personal['achievements'], [])
+        self.assertEqual(personal['dossierPopUps'], [])
+
+
+class DossierAccumulationTests(unittest.TestCase):
+    def test_progress_counts_each_medal_for_account_and_vehicle(self):
+        store = postbattle_store.PostBattleStore(path=None)
+        receipt = ResultPackingTests._receipt(['warrior', 'medalKolobanov'])
+        receipt['account_key'] = store.account_key
+        self.assertTrue(store.accept(receipt))
+        second = dict(receipt)
+        second['receipt_id'] = 'server:8:1'
+        second['arena_unique_id'] = (8 << 32) | 1
+        second['round_id'] = 8
+        second['public_results'] = [
+            dict(row, achievements=['warrior'])
+            for row in receipt['public_results']]
+        second['achievements'] = ['warrior']
+        self.assertTrue(store.accept(second))
+        progress = store.progress()
+        self.assertEqual(
+            progress['achievements'], {'warrior': 2, 'medalKolobanov': 1})
+        self.assertEqual(
+            progress['vehicles']['ussr:R11_MS-1']['achievements'],
+            {'warrior': 2, 'medalKolobanov': 1})
+
+    def test_vehicle_dossier_writes_counters_and_the_hero_aggregate(self):
+        rows = data.dossiers(
+            postbattle_progress={'vehicles': {'ussr:R11_MS-1': {
+                'battles': 3, 'wins': 2, 'changeTime': 3,
+                'achievements': {'warrior': 2, 'medalKolobanov': 1},
+            }}},
+            dossier_factory=_FakeDossier,
+            vehicle_type_resolver=lambda name: 1)[1]
+        self.assertEqual(len(rows), 1)
+        blocks = rows[0][2]
+        self.assertEqual(blocks['achievements']['warrior'], 2)
+        self.assertEqual(blocks['achievements']['medalKolobanov'], 1)
+        # ``warrior`` is a battle hero; Kolobanov's medal is not.
+        self.assertEqual(blocks['achievements']['battleHeroes'], 2)
+
+    def test_account_dossier_carries_the_running_medal_counters(self):
+        compact = data.account_dossier(
+            {'achievements': {'warrior': 5, 'medalKolobanov': 1}},
+            dossier_factory=_FakeDossier)
+        self.assertEqual(compact['achievements'], {
+            'warrior': 5, 'medalKolobanov': 1, 'battleHeroes': 5})
+
+    def test_account_dossier_stays_empty_without_medals(self):
+        self.assertEqual(data.account_dossier({}, _FakeDossier), '')
+        self.assertEqual(
+            data.account_dossier({'achievements': {}}, _FakeDossier), '')
+
+    def test_account_snapshot_publishes_the_dossier_key(self):
+        snapshot = data.stats(postbattle_progress={'achievements': {}})
+        self.assertEqual(snapshot['stats']['dossier'], '')
+
+    def test_a_vehicle_without_medals_leaves_the_block_untouched(self):
+        rows = data.dossiers(
+            postbattle_progress={'vehicles': {'ussr:R11_MS-1': {
+                'battles': 1, 'changeTime': 1, 'achievements': {},
+            }}},
+            dossier_factory=_FakeDossier,
+            vehicle_type_resolver=lambda name: 1)[1]
+        self.assertNotIn('achievements', rows[0][2])
+
+
+class ServerReceiptTests(unittest.TestCase):
+    """The LAN server decides awards and freezes them into the receipt."""
+
+    @staticmethod
+    def _battle():
+        state = BattleState(map_name='01_karelia', team_size=1)
+        state.client_build = CLIENT_BUILD_0922
+        state.phase = 'battle'
+        player = Player(1, _NullSocket(), ('127.0.0.1', 1), name='Alice',
+                        vehicle='ussr:R11_MS-1', team=1,
+                        account_key='a' * 32)
+        player.max_health = 1000
+        player.health = 1000
+        state.players = {1: player}
+        state.vehicle_catalogs = {1: (
+            {'name': 'ussr:R11_MS-1', 'level': 5,
+             'tags': ('lightTank',)},
+            {'name': 'germany:G04_PzVI_Tiger_I', 'level': 7,
+             'tags': ('heavyTank',)},
+        )}
+        state._freeze_round_participants((player,))
+        state.bot_manifest = [
+            {'id': index, 'team': 2, 'slot': index, 'name': 'Bot-%d' % index,
+             'vehicle': 'germany:G04_PzVI_Tiger_I', 'health': 0,
+             'max_health': 1500}
+            for index in range(1, 7)]
+        state.bot_states = dict(
+            (entry['id'], dict(entry, alive=False, death_reason=0,
+                               death_attacker_kind='player',
+                               death_attacker_id=1))
+            for entry in state.bot_manifest)
+        return state, player
+
+    def test_receipt_carries_awards_and_the_new_result_statistics(self):
+        state, unused_player = self._battle()
+        for bot_id in range(1, 7):
+            state._record_frag(
+                'player', 1, 2, 'bot', bot_id, attacker_team=1,
+                projectile_id=bot_id, distance=420.0)
+        state._statistics_row('player', 1).update({
+            'shots_fired': 10, 'shots_hit': 8, 'damage_dealt': 6000,
+            'hits_received': 12, 'potential_damage_received': 2400,
+            'crits_received_mask': 0b1011,
+        })
+
+        self.assertTrue(state._finish_battle(1, 'team_eliminated'))
+
+        receipt = list(state.result_receipts.values())[-1]
+        rows = dict(((row['actor_kind'], row['actor_id']), row)
+                    for row in receipt['public_results'])
+        personal = rows['player', 1]
+        # Six kills of tier-7 heavies in a tier-5 light tank.
+        self.assertIn('warrior', personal['achievements'])
+        self.assertIn('medalOrlik', personal['achievements'])
+        self.assertIn('mainGun', personal['achievements'])
+        self.assertEqual(12, personal['stats']['hits_received'])
+        self.assertEqual(
+            2400, personal['stats']['potential_damage_received'])
+        self.assertEqual(3, personal['stats']['crits_received'])
+        for bot_id in range(1, 7):
+            self.assertEqual([], rows['bot', bot_id]['achievements'])
+
+    def test_awards_survive_the_persisted_receipt_validator(self):
+        state, unused_player = self._battle()
+        for bot_id in range(1, 7):
+            state._record_frag(
+                'player', 1, 2, 'bot', bot_id, attacker_team=1)
+        self.assertTrue(state._finish_battle(1, 'team_eliminated'))
+        receipt = list(state.result_receipts.values())[-1]
+        reloaded = lan_server_module._persisted_result_receipt(
+            json.loads(json.dumps(receipt)))
+        self.assertEqual(
+            reloaded['public_results'][0]['achievements'],
+            receipt['public_results'][0]['achievements'])
+
+    def test_the_validator_rejects_an_unknown_medal_name(self):
+        state, unused_player = self._battle()
+        self.assertTrue(state._finish_battle(1, 'team_eliminated'))
+        receipt = json.loads(json.dumps(
+            list(state.result_receipts.values())[-1]))
+        receipt['public_results'][0]['achievements'] = ['notAMedal']
+        with self.assertRaises(ValueError):
+            lan_server_module._persisted_result_receipt(receipt)
+
+    def test_a_pre_achievement_receipt_still_loads(self):
+        state, unused_player = self._battle()
+        self.assertTrue(state._finish_battle(1, 'team_eliminated'))
+        receipt = json.loads(json.dumps(
+            list(state.result_receipts.values())[-1]))
+        for row in receipt['public_results']:
+            row.pop('achievements')
+            for name in ('hits_received', 'potential_damage_received',
+                         'crits_received'):
+                row['stats'].pop(name)
+        for name in ('hits_received', 'potential_damage_received',
+                     'crits_received'):
+            receipt['stats'].pop(name)
+        reloaded = lan_server_module._persisted_result_receipt(receipt)
+        self.assertEqual(reloaded['public_results'][0]['achievements'], [])
+        self.assertEqual(reloaded['stats']['hits_received'], 0)
+        self.assertTrue(
+            lan_client_module._valid_battle_receipt(reloaded))
+
+
+class CaptureAndLoneStandTests(unittest.TestCase):
+    """Round state #1513 medals read that the server did not record before."""
+
+    def test_dropped_capture_points_credit_the_enemy_that_caused_them(self):
+        state, unused_player = ServerReceiptTests._battle()
+        state.capture_contributors[1]['bot:3'] = 40
+        dropped = state._drop_capture_for_vehicle(
+            'bot', 3, attacker=('player', 1))
+        self.assertEqual(dropped, 40)
+        self.assertEqual(
+            state._statistics_row('player', 1)['dropped_capture_points'], 40)
+
+    def test_a_teammate_never_earns_dropped_capture_points(self):
+        state, unused_player = ServerReceiptTests._battle()
+        state.bot_states[1]['team'] = 1
+        state.capture_contributors[2]['bot:1'] = 20
+        state._drop_capture_for_vehicle('bot', 1, attacker=('player', 1))
+        self.assertEqual(
+            state._statistics_row('player', 1)['dropped_capture_points'], 0)
+
+    def test_capture_points_accumulate_for_the_vehicle_in_the_circle(self):
+        state, unused_player = self._capture_battle()
+        self.assertTrue(state._update_capture())
+        self.assertEqual(
+            state._statistics_row('player', 1)['capture_points'], 1)
+        self.assertIn(('player', 1), state.capture_invaders[2])
+        state.tick += int(round(lan_server_module.TICK_HZ))
+        state._update_capture()
+        self.assertEqual(
+            state._statistics_row('player', 1)['capture_points'], 2)
+
+    @staticmethod
+    def _capture_battle():
+        state, player = ServerReceiptTests._battle()
+        state.bot_states = {}
+        state.bot_manifest = []
+        state.roster_finalized = True
+        player.client_position = True
+        player.x, player.z = 100.0, 100.0
+        player.alive = True
+        player.participating = True
+        player.connected = True
+        state.capture_bases = {2: [(100.0, 100.0)]}
+        # ``_update_capture`` only runs on a whole second of live combat.
+        tick_hz = int(round(lan_server_module.TICK_HZ))
+        state.tick = tick_hz * int(
+            round(lan_server_module.PREBATTLE_SECONDS)) + tick_hz
+        return state, player
+
+    def test_a_one_vehicle_team_records_no_lone_stand(self):
+        state, unused_player = ServerReceiptTests._battle()
+        state.bot_states = dict(
+            (entry['id'], dict(entry, alive=True))
+            for entry in state.bot_manifest)
+        state._record_lone_stands()
+        self.assertEqual(state.lone_stand_enemies, {})
+
+    def test_the_last_survivor_of_a_real_team_records_its_odds(self):
+        state, unused_player = ServerReceiptTests._battle()
+        state.bot_states = dict(
+            (entry['id'], dict(entry, alive=True))
+            for entry in state.bot_manifest)
+        # Give the human a dead team mate so the team really had two.
+        state.bot_states[7] = {'id': 7, 'team': 1, 'alive': False,
+                               'vehicle': 'ussr:R11_MS-1', 'max_health': 1000}
+        state._record_lone_stands()
+        self.assertEqual(
+            state.lone_stand_enemies, {('player', 1): 6})
+
+
+class CritsMaskTests(unittest.TestCase):
+    """#1513 ``crits_mask_parser`` bit positions."""
+
+    @staticmethod
+    def _state(devices=(), destroyed=(), crew=()):
+        return {
+            'devices': [{'name': name, 'state': state}
+                        for name, state in devices],
+            'destroyed': list(destroyed),
+            'crew_ko': list(crew),
+        }
+
+    def test_critical_devices_occupy_the_low_byte(self):
+        mask = lan_server_module._crits_mask(
+            {}, self._state(devices=(('engineHealth', 'critical'),)))
+        self.assertEqual(mask, 1 << 0)
+        mask = lan_server_module._crits_mask(
+            {}, self._state(devices=(('gunHealth', 'critical'),)))
+        self.assertEqual(mask, 1 << 5)
+
+    def test_destroyed_devices_start_at_bit_twelve_and_tracks_share_a_slot(
+            self):
+        left = lan_server_module._crits_mask(
+            {}, self._state(destroyed=('leftTrackHealth',)))
+        right = lan_server_module._crits_mask(
+            {}, self._state(destroyed=('rightTrackHealth',)))
+        self.assertEqual(left, 1 << (12 + 4))
+        self.assertEqual(left, right)
+
+    def test_crew_starts_at_bit_twenty_four_and_numbered_roles_share_a_slot(
+            self):
+        self.assertEqual(
+            lan_server_module._crits_mask({}, self._state(crew=('driver',))),
+            1 << (24 + 1))
+        self.assertEqual(
+            lan_server_module._crits_mask({}, self._state(crew=('loader2',))),
+            1 << (24 + 4))
+
+    def test_a_repeated_crit_sets_no_new_bit(self):
+        previous = self._state(destroyed=('gunHealth',))
+        self.assertEqual(lan_server_module._crits_mask(previous, previous), 0)
+
+
+class _NullSocket(object):
+    def sendall(self, unused_payload):
+        pass
+
+
+class _FakeDossier(object):
+    """Only the block access that ``data.dossiers`` performs."""
+
+    def __init__(self, unused_compact_descr):
+        self.blocks = {}
+
+    def __getitem__(self, name):
+        return self.blocks.setdefault(name, {})
+
+    def makeCompDescr(self):
+        return self.blocks
+
+
+class _Packer(object):
+    def __init__(self, name, calls):
+        self.name = name
+        self.calls = calls
+
+    def pack(self, value):
+        self.calls.append((self.name, dict(value)))
+        return [self.name, dict(value)]
+
+
+class _Packers(object):
+    def __init__(self):
+        self.calls = []
+        for name in ('AVATAR_FULL_RESULTS', 'VEH_FULL_RESULTS',
+                     'COMMON_RESULTS', 'PLAYER_INFO', 'VEH_PUBLIC_RESULTS',
+                     'AVATAR_PUBLIC_RESULTS'):
+            setattr(self, name, _Packer(name, self.calls))
+
+
+class _ReplayConnector(object):
+    def __init__(self, unused_packer, values):
+        self.values = values
+
+
+class _Replay(object):
+    def __init__(self, connector, recordName=None, startRecordName=None):
+        self.connector = connector
+        self.record_name = recordName
+        self.start_name = startRecordName
+
+    def pack(self):
+        return ('SET:%s:%s' % (
+            self.record_name, self.connector.values[self.start_name]
+        )).encode('ascii')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_port_0922_battle_achievements.py
+++ b/tests/test_port_0922_battle_achievements.py
@@ -1,7 +1,11 @@
 """Award and packing contracts for #1513 post-battle achievements."""
 
+import io
 import json
+import os
+import shutil
 import sys
+import tempfile
 from pathlib import Path
 import unittest
 
@@ -80,7 +84,9 @@ def _actor(actor_kind='player', actor_id=1, team=1, **overrides):
         'xp': 500, 'stats': dict(EMPTY_STATS), 'kills': [],
         'damaged_targets': [],
         'exclusive_spot_assists': 0, 'ever_spotted': True,
-        'ally_damage': 0, 'last_shell_finisher': False,
+        'ally_damage': 0, 'ally_hits': 0, 'team_kills': 0,
+        'support_targets': 0, 'solo_capture': True,
+        'last_shell_finisher': False,
         'lucky_devil': False, 'best_deflection_streak': 0,
         'crits_received': 0, 'hits_received': 0,
         'damaging_hits_received': 0, 'deflected_hits_received': 0,
@@ -98,12 +104,13 @@ def _actor(actor_kind='player', actor_id=1, team=1, **overrides):
 
 def _kill(victim_id, victim_tier=5, victim_class='mediumTank',
           victim_kind='bot', death_reason=0, distance=500.0,
-          defended_base=False, actor_speed=10.0):
+          defended_base=False, actor_speed=10.0, victim_speed=12.0):
     return {
         'victim_kind': victim_kind, 'victim_id': victim_id,
         'victim_tier': victim_tier, 'victim_class': victim_class,
         'death_reason': death_reason, 'distance': distance,
         'defended_base': defended_base, 'actor_speed': actor_speed,
+        'victim_speed': victim_speed,
     }
 
 
@@ -168,10 +175,19 @@ class BattleHeroTests(unittest.TestCase):
                           stats={'dropped_capture_points': 70})
         short = _actor(actor_id=3, team=2,
                        stats={'dropped_capture_points': 69})
-        awards = _awards([invader, defender, short])
+        awards = _awards([invader, defender, short], base_captured_team=1)
         self.assertIn('invader', awards[('player', 1)])
         self.assertIn('defender', awards[('player', 2)])
         self.assertEqual(awards[('player', 3)], [])
+
+    def test_invader_needs_the_capture_to_complete(self):
+        # "此荣誉只颁发给成功占领基地" - points alone are not the medal.
+        invader = _actor(actor_id=1, stats={'capture_points': 99})
+        self.assertNotIn(
+            'invader', _awards([invader])[('player', 1)])
+        self.assertNotIn(
+            'invader',
+            _awards([invader], base_captured_team=2)[('player', 1)])
 
     def test_steel_wall_needs_potential_damage_hits_and_survival(self):
         survivor = _actor(actor_id=1, potential_damage_received=1200,
@@ -190,15 +206,55 @@ class BattleHeroTests(unittest.TestCase):
                          max_health=6000)
         self.assertNotIn('mainGun', _awards([hero, tougher])[('player', 1)])
 
-    def test_confederate_counts_enemies_finished_by_someone_else(self):
-        targets = [('bot', index) for index in range(1, 7)]
-        helper = _actor(actor_id=1, damaged_targets=targets)
-        finisher = _actor(actor_id=2, kills=[
-            _kill(index) for index in range(1, 7)])
-        awards = _awards([helper, finisher])
+    def test_fire_support_counts_enemies_hurt_or_immobilised(self):
+        # "战斗中比其它玩家击伤更多的敌方坦克或击毁他们的履带(至少为6辆)".
+        helper = _actor(actor_id=1, support_targets=6)
+        quieter = _actor(actor_id=2, support_targets=5)
+        awards = _awards([helper, quieter])
         self.assertIn('supporter', awards[('player', 1)])
-        # The actor that scored the kills did not "assist" itself.
         self.assertNotIn('supporter', awards[('player', 2)])
+
+    def test_fire_support_ignores_kills_scored_by_other_players(self):
+        # Damaging nobody and letting allies do the work is not support:
+        # the old rule counted "damaged then finished by someone else".
+        bystander = _actor(
+            actor_id=1, support_targets=0,
+            damaged_targets=[('bot', index) for index in range(1, 7)])
+        finisher = _actor(actor_id=2, support_targets=0, kills=[
+            _kill(index) for index in range(1, 7)])
+        awards = _awards([bystander, finisher])
+        self.assertNotIn('supporter', awards[('player', 1)])
+        self.assertNotIn('supporter', awards[('player', 2)])
+
+    def test_scout_needs_a_win(self):
+        # "必须胜利才可以获得."
+        loser = _actor(actor_id=1, stats={'spotted': 12}, won=False)
+        self.assertNotIn('scout', _awards([loser])[('player', 1)])
+
+    def test_damage_hero_and_sniper_forbid_hitting_an_ally(self):
+        # "玩家不能击中盟友坦克" / "玩家不得直接射中任何友军".
+        gunner = _actor(actor_id=1, stats={'damage': 4000}, ally_hits=1)
+        marksman = _actor(
+            actor_id=2, sniper_damage=1200, hits_with_damage=9, ally_hits=1,
+            max_health=900, stats={'shots': 10, 'direct_hits': 9,
+                                   'damage': 1500})
+        awards = _awards([gunner, marksman])
+        self.assertNotIn('mainGun', awards[('player', 1)])
+        self.assertNotIn('sniper2', awards[('player', 2)])
+
+    def test_sniper_needs_damage_above_its_own_hit_points(self):
+        # "距离300米外造成的伤害必须超过玩家车辆的生命值，至少1000点".
+        weak = _actor(actor_id=1, sniper_damage=1200, hits_with_damage=9,
+                      max_health=1200,
+                      stats={'shots': 10, 'direct_hits': 9, 'damage': 1500})
+        self.assertNotIn('sniper2', _awards([weak])[('player', 1)])
+
+    def test_artillery_can_never_be_the_sniper(self):
+        # "自行火炮无法获得."
+        gun = _actor(actor_id=1, vehicle_class='SPG', sniper_damage=1200,
+                     hits_with_damage=9, max_health=900,
+                     stats={'shots': 10, 'direct_hits': 9, 'damage': 1500})
+        self.assertNotIn('sniper2', _awards([gun])[('player', 1)])
 
     def test_scout_and_patrol_duty_use_distinct_spotting_inputs(self):
         scout = _actor(actor_id=1, stats={'spotted': 9})
@@ -254,8 +310,11 @@ class SourcedMedalTests(unittest.TestCase):
         broken = _actor(actor_id=1, best_deflection_streak=9,
                         deflected_hits_received=30)
         self.assertNotIn('ironMan', _awards([broken])[('player', 1)])
+
+    def test_cool_headed_does_not_require_surviving(self):
+        # Its condition text carries no survival clause, unlike Spartan.
         dead = _actor(actor_id=1, best_deflection_streak=12, survived=False)
-        self.assertNotIn('ironMan', _awards([dead])[('player', 1)])
+        self.assertIn('ironMan', _awards([dead])[('player', 1)])
 
     def test_fadin_follows_the_last_shell_finisher_flag(self):
         finisher = _actor(actor_id=1, last_shell_finisher=True)
@@ -284,11 +343,18 @@ class SourcedMedalTests(unittest.TestCase):
                       kills=[_kill(1, death_reason=2, actor_speed=2.0)])
         self.assertNotIn('medalMonolith', _awards([tank])[('player', 1)])
 
-    def test_rock_solid_is_lost_by_damaging_an_ally(self):
+    def test_rock_solid_is_lost_by_destroying_an_ally(self):
         dirty = _actor(actor_id=1, vehicle_class='SPG', stats={'kills': 1},
-                       ally_damage=40,
+                       team_kills=1,
                        kills=[_kill(1, death_reason=2, actor_speed=2.0)])
         self.assertNotIn('medalMonolith', _awards([dirty])[('player', 1)])
+
+    def test_rock_solid_needs_the_victim_to_be_the_faster_vehicle(self):
+        # "击毁您的敌方坦克速度必须高于您的自行火炮速度."
+        slower = _actor(actor_id=1, vehicle_class='SPG', stats={'kills': 1},
+                        kills=[_kill(1, death_reason=2, actor_speed=2.0,
+                                     victim_speed=1.0)])
+        self.assertNotIn('medalMonolith', _awards([slower])[('player', 1)])
 
 
 class EpicMedalTests(unittest.TestCase):
@@ -383,7 +449,8 @@ class EpicMedalTests(unittest.TestCase):
                 for index in (1, 2)]
 
     def test_artillery_medals_require_a_self_propelled_gun(self):
-        gore_stats = {'damage': 8000, 'kills': 2}
+        gore_stats = {'damage': 8000, 'kills': 2,
+                      'damage_received': 400, 'damage_blocked': 200}
         artillery = _actor(actor_id=1, vehicle_class='SPG',
                            max_health=800, stats=gore_stats,
                            damaging_hits_received=2,
@@ -417,24 +484,56 @@ class EpicMedalTests(unittest.TestCase):
             'medalAntiSpgFire',
             _awards([partial] + battery)[('player', 1)])
 
-    def test_gores_medal_is_lost_by_damaging_an_ally(self):
+    def test_gores_medal_is_lost_by_destroying_an_ally(self):
+        # "玩家不能击毁任何盟友坦克"; a friendly hit alone is not the bar,
+        # since "击中或命中盟友坦克也不被计算在内".
         stats = {'damage': 8000, 'kills': 2}
         clean = _actor(actor_id=1, vehicle_class='SPG', max_health=800,
-                       stats=stats)
-        self.assertIn('medalGore', _awards([clean])[('player', 1)])
-        dirty = _actor(actor_id=1, vehicle_class='SPG', max_health=800,
                        stats=stats, ally_damage=120)
-        self.assertNotIn('medalGore', _awards([dirty])[('player', 1)])
+        self.assertIn('medalGore', _awards([clean])[('player', 1)])
+        killer = _actor(actor_id=1, vehicle_class='SPG', max_health=800,
+                        stats=stats, team_kills=1)
+        self.assertNotIn('medalGore', _awards([killer])[('player', 1)])
 
-    def test_cool_blood_counts_close_kills_only(self):
-        close = _actor(actor_id=1, vehicle_class='SPG', stats={'kills': 2},
-                       kills=[_kill(1, distance=40.0),
-                              _kill(2, distance=99.0)])
-        self.assertIn('medalCoolBlood', _awards([close])[('player', 1)])
-        far = _actor(actor_id=1, vehicle_class='SPG', stats={'kills': 2},
-                     kills=[_kill(1, distance=140.0),
-                            _kill(2, distance=99.0)])
-        self.assertNotIn('medalCoolBlood', _awards([far])[('player', 1)])
+    def _cold_blooded(self, **overrides):
+        row = {
+            'vehicle_class': 'SPG', 'tier': 4, 'stats': {'kills': 2},
+            'kills': [_kill(1, victim_class='lightTank', distance=40.0),
+                      _kill(2, victim_class='lightTank', distance=99.0)],
+        }
+        row.update(overrides)
+        return _actor(actor_id=1, **row)
+
+    def test_cold_blooded_needs_close_light_tanks_from_a_tier_four_gun(self):
+        self.assertIn(
+            'medalCoolBlood',
+            _awards([self._cold_blooded()])[('player', 1)])
+
+    def test_cold_blooded_rejects_distant_kills(self):
+        far = self._cold_blooded(kills=[
+            _kill(1, victim_class='lightTank', distance=140.0),
+            _kill(2, victim_class='lightTank', distance=99.0)])
+        self.assertNotIn(
+            'medalCoolBlood', _awards([far])[('player', 1)])
+
+    def test_cold_blooded_counts_light_tanks_only(self):
+        # "击毁至少2辆敌方轻型坦克."
+        heavies = self._cold_blooded(kills=[
+            _kill(1, victim_class='heavyTank', distance=40.0),
+            _kill(2, victim_class='mediumTank', distance=50.0)])
+        self.assertNotIn(
+            'medalCoolBlood', _awards([heavies])[('player', 1)])
+
+    def test_cold_blooded_needs_at_least_a_tier_four_gun(self):
+        # "使用至少为4级的自行火炮."
+        low = self._cold_blooded(tier=3)
+        self.assertNotIn(
+            'medalCoolBlood', _awards([low])[('player', 1)])
+
+    def test_cold_blooded_is_lost_by_destroying_an_ally(self):
+        dirty = self._cold_blooded(team_kills=1)
+        self.assertNotIn(
+            'medalCoolBlood', _awards([dirty])[('player', 1)])
 
     def test_bombardier_kamikaze_sturdy_and_raider(self):
         bomber = _actor(actor_id=1, best_multi_kill_shot=2)
@@ -463,6 +562,49 @@ class EpicMedalTests(unittest.TestCase):
                       ever_spotted=True)
         self.assertNotIn(
             'raider', _awards([seen], base_captured_team=1)[('player', 1)])
+
+    def test_sneaky_needs_the_capture_to_be_solo(self):
+        # "单独占领敌人基地" - a shared capture is not this medal.
+        shared = _actor(actor_id=1, team=1, captured_base=True,
+                        ever_spotted=False, solo_capture=False)
+        self.assertNotIn(
+            'raider', _awards([shared], base_captured_team=1)[('player', 1)])
+
+    def test_sneaky_survives_being_shot_at(self):
+        # "如果坦克被偶然击中或受损并不取消此勋章的获得."
+        battered = _actor(actor_id=1, team=1, captured_base=True,
+                          ever_spotted=False, health=1,
+                          damaging_hits_received=6, crits_received=3)
+        self.assertIn(
+            'raider',
+            _awards([battered], base_captured_team=1)[('player', 1)])
+
+    def test_stark_needs_two_thirds_of_its_hit_points_absorbed(self):
+        # "受到的伤害以及装甲伤害必须是自身坦克生命值的三分之二."
+        row = {
+            'vehicle_class': 'SPG', 'max_health': 900,
+            'damaging_hits_received': 2, 'stats': {
+                'kills': 2, 'damage_received': 400, 'damage_blocked': 200},
+        }
+        self.assertIn(
+            'medalStark', _awards([_actor(actor_id=1, **row)])[('player', 1)])
+        row['stats'] = {
+            'kills': 2, 'damage_received': 300, 'damage_blocked': 200}
+        self.assertNotIn(
+            'medalStark', _awards([_actor(actor_id=1, **row)])[('player', 1)])
+
+    def test_tier_delta_medals_never_count_artillery_victims(self):
+        # "击毁2辆或2辆以上的敌方坦克与自行反坦克炮."
+        scout = _actor(actor_id=1, tier=5, vehicle_class='lightTank',
+                       stats={'kills': 2}, kills=[
+                           _kill(1, victim_tier=6, victim_class='SPG'),
+                           _kill(2, victim_tier=6, victim_class='SPG')])
+        self.assertNotIn('medalOrlik', _awards([scout])[('player', 1)])
+        proper = _actor(actor_id=1, tier=5, vehicle_class='lightTank',
+                        stats={'kills': 2}, kills=[
+                            _kill(1, victim_tier=6, victim_class='heavyTank'),
+                            _kill(2, victim_tier=6, victim_class='AT-SPG')])
+        self.assertIn('medalOrlik', _awards([proper])[('player', 1)])
 
     def test_bots_earn_the_same_medals_as_human_players(self):
         bot = _actor(actor_kind='bot', actor_id=3, stats={'kills': 6})
@@ -627,6 +769,60 @@ class DossierAccumulationTests(unittest.TestCase):
     def test_account_snapshot_publishes_the_dossier_key(self):
         snapshot = data.stats(postbattle_progress={'achievements': {}})
         self.assertEqual(snapshot['stats']['dossier'], '')
+
+    def test_a_corrupt_counter_never_reaches_the_dossier_builder(self):
+        # A hand-edited or partially written cache must not break the account
+        # snapshot the garage is built from.
+        for bad in ('bad', None, True, -1, 0, 1.5, [], {}):
+            counts = {'warrior': bad, 'medalKolobanov': 1}
+            compact = data.account_dossier(
+                {'achievements': counts}, dossier_factory=_FakeDossier)
+            self.assertEqual(
+                {'medalKolobanov': 1}, compact['achievements'],
+                'counter %r must be dropped' % (bad,))
+
+    def test_an_unknown_medal_name_is_dropped_from_persisted_counters(self):
+        store = postbattle_store.PostBattleStore(path=None)
+        store._progress['achievements'] = {
+            'warrior': 3, 'notAMedal': 4, 'sniper': 2}
+        self.assertEqual(
+            {'warrior': 3},
+            postbattle_store._achievement_counts(
+                store._progress['achievements']))
+
+    def test_a_corrupt_cache_still_loads_and_accumulates(self):
+        path = os.path.join(self._temporary_dir(), 'postbattle.json')
+        store = postbattle_store.PostBattleStore(path=path)
+        receipt = ResultPackingTests._receipt(['warrior'])
+        receipt['account_key'] = store.account_key
+        self.assertTrue(store.accept(receipt))
+        with io.open(path, encoding='utf-8') as stream:
+            value = json.load(stream)
+        value['progress']['achievements'] = {
+            'warrior': 'bad', 'medalKolobanov': -2, 'notAMedal': 9}
+        for row in value['progress']['vehicles'].values():
+            row['achievements'] = {'warrior': True}
+        with io.open(path, 'w', encoding='utf-8') as stream:
+            stream.write(json.dumps(value))
+
+        reloaded = postbattle_store.PostBattleStore(path=path)
+
+        self.assertEqual({}, reloaded.progress()['achievements'])
+        second = dict(receipt)
+        second['receipt_id'] = 'server:9:1'
+        second['arena_unique_id'] = (9 << 32) | 1
+        second['round_id'] = 9
+        self.assertTrue(reloaded.accept(second))
+        self.assertEqual(
+            {'warrior': 1}, reloaded.progress()['achievements'])
+        self.assertEqual(
+            {'warrior': 1},
+            reloaded.progress()['vehicles']['ussr:R11_MS-1']['achievements'])
+
+    def _temporary_dir(self):
+        directory = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, directory, True)
+        return directory
 
     def test_a_vehicle_without_medals_leaves_the_block_untouched(self):
         rows = data.dossiers(
@@ -982,6 +1178,40 @@ class LuckyDevilTests(unittest.TestCase):
         self.assertTrue(state._record_frag(
             'player', 1, 2, 'bot', 1, attacker_team=1))
         self.assertEqual(set(), state.lucky_devils)
+
+
+class SupportAndFriendlyFireTests(unittest.TestCase):
+    """Round state the corrected predicates read."""
+
+    def test_real_damage_and_track_kills_both_count_as_support(self):
+        state, unused_player = ServerReceiptTests._battle()
+        state._record_damage(('player', 1), ('bot', 1), 120, {})
+        self.assertEqual(
+            {('bot', 1)}, state.support_targets[('player', 1)])
+
+    def test_a_bounce_never_counts_as_support(self):
+        state, unused_player = ServerReceiptTests._battle()
+        state._record_damage(('player', 1), ('bot', 1), 0, {})
+        self.assertNotIn(('player', 1), state.support_targets)
+
+    def test_a_teammate_is_never_a_support_target(self):
+        state, unused_player = ServerReceiptTests._battle()
+        state.bot_states[1]['team'] = 1
+        state._record_damage(('player', 1), ('bot', 1), 120, {})
+        self.assertNotIn(('player', 1), state.support_targets)
+
+    def test_a_friendly_kill_is_counted_against_the_actor(self):
+        state, unused_player = ServerReceiptTests._battle()
+        state.bot_states[1]['team'] = 1
+        self.assertTrue(state._record_frag(
+            'player', 1, 1, 'bot', 1, attacker_team=1))
+        self.assertEqual(1, state.team_kills[('player', 1)])
+
+    def test_an_enemy_kill_is_not_a_friendly_kill(self):
+        state, unused_player = ServerReceiptTests._battle()
+        self.assertTrue(state._record_frag(
+            'player', 1, 2, 'bot', 1, attacker_team=1))
+        self.assertEqual({}, state.team_kills)
 
 
 class LastShellTests(unittest.TestCase):

--- a/tests/test_port_0922_battle_achievements.py
+++ b/tests/test_port_0922_battle_achievements.py
@@ -78,8 +78,10 @@ def _actor(actor_kind='player', actor_id=1, team=1, **overrides):
         'vehicle': 'ussr:R11_MS-1', 'tier': 5, 'vehicle_class': 'mediumTank',
         'max_health': 1000, 'health': 1000, 'survived': True, 'won': True,
         'xp': 500, 'stats': dict(EMPTY_STATS), 'kills': [],
-        'damaged_targets': [], 'first_spotted': 0,
+        'damaged_targets': [],
         'exclusive_spot_assists': 0, 'ever_spotted': True,
+        'ally_damage': 0, 'last_shell_finisher': False,
+        'lucky_devil': False, 'best_deflection_streak': 0,
         'crits_received': 0, 'hits_received': 0,
         'damaging_hits_received': 0, 'deflected_hits_received': 0,
         'deflected_hits_at_low_health': 0,
@@ -96,12 +98,12 @@ def _actor(actor_kind='player', actor_id=1, team=1, **overrides):
 
 def _kill(victim_id, victim_tier=5, victim_class='mediumTank',
           victim_kind='bot', death_reason=0, distance=500.0,
-          defended_base=False):
+          defended_base=False, actor_speed=10.0):
     return {
         'victim_kind': victim_kind, 'victim_id': victim_id,
         'victim_tier': victim_tier, 'victim_class': victim_class,
         'death_reason': death_reason, 'distance': distance,
-        'defended_base': defended_base,
+        'defended_base': defended_base, 'actor_speed': actor_speed,
     }
 
 
@@ -199,7 +201,7 @@ class BattleHeroTests(unittest.TestCase):
         self.assertNotIn('supporter', awards[('player', 2)])
 
     def test_scout_and_patrol_duty_use_distinct_spotting_inputs(self):
-        scout = _actor(actor_id=1, first_spotted=9)
+        scout = _actor(actor_id=1, stats={'spotted': 9})
         patrol = _actor(actor_id=2, exclusive_spot_assists=6)
         awards = _awards([scout, patrol])
         self.assertIn('scout', awards[('player', 1)])
@@ -219,6 +221,74 @@ class BattleHeroTests(unittest.TestCase):
                              stats={'shots': 10, 'direct_hits': 9,
                                     'damage': 1500})
         self.assertNotIn('sniper2', _awards([close_range])[('player', 1)])
+
+
+class SourcedMedalTests(unittest.TestCase):
+    """Medals whose #1513 constant only became usable with a sourced shape."""
+
+    def test_naidin_needs_every_enemy_light_tank(self):
+        scouts = [_actor(actor_kind='bot', actor_id=index, team=2,
+                         vehicle_class='lightTank', survived=False,
+                         won=False) for index in (1, 2, 3)]
+        hunter = _actor(actor_id=1, stats={'kills': 3}, kills=[
+            _kill(index, victim_class='lightTank') for index in (1, 2, 3)])
+        self.assertIn('huntsman', _awards([hunter] + scouts)[('player', 1)])
+        survivor = _actor(actor_kind='bot', actor_id=4, team=2,
+                          vehicle_class='lightTank', won=False)
+        self.assertNotIn(
+            'huntsman',
+            _awards([hunter] + scouts + [survivor])[('player', 1)])
+
+    def test_naidin_needs_the_enemy_to_field_three_light_tanks(self):
+        scouts = [_actor(actor_kind='bot', actor_id=index, team=2,
+                         vehicle_class='lightTank', survived=False,
+                         won=False) for index in (1, 2)]
+        hunter = _actor(actor_id=1, stats={'kills': 2}, kills=[
+            _kill(index, victim_class='lightTank') for index in (1, 2)])
+        self.assertNotIn(
+            'huntsman', _awards([hunter] + scouts)[('player', 1)])
+
+    def test_cool_headed_counts_bounces_in_a_row(self):
+        steady = _actor(actor_id=1, best_deflection_streak=10)
+        self.assertIn('ironMan', _awards([steady])[('player', 1)])
+        broken = _actor(actor_id=1, best_deflection_streak=9,
+                        deflected_hits_received=30)
+        self.assertNotIn('ironMan', _awards([broken])[('player', 1)])
+        dead = _actor(actor_id=1, best_deflection_streak=12, survived=False)
+        self.assertNotIn('ironMan', _awards([dead])[('player', 1)])
+
+    def test_fadin_follows_the_last_shell_finisher_flag(self):
+        finisher = _actor(actor_id=1, last_shell_finisher=True)
+        self.assertIn('medalFadin', _awards([finisher])[('player', 1)])
+        self.assertNotIn(
+            'medalFadin', _awards([_actor(actor_id=1)])[('player', 1)])
+
+    def test_lucky_follows_the_proximity_flag(self):
+        witness = _actor(actor_id=1, lucky_devil=True)
+        self.assertIn('luckyDevil', _awards([witness])[('player', 1)])
+        self.assertNotIn(
+            'luckyDevil', _awards([_actor(actor_id=1)])[('player', 1)])
+
+    def test_rock_solid_needs_a_crawling_artillery_ram(self):
+        crawl = _actor(actor_id=1, vehicle_class='SPG', stats={'kills': 1},
+                       kills=[_kill(1, death_reason=2, actor_speed=2.0)])
+        self.assertIn('medalMonolith', _awards([crawl])[('player', 1)])
+        fast = _actor(actor_id=1, vehicle_class='SPG', stats={'kills': 1},
+                      kills=[_kill(1, death_reason=2, actor_speed=6.0)])
+        self.assertNotIn('medalMonolith', _awards([fast])[('player', 1)])
+        shot = _actor(actor_id=1, vehicle_class='SPG', stats={'kills': 1},
+                      kills=[_kill(1, death_reason=0, actor_speed=2.0)])
+        self.assertNotIn('medalMonolith', _awards([shot])[('player', 1)])
+        tank = _actor(actor_id=1, vehicle_class='heavyTank',
+                      stats={'kills': 1},
+                      kills=[_kill(1, death_reason=2, actor_speed=2.0)])
+        self.assertNotIn('medalMonolith', _awards([tank])[('player', 1)])
+
+    def test_rock_solid_is_lost_by_damaging_an_ally(self):
+        dirty = _actor(actor_id=1, vehicle_class='SPG', stats={'kills': 1},
+                       ally_damage=40,
+                       kills=[_kill(1, death_reason=2, actor_speed=2.0)])
+        self.assertNotIn('medalMonolith', _awards([dirty])[('player', 1)])
 
 
 class EpicMedalTests(unittest.TestCase):
@@ -307,6 +377,11 @@ class EpicMedalTests(unittest.TestCase):
             _kill(index) for index in range(1, 5)])
         self.assertNotIn('medalDeLanglade', _awards([outside])[('player', 1)])
 
+    def _enemy_battery(self):
+        return [_actor(actor_kind='bot', actor_id=index, team=2,
+                       vehicle_class='SPG', survived=False, won=False)
+                for index in (1, 2)]
+
     def test_artillery_medals_require_a_self_propelled_gun(self):
         gore_stats = {'damage': 8000, 'kills': 2}
         artillery = _actor(actor_id=1, vehicle_class='SPG',
@@ -315,7 +390,8 @@ class EpicMedalTests(unittest.TestCase):
                            kills=[_kill(1, victim_class='SPG'),
                                   _kill(2, victim_class='SPG',
                                         distance=50.0)])
-        awards = _awards([artillery])[('player', 1)]
+        awards = _awards(
+            [artillery] + self._enemy_battery())[('player', 1)]
         self.assertIn('medalGore', awards)
         self.assertIn('medalStark', awards)
         self.assertIn('medalAntiSpgFire', awards)
@@ -324,9 +400,31 @@ class EpicMedalTests(unittest.TestCase):
                       damaging_hits_received=2,
                       kills=[_kill(1, victim_class='SPG'),
                              _kill(2, victim_class='SPG', distance=50.0)])
+        awards = _awards([tank] + self._enemy_battery())[('player', 1)]
         for name in ('medalGore', 'medalStark', 'medalAntiSpgFire',
                      'medalCoolBlood'):
-            self.assertNotIn(name, _awards([tank])[('player', 1)])
+            self.assertNotIn(name, awards)
+
+    def test_counter_battery_fire_needs_the_whole_enemy_battery(self):
+        battery = self._enemy_battery()
+        battery.append(_actor(actor_kind='bot', actor_id=3, team=2,
+                              vehicle_class='SPG', survived=True, won=False))
+        partial = _actor(actor_id=1, vehicle_class='SPG',
+                         stats={'kills': 2},
+                         kills=[_kill(1, victim_class='SPG'),
+                                _kill(2, victim_class='SPG')])
+        self.assertNotIn(
+            'medalAntiSpgFire',
+            _awards([partial] + battery)[('player', 1)])
+
+    def test_gores_medal_is_lost_by_damaging_an_ally(self):
+        stats = {'damage': 8000, 'kills': 2}
+        clean = _actor(actor_id=1, vehicle_class='SPG', max_health=800,
+                       stats=stats)
+        self.assertIn('medalGore', _awards([clean])[('player', 1)])
+        dirty = _actor(actor_id=1, vehicle_class='SPG', max_health=800,
+                       stats=stats, ally_damage=120)
+        self.assertNotIn('medalGore', _awards([dirty])[('player', 1)])
 
     def test_cool_blood_counts_close_kills_only(self):
         close = _actor(actor_id=1, vehicle_class='SPG', stats={'kills': 2},
@@ -792,6 +890,126 @@ class _Packers(object):
                      'COMMON_RESULTS', 'PLAYER_INFO', 'VEH_PUBLIC_RESULTS',
                      'AVATAR_PUBLIC_RESULTS'):
             setattr(self, name, _Packer(name, self.calls))
+
+
+class DetectionTests(unittest.TestCase):
+    """``spotted`` counts detections, not every sighting."""
+
+    @staticmethod
+    def _battle():
+        state, player = ServerReceiptTests._battle()
+        for entry in state.bot_states.values():
+            entry['alive'] = True
+        player.alive = True
+        player.participating = True
+        player.connected = True
+        return state, player
+
+    def test_one_enemy_counts_once_while_it_stays_visible(self):
+        state, unused_player = self._battle()
+        for unused in range(3):
+            state.player_spotted = {1: frozenset({('bot', 1)})}
+            state._commit_detections()
+        self.assertEqual(1, state._statistics_row('player', 1)['spotted'])
+
+    def test_a_target_that_goes_dark_is_a_new_detection(self):
+        state, unused_player = self._battle()
+        state.player_spotted = {1: frozenset({('bot', 1)})}
+        state._commit_detections()
+        state.player_spotted = {1: frozenset()}
+        state._commit_detections()
+        state.player_spotted = {1: frozenset({('bot', 1)})}
+        state._commit_detections()
+        # The same enemy still counts once for this observer, but the team
+        # visibility did drop, so a different observer would be credited.
+        self.assertEqual(1, state._statistics_row('player', 1)['spotted'])
+
+    def test_a_second_observer_is_credited_for_a_re_detection(self):
+        state, unused_player = self._battle()
+        state.bot_states[2]['team'] = 1
+        state.player_spotted = {1: frozenset({('bot', 1)})}
+        state._commit_detections()
+        state.player_spotted = {1: frozenset()}
+        state._commit_detections()
+        state.bot_spotted = {2: frozenset({('bot', 1)})}
+        state._commit_detections()
+        self.assertEqual(1, state._statistics_row('player', 1)['spotted'])
+        self.assertEqual(1, state._statistics_row('bot', 2)['spotted'])
+
+    def test_a_teammate_is_never_a_detection(self):
+        state, unused_player = self._battle()
+        state.bot_states[1]['team'] = 1
+        state.player_spotted = {1: frozenset({('bot', 1)})}
+        state._commit_detections()
+        self.assertEqual(0, state._statistics_row('player', 1)['spotted'])
+
+
+class LuckyDevilTests(unittest.TestCase):
+    """Lucky needs the victim's dying pose, not a living one."""
+
+    @staticmethod
+    def _battle():
+        state, player = ServerReceiptTests._battle()
+        player.alive = True
+        player.participating = True
+        player.connected = True
+        player.x, player.y, player.z = 0.0, 0.0, 0.0
+        for entry in state.bot_states.values():
+            entry.update({'alive': True, 'x': 0.0, 'y': 0.0, 'z': 0.0})
+        return state, player
+
+    def test_a_nearby_enemy_team_kill_credits_the_witness(self):
+        state, unused_player = self._battle()
+        state.bot_states[1]['x'] = 5.0
+        state.bot_states[2]['x'] = 5.0
+        # Bot 2 kills its own team mate right beside the human player.
+        state.bot_states[1]['alive'] = False
+        self.assertTrue(state._record_frag(
+            'bot', 2, 2, 'bot', 1, attacker_team=2))
+        self.assertIn(('player', 1), state.lucky_devils)
+
+    def test_a_distant_witness_earns_nothing(self):
+        state, unused_player = self._battle()
+        state.bot_states[1].update({'x': 40.0, 'alive': False})
+        state.bot_states[2]['x'] = 40.0
+        self.assertTrue(state._record_frag(
+            'bot', 2, 2, 'bot', 1, attacker_team=2))
+        self.assertEqual(set(), state.lucky_devils)
+
+    def test_an_ordinary_kill_credits_nobody(self):
+        state, unused_player = self._battle()
+        state.bot_states[1].update({'x': 5.0, 'alive': False})
+        self.assertTrue(state._record_frag(
+            'player', 1, 2, 'bot', 1, attacker_team=1))
+        self.assertEqual(set(), state.lucky_devils)
+
+
+class LastShellTests(unittest.TestCase):
+    """Fadin's medal needs the final round and the final enemy together."""
+
+    def test_the_last_shell_that_ends_the_battle_earns_it(self):
+        state, unused_player = ServerReceiptTests._battle()
+        state.last_shell_shots['p1'] = True
+        state._record_kill(('player', 1), ('bot', 1), 0, projectile_id='p1')
+        self.assertIn(('player', 1), state.last_shell_finishers)
+
+    def test_a_surviving_enemy_denies_it(self):
+        state, unused_player = ServerReceiptTests._battle()
+        state.bot_states[2]['alive'] = True
+        state.last_shell_shots['p1'] = True
+        state._record_kill(('player', 1), ('bot', 1), 0, projectile_id='p1')
+        self.assertEqual(set(), state.last_shell_finishers)
+
+    def test_a_shell_still_in_the_rack_denies_it(self):
+        state, unused_player = ServerReceiptTests._battle()
+        state.last_shell_shots['p1'] = False
+        state._record_kill(('player', 1), ('bot', 1), 0, projectile_id='p1')
+        self.assertEqual(set(), state.last_shell_finishers)
+
+    def test_a_shot_without_a_reported_inventory_denies_it(self):
+        state, unused_player = ServerReceiptTests._battle()
+        state._record_kill(('player', 1), ('bot', 1), 0, projectile_id='p1')
+        self.assertEqual(set(), state.last_shell_finishers)
 
 
 class _ReplayConnector(object):

--- a/tests/test_port_0922_battle_projectiles.py
+++ b/tests/test_port_0922_battle_projectiles.py
@@ -495,7 +495,12 @@ class BattleProjectileTests(unittest.TestCase):
 
     def test_half_even_player_preinstall_matches_real_server_echo(self):
         half_even_edge = 0.0078125
-        launch_server_time_ms = 15000
+        # The trigger is frozen at the server's own receipt tick, so derive
+        # it from the countdown instead of restating one countdown's value.
+        prebattle_ticks = int(round(
+            server_runtime.PREBATTLE_SECONDS * server_runtime.TICK_HZ))
+        launch_server_time_ms = int(round(
+            prebattle_ticks * 1000.0 / server_runtime.TICK_HZ))
         source_shot = {
             'speed': 100.0,
             'gravity': 9.81,
@@ -533,8 +538,7 @@ class BattleProjectileTests(unittest.TestCase):
         server = server_runtime.BattleState(map_name='04_himmelsdorf')
         server.client_build = server_runtime.CLIENT_BUILD_0922
         server.phase = 'battle'
-        server.tick = int(round(
-            server_runtime.PREBATTLE_SECONDS * server_runtime.TICK_HZ))
+        server.tick = prebattle_ticks
         server.round_id = 9
         server.authority_epoch = 1
         server.bot_authority_id = (

--- a/tests/test_port_0922_battle_projectiles.py
+++ b/tests/test_port_0922_battle_projectiles.py
@@ -4696,7 +4696,7 @@ class BattleProjectileTests(unittest.TestCase):
 
         with mock.patch.object(
                 combat_rules, 'resolve_armor_contact',
-                return_value={'result': 2}), \
+                return_value={'result': 2, 'layer': 'external'}), \
                 mock.patch.object(
                     combat_rules, 'he_nominal_armor', return_value=100.0), \
                 mock.patch.object(
@@ -4714,6 +4714,7 @@ class BattleProjectileTests(unittest.TestCase):
 
         self.assertEqual(390, effect['damage'])
         self.assertEqual(2, effect['shot_result'])
+        self.assertIs(False, effect['structural_armor_hit'])
         self.assertEqual(
             [390.0, 150.0], critical.call_args.args[5]['damage'])
         self.assertFalse(critical.call_args.kwargs['deadeye'])
@@ -4748,6 +4749,7 @@ class BattleProjectileTests(unittest.TestCase):
         with mock.patch.object(
                 combat_rules, 'resolve_armor_contact', return_value={
                     'result': 0, 'component': 'hull', 'distance': 10.0,
+                    'layer': 'structural',
                 }) as resolved, mock.patch.object(
                     combat_rules, 'he_nominal_armor', return_value=100.0), \
                 mock.patch.object(
@@ -4760,6 +4762,7 @@ class BattleProjectileTests(unittest.TestCase):
 
         self.assertEqual(0, effect['damage'])
         self.assertEqual(0, effect['shot_result'])
+        self.assertIs(True, effect['structural_armor_hit'])
         self.assertEqual((1.0, 0.0, 0.0), terminal['world_normal'])
         self.assertEqual(
             0.75,

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -1593,7 +1593,7 @@ class _Client(object):
 
     def send_fire_intent(self, shell_index, shot_origin, shot_direction,
                          dispersion_angle, presentation_ledger,
-                         trigger_server_time_ms):
+                         trigger_server_time_ms, shells_before_shot=None):
         self._fire_intent_seq += 1
         self.sent.append((
             'fire_intent', (shell_index,),
@@ -1604,7 +1604,8 @@ class _Client(object):
              'dispersion_angle': float(dispersion_angle),
              'presentation_ledger': [
                  dict(entry) for entry in presentation_ledger],
-             'trigger_server_time_ms': trigger_server_time_ms}))
+             'trigger_server_time_ms': trigger_server_time_ms,
+             'shells_before_shot': shells_before_shot}))
         return self._fire_intent_seq
 
 
@@ -20504,6 +20505,9 @@ class BattleRuntimeContractTests(unittest.TestCase):
             'dispersion_angle': 0.25,
             'presentation_ledger': [],
             'trigger_server_time_ms': 0,
+            # Read before the local gun debits this round, so the total still
+            # includes the shell being fired.
+            'shells_before_shot': 24,
         }, intent[2])
         current_input = next(item for item in client.sent
                              if item[0] == 'input')
@@ -20620,8 +20624,10 @@ class BattleRuntimeContractTests(unittest.TestCase):
             self.assertFalse(battle.shoot(0.2, -0.1))
         self.assertNotIn('FIRE TRIGGER', fire_output.getvalue())
         self.assertEqual([], battle._avatar.dispersion_queries)
+        # The trailing argument is the shell total standing at the trigger
+        # edge, which Fadin's medal reads.
         client.send_fire_intent.assert_called_once_with(
-            0, [0.0, 2.0, 0.0], [0.0, 0.0, 1.0], 0.25, [], 0)
+            0, [0.0, 2.0, 0.0], [0.0, 0.0, 1.0], 0.25, [], 0, 24)
 
     def test_trigger_without_a_server_clock_is_rejected_before_send(self):
         runtime = _runtime()
@@ -20791,6 +20797,24 @@ class BattleRuntimeContractTests(unittest.TestCase):
         with self.assertRaisesRegex(
                 RuntimeError, 'worker fire intent is malformed'):
             battle.on_fire_intent(dict(intent, unexpected='wire field'))
+        # The relayed shell total is optional, and carrying it is not a
+        # malformed intent.
+        other = BattleRuntime(_runtime())
+        other._worker_mode = True
+        other.state = 'running'
+        other._battle_live = True
+        other._projectile_is_authority = lambda: True
+        other.client = _Client()
+        other.client.authority_epoch = 4
+        other._start_message = {'round_id': 7}
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.assertTrue(other.on_fire_intent(
+                dict(intent, shells_before_shot=1)))
+        # The worker resolves ballistics and never needs the count, so it
+        # accepts the relay and keeps its own frozen intent unchanged.
+        self.assertEqual(
+            battle._player_fire_intents[(2, 3)],
+            other._player_fire_intents[(2, 3)])
         for invalid in (True, 1.0, -1,
                         battle_runtime_module.lan_protocol.MAX_MOTION_TIME_US //
                         1000 + 1):

--- a/tests/test_port_0922_bot_runtime.py
+++ b/tests/test_port_0922_bot_runtime.py
@@ -8305,6 +8305,12 @@ class BotRuntimeTests(unittest.TestCase):
             launch['fire_seq'] for launch in runtime._pending_launches])
         self.assertEqual([0, 1, 2], [
             launch['burst_index'] for launch in runtime._pending_launches])
+        # Each frozen launch carries the shell total it was drawn from, which
+        # Fadin's medal reads and only this worker can know.
+        total = sum(ammo_state.remaining)
+        self.assertEqual([total + 3, total + 2, total + 1], [
+            launch['shells_before_shot']
+            for launch in runtime._pending_launches])
         self.assertEqual(initial_ammo - 3,
                          ammo_state.remaining[ammo_state.loaded])
         self.assertEqual(2, gun_state.clip)

--- a/tests/test_port_0922_input_ledger.py
+++ b/tests/test_port_0922_input_ledger.py
@@ -621,6 +621,35 @@ class InputLedgerFireTests(unittest.TestCase):
         self.assertEqual(results_before, len(self.results))
         self.assertEqual(gun_before, self._gun_state(player))
 
+    def test_a_reported_shell_inventory_is_relayed_not_rejected(self):
+        state, player = self._armed_state()
+
+        self.assertTrue(state.submit_fire_intent(1, _fire_intent(
+            state, intent_seq=1, shells_before_shot=1)))
+
+        relay = player.pending_fire_intents[1]
+        self.assertEqual(1, relay['shells_before_shot'])
+        self.assertEqual('fire_intent', self.relayed[-1]['type'])
+
+    def test_a_trigger_without_a_shell_inventory_still_launches(self):
+        state, player = self._armed_state()
+        intent = _fire_intent(state, intent_seq=1)
+        intent.pop('shells_before_shot', None)
+
+        self.assertTrue(state.submit_fire_intent(1, intent))
+
+        self.assertIsNone(
+            player.pending_fire_intents[1]['shells_before_shot'])
+
+    def test_an_unknown_fire_intent_field_is_still_rejected(self):
+        state, unused_player = self._armed_state()
+
+        self.assertTrue(state.submit_fire_intent(1, _fire_intent(
+            state, intent_seq=1, unexpected_field=1)))
+
+        self.assertEqual(
+            'fire_intent_wire_shape', self.results[-1]['reason'])
+
     def test_fire_bound_to_the_last_valid_input_still_launches(self):
         state, player = self._armed_state()
         self.assertFalse(state.update_input(1, _frame(state, aim_yaw=7.0)))

--- a/tests/test_port_0922_lan_client_projectiles.py
+++ b/tests/test_port_0922_lan_client_projectiles.py
@@ -777,6 +777,30 @@ class ProjectileWireTests(unittest.TestCase):
             4, 'player:7:3', 0, 'impact', 10,
             [0.0, 0.0, 0.0], self.effect('player', 8), [splash]))
 
+    def test_structural_armor_metadata_is_optional_and_soft(self):
+        client = self.active_worker_client()
+        direct = self.effect('player', 8)
+        direct['structural_armor_hit'] = True
+
+        self.assertTrue(client.send_projectile_resolve(
+            4, 'player:7:1', 150, 'impact', 180,
+            [11.0, 2.0, 3.0], direct, []))
+        message = wire_copy(client._outbound_queue[-1][1])
+        self.assertIs(True, message['direct']['structural_armor_hit'])
+
+        # This bit cannot own an admitted projectile. If a future or damaged
+        # worker sends a non-boolean value, retain the terminal and count it
+        # conservatively as an external-module contact.
+        for invalid in (1, 'structural', None, []):
+            with self.subTest(structural_armor_hit=invalid):
+                self.assertTrue(client.send_projectile_resolve(
+                    4, 'player:7:2', 150, 'impact', 180,
+                    [11.0, 2.0, 3.0],
+                    dict(direct, structural_armor_hit=invalid), []))
+                message = wire_copy(client._outbound_queue[-1][1])
+                self.assertIs(
+                    False, message['direct']['structural_armor_hit'])
+
     def test_first_ricochet_wire_keeps_the_blocked_damage_roll(self):
         client = self.active_worker_client()
         direct = self.effect('bot', 17, 11.0)

--- a/tests/test_port_0922_lan_protocol.py
+++ b/tests/test_port_0922_lan_protocol.py
@@ -590,7 +590,12 @@ class LanProtocolTests(unittest.TestCase):
             'shots_penetrated', 'damage_dealt', 'damage_received',
             'damage_blocked', 'damage_assisted_track',
             'damage_assisted_radio', 'damage_assisted_stun',
-            'kills'}, set(rows[1]))
+            'kills', 'capture_points', 'dropped_capture_points',
+            'potential_damage_received', 'hits_received',
+            'damaging_hits_received', 'deflected_hits_received',
+            'crits_received_mask', 'hits_with_damage',
+            'sniper_damage_dealt', 'first_spotted',
+            'deflected_hits_at_low_health'}, set(rows[1]))
         for row in rows.values():
             self.assertTrue(all(key == key.lower() and key.isidentifier()
                                 for key in row))

--- a/tests/test_port_0922_lan_protocol.py
+++ b/tests/test_port_0922_lan_protocol.py
@@ -590,11 +590,13 @@ class LanProtocolTests(unittest.TestCase):
             'shots_penetrated', 'damage_dealt', 'damage_received',
             'damage_blocked', 'damage_assisted_track',
             'damage_assisted_radio', 'damage_assisted_stun',
-            'kills', 'capture_points', 'dropped_capture_points',
+            'kills', 'spotted',
+            'capture_points', 'dropped_capture_points',
             'potential_damage_received', 'hits_received',
             'damaging_hits_received', 'deflected_hits_received',
             'crits_received_mask', 'hits_with_damage',
-            'sniper_damage_dealt', 'first_spotted',
+            'sniper_damage_dealt', 'deflection_streak',
+            'best_deflection_streak',
             'deflected_hits_at_low_health'}, set(rows[1]))
         for row in rows.values():
             self.assertTrue(all(key == key.lower() and key.isidentifier()

--- a/tests/test_port_0922_server_bot_ai.py
+++ b/tests/test_port_0922_server_bot_ai.py
@@ -886,7 +886,8 @@ class ServerBotTacticsTests(unittest.TestCase):
         state = BattleState()
         state.client_build = CLIENT_BUILD_0922
         state.phase = 'battle'
-        state.tick = int(round(PREBATTLE_SECONDS * TICK_HZ))
+        prebattle_ticks = int(round(PREBATTLE_SECONDS * TICK_HZ))
+        state.tick = prebattle_ticks
         state.bot_authority_id = SIMULATION_WORKER_AUTHORITY_ID
         state.bot_manifest_authority_id = SIMULATION_WORKER_AUTHORITY_ID
         state.bot_manifest = list(self.manifest)
@@ -931,11 +932,14 @@ class ServerBotTacticsTests(unittest.TestCase):
             state.bot_planner._recent_hits[11]['attacker'])
         for unused in range(BOT_PLANNER_INTERVAL_TICKS - 1):
             state.tick_once(1.0 / TICK_HZ)
-        self.assertEqual([451], build_ticks)
+        self.assertEqual([prebattle_ticks + 1], build_ticks)
 
         state.tick_once(1.0 / TICK_HZ)
 
-        self.assertEqual([451, 481], build_ticks)
+        self.assertEqual(
+            [prebattle_ticks + 1,
+             prebattle_ticks + 1 + BOT_PLANNER_INTERVAL_TICKS],
+            build_ticks)
         order = next(
             order for order in state.bot_orders['orders']
             if order['id'] == 11)

--- a/tests/test_port_0922_server_projectiles.py
+++ b/tests/test_port_0922_server_projectiles.py
@@ -33,6 +33,7 @@ from lan_battle_server import (  # noqa: E402
 )
 from gui.mods.offline_lan_0922 import vehicle_physics
 from effective_params_fixture import effective_params
+import lan_battle_server as lan_server_module
 
 
 class _Socket(object):
@@ -1412,6 +1413,83 @@ class ServerProjectileLedgerTests(unittest.TestCase):
                     shells_before_shot=7)))
 
         self.assertIs(False, state.last_shell_shots['1:b:16:1'])
+
+    @staticmethod
+    def _ignite_player_with_projectile(state, last_shell):
+        projectile_id = '1:p:1:1'
+        self_launch = _launch()
+        if not _launch_authority(state, self_launch):
+            raise AssertionError('projectile launch failed')
+        state.last_shell_shots[projectile_id] = bool(last_shell)
+        target = state.players[2]
+        target.health = 5
+        target.max_health = 1000
+        target.critical = {
+            'devices': [], 'destroyed': [], 'crew_ko': [],
+            'crew_roster': ['commander'], 'fire': False,
+            'ammo_rack_death': False, 'events': [],
+        }
+        critical = dict(target.critical)
+        critical.update({
+            'fire': True,
+            'events': [{'kind': 'fire', 'state': True, 'cause': 'shot'}],
+        })
+        direct = _effect(
+            damage=0, critical=critical,
+            critical_target_base_revision=0,
+            critical_target_ack_seq=0, hull_damage=0,
+            critical_delta={
+                'devices': [], 'crew_ko': [], 'ignite': True,
+            })
+        if not state.resolve_projectile(
+                SIMULATION_WORKER_AUTHORITY_ID,
+                _resolve(projectile_id, direct=direct)):
+            raise AssertionError(state.last_projectile_resolve_reject)
+        return target
+
+    def test_last_shell_fire_that_burns_the_final_enemy_awards_fadin(self):
+        state = _state()
+        target = self._ignite_player_with_projectile(state, True)
+        self.assertEqual(
+            ('player', 1),
+            state.last_shell_fire_sources[('player', 2)])
+
+        with mock.patch.object(
+                lan_server_module.player_critical_mechanics,
+                'advance_fire', return_value={
+                    'damage': 5, 'critical': target.critical,
+                    'fire_elapsed': 1.0, 'fire_timer': 0.0,
+                }):
+            state._tick_player_fire(1.0)
+
+        self.assertFalse(target.alive)
+        self.assertIn(('player', 1), state.last_shell_finishers)
+        self.assertNotIn(('player', 2), state.last_shell_fire_sources)
+
+    def test_non_last_shell_fire_does_not_award_fadin(self):
+        state = _state()
+        target = self._ignite_player_with_projectile(state, False)
+        self.assertNotIn(('player', 2), state.last_shell_fire_sources)
+
+        with mock.patch.object(
+                lan_server_module.player_critical_mechanics,
+                'advance_fire', return_value={
+                    'damage': 5, 'critical': target.critical,
+                    'fire_elapsed': 1.0, 'fire_timer': 0.0,
+                }):
+            state._tick_player_fire(1.0)
+
+        self.assertFalse(target.alive)
+        self.assertEqual(set(), state.last_shell_finishers)
+
+    def test_extinguished_fire_discards_last_shell_lineage(self):
+        state = _state()
+        target = self._ignite_player_with_projectile(state, True)
+        target.critical = dict(target.critical, fire=False)
+
+        state._tick_player_fire(1.0)
+
+        self.assertNotIn(('player', 2), state.last_shell_fire_sources)
 
     def test_an_unknown_launch_field_is_still_rejected(self):
         state = _state()
@@ -3030,6 +3108,33 @@ class ServerProjectileLedgerTests(unittest.TestCase):
         self.assertEqual(900, victim.health)
         self.assertEqual(
             420, state._statistics_row('player', 2)['damage_blocked'])
+
+    def test_sturdy_counts_only_structural_low_health_deflections(self):
+        cases = (
+            ('structural', True, 1),
+            ('external', False, 0),
+            ('missing', None, 0),
+            ('malformed', 'structural', 0),
+        )
+        for label, structural, expected in cases:
+            with self.subTest(layer=label):
+                state = _state()
+                self.assertTrue(_launch_authority(state, _launch()))
+                victim = state.players[2]
+                victim.health = 50
+                direct = _effect(damage=0, shot_result=0)
+                if structural is not None:
+                    direct['structural_armor_hit'] = structural
+
+                self.assertTrue(state.ricochet_projectile(
+                    SIMULATION_WORKER_AUTHORITY_ID,
+                    _ricochet('1:p:1:1', direct=direct)))
+
+                row = state._statistics_row('player', 2)
+                self.assertEqual(1, row['deflected_hits_received'])
+                self.assertEqual(
+                    expected, row['deflected_hits_at_low_health'])
+                self.assertIn('1:p:1:1', state.projectiles)
 
     def test_splash_never_credits_blocked_damage(self):
         # Player 4 shares team 2 with the direct victim, so only the splash

--- a/tests/test_port_0922_server_projectiles.py
+++ b/tests/test_port_0922_server_projectiles.py
@@ -1355,6 +1355,46 @@ class ServerProjectileLedgerTests(unittest.TestCase):
         enabled.players[1].siege_state = SIEGE_ENABLED
         self.assertTrue(_launch_authority(enabled, _launch()))
 
+    @staticmethod
+    def _armed_bot(state, bot_id=16):
+        state.bot_states[bot_id] = {
+            'id': bot_id, 'team': 2, 'vehicle': 'ussr:R11_MS-1',
+            'health': 500, 'max_health': 500, 'alive': True,
+            'display_health': 500, 'fire_seq': 0,
+        }
+        state.bot_pending_projectile_launches.add((bot_id, 1))
+
+    def test_a_reported_shell_inventory_is_admitted_and_frozen(self):
+        state = _state()
+        self._armed_bot(state)
+
+        self.assertTrue(state.launch_projectile(
+            SIMULATION_WORKER_AUTHORITY_ID,
+            _launch(shooter_id=16, shooter_kind='bot',
+                    shells_before_shot=1)))
+
+        self.assertIs(True, state.last_shell_shots['1:b:16:1'])
+
+    def test_a_launch_with_shells_left_is_not_a_last_shell(self):
+        state = _state()
+        self._armed_bot(state)
+
+        self.assertTrue(state.launch_projectile(
+            SIMULATION_WORKER_AUTHORITY_ID,
+            _launch(shooter_id=16, shooter_kind='bot',
+                    shells_before_shot=7)))
+
+        self.assertIs(False, state.last_shell_shots['1:b:16:1'])
+
+    def test_an_unknown_launch_field_is_still_rejected(self):
+        state = _state()
+        self._armed_bot(state)
+
+        self.assertFalse(state.launch_projectile(
+            SIMULATION_WORKER_AUTHORITY_ID,
+            _launch(shooter_id=16, shooter_kind='bot',
+                    unexpected_field=1)))
+
     def test_modern_player_launch_is_atomic_and_idempotent(self):
         state = _state()
         message = _launch()

--- a/tests/test_port_0922_server_projectiles.py
+++ b/tests/test_port_0922_server_projectiles.py
@@ -1375,6 +1375,33 @@ class ServerProjectileLedgerTests(unittest.TestCase):
 
         self.assertIs(True, state.last_shell_shots['1:b:16:1'])
 
+    def test_a_zero_shell_report_cannot_award_the_last_shell(self):
+        # A shot was drawn from at least one shell, so zero fails the bound.
+        # The shot itself is already admitted and must still resolve, so the
+        # bad achievement input is contained to itself rather than destroying
+        # a legal launch.
+        state = _state()
+        self._armed_bot(state)
+
+        self.assertTrue(state.launch_projectile(
+            SIMULATION_WORKER_AUTHORITY_ID,
+            _launch(shooter_id=16, shooter_kind='bot',
+                    shells_before_shot=0)))
+
+        self.assertEqual({}, state.last_shell_shots)
+        self.assertIn('1:b:16:1', state.projectiles)
+
+    def test_two_shells_before_the_shot_is_not_a_last_shell(self):
+        state = _state()
+        self._armed_bot(state)
+
+        self.assertTrue(state.launch_projectile(
+            SIMULATION_WORKER_AUTHORITY_ID,
+            _launch(shooter_id=16, shooter_kind='bot',
+                    shells_before_shot=2)))
+
+        self.assertIs(False, state.last_shell_shots['1:b:16:1'])
+
     def test_a_launch_with_shells_left_is_not_a_last_shell(self):
         state = _state()
         self._armed_bot(state)

--- a/tools/account_lobby_consumer_contract.json
+++ b/tools/account_lobby_consumer_contract.json
@@ -34,6 +34,7 @@
       "globalRating"
     ],
     "statsDirectKeys": [
+      "dossier",
       "credits",
       "gold",
       "crystal",


### PR DESCRIPTION
Offline rounds never produced a medal. Nothing decided an award, the result
packer sent an empty `achievements` list on every row, and it never sent
`dossierPopUps` at all, so the `#1513` results screen had nothing to render.

## Where the numbers come from

Wargaming's battle server, not the client, decides medals, so
`res/packages/scripts.pkg` of HD `0.9.22.0.1 #1513` ships the thresholds
without the predicates. `scripts/common/arena_achievements.py` holds
`ACHIEVEMENT_CONDITIONS`, and `getAchievementCondition` only reads
`ACHIEVEMENT_CONDITIONS_EXT` when `ARENA_BONUS_TYPE_CAPS.checkAny` accepts the
arena bonus type — that build answers `False` for every bonus type, so the
regular battles this product packs (`bonusType` 1) use the base table.

The table holds 62 entries across every mode this build ever shipped.
`scripts/item_defs/achievements.xml` selects the subset that matters: every
achievement there carries a `mode`, and only `mode="random"` belongs to these
battles. Those thresholds were copied verbatim and diffed against the pinned
client; the new `battle_achievements` module carries the copy and the proof.
Each predicate pairs one exact constant with the publicly documented shape of
that medal. Nothing is tuned by feel.

Two medals had no public condition text under their internal name.
`item_defs/achievements.xml` places `huntsman` in the `epic` section and
`ACHIEVEMENTS.pyc` gives it a `heroInfo` key, which only medals named after a
person carry; it is the one epic medal in Wargaming's published list left
unmatched once every other name is bound, so `huntsman` is Naidin's Medal —
destroy every enemy light tank, at least three. `ironMan` is the one
commemorative medal left unmatched the same way, and its `minHits` of 10 is
Cool-Headed: ten ricochets and non-penetrations in a row.

## Awarded (39)

Battle heroes, one actor per battle, ordered by the medal's own metric and
tie-broken on earned experience: `warrior`, `invader`, `defender`,
`steelwall`, `mainGun`, `supporter`, `scout`, `evileye`, `sniper2`.

Historical, special and commemorative medals, per actor: `heroesOfRassenay`,
`medalLafayettePool`, `medalRadleyWalters`, `medalOrlik`, `medalOskin`,
`medalNikolas`, `medalLehvaslaiho`, `medalHalonen`, `medalBurda`,
`medalPascucci`, `medalDumitru`, `medalTamadaYoshio`, `medalBillotte`,
`medalBrunoPietro`, `medalTarczay`, `medalKolobanov`, `medalDeLanglade`,
`medalGore`, `medalStark`, `medalCoolBlood`, `medalAntiSpgFire`,
`bombardier`, `kamikaze`, `sturdy`, `raider`, `medalFadin`, `huntsman`,
`ironMan`, `luckyDevil`, `medalMonolith`.

Bots are ordinary participants and can take a battle-hero medal.

## Deliberately not awarded (7)

Four of these the client itself rules out, and the pinned build says so:

- `gui/shared/gui_items/dossier/factories.pyc` registers `sniper` and
  `medalWittmann` as `DeprecatedAchievement`, whose `checkIsValid` returns
  `validators.alreadyAchieved`. `#1513` accepts an existing one in a dossier
  and refuses a newly earned one.
- `alaric` and `lumberjack` have thresholds and record IDs but no entry at all
  in `item_defs/achievements.xml`, so the client has no metadata to render
  them. Wargaming cancelled both before release.

The last three are product decisions rather than missing data:
`medalBrothersInArms` and `medalCrucialContribution` are platoon awards and
this product has no platoons, and `markOfMastery` needs the per-vehicle
experience distributions retail computes.

Which subset of the 62-entry `#1513` condition table applies at all comes from
`item_defs/achievements.xml`: every achievement there carries a `mode`, and
only `mode="random"` belongs to the battles this product packs.

## What else changed

- **Capture points were never recorded.** `capture_points` and
  `dropped_capture_points` existed in the receipt but nothing ever wrote them,
  so both results columns read zero and Invader and Defender could not exist.
  The server now credits each capturing vehicle per capture tick, and credits
  the enemy whose damage reset a capture.
- **New canonical round state** the results screen shows and the conditions
  read: hits received, potential damage received, damaging and deflected hits
  received, the longest run of consecutive bounces, critical hits received,
  hits that dealt damage, damage dealt from 300 m or more, damage dealt to
  one's own team, and each kill's rammer speed.
- **`spotted` is now a detection count.** A vehicle is detected when it becomes
  visible to a team that could not see it a moment earlier, and every direct
  observer on that team at that instant detected it; the statistic counts
  distinct enemies per observer. It used to count every enemy a vehicle had
  ever directly seen, with no team fence and no way back down, so teammates
  inflated it. Patrol Duty reads the same number and earned experience moves
  with it.
- **Ammunition reaches the server from whoever owns the gun.** The visible
  client puts `shells_before_shot` on its fire intent, read before the local
  gun debits the round; the worker puts the same field on a Bot launch,
  computed from the inventory it has just debited. Neither side infers it.
  Four exact contracts gate that path — the fire-intent key set, the
  projectile-launch allowlist, the worker's relay check, and the projection
  that decides which Bot fields reach the launch publisher. The first three
  reject an unknown field outright and now accept this one as optional, each
  with a regression test that an unknown field is still refused; the fourth
  dropped it silently, which would have left Bots unable to earn the medal
  with nothing to show for it.
- **Two shipped predicates corrected.** Gore's Medal now requires a clean sheet
  against one's own team, which its published condition states, and
  Counter-Battery Fire now asks for the whole enemy battery rather than any two
  artillery kills, the same "all of one class" shape Naidin's Medal uses.
- **`crits` interaction bitmask.** `gui/shared/crits_mask_parser.py` reads bits
  0-7 as critically damaged devices, 12-23 as destroyed devices and 24-31 as
  destroyed crew. The server builds exactly that mask; a decode against the
  pinned parser returns the modules and crew it was built from.
- **Dossiers.** Vehicle and account dossiers keep one counter per medal plus
  the `battleHeroes` aggregate, and the account snapshot now publishes the
  `stats` key `dossier` that `StatsRequester.accountDossier` reads. `#1513`
  `PlayerAccount._update` has no special path for that key, so it stays a
  plain cache write in the incremental post-battle diff.

## Verified

- Every copied threshold diffed against `arena_achievements` in the pinned
  client with zero drift, and all 39 awardable names resolved through the real
  `dossiers2.custom.records.RECORD_DB_IDS`.
- `sniper` and `medalWittmann` confirmed as `DeprecatedAchievement` by
  disassembling the `factories.pyc` registry, and `alaric` and `lumberjack`
  confirmed absent from `item_defs/achievements.xml`.
- `VEH_FULL_RESULTS` and `VEH_PUBLIC_RESULTS` round-trip `achievements`,
  `dossierPopUps`, `directHitsReceived` and `potentialDamageReceived` through
  the pinned packers.
- `getVehicleDossierDescr` and `getAccountDossierDescr` round-trip the medal
  counters; an unregistered name raises `KeyError`, which the writer skips.
- A server crits mask decodes through the pinned `critsParserGenerator` to the
  exact modules and crew it was built from.
- Full `python -m unittest discover -s tests` suite, plus the CPython 2.7
  source compile gate over `src/res/scripts/client`.

## Known deviations

- `sniper2` omits the documented "damage must exceed your own hit points"
  clause, which is not one of the `#1513` constants.
- `medalStark` omits the documented "damage received plus blocked is at least
  two thirds of your hit points" clause for the same reason.
- `medalCoolBlood` omits the documented "light tanks only, Tier IV or above"
  clauses; `#1513` ships only the distance and the kill count, and the wiki
  text cannot be dated to this build.
- `luckyDevil` is faithful but rarely reachable: it needs the enemy team to
  destroy one of its own members within 10.99 m of the recipient.
- A re-requested archived result carries the account's current medal totals as
  the badge counters, not the totals at that battle.

## Not proved

Only acceptance on the exact Windows client can show the results window
rendering these ribbons, counters and tooltips, or the profile page listing
them.

## Also restores a red `main`

`main` has been failing its own test suite since 265fb9a, "Shorten prebattle
countdown to ten seconds", which carried `[skip ci]` and so was never checked.
Its parent ca42ded is the last green run. Two tests restated that countdown as
a literal instead of deriving it:

- `test_half_even_player_preinstall_matches_real_server_echo` froze the trigger
  at `15000` ms while setting the server tick from `PREBATTLE_SECONDS`. At ten
  seconds the trigger is five seconds past the server's own receipt time, so
  `launch_projectile` rejects it through the `_exact_int(..., 0,
  self._server_time_ms())` bound.
- `test_observation_and_damage_memory_survive_skipped_plan_ticks` expected
  planner builds on ticks `451` and `481`, which were `PREBATTLE_SECONDS *
  TICK_HZ + 1` and one planner interval later.

Both now derive the value they were asserting, so the next countdown change
cannot break them again. This is why the achievements work is committed on top
of a red base; without it the `Run client test suite` step fails and the
packaging steps never run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
