### PR TITLE
Fix Bot cover timing, exposed-part aim, and route recovery

### DIFF
--- a/server/server_bot_ai.py
+++ b/server/server_bot_ai.py
@@ -51,6 +51,7 @@ CLOSE_THREAT_FOCUS_LIMIT = 4
 ROUTE_REBALANCE_SECONDS = 4.0
 ROUTE_LEASE_SECONDS = 6.0
 MAX_BASE_DEFENDERS = 3
+BASE_DEFENSE_RELEASE_SECONDS = 3.0
 MAX_BASE_CAPTURERS = 3
 CAPTURE_STAGING_RADIUS = 30.0
 MIN_ROUTE_CLASS_AFFINITY = 0.20
@@ -518,7 +519,10 @@ class BotPlanner(object):
             if bot_id not in live_bots:
                 del self._artillery_anchors[bot_id]
         for bot_id, hit in list(self._recent_hits.items()):
+            attacker = (known_targets.get(hit.get("attacker"))
+                        if isinstance(hit, dict) else None)
             if (bot_id not in live_bots or not isinstance(hit, dict) or
+                    attacker is None or not attacker.get("alive") or
                     _number(now) - _number(hit.get("reported_at")) >
                     RECENT_HIT_SECONDS):
                 del self._recent_hits[bot_id]
@@ -648,6 +652,49 @@ class BotPlanner(object):
             return (0, eta + diversion, eta, bot["id"])
         return (1, eta - deadline, eta + diversion, bot["id"])
 
+    @staticmethod
+    def _defense_contributor_keys(defense, team):
+        if not isinstance(defense, dict):
+            return set()
+        contributor_map = defense.get("contributors")
+        contributor_map = (contributor_map
+                           if isinstance(contributor_map, dict) else {})
+        raw = contributor_map.get(str(team), contributor_map.get(team, ()))
+        result = set()
+        if not isinstance(raw, (list, tuple)):
+            return result
+        for value in raw:
+            if not isinstance(value, dict):
+                continue
+            kind = str(value.get("kind") or "")
+            vehicle_id = _integer(value.get("id"))
+            if kind in ("human", "bot") and vehicle_id > 0:
+                result.add((kind, vehicle_id))
+        return result
+
+    @staticmethod
+    def _defense_retention_key(bot, point, contacts, contributor_keys):
+        """Prefer an arrived responder which can stop the current capture."""
+        state = bot["state"]
+        distance = math.hypot(
+            point["x"] - _number(state.get("x")),
+            point["z"] - _number(state.get("z")))
+        can_engage = False
+        if (distance <= ROUTE_ARRIVAL_RADIUS and
+                BotPlanner._weapon_ready(bot)):
+            for contact in contacts or ():
+                key = (str(contact.get("target_kind") or ""),
+                       _integer(contact.get("id")))
+                if (key in contributor_keys and contact.get("visible") and
+                        bot["id"] in contact.get(
+                            "shootable_by_bot_ids", ())):
+                    can_engage = True
+                    break
+        speed = _number(bot.get("profile", {}).get("speed"))
+        cruise = _clamp(speed * 0.65, 4.0, 22.0)
+        eta = 3.0 + distance * 1.30 / cruise
+        return (0 if can_engage else 1, eta, bot["id"])
+
     def _update_base_defense(self, bots, contacts, defense, now):
         """Keep a small, stable responder group while an own base is invaded."""
         if not isinstance(defense, dict):
@@ -673,21 +720,23 @@ class BotPlanner(object):
             raw_state = raw_state if isinstance(raw_state, dict) else {}
             invaders = max(0, _integer(raw_state.get("invaders")))
             points = self._defense_points(bases, team)
+            contributor_keys = self._defense_contributor_keys(
+                defense, team)
             reserve_limit = (1 if len(live) == 1 else
                              max(0, len(live) - 1))
             if len(responders) > reserve_limit:
-                deadline = max(
-                    0.0, _number(raw_state.get("time_left")) - 2.0)
                 ranked = sorted(
-                    responders, key=lambda bot_id: self._defense_eta(
+                    responders, key=lambda bot_id:
+                    self._defense_retention_key(
                         live[bot_id], responders[bot_id]["point"],
-                        contacts.get(team, ()), deadline))
+                        contacts.get(team, ()), contributor_keys))
                 keep = set(ranked[:reserve_limit])
                 for bot_id in list(responders):
                     if bot_id not in keep:
                         del responders[bot_id]
 
             if invaders <= 0:
+                incident["release_since"] = None
                 if not responders:
                     incident["clear_since"] = None
                     incident["need"] = 0
@@ -709,8 +758,33 @@ class BotPlanner(object):
                     desired = 1
                 else:
                     desired = 0
-                incident["need"] = max(
-                    _integer(incident.get("need")), desired)
+                previous_need = max(
+                    0, _integer(incident.get("need")))
+                if desired >= previous_need:
+                    incident["need"] = desired
+                    incident["release_since"] = None
+                else:
+                    release_since = incident.get("release_since")
+                    if release_since is None:
+                        incident["release_since"] = _number(now)
+                    elif (_number(now) - _number(release_since) >=
+                          BASE_DEFENSE_RELEASE_SECONDS):
+                        incident["need"] = max(
+                            desired, previous_need - 1)
+                        incident["release_since"] = _number(now)
+
+                keep_limit = min(
+                    _integer(incident.get("need")), reserve_limit)
+                if len(responders) > keep_limit:
+                    ranked = sorted(
+                        responders, key=lambda bot_id:
+                        self._defense_retention_key(
+                            live[bot_id], responders[bot_id]["point"],
+                            contacts.get(team, ()), contributor_keys))
+                    keep = set(ranked[:keep_limit])
+                    for bot_id in list(responders):
+                        if bot_id not in keep:
+                            del responders[bot_id]
 
                 point_by_id = dict((value["id"], value) for value in points)
                 for bot_id, record in list(responders.items()):
@@ -894,19 +968,7 @@ class BotPlanner(object):
                                   defenders, defense):
         if not defenders or not isinstance(defense, dict):
             return assignments
-        contributor_map = defense.get("contributors")
-        contributor_map = (contributor_map
-                           if isinstance(contributor_map, dict) else {})
-        raw = contributor_map.get(str(team), contributor_map.get(team, ()))
-        contributor_keys = set()
-        if isinstance(raw, (list, tuple)):
-            for value in raw:
-                if not isinstance(value, dict):
-                    continue
-                kind = str(value.get("kind") or "")
-                vehicle_id = _integer(value.get("id"))
-                if kind in ("human", "bot") and vehicle_id > 0:
-                    contributor_keys.add((kind, vehicle_id))
+        contributor_keys = self._defense_contributor_keys(defense, team)
         if not contributor_keys:
             return assignments
         result = dict(assignments)
@@ -1000,6 +1062,82 @@ class BotPlanner(object):
             self._recent_hits.pop(_integer(bot_id), None)
             return None
         return hit
+
+    @staticmethod
+    def _weapon_can_recover(bot):
+        """Return whether current inventory can eventually supply a shot."""
+        state = bot.get("state") if isinstance(bot.get("state"), dict) else {}
+        remaining = state.get("ammo_remaining")
+        return bool(
+            isinstance(remaining, (list, tuple)) and
+            sum(max(0, _integer(value)) for value in remaining) > 0)
+
+    @staticmethod
+    def _weapon_ready(bot):
+        """Return whether this Bot can turn a firing lane into a current shot."""
+        if not BotPlanner._weapon_can_recover(bot):
+            return False
+        state = bot.get("state") if isinstance(bot.get("state"), dict) else {}
+        critical = state.get("critical")
+        critical = critical if isinstance(critical, dict) else {}
+        if "gunHealth" in set(str(value) for value in
+                              (critical.get("destroyed") or ())):
+            return False
+        remaining = state.get("ammo_remaining")
+        if isinstance(remaining, (list, tuple)):
+            loaded = _integer(state.get("shell_index"), -1)
+            if (loaded < 0 or loaded >= len(remaining) or
+                    _integer(remaining[loaded]) <= 0):
+                return False
+
+        # A burst which is already in flight owns its remaining rounds even
+        # though the ordinary loaded-shell snapshot is reload-pending.
+        if state.get("burst_active"):
+            return True
+        if state.get("ammo_reload_pending") is True:
+            return False
+        if "clip" in state and _integer(state.get("clip")) <= 0:
+            return False
+        if ("reload_time" in state and
+                _number(state.get("reload_time")) > 0.0):
+            return False
+        return True
+
+    @staticmethod
+    def _magazine_has_followup(bot):
+        """Return whether an exposed magazine or burst still has a next shot."""
+        state = bot.get("state") if isinstance(bot.get("state"), dict) else {}
+        if state.get("burst_active"):
+            return True
+        if (_integer(state.get("clip_size"), 1) <= 1 or
+                _integer(state.get("clip")) <= 0):
+            return False
+        remaining = state.get("ammo_remaining")
+        return bool(
+            isinstance(remaining, (list, tuple)) and
+            sum(max(0, _integer(value)) for value in remaining) > 0)
+
+    def _hit_requires_withdrawal(self, bot, hit, threat, team_bots):
+        """Escalate damage only when it is material or cannot be answered."""
+        if not isinstance(hit, dict):
+            return False
+        state = bot.get("state") if isinstance(bot.get("state"), dict) else {}
+        max_health = max(1.0, _number(state.get("max_health"), 1.0))
+        if (_number(hit.get("damage")) / max_health >=
+                LOW_HEALTH_BASE_FRACTION):
+            return True
+        if isinstance(threat, dict):
+            shooters = threat.get("shootable_by_bot_ids") or ()
+            if (threat.get("visible") and bot["id"] in shooters and
+                    self._weapon_ready(bot)):
+                return False
+            armed_support = [
+                ally for ally in (team_bots or ())
+                if (ally["id"] in shooters and self._weapon_ready(ally))
+            ]
+            return self._ally_support_score(
+                bot, armed_support, threat) < 0.70
+        return True
 
     def _recent_threat_contact(self, bot, contacts, now):
         hit = self._recent_hit(bot["id"], now)
@@ -1240,7 +1378,9 @@ class BotPlanner(object):
                 sort_key = (
                     score, bot["id"], str(contact.get("target_kind") or ""),
                     contact["id"], distance)
-                candidate = (sort_key, bot, contact, distance)
+                candidate = (
+                    sort_key, bot, contact, distance,
+                    self._weapon_ready(bot))
                 candidates.append(candidate)
                 by_bot.setdefault(bot["id"], []).append(candidate)
 
@@ -1258,9 +1398,12 @@ class BotPlanner(object):
                 # empty.  Keep the unexpired movement lease, while the order's
                 # fire flag still follows the current (negative) lane sample.
                 leased_contact = None
-                leased_distance = 0.0
+                cover_state = self._cover_states.get(bot["id"])
+                cover_target = (cover_state.get("target")
+                                if isinstance(cover_state, dict) else None)
                 if (isinstance(previous, dict) and
-                        _number(now) < _number(previous.get("until"))):
+                        (_number(now) < _number(previous.get("until")) or
+                         cover_target == previous.get("target"))):
                     bx = _number(bot["state"].get("x"))
                     bz = _number(bot["state"].get("z"))
                     for contact in contacts:
@@ -1274,16 +1417,16 @@ class BotPlanner(object):
                         if distance <= self._engagement_range(bot, contact):
                             leased_contact = dict(contact)
                             leased_contact["movement_lease"] = True
-                            leased_distance = distance
                             break
                 if leased_contact is not None:
-                    key = (leased_contact.get("target_kind"),
-                           leased_contact["id"])
-                    if reservations.get(key, 0) < self._focus_limit(
-                            leased_contact, leased_distance):
-                        reservations[key] = reservations.get(key, 0) + 1
-                        assigned[bot["id"]] = leased_contact
+                    if not self._weapon_can_recover(bot):
+                        self._target_assignments.pop(bot["id"], None)
                         continue
+                    if cover_target == previous.get("target"):
+                        previous["until"] = (
+                            _number(now) + TARGET_LEASE_SECONDS)
+                    assigned[bot["id"]] = leased_contact
+                    continue
                 self._target_assignments.pop(bot["id"], None)
                 continue
             if not isinstance(previous, dict):
@@ -1297,6 +1440,15 @@ class BotPlanner(object):
                     break
             if previous_candidate is None:
                 self._target_assignments.pop(bot["id"], None)
+                continue
+            if not previous_candidate[4]:
+                if self._weapon_can_recover(bot):
+                    contact = dict(previous_candidate[2])
+                    contact["movement_lease"] = True
+                    assigned[bot["id"]] = contact
+                    previous["until"] = _number(now) + TARGET_LEASE_SECONDS
+                else:
+                    self._target_assignments.pop(bot["id"], None)
                 continue
             best_score = bot_candidates[0][0][0]
             lease_expired = _number(now) >= _number(previous.get("until"))
@@ -1328,7 +1480,8 @@ class BotPlanner(object):
             if lease_expired:
                 previous["until"] = _number(now) + TARGET_LEASE_SECONDS
         for (unused_sort_key, bot, contact, distance) in sorted(
-                candidates, key=lambda value: value[0]):
+                (candidate[:4] for candidate in candidates
+                 if candidate[4]), key=lambda value: value[0]):
             if bot["id"] in assigned:
                 continue
             key = (contact.get("target_kind"), contact["id"])
@@ -1336,6 +1489,25 @@ class BotPlanner(object):
                     contact, distance):
                 continue
             reservations[key] = reservations.get(key, 0) + 1
+            assigned[bot["id"]] = contact
+            self._target_assignments[bot["id"]] = {
+                "target": key,
+                "until": _number(now) + TARGET_LEASE_SECONDS,
+            }
+        # Reloading and repairable vehicles still need one tactical contact
+        # for spacing, withdrawal and cover.  Add that movement-only lease
+        # after every current shooter has competed for the focus cap, so it
+        # cannot displace fire that is actually available.
+        for bot in bots:
+            if bot["id"] in assigned or not self._weapon_can_recover(bot):
+                continue
+            bot_candidates = sorted(
+                by_bot.get(bot["id"], ()), key=lambda value: value[0])
+            if not bot_candidates or bot_candidates[0][4]:
+                continue
+            contact = dict(bot_candidates[0][2])
+            contact["movement_lease"] = True
+            key = (contact.get("target_kind"), contact["id"])
             assigned[bot["id"]] = contact
             self._target_assignments[bot["id"]] = {
                 "target": key,
@@ -2002,14 +2174,30 @@ class BotPlanner(object):
             state["face_position"] = _point(
                 order.get("face_position") or focus["position"])
         elif (phase == "hold" and not urgent and not hold_only and
-              _number(now) >= _number(state.get("phase_until"))):
+              _number(now) >= _number(state.get("phase_until")) and
+              self._weapon_ready(bot)):
             phase = "peek"
             self._begin_cover_phase(state, phase, now, peek_distance)
+            state["peek_fire_seq"] = _integer(
+                bot.get("state", {}).get("fire_seq"))
         elif phase == "peek" and peek_distance <= 4.5:
+            bot_state = bot.get("state") if isinstance(
+                bot.get("state"), dict) else {}
+            fire_seq = _integer(bot_state.get("fire_seq"))
+            shot_advanced = fire_seq > _integer(
+                state.get("peek_fire_seq"), fire_seq)
             if _number(state.get("phase_until")) <= 0.0:
                 state["phase_until"] = (_number(now) + 1.0 +
                                         personality["aggression"] * 1.8)
-            elif _number(now) >= _number(state.get("phase_until")):
+            if shot_advanced and self._magazine_has_followup(bot):
+                state["peek_fire_seq"] = fire_seq
+                state["phase_until"] = (
+                    _number(now) + max(
+                        _number(bot_state.get("reload_time")),
+                        1.0 + personality["aggression"] * 1.8))
+            elif (shot_advanced or
+                  (not bot_state.get("burst_active") and
+                   _number(now) >= _number(state.get("phase_until")))):
                 phase = "return"
                 self._begin_cover_phase(
                     state, phase, now, cover_distance)
@@ -2067,7 +2255,8 @@ class BotPlanner(object):
         order["target_kind"] = contact.get("target_kind")
         order["aim_position"] = dict(contact["position"])
         order["face_position"] = dict(contact["position"])
-        order["fire_allowed"] = bool(fire_allowed)
+        order["fire_allowed"] = bool(
+            fire_allowed and BotPlanner._weapon_ready(bot))
         order["shell_index"] = BotPlanner._shell_index(
             profile, contact, personality, bot.get("state"))
 
@@ -2161,6 +2350,8 @@ class BotPlanner(object):
             LOW_HEALTH_BASE_FRACTION + personality["caution"] * 0.18)
         recent_hit = self._recent_hit(bot["id"], now)
         threat_contact = self._recent_threat_contact(bot, contacts, now)
