### PR TITLE
Keep as many named saves as the player wants

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -63,10 +63,22 @@ and fuel tank, plus an automatic fire extinguisher, a large first aid kit and a
 large repair kit. Every item costs nothing.
 
 Change modules, optional devices, consumables, shells, camouflage and crew
-skills as you like. Each change is written to
-mods\configs\offline_lan_0922\garage_state.json, so the garage survives a
-restart. Crew skills, optional devices and consumables move the same values the
-garage parameters panel shows, and the battle uses those values.
+skills as you like. Each change is written to the selected save, so the garage
+survives a restart. Crew skills, optional devices and consumables move the same
+values the garage parameters panel shows, and the battle uses those values.
+
+Saves
+-----
+
+The Launcher's Saves tab keeps as many independent saves as you want. Each one
+has its own garage, crew, account settings and battle results, and the selected
+save is the one the game starts with. Saves live in
+%APPDATA%\Wargaming.net\WorldOfTanks\offline_lan_0922\saves\<save>\. A save you
+made in an older build keeps working: its files move into the default save the
+first time this build starts.
+
+Vehicle data profiles are not part of a save. They change the client's shared
+vehicle catalogue for a whole room, so they stay with the installation.
 
 The Launcher's Tools tab can also edit vehicle data directly. A vehicle data
 profile is a named set of Packed XML field changes (health, damage,
@@ -109,10 +121,11 @@ Troubleshooting
   mods\configs\offline_lan_0922\config.json as a backup, and extract this ZIP
   again. This restores the default configuration without deleting the garage,
   account progress, vehicle-data overrides or battle results. To reset every
-  ordinary offline save manually, delete config.json, server_endpoint.json,
-  account_state.json, garage_state.json and postbattle_state.json while the
-  game is closed, then extract this ZIP again. Vehicle-data overlays are
-  separate and are not removed by that reset.
+  ordinary offline save manually, delete config.json and server_endpoint.json
+  in mods\configs\offline_lan_0922 and the saves folder under
+  %APPDATA%\Wargaming.net\WorldOfTanks\offline_lan_0922 while the game is
+  closed, then extract this ZIP again. Vehicle-data overlays are separate and
+  are not removed by that reset.
 - Bot tracks and road wheels do not turn. A broken enemy track therefore has no
   visual cue; read the damage panel instead.
 - The client is 32-bit but its executable is large-address-aware, so on 64-bit

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -122,10 +122,11 @@ Troubleshooting
   again. This restores the default configuration without deleting the garage,
   account progress, vehicle-data overrides or battle results. To reset every
   ordinary offline save manually, delete config.json and server_endpoint.json
-  in mods\configs\offline_lan_0922 and the saves folder under
+  in mods\configs\offline_lan_0922, then delete account_state.json,
+  garage_state.json, postbattle_state.json and the saves folder under
   %APPDATA%\Wargaming.net\WorldOfTanks\offline_lan_0922 while the game is
-  closed, then extract this ZIP again. Vehicle-data overlays are separate and
-  are not removed by that reset.
+  closed. Extract this ZIP again afterwards. Vehicle-data overlays are
+  separate and are not removed by that reset.
 - Bot tracks and road wheels do not turn. A broken enemy track therefore has no
   visual cue; read the damage panel instead.
 - The client is 32-bit but its executable is large-address-aware, so on 64-bit

--- a/README.md
+++ b/README.md
@@ -38,12 +38,22 @@ The 0.9.22 client gets a working offline garage:
   kit and a large repair kit.
 - You can change modules, optional devices, consumables, shells, camouflage
   and crew skills. Every item costs nothing.
-- The garage is written to `mods/configs/offline_lan_0922/garage_state.json`
-  after each change, so it survives a restart.
+- The garage is written to the selected save after each change, so it survives
+  a restart.
 - The battle runs the vehicle the garage fitted. Crew skills, optional devices
   and consumables move the same values the garage parameters panel shows: view
   range, concealment, reload, aim time, dispersion, traverse, engine power,
   terrain resistance and repair speed.
+
+## Saves
+
+The launcher's Saves tab keeps any number of independent saves. Each one owns
+its own garage, crew, account settings and battle results under
+`%APPDATA%/Wargaming.net/WorldOfTanks/offline_lan_0922/saves/<save>/`, and the
+selected save is written into the client configuration when the game starts.
+State written by a build without saves moves into the default save on the next
+start. Vehicle data profiles are deliberately not part of a save: they change
+the client catalogue for a whole room, so they belong to the installation.
 
 The launcher's Tools tab can also edit vehicle data directly. A vehicle data
 profile is a named set of Packed XML field changes (health, damage,

--- a/build_wotmod.py
+++ b/build_wotmod.py
@@ -112,11 +112,12 @@ def _archive_tree(source_root, destination):
 
 def _release_config():
     return {
-        'schema': 2,
+        'schema': 3,
         'enabled': True,
         'host': '127.0.0.1',
         'port': 28782,
         'name': 'Player',
+        'save_slot': 'default',
         'vehicle': 'ussr:R11_MS-1',
         'max_health': 90,
         'startupTimeoutSeconds': 30.0,

--- a/launcher/core.py
+++ b/launcher/core.py
@@ -470,7 +470,8 @@ def _read_json(path):
     return value if isinstance(value, dict) else None
 
 
-def write_0_9_22_settings(game_root, mode, host, port, name=None):
+def write_0_9_22_settings(game_root, mode, host, port, name=None,
+                          save_slot=None):
     config_dir = os.path.join(game_root, "mods", "configs", "offline_lan_0922")
     endpoint_path = os.path.join(config_dir, "server_endpoint.json")
     _write_json(endpoint_path, {
@@ -478,20 +479,35 @@ def write_0_9_22_settings(game_root, mode, host, port, name=None):
         "host": host,
         "port": int(port),
     })
+    try:
+        from . import save_slots
+    except ImportError:
+        import save_slots
+
     written = [endpoint_path]
-    if name:
+    if save_slot is not None and not save_slots.valid_slot_id(save_slot):
+        raise LauncherError("This save cannot be selected.")
+    if name or save_slot:
         config_path = os.path.join(config_dir, "config.json")
         config = _read_json(config_path)
         if config is not None:
-            config["name"] = name
+            if name:
+                config["name"] = name
+            if save_slot:
+                # The client resolves its garage, post-battle results, and
+                # account settings from this field, so the selected save takes
+                # effect for the run this launch starts.
+                config["save_slot"] = save_slot
             _write_json(config_path, config)
             written.append(config_path)
     return written
 
 
-def write_settings(game_root, port_version, mode, host, port, name=None):
+def write_settings(game_root, port_version, mode, host, port, name=None,
+                   save_slot=None):
     if port_version == PORT_0_9_22:
-        return write_0_9_22_settings(game_root, mode, host, port, name)
+        return write_0_9_22_settings(
+            game_root, mode, host, port, name, save_slot)
     raise LauncherError("This game folder is not a supported client.")
 
 
@@ -521,6 +537,11 @@ _MUTABLE_STATE_0_9_22 = (
     "garage_state.json",
     "postbattle_state.json",
 )
+
+# Where save slots live below the user data directory.  It matches the client's
+# ``config.SAVES_DIR_NAME`` and only ever appears inside the game folder when
+# the installation has no APPDATA to use instead.
+SAVES_DIR_NAME_0_9_22 = "saves"
 
 # Directories the launcher replaces as one unit, the files of its own package
 # it removes from a shared directory, and the members it writes only when they
@@ -1278,6 +1299,11 @@ def install_client_mod(game_root, port_version, base_dir=None, force=False):
 def _valid_0_9_22_config(path):
     """Match the startup-fatal part of the client config contract."""
     try:
+        from . import save_slots
+    except ImportError:
+        import save_slots
+
+    try:
         with open(path, "rb") as stream:
             value = json.load(stream)
         if not isinstance(value, dict):
@@ -1294,6 +1320,11 @@ def _valid_0_9_22_config(path):
             if name in value and (not isinstance(value[name], str) or
                                   not value[name]):
                 return False
+        # The client refuses to start on an unusable save id, so startup
+        # repair has to recognise the same fatal value and quarantine it.
+        if "save_slot" in value and not save_slots.valid_slot_id(
+                value["save_slot"]):
+            return False
         for name in ("physics_tuning", "he_tuning"):
             if name in value and not isinstance(value[name], dict):
                 return False
@@ -1465,6 +1496,12 @@ def reset_0_9_22_state(game_root, base_dir=None, is_running=None):
                    for name in sorted(os.listdir(state_root))
                    if _reset_state_name(name) and
                    os.path.isfile(os.path.join(state_root, name))]
+        # An installation without APPDATA keeps its save slots here instead,
+        # so a reset that skipped this directory would leave every earned
+        # garage behind and contradict what the confirmation promised.
+        saves_root = os.path.join(state_root, SAVES_DIR_NAME_0_9_22)
+        if os.path.isdir(saves_root) and not os.path.islink(saves_root):
+            targets.append(saves_root)
     preferences_path = _isolated_0_9_22_preferences_path()
     if preferences_path is not None and os.path.lexists(preferences_path):
         if (os.path.islink(preferences_path) or

--- a/launcher/core.py
+++ b/launcher/core.py
@@ -1487,10 +1487,17 @@ def reset_0_9_22_state(game_root, base_dir=None, is_running=None):
     import shutil
     import tempfile
 
+    try:
+        from . import save_slots
+    except ImportError:
+        import save_slots
+
     _require_0_9_22_maintenance_target(game_root, is_running)
     state_root = _relative_path(
         game_root, "mods/configs/offline_lan_0922")
     targets = []
+    fallback_saves_root = os.path.join(
+        state_root, SAVES_DIR_NAME_0_9_22)
     if os.path.isdir(state_root):
         targets = [os.path.join(state_root, name)
                    for name in sorted(os.listdir(state_root))
@@ -1499,9 +1506,31 @@ def reset_0_9_22_state(game_root, base_dir=None, is_running=None):
         # An installation without APPDATA keeps its save slots here instead,
         # so a reset that skipped this directory would leave every earned
         # garage behind and contradict what the confirmation promised.
-        saves_root = os.path.join(state_root, SAVES_DIR_NAME_0_9_22)
-        if os.path.isdir(saves_root) and not os.path.islink(saves_root):
-            targets.append(saves_root)
+        if (os.path.isdir(fallback_saves_root) and
+                not os.path.islink(fallback_saves_root)):
+            targets.append(fallback_saves_root)
+    active_saves_root = save_slots.saves_root(game_root)
+    same_saves_root = (
+        os.path.normcase(os.path.abspath(active_saves_root)) ==
+        os.path.normcase(os.path.abspath(fallback_saves_root)))
+    if not same_saves_root:
+        # The default slot deliberately keeps the old APPDATA-root files for
+        # downgrade safety. A confirmed reset must remove those copies too,
+        # otherwise the next start migrates them straight back into default.
+        active_state_root = os.path.dirname(active_saves_root)
+        if os.path.isdir(active_state_root):
+            targets.extend(
+                os.path.join(active_state_root, name)
+                for name in sorted(os.listdir(active_state_root))
+                if _reset_state_name(name) and
+                os.path.isfile(os.path.join(active_state_root, name)))
+        if os.path.lexists(active_saves_root):
+            if (os.path.islink(active_saves_root) or
+                    not os.path.isdir(active_saves_root)):
+                raise LauncherError(
+                    "The offline saves path is not a regular directory; it "
+                    "was left unchanged.")
+            targets.append(active_saves_root)
     preferences_path = _isolated_0_9_22_preferences_path()
     if preferences_path is not None and os.path.lexists(preferences_path):
         if (os.path.islink(preferences_path) or
@@ -1515,19 +1544,27 @@ def reset_0_9_22_state(game_root, base_dir=None, is_running=None):
     backup_roots = [backup_root]
     moved = []
     try:
-        preferences_backup_root = None
-        if preferences_path is not None and preferences_path in targets:
-            # LOCALAPPDATA and the game can be on different volumes. Keep this
-            # backup beside the profile so both the delete and rollback remain
-            # atomic filesystem replacements.
-            preferences_backup_root = tempfile.mkdtemp(
-                prefix=".wot-offline-reset-",
-                dir=os.path.dirname(preferences_path))
-            backup_roots.append(preferences_backup_root)
+        external_backup_roots = {}
+        absolute_game_root = os.path.abspath(game_root)
+        for target in targets:
+            absolute_target = os.path.abspath(target)
+            try:
+                target_is_external = os.path.commonpath(
+                    (absolute_game_root, absolute_target)) != absolute_game_root
+            except ValueError:
+                target_is_external = True
+            if target_is_external:
+                # APPDATA and the game can be on different volumes. Keep each
+                # external backup beside its target so both the delete and
+                # rollback remain atomic filesystem replacements.
+                external_backup = tempfile.mkdtemp(
+                    prefix=".wot-offline-reset-",
+                    dir=os.path.dirname(target))
+                external_backup_roots[target] = external_backup
+                backup_roots.append(external_backup)
         for index, target in enumerate(targets):
-            target_backup_root = (
-                preferences_backup_root
-                if target == preferences_path else backup_root)
+            target_backup_root = external_backup_roots.get(
+                target, backup_root)
             backup = os.path.join(target_backup_root, str(index))
             os.replace(target, backup)
             moved.append((target, backup))

--- a/launcher/save_slots.py
+++ b/launcher/save_slots.py
@@ -1,0 +1,310 @@
+"""Named save slots for one installation's earned player progress.
+
+A save slot is a directory holding exactly the files that record what a player
+has earned: the garage, the post-battle results, and the account settings the
+retail server would otherwise own.  The client mod resolves those three paths
+from ``config.json``'s ``save_slot`` field, so switching slots here and writing
+that field is the whole of the switch.
+
+What a slot deliberately does not own:
+
+- ``server_endpoint.json`` and the waiting-room state describe this machine's
+  current room, not the player's progress;
+- ``vehicle_profiles.json`` (``vehicle_overlays``) modifies the shared client
+  catalogue for a whole room.  It is a data mod, not a save, and mixing the two
+  would make a room's vehicle data change when a player picked another slot.
+
+The mod owns the contents of the three state files.  This module only creates,
+renames, lists, and deletes their containing directories, plus the small
+``save.json`` record naming the slot and how it was created.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import time
+
+SAVES_DIR_NAME = "saves"
+DEFAULT_SLOT_ID = "default"
+METADATA_NAME = "save.json"
+METADATA_SCHEMA = 1
+
+# How a slot was created.  ``unlocked`` is the historical offline garage: every
+# vehicle owned and every balance effectively unlimited.  ``new_account``
+# starts from the tier-1 vehicles the way a fresh retail account does.
+MODE_UNLOCKED = "unlocked"
+MODE_NEW_ACCOUNT = "new_account"
+MODES = (MODE_UNLOCKED, MODE_NEW_ACCOUNT)
+
+MAX_SLOT_NAME_LENGTH = 64
+STATE_FILE_NAMES = (
+    "garage_state.json",
+    "postbattle_state.json",
+    "account_state.json",
+)
+APPDATA_PARTS = ("Wargaming.net", "WorldOfTanks", "offline_lan_0922")
+LEGACY_RELATIVE = "mods/configs/offline_lan_0922"
+
+# The id becomes one directory name.  Keep it to characters that need no
+# escaping on Windows and cannot walk out of the saves root.
+_SLOT_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
+_UNSAFE_ID_CHARS = re.compile(r"[^A-Za-z0-9_-]+")
+
+
+class SaveSlotError(Exception):
+    pass
+
+
+def valid_slot_id(value):
+    return bool(isinstance(value, str) and _SLOT_ID.match(value))
+
+
+def _contained(root, path, label):
+    absolute_root = os.path.abspath(root)
+    absolute_path = os.path.abspath(path)
+    try:
+        if os.path.commonpath((absolute_root, absolute_path)) != absolute_root:
+            raise SaveSlotError("%s escapes the saves directory." % label)
+    except ValueError:
+        raise SaveSlotError("%s escapes the saves directory." % label)
+    return absolute_path
+
+
+def saves_root(game_root=None, environment=None):
+    """Return the saves directory, matching the mod's own resolution order.
+
+    ``config.USER_DATA_DIR`` prefers ``%APPDATA%`` and falls back to the
+    directory holding ``config.json``.  Resolving it the same way here means
+    the launcher and the client always agree on where a slot lives.
+    """
+    environment = os.environ if environment is None else environment
+    appdata = environment.get("APPDATA")
+    if isinstance(appdata, str) and appdata.strip():
+        return os.path.join(
+            os.path.abspath(appdata.strip()), *APPDATA_PARTS, SAVES_DIR_NAME)
+    if not game_root:
+        raise SaveSlotError(
+            "Save slots need either APPDATA or the game folder.")
+    return os.path.join(
+        os.path.abspath(game_root), *LEGACY_RELATIVE.split("/"),
+        SAVES_DIR_NAME)
+
+
+def slot_dir(slot_id, game_root=None, environment=None, root=None):
+    if not valid_slot_id(slot_id):
+        raise SaveSlotError(
+            "A save id may only use letters, digits, _ and -.")
+    root = saves_root(game_root, environment) if root is None else root
+    return _contained(root, os.path.join(root, slot_id), "The save")
+
+
+def metadata_path(slot_id, game_root=None, environment=None, root=None):
+    return os.path.join(
+        slot_dir(slot_id, game_root, environment, root), METADATA_NAME)
+
+
+def _normalized_name(raw_name):
+    if not isinstance(raw_name, str):
+        raise SaveSlotError("The save name must be text.")
+    name = " ".join(raw_name.split())
+    if not name:
+        raise SaveSlotError("The save name must not be empty.")
+    if len(name) > MAX_SLOT_NAME_LENGTH:
+        raise SaveSlotError(
+            "The save name may be at most %d characters."
+            % MAX_SLOT_NAME_LENGTH)
+    return name
+
+
+def _normalized_mode(raw_mode):
+    mode = str(raw_mode or "").strip()
+    if mode not in MODES:
+        raise SaveSlotError("Unknown save type: %r" % (raw_mode,))
+    return mode
+
+
+def _read_metadata(path):
+    try:
+        with open(path, "rb") as stream:
+            value = json.load(stream)
+    except (IOError, OSError, ValueError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _write_metadata(path, value):
+    directory = os.path.dirname(path)
+    if directory and not os.path.isdir(directory):
+        os.makedirs(directory)
+    temporary = path + ".tmp"
+    with open(temporary, "w", encoding="utf-8") as stream:
+        json.dump(value, stream, indent=2, sort_keys=True, ensure_ascii=False)
+        stream.write("\n")
+    os.replace(temporary, path)
+
+
+def _record(slot_id, directory, metadata):
+    """Return one displayable slot record.
+
+    A slot whose ``save.json`` is missing or unreadable is still a real save:
+    the three state files beside it are what the player earned.  Report it with
+    a fallback name rather than hiding progress behind a damaged label.
+    """
+    metadata = metadata if isinstance(metadata, dict) else {}
+    name = metadata.get("name")
+    if not isinstance(name, str) or not name.strip():
+        name = slot_id
+    mode = metadata.get("mode")
+    if mode not in MODES:
+        mode = MODE_UNLOCKED
+    try:
+        created = int(metadata.get("created", 0) or 0)
+    except (TypeError, ValueError):
+        created = 0
+    return {
+        "id": slot_id,
+        "name": " ".join(name.split())[:MAX_SLOT_NAME_LENGTH],
+        "mode": mode,
+        "created": created,
+        "path": directory,
+        "has_state": any(
+            os.path.isfile(os.path.join(directory, state_name))
+            for state_name in STATE_FILE_NAMES),
+    }
+
+
+def default_record(game_root=None, environment=None, root=None):
+    """Return the always-present default slot, created or not.
+
+    An installation that upgraded from an older package has no ``saves``
+    directory at all until the client migrates its state on the next start, so
+    the default slot must be listable before it exists on disk.
+    """
+    directory = slot_dir(DEFAULT_SLOT_ID, game_root, environment, root)
+    return _record(
+        DEFAULT_SLOT_ID, directory,
+        _read_metadata(os.path.join(directory, METADATA_NAME)))
+
+
+def list_slots(game_root=None, environment=None, root=None):
+    """Return every save slot, default first and the rest by name."""
+    root = saves_root(game_root, environment) if root is None else root
+    records = {DEFAULT_SLOT_ID: default_record(root=root)}
+    try:
+        entries = sorted(os.listdir(root))
+    except (IOError, OSError):
+        entries = []
+    for entry in entries:
+        if not valid_slot_id(entry) or entry == DEFAULT_SLOT_ID:
+            continue
+        directory = os.path.join(root, entry)
+        if not os.path.isdir(directory):
+            continue
+        records[entry] = _record(
+            entry, directory,
+            _read_metadata(os.path.join(directory, METADATA_NAME)))
+    ordered = [records.pop(DEFAULT_SLOT_ID)]
+    ordered.extend(sorted(
+        records.values(), key=lambda row: (row["name"].lower(), row["id"])))
+    return ordered
+
+
+def read_slot(slot_id, game_root=None, environment=None, root=None):
+    directory = slot_dir(slot_id, game_root, environment, root)
+    if slot_id != DEFAULT_SLOT_ID and not os.path.isdir(directory):
+        raise SaveSlotError("This save no longer exists.")
+    return _record(
+        slot_id, directory,
+        _read_metadata(os.path.join(directory, METADATA_NAME)))
+
+
+def _allocate_slot_id(name, root):
+    """Derive a directory name from the display name.
+
+    A Chinese or otherwise non-ASCII name leaves nothing usable behind, so fall
+    back to a numbered ``save`` id instead of encoding the name into a path.
+    """
+    base = _UNSAFE_ID_CHARS.sub("-", name).strip("-")[:48]
+    if not base or not _SLOT_ID.match(base):
+        base = "save"
+    candidate = base
+    suffix = 2
+    while os.path.exists(os.path.join(root, candidate)):
+        candidate = "%s-%d" % (base, suffix)
+        suffix += 1
+        if suffix > 9999:
+            raise SaveSlotError("Too many saves with a similar name.")
+    return candidate
+
+
+def create_slot(name, mode, game_root=None, environment=None, root=None,
+                now=None):
+    """Create one empty slot directory and its ``save.json`` record.
+
+    The state files are deliberately not written here.  The client creates each
+    one the first time it has something to save, and an empty slot is exactly
+    what a new save is.
+    """
+    name = _normalized_name(name)
+    mode = _normalized_mode(mode)
+    root = saves_root(game_root, environment) if root is None else root
+    if not os.path.isdir(root):
+        os.makedirs(root)
+    slot_id = _allocate_slot_id(name, root)
+    directory = slot_dir(slot_id, root=root)
+    try:
+        os.makedirs(directory)
+    except (IOError, OSError) as error:
+        raise SaveSlotError("The save could not be created: %s" % error)
+    try:
+        _write_metadata(os.path.join(directory, METADATA_NAME), {
+            "schema": METADATA_SCHEMA,
+            "id": slot_id,
+            "name": name,
+            "mode": mode,
+            "created": int(time.time() if now is None else now),
+        })
+    except (IOError, OSError) as error:
+        shutil.rmtree(directory, ignore_errors=True)
+        raise SaveSlotError("The save could not be created: %s" % error)
+    return read_slot(slot_id, root=root)
+
+
+def rename_slot(slot_id, name, game_root=None, environment=None, root=None):
+    """Change a slot's display name, keeping its directory and state."""
+    name = _normalized_name(name)
+    record = read_slot(slot_id, game_root, environment, root)
+    path = os.path.join(record["path"], METADATA_NAME)
+    metadata = _read_metadata(path) or {}
+    metadata.update({
+        "schema": METADATA_SCHEMA,
+        "id": slot_id,
+        "name": name,
+        "mode": record["mode"],
+        "created": record["created"] or int(time.time()),
+    })
+    try:
+        _write_metadata(path, metadata)
+    except (IOError, OSError) as error:
+        raise SaveSlotError("The save could not be renamed: %s" % error)
+    return read_slot(slot_id, game_root, environment, root)
+
+
+def delete_slot(slot_id, game_root=None, environment=None, root=None):
+    """Delete one slot directory and everything the player earned in it.
+
+    The default slot is the fallback every install can always select, and it
+    also owns the state migrated from packages that predate save slots, so it
+    is never deletable.  Resetting it is what "Reset all offline data" is for.
+    """
+    if slot_id == DEFAULT_SLOT_ID:
+        raise SaveSlotError("The default save cannot be deleted.")
+    record = read_slot(slot_id, game_root, environment, root)
+    try:
+        shutil.rmtree(record["path"])
+    except (IOError, OSError) as error:
+        raise SaveSlotError("The save could not be deleted: %s" % error)
+    return record

--- a/launcher/save_slots.py
+++ b/launcher/save_slots.py
@@ -70,6 +70,15 @@ def _contained(root, path, label):
             raise SaveSlotError("%s escapes the saves directory." % label)
     except ValueError:
         raise SaveSlotError("%s escapes the saves directory." % label)
+    # The slot itself must not be a symlink or junction. Resolve the root once
+    # so APPDATA may legitimately be redirected, then require every component
+    # below that root to retain its expected real path.
+    relative = os.path.relpath(absolute_path, absolute_root)
+    expected_real_path = os.path.abspath(
+        os.path.join(os.path.realpath(absolute_root), relative))
+    real_path = os.path.realpath(absolute_path)
+    if os.path.normcase(real_path) != os.path.normcase(expected_real_path):
+        raise SaveSlotError("%s escapes the saves directory." % label)
     return absolute_path
 
 
@@ -136,9 +145,6 @@ def _read_metadata(path):
 
 
 def _write_metadata(path, value):
-    directory = os.path.dirname(path)
-    if directory and not os.path.isdir(directory):
-        os.makedirs(directory)
     temporary = path + ".tmp"
     with open(temporary, "w", encoding="utf-8") as stream:
         json.dump(value, stream, indent=2, sort_keys=True, ensure_ascii=False)
@@ -200,7 +206,10 @@ def list_slots(game_root=None, environment=None, root=None):
     for entry in entries:
         if not valid_slot_id(entry) or entry == DEFAULT_SLOT_ID:
             continue
-        directory = os.path.join(root, entry)
+        try:
+            directory = slot_dir(entry, root=root)
+        except SaveSlotError:
+            continue
         if not os.path.isdir(directory):
             continue
         records[entry] = _record(
@@ -277,6 +286,12 @@ def rename_slot(slot_id, name, game_root=None, environment=None, root=None):
     """Change a slot's display name, keeping its directory and state."""
     name = _normalized_name(name)
     record = read_slot(slot_id, game_root, environment, root)
+    if (slot_id == DEFAULT_SLOT_ID and
+            not os.path.isdir(record["path"])):
+        try:
+            os.makedirs(record["path"])
+        except (IOError, OSError) as error:
+            raise SaveSlotError("The save could not be renamed: %s" % error)
     path = os.path.join(record["path"], METADATA_NAME)
     metadata = _read_metadata(path) or {}
     metadata.update({

--- a/launcher/tests/test_launcher_core.py
+++ b/launcher/tests/test_launcher_core.py
@@ -1115,6 +1115,57 @@ class ClientInstallTest(unittest.TestCase):
             self.game, *saves_root.rstrip("/").split("/"))))
         self.assertEqual("keep", self._read(state_root + "notes.json"))
 
+    def test_reset_deletes_save_slots_from_appdata(self):
+        default_config = json.dumps({"enabled": True})
+        self._stage_0_9_22(default_config)
+        self._make_0_9_22_target()
+        appdata = os.path.join(self.work, "appdata")
+        saves_root = os.path.join(
+            appdata, "Wargaming.net", "WorldOfTanks", "offline_lan_0922",
+            core.SAVES_DIR_NAME_0_9_22)
+        state_root = os.path.dirname(saves_root)
+        self._write(
+            saves_root, "default/garage_state.json", "default garage")
+        self._write(
+            saves_root, "career/postbattle_state.json", "career results")
+        self._write(state_root, "garage_state.json", "legacy garage")
+        self._write(state_root, "notes.json", "keep")
+
+        with mock.patch.dict(os.environ, {"APPDATA": appdata}):
+            core.reset_0_9_22_state(
+                self.game, self.payload, is_running=lambda: False)
+
+        self.assertFalse(os.path.exists(saves_root))
+        self.assertFalse(os.path.exists(os.path.join(
+            state_root, "garage_state.json")))
+        with open(os.path.join(state_root, "notes.json")) as stream:
+            self.assertEqual("keep", stream.read())
+
+    def test_failed_reset_restores_appdata_saves_and_legacy_state(self):
+        self._make_0_9_22_target()
+        appdata = os.path.join(self.work, "appdata")
+        saves_root = os.path.join(
+            appdata, "Wargaming.net", "WorldOfTanks", "offline_lan_0922",
+            core.SAVES_DIR_NAME_0_9_22)
+        state_root = os.path.dirname(saves_root)
+        self._write(
+            saves_root, "default/garage_state.json", "default garage")
+        self._write(state_root, "garage_state.json", "legacy garage")
+
+        with mock.patch.dict(os.environ, {"APPDATA": appdata}), \
+                mock.patch.object(
+                    core, "install_client_mod",
+                    side_effect=core.LauncherError("install failed")):
+            with self.assertRaisesRegex(core.LauncherError, "install failed"):
+                core.reset_0_9_22_state(
+                    self.game, self.payload, is_running=lambda: False)
+
+        with open(os.path.join(
+                saves_root, "default", "garage_state.json")) as stream:
+            self.assertEqual("default garage", stream.read())
+        with open(os.path.join(state_root, "garage_state.json")) as stream:
+            self.assertEqual("legacy garage", stream.read())
+
     def test_reset_also_deletes_only_the_isolated_client_preferences(self):
         default_config = json.dumps({"enabled": True})
         self._stage_0_9_22(default_config)

--- a/launcher/tests/test_launcher_core.py
+++ b/launcher/tests/test_launcher_core.py
@@ -810,6 +810,47 @@ class ClientInstallTest(unittest.TestCase):
         self.assertEqual("mine", self._read(
             "mods/configs/offline_lan_0922/config.json"))
 
+    def test_the_selected_save_reaches_the_client_configuration(self):
+        self._stage_0_9_22()
+        self._write(self.game, "mods/configs/offline_lan_0922/config.json",
+                    json.dumps({"schema": 3, "name": "Player",
+                                "save_slot": "default"}))
+
+        core.write_settings(
+            self.game, core.PORT_0_9_22, core.MODE_SINGLE, "127.0.0.1",
+            28782, "Peng", "career-2")
+
+        config = json.loads(
+            self._read("mods/configs/offline_lan_0922/config.json"))
+        self.assertEqual("career-2", config["save_slot"])
+        self.assertEqual("Peng", config["name"])
+
+    def test_a_launch_without_a_save_leaves_the_configured_one_alone(self):
+        self._stage_0_9_22()
+        self._write(self.game, "mods/configs/offline_lan_0922/config.json",
+                    json.dumps({"schema": 3, "save_slot": "career-2"}))
+
+        core.write_settings(
+            self.game, core.PORT_0_9_22, core.MODE_SINGLE, "127.0.0.1", 28782)
+
+        config = json.loads(
+            self._read("mods/configs/offline_lan_0922/config.json"))
+        self.assertEqual("career-2", config["save_slot"])
+
+    def test_an_unusable_save_id_never_reaches_the_client(self):
+        self._stage_0_9_22()
+        self._write(self.game, "mods/configs/offline_lan_0922/config.json",
+                    json.dumps({"schema": 3, "save_slot": "default"}))
+
+        with self.assertRaises(core.LauncherError):
+            core.write_settings(
+                self.game, core.PORT_0_9_22, core.MODE_SINGLE, "127.0.0.1",
+                28782, "Peng", "../escape")
+
+        config = json.loads(
+            self._read("mods/configs/offline_lan_0922/config.json"))
+        self.assertEqual("default", config["save_slot"])
+
     def test_0_9_22_install_writes_a_missing_configuration(self):
         self._stage_0_9_22()
         core.install_client_mod(self.game, core.PORT_0_9_22, self.payload)
@@ -864,6 +905,38 @@ class ClientInstallTest(unittest.TestCase):
         self.assertEqual("theirs", self._read(
             "mods/0.9.22.0.1/com.other.mod.wotmod"))
         self.assertIn("kept the saved endpoint", " ".join(actions))
+
+    def test_startup_repair_quarantines_an_unusable_save_id(self):
+        """The client refuses to start on it, so repair has to notice it too."""
+        default_config = json.dumps({"enabled": True, "save_slot": "default"})
+        self._stage_0_9_22(default_config)
+        self._make_0_9_22_target()
+        broken = json.dumps({"enabled": True, "save_slot": "../escape"})
+        self._write(
+            self.game, "mods/configs/offline_lan_0922/config.json", broken)
+
+        core.repair_0_9_22_startup(
+            self.game, self.payload, is_running=lambda: False)
+
+        self.assertEqual(default_config, self._read(
+            "mods/configs/offline_lan_0922/config.json"))
+        self.assertEqual(broken, self._read(
+            "mods/configs/offline_lan_0922/config.json.invalid"))
+
+    def test_startup_repair_keeps_a_named_save(self):
+        default_config = json.dumps({"enabled": True})
+        self._stage_0_9_22(default_config)
+        self._make_0_9_22_target()
+        saved_config = json.dumps({"enabled": True, "save_slot": "career-2"})
+        self._write(
+            self.game, "mods/configs/offline_lan_0922/config.json",
+            saved_config)
+
+        core.repair_0_9_22_startup(
+            self.game, self.payload, is_running=lambda: False)
+
+        self.assertEqual(saved_config, self._read(
+            "mods/configs/offline_lan_0922/config.json"))
 
     def test_startup_repair_keeps_a_valid_config(self):
         default_config = json.dumps({"enabled": True})
@@ -1018,6 +1091,29 @@ class ClientInstallTest(unittest.TestCase):
         self.assertEqual("theirs", self._read(
             "mods/0.9.22.0.1/com.other.mod.wotmod"))
         self.assertIn("Deleted 7 offline saved-data file(s).", actions)
+
+    def test_reset_deletes_the_save_slots_of_an_installation_without_appdata(
+            self):
+        """Without APPDATA the client keeps its saves inside the game folder.
+
+        Leaving them behind would contradict the reset confirmation and would
+        also leave the next start reading a garage the player asked to drop.
+        """
+        default_config = json.dumps({"enabled": True})
+        self._stage_0_9_22(default_config)
+        self._make_0_9_22_target()
+        state_root = "mods/configs/offline_lan_0922/"
+        saves_root = state_root + core.SAVES_DIR_NAME_0_9_22 + "/"
+        self._write(self.game, saves_root + "default/garage_state.json", "a")
+        self._write(self.game, saves_root + "career/postbattle_state.json", "b")
+        self._write(self.game, state_root + "notes.json", "keep")
+
+        core.reset_0_9_22_state(
+            self.game, self.payload, is_running=lambda: False)
+
+        self.assertFalse(os.path.exists(os.path.join(
+            self.game, *saves_root.rstrip("/").split("/"))))
+        self.assertEqual("keep", self._read(state_root + "notes.json"))
 
     def test_reset_also_deletes_only_the_isolated_client_preferences(self):
         default_config = json.dumps({"enabled": True})

--- a/launcher/tests/test_launcher_window.py
+++ b/launcher/tests/test_launcher_window.py
@@ -1097,6 +1097,23 @@ class WindowTest(unittest.TestCase):
             wot_launcher.save_slots.DEFAULT_SLOT_ID,
             self.window._save_slot_id)
 
+    def test_a_save_cannot_be_deleted_while_any_game_client_is_running(self):
+        saves_root = self._saves_root()
+        with mock.patch.object(
+                self.window, "_ask_save_slot_name", return_value="Career"):
+            self.window._new_save_slot()
+        career = self.window._save_slot_id
+
+        with mock.patch.object(core, "game_is_running", return_value=True), \
+                mock.patch.object(
+                    self.window, "_confirm_delete_save_slot") as confirm:
+            self.assertFalse(self.window._delete_save_slot())
+
+        confirm.assert_not_called()
+        self.assertTrue(os.path.isdir(os.path.join(saves_root, career)))
+        self.assertIn(
+            "Close World of Tanks before deleting a save", self._log_text())
+
     def test_a_save_deleted_outside_the_launcher_falls_back_to_the_default(
             self):
         saves_root = self._saves_root()
@@ -1124,6 +1141,22 @@ class WindowTest(unittest.TestCase):
         self.assertEqual(3, len(labels))
         self.assertIn("Career (%s)" % first, labels)
         self.assertIn("Career (%s)" % second, labels)
+
+    def test_a_save_named_like_the_default_stays_distinguishable(self):
+        self._saves_root()
+        default_label = self.window._t("Default save")
+        with mock.patch.object(
+                self.window, "_ask_save_slot_name",
+                return_value=default_label):
+            self.window._new_save_slot()
+            custom = self.window._save_slot_id
+
+        labels = tuple(self.window.save_slot_box.cget("values"))
+        self.assertIn(
+            "%s (%s)" % (
+                default_label, wot_launcher.save_slots.DEFAULT_SLOT_ID),
+            labels)
+        self.assertIn("%s (%s)" % (default_label, custom), labels)
 
     def test_new_profile_is_selected_and_opened(self):
         with mock.patch(

--- a/launcher/tests/test_launcher_window.py
+++ b/launcher/tests/test_launcher_window.py
@@ -1014,6 +1014,117 @@ class WindowTest(unittest.TestCase):
         self.assertIn("could not be checked", self._log_text())
         self.assertIn("unsafe overlay path", self._log_text())
 
+    def _saves_root(self):
+        root = os.path.join(self.settings_dir, "appdata")
+        patch = mock.patch.dict(os.environ, {"APPDATA": root})
+        patch.start()
+        self.addCleanup(patch.stop)
+        self.window._refresh_save_slots()
+        return os.path.join(
+            root, "Wargaming.net", "WorldOfTanks", "offline_lan_0922",
+            "saves")
+
+    def test_the_default_save_is_offered_and_cannot_be_deleted(self):
+        self._saves_root()
+
+        self.assertEqual(
+            (self.window._t("Default save"),),
+            tuple(self.window.save_slot_box.cget("values")))
+        self.assertEqual(
+            wot_launcher.save_slots.DEFAULT_SLOT_ID,
+            self.window._save_slot_id)
+        self.assertEqual(
+            "disabled", self.window.delete_save_slot_button.cget("state"))
+        self.assertFalse(self.window._delete_save_slot())
+        self.assertIn("default save cannot be deleted", self._log_text())
+
+    def test_a_new_save_becomes_the_selected_one_and_is_remembered(self):
+        saves_root = self._saves_root()
+        with mock.patch.object(
+                self.window, "_ask_save_slot_name", return_value="Career"):
+            self.assertTrue(self.window._new_save_slot())
+
+        self.assertNotEqual(
+            wot_launcher.save_slots.DEFAULT_SLOT_ID,
+            self.window._save_slot_id)
+        self.assertEqual("Career", self.window.save_slot.get())
+        self.assertTrue(os.path.isdir(
+            os.path.join(saves_root, self.window._save_slot_id)))
+        self.assertEqual(
+            self.window._save_slot_id,
+            core.load_settings().get("save_slot"))
+        self.assertEqual(
+            "normal", self.window.delete_save_slot_button.cget("state"))
+
+    def test_selecting_another_save_records_it_for_the_next_launch(self):
+        self._saves_root()
+        with mock.patch.object(
+                self.window, "_ask_save_slot_name", return_value="Career"):
+            self.window._new_save_slot()
+        career = self.window._save_slot_id
+
+        self.window.save_slot.set(self.window._t("Default save"))
+        self.assertTrue(self.window._save_slot_selected())
+        self.assertEqual(
+            wot_launcher.save_slots.DEFAULT_SLOT_ID,
+            self.window._save_slot_id)
+        self.assertEqual(
+            wot_launcher.save_slots.DEFAULT_SLOT_ID,
+            core.load_settings().get("save_slot"))
+
+        self.window.save_slot.set("Career")
+        self.assertTrue(self.window._save_slot_selected())
+        self.assertEqual(career, self.window._save_slot_id)
+
+    def test_deleting_the_selected_save_returns_to_the_default(self):
+        saves_root = self._saves_root()
+        with mock.patch.object(
+                self.window, "_ask_save_slot_name", return_value="Career"):
+            self.window._new_save_slot()
+        career = self.window._save_slot_id
+
+        with mock.patch.object(
+                self.window, "_confirm_delete_save_slot", return_value=False):
+            self.assertFalse(self.window._delete_save_slot())
+        self.assertTrue(os.path.isdir(os.path.join(saves_root, career)))
+
+        with mock.patch.object(
+                self.window, "_confirm_delete_save_slot", return_value=True):
+            self.assertTrue(self.window._delete_save_slot())
+
+        self.assertFalse(os.path.exists(os.path.join(saves_root, career)))
+        self.assertEqual(
+            wot_launcher.save_slots.DEFAULT_SLOT_ID,
+            self.window._save_slot_id)
+
+    def test_a_save_deleted_outside_the_launcher_falls_back_to_the_default(
+            self):
+        saves_root = self._saves_root()
+        with mock.patch.object(
+                self.window, "_ask_save_slot_name", return_value="Career"):
+            self.window._new_save_slot()
+        shutil.rmtree(os.path.join(saves_root, self.window._save_slot_id))
+
+        self.window._refresh_save_slots()
+
+        self.assertEqual(
+            wot_launcher.save_slots.DEFAULT_SLOT_ID,
+            self.window._save_slot_id)
+
+    def test_saves_with_the_same_name_stay_distinguishable(self):
+        self._saves_root()
+        with mock.patch.object(
+                self.window, "_ask_save_slot_name", return_value="Career"):
+            self.window._new_save_slot()
+            first = self.window._save_slot_id
+            self.window._new_save_slot()
+            second = self.window._save_slot_id
+
+        labels = tuple(self.window.save_slot_box.cget("values"))
+        self.assertEqual(3, len(labels))
+        self.assertIn("Career (%s)" % first, labels)
+        self.assertIn("Career (%s)" % second, labels)
+
     def test_new_profile_is_selected_and_opened(self):
         with mock.patch(
                 "wot_launcher.vehicle_overlays.list_vehicle_profiles",

--- a/launcher/tests/test_save_slots.py
+++ b/launcher/tests/test_save_slots.py
@@ -138,6 +138,23 @@ class SaveSlotsTests(unittest.TestCase):
 
         self.assertEqual(["default"], self._names())
 
+    def test_a_linked_slot_cannot_read_or_write_outside_the_saves_root(self):
+        os.makedirs(self.root)
+        outside = os.path.join(os.path.dirname(self.root), "outside")
+        os.makedirs(outside)
+        linked = os.path.join(self.root, "linked")
+        try:
+            os.symlink(outside, linked, target_is_directory=True)
+        except (AttributeError, NotImplementedError, OSError):
+            self.skipTest("directory symlinks are unavailable")
+
+        self.assertEqual(["default"], self._names())
+        with self.assertRaises(save_slots.SaveSlotError):
+            save_slots.read_slot("linked", root=self.root)
+        with self.assertRaises(save_slots.SaveSlotError):
+            save_slots.rename_slot("linked", "Outside", root=self.root)
+        self.assertFalse(os.path.exists(os.path.join(outside, "save.json")))
+
     def test_the_saves_root_follows_appdata_and_falls_back_to_the_game(self):
         appdata = save_slots.saves_root(
             environment={"APPDATA": os.path.join("C:\\", "Users", "p",

--- a/launcher/tests/test_save_slots.py
+++ b/launcher/tests/test_save_slots.py
@@ -1,0 +1,159 @@
+import json
+import os
+import tempfile
+import unittest
+
+import save_slots
+
+
+class SaveSlotsTests(unittest.TestCase):
+    def setUp(self):
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        self.root = os.path.join(directory.name, "saves")
+
+    def _names(self):
+        return [row["name"] for row in save_slots.list_slots(root=self.root)]
+
+    def test_the_default_save_is_listable_before_it_exists_on_disk(self):
+        rows = save_slots.list_slots(root=self.root)
+
+        self.assertEqual([save_slots.DEFAULT_SLOT_ID],
+                         [row["id"] for row in rows])
+        self.assertFalse(rows[0]["has_state"])
+        self.assertFalse(os.path.isdir(self.root))
+
+    def test_a_created_save_owns_an_empty_directory_and_a_record(self):
+        record = save_slots.create_slot(
+            "Career", save_slots.MODE_UNLOCKED, root=self.root, now=1700)
+
+        self.assertEqual("Career", record["name"])
+        self.assertEqual(save_slots.MODE_UNLOCKED, record["mode"])
+        self.assertEqual(1700, record["created"])
+        self.assertFalse(record["has_state"])
+        self.assertEqual(
+            [save_slots.METADATA_NAME], os.listdir(record["path"]))
+        with open(os.path.join(record["path"], save_slots.METADATA_NAME),
+                  "rb") as stream:
+            self.assertEqual("Career", json.load(stream)["name"])
+
+    def test_a_non_ascii_name_still_produces_a_usable_directory_name(self):
+        record = save_slots.create_slot(
+            "生涯存档", save_slots.MODE_UNLOCKED, root=self.root)
+
+        self.assertTrue(save_slots.valid_slot_id(record["id"]))
+        self.assertEqual("生涯存档", record["name"])
+        self.assertTrue(os.path.isdir(record["path"]))
+
+    def test_two_saves_with_the_same_name_keep_separate_directories(self):
+        first = save_slots.create_slot(
+            "Career", save_slots.MODE_UNLOCKED, root=self.root)
+        second = save_slots.create_slot(
+            "Career", save_slots.MODE_UNLOCKED, root=self.root)
+
+        self.assertNotEqual(first["id"], second["id"])
+        self.assertNotEqual(first["path"], second["path"])
+        self.assertEqual(["default", "Career", "Career"], self._names())
+
+    def test_a_save_name_is_normalized_and_bounded(self):
+        record = save_slots.create_slot(
+            "  spaced   out  ", save_slots.MODE_UNLOCKED, root=self.root)
+        self.assertEqual("spaced out", record["name"])
+
+        for bad in ("", "   ", "x" * (save_slots.MAX_SLOT_NAME_LENGTH + 1),
+                    None, 5):
+            with self.assertRaises(save_slots.SaveSlotError):
+                save_slots.create_slot(
+                    bad, save_slots.MODE_UNLOCKED, root=self.root)
+
+    def test_an_unknown_save_type_is_refused(self):
+        with self.assertRaises(save_slots.SaveSlotError):
+            save_slots.create_slot("Career", "everything", root=self.root)
+
+    def test_a_save_id_may_not_escape_the_saves_directory(self):
+        for value in ("", ".", "..", "a/b", "a\\b", "-lead", "x" * 65, None):
+            self.assertFalse(save_slots.valid_slot_id(value), repr(value))
+            with self.assertRaises(save_slots.SaveSlotError):
+                save_slots.slot_dir(value, root=self.root)
+
+    def test_renaming_keeps_the_directory_and_everything_earned_in_it(self):
+        record = save_slots.create_slot(
+            "Career", save_slots.MODE_UNLOCKED, root=self.root, now=1700)
+        state = os.path.join(record["path"], "garage_state.json")
+        with open(state, "w", encoding="utf-8") as stream:
+            stream.write("{}")
+
+        renamed = save_slots.rename_slot(
+            record["id"], "Second career", root=self.root)
+
+        self.assertEqual(record["id"], renamed["id"])
+        self.assertEqual("Second career", renamed["name"])
+        self.assertEqual(1700, renamed["created"])
+        self.assertTrue(renamed["has_state"])
+        self.assertTrue(os.path.isfile(state))
+
+    def test_a_save_with_an_unreadable_record_is_still_reported(self):
+        record = save_slots.create_slot(
+            "Career", save_slots.MODE_UNLOCKED, root=self.root)
+        with open(os.path.join(record["path"], save_slots.METADATA_NAME),
+                  "w", encoding="utf-8") as stream:
+            stream.write("not json")
+        with open(os.path.join(record["path"], "garage_state.json"),
+                  "w", encoding="utf-8") as stream:
+            stream.write("{}")
+
+        rows = save_slots.list_slots(root=self.root)
+
+        damaged = [row for row in rows if row["id"] == record["id"]]
+        self.assertEqual(1, len(damaged))
+        self.assertEqual(record["id"], damaged[0]["name"])
+        self.assertTrue(damaged[0]["has_state"])
+
+    def test_deleting_a_save_removes_its_directory(self):
+        record = save_slots.create_slot(
+            "Career", save_slots.MODE_UNLOCKED, root=self.root)
+
+        save_slots.delete_slot(record["id"], root=self.root)
+
+        self.assertFalse(os.path.exists(record["path"]))
+        self.assertEqual(["default"], self._names())
+
+    def test_the_default_save_cannot_be_deleted(self):
+        with self.assertRaises(save_slots.SaveSlotError):
+            save_slots.delete_slot(
+                save_slots.DEFAULT_SLOT_ID, root=self.root)
+
+    def test_a_missing_save_is_refused_rather_than_recreated(self):
+        with self.assertRaises(save_slots.SaveSlotError):
+            save_slots.read_slot("gone", root=self.root)
+        with self.assertRaises(save_slots.SaveSlotError):
+            save_slots.rename_slot("gone", "Career", root=self.root)
+
+    def test_a_stray_file_in_the_saves_directory_is_not_a_save(self):
+        os.makedirs(self.root)
+        with open(os.path.join(self.root, "notes.txt"), "w",
+                  encoding="utf-8") as stream:
+            stream.write("hello")
+        os.makedirs(os.path.join(self.root, "not a slot id"))
+
+        self.assertEqual(["default"], self._names())
+
+    def test_the_saves_root_follows_appdata_and_falls_back_to_the_game(self):
+        appdata = save_slots.saves_root(
+            environment={"APPDATA": os.path.join("C:\\", "Users", "p",
+                                                 "AppData", "Roaming")})
+        self.assertTrue(appdata.endswith(
+            os.path.join("offline_lan_0922", "saves")))
+
+        fallback = save_slots.saves_root(
+            game_root=os.path.join("D:\\", "WoT"), environment={})
+        self.assertTrue(fallback.endswith(
+            os.path.join("offline_lan_0922", "saves")))
+        self.assertIn("mods", fallback)
+
+        with self.assertRaises(save_slots.SaveSlotError):
+            save_slots.saves_root(environment={})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/launcher/wot_launcher.py
+++ b/launcher/wot_launcher.py
@@ -991,13 +991,16 @@ class LauncherWindow(object):
         until the player renames it, so the label falls back to the directory
         id whenever the name alone would not identify the save.
         """
-        name = record["name"]
-        if (record["id"] == save_slots.DEFAULT_SLOT_ID and
-                name == save_slots.DEFAULT_SLOT_ID):
-            name = self._t("Default save")
+        def display_name(row):
+            if (row["id"] == save_slots.DEFAULT_SLOT_ID and
+                    row["name"] == save_slots.DEFAULT_SLOT_ID):
+                return self._t("Default save")
+            return row["name"]
+
+        name = display_name(record)
         same_name = sum(
             1 for row in self._save_slot_records
-            if row["name"] == record["name"])
+            if display_name(row) == name)
         return "%s (%s)" % (name, record["id"]) if same_name > 1 else name
 
     def _refresh_save_slots(self, status=None):
@@ -1115,6 +1118,9 @@ class LauncherWindow(object):
     def _delete_save_slot(self):
         if self._busy or self._maintenance_busy:
             self._log("Wait for the current launcher operation to finish.")
+            return False
+        if core.game_is_running():
+            self._log("Close World of Tanks before deleting a save.")
             return False
         record = self._selected_save_slot_record()
         if record is None or record["id"] == save_slots.DEFAULT_SLOT_ID:

--- a/launcher/wot_launcher.py
+++ b/launcher/wot_launcher.py
@@ -20,12 +20,13 @@ if __package__ in (None, ""):
     import core
     import error_reports
     import i18n
+    import save_slots
     import vehicle_editor_ui
     import vehicle_overlays
 else:
     from . import (
         bot_lineup_profiles, bot_lineup_ui, core, error_reports, i18n,
-        vehicle_editor_ui, vehicle_overlays)
+        save_slots, vehicle_editor_ui, vehicle_overlays)
 
 
 LAUNCHER_VERSION = "0.6.7"
@@ -105,6 +106,22 @@ _CHINESE = {
         "无法移除本机车辆属性方案：%s",
     "Vehicle profiles are available for the 0.9.22 client.":
         "车辆属性方案仅适用于 0.9.22 客户端。",
+    "Saves": "存档",
+    "Save": "存档",
+    "Default save": "默认存档",
+    "New save...": "新建存档…",
+    "Rename save...": "重命名存档…",
+    "Delete save...": "删除存档…",
+    "New save": "新建存档",
+    "Rename save": "重命名存档",
+    "Save name:": "存档名称：",
+    "Delete save?": "删除存档？",
+    "Delete save '%s'? Its garage, crew, account settings and battle "
+    "results are removed permanently.":
+        "确定删除存档“%s”吗？它的车库、乘员、账号设置和战斗记录将被永久删除。",
+    "Each save keeps its own garage, crew, account settings and battle "
+    "results. The selected save is the one the game starts with.":
+        "每个存档有独立的车库、乘员、账号设置和战斗记录。启动游戏时使用当前选中的存档。",
     "Repair": "修复",
     "Repair startup (keep saved data)": "修复启动问题（保留存档）",
     "Normal client stuck loading? Clean preferences...":
@@ -535,12 +552,50 @@ class LauncherWindow(object):
 
         self.tools_tabs = self._ttk.Notebook(frame)
         self.tools_tabs.grid(row=3, column=0, sticky="we", pady=(0, 8))
+        self.save_panel = tk.Frame(self.tools_tabs, padx=10, pady=10)
         self.vehicle_panel = tk.Frame(self.tools_tabs, padx=10, pady=10)
         self.bot_lineup_panel = tk.Frame(self.tools_tabs, padx=10, pady=10)
         self.repair_panel = tk.Frame(self.tools_tabs, padx=10, pady=10)
+        self.tools_tabs.add(self.save_panel, text="")
         self.tools_tabs.add(self.vehicle_panel, text="")
         self.tools_tabs.add(self.bot_lineup_panel, text="")
         self.tools_tabs.add(self.repair_panel, text="")
+
+        self._save_slot_records = []
+        self._save_slot_id_by_label = {}
+        self._save_slot_id = str(
+            settings.get("save_slot") or save_slots.DEFAULT_SLOT_ID)
+        if not save_slots.valid_slot_id(self._save_slot_id):
+            self._save_slot_id = save_slots.DEFAULT_SLOT_ID
+        self.save_slot_label = tk.Label(self.save_panel, text="")
+        self.save_slot_label.grid(row=0, column=0, sticky="w")
+        self.save_slot = tk.StringVar(value="")
+        self.save_slot_box = self._ttk.Combobox(
+            self.save_panel, textvariable=self.save_slot, values=(),
+            state="readonly", width=40)
+        self.save_slot_box.grid(row=0, column=1, sticky="we", padx=(6, 0))
+        self.save_slot_box.bind(
+            "<<ComboboxSelected>>", self._save_slot_selected)
+        save_actions = tk.Frame(self.save_panel)
+        save_actions.grid(
+            row=1, column=0, columnspan=2, sticky="we", pady=(6, 0))
+        self.new_save_slot_button = tk.Button(
+            save_actions, text="", command=self._new_save_slot)
+        self.new_save_slot_button.pack(side="left", fill="x", expand=True)
+        self.rename_save_slot_button = tk.Button(
+            save_actions, text="", command=self._rename_save_slot)
+        self.rename_save_slot_button.pack(
+            side="left", fill="x", expand=True, padx=(6, 0))
+        self.delete_save_slot_button = tk.Button(
+            save_actions, text="", command=self._delete_save_slot)
+        self.delete_save_slot_button.pack(
+            side="left", fill="x", expand=True, padx=(6, 0))
+        self.save_help_label = tk.Label(
+            self.save_panel, text="", anchor="w", justify="left",
+            wraplength=620)
+        self.save_help_label.grid(
+            row=2, column=0, columnspan=2, sticky="we", pady=(8, 0))
+        self.save_panel.grid_columnconfigure(1, weight=1)
 
         self._bot_lineup_store = bot_lineup_profiles.normalize_store(
             settings.get("bot_lineup_profiles"))
@@ -702,6 +757,16 @@ class LauncherWindow(object):
         self.network_help_label.config(text=self._t(
             "To host: start the server, then join the game. Other players use "
             "a LAN address shown in the log."))
+        self.tools_tabs.tab(self.save_panel, text=self._t("Saves"))
+        self.save_slot_label.config(text=self._t("Save"))
+        self.new_save_slot_button.config(text=self._t("New save..."))
+        self.rename_save_slot_button.config(text=self._t("Rename save..."))
+        self.delete_save_slot_button.config(text=self._t("Delete save..."))
+        self.save_help_label.config(text=self._t(
+            "Each save keeps its own garage, crew, account settings and "
+            "battle results. The selected save is the one the game starts "
+            "with."))
+        self._refresh_save_slots()
         self.tools_tabs.tab(
             self.vehicle_panel, text=self._t("Vehicle modifier"))
         self.tools_tabs.tab(
@@ -803,6 +868,7 @@ class LauncherWindow(object):
         self._selected_client = status["client"]
         self._refresh_profiles(status)
         self._refresh_bot_lineup_profiles()
+        self._refresh_save_slots(status)
         self._update_action_controls()
         self._refresh_mode()
         return status
@@ -917,6 +983,158 @@ class LauncherWindow(object):
     def _profile_selected(self, unused_event=None):
         self._update_action_controls()
         self._save_settings()
+
+    def _save_slot_label(self, record):
+        """Return one unambiguous list entry for a save.
+
+        Two saves may carry the same name, and the default save has no name
+        until the player renames it, so the label falls back to the directory
+        id whenever the name alone would not identify the save.
+        """
+        name = record["name"]
+        if (record["id"] == save_slots.DEFAULT_SLOT_ID and
+                name == save_slots.DEFAULT_SLOT_ID):
+            name = self._t("Default save")
+        same_name = sum(
+            1 for row in self._save_slot_records
+            if row["name"] == record["name"])
+        return "%s (%s)" % (name, record["id"]) if same_name > 1 else name
+
+    def _refresh_save_slots(self, status=None):
+        game_root = (status or {}).get("path") or self.game_root.get().strip()
+        try:
+            records = save_slots.list_slots(game_root or None)
+        except save_slots.SaveSlotError as error:
+            # Without APPDATA a save still needs the game folder to live in.
+            # Keep the launcher usable and let the player pick a folder first.
+            if hasattr(self, "log_view"):
+                self._log("Saves could not be listed: %s" % error)
+            records = []
+        self._save_slot_records = list(records)
+        self._save_slot_id_by_label = {}
+        values = []
+        for record in self._save_slot_records:
+            label = self._save_slot_label(record)
+            self._save_slot_id_by_label[label] = record["id"]
+            values.append(label)
+        self.save_slot_box.config(values=tuple(values))
+        selected = [label for label, slot_id
+                    in self._save_slot_id_by_label.items()
+                    if slot_id == self._save_slot_id]
+        if selected:
+            self.save_slot.set(selected[0])
+        elif values:
+            # The selected save was deleted outside the launcher.  Fall back to
+            # the default rather than starting the game with a save id that no
+            # longer resolves to any progress.
+            self._save_slot_id = save_slots.DEFAULT_SLOT_ID
+            self.save_slot.set(values[0])
+        else:
+            self.save_slot.set("")
+        self.delete_save_slot_button.config(
+            state=("disabled"
+                   if self._save_slot_id == save_slots.DEFAULT_SLOT_ID
+                   else "normal"))
+        return tuple(values)
+
+    def _save_slot_selected(self, unused_event=None):
+        slot_id = self._save_slot_id_by_label.get(self.save_slot.get())
+        if slot_id is None or slot_id == self._save_slot_id:
+            return False
+        self._save_slot_id = slot_id
+        self._refresh_save_slots()
+        self._save_settings()
+        self._log("Selected save '%s'." % self.save_slot.get())
+        return True
+
+    def _ask_save_slot_name(self, title, current=None):
+        from tkinter import simpledialog
+
+        return simpledialog.askstring(
+            self._t(title), self._t("Save name:"), initialvalue=current)
+
+    def _confirm_delete_save_slot(self, label):
+        from tkinter import messagebox
+
+        return messagebox.askyesno(
+            self._t("Delete save?"),
+            self._t("Delete save '%s'? Its garage, crew, account settings "
+                    "and battle results are removed permanently.") % label,
+            icon="warning")
+
+    def _selected_save_slot_record(self):
+        for record in self._save_slot_records:
+            if record["id"] == self._save_slot_id:
+                return record
+        return None
+
+    def _new_save_slot(self):
+        if self._busy or self._maintenance_busy:
+            self._log("Wait for the current launcher operation to finish.")
+            return False
+        game_root = self.game_root.get().strip()
+        raw_name = self._ask_save_slot_name("New save")
+        if raw_name is None:
+            return False
+        try:
+            record = save_slots.create_slot(
+                raw_name, save_slots.MODE_UNLOCKED, game_root or None)
+        except save_slots.SaveSlotError as error:
+            self._log("Could not create the save: %s" % error)
+            return False
+        self._save_slot_id = record["id"]
+        self._refresh_save_slots()
+        self._save_settings()
+        self._log("Created save '%s'." % record["name"])
+        return True
+
+    def _rename_save_slot(self):
+        if self._busy or self._maintenance_busy:
+            self._log("Wait for the current launcher operation to finish.")
+            return False
+        record = self._selected_save_slot_record()
+        if record is None:
+            self._log("Select a save before renaming it.")
+            return False
+        game_root = self.game_root.get().strip()
+        current = ("" if record["name"] == record["id"] else record["name"])
+        raw_name = self._ask_save_slot_name("Rename save", current)
+        if raw_name is None:
+            return False
+        try:
+            renamed = save_slots.rename_slot(
+                record["id"], raw_name, game_root or None)
+        except save_slots.SaveSlotError as error:
+            self._log("Could not rename the save: %s" % error)
+            return False
+        self._refresh_save_slots()
+        self._save_settings()
+        self._log("Renamed save to '%s'." % renamed["name"])
+        return True
+
+    def _delete_save_slot(self):
+        if self._busy or self._maintenance_busy:
+            self._log("Wait for the current launcher operation to finish.")
+            return False
+        record = self._selected_save_slot_record()
+        if record is None or record["id"] == save_slots.DEFAULT_SLOT_ID:
+            self._log("The default save cannot be deleted.")
+            return False
+        label = self.save_slot.get()
+        if not self._confirm_delete_save_slot(label):
+            self._log("Save deletion was cancelled.")
+            return False
+        game_root = self.game_root.get().strip()
+        try:
+            save_slots.delete_slot(record["id"], game_root or None)
+        except save_slots.SaveSlotError as error:
+            self._log("Could not delete the save: %s" % error)
+            return False
+        self._save_slot_id = save_slots.DEFAULT_SLOT_ID
+        self._refresh_save_slots()
+        self._save_settings()
+        self._log("Deleted save '%s'." % record["name"])
+        return True
 
     def _refresh_bot_lineup_profiles(self):
         self._bot_lineup_store = bot_lineup_profiles.normalize_store(
@@ -1357,6 +1575,7 @@ class LauncherWindow(object):
             "vehicle_profile": self.vehicle_profile.get().strip(),
             "bot_lineup_profile": self.bot_lineup_profile.get().strip(),
             "bot_lineup_profiles": self._bot_lineup_store,
+            "save_slot": self._save_slot_id,
             "language": self.language_preference,
             COLLECT_CRASH_REPORTS_SETTING:
                 bool(self.collect_crash_reports.get()),
@@ -1837,8 +2056,9 @@ class LauncherWindow(object):
                             prepared["installedMembers"],
                             "" if prepared["installedMembers"] == 1 else "s"))
                 self._log(core.ensure_0_9_22_preferences_isolation(game_root))
-            for path in core.write_settings(game_root, session["client"],
-                                            session["mode"], host, port, name):
+            for path in core.write_settings(
+                    game_root, session["client"], session["mode"], host, port,
+                    name, self._save_slot_id):
                 self._log("Wrote %s" % path)
             if session["needs_server"]:
                 start_options = {

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/garage_store.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/garage_store.py
@@ -40,10 +40,7 @@ except NameError:
 # crew XP idempotent.  Schema 3 remains readable and upgrades on the next save.
 SCHEMA = 4
 READABLE_SCHEMAS = (3, SCHEMA)
-STATE_PATH = os.path.join(
-    port_config.USER_DATA_DIR, 'garage_state.json')
-LEGACY_STATE_PATH = os.path.join(
-    port_config.LEGACY_USER_DATA_DIR, 'garage_state.json')
+STATE_FILE_NAME = 'garage_state.json'
 
 _VEHICLE_INT_KEYS = ('eqs', 'eqsLayout', 'shells', 'shellsLayoutIdx')
 _ARTEFACT_ITEM_TYPES = (9, 10, 11)
@@ -98,9 +95,10 @@ def _int_map(value):
 class GarageStore(object):
     """Load and save the mutable parts of one garage snapshot."""
 
-    def __init__(self, path=STATE_PATH):
-        self._path = (port_config.migrate_legacy_user_file(
-            path, LEGACY_STATE_PATH) if path == STATE_PATH else path)
+    def __init__(self, path=port_config.ACTIVE_SAVE_SLOT):
+        if path is port_config.ACTIVE_SAVE_SLOT:
+            path = port_config.save_slot_state_path(STATE_FILE_NAME)
+        self._path = path
         self._dirty = False
         self._battle_receipts = []
         self._receipts_loaded = False

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/postbattle_store.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/postbattle_store.py
@@ -31,10 +31,7 @@ except NameError:
 
 
 SCHEMA = 1
-STATE_PATH = os.path.join(
-    port_config.USER_DATA_DIR, 'postbattle_state.json')
-LEGACY_STATE_PATH = os.path.join(
-    port_config.LEGACY_USER_DATA_DIR, 'postbattle_state.json')
+STATE_FILE_NAME = 'postbattle_state.json'
 MAX_HISTORY = 256
 INTERACTION_FIELDS = (
     ('spotted', 'spotted', 0, 1),
@@ -578,9 +575,10 @@ def pack_battle_result(receipt, packers=None, replay_types=None,
 class PostBattleStore(object):
     """Apply each LAN receipt once and retain it until the native 1501 ack."""
 
-    def __init__(self, path=STATE_PATH):
-        self._path = (port_config.migrate_legacy_user_file(
-            path, LEGACY_STATE_PATH) if path == STATE_PATH else path)
+    def __init__(self, path=port_config.ACTIVE_SAVE_SLOT):
+        if path is port_config.ACTIVE_SAVE_SLOT:
+            path = port_config.save_slot_state_path(STATE_FILE_NAME)
+        self._path = path
         self._account_key = uuid.uuid4().hex
         self._pending = {}
         self._history = []

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/state.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/state.py
@@ -14,18 +14,16 @@ except NameError:
     integer_types = (int,)
 
 
-STATE_PATH = os.path.join(
-    port_config.USER_DATA_DIR, 'account_state.json')
-LEGACY_STATE_PATH = os.path.join(
-    port_config.LEGACY_USER_DATA_DIR, 'account_state.json')
+STATE_FILE_NAME = 'account_state.json'
 
 
 class AccountState(object):
     """Persist the integer settings that #1513 normally stores server-side."""
 
-    def __init__(self, path=STATE_PATH):
-        self._path = (port_config.migrate_legacy_user_file(
-            path, LEGACY_STATE_PATH) if path == STATE_PATH else path)
+    def __init__(self, path=port_config.ACTIVE_SAVE_SLOT):
+        if path is port_config.ACTIVE_SAVE_SLOT:
+            path = port_config.save_slot_state_path(STATE_FILE_NAME)
+        self._path = path
         self._int_user_settings = {}
         self._load()
 

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/config.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/config.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 import json
 import os
+import re
 
 
 try:
@@ -50,12 +51,28 @@ PLAYER_MODE = 'player'
 SIMULATION_WORKER_MODE = 'simulation_worker'
 CLIENT_MODES = frozenset((PLAYER_MODE, SIMULATION_WORKER_MODE))
 
+# One save slot owns every file that records what this player has earned.
+# ``vehicle_profiles.json`` deliberately stays outside a slot: a vehicle data
+# profile modifies the shared client catalogue for a whole room, so it belongs
+# to the installation rather than to one player's progress.
+SAVES_DIR_NAME = 'saves'
+DEFAULT_SAVE_SLOT = 'default'
+SAVE_METADATA_FILE_NAME = 'save.json'
+SAVE_MODE_UNLOCKED = 'unlocked'
+SAVE_MODE_NEW_ACCOUNT = 'new_account'
+SAVE_MODES = frozenset((SAVE_MODE_UNLOCKED, SAVE_MODE_NEW_ACCOUNT))
+# A slot id becomes one directory name, so keep it to characters that need no
+# escaping on Windows and cannot walk out of the saves root.
+_SAVE_SLOT_ID = re.compile(r'^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$')
+
 DEFAULT_CONFIG = {
-    'schema': 2,
+    'schema': 3,
     'enabled': True,
     # The normal package remains a player client. A separate copied game
     # directory may opt into the native-space simulation worker explicitly.
     'client_mode': PLAYER_MODE,
+    # The launcher owns which save slot this installation plays.
+    'save_slot': DEFAULT_SAVE_SLOT,
     'host': '127.0.0.1',
     'port': 28782,
     'name': 'Player',
@@ -212,6 +229,9 @@ def _load_config_file(path):
             config.get('client_mode') not in CLIENT_MODES):
         raise ValueError(
             'client_mode must be player or simulation_worker')
+    if not valid_save_slot(config.get('save_slot')):
+        raise ValueError(
+            'save_slot must be 1-64 characters of A-Z, a-z, 0-9, _ or -')
     if not isinstance(config.get('vehicle'), string_types) or not config['vehicle']:
         raise ValueError('vehicle must be a non-empty string')
     if not isinstance(config.get('name'), string_types) or not config['name']:
@@ -386,6 +406,85 @@ def migrate_legacy_user_file(path, legacy_path):
 
 # Backward-compatible private name for older extracted packages.
 _write = write_json
+
+
+class _ActiveSaveSlot(object):
+    """Default marker: resolve this path from the active save slot.
+
+    ``None`` already means "keep this store in memory" for the hidden worker,
+    so a store cannot use it to mean "use the normal location" as well.
+    """
+
+    def __repr__(self):
+        return 'ACTIVE_SAVE_SLOT'
+
+
+ACTIVE_SAVE_SLOT = _ActiveSaveSlot()
+
+
+def valid_save_slot(value):
+    return bool(isinstance(value, string_types) and
+                _SAVE_SLOT_ID.match(value))
+
+
+_active_save_slot = DEFAULT_SAVE_SLOT
+
+
+def active_save_slot():
+    """Return the slot ``load`` last resolved from ``config.json``."""
+    return _active_save_slot
+
+
+def set_active_save_slot(value):
+    global _active_save_slot
+    if not valid_save_slot(value):
+        raise ValueError(
+            'save_slot must be 1-64 characters of A-Z, a-z, 0-9, _ or -')
+    _active_save_slot = str(value)
+    return _active_save_slot
+
+
+def saves_root(user_data_dir=None):
+    return os.path.join(
+        USER_DATA_DIR if user_data_dir is None else user_data_dir,
+        SAVES_DIR_NAME)
+
+
+def save_slot_dir(slot=None, user_data_dir=None):
+    slot = active_save_slot() if slot is None else slot
+    if not valid_save_slot(slot):
+        raise ValueError(
+            'save_slot must be 1-64 characters of A-Z, a-z, 0-9, _ or -')
+    return os.path.join(saves_root(user_data_dir), str(slot))
+
+
+def save_slot_state_path(file_name, slot=None, user_data_dir=None):
+    """Return one state file's path inside a save slot.
+
+    Every earned-progress file moved under ``saves/<slot>/`` at config schema
+    3.  Older packages wrote the same names one directory higher, and older
+    ones still wrote them beside ``config.json``, so the default slot adopts
+    whichever of those an upgrading installation still has.  A slot the player
+    created later must start empty, so it never inherits them.
+    """
+    path = os.path.join(
+        save_slot_dir(slot, user_data_dir), str(file_name))
+    if (active_save_slot() if slot is None else slot) != DEFAULT_SAVE_SLOT:
+        return path
+    if user_data_dir is not None:
+        legacy_dirs = (user_data_dir,)
+    else:
+        legacy_dirs = (USER_DATA_DIR, LEGACY_USER_DATA_DIR)
+    for legacy_dir in legacy_dirs:
+        migrated = migrate_legacy_user_file(
+            path, os.path.join(legacy_dir, str(file_name)))
+        if migrated != path:
+            # The copy failed.  Reading the old file in place keeps a saved
+            # garage usable instead of silently starting an empty slot.
+            return migrated
+        if os.path.isfile(path):
+            return path
+    return path
 
 
 def format_endpoint(host, port):
@@ -611,4 +710,7 @@ def load(path=CONFIG_PATH, endpoint_path=None, environ=None):
         save_endpoint(base_endpoint[0], base_endpoint[1], endpoint_path)
     config['host'], config['port'] = _environment_endpoint(
         config['host'], config['port'], environ)
+    # Every state store resolves its path from the active slot, so publish the
+    # loaded choice before the first store is constructed.
+    set_active_save_slot(config['save_slot'])
     return config

--- a/tests/test_port_0922.py
+++ b/tests/test_port_0922.py
@@ -794,7 +794,8 @@ class PortConfigTests(unittest.TestCase):
 
             migrated = config_module.load(str(path))
 
-            self.assertEqual(2, migrated['schema'])
+            self.assertEqual(
+                config_module.DEFAULT_CONFIG['schema'], migrated['schema'])
             self.assertTrue(migrated['native_remote_vehicles'])
 
             path.write_text(

--- a/tests/test_port_0922_release.py
+++ b/tests/test_port_0922_release.py
@@ -23,6 +23,12 @@ class ReleaseBuilderTests(unittest.TestCase):
             self.assertNotIn(name, source, name)
 
     def test_the_state_owners_write_only_into_the_external_user_directory(self):
+        """Each store names its file and defers the location to one owner.
+
+        ``config.save_slot_state_path`` is that owner: it puts the file inside
+        the active save slot below the external user directory, and migrates
+        the pre-save-slot locations for the default slot.
+        """
         package = (PORT_ROOT / 'src' / 'res' / 'scripts' / 'client' / 'gui' /
                    'mods' / 'offline_lan_0922')
         for module, name in (
@@ -32,8 +38,16 @@ class ReleaseBuilderTests(unittest.TestCase):
                  'postbattle_state.json')):
             source = (package / module).read_text(encoding='utf-8')
             self.assertIn(name, source, module)
-            self.assertIn('port_config.USER_DATA_DIR', source, module)
-            self.assertIn('migrate_legacy_user_file', source, module)
+            self.assertIn('port_config.ACTIVE_SAVE_SLOT', source, module)
+            self.assertIn(
+                'port_config.save_slot_state_path(STATE_FILE_NAME)',
+                source, module)
+            self.assertNotIn('port_config.USER_DATA_DIR', source, module)
+
+        config_source = (package / 'config.py').read_text(encoding='utf-8')
+        self.assertIn('def save_slot_state_path(', config_source)
+        self.assertIn('USER_DATA_DIR', config_source)
+        self.assertIn('migrate_legacy_user_file', config_source)
 
 
 if __name__ == '__main__':

--- a/tests/test_port_0922_save_slots.py
+++ b/tests/test_port_0922_save_slots.py
@@ -1,0 +1,152 @@
+"""Save slots: the client resolves earned progress from one named slot."""
+
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_ROOT = (ROOT / 'src' / 'res' / 'scripts' /
+                'client' / 'gui' / 'mods' / 'offline_lan_0922')
+
+
+def _load_port_source(name):
+    path = PACKAGE_ROOT / (name + '.py')
+    spec = importlib.util.spec_from_file_location(
+        'saveslots0922_' + name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class SaveSlotConfigTests(unittest.TestCase):
+    def setUp(self):
+        self.config = _load_port_source('config')
+        self.addCleanup(
+            self.config.set_active_save_slot,
+            self.config.DEFAULT_SAVE_SLOT)
+
+    def test_a_slot_id_may_not_escape_the_saves_directory(self):
+        for value in ('', '.', '..', 'a/b', 'a\\b', '-lead', '_lead',
+                      'x' * 65, None, 3):
+            self.assertFalse(self.config.valid_save_slot(value), repr(value))
+        for value in ('default', 'a', 'save-2', 'A_1', 'x' * 64):
+            self.assertTrue(self.config.valid_save_slot(value), repr(value))
+
+    def test_setting_an_unusable_slot_leaves_the_previous_one_active(self):
+        self.config.set_active_save_slot('keep-me')
+        with self.assertRaises(ValueError):
+            self.config.set_active_save_slot('../escape')
+        self.assertEqual('keep-me', self.config.active_save_slot())
+
+    def test_each_slot_owns_a_separate_directory(self):
+        with tempfile.TemporaryDirectory() as directory:
+            first = self.config.save_slot_state_path(
+                'garage_state.json', 'default', directory)
+            second = self.config.save_slot_state_path(
+                'garage_state.json', 'career', directory)
+            self.assertNotEqual(first, second)
+            self.assertEqual(
+                os.path.join(directory, 'saves', 'career',
+                             'garage_state.json'),
+                second)
+
+    def test_the_default_slot_adopts_state_written_before_save_slots(self):
+        with tempfile.TemporaryDirectory() as directory:
+            legacy = os.path.join(directory, 'garage_state.json')
+            with open(legacy, 'w', encoding='utf-8') as stream:
+                json.dump({'schema': 4, 'vehicles': {}}, stream)
+
+            path = self.config.save_slot_state_path(
+                'garage_state.json', 'default', directory)
+
+            self.assertEqual(
+                os.path.join(directory, 'saves', 'default',
+                             'garage_state.json'),
+                path)
+            self.assertTrue(os.path.isfile(path))
+            with open(path, 'rb') as stream:
+                self.assertEqual(4, json.load(stream)['schema'])
+            # The old copy is retained so an older package still starts.
+            self.assertTrue(os.path.isfile(legacy))
+
+    def test_a_new_slot_never_inherits_the_pre_save_slot_state(self):
+        with tempfile.TemporaryDirectory() as directory:
+            legacy = os.path.join(directory, 'garage_state.json')
+            with open(legacy, 'w', encoding='utf-8') as stream:
+                json.dump({'schema': 4, 'vehicles': {}}, stream)
+
+            path = self.config.save_slot_state_path(
+                'garage_state.json', 'career', directory)
+
+            self.assertFalse(os.path.isfile(path))
+
+    def test_load_publishes_the_configured_slot_to_every_store(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / 'config.json'
+            path.write_text(
+                '{"schema": 3, "save_slot": "career"}', encoding='utf-8')
+
+            config = self.config.load(str(path))
+
+            self.assertEqual('career', config['save_slot'])
+            self.assertEqual('career', self.config.active_save_slot())
+
+    def test_an_unusable_configured_slot_is_quarantined_to_the_default(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / 'config.json'
+            path.write_text(
+                '{"schema": 3, "save_slot": "../escape"}', encoding='utf-8')
+
+            config = self.config.load(str(path))
+
+            self.assertEqual(
+                self.config.DEFAULT_SAVE_SLOT, config['save_slot'])
+
+    def test_a_config_written_before_save_slots_keeps_the_default_slot(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / 'config.json'
+            path.write_text('{"schema": 2}', encoding='utf-8')
+
+            config = self.config.load(str(path))
+
+            self.assertEqual(
+                self.config.DEFAULT_SAVE_SLOT, config['save_slot'])
+            self.assertEqual(
+                self.config.DEFAULT_CONFIG['schema'], config['schema'])
+
+
+class SaveSlotStoreTests(unittest.TestCase):
+    """Every earned-progress store must follow the active slot."""
+
+    def test_the_three_stores_name_their_own_file(self):
+        names = {}
+        for module in ('garage_store', 'postbattle_store', 'state'):
+            source = (PACKAGE_ROOT / 'account_rpc' /
+                      (module + '.py')).read_text(encoding='utf-8')
+            self.assertIn(
+                'port_config.save_slot_state_path(STATE_FILE_NAME)', source,
+                module)
+            for line in source.splitlines():
+                if line.startswith('STATE_FILE_NAME = '):
+                    names[module] = line.split('=', 1)[1].strip()
+        self.assertEqual(
+            {'garage_store': "'garage_state.json'",
+             'postbattle_store': "'postbattle_state.json'",
+             'state': "'account_state.json'"},
+            names)
+
+    def test_an_in_memory_store_is_still_available_to_the_hidden_worker(self):
+        """``None`` keeps meaning "do not persist" after the slot change."""
+        source = (PACKAGE_ROOT / 'bootstrap.py').read_text(encoding='utf-8')
+        self.assertIn('AccountState(path=None)', source)
+        state_source = (PACKAGE_ROOT / 'account_rpc' /
+                        'state.py').read_text(encoding='utf-8')
+        self.assertIn('if self._path is None', state_source)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds a **Saves** tab to the launcher. Players can create, rename, select, and
delete named saves before starting the game. Each save keeps its own garage,
crew, account settings, and battle results.

## How it works

- `config.json` records the selected save. The client publishes that choice
  before constructing any persistent store.
- Garage, post-battle, and account state now live under
  `saves/<save-id>/`.
- The default save adopts data written by older packages on first use. A newly
  created save starts empty and never inherits another save.
- The hidden worker continues to keep these stores in memory.

## Safety and recovery

- Reset removes both the active save directory and the old files that would
  otherwise be imported again on the next start. If reinstalling the payload
  fails, moved data is restored.
- A save cannot be deleted while a game client is running.
- Save operations reject directory links that lead outside the saves folder.
- Duplicate display names, including a custom name matching “Default save,”
  remain distinguishable by save id.
- Older files are retained during ordinary migration so rolling back to an
  earlier package remains possible.

## Deliberately not included

The on-disk format reserves a `new_account` mode, but this UI creates only
unlocked saves. A fresh-account career needs vehicle ownership, inventory, and
prices; exposing the mode before those rules exist would produce a misleading
fully unlocked garage.

Vehicle-data profiles remain installation-wide because a LAN room shares one
modified vehicle catalogue.

## Checks

- Main test suite: 3,623 passed.
- Launcher test suite: 511 passed, 2 skipped.
- All 91 client Python files compile with CPython 2.7.

The remaining hands-on check is the Windows launcher flow: migrate an existing
default save, switch between two saves, confirm their garage/crew/results stay
separate, and run Reset once.