+        withdraw_after_hit = self._hit_requires_withdrawal(
+            bot, recent_hit, threat_contact, team_bots)
         order = {
             "id": bot["id"],
             "team": bot["team"],
@@ -2233,7 +2424,7 @@ class BotPlanner(object):
                 self._apply_retreat_order(
                     order, bot, retreat_point, move, now,
                     "low_health_retreat", "low_health_defend")
-            elif recent_hit is not None:
+            elif withdraw_after_hit:
                 self._apply_retreat_order(
                     order, bot, retreat_point, move, now,
                     "under_fire_withdraw", "under_fire_hold")
@@ -2277,7 +2468,7 @@ class BotPlanner(object):
                 order, bot, profile, personality)
             return order
 
-        if recent_hit is not None:
+        if withdraw_after_hit:
             cover_focus = threat_contact or focus
             cover_observers = cover_focus.get("shootable_by_bot_ids")
             self._set_target(
@@ -2315,10 +2506,16 @@ class BotPlanner(object):
             return order
 
         if not locally_shootable:
-            if (focus.get("movement_lease") and
-                    self._apply_leased_movement_order(
-                        order, bot, focus)):
-                return order
+            if focus.get("movement_lease"):
+                if (bot["id"] in self._cover_states and
+                        self._apply_cover_order(
+                            order, bot, focus, personality, now)):
+                    self._engage_anchors.pop(bot["id"], None)
+                    self._combat_states.pop(bot["id"], None)
+                    return order
+                if self._apply_leased_movement_order(
+                        order, bot, focus):
+                    return order
             self._engage_anchors.pop(bot["id"], None)
             self._combat_states.pop(bot["id"], None)
             self._retreat_states.pop(bot["id"], None)

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
@@ -34,6 +34,16 @@ BLOCKED_STEP_REPLAN_SECONDS = 1.0
 BLOCKED_STEP_REPLAN_VERDICTS = 4
 BLOCKED_STEP_EDGE_TTL = 12.0
 BLOCKED_STEP_EDGE_PENALTY = 240.0
+# LocalDriver deliberately owns short-lived contact recovery, but displacement
+# alone cannot detect a tank that rocks or circles without advancing its route.
+# Track progress towards the navigator's stable local target and, after a long
+# grace, make only this bot avoid the unproductive edge for one replan.
+MACRO_PROGRESS_METRES = 0.20
+MACRO_STALL_SECONDS = 12.0
+MACRO_TARGET_CHANGE_METRES = 2.0
+MACRO_EDGE_TTL = 4.0
+MACRO_EDGE_PENALTY = 240.0
+PENDING_INTENT_PROGRESS_METRES = 0.20
 # A controlled ford admits LocalDriver's first avoidance branch, and no wider.
 CONTROLLED_SHALLOW_YAW_WINDOW = FIRST_CANDIDATE_OFFSET + 0.03
 # The commit side sees an integrated hull yaw rather than the candidate the
@@ -385,6 +395,15 @@ class TerrainGrid(object):
 				return True
 		return False
 
+	def path_has_edge_penalty(self, path, edge_penalties):
+		if not edge_penalties:
+			return False
+		for index in range(len(path) - 1):
+			if any(edge in edge_penalties for edge in
+					self._edge_keys_for_segment(path[index], path[index + 1])):
+				return True
+		return False
+
 	def _ground(self, x, z, hint_y):
 		if not self._inside(x, z):
 			return None
@@ -643,7 +662,8 @@ class TerrainGrid(object):
 		return penalty
 
 	def safe_local_target(self, current, goal, now, avoid_points=None,
-			side_preference=1.0):
+			side_preference=1.0, edge_penalties=None,
+			minimum_offset=0.0):
 		"""Choose one short, fully probed detour when the global search fails.
 
 		This is deliberately not a direct-to-goal fallback. Every candidate must
@@ -665,6 +685,8 @@ class TerrainGrid(object):
 		best = None
 		for distance in distances:
 			for offset in offsets:
+				if abs(offset) < max(0.0, float(minimum_offset)):
+					continue
 				yaw = desired_yaw + offset
 				x = float(current[0]) + math.sin(yaw) * distance
 				z = float(current[2]) + math.cos(yaw) * distance
@@ -673,6 +695,11 @@ class TerrainGrid(object):
 					continue
 				candidate = (x, y, z)
 				if not self.dry_segment_clear(current, candidate, now):
+					continue
+				if (edge_penalties and any(
+						edge in edge_penalties
+						for edge in self._edge_keys_for_segment(
+							current, candidate))):
 					continue
 				cell = self.cell_for(candidate)
 				score = (_distance_2d(candidate, goal) + abs(offset) * 3.5 +
@@ -683,23 +710,25 @@ class TerrainGrid(object):
 		return best[2] if best is not None else None
 
 	def plan(self, start, goal, avoid_points=None, max_expansions=1600, now=0.0,
-			prefer_clearance=True, edge_penalties=None):
+			prefer_clearance=True, edge_penalties=None,
+			hard_edge_penalties=None):
 		"""Return a supported path synchronously (mainly for tests/tools)."""
 		search = self.begin_plan(
 			start, goal, avoid_points, max_expansions, now, prefer_clearance,
-			edge_penalties)
+			edge_penalties, hard_edge_penalties)
 		while not search.done:
 			search.step(256)
 		return search.result
 
 	def begin_plan(self, start, goal, avoid_points=None, max_expansions=1600,
-			now=0.0, prefer_clearance=False, edge_penalties=None):
+			now=0.0, prefer_clearance=False, edge_penalties=None,
+			hard_edge_penalties=None):
 		return _TerrainSearch(self._plan_steps(
 			start, goal, avoid_points, max_expansions, now,
-			bool(prefer_clearance), edge_penalties))
+			bool(prefer_clearance), edge_penalties, hard_edge_penalties))
 
 	def _plan_steps(self, start, goal, avoid_points, max_expansions, now,
-			prefer_clearance, edge_penalties):
+			prefer_clearance, edge_penalties, hard_edge_penalties):
 		start_cell = self.cell_for(start)
 		goal_cell = self.cell_for(goal)
 		if self.prebaked:
@@ -750,6 +779,10 @@ class TerrainGrid(object):
 				next_y = self._edge(current, current_y, next_cell)
 				if next_y is None:
 					continue
+				edge_key = tuple(sorted((current, next_cell)))
+				if (hard_edge_penalties and
+						edge_key in hard_edge_penalties):
+					continue
 				if offset_x and offset_z and not self.prebaked:
 					# Do not squeeze diagonally across a blocked corner.
 					if (self._edge(current, current_y,
@@ -771,8 +804,7 @@ class TerrainGrid(object):
 					slope_cost *= 1.25
 				local_penalty = 0.0
 				if edge_penalties:
-					local_penalty = float(edge_penalties.get(
-						tuple(sorted((current, next_cell))), 0.0))
+					local_penalty = float(edge_penalties.get(edge_key, 0.0))
 				new_cost = (cost_so_far[current] + run + slope_cost +
 				            self._penalty(
 				                next_cell, avoid_points, prefer_clearance) +
@@ -793,6 +825,11 @@ class TerrainGrid(object):
 					               (new_cost + heuristic, sequence, next_cell, new_cost))
 			yield None
 		if reached is None:
+			if hard_edge_penalties and closest == start_cell:
+				# A per-bot macro veto that leaves no forward progress is a real
+				# failed route, not a sparse-anchor success at the start cell.
+				yield ()
+				return
 			# Sparse strategic anchors are hand placed on a minimap. A point a few
 			# metres inside a building footprint, cliff lip or water edge must not
 			# invalidate an otherwise complete route. Use the nearest cell A* could
@@ -821,11 +858,15 @@ class TerrainGrid(object):
 		goal_y = self._ground(float(goal[0]), float(goal[2]), path[-1][1])
 		goal_point = (float(goal[0]), goal_y if goal_y is not None else path[-1][1],
 		              float(goal[2]))
-		if self.segment_clear(path[-1], goal_point):
+		if (self.segment_clear(path[-1], goal_point) and
+				not self.path_has_edge_penalty(
+					(path[-1], goal_point), hard_edge_penalties)):
 			path.append(goal_point)
-		yield self._smooth(tuple(path), now, prefer_clearance)
+		yield self._smooth(
+			tuple(path), now, prefer_clearance, hard_edge_penalties)
 
-	def _smooth(self, path, now=0.0, prefer_clearance=False):
+	def _smooth(self, path, now=0.0, prefer_clearance=False,
+			edge_penalties=None):
 		if len(path) < 3:
 			return path
 		result = [path[0]]
@@ -838,6 +879,10 @@ class TerrainGrid(object):
 						 path, index, furthest)) and
 						self.shortcut_preserves_climb_approach(
 						path, index, furthest) and
+						not (edge_penalties and any(
+							edge in edge_penalties for edge in
+							self._edge_keys_for_segment(
+								path[index], path[furthest]))) and
 						self.dry_segment_clear(
 							path[index], path[furthest], now)):
 					break
@@ -886,6 +931,8 @@ class TerrainNavigator(object):
 		self.search_times = {}
 		self.bot_states = {}
 		self.bot_failed_edges = {}
+		self.bot_macro_edges = {}
+		self.bot_direct_progress = {}
 		self.search_frame_time = None
 		self.housekeeping_time = None
 		self.search_next_key = None
@@ -964,6 +1011,11 @@ class TerrainNavigator(object):
 			'blocked_step_replans': sum(
 				int(state.get('blocked_step_replans', 0))
 				for state in self.bot_states.values()),
+			'macro_progress_replans': sum(
+				int(state.get('macro_progress_replans', 0))
+				for state in self.bot_states.values()) + sum(
+				int(state.get('replans', 0))
+				for state in self.bot_direct_progress.values()),
 		}
 
 	def _fallback_target(self, bot_id, current, goal, now, avoid_points, state,
@@ -988,7 +1040,8 @@ class TerrainNavigator(object):
 		if allow_safe_local:
 			fallback = self.grid.safe_local_target(
 				current, goal, now, avoid_points,
-				1.0 if (int(bot_id) % 2) else -1.0)
+				1.0 if (int(bot_id) % 2) else -1.0,
+				self._active_macro_edge_penalties(bot_id, now))
 			if fallback is not None:
 				state['last_target'] = tuple(fallback)
 				state['navigation_status'] = 'safe'
@@ -1003,7 +1056,8 @@ class TerrainNavigator(object):
 		return tuple(goal)
 
 	def _pending_target(self, bot_id, current, goal, now, state,
-			avoid_points=None):
+			avoid_points=None, allow_last_target=True,
+			immediate_safe_local=False):
 		"""Continue a proved local edge, else make bounded probed progress.
 
 		Returning the hull's own position is a complete stop: the driver reads it
@@ -1017,12 +1071,14 @@ class TerrainNavigator(object):
 		means the only safe action is to hold.
 		"""
 		last_target = state.get('last_target')
-		if last_target is not None:
+		if allow_last_target and last_target is not None:
 			last_target = tuple(last_target)
 			shallow = self.grid.segment_has_baked_hazard(
 				current, last_target, BAKED_SHALLOW_WATER)
 			controlled = state.get('controlled_shallow_target')
 			if (self.grid.segment_penalty(current, last_target, now) <= 0.0 and
+					not self._macro_edges_penalized(
+						bot_id, current, last_target, now) and
 					self.grid.segment_clear(current, last_target) and
 					(not shallow or controlled == last_target) and
 					_distance_2d(current, last_target) >
@@ -1036,10 +1092,12 @@ class TerrainNavigator(object):
 			started = float(now)
 			state['pending_since'] = started
 		if (goal is not None and
-				float(now) - float(started) >= PENDING_PROGRESS_SECONDS):
+				(immediate_safe_local or
+				 float(now) - float(started) >= PENDING_PROGRESS_SECONDS)):
 			fallback = self.grid.safe_local_target(
 				current, goal, now, avoid_points,
-				1.0 if (int(bot_id) % 2) else -1.0)
+				1.0 if (int(bot_id) % 2) else -1.0,
+				self._active_macro_edge_penalties(bot_id, now))
 			if fallback is not None:
 				state['last_target'] = tuple(fallback)
 				state['navigation_status'] = 'pending'
@@ -1051,6 +1109,170 @@ class TerrainNavigator(object):
 		state['target_is_terminal'] = False
 		self._set_fallback_mode(bot_id, 'pending')
 		return tuple(current)
+
+	@staticmethod
+	def _target_advances_new_intent(current, target, goal):
+		"""Whether an old local target remains useful for a new request."""
+		if target is None or goal is None:
+			return False
+		to_target_x = float(target[0]) - float(current[0])
+		to_target_z = float(target[2]) - float(current[2])
+		to_goal_x = float(goal[0]) - float(current[0])
+		to_goal_z = float(goal[2]) - float(current[2])
+		if (to_target_x * to_goal_x + to_target_z * to_goal_z) <= 0.0:
+			return False
+		return (_distance_2d(target, goal) +
+		        PENDING_INTENT_PROGRESS_METRES < _distance_2d(current, goal))
+
+	def _reset_macro_progress(self, state, current, target, now):
+		state['macro_progress_at'] = float(now)
+		state['macro_progress_position'] = tuple(current)
+		state['macro_progress_target'] = (
+			tuple(target) if target is not None else None)
+		state['macro_progress_path_key'] = state.get('path_key')
+		state['macro_progress_index'] = int(state.get('index', 0))
+
+	def observe_direct_target(self, bot_id, current, goal, path_key, now,
+			movement_intent=True):
+		"""Return a bounded local escape when a proved direct edge stalls."""
+		bot_id = int(bot_id)
+		path_identity = tuple(path_key)
+		state = self.bot_direct_progress.get(bot_id)
+		if state is None:
+			state = {'path_key': path_identity, 'target': tuple(goal),
+			         'position': tuple(current), 'progress_at': float(now),
+			         'replans': 0}
+			self.bot_direct_progress[bot_id] = state
+		if (state.get('path_key') != path_identity or
+				_distance_2d(state.get('target', goal), goal) >
+				MACRO_TARGET_CHANGE_METRES or not movement_intent or
+				_distance_2d(current, goal) <= WAYPOINT_ARRIVAL_RADIUS):
+			state['path_key'] = path_identity
+			state['target'] = tuple(goal)
+			state['position'] = tuple(current)
+			state['progress_at'] = float(now)
+			state.pop('escape_target', None)
+			state.pop('escape_until', None)
+			return None
+		escape = state.get('escape_target')
+		if escape is not None:
+			escape = tuple(escape)
+			if (float(now) < float(state.get('escape_until', now)) and
+					_distance_2d(current, escape) > WAYPOINT_ARRIVAL_RADIUS and
+					self.grid.dry_segment_clear(current, escape, now)):
+				return escape
+			state['target'] = tuple(goal)
+			state['position'] = tuple(current)
+			state['progress_at'] = float(now)
+			state.pop('escape_target', None)
+			state.pop('escape_until', None)
+			return None
+		target = tuple(state.get('target') or goal)
+		reference = tuple(state.get('position') or current)
+		progress = (_distance_2d(reference, target) -
+		            _distance_2d(current, target))
+		if progress >= MACRO_PROGRESS_METRES:
+			state['target'] = tuple(goal)
+			state['position'] = tuple(current)
+			state['progress_at'] = float(now)
+			return None
+		if (float(now) - float(state.get('progress_at', now)) <
+				MACRO_STALL_SECONDS):
+			return None
+		escape = self.grid.safe_local_target(
+			current, goal, now, None,
+			1.0 if (bot_id % 2) else -1.0,
+			None, FIRST_CANDIDATE_OFFSET)
+		state['target'] = tuple(goal)
+		state['position'] = tuple(current)
+		state['progress_at'] = float(now)
+		if escape is None:
+			return None
+		state['escape_target'] = tuple(escape)
+		state['escape_until'] = float(now) + MACRO_EDGE_TTL
+		state['replans'] = int(state.get('replans', 0)) + 1
+		return tuple(escape)
+
+	def _start_macro_replan(self, bot_id, state, current, target, now):
+		"""Reroute one bot without changing shared terrain or hazard state."""
+		escape = self.grid.safe_local_target(
+			current, target, now, None,
+			1.0 if (int(bot_id) % 2) else -1.0,
+			None, FIRST_CANDIDATE_OFFSET)
+		key = self.grid._edge_cells_for_segment(current, target)
+		if key is None and escape is None:
+			return False
+		if escape is not None:
+			state['macro_escape_target'] = tuple(escape)
+			state['macro_escape_until'] = float(now) + MACRO_EDGE_TTL
+		else:
+			macro_edges = self.bot_macro_edges.setdefault(int(bot_id), {})
+			macro_edges[key] = (
+				float(now) + MACRO_EDGE_TTL, MACRO_EDGE_PENALTY)
+		state['replan_generation'] = int(
+			state.get('replan_generation', 0)) + 1
+		state['macro_progress_replans'] = int(
+			state.get('macro_progress_replans', 0)) + 1
+		state['path_key'] = None
+		state['index'] = 0
+		state['recovery_start'] = tuple(current)
+		state['replan_active'] = escape is None
+		state['macro_replan_active'] = True
+		state['pending_since'] = float(now) - PENDING_PROGRESS_SECONDS
+		state.pop('controlled_shallow_target', None)
+		self._cancel_bot_searches(bot_id)
+		self._reset_macro_progress(state, current, target, now)
+		return True
+
+	def _finish_macro_replan(self, bot_id, state):
+		self.bot_macro_edges.pop(int(bot_id), None)
+		state.pop('macro_escape_target', None)
+		state.pop('macro_escape_until', None)
+		state['macro_replan_active'] = False
+		state['replan_active'] = False
+		state['recovery_start'] = None
+		state['path_key'] = None
+		state['index'] = 0
+		self._cancel_bot_searches(bot_id)
+
+	def _observe_macro_progress(self, bot_id, state, current, goal, now):
+		"""Observe progress along the issued path target, not arbitrary motion."""
+		target = state.get('last_target')
+		if (state.get('macro_replan_active') and
+				state.get('macro_escape_target') is None and
+				not self._active_macro_edge_penalties(bot_id, now)):
+			self._finish_macro_replan(bot_id, state)
+			self._reset_macro_progress(state, current, target, now)
+			return False
+		if (target is None or
+				_distance_2d(current, target) <= WAYPOINT_ARRIVAL_RADIUS or
+				_distance_2d(current, goal) <= WAYPOINT_ARRIVAL_RADIUS):
+			self._reset_macro_progress(state, current, target, now)
+			return False
+		tracked_target = state.get('macro_progress_target')
+		path_changed = (
+			state.get('macro_progress_path_key') != state.get('path_key') or
+			int(state.get('macro_progress_index', 0)) !=
+			int(state.get('index', 0)))
+		if (tracked_target is None or path_changed or
+				_distance_2d(tracked_target, target) >
+				MACRO_TARGET_CHANGE_METRES):
+			self._reset_macro_progress(state, current, target, now)
+			return False
+		reference = state.get('macro_progress_position') or current
+		progress = (_distance_2d(reference, target) -
+		            _distance_2d(current, target))
+		state['macro_progress_target'] = tuple(target)
+		if progress >= MACRO_PROGRESS_METRES:
+			if state.get('macro_replan_active'):
+				self._finish_macro_replan(bot_id, state)
+			self._reset_macro_progress(state, current, target, now)
+			return False
+		if (float(now) - float(state.get('macro_progress_at', now)) >=
+				MACRO_STALL_SECONDS):
+			return self._start_macro_replan(
+				bot_id, state, current, target, now)
+		return False
 
 	@staticmethod
 	def _path_owner(path_key):
@@ -1078,9 +1300,36 @@ class TerrainNavigator(object):
 			self.bot_failed_edges.pop(int(bot_id), None)
 		return result or None
 
+	def _active_macro_edge_penalties(self, bot_id, now):
+		if bot_id is None:
+			return None
+		failed = self.bot_macro_edges.get(int(bot_id))
+		if not failed:
+			return None
+		result = {}
+		for key, value in list(failed.items()):
+			if float(now) >= float(value[0]):
+				failed.pop(key, None)
+			else:
+				result[key] = float(value[1])
+		if not failed:
+			self.bot_macro_edges.pop(int(bot_id), None)
+		return result or None
+
+	def _active_planning_edge_penalties(self, bot_id, now):
+		result = dict(self._active_bot_edge_penalties(bot_id, now) or {})
+		result.update(self._active_macro_edge_penalties(bot_id, now) or {})
+		return result or None
+
+	def _macro_edges_penalized(self, bot_id, start, end, now):
+		penalties = self._active_macro_edge_penalties(bot_id, now)
+		return bool(penalties and any(
+			edge in penalties
+			for edge in self.grid._edge_keys_for_segment(start, end)))
+
 	def _bot_edges_penalized(self, bot_id, start, end, now):
 		"""True when this bot's own escalation covers any edge of the segment."""
-		penalties = self._active_bot_edge_penalties(bot_id, now)
+		penalties = self._active_planning_edge_penalties(bot_id, now)
 		return bool(penalties and any(
 			edge in penalties
 			for edge in self.grid._edge_keys_for_segment(start, end)))
@@ -1137,6 +1386,10 @@ class TerrainNavigator(object):
 		state['index'] = 0
 		state['recovery_start'] = tuple(current)
 		state['replan_active'] = True
+		state['macro_replan_active'] = False
+		self.bot_macro_edges.pop(bot_id, None)
+		state.pop('macro_escape_target', None)
+		state.pop('macro_escape_until', None)
 		state.pop('controlled_shallow_target', None)
 		self._cancel_bot_searches(bot_id)
 		return True
@@ -1291,6 +1544,8 @@ class TerrainNavigator(object):
 			self.grid.prune_failed_edges(now)
 			for bot_id in list(self.bot_failed_edges):
 				self._active_bot_edge_penalties(bot_id, now)
+			for bot_id in list(self.bot_macro_edges):
+				self._active_macro_edge_penalties(bot_id, now)
 			self.grid.trim_caches()
 
 	def _path(self, path_key, start, goal, now, avoid_points):
@@ -1310,9 +1565,13 @@ class TerrainNavigator(object):
 				owner, keep_key=key, kind=path_key[0])
 		if key in self.paths:
 			path = self.paths[key]
+			hard_edge_penalties = self._active_macro_edge_penalties(
+				owner, now)
 			# A probe can fail while distant chunks are still streaming. Successful
 			# paths are permanent for the battle; failed ones get another chance.
-			if path and not self.grid.path_has_penalty(path, now):
+			if (path and not self.grid.path_has_penalty(path, now) and
+					not self.grid.path_has_edge_penalty(
+						path, hard_edge_penalties)):
 				self.path_times[key] = float(now)
 				return key, path
 			if path:
@@ -1326,7 +1585,9 @@ class TerrainNavigator(object):
 				self.grid.clear_negative_cache()
 		search = self.searches.get(key)
 		if search is None:
-			edge_penalties = self._active_bot_edge_penalties(owner, now)
+			edge_penalties = self._active_planning_edge_penalties(owner, now)
+			hard_edge_penalties = self._active_macro_edge_penalties(
+				owner, now)
 			penalized_direct = bool(
 				edge_penalties and any(
 					edge in edge_penalties
@@ -1347,7 +1608,8 @@ class TerrainNavigator(object):
 				start, goal, avoid_points=None,
 				max_expansions=self.search_max_expansions, now=now,
 				prefer_clearance=self._prefers_baked_clearance(path_key),
-				edge_penalties=edge_penalties)
+				edge_penalties=edge_penalties,
+				hard_edge_penalties=hard_edge_penalties)
 			self.searches[key] = search
 			self.search_times[key] = float(now)
 		self._advance_searches(now)
@@ -1419,6 +1681,8 @@ class TerrainNavigator(object):
 			horizon = max(
 				self.grid.cell_size * 2.0, float(lookahead_distance))
 		prefer_clearance = self._prefers_baked_clearance(path_key)
+		edge_penalties = self._active_macro_edge_penalties(
+			self._path_owner(path_key), now)
 		for candidate in range(index + 1, limit):
 			if (horizon is not None and candidate > index + 1 and
 					_distance_2d(current, path[candidate]) > horizon):
@@ -1428,6 +1692,8 @@ class TerrainNavigator(object):
 						 path, index, candidate)) and
 					self.grid.live_shortcut_preserves_climb_approach(
 						current, path, index, candidate) and
+					not self.grid.path_has_edge_penalty(
+						(current, path[candidate]), edge_penalties) and
 					self.grid.dry_segment_clear(
 						current, path[candidate], now)):
 				lookahead = candidate
@@ -1436,9 +1702,11 @@ class TerrainNavigator(object):
 		return lookahead
 
 	def next_target(self, bot_id, current, goal, path_key, now,
-			anchor=None, avoid_points=None, lookahead_distance=None):
+			anchor=None, avoid_points=None, lookahead_distance=None,
+			movement_intent=True):
 		"""Return a terrain-safe local target, holding if no safe path is ready."""
 		bot_id = int(bot_id)
+		self.bot_direct_progress.pop(bot_id, None)
 		# Search progress is a navigator-wide frame task, not a cache-miss side
 		# effect. Once every active bot had a cached/partial path, _path() returned
 		# before advancing unrelated join and continuation jobs, leaving the whole
@@ -1454,6 +1722,13 @@ class TerrainNavigator(object):
 			         'planned_at': 0.0, 'navigation_status': 'pending',
 			         'target_is_terminal': False,
 			         'replan_generation': 0, 'replan_active': False,
+			         'macro_replan_active': False,
+			         'macro_progress_replans': 0,
+			         'macro_progress_at': float(now),
+			         'macro_progress_position': tuple(current),
+			         'macro_progress_target': None,
+			         'macro_progress_path_key': None,
+			         'macro_progress_index': 0,
 			         'blocked_step_replans': 0,
 			         'blocked_step_tracker': None,
 			         'blocked_step_escalated_until': 0.0}
@@ -1473,9 +1748,18 @@ class TerrainNavigator(object):
 			state['planned_goal'] = tuple(goal)
 			state['planned_at'] = float(now)
 		request_key = self._cache_key(path_key, goal)
-		if state.get('request_key') != request_key:
+		had_request = state.get('request_key') is not None
+		request_changed = state.get('request_key') != request_key
+		request_transition = bool(had_request and request_changed)
+		allow_pending_last_target = True
+		if request_changed:
 			# A new route segment or combat target is not evidence that the previous
-			# request stalled. Reset recovery before evaluating progress.
+			# request stalled. A locally safe old target may bridge an asynchronous
+			# search only when it still advances the new intent.
+			allow_pending_last_target = self._target_advances_new_intent(
+				current, state.get('last_target'), goal)
+			if not allow_pending_last_target:
+				state.pop('last_target', None)
 			self._cancel_bot_searches(bot_id)
 			state['request_key'] = request_key
 			state['path_key'] = None
@@ -1487,12 +1771,48 @@ class TerrainNavigator(object):
 			state['recovery_key'] = None
 			state['recovery_start'] = None
 			state['replan_active'] = False
-		if _distance_2d(current, state['last_position']) >= 2.0:
+			state['macro_replan_active'] = False
+			self.bot_macro_edges.pop(bot_id, None)
+			state.pop('macro_escape_target', None)
+			state.pop('macro_escape_until', None)
+			state.pop('pending_since', None)
+			# A shallow-water grant belongs to the exact A* request that selected it.
+			# The replacement request must prove its own ford before steering there.
+			state.pop('controlled_shallow_target', None)
+			self._reset_macro_progress(
+				state, current, state.get('last_target'), now)
+		elif movement_intent:
+			self._observe_macro_progress(bot_id, state, current, goal, now)
+		else:
+			# A tactical throttle hold may retain a distant movement order. Keep its
+			# route warm, but start any stall lease only after movement resumes.
+			if state.get('macro_replan_active'):
+				self._finish_macro_replan(bot_id, state)
+			self._reset_macro_progress(
+				state, current, state.get('last_target'), now)
+		escape = state.get('macro_escape_target')
+		if escape is not None:
+			escape = tuple(escape)
+			if (float(now) < float(state.get('macro_escape_until', now)) and
+					_distance_2d(current, escape) > WAYPOINT_ARRIVAL_RADIUS and
+					self.grid.dry_segment_clear(current, escape, now)):
+				state.pop('controlled_shallow_target', None)
+				state['last_target'] = escape
+				state['navigation_status'] = 'safe'
+				state['target_is_terminal'] = False
+				self._set_fallback_mode(bot_id, None)
+				return escape
+			self._finish_macro_replan(bot_id, state)
+			self._reset_macro_progress(
+				state, current, state.get('last_target'), now)
+		if (not state.get('macro_replan_active') and
+				_distance_2d(current, state['last_position']) >= 2.0):
 			state['last_position'] = tuple(current)
 			state['progress_time'] = float(now)
 			state['recovery'] = 0
 			state['recovery_until'] = 0.0
 			state['replan_active'] = False
+			state['recovery_start'] = None
 		plan_start = tuple(anchor or current)
 		if anchor is not None:
 			# Strategic route annotations are two-dimensional and LAN protocol v5
@@ -1518,7 +1838,9 @@ class TerrainNavigator(object):
 		key, path = self._path(effective_key, plan_start, goal, now,
 		                       None)
 		if path is None:
-			if self.grid.dry_segment_clear(current, goal, now):
+			if (self.grid.dry_segment_clear(current, goal, now) and
+					not self._macro_edges_penalized(
+						bot_id, current, goal, now)):
 				state.pop('controlled_shallow_target', None)
 				state['last_target'] = tuple(goal)
 				state['navigation_status'] = 'safe'
@@ -1526,9 +1848,12 @@ class TerrainNavigator(object):
 				self._set_fallback_mode(bot_id, 'safe_direct')
 				return tuple(goal)
 			return self._pending_target(
-				bot_id, current, goal, now, state, avoid_points)
+				bot_id, current, goal, now, state, avoid_points,
+				allow_pending_last_target, request_transition)
 		if not path:
-			if self.grid.dry_segment_clear(current, goal, now):
+			if (self.grid.dry_segment_clear(current, goal, now) and
+					not self._macro_edges_penalized(
+						bot_id, current, goal, now)):
 				state.pop('controlled_shallow_target', None)
 				state['last_target'] = tuple(goal)
 				state['navigation_status'] = 'safe'
@@ -1568,6 +1893,8 @@ class TerrainNavigator(object):
 		current_segment_shallow = self.grid.segment_has_baked_hazard(
 			current, path[index], BAKED_SHALLOW_WATER)
 		if (self.grid.segment_penalty(current, path[index], now) > 0.0 or
+				self._macro_edges_penalized(
+					bot_id, current, path[index], now) or
 				(current_segment_shallow and
 				 not self._planned_current_segment_clear(
 					 current, path, index, now,
@@ -1577,7 +1904,8 @@ class TerrainNavigator(object):
 			key, joined_path = self._path(join_key, current, goal, now, avoid_points)
 			if joined_path is None:
 				return self._pending_target(
-				bot_id, current, goal, now, state, avoid_points)
+					bot_id, current, goal, now, state, avoid_points,
+					allow_pending_last_target, request_transition)
 			if not joined_path:
 				# The cached strategic path is unusable from this hull's actual
 				# position and the join search has conclusively failed. Reuse the
@@ -1635,7 +1963,8 @@ class TerrainNavigator(object):
 				return selected
 			if continued is None:
 				return self._pending_target(
-				bot_id, current, goal, now, state, avoid_points)
+					bot_id, current, goal, now, state, avoid_points,
+					allow_pending_last_target, request_transition)
 			return self._fallback_target(
 				bot_id, current, goal, now, avoid_points, state, True)
 		selected = tuple(path[lookahead])

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -3071,6 +3071,7 @@ class BattleRuntime(object):
                 firing_lane_probe=self._bot_firing_lane,
                 friendly_lane_probe=self._bot_friendly_firing_lane,
                 direct_launch_origin_probe=self._bot_direct_launch_origin,
+                direct_aim_point_probe=self._bot_aim_point,
                 ballistic_solution_probe=self._bot_ballistic_solution,
                 artillery_launch_probe=self._bot_artillery_launch,
                 artillery_friendly_lane_probe=(
@@ -18280,8 +18281,72 @@ class BattleRuntime(object):
             'foliage_bonus': foliage_bonus,
         }
 
+    def _bot_aim_context(self, source, target):
+        """Keep candidate ownership on the current source/target records."""
+        if not isinstance(target, dict) or not target.get('alive', True):
+            return None
+        try:
+            source_key = 'bot:%d' % int(source['id'])
+            kind = 'player' if target.get('kind') == 'human' else 'bot'
+            target_key = '%s:%d' % (
+                kind, int(target.get('network_id', target.get('id'))))
+        except (KeyError, TypeError, ValueError, OverflowError):
+            return None
+        source_record = self._records.get(source_key)
+        target_record = self._records.get(target_key)
+        if (source_record is None or target_record is None or
+                source_record.get('tombstone') or
+                target_record.get('tombstone') or
+                not source_record.get('ready') or
+                not target_record.get('ready')):
+            return None
+        source_entity = self._server_entity(source_record.get('engine_id'))
+        target_entity = self._server_entity(target_record.get('engine_id'))
+        if (source_entity is None or target_entity is None or
+                not getattr(source_entity, 'isStarted', False) or
+                not getattr(target_entity, 'isStarted', False)):
+            return None
+        descriptor = getattr(target_entity, 'typeDescriptor', None)
+        source_descriptor = getattr(source_entity, 'typeDescriptor', None)
+        if descriptor is None or source_descriptor is None:
+            return None
+        candidates = source_record.setdefault('bot_aim_targets', {})
+        entry = candidates.get(target_key)
+        geometry_ready = tuple(
+            _field(_field(_field(descriptor, name), 'hitTester'),
+                   'bbox') is not None for name in ('hull', 'turret'))
+        if (entry is None or entry['record'] is not target_record or
+                entry['descriptor'] is not descriptor or
+                entry['geometry_ready'] != geometry_ready):
+            entry = {'record': target_record, 'descriptor': descriptor,
+                     'samples': shot_geometry.vehicle_aim_samples(descriptor),
+                     'geometry_ready': geometry_ready,
+                     'cursor': 0, 'selected': None}
+            candidates[target_key] = entry
+        return source_record, source_descriptor, entry
+
+    def _bot_aim_point(self, source, target):
+        """Project the selected part at the supplied, visibility-owned pose."""
+        try:
+            context = self._bot_aim_context(source, target)
+            if context is None:
+                return None
+            entry = context[2]
+            sample = entry['selected']
+            if sample is None:
+                return None
+            return {
+                'aim_position': shot_geometry.vehicle_aim_point(sample, target),
+                # Replacing an entity or descriptor invalidates a solved shot,
+                # even when the replacement happens to have the same bbox.
+                'aim_token': (id(entry['record']), id(entry['descriptor']),
+                              sample),
+            }
+        except Exception:
+            return None
+
     def _bot_firing_lane(self, source, target):
-        """Probe static space between, rather than inside, two vehicle hulls."""
+        """Select a real exposed part with at most two static rays per job."""
         profile = source.get('profile')
         profile = profile if isinstance(profile, dict) else {}
         if str(profile.get('class_tag') or '') == 'SPG':
@@ -18292,29 +18357,53 @@ class BattleRuntime(object):
             ready, solution = self._artillery.request(
                 source, target, descriptor, shell_index, self._clock())
             return bool(ready and solution is not None)
-        source_position = _xyz(source)
-        target_position = target.get('position') or _xyz(target)
-        dx = target_position[0] - source_position[0]
-        dz = target_position[2] - source_position[2]
-        distance = math.sqrt(dx * dx + dz * dz)
-        # Keep a short but real world segment between close hulls. Treating the
-        # absence of the default eight-metre middle section as clear let tanks
-        # on opposite sides of a thin wall enter engage/hold and fire forever.
-        clearance = min(4.0, max(0.0, (distance - 0.75) * 0.5))
-        for target_height in (1.5, 2.2):
-            segment = bot_planner.trimmed_sight_segment(
-                source_position, target_position, 2.5, target_height,
-                clearance, clearance)
-            if segment is None:
+        entry = None
+        try:
+            context = self._bot_aim_context(source, target)
+            if context is None:
                 return False
-            if not segment:
+            record, descriptor, entry = context
+            samples = entry['samples']
+            if not samples:
                 return False
-            start, end = segment
-            hit = self._runtime.bigworld.wg_collideSegment(
-                self._avatar.spaceID,
-                self._vector(start), self._vector(end), 128)
-            if hit is None:
-                return True
+            pose_key = (id(descriptor), self._last_frame_time,
+                        source.get('fire_seq', 0)) + tuple(source.get(name, 0.0)
+                for name in ('x', 'y', 'z', 'yaw', 'pitch', 'roll',
+                             'aim_yaw', 'turret_yaw', 'gun_pitch'))
+            cached = record.get('bot_lane_origin')
+            origin = cached[1] if cached and cached[0] == pose_key else None
+            if origin is None:
+                origin = self._bot_direct_launch_origin(
+                    source, descriptor, source.get('shell_index', 0),
+                    int(source.get('fire_seq', 0)) + 1, 0.0, 0.0, 0.0)
+                if origin is None:
+                    entry['selected'] = None
+                    return False
+                record['bot_lane_origin'] = (pose_key, origin)
+            selected = entry['selected']
+            attempts = [selected] if selected is not None else []
+            # Keep a still-clear part stable. On blockage, rotate through the
+            # remaining bbox samples across the existing bounded lane jobs.
+            visited = 0
+            while len(attempts) < 2 and visited < len(samples):
+                index = entry['cursor'] % len(samples)
+                entry['cursor'] = (index + 1) % len(samples)
+                visited += 1
+                if samples[index] not in attempts:
+                    attempts.append(samples[index])
+            entry['selected'] = None
+            for sample in attempts:
+                point = shot_geometry.vehicle_aim_point(sample, target)
+                hit = self._runtime.bigworld.wg_collideSegment(
+                    self._avatar.spaceID, self._vector(origin),
+                    self._vector(point), 128)
+                if hit is None:
+                    entry['selected'] = sample
+                    return True
+        except Exception:
+            if entry is not None:
+                entry['selected'] = None
+            return False
         return False
 
     def _bot_friendly_path_verdict(

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -101,9 +101,12 @@ MAX_WORKER_SHOT_LANE_PAIRS_PER_FRAME = 16
 # visibility, planning, ballistics and observation serialisation consume.  In
 # particular, do not clone a complete Bot authority state for every enemy
 # observer pair.
-_TARGET_DYNAMIC_FIELDS = (
-    'team', 'alive', 'health', 'max_health',
-    'x', 'y', 'z', 'yaw', 'speed', 'velocity', 'fire_seq', 'critical',
+_TARGET_POSE_FIELDS = (
+    'x', 'y', 'z', 'yaw', 'pitch', 'roll', 'aim_yaw', 'turret_yaw',
+    'gun_pitch', 'speed', 'velocity',
+)
+_TARGET_DYNAMIC_FIELDS = _TARGET_POSE_FIELDS + (
+    'team', 'alive', 'health', 'max_health', 'fire_seq', 'critical',
 )
 _HUMAN_TARGET_STATIC_FIELDS = (
     'vehicle', 'vehicle_compact_descr', 'effective_params',
@@ -1886,6 +1889,7 @@ class BotRuntime(object):
                  vehicle_selector=None, visibility_probe=None,
                  firing_lane_probe=None, friendly_lane_probe=None,
                  direct_launch_origin_probe=None,
+                 direct_aim_point_probe=None,
                  ballistic_solution_probe=None,
                  artillery_launch_probe=None,
                  artillery_friendly_lane_probe=None,
@@ -1902,6 +1906,9 @@ class BotRuntime(object):
         self.local_player_id = local_player_id
         self.descriptor_resolver = descriptor_resolver or (lambda unused: {})
         self.player_descriptor_resolver = player_descriptor_resolver
+        # Production resolves the same descriptor-local part selected by the
+        # bounded firing-lane queue. None retains the engine-free test seam.
+        self.direct_aim_point_probe = direct_aim_point_probe
         self.direction_probe = self._adapt_direction_probe(
             direction_probe or (lambda *unused: True))
         self.adapter_factory = adapter_factory or BotAdapter
@@ -4835,6 +4842,14 @@ class BotRuntime(object):
     def _copy_target_fields(raw, names):
         return dict((name, raw[name]) for name in names if name in raw)
 
+    @staticmethod
+    def _target_pose_snapshot(target):
+        remembered = BotRuntime._copy_target_fields(target, _TARGET_POSE_FIELDS)
+        remembered['position'] = _position(target)
+        for name in ('x', 'y', 'z', 'yaw', 'speed'):
+            remembered.setdefault(name, 0.0)
+        return remembered
+
     def _human_observation_target(
             self, raw, tick_cache=None, player_id=None):
         if player_id is None:
@@ -4951,14 +4966,7 @@ class BotRuntime(object):
                     continue
                 entry[3].add(source['id'])
                 team_visibility[key] = True
-                remembered = {
-                    'position': _position(target),
-                    'x': target.get('x', 0.0),
-                    'y': target.get('y', 0.0),
-                    'z': target.get('z', 0.0),
-                    'yaw': target.get('yaw', 0.0),
-                    'speed': target.get('speed', 0.0),
-                }
+                remembered = self._target_pose_snapshot(target)
                 self._visible_target_poses[key] = remembered
                 entry[2].update(remembered)
                 duration = spotting.SPOT_MEMORY_SECONDS
@@ -4991,18 +4999,15 @@ class BotRuntime(object):
             key = (source_team, target.get('kind'),
                    int(target.get('network_id', 0)))
             if target['fresh_visible']:
-                remembered = {
-                    'position': _position(target),
-                    'x': target.get('x', 0.0),
-                    'y': target.get('y', 0.0),
-                    'z': target.get('z', 0.0),
-                    'yaw': target.get('yaw', 0.0),
-                    'speed': target.get('speed', 0.0),
-                }
+                remembered = self._target_pose_snapshot(target)
                 self._visible_target_poses[key] = remembered
                 target.update(remembered)
                 return True
             remembered = self._visible_target_poses.get(key)
+            # Discard every live pose field first: an old observation can lack
+            # articulation or velocity that the current hidden entity has.
+            for name in _TARGET_POSE_FIELDS:
+                target.pop(name, None)
             if remembered is None:
                 # The server treats a first hidden sample as a valid no-op.
                 # Publish a shape-complete neutral record, but never expose
@@ -5080,7 +5085,7 @@ class BotRuntime(object):
         if live is not None:
             if target.get('fresh_visible') is True:
                 target['position'] = _position(live)
-                pose_fields = ('x', 'y', 'z', 'yaw', 'speed')
+                pose_fields = _TARGET_POSE_FIELDS
             else:
                 pose_fields = ()
             for name in (('alive', 'health', 'max_health', 'team') +
@@ -6510,17 +6515,30 @@ class BotRuntime(object):
         direct_target = bool(
             direct_close and callable(direct) and
             not direct_penalized and direct(position, goal, now))
+        # Short, clear routes still need the navigator's progress monitor:
+        # local motion alone cannot distinguish travel from oscillation.
+        throttle_override = strategic.get('throttle_override')
+        driver = getattr(self.adapter, 'driver', None)
+        driver_state = getattr(driver, 'states', {}).get(int(bot_id), {})
+        movement_intent = bool(
+            (throttle_override is None or float(throttle_override) > 0.0)
+            and not driver_state.get('traffic_waiting', False)
+            and int(bot_id) not in self._artillery_intents
+            and int(bot_id) not in self._artillery_reproofs)
         if direct_target:
-            target = tuple(goal)
+            escape = self.navigator.observe_direct_target(
+                bot_id, position, goal, path_key, now, movement_intent)
+            target = tuple(escape or goal)
         else:
             target = self.navigator.next_target(
                 bot_id, position, goal, path_key, now,
-                anchor, avoid, lookahead_distance)
+                anchor, avoid, lookahead_distance,
+                movement_intent=movement_intent)
         terminal = getattr(self.navigator, 'target_is_terminal', None)
         state['navigation_stop_at_target'] = bool(
             stop_at_goal and
-            (direct_target or
-             (callable(terminal) and terminal(bot_id))))
+            ((direct_target and tuple(target) == tuple(goal)) or
+             (not direct_target and callable(terminal) and terminal(bot_id))))
         if mode in ('route', 'advance') and anchor is None:
             target = self._route_lane_target(
                 bot_id, position, goal, target, strategic, now)
@@ -7562,11 +7580,25 @@ class BotRuntime(object):
         start = self._exact_shot_origin(state, descriptor, shell_index)
         if start is None:
             return None
-        target_position = _point(
-            target.get('position'), _position(target))
-        target_position = (
-            target_position[0], target_position[1] + 1.0,
-            target_position[2])
+        aim_token = None
+        if callable(self.direct_aim_point_probe):
+            selected = self.direct_aim_point_probe(state, target)
+            if not isinstance(selected, dict):
+                return None
+            try:
+                target_position = _water_sensor_vector(
+                    selected['aim_position'], 3, 'bot aim point')
+                aim_token = selected['aim_token']
+            except (KeyError, TypeError, ValueError):
+                return None
+        else:
+            # The logical runtime has no target model. BattleRuntime always
+            # supplies the exact part-selection seam above, including failure.
+            target_position = _point(
+                target.get('position'), _position(target))
+            target_position = (
+                target_position[0], target_position[1] + 1.0,
+                target_position[2])
         solution = ballistics.ballistic_intercept(
             start, target_position, self._target_velocity(target),
             speed, gravity, -math.pi * 0.5, math.pi * 0.5)
@@ -7589,7 +7621,20 @@ class BotRuntime(object):
             # the exact frozen muzzle instead of crossing the native
             # HP_gunFire boundary a second time for the identical pose.
             '_origin': start,
+            '_aim_token': aim_token,
         }
+
+    def _direct_aim_matches(self, state, target, solution):
+        """A lane refresh may select a new part after this tick's gun slew."""
+        if not callable(self.direct_aim_point_probe):
+            return True
+        selected = self.direct_aim_point_probe(state, target)
+        matches = bool(
+            isinstance(selected, dict) and isinstance(solution, dict) and
+            selected.get('aim_token') == solution.get('_aim_token'))
+        if not matches:
+            self._ballistic_solution_cache.pop(int(state['id']), None)
+        return matches
 
     @staticmethod
     def _artillery_target_identity(target):
@@ -9560,14 +9605,7 @@ class BotRuntime(object):
                 team_visibility[key] = bool(
                     fresh_visible or team_visibility.get(key, False))
                 if fresh_visible:
-                    remembered = {
-                        'position': _position(observed_target),
-                        'x': observed_target.get('x', 0.0),
-                        'y': observed_target.get('y', 0.0),
-                        'z': observed_target.get('z', 0.0),
-                        'yaw': observed_target.get('yaw', 0.0),
-                        'speed': observed_target.get('speed', 0.0),
-                    }
+                    remembered = self._target_pose_snapshot(observed_target)
                     self._visible_target_poses[key] = remembered
                     observed_target.update(remembered)
                 if collect_observation:
@@ -10249,7 +10287,7 @@ class BotRuntime(object):
                                 self._probe_finished(1, probe_started)
                         lane_clear, lane_verdict = \
                             self._friendly_lane_verdict(lane_value)
-                else:
+                elif self._direct_aim_matches(state, target, ballistic_solution):
                     launch_preview = self._direct_launch_preview(
                         state, descriptor, state['shell_index'], gun_state,
                         ballistic_solution)

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/shot_geometry.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/shot_geometry.py
@@ -19,6 +19,8 @@ __all__ = (
     'shot_origin_and_direction',
     'transform_vehicle_point',
     'transform_vehicle_vector',
+    'vehicle_aim_point',
+    'vehicle_aim_samples',
     'world_direction_to_local_gun_angles',
 )
 
@@ -129,6 +131,71 @@ def transform_vehicle_point(point, position, yaw, pitch=0.0, roll=0.0):
     position = _vector3(position, 'vehicle position')
     return _add(position, transform_vehicle_vector(
         point, yaw, pitch, roll))
+
+
+def vehicle_aim_samples(descriptor):
+    """Return bounded hull/turret samples in their reviewed #1513 frames.
+
+    Quarter-box centres sample partial exposure without inventing a vehicle
+    height. Missing geometry contributes no candidate. These are aiming
+    hypotheses, not armour plates or proof that a projectile penetrates.
+    """
+    chassis = _field(descriptor, 'chassis')
+    hull = _field(descriptor, 'hull')
+    try:
+        hull_mount = _vector3(_field(chassis, 'hullPosition'),
+                              'chassis.hullPosition')
+    except (TypeError, ValueError):
+        return ()
+    components = [('hull', hull, hull_mount, 0.0)]
+    try:
+        turret_mount = _add(hull_mount, _vector3(
+            _field(hull, 'turretPositions')[0], 'hull.turretPositions[0]'))
+        static_yaw = _field(_field(descriptor, 'gun'), 'staticTurretYaw')
+        if static_yaw is not None:
+            static_yaw = _finite_number(static_yaw, 'staticTurretYaw')
+        components.append(('turret', _field(descriptor, 'turret'),
+                           turret_mount, static_yaw))
+    except (TypeError, ValueError, IndexError, KeyError):
+        pass
+    centres = []
+    edges = []
+    for name, component, mount, static_yaw in components:
+        try:
+            bbox = _field(_field(component, 'hitTester'), 'bbox')
+            lower = _vector3(bbox[0], 'aim bbox minimum')
+            upper = _vector3(bbox[1], 'aim bbox maximum')
+            if any(upper[axis] <= lower[axis] for axis in range(3)):
+                continue
+        except (TypeError, ValueError, IndexError, KeyError):
+            continue
+        centre = tuple((lower[axis] + upper[axis]) * 0.5
+                       for axis in range(3))
+        centres.append((name, mount, centre, static_yaw))
+        for axis, sign in ((0, -1.0), (0, 1.0), (1, 1.0)):
+            point = list(centre)
+            point[axis] += (upper[axis] - lower[axis]) * 0.25 * sign
+            edges.append((name, mount, tuple(point), static_yaw))
+    return tuple(centres + edges)
+
+
+def vehicle_aim_point(sample, pose):
+    """Resolve a retained part sample against the current observed pose."""
+    name, mount, point, static_yaw = sample
+    yaw = _finite_number(pose.get('yaw', 0.0), 'target yaw')
+    if name == 'turret':
+        turret_yaw = (static_yaw if static_yaw is not None else
+                      pose.get('turret_yaw',
+                               pose.get('aim_yaw', yaw) - yaw))
+        point = _rotate_y(point, _finite_number(turret_yaw, 'target turret'))
+    elif name != 'hull':
+        raise ValueError('unknown aim component')
+    position = pose.get('position')
+    if position is None:
+        position = (pose['x'], pose['y'], pose['z'])
+    return transform_vehicle_point(
+        _add(mount, point), position, yaw,
+        pose.get('pitch', 0.0), pose.get('roll', 0.0))
 
 
 def _mount_offsets(descriptor, turret_index):

--- a/tests/test_port_0922_ai.py
+++ b/tests/test_port_0922_ai.py
@@ -781,6 +781,86 @@ class BotAiPortTests(unittest.TestCase):
         self.assertEqual(current, held)
         self.assertEqual('pending', navigator.fallback_modes[7])
 
+    def test_new_pending_request_reuses_only_a_target_that_advances_it(self):
+        graph = self._baked_graph(7, 7, blocked=((3, 5),))
+        navigator = TerrainNavigator(
+            lambda *unused: None, baked_graph=graph)
+        current = (22.0, 0.0, 32.0)
+        old_goal = (22.0, 0.0, 36.0)
+        new_goal = (22.0, 0.0, 44.0)
+
+        old_target = navigator.next_target(
+            11, current, old_goal, ('route', 1, 'near-north'), 1.0)
+        selected = navigator.next_target(
+            11, current, new_goal, ('route', 1, 'far-north'), 1.1)
+
+        self.assertEqual(old_goal, old_target)
+        self.assertEqual(old_target, selected)
+        self.assertEqual('pending', navigator.bot_states[11][
+            'navigation_status'])
+        self.assertTrue(navigator.searches)
+
+    def test_new_pending_request_immediately_replaces_opposed_old_target(self):
+        graph = self._baked_graph(7, 7, blocked=((3, 2),))
+        navigator = TerrainNavigator(
+            lambda *unused: None, baked_graph=graph)
+        current = (22.0, 0.0, 32.0)
+        old_goal = (22.0, 0.0, 36.0)
+        new_goal = (22.0, 0.0, 20.0)
+
+        old_target = navigator.next_target(
+            11, current, old_goal, ('route', 1, 'north'), 1.0)
+        old_request = navigator.bot_states[11]['request_key']
+        selected = navigator.next_target(
+            11, current, new_goal, ('route', 1, 'south'), 1.1)
+        state = navigator.bot_states[11]
+
+        self.assertEqual(old_goal, old_target)
+        self.assertNotEqual(old_request, state['request_key'])
+        self.assertEqual('pending', state['navigation_status'])
+        self.assertTrue(navigator.searches)
+        self.assertNotEqual(current, selected)
+        self.assertNotEqual(old_target, selected)
+        self.assertLess(_distance_2d(selected, new_goal),
+                        _distance_2d(current, new_goal))
+        self.assertTrue(navigator.grid.dry_segment_clear(
+            current, selected, 1.1))
+
+    def test_opposed_old_target_stays_retired_after_no_safe_first_step(self):
+        graph = self._baked_graph(7, 7, blocked=((3, 2),))
+        navigator = TerrainNavigator(
+            lambda *unused: None, baked_graph=graph)
+        current = (22.0, 0.0, 32.0)
+        old_goal = (22.0, 0.0, 36.0)
+        new_goal = (22.0, 0.0, 20.0)
+        old_target = navigator.next_target(
+            11, current, old_goal, ('route', 1, 'north'), 1.0)
+        safe_local_target = navigator.grid.safe_local_target
+        safe_calls = [0]
+
+        def delayed_safe_local(*args, **kwargs):
+            safe_calls[0] += 1
+            if safe_calls[0] == 1:
+                return None
+            return safe_local_target(*args, **kwargs)
+
+        navigator._path = lambda *unused: (('pending-south',), None)
+        navigator.grid.safe_local_target = delayed_safe_local
+        first = navigator.next_target(
+            11, current, new_goal, ('route', 1, 'south'), 1.1)
+        second = navigator.next_target(
+            11, current, new_goal, ('route', 1, 'south'), 1.2)
+        third = navigator.next_target(
+            11, current, new_goal, ('route', 1, 'south'), 1.8)
+
+        self.assertEqual(old_goal, old_target)
+        self.assertEqual(current, first)
+        self.assertNotEqual(old_target, second)
+        self.assertEqual(current, second)
+        self.assertNotEqual(old_target, third)
+        self.assertLess(_distance_2d(third, new_goal),
+                        _distance_2d(current, new_goal))
+
     def test_completed_route_target_restarts_the_pending_grace(self):
         """A real routed target ends the episode; a probed step does not."""
         navigator = self._pending_navigator()
@@ -1122,6 +1202,190 @@ class BotAiPortTests(unittest.TestCase):
             1, navigator.bot_states[11]['blocked_step_replans'])
         self.assertEqual(0, navigator.bot_states[12].get(
             'blocked_step_replans', 0))
+
+    def test_macro_hard_edge_expires_and_restores_the_only_corridor(self):
+        navigator = TerrainNavigator(
+            lambda *unused: None, baked_graph=self._baked_graph(5, 1))
+        current = (14.0, 0.0, 20.0)
+        goal = (26.0, 0.0, 20.0)
+        edge = ((1, 0), (2, 0))
+        navigator.bot_failed_edges[31] = {
+            edge: (20.0, 240.0),
+        }
+        navigator.bot_macro_edges[31] = {
+            edge: (5.0, 240.0),
+        }
+
+        blocked = navigator.grid.plan(
+            current, goal, now=1.0,
+            edge_penalties=navigator._active_planning_edge_penalties(31, 1.0),
+            hard_edge_penalties=navigator._active_macro_edge_penalties(31, 1.0))
+        restored = navigator.grid.plan(
+            current, goal, now=5.1,
+            edge_penalties=navigator._active_planning_edge_penalties(31, 5.1),
+            hard_edge_penalties=navigator._active_macro_edge_penalties(31, 5.1))
+
+        self.assertEqual((), blocked)
+        self.assertTrue(restored)
+        self.assertTrue(navigator.grid.path_has_edge_penalty(restored, {edge: 1.0}))
+        self.assertNotIn(31, navigator.bot_macro_edges)
+
+    def test_macro_progress_replans_a_shuffling_bot_without_shared_penalty(self):
+        graph = self._baked_graph(7, 7)
+        hazards_before = tuple(graph['hazards'])
+        navigator = TerrainNavigator(
+            lambda *unused: None, baked_graph=graph)
+        goal = (34.0, 0.0, 32.0)
+        route_key = ('route', 1, 'east')
+        old_target = None
+        rerouted = None
+        now = 1.0
+
+        for step in range(64):
+            current = (14.1 if step & 1 else 14.0, 0.0, 32.0)
+            selected = navigator.next_target(
+                21, current, goal, route_key, now)
+            if old_target is None and selected != current:
+                old_target = selected
+            if (navigator.bot_states[21]['macro_progress_replans'] and
+                    selected not in (current, old_target)):
+                rerouted = selected
+                break
+            now += 0.25
+
+        self.assertEqual(goal, old_target)
+        self.assertIsNotNone(rerouted)
+        self.assertNotEqual(old_target, rerouted)
+        self.assertEqual(1, navigator.bot_states[21][
+            'macro_progress_replans'])
+        self.assertEqual(rerouted, navigator.bot_states[21].get(
+            'macro_escape_target'))
+        self.assertEqual(goal, navigator.next_target(
+            22, (14.0, 0.0, 32.0), goal, route_key, now))
+        self.assertNotIn(22, navigator.bot_macro_edges)
+        self.assertFalse(navigator.grid._failed_edges)
+        self.assertEqual(hazards_before, tuple(navigator.grid._baked_hazards))
+
+    def test_runtime_near_goal_direct_path_still_observes_macro_progress(self):
+        from gui.mods.offline_lan_0922.bot_runtime import BotRuntime
+
+        runtime = BotRuntime(1)
+        runtime.adapter = BotAdapter('04_himmelsdorf', 1)
+        runtime.navigator = TerrainNavigator(
+            lambda *unused: None, baked_graph=self._baked_graph(7, 7))
+        runtime.states = {41: {'id': 41, 'team': 1}}
+        goal = (26.0, 0.0, 32.0)
+        strategic = {'combat_mode': 'engage', 'target_id': 91}
+        first = None
+        rerouted = None
+        now = 1.0
+        driver_state = {'now': now, 'speed': 0.0}
+
+        for step in range(64):
+            current = (14.1 if step & 1 else 14.0, 0.0, 32.0)
+            driver_state['now'] = now
+            selected = runtime._navigation_target(
+                41, current, goal, strategic,
+                driver_state)
+            if first is None:
+                first = selected
+            state = runtime.navigator.bot_direct_progress.get(41, {})
+            if (state.get('replans') and
+                    selected not in (current, first)):
+                rerouted = selected
+                break
+            now += 0.25
+
+        self.assertEqual(goal, first)
+        self.assertIsNotNone(rerouted)
+        self.assertEqual(1, runtime.navigator.bot_direct_progress[41][
+            'replans'])
+        self.assertFalse(driver_state['navigation_stop_at_target'])
+
+    def test_runtime_hold_and_traffic_wait_pause_macro_progress_lease(self):
+        from gui.mods.offline_lan_0922.bot_runtime import BotRuntime
+
+        runtime = BotRuntime(1)
+        runtime.adapter = BotAdapter('04_himmelsdorf', 1)
+        runtime.navigator = TerrainNavigator(
+            lambda *unused: None, baked_graph=self._baked_graph(7, 7))
+        runtime.states = {
+            42: {'id': 42, 'team': 1},
+            43: {'id': 43, 'team': 1},
+            44: {'id': 44, 'team': 1},
+        }
+        current = (14.0, 0.0, 32.0)
+        goal = (26.0, 0.0, 32.0)
+        arrived_goal = (15.0, 0.0, 32.0)
+        held = {
+            'combat_mode': 'engage', 'target_id': 92,
+            'throttle_override': 0.0,
+        }
+        moving = {'combat_mode': 'engage', 'target_id': 93}
+        traffic_state = runtime.adapter.driver._state(43, 1, current)
+        traffic_state['traffic_waiting'] = True
+
+        for step in range(64):
+            now = 1.0 + step * 0.25
+            runtime._navigation_target(
+                42, current, goal, held, {'now': now, 'speed': 0.0})
+            runtime._navigation_target(
+                43, current, goal, moving, {'now': now, 'speed': 0.0})
+            arrived = runtime._navigation_target(
+                44, current, arrived_goal, moving,
+                {'now': now, 'speed': 0.0})
+        traffic_state['traffic_waiting'] = False
+        runtime._navigation_target(
+            42, current, goal, moving, {'now': 17.0, 'speed': 0.0})
+        runtime._navigation_target(
+            43, current, goal, moving, {'now': 17.0, 'speed': 0.0})
+
+        self.assertEqual(0, runtime.navigator.bot_direct_progress[42][
+            'replans'])
+        self.assertEqual(0, runtime.navigator.bot_direct_progress[43][
+            'replans'])
+        self.assertEqual(arrived_goal, arrived)
+        self.assertEqual(0, runtime.navigator.bot_direct_progress[44][
+            'replans'])
+
+    def test_macro_progress_accepts_slow_waypoint_detour_and_tactical_hold(self):
+        navigator = TerrainNavigator(lambda *unused: 0.0)
+        navigator.grid.segment_clear = lambda *unused: True
+        navigator.grid.segment_penalty = lambda *unused: 0.0
+        navigator.grid.segment_has_baked_hazard = lambda *unused: False
+        detour = ((0.0, 0.0, 0.0),
+                  (0.0, 0.0, 20.0),
+                  (20.0, 0.0, 20.0),
+                  (20.0, 0.0, 0.0))
+        navigator._path = lambda key, *unused: (key, detour)
+        navigator._lookahead_index = (
+            lambda current, path, index, *unused: index)
+        now = 1.0
+
+        for step in range(64):
+            current = (0.0, 0.0, float(step) * 0.05)
+            selected = navigator.next_target(
+                31, current, detour[-1], ('route', 1, 'detour'), now)
+            self.assertEqual(detour[1], selected)
+            now += 0.25
+
+        self.assertGreater(_distance_2d(current, detour[-1]),
+                           _distance_2d(detour[0], detour[-1]))
+
+        hold = detour[0]
+        for step in range(64):
+            navigator.next_target(
+                32, hold, detour[-1], ('hold', 1), now + step * 0.25,
+                movement_intent=False)
+        resumed = navigator.next_target(
+            32, hold, detour[-1], ('hold', 1), now + 16.0,
+            movement_intent=True)
+
+        self.assertEqual(0, navigator.bot_states[31][
+            'macro_progress_replans'])
+        self.assertEqual(0, navigator.bot_states[32][
+            'macro_progress_replans'])
+        self.assertEqual(detour[1], resumed)
 
     def test_shore_ford_episode_crosses_instead_of_oscillating(self):
         open_cells = set(((0, 2), (1, 2), (2, 2), (3, 2)))

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -10452,8 +10452,62 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertTrue(result['collision'])
         soft.assert_not_called()
 
-    def test_bot_firing_lane_trims_hulls_and_tries_two_target_heights(self):
+    def _bot_lane_scene(self, target_kind='bot'):
         runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        descriptor = _Descriptor()
+        descriptor.hull.turretPositions = (_Vector(0.0, 1.4, 0.0),)
+        runtime.bigworld.entities.update({
+            10: types.SimpleNamespace(isStarted=True,
+                                      typeDescriptor=_Descriptor()),
+            20: types.SimpleNamespace(isStarted=True,
+                                      typeDescriptor=descriptor),
+        })
+        target_key = 'player:2' if target_kind == 'human' else 'bot:12'
+        battle._records = {
+            'bot:11': {'engine_id': 10, 'ready': True},
+            target_key: {'engine_id': 20, 'ready': True},
+        }
+        battle._bot_direct_launch_origin = lambda *unused: (0.0, 2.5, 0.0)
+        source = {'id': 11, 'x': 0.0, 'y': 0.0, 'z': 0.0, 'yaw': 0.0}
+        target = {'id': 12, 'network_id': 2 if target_kind == 'human' else 12,
+                  'kind': target_kind, 'position': (0.0, 0.0, 100.0),
+                  'yaw': 0.0, 'alive': True}
+        return runtime, battle, source, target, descriptor
+
+    def test_bot_exposed_turret_selection_drives_the_actual_ballistic_aim(self):
+        runtime, battle, source, target, descriptor = self._bot_lane_scene()
+        rays = []
+
+        def wall(unused_space_id, start, end, unused_mask):
+            rays.append((start, end))
+            height = start.y + (end.y - start.y) * 90.0 / end.z
+            return (_Vector(0.0, height, 90.0),) if height < 1.8 else None
+
+        runtime.bigworld.wg_collideSegment = wall
+        self.assertTrue(battle._bot_firing_lane(source, target))
+        self.assertEqual(2, len(rays))
+        self.assertAlmostEqual(1.2, rays[0][1].y)
+        self.assertAlmostEqual(2.2, rays[1][1].y)
+        selected = battle._bot_aim_point(source, target)
+        self.assertAlmostEqual(2.2, selected['aim_position'][1])
+
+        bots = bot_runtime.BotRuntime(
+            1, direct_launch_origin_probe=battle._bot_direct_launch_origin,
+            direct_aim_point_probe=battle._bot_aim_point)
+        solution = bots._local_ballistic_solution(source, target, descriptor, 0)
+        self.assertIsNotNone(solution)
+        self.assertAlmostEqual(2.2, solution['aim_position'][1])
+        speed = descriptor.gun.shots[0].speed
+        gravity = descriptor.gun.shots[0].gravity
+        time_at_wall = 90.0 / (speed * math.cos(solution['pitch']))
+        height = (2.5 - speed * math.sin(solution['pitch']) * time_at_wall -
+                  gravity * time_at_wall ** 2 * 0.5)
+        self.assertGreater(height, 1.8)
+
+    def test_bot_firing_lane_rotates_real_samples_with_two_ray_budget(self):
+        runtime, battle, source, target, unused = self._bot_lane_scene()
         rays = []
 
         def collide(unused_space_id, start, end, unused_mask):
@@ -10461,26 +10515,24 @@ class BattleRuntimeContractTests(unittest.TestCase):
             return (_Vector(start.x + 1.0, start.y, start.z),)
 
         runtime.bigworld.wg_collideSegment = collide
-        battle = BattleRuntime(runtime)
-        battle._avatar = runtime.bigworld.avatar
-        source = {'x': 0.0, 'y': 0.0, 'z': 0.0}
-        target = {'position': (0.0, 0.0, 100.0)}
-
         self.assertFalse(battle._bot_firing_lane(source, target))
-
         self.assertEqual(2, len(rays))
-        self.assertEqual({1.5, 2.2}, {round(end.y, 1)
-                                     for unused, end in rays})
-        self.assertTrue(all(round(start.z, 1) == 4.0
+        self.assertFalse(battle._bot_firing_lane(source, target))
+        self.assertEqual(4, len(rays))
+        self.assertTrue(any(end.x != 0.0 for unused, end in rays))
+        self.assertTrue(all(round(start.z, 1) == 0.0
                             for start, unused in rays))
-        self.assertTrue(all(round(end.z, 1) == 96.0
+        self.assertTrue(all(round(end.z, 1) == 100.0
                             for unused, end in rays))
-
+        self.assertIsNone(battle._bot_aim_point(source, target))
         runtime.bigworld.wg_collideSegment = lambda *unused: None
         self.assertTrue(battle._bot_firing_lane(source, target))
+        selected = battle._bot_aim_point(source, target)
+        self.assertTrue(battle._bot_firing_lane(source, target))
+        self.assertEqual(selected, battle._bot_aim_point(source, target))
 
     def test_bot_firing_lane_probes_close_targets_instead_of_assuming_clear(self):
-        runtime = _runtime()
+        runtime, battle, source, target, unused = self._bot_lane_scene()
         rays = []
 
         def wall(unused_space_id, start, end, unused_mask):
@@ -10488,10 +10540,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
             return (_Vector(start.x, start.y, start.z + 0.25),)
 
         runtime.bigworld.wg_collideSegment = wall
-        battle = BattleRuntime(runtime)
-        battle._avatar = runtime.bigworld.avatar
-        source = {'x': 0.0, 'y': 0.0, 'z': 0.0}
-        target = {'position': (0.0, 0.0, 8.0)}
+        target['position'] = (0.0, 0.0, 8.0)
 
         self.assertFalse(battle._bot_firing_lane(source, target))
         self.assertEqual(2, len(rays))
@@ -10499,6 +10548,53 @@ class BattleRuntimeContractTests(unittest.TestCase):
 
         runtime.bigworld.wg_collideSegment = lambda *unused: None
         self.assertTrue(battle._bot_firing_lane(source, target))
+
+    def test_bot_aim_lifecycle_and_observed_pose_for_human_and_bot_targets(self):
+        for kind in ('human', 'bot'):
+            runtime, battle, source, target, descriptor = self._bot_lane_scene(kind)
+            runtime.bigworld.wg_collideSegment = lambda *unused: None
+            entity = runtime.bigworld.entities[20]
+            entity.isStarted = False
+            self.assertFalse(battle._bot_firing_lane(source, target))
+            entity.isStarted = True
+            hull_bbox = descriptor.hull.hitTester.bbox
+            turret_bbox = descriptor.turret.hitTester.bbox
+            descriptor.hull.hitTester.bbox = None
+            descriptor.turret.hitTester.bbox = None
+            self.assertFalse(battle._bot_firing_lane(source, target))
+            descriptor.hull.hitTester.bbox = hull_bbox
+            descriptor.turret.hitTester.bbox = turret_bbox
+            self.assertTrue(battle._bot_firing_lane(source, target))
+            first = battle._bot_aim_point(source, target)
+            # A hidden/live entity position is not an observation. The supplied
+            # target pose alone owns where the retained sample is projected.
+            entity.position = _Vector(500.0, 500.0, 500.0)
+            self.assertEqual(first, battle._bot_aim_point(source, target))
+            target['position'] = (10.0, 3.0, 80.0)
+            moved = battle._bot_aim_point(source, target)
+            self.assertEqual(first['aim_token'], moved['aim_token'])
+            self.assertAlmostEqual(4.2, moved['aim_position'][1])
+            key = 'player:2' if kind == 'human' else 'bot:12'
+            battle._records[key] = dict(battle._records[key])
+            self.assertIsNone(battle._bot_aim_point(source, target))
+            self.assertTrue(battle._bot_firing_lane(source, target))
+            self.assertNotEqual(first['aim_token'],
+                                battle._bot_aim_point(source, target)['aim_token'])
+            battle._records[key]['tombstone'] = True
+            self.assertIsNone(battle._bot_aim_point(source, target))
+
+    def test_bot_aim_missing_muzzle_or_failed_native_ray_revokes_selection(self):
+        runtime, battle, source, target, unused = self._bot_lane_scene()
+        runtime.bigworld.wg_collideSegment = lambda *unused: None
+        self.assertTrue(battle._bot_firing_lane(source, target))
+        runtime.bigworld.wg_collideSegment = mock.Mock(side_effect=RuntimeError('BSP'))
+        self.assertFalse(battle._bot_firing_lane(source, target))
+        self.assertIsNone(battle._bot_aim_point(source, target))
+        runtime.bigworld.wg_collideSegment = mock.Mock(return_value=None)
+        battle._last_frame_time = 1.0
+        battle._bot_direct_launch_origin = lambda *unused: None
+        self.assertFalse(battle._bot_firing_lane(source, target))
+        runtime.bigworld.wg_collideSegment.assert_not_called()
 
     def test_bot_friendly_lane_uses_the_frozen_dispersed_parabola(self):
         runtime = _runtime()

--- a/tests/test_port_0922_bot_runtime.py
+++ b/tests/test_port_0922_bot_runtime.py
@@ -7169,6 +7169,73 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertLessEqual(solution['pitch'], 0.15)
         self.assertGreater(solution['flight_time'], 0.25)
 
+    def test_selected_part_aim_is_led_and_missing_geometry_blocks_solution(self):
+        selection = [{'aim_position': (0.0, 3.0, 300.0), 'aim_token': ('turret',)}]
+        runtime = self.module.BotRuntime(
+            1, direct_aim_point_probe=lambda *unused: selection[0])
+        state = {'id': 11, 'x': 0.0, 'y': 0.0, 'z': 0.0}
+        target = {'position': (0.0, 0.0, 300.0),
+                  'yaw': math.pi * 0.5, 'speed': 20.0}
+        solution = runtime._local_ballistic_solution(
+            state, target, _combat_descriptor(), 0)
+        self.assertIsNotNone(solution)
+        self.assertAlmostEqual(3.0, solution['aim_position'][1])
+        self.assertGreater(solution['aim_position'][0], 1.0)
+        self.assertEqual(('turret',), solution['_aim_token'])
+        self.assertTrue(runtime._direct_aim_matches(state, target, solution))
+        runtime._ballistic_solution_cache[11] = ('cached',)
+        selection[0] = {'aim_position': (0.0, 1.5, 300.0), 'aim_token': ('hull',)}
+        self.assertFalse(runtime._direct_aim_matches(state, target, solution))
+        self.assertNotIn(11, runtime._ballistic_solution_cache)
+        for missing in (None, {'aim_position': (0, float('nan'), 300)}):
+            selection[0] = missing
+            self.assertIsNone(runtime._local_ballistic_solution(
+                state, target, _combat_descriptor(), 0))
+
+    def test_lane_part_change_after_slew_defers_only_new_shot_admission(self):
+        selection = [{'aim_position': (0.0, 1.0, 100.0), 'aim_token': ('hull',)}]
+
+        def lane(*unused):
+            selection[0] = {'aim_position': (0.0, 2.2, 100.0),
+                            'aim_token': ('turret',)}
+            return True
+
+        command = {
+            'target_yaw': 0.0, 'throttle': 0.0, 'turn': 0.0,
+            'shell_index': 0, 'fire_allowed': True,
+            'target_id': self.module.HUMAN_TARGET_ID_BASE + 2,
+            'fire_range': 500.0, 'combat_mode': 'engage',
+            'aim_position': (0.0, 1.0, 100.0),
+            'face_position': (0.0, 1.0, 100.0),
+            'move_position': (0.0, 0.0, 0.0),
+            'recovery_mode': 'arrived', 'movement_intent': False,
+        }
+        runtime = self.module.BotRuntime(
+            1, descriptor_resolver=lambda unused: _combat_descriptor(
+                reload_time=0.01, clip=(1,)),
+            adapter_factory=lambda *unused, **kwargs: _FixedAdapter(command),
+            direction_probe=lambda *unused: {'clear': True, 'slope': 0.0},
+            visibility_probe=lambda *unused: True,
+            firing_lane_probe=lane,
+            direct_aim_point_probe=lambda *unused: selection[0],
+            ground_probe=lambda *unused: 0.0,
+            physics_ground_probe=lambda *unused: 0.0,
+            spawn_resolver=_spawn_resolver, baked_graph=_graph())
+        runtime.battle_start(self.start)
+        runtime._next_observation = 100.0
+        runtime._next_shot_lane_refresh = 100.0
+        runtime._next_cover_refresh = 100.0
+        player = _admit_player({'id': 2, 'team': 1, 'alive': True,
+                                'x': 0.0, 'y': 0.0, 'z': 100.0})
+        runtime.states[11].update(x=0.0, y=0.0, z=0.0, yaw=0.0)
+        blocked = runtime.update(0.2, 1.0, players=[player])[0]['bots'][0]
+        self.assertEqual(0, blocked['fire_seq'])
+        self.assertNotIn(11, runtime._ballistic_solution_cache)
+        fired = runtime.update(0.2, 1.2, players=[player])[0]['bots'][0]
+        self.assertEqual(1, fired['fire_seq'])
+        self.assertTrue(runtime.states[11]['gun_aligned'])
+        self.assertLess(fired['gun_pitch'], 0.0)
+
     def test_spg_requires_a_client_proved_arc_and_accepts_low_root_fallback(self):
         descriptor = _combat_descriptor()
         target = {
@@ -12559,7 +12626,8 @@ class BotRuntimeTests(unittest.TestCase):
             'id': 2, 'team': 2, 'alive': True,
             'vehicle': 'ussr:R11_MS-1',
             'x': 10.0, 'y': 1.0, 'z': 100.0,
-            'yaw': 0.2, 'speed': 4.0, 'health': 900,
+            'yaw': 0.2, 'pitch': 0.1, 'roll': -0.1,
+            'turret_yaw': 0.4, 'speed': 4.0, 'health': 900,
             'max_health': 1000,
         })
         unused_contacts, lookup = runtime._contacts_for(
@@ -12567,9 +12635,12 @@ class BotRuntimeTests(unittest.TestCase):
         planner_id = self.module.HUMAN_TARGET_ID_BASE + 2
         self.assertEqual((10.0, 1.0, 100.0),
                          lookup[planner_id]['position'])
+        self.assertEqual((0.1, -0.1, 0.4), tuple(
+            lookup[planner_id][name] for name in ('pitch', 'roll', 'turret_yaw')))
 
         visible[0] = False
         player.update(x=80.0, y=2.0, z=240.0, yaw=1.2,
+                      pitch=0.3, roll=0.2, turret_yaw=-0.5,
                       speed=20.0, health=700)
         contacts, lookup = runtime._contacts_for(source, [player], 1.1)
         hidden_human = lookup[planner_id]
@@ -12587,6 +12658,13 @@ class BotRuntimeTests(unittest.TestCase):
             refreshed_human['z'], refreshed_human['yaw'],
             refreshed_human['speed']))
         self.assertEqual(700, refreshed_human['health'])
+        self.assertEqual((0.1, -0.1, 0.4), tuple(
+            refreshed_human[name] for name in ('pitch', 'roll', 'turret_yaw')))
+        visible[0] = True
+        unused, fresh_lookup = runtime._contacts_for(source, [player], 1.15)
+        self.assertEqual((0.3, 0.2, -0.5), tuple(
+            fresh_lookup[planner_id][name]
+            for name in ('pitch', 'roll', 'turret_yaw')))
 
         bot = {
             'id': 12, 'team': 2, 'alive': True,
@@ -13651,11 +13729,16 @@ class BotRuntimeTests(unittest.TestCase):
                 return True
 
         class Navigator(object):
+            @staticmethod
+            def observe_direct_target(*unused):
+                return None
+
             grid = Grid()
             bot_states = {}
 
             def next_target(self, bot_id, position, goal, path_key, now,
-                            anchor, avoid, lookahead_distance=None):
+                            anchor, avoid, lookahead_distance=None,
+                            movement_intent=True):
                 calls.append((bot_id, goal, path_key, anchor))
                 # The navigation result is deliberately unrelated to the
                 # macro goal. A post-A* translation would change this tuple.
@@ -14170,12 +14253,17 @@ class BotRuntimeTests(unittest.TestCase):
                 return True
 
         class Navigator(object):
+            @staticmethod
+            def observe_direct_target(*unused):
+                return None
+
             def __init__(self):
                 self.grid = Grid()
                 self.bot_states = {}
 
             def next_target(self, bot_id, position, goal, path_key, now,
-                            anchor, avoid, lookahead_distance=None):
+                            anchor, avoid, lookahead_distance=None,
+                            movement_intent=True):
                 calls.append((goal, path_key))
                 self.bot_states[bot_id] = {
                     'navigation_status': 'blocked',
@@ -14633,14 +14721,21 @@ class BotRuntimeTests(unittest.TestCase):
                 return self.allow_direct
 
         class Navigator(object):
+            @staticmethod
+            def observe_direct_target(*unused):
+                return None
+
             def __init__(self):
                 self.grid = Grid()
                 self.penalized = False
                 self.penalty_calls = []
 
             def next_target(self, bot_id, position, goal, path_key, now,
-                            anchor, avoid, lookahead_distance=None):
+                            anchor, avoid, lookahead_distance=None,
+                            movement_intent=True):
                 calls.append(('planned', bot_id, path_key))
+                if self.grid.allow_direct and not self.penalized:
+                    return tuple(goal)
                 return (4.0, 0.0, 8.0)
 
             @staticmethod
@@ -14705,8 +14800,13 @@ class BotRuntimeTests(unittest.TestCase):
         calls = []
 
         class Navigator(object):
+            @staticmethod
+            def observe_direct_target(*unused):
+                return None
+
             def next_target(self, bot_id, position, goal, path_key, now,
-                            anchor, avoid, lookahead_distance=None):
+                            anchor, avoid, lookahead_distance=None,
+                            movement_intent=True):
                 calls.append(path_key)
                 return goal
 
@@ -14726,6 +14826,27 @@ class BotRuntimeTests(unittest.TestCase):
             ('local', 11, 'base_defense', '1:0'),
             ('local', 11, 'base_defense', '1:0'),
         ], calls)
+
+    def test_artillery_proof_hold_does_not_accumulate_macro_stall_time(self):
+        runtime = self.module.BotRuntime(1, baked_graph=_graph())
+        runtime.navigator = self.module.TerrainNavigator(
+            lambda *unused: None, baked_graph=_graph())
+        runtime.states = {11: {'id': 11, 'team': 1}}
+        current = (0.0, 0.0, 0.0)
+        goal = (0.0, 0.0, 100.0)
+        strategic = {'combat_mode': 'artillery_deploy', 'target_id': 21}
+        for pending in (runtime._artillery_intents, runtime._artillery_reproofs):
+            pending[11] = {'created': 1.0}
+            for now in range(1, 31):
+                runtime._navigation_target(
+                    11, current, goal, strategic, {'now': float(now)})
+            self.assertEqual(0, runtime.navigator.bot_states[11][
+                'macro_progress_replans'])
+            pending.clear()
+            runtime._navigation_target(
+                11, current, goal, strategic, {'now': 30.1})
+            self.assertEqual(0, runtime.navigator.bot_states[11][
+                'macro_progress_replans'])
 
     def test_planner_selects_near_fast_stable_base_defenders(self):
         planner = BotPlanner()
@@ -14841,6 +14962,10 @@ class BotRuntimeTests(unittest.TestCase):
             'x': 400.0, 'y': 0.0, 'z': 0.0,
             'health': 1000, 'max_health': 1000,
         }]
+        for state in states:
+            state.update(ammo_remaining=[40], shell_index=0,
+                         ammo_reload_pending=False, reload_time=0.0,
+                         clip=1, clip_size=1, burst_active=False)
         enemy = {'id': 2, 'team': 2, 'alive': True}
         self.assertEqual(1, planner.report_contacts([{
             'observing_team': 1, 'target_kind': 'human',
@@ -14976,6 +15101,10 @@ class BotRuntimeTests(unittest.TestCase):
                 'world_pose': True, 'x': x, 'y': 0.0, 'z': 0.0,
                 'health': 1000, 'max_health': 1000,
             })
+        for state in states:
+            state.update(ammo_remaining=[40], shell_index=0,
+                         ammo_reload_pending=False, reload_time=0.0,
+                         clip=1, clip_size=1, burst_active=False)
         enemies = [
             {'id': 2, 'team': 2, 'alive': True},
             {'id': 3, 'team': 2, 'alive': True},
@@ -15296,7 +15425,7 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertFalse(orders[11]['fire_allowed'])
         self.assertEqual(2, orders[12]['target_id'])
         self.assertEqual('human', orders[12]['target_kind'])
-        self.assertTrue(orders[12]['fire_allowed'])
+        self.assertFalse(orders[12]['fire_allowed'])
 
         payload = planner.build_orders(
             manifest, bot_states, [enemy], 1.0)
@@ -15305,9 +15434,16 @@ class BotRuntimeTests(unittest.TestCase):
             'bot_orders': payload['orders'],
         }))
         # Team spotting does not pull bot 11 off its route. Bot 12 owns the
-        # current firing lane and remains the only assigned shooter.
+        # current firing lane and becomes the sole shooter after reloading.
         for index in range(4):
-            runtime.update(.06, 1.21 + index * .21, players=[enemy])
+            now = 1.21 + index * .21
+            runtime.update(.06, now, players=[enemy])
+            payload = planner.build_orders(
+                manifest, list(runtime.states.values()), [enemy], now)
+            runtime._apply_orders({
+                'bot_order_revision': payload['revision'],
+                'bot_orders': payload['orders'],
+            })
         self.assertEqual(0, runtime.states[11]['fire_seq'])
         self.assertGreater(runtime.states[12]['fire_seq'], 0)
 
@@ -15371,6 +15507,21 @@ class BotRuntimeTests(unittest.TestCase):
         yaws = []
         turns = []
         for frame in range(750):
+            if frame and frame % 50 == 0:
+                now = 1.0 + frame * 0.02
+                bot_states = [dict(runtime.states[11])]
+                planner.report_contacts([{
+                    'observing_team': 1, 'target_kind': 'human',
+                    'target_id': 2, 'target_team': 2,
+                    'visible': True, 'shootable_by_bot_ids': [11],
+                    'x': 0.0, 'y': 0.0, 'z': 20.0,
+                    'health': 1000, 'max_health': 1000,
+                }], planner.known_targets(bot_states, [enemy]), now)
+                payload = planner.build_orders(manifest, bot_states, [enemy], now)
+                runtime._apply_orders({
+                    'bot_order_revision': payload['revision'],
+                    'bot_orders': payload['orders'],
+                })
             runtime.update(0.02, 1.0 + frame * 0.02,
                            players=[enemy])
             yaws.append(runtime.states[11]['yaw'])
@@ -15401,6 +15552,10 @@ class BotRuntimeTests(unittest.TestCase):
             'id': 11, 'team': 1, 'alive': True,
             'x': 0.0, 'y': 0.0, 'z': 0.0, 'yaw': 0.0,
         }]
+        for state in bot_states:
+            state.update(ammo_remaining=[40], shell_index=0,
+                         ammo_reload_pending=False, reload_time=0.0,
+                         clip=1, clip_size=1, burst_active=False)
         enemy = {
             'id': 2, 'team': 2, 'alive': True,
             'x': 0.0, 'y': 0.0, 'z': 150.0,
@@ -16123,6 +16278,7 @@ class BotRuntimeTests(unittest.TestCase):
         observation_batches = 0
         observation_times = []
         per_frame_lane_probes = []
+        ready_order_batches = 0
 
         # Drive the runtime at 50 FPS for 120 seconds. Periodic firing-lane
         # refreshes and current-fire safety checks share one frame budget.
@@ -16175,13 +16331,17 @@ class BotRuntimeTests(unittest.TestCase):
                     self.assertIn(order['id'],
                                   contact['shootable_by_bot_ids'])
             if len(runtime._shot_los_cache) == 420:
-                self.assertEqual(2, targeted)
-                self.assertEqual(2, firing)
-            else:
-                self.assertLessEqual(targeted, 2)
-                self.assertLessEqual(firing, targeted)
+                # Reload and empty ammunition now affect permission even when
+                # a lane exists. Only the two clear observers may be targeted.
+                self.assertTrue(all(order['id'] in (11, 25)
+                                    for order in orders
+                                    if order['target_id'] is not None))
+            self.assertLessEqual(targeted, 2)
+            self.assertLessEqual(firing, targeted)
+            ready_order_batches += int(firing > 0)
 
         self.assertTrue(observation_times)
+        self.assertGreater(ready_order_batches, 0)
         self.assertLessEqual(
             observation_times[0],
             1.0 + self.module.PUBLICATION_SECONDS + 0.02 + 1e-6)

--- a/tests/test_port_0922_server_bot_ai.py
+++ b/tests/test_port_0922_server_bot_ai.py
@@ -76,8 +76,36 @@ def _state(bot_id, team, x, z):
         'yaw': 0.0,
         'health': 1000,
         'max_health': 1000,
+        'fire_seq': 0,
+        'shell_index': 0,
+        'next_shell_index': 0,
+        'ammo_remaining': [20],
+        'ammo_reload_pending': False,
+        'reload_time': 0.0,
+        'reload_duration': 20.0,
+        'clip': 1,
+        'clip_size': 1,
+        'burst_active': False,
         'critical': {},
     }
+
+
+def _weapon_state(raw, reload_time=0.0, clip=1, clip_size=1,
+                  ammunition=(20,), reload_pending=False, fire_seq=0,
+                  burst_active=False):
+    raw.update({
+        'fire_seq': int(fire_seq),
+        'shell_index': 0,
+        'next_shell_index': 0,
+        'ammo_remaining': list(ammunition),
+        'ammo_reload_pending': bool(reload_pending),
+        'reload_time': float(reload_time),
+        'reload_duration': 20.0,
+        'clip': int(clip),
+        'clip_size': int(clip_size),
+        'burst_active': bool(burst_active),
+    })
+    return raw
 
 
 def _contact(target_id, x, z, observers, class_tag='mediumTank'):
@@ -318,6 +346,433 @@ class ServerBotTacticsTests(unittest.TestCase):
             self.manifest, self.states, players, 3.1)['orders'][0]
         self.assertIsNone(expired['target_id'])
         self.assertEqual('route', expired['combat_mode'])
+
+    def test_ready_shooter_preempts_a_reloading_target_lease(self):
+        planner = BotPlanner()
+        manifest = [
+            _bot(11, 1, 0, self.route, 'mediumTank'),
+            _bot(12, 1, 1, self.route, 'mediumTank'),
+        ]
+        states = [
+            _weapon_state(_state(11, 1, 0, 0)),
+            _weapon_state(_state(12, 1, 20, 0)),
+        ]
+        contact = _contact(2, 0, 240, [11, 12])
+        contact.update({'health': 500, 'max_health': 1000})
+        players = self._report(planner, [contact])
+
+        first = dict((order['id'], order) for order in
+                     planner.build_orders(
+                         manifest, states, players, 1.0)['orders'])
+        self.assertEqual(2, first[11]['target_id'])
+        self.assertIsNone(first[12]['target_id'])
+
+        states[0].update({
+            'reload_time': 8.0,
+            'ammo_reload_pending': True,
+        })
+        ready_only = _contact(2, 0, 240, [12])
+        ready_only.update({'health': 500, 'max_health': 1000})
+        self.assertEqual(1, planner.report_contacts(
+            [ready_only], planner.known_targets(states, players), 1.5))
+        reallocated = dict((order['id'], order) for order in
+                           planner.build_orders(
+                               manifest, states, players, 1.5)['orders'])
+
+        self.assertEqual(2, reallocated[11]['target_id'])
+        self.assertFalse(reallocated[11]['fire_allowed'])
+        self.assertEqual(first[11]['combat_mode'],
+                         reallocated[11]['combat_mode'])
+        self.assertEqual(first[11]['move_position'],
+                         reallocated[11]['move_position'])
+        self.assertEqual(2, reallocated[12]['target_id'])
+        self.assertTrue(reallocated[12]['fire_allowed'])
+
+    def test_unavailable_weapons_do_not_consume_focus_capacity(self):
+        unavailable_states = (
+            (True, _weapon_state(
+                _state(11, 1, 0, 0), reload_time=8.0,
+                reload_pending=True)),
+            (True, _weapon_state(
+                _state(11, 1, 0, 0), reload_time=20.0,
+                clip=0, clip_size=3, reload_pending=True)),
+            (False, _weapon_state(
+                _state(11, 1, 0, 0), ammunition=(0,))),
+            (True, _weapon_state(_state(11, 1, 0, 0))),
+        )
+        unavailable_states[-1][1]['critical'] = {
+            'destroyed': ['gunHealth'],
+        }
+
+        for keeps_movement_target, unavailable in unavailable_states:
+            with self.subTest(state=unavailable):
+                planner = BotPlanner()
+                manifest = [
+                    _bot(11, 1, 0, self.route, 'mediumTank'),
+                    _bot(12, 1, 1, self.route, 'mediumTank'),
+                ]
+                states = [
+                    unavailable,
+                    _weapon_state(_state(12, 1, 20, 0)),
+                ]
+                contact = _contact(2, 0, 240, [11, 12])
+                contact.update({'health': 500, 'max_health': 1000})
+                players = self._report(planner, [contact])
+
+                orders = dict((order['id'], order) for order in
+                              planner.build_orders(
+                                  manifest, states, players, 1.0)['orders'])
+
+                if keeps_movement_target:
+                    self.assertEqual(2, orders[11]['target_id'])
+                    self.assertFalse(orders[11]['fire_allowed'])
+                else:
+                    self.assertIsNone(orders[11]['target_id'])
+                    self.assertEqual('route', orders[11]['combat_mode'])
+                    self.assertNotEqual(
+                        {'x': 0.0, 'y': 0.0, 'z': 0.0},
+                        orders[11]['move_position'])
+                self.assertEqual(2, orders[12]['target_id'])
+                self.assertTrue(orders[12]['fire_allowed'])
+
+    def test_reloading_vehicle_uses_a_new_close_threat_for_withdrawal(self):
+        planner = BotPlanner()
+        states = [_weapon_state(
+            _state(11, 1, 0, 0), reload_time=8.0,
+            reload_pending=True)]
+        contact = _contact(2, 0, 20, [11])
+        players = self._report(planner, [contact])
+
+        order = planner.build_orders(
+            self.manifest, states, players, 1.0)['orders'][0]
+
+        self.assertEqual(2, order['target_id'])
+        self.assertEqual('withdraw', order['combat_mode'])
+        self.assertFalse(order['fire_allowed'])
+
+    def test_exhausted_weapon_releases_an_old_lease(self):
+        planner = BotPlanner()
+        manifest = [
+            _bot(11, 1, 0, self.route, 'mediumTank'),
+            _bot(12, 1, 1, self.route, 'mediumTank'),
+        ]
+        states = [
+            _weapon_state(_state(11, 1, 0, 0)),
+            _weapon_state(_state(12, 1, 20, 0)),
+        ]
+        contact = _contact(2, 0, 240, [11, 12])
+        contact.update({'health': 500, 'max_health': 1000})
+        players = self._report(planner, [contact])
+        first = dict((order['id'], order) for order in
+                     planner.build_orders(
+                         manifest, states, players, 1.0)['orders'])
+        self.assertEqual(2, first[11]['target_id'])
+
+        states[0].update({
+            'ammo_remaining': [0],
+            'clip': 0,
+        })
+        ready_only = _contact(2, 0, 240, [12])
+        ready_only.update({'health': 500, 'max_health': 1000})
+        self.assertEqual(1, planner.report_contacts(
+            [ready_only], planner.known_targets(states, players), 1.5))
+        orders = dict((order['id'], order) for order in
+                      planner.build_orders(
+                          manifest, states, players, 1.5)['orders'])
+
+        self.assertIsNone(orders[11]['target_id'])
+        self.assertNotIn(11, planner._target_assignments)
+        self.assertEqual(2, orders[12]['target_id'])
+        self.assertTrue(orders[12]['fire_allowed'])
+
+    def test_cover_movement_lease_does_not_reserve_a_firing_slot(self):
+        planner = BotPlanner()
+        manifest = [
+            _bot(11, 1, 0, self.route, 'mediumTank'),
+            _bot(12, 1, 1, self.route, 'mediumTank'),
+        ]
+        states = [
+            _weapon_state(_state(11, 1, 0, 0)),
+            _weapon_state(_state(12, 1, 20, 0)),
+        ]
+        initial_contact = _contact(2, 0, 150, [11])
+        initial_contact.update({'health': 500, 'max_health': 1000})
+        players = self._report(planner, [initial_contact])
+        self.assertEqual(1, planner.report_affordances(
+            [_cover_report(11, 2)], planner.known_bots(manifest, states),
+            planner.known_targets(states, players), 1.0))
+        approach = dict((order['id'], order) for order in
+                        planner.build_orders(
+                            manifest, states, players, 1.0)['orders'])
+        self.assertEqual('take_cover', approach[11]['combat_mode'])
+        states[0].update(approach[11]['move_position'])
+
+        ready_only = _contact(2, 0, 150, [12])
+        ready_only.update({'health': 500, 'max_health': 1000})
+        self.assertEqual(1, planner.report_contacts(
+            [ready_only], planner.known_targets(states, players), 2.0))
+        holding = dict((order['id'], order) for order in
+                       planner.build_orders(
+                           manifest, states, players, 2.0)['orders'])
+
+        self.assertEqual('cover_hold', holding[11]['combat_mode'])
+        self.assertFalse(holding[11]['fire_allowed'])
+        self.assertEqual(2, holding[12]['target_id'])
+        self.assertTrue(holding[12]['fire_allowed'])
+
+        peeking = dict((order['id'], order) for order in
+                       planner.build_orders(
+                           manifest, states, players, 4.0)['orders'])
+        self.assertEqual('cover_peek', peeking[11]['combat_mode'])
+        self.assertFalse(peeking[11]['fire_allowed'])
+        self.assertEqual(2, peeking[12]['target_id'])
+        self.assertTrue(peeking[12]['fire_allowed'])
+
+    def test_destroyed_gun_keeps_its_movement_lease_until_repaired(self):
+        planner = BotPlanner()
+        manifest = [
+            _bot(11, 1, 0, self.route, 'mediumTank'),
+            _bot(12, 1, 1, self.route, 'mediumTank'),
+        ]
+        states = [
+            _weapon_state(_state(11, 1, 0, 0)),
+            _weapon_state(_state(12, 1, 20, 0)),
+        ]
+        contact = _contact(2, 0, 240, [11, 12])
+        contact.update({'health': 500, 'max_health': 1000})
+        players = self._report(planner, [contact])
+        first = dict((order['id'], order) for order in
+                     planner.build_orders(
+                         manifest, states, players, 1.0)['orders'])
+        self.assertEqual(2, first[11]['target_id'])
+
+        states[0]['critical'] = {'destroyed': ['gunHealth']}
+        self.assertEqual(1, planner.report_contacts(
+            [contact], planner.known_targets(states, players), 1.5))
+        destroyed = dict((order['id'], order) for order in
+                         planner.build_orders(
+                             manifest, states, players, 1.5)['orders'])
+        self.assertEqual(2, destroyed[11]['target_id'])
+        self.assertFalse(destroyed[11]['fire_allowed'])
+        self.assertEqual(first[11]['move_position'],
+                         destroyed[11]['move_position'])
+        self.assertEqual(2, destroyed[12]['target_id'])
+        self.assertTrue(destroyed[12]['fire_allowed'])
+
+        states[0]['critical'] = {'destroyed': []}
+        self.assertEqual(1, planner.report_contacts(
+            [contact], planner.known_targets(states, players), 19.6))
+        repaired = dict((order['id'], order) for order in
+                        planner.build_orders(
+                            manifest, states, players, 19.6)['orders'])
+        self.assertEqual(2, repaired[11]['target_id'])
+        self.assertTrue(repaired[11]['fire_allowed'])
+        self.assertIsNone(repaired[12]['target_id'])
+
+    def test_active_burst_keeps_focus_while_reload_is_pending(self):
+        planner = BotPlanner()
+        manifest = [
+            _bot(11, 1, 0, self.route, 'mediumTank'),
+            _bot(12, 1, 1, self.route, 'mediumTank'),
+        ]
+        states = [
+            _weapon_state(
+                _state(11, 1, 0, 0), reload_time=1.0,
+                clip=2, clip_size=3, reload_pending=True,
+                fire_seq=1, burst_active=True),
+            _weapon_state(_state(12, 1, 20, 0)),
+        ]
+        contact = _contact(2, 0, 240, [11, 12])
+        contact.update({'health': 500, 'max_health': 1000})
+        players = self._report(planner, [contact])
+
+        orders = dict((order['id'], order) for order in
+                      planner.build_orders(
+                          manifest, states, players, 1.0)['orders'])
+
+        self.assertEqual(2, orders[11]['target_id'])
+        self.assertTrue(orders[11]['fire_allowed'])
+        self.assertIsNone(orders[12]['target_id'])
+
+    def test_minor_answerable_hit_does_not_force_withdrawal(self):
+        planner = BotPlanner()
+        self.states[0] = _weapon_state(self.states[0])
+        contact = _contact(2, 0, 150, [11])
+        players = self._report(planner, [contact])
+        self.assertTrue(planner.report_damage(
+            11, 'player', 2, 1, 1.1))
+
+        order = planner.build_orders(
+            self.manifest, self.states, players, 1.1)['orders'][0]
+
+        self.assertEqual(2, order['target_id'])
+        self.assertTrue(order['fire_allowed'])
+        self.assertNotIn(order['combat_mode'], (
+            'under_fire_withdraw', 'under_fire_hold'))
+
+    def test_minor_unanswerable_hit_uses_nearby_support(self):
+        contact = _contact(2, 0, 50, [12])
+        players = [{'id': 2, 'team': 2, 'alive': True}]
+
+        unsupported = BotPlanner()
+        solo_states = [_weapon_state(_state(11, 1, 0, 0))]
+        self.assertEqual(1, unsupported.report_contacts(
+            [contact], unsupported.known_targets(solo_states, players), 1.0))
+        self.assertTrue(unsupported.report_damage(
+            11, 'player', 2, 1, 1.1))
+        solo = unsupported.build_orders(
+            self.manifest, solo_states, players, 1.1)['orders'][0]
+        self.assertEqual('under_fire_withdraw', solo['combat_mode'])
+
+        supported = BotPlanner()
+        manifest = [
+            _bot(11, 1, 0, self.route, 'mediumTank'),
+            _bot(12, 1, 1, self.route, 'mediumTank'),
+        ]
+        states = [
+            _weapon_state(_state(11, 1, 0, 0)),
+            _weapon_state(_state(12, 1, 0, 0)),
+        ]
+        self.assertEqual(1, supported.report_contacts(
+            [contact], supported.known_targets(states, players), 1.0))
+        self.assertTrue(supported.report_damage(
+            11, 'player', 2, 1, 1.1))
+        orders = dict((order['id'], order) for order in
+                      supported.build_orders(
+                          manifest, states, players, 1.1)['orders'])
+
+        self.assertEqual('route', orders[11]['combat_mode'])
+        self.assertEqual(2, orders[11]['target_id'])
+        self.assertFalse(orders[11]['fire_allowed'])
+        self.assertEqual(2, orders[12]['target_id'])
+        self.assertTrue(orders[12]['fire_allowed'])
+
+        for unavailable in ('no_lane', 'empty', 'destroyed'):
+            with self.subTest(unavailable=unavailable):
+                planner = BotPlanner()
+                ally = _weapon_state(_state(12, 1, 0, 0))
+                shooters = [12]
+                if unavailable == 'no_lane':
+                    shooters = []
+                elif unavailable == 'empty':
+                    ally.update({'ammo_remaining': [0], 'clip': 0})
+                else:
+                    ally['critical'] = {'destroyed': ['gunHealth']}
+                blocked_contact = _contact(2, 0, 50, shooters)
+                blocked_states = [
+                    _weapon_state(_state(11, 1, 0, 0)), ally,
+                ]
+                self.assertEqual(1, planner.report_contacts(
+                    [blocked_contact], planner.known_targets(
+                        blocked_states, players), 1.0))
+                self.assertTrue(planner.report_damage(
+                    11, 'player', 2, 1, 1.1))
+
+                blocked = dict((order['id'], order) for order in
+                               planner.build_orders(
+                                   manifest, blocked_states, players,
+                                   1.1)['orders'])
+
+                self.assertEqual(
+                    'under_fire_withdraw', blocked[11]['combat_mode'])
+
+    def test_dead_recent_attacker_is_cleared_before_ordering(self):
+        planner = BotPlanner()
+        contact = _contact(2, 0, 150, [11])
+        players = self._report(planner, [contact])
+        self.assertTrue(planner.report_damage(
+            11, 'player', 2, 240, 1.1))
+        players[0]['alive'] = False
+
+        order = planner.build_orders(
+            self.manifest, self.states, players, 1.2)['orders'][0]
+
+        self.assertNotIn(11, planner._recent_hits)
+        self.assertIsNone(order['target_id'])
+        self.assertEqual('route', order['combat_mode'])
+
+    def test_cover_waits_for_reload_and_completes_the_exposed_magazine(self):
+        planner = BotPlanner()
+        self.states[0] = _weapon_state(
+            self.states[0], clip=3, clip_size=3)
+        contact = _contact(2, 0, 150, [11])
+        players = self._report(planner, [contact])
+        known_bots = planner.known_bots(self.manifest, self.states)
+        known_targets = planner.known_targets(self.states, players)
+        self.assertEqual(1, planner.report_affordances(
+            [_cover_report(11, 2)], known_bots, known_targets, 1.0))
+
+        approach = planner.build_orders(
+            self.manifest, self.states, players, 1.0)['orders'][0]
+        self.assertEqual('take_cover', approach['combat_mode'])
+        self.states[0].update(approach['move_position'])
+        self.states[0].update({
+            'reload_time': 10.0,
+            'ammo_reload_pending': True,
+        })
+        holding = planner.build_orders(
+            self.manifest, self.states, players, 2.0)['orders'][0]
+        self.assertEqual('cover_hold', holding['combat_mode'])
+
+        self.states[0]['reload_time'] = 8.0
+        blocked_contact = _contact(2, 0, 150, [])
+        self.assertEqual(1, planner.report_contacts(
+            [blocked_contact], planner.known_targets(
+                self.states, players), 4.0))
+        blocked = planner.build_orders(
+            self.manifest, self.states, players, 4.0)['orders'][0]
+        self.assertEqual('cover_hold', blocked['combat_mode'])
+        self.assertFalse(blocked['fire_allowed'])
+
+        self.states[0].update({
+            'reload_time': 0.0,
+            'ammo_reload_pending': False,
+        })
+        peeking = planner.build_orders(
+            self.manifest, self.states, players, 4.1)['orders'][0]
+        self.assertEqual('cover_peek', peeking['combat_mode'])
+        self.assertFalse(peeking['fire_allowed'])
+        self.states[0].update(peeking['move_position'])
+        at_peek = planner.build_orders(
+            self.manifest, self.states, players, 4.2)['orders'][0]
+        self.assertEqual('cover_peek', at_peek['combat_mode'])
+
+        self.states[0].update({
+            'fire_seq': 1,
+            'clip': 2,
+            'ammo_remaining': [19],
+            'reload_time': 0.8,
+            'reload_duration': 1.0,
+            'ammo_reload_pending': True,
+        })
+        followup = planner.build_orders(
+            self.manifest, self.states, players, 4.3)['orders'][0]
+        self.assertEqual('cover_peek', followup['combat_mode'])
+
+        self.states[0].update({
+            'fire_seq': 2,
+            'clip': 1,
+            'ammo_remaining': [18],
+            'reload_time': 0.8,
+            'reload_duration': 1.0,
+            'ammo_reload_pending': True,
+            'burst_active': True,
+        })
+        bursting = planner.build_orders(
+            self.manifest, self.states, players, 4.4)['orders'][0]
+        self.assertEqual('cover_peek', bursting['combat_mode'])
+
+        self.states[0].update({
+            'fire_seq': 3,
+            'clip': 0,
+            'ammo_remaining': [17],
+            'reload_time': 20.0,
+            'reload_duration': 20.0,
+            'burst_active': False,
+        })
+        returning = planner.build_orders(
+            self.manifest, self.states, players, 4.5)['orders'][0]
+        self.assertEqual('cover_return', returning['combat_mode'])
 
     def test_cover_lease_outlives_full_roster_refresh_cycle(self):
         planner = BotPlanner()
@@ -1084,6 +1539,108 @@ class ServerBotArtilleryTests(unittest.TestCase):
         self.assertEqual('1:0', order['defense_base_id'])
         self.assertEqual({'x': 0.0, 'y': 0.0, 'z': 0.0},
                          order['move_position'])
+
+    def test_base_defense_releases_one_excess_responder_per_delay(self):
+        planner = BotPlanner()
+        route = _route('defense-lane', [
+            (0, -100, False), (0, 100, False), (0, 500, False),
+        ])
+        manifest = [
+            _bot(11 + index, 1, index, route, 'mediumTank')
+            for index in range(4)
+        ]
+        states = [
+            _state(bot['id'], 1, index * 20, 0)
+            for index, bot in enumerate(manifest)
+        ]
+        defense = {
+            'bases': {'1': [
+                {'id': '1:0', 'x': 0.0, 'y': 0.0, 'z': -100.0},
+            ]},
+            'states': {'1': {
+                'points': 20,
+                'time_left': 60.0,
+                'invaders': 3,
+                'stopped': False,
+            }},
+            'contributors': {'1': []},
+        }
+
+        first = planner.build_orders(
+            manifest, states, [], 1.0, defense)['orders']
+        first_ids = {order['id'] for order in first
+                     if order['combat_mode'] == 'base_defense'}
+        self.assertEqual(3, len(first_ids))
+
+        defense['states']['1']['invaders'] = 1
+        delayed = planner.build_orders(
+            manifest, states, [], 2.0, defense)['orders']
+        delayed_ids = {order['id'] for order in delayed
+                       if order['combat_mode'] == 'base_defense'}
+        self.assertEqual(first_ids, delayed_ids)
+
+        reduced_once = planner.build_orders(
+            manifest, states, [], 5.1, defense)['orders']
+        reduced_once_ids = {order['id'] for order in reduced_once
+                            if order['combat_mode'] == 'base_defense'}
+        self.assertEqual(2, len(reduced_once_ids))
+        self.assertTrue(reduced_once_ids < first_ids)
+
+        reduced_twice = planner.build_orders(
+            manifest, states, [], 8.2, defense)['orders']
+        reduced_twice_ids = {order['id'] for order in reduced_twice
+                             if order['combat_mode'] == 'base_defense'}
+        self.assertEqual(1, len(reduced_twice_ids))
+        self.assertTrue(reduced_twice_ids < reduced_once_ids)
+
+    def test_base_defense_keeps_an_arrived_responder_firing_on_capturer(self):
+        planner = BotPlanner()
+        route = _route('defense-lane', [
+            (0, -100, False), (0, 100, False), (0, 500, False),
+        ])
+        manifest = [
+            _bot(11 + index, 1, index, route, 'mediumTank')
+            for index in range(3)
+        ]
+        states = [
+            _weapon_state(_state(bot['id'], 1, 0, -100))
+            for bot in manifest
+        ]
+        defense = {
+            'bases': {'1': [
+                {'id': '1:0', 'x': 0.0, 'y': 0.0, 'z': -100.0},
+            ]},
+            'states': {'1': {
+                'points': 20,
+                'time_left': 60.0,
+                'invaders': 2,
+                'stopped': False,
+            }},
+            'contributors': {'1': [
+                {'kind': 'human', 'id': 2},
+            ]},
+        }
+        initial = planner.build_orders(
+            manifest, states, [], 1.0, defense)['orders']
+        initial_ids = {order['id'] for order in initial
+                       if order['combat_mode'] == 'base_defense'}
+        self.assertEqual({11, 12}, initial_ids)
+
+        player = {'id': 2, 'team': 2, 'alive': True}
+        contact = _contact(2, 0, -80, [11])
+        self.assertEqual(1, planner.report_contacts(
+            [contact], planner.known_targets(states, [player]), 2.0))
+        defense['states']['1']['invaders'] = 1
+        planner.build_orders(manifest, states, [player], 2.0, defense)
+        reduced = planner.build_orders(
+            manifest, states, [player], 5.1, defense)['orders']
+        retained_ids = {order['id'] for order in reduced
+                        if order['combat_mode'] == 'base_defense'}
+
+        self.assertEqual({11}, retained_ids)
+        retained = next(order for order in reduced if order['id'] == 11)
+        self.assertEqual(2, retained['target_id'])
+        self.assertTrue(retained['fire_allowed'])
 
     def test_spg_is_never_a_pressured_route_donor(self):
         planner = BotPlanner()

--- a/tests/test_port_0922_shot_geometry.py
+++ b/tests/test_port_0922_shot_geometry.py
@@ -196,6 +196,46 @@ class ShotGeometryTest(unittest.TestCase):
                 ValueError, 'invalid activeTurretPosition'):
             shot_geometry.compute_barrel_local_point(descriptor, 0.0, 0.0)
 
+    def test_aim_samples_use_part_bounds_and_current_articulated_pose(self):
+        descriptor = _mode_descriptor(SIEGE_VEHICLES[0])
+        descriptor.turret.hitTester = _Tester((0.0, 0.0, 0.0), (2.0, 2.0, 4.0))
+        samples = shot_geometry.vehicle_aim_samples(descriptor)
+        self.assertEqual(8, len(samples))
+        self.assertEqual(('hull', 'turret'), tuple(s[0] for s in samples[:2]))
+        pose = {'position': (10.0, 20.0, 30.0), 'yaw': math.pi / 2.0,
+                'turret_yaw': -math.pi / 2.0}
+        self.assertVectorAlmostEqual(
+            (9.9, 21.3, 29.8), shot_geometry.vehicle_aim_point(samples[0], pose))
+        # The current #1513 compound uses the first turret mount, even on a
+        # descriptor with a different active barrel mount.
+        self.assertVectorAlmostEqual(
+            (11.2, 22.8, 31.65), shot_geometry.vehicle_aim_point(samples[1], pose))
+        posed = dict(pose, pitch=0.2, roll=-0.3)
+        self.assertNotEqual(shot_geometry.vehicle_aim_point(samples[1], pose),
+                            shot_geometry.vehicle_aim_point(samples[1], posed))
+        self.assertVectorAlmostEqual(
+            shot_geometry.transform_vehicle_point(
+                (-1.65, 2.8, 1.2), posed['position'], posed['yaw'], 0.2, -0.3),
+            shot_geometry.vehicle_aim_point(samples[1], posed))
+
+    def test_fixed_turret_aim_ignores_unavailable_articulation(self):
+        descriptor = _mode_descriptor(SIEGE_VEHICLES[0])
+        descriptor.gun.staticTurretYaw = math.pi
+        descriptor.turret.hitTester = _Tester((0.0, 0.0, 0.0), (2.0, 2.0, 4.0))
+        sample = shot_geometry.vehicle_aim_samples(descriptor)[1]
+        self.assertVectorAlmostEqual(
+            (-0.65, 2.8, -1.8), shot_geometry.vehicle_aim_point(
+                sample, {'x': 0, 'y': 0, 'z': 0, 'turret_yaw': 0.7}))
+
+    def test_missing_or_invalid_aim_geometry_has_no_invented_part(self):
+        descriptor = _mode_descriptor(SIEGE_VEHICLES[0])
+        descriptor.turret.hitTester.bbox = None
+        self.assertEqual({'hull'},
+                         {s[0] for s in shot_geometry.vehicle_aim_samples(descriptor)})
+        descriptor.hull.hitTester.bbox = (
+            _Vector(0.0, 0.0, 0.0), _Vector(float('nan'), 1.0, 2.0))
+        self.assertEqual((), shot_geometry.vehicle_aim_samples(descriptor))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Bots could reserve targets while unable to shoot, leave cover during reload, and select a clear ray above an obstacle while still aiming the shell into the hidden hull. Small oscillations also kept resetting local recovery without advancing the route.

- Select hull/turret samples from the current #1513 descriptor and use the same observed sample for ballistic lead, gun aiming, and final shot admission. Keep two static rays per lane job, invalidate replaced entities, and retain hidden targets' last observed articulation.
- Reserve focus capacity for vehicles with ammunition, a usable gun, and a current firing lane. Preserve tactical movement during reload and repair. Connect cover hold/peek/return to actual shots, magazines, and bursts; a covered vehicle can peek without first having a firing lane from behind cover.
- Grade damage reactions by severity and available return fire, clear dead attackers, and release surplus base defenders gradually while retaining vehicles able to engage the invaders.
- Detect sustained lack of route progress, recover locally with bounded private state, and discard stale waypoints when tactical intent changes. Tactical holds, traffic waits, and pending artillery proofs pause the progress monitor.

Focused tactical, geometry, visibility-memory, shot-admission, navigation, and lifecycle regressions pass, including the original 15/24 FPS Himmelsdorf departure scenario. Launcher tests pass (480 tests, 2 skipped), and all 91 client modules compile under CPython 2.7.18. The complete repository unittest suite passes on the final tree (3,643 tests). Both push and pull-request CI pass for commit `81abe2654d3d0fbffaceb987964b865067d7e2c7`: Windows server build/smoke checks, complete test suites, Python 2.7 client packaging and validation, and Windows launcher build/bundled-server checks. [CI run](https://github.com/pengw0048/wot-offline-battles/actions/runs/33963911134).

Exact Windows Chinese HD 0.9.22.0.1 #1513 gameplay, native BSP/muzzle behavior, and frame pacing remain untested here. This change adds no new native API or newer-client compatibility, and does not claim full armour-aware cover tactics or guaranteed penetration.
