### PR TITLE
Correct shell RNG, AP/APCR ricochets and HE blast geometry

### DIFF
--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -362,11 +362,11 @@ contracts: `maxHpForShootingThrough` is `19`, and every listed material has
 `projectilePiercingPowerReduction` factor/minimum values `(0, 25)`. Version
 0.3.68 therefore lets AP, APCR and APHE continue only through an item whose
 scale-adjusted health is at most 19. Each accepted item leaves damage unchanged
-and adds a fixed 25 mm penetration loss; multiple items accumulate. The first
-operation that actually needs penetration lazily samples one shell factor and
-reuses it, while the range-dependent mean is evaluated at each tested obstacle
-distance and again at the vehicle. A pure miss or HE/HEAT stopped by a
-destructible consumes no penetration RNG. A sampled remainder below 1 mm makes
+and adds a fixed 25 mm penetration loss; multiple items accumulate. Each launch
+freezes one shell factor and reuses it, while the range-dependent mean is
+evaluated at each tested obstacle distance and again at the vehicle. Scene
+queries without an admitted projectile sample lazily only when penetration is
+needed. A sampled remainder below 1 mm makes
 the shell disappear at that
 obstacle. An above-threshold item may be destroyed but stops traversal. Under
 the pre-1.13 HE mechanics used by #1513, HE and HEAT stop at the first
@@ -376,12 +376,43 @@ The threshold and material reduction are exact pinned-resource evidence.
 Official same-family mechanics descriptions support the shell-family split,
 cumulative penetration reduction and unchanged damage. The proprietary retail
 0.9.22 server implementation and its exact operation order are not published,
-however. The lazy one-factor, per-tested-hit-range, then cumulative-reduction
+however. The one-factor, per-tested-hit-range, then cumulative-reduction
 order above is therefore documented as a high-confidence reconstruction rather than an exact
 server-source copy. The resulting fragile/module payload preserves its encoded
 shot bit, but the local manager order is unsynchronized: the copied projectile
 path does not deliver the retail server's later `damagedDestructibles` payload
 required to release a projectile-synchronized native order.
+
+Shell penetration and vehicle-damage rolls use a reconstruction of the public
+normal-distribution rule. The former uniform draw inside +/-25% overproduced
+both high and low rolls. [Overlord's February 2011 answer](https://wot-news.com/track/post/eu/Overlord/1298631177)
+describes normal damage, penetration and dispersion with a 2.5-sigma interval;
+[MrConway's June 2017 answer](https://wot-news.com/track/post/eu/MrConway/1497292760)
+still explicitly describes nonuniform penetration and damage. Accordingly,
+the shell value has mean equal to its descriptor value, standard deviation
+equal to 10% of that value, and limits of +/-25%. Out-of-interval samples are
+redrawn. **Resampling is an explicit reconstruction choice:** neither public
+answer identifies the outlier algorithm, and the 2011 sigma value is not
+exact #1513 server evidence. No claim of proprietary-server RNG equivalence
+follows from local distribution tests. This change covers the armour-damage
+channel even when a track material selects it; the separate devices-damage
+channel and aiming dispersion retain their existing laws.
+
+One accepted penetration factor remains frozen across range, obstacles,
+ordered vehicle layers and a ricochet continuation. AP/APCR continuations
+preserve penetration spent on external plates, use the selected ricochet
+plate's actual trajectory position/time/distance, and apply their retained
+base multiplier to later destructibles. The native query may be in a moving
+target's frozen frame; its selected collision fraction is mapped onto the
+corresponding projectile chord before creating the reflected segment.
+
+Independent affine and moving-plane tests exercise the real component adapter,
+chord, armour resolver and wire-effect parser for ordinary player/Bot AP/APCR
+hits. They check component transforms, impact points, material identity,
+relative incidence and reuse of the frozen roll. They establish local geometry
+and data flow, not the exact Windows native BSP implementation, presentation
+timing or parity with a live retail server. The stock penetration preview and
+AP/APCR normalization/material laws are unchanged.
 
 The complete streamed-slot boundary comes from the exact #1513 native path:
 `game.onChunkLoad(spaceID, chunkID, numDestructibles, isOutside)` writes

--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -1235,6 +1235,40 @@ killing or dead-target hit. Retail's companion `inputHandler.onVehicleShaken`
 camera shake is not ported. Whether the resulting rocking magnitude matches
 retail still needs exact Windows acceptance.
 
+Non-penetrating HE and nearby splash now require a real structural collision
+inside the shell's blast sphere. The previous victim-origin radius check and
+whole-hull minimum-armour fallback could respectively miss a large vehicle's
+near surface and invent damage when no plate was hit. Loaded component
+`hitTester.bbox` values now provide at most thirteen directions per structural
+component; the existing four-field native collision adapter establishes the
+first structural plate on each ray. Selection maximizes the existing HE damage
+law over reachable candidates, sharing one victim damage roll and using the
+actual burst-to-plate distance and nominal armour. External screens remain in
+the collision prefix; their gap to the structural plate now contributes to
+blast distance. This change retains the existing structural armour absorption
+policy and does not add an unverified screen absorption formula.
+
+Blast candidates also require a clear static scenery segment through the
+existing mask-128 query and broken-destructible filter. A surface burst starts
+that visibility query on the incoming side so a wall cannot be bypassed by
+starting inside it. Direct HE uses the established collision-query burst;
+nearby victims use the projectile cursor and the same per-target presentation
+offset as direct collision. Hull/ground split and detached-turret histories
+retain the direct-collision path's explicitly recorded live-pose boundary.
+Missing geometry never supplies armour or an interior critical cone, and a
+failed nearby victim cannot discard another victim's effect. Penetrating HE
+keeps full direct damage and does not add an external splash explosion.
+
+These changes follow the historical [Wargaming HE damage explanation](https://worldoftanks.com/en/news/general-news/high-explosive-damage-explanation/),
+which describes damage through reachable armour in an explosion sphere. The
+finite component directions are a local implementation, not recovered retail
+server sampling. Dynamic vehicle/wreck occlusion and exhaustive weak-spot
+coverage are not established by this static-scene check. AP/APCR normalization,
+HEAT gap accounting and the stock penetration preview remain unchanged.
+Pure-data and adapter tests establish the stated local geometry and terminal
+contracts; exact Chinese HD #1513 Windows gameplay and frame pacing still need
+runtime acceptance.
+
 Critical-hit calculation follows the same proposal/commit boundary. The
 firing client runs a device law derived from the retired predecessor against an
 explicit detached snapshot of the target descriptor, pose, collision

--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -385,18 +385,35 @@ required to release a projectile-synchronized native order.
 
 Shell penetration and vehicle-damage rolls use a reconstruction of the public
 normal-distribution rule. The former uniform draw inside +/-25% overproduced
-both high and low rolls. [Overlord's February 2011 answer](https://wot-news.com/track/post/eu/Overlord/1298631177)
-describes normal damage, penetration and dispersion with a 2.5-sigma interval;
+both high and low rolls. [WG's May 2013 explanation for 8.6](https://wot-news.com/track/post/ru/HuKoguM/1369231089)
+explicitly changes damage and penetration from two to three sigma;
+the [North American 8.6 release notes](https://worldoftanks.com/en/news/general-news/86-update-notes/)
+confirm the reduction of extreme damage and penetration rolls. That entry is
+absent from the European release-notes page. The earlier 2011 recollection
+of 2.5 sigma does not establish the law for a client released after 8.6.
 [MrConway's June 2017 answer](https://wot-news.com/track/post/eu/MrConway/1497292760)
 still explicitly describes nonuniform penetration and damage. Accordingly,
 the shell value has mean equal to its descriptor value, standard deviation
-equal to 10% of that value, and limits of +/-25%. Out-of-interval samples are
-redrawn. **Resampling is an explicit reconstruction choice:** neither public
-answer identifies the outlier algorithm, and the 2011 sigma value is not
-exact #1513 server evidence. No claim of proprietary-server RNG equivalence
+equal to one twelfth of that value, and limits of +/-25%. Out-of-interval
+samples are redrawn. **Resampling is an explicit reconstruction choice:**
+the published three-sigma cutoff does not specify the generator's exact
+outlier algorithm. The versioned announcement and release notes support this
+reconstruction, but do not expose the proprietary #1513 server. No claim of
+proprietary-server RNG equivalence
 follows from local distribution tests. This change covers the armour-damage
 channel even when a track material selects it; the separate devices-damage
 channel and aiming dispersion retain their existing laws.
+
+Aiming dispersion is a separate unresolved version gap. The implemented
+radial two-sigma law follows the [8.6 accuracy explanation](https://worldoftanks.com/en/news/general-news/some-changes-coming-86-update/),
+including uniform radial redistribution of outliers. It gives about 16.3%
+of shots within the innermost tenth of the radius. The [9.6 accuracy update](https://worldoftanks.com/en/news/general-news/9-6-accuracy-changes/)
+reduces central hits; the [retained Russian support explanation](https://lesta.ru/support/ru/products/mt/article/35718/)
+states the historical change from 16% to 10%. The official 3,000-shot diagrams
+do not publish a complete sampling law. The 9.6 reweighting is not implemented;
+the current scatter model must not be described as verified #1513 accuracy.
+Matching the client-owned cone angle and armour preview cannot establish
+matching weak-spot hit probabilities. No guessed ring weights have been added.
 
 One accepted penetration factor remains frozen across range, obstacles,
 ordered vehicle layers and a ricochet continuation. AP/APCR continuations

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -12290,6 +12290,7 @@ class BattleRuntime(object):
         nearest_evidence = None
         nearest_fraction = 1.0
         nearest_query = None
+        nearest_trajectory_query = None
         nearest_collision_pose = None
         broadphase_sq = PROJECTILE_BROADPHASE_RADIUS ** 2
         for key, record in self._projectile_chord_records(
@@ -12412,6 +12413,12 @@ class BattleRuntime(object):
                     nearest_evidence = evidence
                     nearest_fraction = fraction
                     nearest_query = (query_start, query_end)
+                    nearest_trajectory_query = {
+                        'start': tuple(start),
+                        'end': tuple(end),
+                        'absolute_start': float(absolute_start),
+                        'absolute_end': float(absolute_end),
+                    }
                     nearest_collision_pose = None
                 continue
             sweep_fractions = self._projectile_pose_sweep_fractions(
@@ -12509,6 +12516,16 @@ class BattleRuntime(object):
                     nearest_evidence = evidence
                     nearest_fraction = fraction
                     nearest_query = (query_start, query_end)
+                    nearest_trajectory_query = {
+                        'start': tuple(projectile_start),
+                        'end': tuple(projectile_end),
+                        'absolute_start': float(absolute_start) +
+                        (float(absolute_end) - float(absolute_start)) *
+                        segment_start_fraction,
+                        'absolute_end': float(absolute_start) +
+                        (float(absolute_end) - float(absolute_start)) *
+                        segment_end_fraction,
+                    }
                     nearest_collision_pose = segment_collision_pose
 
         scene_end_tuple = lerp3(start, end, nearest_fraction)
@@ -12554,6 +12571,7 @@ class BattleRuntime(object):
                 'collisions': nearest_collisions,
                 'collision_evidence': nearest_evidence,
                 'query': nearest_query,
+                'trajectory_query': nearest_trajectory_query,
                 'collision_pose': nearest_collision_pose,
                 'piercing_loss': meta['piercing_loss'],
                 'penetration_factor': meta.get('penetration_factor'),
@@ -12941,6 +12959,11 @@ class BattleRuntime(object):
                 'base_penetration_multiplier', 1.0))
         result = 1 if contact is None else contact['result']
         terminal_data['armor_contact'] = contact
+        terminal_data['ricochet_contact'] = None
+        if contact is not None and int(result) == 0:
+            terminal_data['ricochet_contact'] = (
+                self._projectile_ricochet_contact(
+                    meta, state, terminal_data, collisions, contact))
         terminal_data['world_normal'] = None
         if contact is not None and collision_evidence:
             matching = []
@@ -12958,13 +12981,7 @@ class BattleRuntime(object):
             record, critical_target, shot, trace_start, trace_end,
             collisions, result,
             historic=isinstance(collision_pose, dict))
-        damage_rolls = []
-
-        def capture_damage_roll(low, high):
-            """Record the exact roll the damage law is about to consume."""
-            rolled = random.uniform(low, high)
-            damage_rolls.append(rolled)
-            return rolled
+        damage_roll = combat_rules.shell_damage_roll(shot)
 
         critical_impact = self._vector(terminal_data['impact'])
         query_delta = query[1] - query[0]
@@ -12987,7 +13004,7 @@ class BattleRuntime(object):
             terminal_data['blast_impact'] = _xyz(critical_impact)
         damage = combat_rules.damage(
             shot, 2 if is_he else result, 0.0,
-            random_uniform=capture_damage_roll,
+            rolled_damage=damage_roll,
             spall_coefficient=tank_collision.descriptor_spall_coefficient(
                 getattr(critical_target, 'typeDescriptor', None)))
         blast_contact = None
@@ -13038,7 +13055,7 @@ class BattleRuntime(object):
             critical_target, critical)
         potential_damage = None
         if contact is not None:
-            potential_damage = int(damage_rolls[0]) if damage_rolls else 0
+            potential_damage = int(damage_roll)
         return self._projectile_effect(
             record, damage, result, terminal_data['impact'],
             critical, hull_damage, critical_delta,
@@ -13048,8 +13065,73 @@ class BattleRuntime(object):
                 contact is not None and
                 contact.get('layer') == 'structural'))
 
+    def _projectile_ricochet_contact(
+            self, meta, state, terminal_data, collisions, contact):
+        """Map the selected native plate back onto the projectile trajectory."""
+        current_time = self._projectile_elapsed_ms(meta, state)
+        current_distance = self._projectile_checked_distance(meta, state)
+        current_loss = self._projectile_checked_piercing_loss(meta)
+        result = {
+            'impact': tuple(terminal_data['impact']),
+            'resolved_time_ms': current_time,
+            'checked_distance': current_distance,
+            'piercing_loss': max(
+                current_loss,
+                _number(contact.get('accumulated_loss'), current_loss)),
+            'elapsed_delta': 0.0,
+        }
+        mapping = terminal_data.get('trajectory_query')
+        if mapping is None:
+            return result
+        query = terminal_data.get('query')
+        try:
+            query_length = float((query[1] - query[0]).length)
+            first_distance = min(
+                float(collision.dist) for collision in collisions)
+            contact_distance = float(contact['distance'])
+            trajectory_start = tuple(
+                float(mapping['start'][index]) for index in range(3))
+            trajectory_end = tuple(
+                float(mapping['end'][index]) for index in range(3))
+            absolute_start = float(mapping['absolute_start'])
+            absolute_end = float(mapping['absolute_end'])
+        except (AttributeError, IndexError, KeyError, TypeError, ValueError,
+                OverflowError):
+            raise ValueError('ricochet trajectory mapping is malformed')
+        if query_length <= 0.000001 or absolute_end < absolute_start:
+            raise ValueError('ricochet trajectory mapping is degenerate')
+        first_fraction = first_distance / query_length
+        contact_fraction = contact_distance / query_length
+        if contact_fraction + 0.000001 < first_fraction:
+            raise ValueError('ricochet contact precedes the vehicle impact')
+        # Do not use lerp3 here: an exact ten-calibre extension may put the
+        # selected plate beyond the original chord and needs linear
+        # extrapolation from that chord's already-reviewed mapping.
+        trajectory_delta = tuple(
+            trajectory_end[index] - trajectory_start[index]
+            for index in range(3))
+        contact_impact = tuple(
+            trajectory_start[index] +
+            trajectory_delta[index] * contact_fraction
+            for index in range(3))
+        trajectory_length = math.sqrt(sum(
+            value * value for value in trajectory_delta))
+        fraction_delta = max(0.0, contact_fraction - first_fraction)
+        elapsed_delta = max(
+            0.0, (absolute_end - absolute_start) * fraction_delta)
+        result.update({
+            'impact': contact_impact,
+            'resolved_time_ms': current_time +
+            int(round(elapsed_delta * 1000.0)),
+            'checked_distance': current_distance +
+            trajectory_length * fraction_delta,
+            'elapsed_delta': elapsed_delta,
+        })
+        return result
+
     def _projectile_splash_effects(self, meta, impact, direct_key, state=None,
                                    visual_impact=None):
+
         source = self._projectile_source_entity(meta)
         shot = self._projectile_shot(meta)
         if not shot or not combat_rules.is_he(shot):
@@ -13307,18 +13389,33 @@ class BattleRuntime(object):
                 float(gravity[index]) * elapsed
                 for index in range(3))
         ricochet = None
+        ricochet_contact = (data.get('ricochet_contact')
+                             if isinstance(data, dict) else None)
+        ricochet_time = (int(ricochet_contact['resolved_time_ms'])
+                          if isinstance(ricochet_contact, dict) else
+                          self._projectile_elapsed_ms(meta, state))
+        ricochet_distance = (
+            float(ricochet_contact['checked_distance'])
+            if isinstance(ricochet_contact, dict) else
+            float(state.get('distance', 0.0)))
         if (outcome == 'impact' and hit_vehicle and direct is not None and
                 int(direct.get('shot_result', -1)) == 0 and
                 int(meta.get('ricochet_count', 0)) == 0 and
-                self._projectile_elapsed_ms(meta, state) <
-                int(meta.get('max_time_ms', 0)) and
-                float(state.get('distance', 0.0)) <
+                ricochet_time < int(meta.get('max_time_ms', 0)) and
+                ricochet_distance <
                 float(meta.get('max_distance', 0.0)) and
                 data.get('world_normal') is not None):
             shot = self._projectile_shot(meta)
             shell_kind = _field(_field(shot, 'shell', {}), 'kind', None)
             multiplier = combat_rules.first_ricochet_penetration_multiplier(
                 shell_kind)
+            if incoming is not None and isinstance(ricochet_contact, dict):
+                contact_elapsed = max(
+                    0.0, float(ricochet_contact.get('elapsed_delta', 0.0)))
+                incoming = tuple(
+                    incoming[index] +
+                    float(gravity[index]) * contact_elapsed
+                    for index in range(3))
             if incoming is not None:
                 reflected = ideal_reflection_velocity(
                     incoming, data['world_normal'])
@@ -13328,16 +13425,25 @@ class BattleRuntime(object):
                 speed = math.sqrt(sum(value * value for value in reflected))
                 if 0.000001 < speed <= lan_protocol.MAX_PROJECTILE_VELOCITY:
                     direction = tuple(value / speed for value in reflected)
+                    ricochet_impact = (
+                        tuple(ricochet_contact['impact'])
+                        if isinstance(ricochet_contact, dict) else impact)
                     segment_origin = tuple(
-                        impact[index] + direction[index] * 0.002
+                        ricochet_impact[index] + direction[index] * 0.002
                         for index in range(3))
                     ricochet = {
                         'state': state,
-                        'impact': impact,
+                        'impact': ricochet_impact,
                         'segment_origin': segment_origin,
                         'segment_velocity': reflected,
                         'base_penetration_multiplier': multiplier,
                         'direct': direct,
+                        'resolved_time_ms': ricochet_time,
+                        'checked_distance': ricochet_distance,
+                        'piercing_loss': (
+                            ricochet_contact['piercing_loss']
+                            if isinstance(ricochet_contact, dict) else
+                            self._projectile_checked_piercing_loss(meta)),
                     }
         wreck_hit = None
         if hit_vehicle and direct is None:
@@ -13423,18 +13529,21 @@ class BattleRuntime(object):
                     'authority_epoch': self._projectile_epoch,
                     'projectile_id': meta['projectile_id'],
                     'base_checked_ms': int(meta.get('base_checked_ms', 0)),
-                    'resolved_time_ms': self._projectile_elapsed_ms(
-                        meta, state),
+                    'resolved_time_ms': int(pending.get(
+                        'resolved_time_ms',
+                        self._projectile_elapsed_ms(meta, state))),
                     'impact': list(pending['impact']),
                     'segment_origin': list(pending['segment_origin']),
                     'segment_velocity': list(pending['segment_velocity']),
                     'base_penetration_multiplier': pending[
                         'base_penetration_multiplier'],
                     'direct': copy.deepcopy(pending['direct']),
-                    'checked_distance': self._projectile_checked_distance(
-                        meta, state),
-                    'piercing_loss': self._projectile_checked_piercing_loss(
-                        meta),
+                    'checked_distance': max(
+                        self._projectile_checked_distance(meta, state),
+                        _number(pending.get('checked_distance'), 0.0)),
+                    'piercing_loss': max(
+                        self._projectile_checked_piercing_loss(meta),
+                        _number(pending.get('piercing_loss'), 0.0)),
                     'penetration_factor': float(
                         meta.get('penetration_factor', 1.0)),
                     'destructibles': copy.deepcopy(
@@ -21371,6 +21480,11 @@ class BattleRuntime(object):
         initial_piercing_loss = max(
             0.0, _number(initial_piercing_loss, 0.0))
         distance_offset = max(0.0, _number(distance_offset, 0.0))
+        base_penetration_multiplier = 1.0
+        if isinstance(projectile_state, dict):
+            base_penetration_multiplier = _number(
+                (projectile_state.get('payload') or {}).get(
+                    'base_penetration_multiplier'), 1.0)
         if self._destructibles is None:
             hit = self._runtime.bigworld.wg_collideSegment(
                 self._avatar.spaceID, start, end, 128)
@@ -21416,7 +21530,8 @@ class BattleRuntime(object):
                     combat_rules.sampled_piercing(
                         shot, piercing_distance,
                         penetration_factor,
-                        piercing_loss) < 1.0):
+                        piercing_loss,
+                        base_penetration_multiplier) < 1.0):
                 return {
                     'world_distance': obstacle_distance,
                     'piercing_loss': piercing_loss,

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -35,7 +35,7 @@ from gui.mods.offline_lan_0922.entities.remote_vehicle import (
     _collide_vehicle_evidence_at_matrix,
     _component_aim_angles, _pose_components, collide_vehicle_at_matrix,
     encode_damage_sticker, pose_animation_writes,
-    reset_pose_animation_writes)
+    reset_pose_animation_writes, vehicle_blast_probe_points_at_matrix)
 from gui.mods.offline_lan_0922.entities.runtime import EntityPropertyBuilder
 from gui.mods.offline_lan_0922.projectile_manager import InFlightProjectiles
 from gui.mods.offline_lan_0922.projectile_runtime import (
@@ -12739,9 +12739,8 @@ class BattleRuntime(object):
         if potential_damage is not None:
             # The armour ledger needs the roll the damage law already made,
             # before armour and modules reduced it.  Splash carries no roll:
-            # its own law rolls a different quantity and the server excludes
-            # splash from blocked damage.  An overlay-edited shell can roll
-            # past 5000, the exact ceiling the wire validator and the battle
+            # the server excludes splash from blocked damage. An overlay-edited
+            # shell can roll past 5000, the ceiling the wire validator and battle
             # server enforce, so saturate the statistic instead of letting
             # the validator drop the whole terminal.
             effect['potential_damage'] = max(
@@ -12764,6 +12763,136 @@ class BattleRuntime(object):
             effect.update(self._critical_proposal_contract(
                 record, critical, hull_damage, critical_delta))
         return effect
+
+    def _projectile_he_scene_origin(self, impact, state):
+        """Keep a surface burst's visibility ray on the incoming side."""
+        burst = self._vector(impact)
+        if not isinstance(state, dict):
+            return burst
+        try:
+            elapsed = float(state.get('elapsed', 0.0))
+            velocity = state['velocity']
+            gravity = state['gravity']
+            incoming = self._vector(tuple(
+                float(velocity[axis]) + float(gravity[axis]) * elapsed
+                for axis in range(3)))
+            if incoming.length > 1.0e-9:
+                incoming.normalise()
+                return burst - incoming.scale(2.0 * _SHOT_OCCLUSION_EPSILON)
+        except (KeyError, TypeError, ValueError, IndexError):
+            pass
+        return burst
+
+    def _projectile_he_world_visible(self, scene_start, point, burst):
+        """Test scenery without destroying props while searching blast rays."""
+        endpoint = self._vector(point)
+        if (endpoint - burst).length <= _SHOT_OCCLUSION_EPSILON:
+            # This is the already established direct contact itself.
+            return True
+        distance = float((endpoint - scene_start).length)
+        collision_filter = None
+        make_filter = getattr(
+            self._destructibles, 'horizontal_collision_filter', None)
+        if callable(make_filter):
+            collision_filter = make_filter(scene_start, endpoint)
+        hit = self._collide_down(scene_start, endpoint, collision_filter)
+        return (hit is None or
+                float((hit[0] - scene_start).length) +
+                _SHOT_OCCLUSION_EPSILON >= distance)
+
+    def _projectile_he_blast_contact(
+            self, meta, record, target, shot, impact, rolled_damage,
+            state=None, pose=None, seed=None):
+        """Choose maximum damage among proved, reachable native surfaces.
+
+        Component bounds only generate finite directions. Every damage
+        candidate needs a real structural collision inside the blast sphere;
+        neither a missing ray nor an unavailable model supplies armour.
+        """
+        burst = self._vector(impact)
+        radius = combat_rules.he_radius(shot)
+        if radius <= 0.0:
+            return None
+        probe_target = target
+        body_matrix = None
+        chassis_matrix = None
+        if pose is not None:
+            descriptor = self._projectile_descriptor_at_pose(target, pose)
+            if (self._projectile_pitch_hull_aiming(descriptor) or
+                    bool(getattr(target, 'isTurretDetached', False))):
+                return None
+            probe_target = self._projectile_frozen_target(target, pose)
+            if probe_target is None:
+                return None
+            body_matrix = probe_target.matrix
+        elif record.get('local') and self._local_matrix is not None:
+            body_matrix = self._local_body_pose()
+            chassis_matrix = self._local_matrix
+        elif record.get('native_remote'):
+            body_matrix, chassis_matrix = self._projectile_vehicle_matrices(
+                record, target)
+        else:
+            body_matrix = getattr(target, 'matrix', None)
+        spall = tank_collision.descriptor_spall_coefficient(
+            getattr(probe_target, 'typeDescriptor', None))
+        scene_start = self._projectile_he_scene_origin(impact, state)
+        candidates = []
+
+        def collect(start, end, collisions):
+            contact = combat_rules.he_blast_contact(
+                shot, impact, _xyz(start), _xyz(end), collisions,
+                rolled_damage, spall_coefficient=spall)
+            if contact is not None:
+                candidates.append(contact)
+
+        points = list(vehicle_blast_probe_points_at_matrix(
+            probe_target, body_matrix, burst, radius, self._runtime.math,
+            chassis_matrix=chassis_matrix))
+        if seed is not None:
+            collect(seed[0], seed[1], seed[2])
+            # Keep the precise incoming direction as an additional probe;
+            # its existing module trace can be shorter than the HE sphere.
+            delta = seed[1] - seed[0]
+            if delta.length > 1.0e-9:
+                delta.normalise()
+                points.insert(0, burst + delta.scale(radius))
+        directions = set()
+        for point in points:
+            delta = point - burst
+            if delta.length <= 1.0e-9:
+                continue
+            delta.normalise()
+            key = tuple(round(value, 9) for value in _xyz(delta))
+            if key in directions:
+                continue
+            directions.add(key)
+            start = burst - delta.scale(_SHOT_OCCLUSION_EPSILON)
+            end = burst + delta.scale(radius)
+            try:
+                if body_matrix is not None:
+                    collisions = collide_vehicle_at_matrix(
+                        probe_target, body_matrix, start, end,
+                        self._runtime.math, chassis_matrix=chassis_matrix)
+                else:
+                    collisions = target.collideSegmentExt(start, end)
+                collect(start, end, collisions)
+            except Exception as error:
+                self._report_projectile_terminal_failure(
+                    meta, state or {}, 'he_surface',
+                    str(record.get('network_id')), error)
+        # Reuse the victim's one damage roll for selection and application.
+        # A blocked weak spot does not hide another reachable candidate.
+        candidates.sort(key=lambda item: (-item['damage'], item['distance']))
+        for contact in candidates:
+            try:
+                if self._projectile_he_world_visible(
+                        scene_start, contact['point'], burst):
+                    return contact
+            except Exception as error:
+                self._report_projectile_terminal_failure(
+                    meta, state or {}, 'he_occlusion',
+                    str(record.get('network_id')), error)
+        return None
 
     def _projectile_direct_effect(self, meta, state, terminal_data):
         target_key = terminal_data.get('target_key')
@@ -12825,8 +12954,6 @@ class BattleRuntime(object):
             if matching:
                 terminal_data['world_normal'] = _xyz(
                     matching[0].worldNormal)
-        armor = combat_rules.he_nominal_armor(
-            collisions, getattr(critical_target, 'typeDescriptor', None))
         damage_sticker = self._projectile_damage_sticker(
             record, critical_target, shot, trace_start, trace_end,
             collisions, result,
@@ -12839,18 +12966,6 @@ class BattleRuntime(object):
             damage_rolls.append(rolled)
             return rolled
 
-        damage = combat_rules.damage(
-            shot, result, armor, random_uniform=capture_damage_roll,
-            spall_coefficient=tank_collision.descriptor_spall_coefficient(
-                getattr(critical_target, 'typeDescriptor', None)))
-        hull_damage = damage
-        legacy_shell = combat_rules.legacy_shot(shot).get('shell') or {}
-        attacker_id = int(getattr(
-            source, 'id', meta.get('shooter_id', 0)))
-        deadeye = bool(_field(shot, 'deadeye', False))
-        layers = combat_rules.collision_layers(collisions)
-        critical = None
-        critical_delta = {}
         critical_impact = self._vector(terminal_data['impact'])
         query_delta = query[1] - query[0]
         query_length = float(query_delta.length)
@@ -12865,16 +12980,53 @@ class BattleRuntime(object):
                 0.0, min(query_length, float(contact_distance)))
             query_delta.normalise()
             critical_impact = query[0] + query_delta.scale(contact_distance)
+        is_he = combat_rules.is_he(shot)
+        if is_he:
+            # Direct and nearby victims share one combat burst even when the
+            # moving-target query differs from the visual projectile chord.
+            terminal_data['blast_impact'] = _xyz(critical_impact)
+        damage = combat_rules.damage(
+            shot, 2 if is_he else result, 0.0,
+            random_uniform=capture_damage_roll,
+            spall_coefficient=tank_collision.descriptor_spall_coefficient(
+                getattr(critical_target, 'typeDescriptor', None)))
+        blast_contact = None
+        if is_he and int(result) != 2:
+            try:
+                blast_contact = self._projectile_he_blast_contact(
+                    meta, record, target, shot, _xyz(critical_impact),
+                    damage, state=state, pose=collision_pose,
+                    seed=(query[0], query[1], terminal_data['collisions']))
+            except Exception as error:
+                self._report_projectile_terminal_failure(
+                    meta, state, 'he_direct_surface',
+                    str(record.get('network_id')), error)
+            damage = 0 if blast_contact is None else blast_contact['damage']
+        hull_damage = damage
+        legacy_shell = combat_rules.legacy_shot(shot).get('shell') or {}
+        attacker_id = int(getattr(
+            source, 'id', meta.get('shooter_id', 0)))
+        deadeye = bool(_field(shot, 'deadeye', False))
+        layers = combat_rules.collision_layers(collisions)
+        explosion_direction = trace_end - trace_start
+        if blast_contact is not None:
+            layers = combat_rules.collision_layers(
+                blast_contact['collisions'])
+            explosion_direction = self._vector(blast_contact['direction'])
+        critical = None
+        critical_delta = {}
         if int(result) == 0:
             damage = 0
             hull_damage = 0
         self._install_critical_equipment_effects(record, critical_target)
-        if int(result) != 0 and combat_rules.is_he(shot):
+        if int(result) != 0 and is_he:
             damage, critical, critical_delta = (
                 critical_damage.propose_explosion(
                     critical_target, layers, critical_impact,
-                    trace_end - trace_start, damage, legacy_shell,
-                    attacker_id, deadeye=deadeye, with_delta=True))
+                    explosion_direction, damage, legacy_shell,
+                    attacker_id, deadeye=deadeye, with_delta=True,
+                    allow_interior=(int(result) == 2 or
+                                    blast_contact is not None)))
         elif int(result) != 0:
             damage, critical, critical_delta = critical_damage.propose_direct(
                 critical_target, layers, trace_start, trace_end, damage,
@@ -12896,13 +13048,13 @@ class BattleRuntime(object):
                 contact is not None and
                 contact.get('layer') == 'structural'))
 
-    def _projectile_splash_effects(self, meta, impact, direct_key):
+    def _projectile_splash_effects(self, meta, impact, direct_key, state=None,
+                                   visual_impact=None):
         source = self._projectile_source_entity(meta)
         shot = self._projectile_shot(meta)
-        if not shot:
+        if not shot or not combat_rules.is_he(shot):
             return []
-        radius = combat_rules.he_radius(shot)
-        if radius <= 0.0:
+        if combat_rules.he_radius(shot) <= 0.0:
             return []
         burst = self._vector(impact)
         legacy_shell = combat_rules.legacy_shot(shot).get('shell') or {}
@@ -12917,51 +13069,69 @@ class BattleRuntime(object):
                     not getattr(target, 'isStarted', False) or
                     not self._record_alive(record, target)):
                 continue
-            position = _xyz(getattr(
-                target, 'position', record.get('state', {})))
-            delta = tuple(position[index] - impact[index]
-                          for index in range(3))
-            distance = math.sqrt(sum(value * value for value in delta))
-            if distance > radius:
-                continue
-            aim = self._vector((
-                position[0], position[1] + 1.0, position[2]))
             try:
-                if record.get('native_remote'):
-                    body_matrix, chassis_matrix = \
-                        self._projectile_vehicle_matrices(record, target)
-                    collisions = tuple(collide_vehicle_at_matrix(
-                        target, body_matrix, burst, aim,
-                        self._runtime.math,
-                        chassis_matrix=chassis_matrix) or ())
-                else:
-                    collisions = tuple(
-                        target.collideSegmentExt(burst, aim) or ())
-                nominal = combat_rules.he_nominal_armor(
-                    collisions, target.typeDescriptor)
-            except Exception:
-                collisions = ()
-                nominal = combat_rules.he_hull_armor(
-                    target.typeDescriptor)
-            damage = combat_rules.he_splash_damage(
-                shot, nominal, distance / radius,
-                spall_coefficient=tank_collision.descriptor_spall_coefficient(
-                    target.typeDescriptor))
-            if damage <= 0:
-                continue
-            hull_damage = damage
-            self._install_critical_equipment_effects(record, target)
-            damage, critical, critical_delta = (
-                critical_damage.propose_explosion(
-                    target, combat_rules.collision_layers(collisions),
-                    burst, aim - burst, damage, legacy_shell,
-                    int(getattr(source, 'id', meta.get('shooter_id', 0))),
-                    deadeye=bool(_field(shot, 'deadeye', False)),
-                    with_delta=True))
-            critical = self._critical_with_crew_roster(target, critical)
-            effects.append(self._projectile_effect(
-                record, damage, 2, impact, critical, hull_damage,
-                critical_delta, position))
+                pose = None
+                critical_target = target
+                if state is not None:
+                    # Use the same target timeline as the projectile chord.
+                    offset = float((meta.get('presentation_offsets') or {}).get(
+                        key, 0.0))
+                    pose = self._projectile_historic_pose(
+                        key, float(state['cursor_time']) - offset)
+                    if pose is None:
+                        self._report_projectile_terminal_failure(
+                            meta, state, 'he_splash_pose', key,
+                            'historic_pose_unavailable')
+                        continue
+                    descriptor = self._projectile_descriptor_at_pose(target, pose)
+                    if (self._projectile_pitch_hull_aiming(descriptor) or
+                            bool(getattr(target, 'isTurretDetached', False))):
+                        # Match the existing chord boundary for vehicles whose
+                        # separate body/ground or attachment history is absent.
+                        record['projectile_collision_pose_boundary'] = (
+                            'pitch_hull_body_ground_unavailable_live_fallback'
+                            if self._projectile_pitch_hull_aiming(descriptor)
+                            else 'turret_attachment_history_unavailable_live_fallback')
+                        pose = None
+                    else:
+                        critical_target = self._projectile_frozen_target(
+                            target, pose)
+                        if critical_target is None:
+                            self._report_projectile_terminal_failure(
+                                meta, state, 'he_splash_pose', key,
+                                'historic_component_matrix_unavailable')
+                            continue
+                # One victim roll is shared by all candidate directions.
+                rolled_damage = combat_rules.damage(shot, 2, 0.0)
+                contact = self._projectile_he_blast_contact(
+                    meta, record, target, shot, impact, rolled_damage,
+                    state=state, pose=pose)
+                if contact is None or contact['damage'] <= 0:
+                    continue
+                hull_damage = contact['damage']
+                self._install_critical_equipment_effects(record, critical_target)
+                damage, critical, critical_delta = (
+                    critical_damage.propose_explosion(
+                        critical_target,
+                        combat_rules.collision_layers(contact['collisions']),
+                        burst, self._vector(contact['direction']), hull_damage,
+                        legacy_shell,
+                        int(getattr(source, 'id', meta.get('shooter_id', 0))),
+                        deadeye=bool(_field(shot, 'deadeye', False)),
+                        with_delta=True))
+                critical = self._critical_with_crew_roster(
+                    critical_target, critical)
+                position = _xyz(getattr(
+                    critical_target, 'position', record.get('state', {})))
+                effects.append(self._projectile_effect(
+                    record, damage, 2,
+                    impact if visual_impact is None else visual_impact,
+                    critical, hull_damage, critical_delta, position))
+            except Exception as error:
+                # A missing victim surface cannot discard an established
+                # direct effect or prevent other blast victims from resolving.
+                self._report_projectile_terminal_failure(
+                    meta, state or {}, 'he_splash', key, error)
             if len(effects) >= 30:
                 break
         return effects
@@ -13107,9 +13277,14 @@ class BattleRuntime(object):
             if outcome == 'impact':
                 impact = tuple(data.get('impact', impact))
                 direct = self._projectile_direct_effect(meta, state, data)
-                if meta.get('is_he'):
+                if (meta.get('is_he') and
+                        not (direct is not None and
+                             int(direct.get('shot_result', 1)) == 2)):
+                    # A penetrating HE shell bursts inside its direct victim.
                     splash = self._projectile_splash_effects(
-                        meta, impact, data.get('target_key'))
+                        meta, data.get('blast_impact', impact),
+                        data.get('target_key'), state=state,
+                        visual_impact=impact)
         except Exception as error:
             # A malformed native collision/proposal cannot be allowed to
             # damage a different target. Retire the ledger entry without

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/combat_rules.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/combat_rules.py
@@ -69,7 +69,7 @@ def _offh_material_flag(material, name, default):
 
 def _offh_resolve_armor_contact(shot, dist_m, all_hits,
 		initial_pierce_loss=0.0, penetration_factor=None,
-		base_penetration_multiplier=1.0):
+		base_penetration_multiplier=1.0, random_gauss=None):
 	'''Resolve the terminal external or structural plate in projectile order.
 
 	Returns a contact dictionary for the plate that stops external traversal or
@@ -104,7 +104,7 @@ def _offh_resolve_armor_contact(shot, dist_m, all_hits,
 			continue
 		_comp = _h[3] if len(_h) > 3 else None
 		if factor is None:
-			factor = random.uniform(0.75, 1.25)
+			factor = sample_penetration_factor(random_gauss)
 		if base_pierce is None:
 			base_pierce = (_offh_range_piercing(shot, dist_m) *
 				float(base_penetration_multiplier) * float(factor))
@@ -176,11 +176,12 @@ def _offh_resolve_armor_contact(shot, dist_m, all_hits,
 
 
 def _offh_resolve_hull_hit(shot, dist_m, all_hits, initial_pierce_loss=0.0,
-		penetration_factor=None, base_penetration_multiplier=1.0):
+		penetration_factor=None, base_penetration_multiplier=1.0,
+		random_gauss=None):
 	'''Keep the legacy structural-hit tuple contract unchanged.'''
 	contact = _offh_resolve_armor_contact(
 		shot, dist_m, all_hits, initial_pierce_loss, penetration_factor,
-		base_penetration_multiplier)
+		base_penetration_multiplier, random_gauss)
 	if contact is None or contact['layer'] != 'structural':
 		return None
 	return (contact['result'], contact['effective_armor'],
@@ -335,7 +336,7 @@ def _offh_he_apply_tuning(overrides):
 
 def _offh_penetration(shot, dist_m, armor, hit_angle_cos, pierce_loss=0.0,
 		penetration_factor=None, material=None, allow_ricochet=True,
-		base_penetration_multiplier=1.0):
+		base_penetration_multiplier=1.0, random_gauss=None):
 	'''Armour test shared by the player and by bot-vs-bot fire.
 
 	Returns (result, eff_armor, pierce): 0 ricochet, 1 no penetration, 2 penetration.
@@ -358,7 +359,7 @@ def _offh_penetration(shot, dist_m, armor, hit_angle_cos, pierce_loss=0.0,
 	pierce = (_offh_range_piercing(shot, dist_m) *
 		float(base_penetration_multiplier))
 	if penetration_factor is None:
-		penetration_factor = random.uniform(0.75, 1.25)
+		penetration_factor = sample_penetration_factor(random_gauss)
 	pierce *= float(penetration_factor)
 	# spaced armour already crossed (tracks, external devices) is subtracted here
 	pierce -= float(pierce_loss or 0.0)
@@ -602,31 +603,47 @@ def he_blast_contact(shot, burst, start, end, collisions, rolled_damage,
 	return None
 
 
-def _call_with_uniform(function, uniform, *args):
-    if uniform is None:
-        return function(*args)
-    original = random.uniform
-    random.uniform = uniform
-    try:
-        return function(*args)
-    finally:
-        random.uniform = original
+def sample_shell_value(mean, random_gauss=None):
+    """Reconstruct the publicly described +/-25%, 2.5-sigma shell roll.
+
+    WG described penetration and vehicle damage as normal, not uniform:
+    https://wot-news.com/track/post/eu/Overlord/1298631177
+    https://wot-news.com/track/post/eu/MrConway/1497292760
+    Those statements do not specify outlier handling. Conditional resampling
+    is an explicit reconstruction choice, not a recovered #1513 server ABI;
+    it preserves the normal density inside the stated interval without
+    inventing probability mass at the endpoints. See COMPATIBILITY_REVIEW.
+    """
+    mean = float(mean)
+    if mean != mean or abs(mean) == float('inf'):
+        raise ValueError('shell roll mean must be finite')
+    if mean <= 0.0:
+        return 0.0
+    sampler = random.gauss if random_gauss is None else random_gauss
+    minimum, maximum = mean * 0.75, mean * 1.25
+    sigma = mean * 0.25 / 2.5
+    while True:
+        value = float(sampler(mean, sigma))
+        if value != value or abs(value) == float('inf'):
+            raise ValueError('shell roll must be finite')
+        if minimum <= value <= maximum:
+            return value
+
 
 
 def penetration(shot, distance, armor, hit_angle_cos,
-                pierce_loss=0.0, random_uniform=None,
+                pierce_loss=0.0, random_gauss=None,
                 penetration_factor=None, material=None,
                 base_penetration_multiplier=1.0):
-    return _call_with_uniform(
-        _offh_penetration, random_uniform, legacy_shot(shot),
+    return _offh_penetration(
+        legacy_shot(shot),
         distance, armor, hit_angle_cos, pierce_loss, penetration_factor,
-        material, True, base_penetration_multiplier)
+        material, True, base_penetration_multiplier, random_gauss)
 
 
-def sample_penetration_factor(random_uniform=None):
-    """Draw the one #1513 penetration random factor owned by a shell."""
-    sampler = random.uniform if random_uniform is None else random_uniform
-    return float(sampler(0.75, 1.25))
+def sample_penetration_factor(random_gauss=None):
+    """Draw the one penetration factor frozen and owned by a shell."""
+    return sample_shell_value(1.0, random_gauss)
 
 
 def range_piercing(shot, distance):
@@ -657,23 +674,23 @@ def nominal_piercing_after_loss(shot, distance, pierce_loss=0.0):
                float(pierce_loss or 0.0))
 
 
-def resolve_armor_contact(shot, distance, collisions, random_uniform=None,
+def resolve_armor_contact(shot, distance, collisions, random_gauss=None,
                           pierce_loss=0.0, penetration_factor=None,
                           base_penetration_multiplier=1.0):
     """Return the terminal external or structural armor contact."""
-    return _call_with_uniform(
-        _offh_resolve_armor_contact, random_uniform, legacy_shot(shot),
+    return _offh_resolve_armor_contact(
+        legacy_shot(shot),
         distance, collision_layers(collisions), pierce_loss,
-        penetration_factor, base_penetration_multiplier)
+        penetration_factor, base_penetration_multiplier, random_gauss)
 
 
-def resolve_hull_hit(shot, distance, collisions, random_uniform=None,
+def resolve_hull_hit(shot, distance, collisions, random_gauss=None,
                      pierce_loss=0.0, penetration_factor=None,
                      base_penetration_multiplier=1.0):
-    return _call_with_uniform(
-        _offh_resolve_hull_hit, random_uniform, legacy_shot(shot),
+    return _offh_resolve_hull_hit(
+        legacy_shot(shot),
         distance, collision_layers(collisions), pierce_loss,
-        penetration_factor, base_penetration_multiplier)
+        penetration_factor, base_penetration_multiplier, random_gauss)
 
 
 def he_nominal_armor(collisions, descriptor=None):
@@ -681,9 +698,8 @@ def he_nominal_armor(collisions, descriptor=None):
         collision_layers(collisions), descriptor)
 
 
-def damage(shot, result, nominal_armor, random_uniform=None,
-           spall_coefficient=1.0):
-    """Apply the legacy direct-damage formula to the resolved vehicle hit."""
+def shell_damage_roll(shot, random_gauss=None):
+    """Draw vehicle damage before armour absorption and integer HP display."""
     converted = legacy_shot(shot)
     shell = converted.get('shell') or {}
     raw = shell.get('damage')
@@ -694,8 +710,16 @@ def damage(shot, result, nominal_armor, random_uniform=None,
             average = float(raw)
         except (TypeError, ValueError):
             return 0
-    uniform = random_uniform or random.uniform
-    rolled = int(uniform(average * 0.75, average * 1.25))
+    return sample_shell_value(average, random_gauss)
+
+
+def damage(shot, result, nominal_armor, random_gauss=None,
+           spall_coefficient=1.0, rolled_damage=None):
+    """Apply direct damage, optionally reusing the caller's exact frozen roll."""
+    converted = legacy_shot(shot)
+    if rolled_damage is None:
+        rolled_damage = shell_damage_roll(converted, random_gauss)
+    rolled = int(rolled_damage)
     if int(result) == 2:
         return rolled
     if _offh_is_he(converted):
@@ -717,19 +741,9 @@ def he_factors(shot):
 
 
 def he_splash_damage(shot, nominal_armor, distance_fraction,
-                     random_uniform=None, spall_coefficient=1.0):
+                     random_gauss=None, spall_coefficient=1.0):
     converted = legacy_shot(shot)
-    shell = converted.get('shell') or {}
-    raw = shell.get('damage')
-    try:
-        average = float(raw[0])
-    except (TypeError, ValueError, IndexError):
-        try:
-            average = float(raw)
-        except (TypeError, ValueError):
-            return 0
-    uniform = random_uniform or random.uniform
-    rolled = uniform(average * 0.75, average * 1.25)
+    rolled = shell_damage_roll(converted, random_gauss)
     return _offh_he_damage(
         converted, rolled, nominal_armor, distance_fraction,
         spall_coefficient)

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/combat_rules.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/combat_rules.py
@@ -604,11 +604,15 @@ def he_blast_contact(shot, burst, start, end, collisions, rolled_damage,
 
 
 def sample_shell_value(mean, random_gauss=None):
-    """Reconstruct the publicly described +/-25%, 2.5-sigma shell roll.
+    """Reconstruct the post-8.6 +/-25%, three-sigma shell roll.
 
     WG described penetration and vehicle damage as normal, not uniform:
-    https://wot-news.com/track/post/eu/Overlord/1298631177
+    https://wot-news.com/track/post/ru/HuKoguM/1369231089
+    https://worldoftanks.com/en/news/general-news/86-update-notes/
     https://wot-news.com/track/post/eu/MrConway/1497292760
+    The 8.6 announcement explicitly changes damage/penetration from two to
+    three sigma; the release notes confirm fewer extreme rolls. The older
+    2011 recollection of 2.5 sigma must not override this versioned change.
     Those statements do not specify outlier handling. Conditional resampling
     is an explicit reconstruction choice, not a recovered #1513 server ABI;
     it preserves the normal density inside the stated interval without
@@ -621,7 +625,7 @@ def sample_shell_value(mean, random_gauss=None):
         return 0.0
     sampler = random.gauss if random_gauss is None else random_gauss
     minimum, maximum = mean * 0.75, mean * 1.25
-    sigma = mean * 0.25 / 2.5
+    sigma = mean * 0.25 / 3.0
     while True:
         value = float(sampler(mean, sigma))
         if value != value or abs(value) == float('inf'):

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/combat_rules.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/combat_rules.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 """Pinned #1513 armour and HE laws behind native input adapters."""
 
+import math
 import random
 
 
@@ -223,32 +224,6 @@ def _offh_he_radius(shot):
 	return (cal * cal / 5555.0) if cal > 0.0 else 0.0
 
 
-def _offh_he_hull_armor(td):
-	'''Thinnest STRUCTURAL plate the hull carries, from the descriptor.
-	
-	Used when the blast ray finds no plate at all. Returning 0 there let the
-	blast through untouched; the thinnest plate is the attacker-friendly but
-	still bounded assumption - blast looks for the weak facing.'''
-	best = None
-	try:
-		_hull = getattr(td, 'hull', None)
-		if isinstance(_hull, dict):
-			mats = _hull.get('materials') or {}
-		else:
-			mats = getattr(_hull, 'materials', None) or {}
-		for m in mats.values():
-			if getattr(m, 'vehicleDamageFactor', 1.0) == 0.0:
-				continue
-			a = float(getattr(m, 'armor', 0.0) or 0.0)
-			if a <= 0.0:
-				continue
-			if best is None or a < best:
-				best = a
-	except Exception:
-		return 0.0
-	return best or 0.0
-
-
 def _offh_he_nominal_armor(all_hits, td=None):
 	'''Nominal thickness of the first STRUCTURAL plate on the ray.
 	
@@ -271,9 +246,8 @@ def _offh_he_nominal_armor(all_hits, td=None):
 			best = (_d, _a)
 	if best is not None:
 		return best[1]
-	# No plate on the ray. Zero would hand the blast a free pass, so fall back to
-	# the hull's thinnest structural plate when the descriptor is available.
-	return _offh_he_hull_armor(td) if td is not None else 0.0
+	# An unavailable plate is not the descriptor's thinnest plate.
+	return None
 
 
 def _offh_he_factor(shell, name, default, maximum=None):
@@ -500,6 +474,134 @@ def collision_layers(collisions):
     return sorted(result, key=lambda item: item[0])
 
 
+def _offh_he_xyz(value):
+	"""Read one finite three-coordinate point from a native vector or tuple."""
+	try:
+		result = tuple(float(value[index]) for index in range(3))
+	except (AttributeError, IndexError, KeyError, TypeError, ValueError,
+			OverflowError):
+		return None
+	if any(item != item or abs(item) == float('inf') for item in result):
+		return None
+	return result
+
+
+def _offh_he_collision_values(collision):
+	"""Extract distance and material while retaining the native collision."""
+	try:
+		distance = getattr(collision, 'dist')
+		material = getattr(collision, 'matInfo')
+	except (AttributeError, TypeError):
+		try:
+			distance = collision[0]
+			material = collision[2]
+		except (IndexError, KeyError, TypeError):
+			return None
+	try:
+		distance = float(distance)
+	except (TypeError, ValueError, OverflowError):
+		return None
+	if distance != distance or abs(distance) == float('inf'):
+		return None
+	return distance, material, collision
+
+
+def _offh_he_material_is_structural(material):
+	"""Only an explicit positive vehicle-damage factor is structure."""
+	factor = _offh_material_value(
+		material, 'vehicleDamageFactor', _OFFH_MISSING)
+	if factor is _OFFH_MISSING:
+		return False
+	try:
+		factor = float(factor)
+	except (TypeError, ValueError, OverflowError):
+		return False
+	return factor == factor and abs(factor) != float('inf') and factor > 0.0
+
+
+def he_blast_contact(shot, burst, start, end, collisions, rolled_damage,
+					 spall_coefficient=1.0):
+	"""Resolve one real structural HE contact from already-native ray evidence.
+
+	``collisions`` remains native evidence: this routine only orders it, rebuilds
+	the contact along ``start``/``end``, and applies the existing HE formula to
+	the first structural material at or beyond the burst.  It never samples
+	randomness and never substitutes a descriptor-wide armour fallback.
+	"""
+	converted = legacy_shot(shot)
+	if not _offh_is_he(converted):
+		return None
+	burst = _offh_he_xyz(burst)
+	start = _offh_he_xyz(start)
+	end = _offh_he_xyz(end)
+	radius = _offh_he_radius(converted)
+	try:
+		rolled_damage = float(rolled_damage)
+	except (TypeError, ValueError, OverflowError):
+		return None
+	if (burst is None or start is None or end is None or radius <= 0.0 or
+			rolled_damage != rolled_damage or abs(rolled_damage) == float('inf')):
+		return None
+	delta = tuple(end[index] - start[index] for index in range(3))
+	length_squared = sum(item * item for item in delta)
+	if length_squared <= 0.0:
+		return None
+	length = math.sqrt(length_squared)
+	direction = tuple(item / length for item in delta)
+	burst_along = sum((burst[index] - start[index]) * direction[index]
+					for index in range(3))
+	ordered = []
+	for collision in collisions or ():
+		values = _offh_he_collision_values(collision)
+		if values is not None:
+			ordered.append(values)
+	ordered.sort(key=lambda item: item[0])
+	through_contact = []
+	for distance_along, material, collision in ordered:
+		# The native distance must be on the queried segment; no extrapolated
+		# evidence may create HE damage outside its blast ray.
+		if distance_along < 0.0 or distance_along > length:
+			continue
+		if distance_along < burst_along - 1.0e-3:
+			continue
+		point = tuple(start[index] + direction[index] * distance_along
+					  for index in range(3))
+		distance = math.sqrt(sum(
+			(point[index] - burst[index]) ** 2 for index in range(3)))
+		structural = _offh_he_material_is_structural(material)
+		if distance > radius:
+			# A real structural plate in front of the query blocks a later one,
+			# even when this ray reached it outside the blast sphere.
+			if structural:
+				return None
+			continue
+		through_contact.append(collision)
+		if not structural:
+			continue
+		try:
+			nominal_armor = float(
+				_offh_material_value(material, 'armor', _OFFH_MISSING))
+		except (TypeError, ValueError, OverflowError):
+			return None
+		if (nominal_armor != nominal_armor or
+				abs(nominal_armor) == float('inf') or nominal_armor < 0.0):
+			return None
+		uses_liner = _offh_material_flag(
+			material, 'useAntifragmentationLining', True)
+		spall = spall_coefficient if uses_liner else 1.0
+		return {
+			'damage': _offh_he_damage(
+				converted, rolled_damage, nominal_armor, distance / radius, spall),
+			'nominal_armor': nominal_armor,
+			'distance': distance,
+			'point': point,
+			'direction': direction,
+			'collision': collision,
+			'collisions': tuple(through_contact),
+		}
+	return None
+
+
 def _call_with_uniform(function, uniform, *args):
     if uniform is None:
         return function(*args)
@@ -608,10 +710,6 @@ def he_radius(shot):
 
 def is_he(shot):
     return _offh_is_he(legacy_shot(shot))
-
-
-def he_hull_armor(descriptor):
-    return _offh_he_hull_armor(descriptor)
 
 
 def he_factors(shot):

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/critical_damage.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/critical_damage.py
@@ -1473,13 +1473,14 @@ def propose_direct(vehicle, collisions, start_pos, end_pos, hull_damage,
 
 
 def apply_explosion(vehicle, collisions, burst, direction, hull_damage,
-                    shell, attacker_id, deadeye=False):
+                    shell, attacker_id, deadeye=False, allow_interior=True):
     """Apply one HE interior cone and return its authoritative delta.
 
     Penetrating HE, a non-penetrating direct hit, and remote splash all use this
     same entry point. Native collision materials still score exposed modules;
     adopted interior targets come only from the finite cone, never the solid
-    projectile ray.
+    projectile ray. Without a reachable structural surface, callers disable
+    the interior cone while preserving collisions with exposed modules.
     """
     covered = set()
     for collision in collisions or ():
@@ -1491,9 +1492,9 @@ def apply_explosion(vehicle, collisions, burst, direction, hull_damage,
         except Exception:
             continue
     try:
-        hits = _offh_internal_cone_hits(
+        hits = (_offh_internal_cone_hits(
             vehicle, getattr(vehicle, 'typeDescriptor', None), burst,
-            direction, shell, covered)
+            direction, shell, covered) if allow_interior else ())
     except Exception as error:
         LOG_DEBUG('HE interior cone unavailable:', str(error))
         hits = None
@@ -1507,7 +1508,8 @@ def apply_explosion(vehicle, collisions, burst, direction, hull_damage,
 
 
 def propose_explosion(vehicle, collisions, burst, direction, hull_damage,
-                      shell, attacker_id, deadeye=False, with_delta=False):
+                      shell, attacker_id, deadeye=False, with_delta=False,
+                      allow_interior=True):
     """Return an HE-cone critical proposal without mutating the live Vehicle."""
     if vehicle is None:
         raise ValueError('critical proposal requires a vehicle')
@@ -1515,7 +1517,7 @@ def propose_explosion(vehicle, collisions, burst, direction, hull_damage,
     before = _state(shadow)
     damage, payload = apply_explosion(
         shadow, collisions, burst, direction, hull_damage, shell,
-        attacker_id, deadeye)
+        attacker_id, deadeye, allow_interior=allow_interior)
     if with_delta:
         after = _state(shadow)
         delta = _damage_delta(

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/device_damage.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/device_damage.py
@@ -516,6 +516,12 @@ def module_damage_roll(shell, index=1):
     dmg = shell_damage_base(shell, index)
     if dmg is None:
         return None
+    if index == 0:
+        # Track materials may explicitly select the armour-damage channel.
+        # Keep its distribution identical to vehicle HP damage. Public RNG
+        # descriptions do not establish the separate devices-channel law.
+        from gui.mods.offline_lan_0922 import combat_rules
+        return combat_rules.sample_shell_value(dmg)
     lo = dmg * (1.0 - DAMAGE_RANDOMIZATION)
     hi = dmg * (1.0 + DAMAGE_RANDOMIZATION)
     return random.uniform(lo, hi)

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/entities/remote_vehicle.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/entities/remote_vehicle.py
@@ -1523,6 +1523,153 @@ def _pose_components(vehicle, math_module):
     return result
 
 
+def _finite_blast_coordinate(value):
+    """Return one finite geometry coordinate, or ``None``."""
+    try:
+        value = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if math.isnan(value) or math.isinf(value):
+        return None
+    return value
+
+
+def _blast_bbox_bounds(bbox):
+    """Read one loaded native hit-test AABB without inventing dimensions."""
+    try:
+        lower = tuple(_finite_blast_coordinate(bbox[0][axis])
+                      for axis in range(3))
+        upper = tuple(_finite_blast_coordinate(bbox[1][axis])
+                      for axis in range(3))
+    except (AttributeError, IndexError, KeyError, TypeError):
+        return None
+    if (None in lower or None in upper or
+            any(lower[axis] > upper[axis] for axis in range(3))):
+        return None
+    return lower, upper
+
+
+def _blast_component_has_structure(component):
+    """Whether a component can contain a vehicle-damaging native material."""
+    materials = _component_value(component, 'materials', {}) or {}
+    try:
+        values = materials.itervalues()
+    except AttributeError:
+        try:
+            values = materials.values()
+        except AttributeError:
+            return False
+    for material in values:
+        factor = _finite_blast_coordinate(
+            _component_value(material, 'vehicleDamageFactor'))
+        if factor is not None and factor > 0.0:
+            return True
+    return False
+
+
+def _blast_bbox_probe_locals(burst, lower, upper):
+    """Return the finite, deterministic AABB surface candidates for a burst."""
+    closest = tuple(max(lower[axis], min(upper[axis], burst[axis]))
+                    for axis in range(3))
+    result = [closest]
+    middle = tuple((lower[axis] + upper[axis]) * 0.5
+                   for axis in range(3))
+    for axis in range(3):
+        for bound in (lower[axis], upper[axis]):
+            face_center = list(middle)
+            face_center[axis] = bound
+            result.append(tuple(face_center))
+            projection = list(closest)
+            projection[axis] = bound
+            result.append(tuple(projection))
+    unique = []
+    seen = set()
+    for point in result:
+        if point not in seen:
+            seen.add(point)
+            unique.append(point)
+    return unique
+
+
+def vehicle_blast_probe_points_at_matrix(vehicle, vehicle_matrix, burst,
+                                         radius, math_module,
+                                         chassis_matrix=None):
+    """Return bounded native probe endpoints for an HE blast at a frozen pose.
+
+    Each loaded structural component contributes its closest AABB point, face
+    centres, and nearest projections onto those faces (at most thirteen local
+    candidates).  They are only broad candidate directions: the caller must
+    still run native collision to establish a real plate, blast distance and
+    occlusion.  This finite set is deliberately not an exhaustive retail HE
+    surface search.
+    """
+    radius = _finite_blast_coordinate(radius)
+    if vehicle is None or vehicle_matrix is None or radius is None or radius <= 0.0:
+        return ()
+    try:
+        burst = tuple(_finite_blast_coordinate(getattr(burst, axis))
+                      for axis in ('x', 'y', 'z'))
+    except (AttributeError, TypeError):
+        return ()
+    if None in burst:
+        return ()
+    try:
+        burst = math_module.Vector3(burst)
+        components = _pose_components(vehicle, math_module)
+    except (AttributeError, IndexError, KeyError, TypeError, ValueError,
+            OverflowError):
+        return ()
+    result = []
+    seen = set()
+    radius_squared = radius * radius
+    for component_index, pair in enumerate(components):
+        try:
+            component, component_matrix = pair
+            tester = _component_value(component, 'hitTester')
+            local_hit_test = getattr(tester, 'localHitTest', None)
+            bounds = _blast_bbox_bounds(_component_value(tester, 'bbox'))
+            if (not callable(local_hit_test) or bounds is None or
+                    not _blast_component_has_structure(component)):
+                continue
+            root_matrix = (chassis_matrix if component_index == 0 and
+                           chassis_matrix is not None else vehicle_matrix)
+            world_to_root = math_module.Matrix(root_matrix)
+            world_to_root.invert()
+            root_burst = world_to_root.applyPoint(burst)
+            local_burst = component_matrix.applyPoint(root_burst)
+            local_burst = tuple(_finite_blast_coordinate(
+                getattr(local_burst, axis)) for axis in ('x', 'y', 'z'))
+            if None in local_burst:
+                continue
+            lower, upper = bounds
+            closest = tuple(max(lower[axis], min(upper[axis],
+                                                 local_burst[axis]))
+                            for axis in range(3))
+            distance_squared = sum(
+                (local_burst[axis] - closest[axis]) ** 2
+                for axis in range(3))
+            if distance_squared > radius_squared:
+                continue
+            component_to_root = math_module.Matrix(component_matrix)
+            component_to_root.invert()
+            for local_point in _blast_bbox_probe_locals(
+                    local_burst, lower, upper):
+                root_point = component_to_root.applyPoint(
+                    math_module.Vector3(local_point))
+                world_point = root_matrix.applyPoint(root_point)
+                coordinate = tuple(_finite_blast_coordinate(
+                    getattr(world_point, axis)) for axis in ('x', 'y', 'z'))
+                if coordinate is None or None in coordinate or coordinate in seen:
+                    continue
+                seen.add(coordinate)
+                result.append(math_module.Vector3(coordinate))
+        except (AttributeError, IndexError, KeyError, TypeError, ValueError,
+                OverflowError):
+            # Missing optional geometry must not suppress other components.
+            continue
+    return tuple(result)
+
+
 def _damage_sticker_coordinate(value, lower, upper):
     """Quantize one #1513 damage-sticker coordinate to its wire byte."""
     value = float(value)

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/gun_mechanics.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/gun_mechanics.py
@@ -5,8 +5,9 @@ from __future__ import print_function
 The source implementation keeps this state inside ``offline_battle.py``.
 These methods preserve its descriptor reads, bloom/convergence formulas,
 empty-at-countdown start and clip transitions. Shot dispersion uses the
-bounded two-sigma model documented for #1513 instead of the unbounded 0.8.2
-offline approximation.
+bounded two-sigma model described for 8.6 instead of the unbounded 0.8.2
+offline approximation. The later 9.6 central-zone adjustment remains
+unimplemented; the radial probability law is not verified #1513 behaviour.
 """
 
 import math
@@ -515,12 +516,14 @@ class GunState(object):
                 dispersion_angle=None, uniform=None):
         """Scatter inside the current #1513 aiming cone.
 
-        Retail uses a radial normal distribution with the aiming circle as a
-        hard boundary. Since 8.6 the circle is the two-sigma limit and an
-        outlying normal sample is redistributed from the centre to the edge
-        instead of being left outside or piled on its edge. 9.6 subsequently
-        reweighted the innermost zone, but the exact server-side zone table is
-        not present in the #1513 client.
+        The retained radial normal model uses the aiming circle as a hard
+        boundary. In the published 8.6 model the circle is the two-sigma
+        limit and an outlying normal sample is redistributed from the centre
+        to the edge instead of being left outside or piled on its edge. 9.6
+        reweighted the innermost zone from about 16% to 10%. That adjustment
+        is NOT implemented here: the available public diagrams and client
+        resources do not provide its full sampling law. Preserving the cone
+        boundary does not establish retail weak-spot hit probabilities.
 
         The former port added three unbounded ``dispersion / 3`` samples to
         the world axes. About 1.1 percent of its lateral samples landed beyond

--- a/tests/test_port_0922_battle_projectiles.py
+++ b/tests/test_port_0922_battle_projectiles.py
@@ -5303,7 +5303,7 @@ class BattleProjectileTests(unittest.TestCase):
                     mock.patch('random.uniform',
                                side_effect=lambda low, high: low), \
                     mock.patch('random.gauss',
-                               side_effect=lambda mean, sigma: mean - 2.5 * sigma), \
+                               side_effect=lambda mean, sigma: mean - 3.0 * sigma), \
                     mock.patch('random.random', return_value=0.0):
                 effect = battle._projectile_direct_effect(
                     meta, {'start': (0.0, 1.0, 0.0), 'distance': 10.0},
@@ -5494,7 +5494,7 @@ class BattleProjectileTests(unittest.TestCase):
                 else:
                     self.assertEqual(potential, effect['potential_damage'])
                 self.assertEqual(
-                    (390.0, 39.0), gaussian.call_args.args)
+                    (390.0, 32.5), gaussian.call_args.args)
 
     def test_overlay_edited_shell_saturates_instead_of_losing_the_shot(self):
         battle, unused_bigworld = _battle()

--- a/tests/test_port_0922_battle_projectiles.py
+++ b/tests/test_port_0922_battle_projectiles.py
@@ -1155,8 +1155,8 @@ class BattleProjectileTests(unittest.TestCase):
                         mock.patch.object(
                             critical_damage, 'propose_explosion',
                             side_effect=critical), \
-                        mock.patch.object(combat_rules.random, 'uniform',
-                                          side_effect=lambda a, b: (a + b) / 2):
+                        mock.patch.object(combat_rules.random, 'gauss',
+                                          side_effect=lambda mean, unused_sigma: mean):
                     effect = battle._projectile_direct_effect(
                         meta, state, terminal_data)
 
@@ -2707,6 +2707,20 @@ class BattleProjectileTests(unittest.TestCase):
         # -0.04 s: exactly 0.9 m behind the uncompensated authority pose.
         self.assertEqual(1, len(poses))
         self.assertAlmostEqual(-0.4, poses[0]['z'], places=6)
+        terminal_data = battle._projectile_terminal_data['player:7:1']
+        self.assertNotEqual(
+            tuple(terminal_data['query'][0]),
+            terminal_data['trajectory_query']['start'])
+        self.assertEqual(
+            (0.0, 1.0, 0.0),
+            terminal_data['trajectory_query']['start'])
+        self.assertEqual(
+            (10.0, 1.0, 0.0),
+            terminal_data['trajectory_query']['end'])
+        self.assertEqual(
+            (0.0, 0.1),
+            (terminal_data['trajectory_query']['absolute_start'],
+             terminal_data['trajectory_query']['absolute_end']))
 
         # The candidate keeps advancing along its own historical timeline for
         # the rest of the flight.  It is never frozen at the displayed pose,
@@ -4297,6 +4311,54 @@ class BattleProjectileTests(unittest.TestCase):
         self.assertEqual(10.5, sampled.call_args[0][1])
         self.assertEqual(7.0, sampled.call_args[0][3])
 
+    def test_ricochet_scene_uses_the_current_segment_penetration(self):
+        battle, unused_bigworld = _battle()
+
+        class _Destructibles(object):
+            def __init__(self):
+                self.calls = 0
+
+            def shot_world_distance(self, *unused_args):
+                self.calls += 1
+                if self.calls == 1:
+                    return {
+                        'piercing_loss': 10.0,
+                        'loss_distance': 0.5,
+                        'continue_from': 1.0,
+                    }
+                return {
+                    'piercing_loss': 0.0,
+                    'world_distance': 999999.0,
+                }
+
+        battle._destructibles = _Destructibles()
+        state = {
+            'start': (0.0, 0.0, 0.0),
+            'payload': {
+                'range_origin': (0.0, 0.0, 0.0),
+                'base_penetration_multiplier': 0.75,
+            },
+        }
+        shot = {
+            'piercingPower': (100.0, 100.0),
+            'maxDistance': 100.0,
+            'shell': {'kind': 'ARMOR_PIERCING'},
+        }
+
+        scene = battle._resolve_shot_scene(
+            _Vector((0.0, 0.0, 0.0)), _Vector((2.0, 0.0, 0.0)),
+            _Vector((1.0, 0.0, 0.0)), shot,
+            penetration_factor=1.0, initial_piercing_loss=70.0,
+            projectile_state=state)
+
+        # The first ricochet retains 75 penetration before the old 70 and new
+        # 10 losses. It therefore stops at this destructible. Reusing the
+        # original 100 penetration would incorrectly leave 20 and trace on.
+        self.assertEqual(1, battle._destructibles.calls)
+        self.assertTrue(scene['stopped_by_destructible'])
+        self.assertEqual(0.5, scene['world_distance'])
+        self.assertEqual(80.0, scene['piercing_loss'])
+
     def test_nonimpact_resolution_sends_no_impact_position(self):
         battle, unused_bigworld = _battle()
         meta = battle._projectile_wire_meta(_event())
@@ -4697,8 +4759,8 @@ class BattleProjectileTests(unittest.TestCase):
                 mock.patch.object(
                     combat_rules, 'he_nominal_armor', return_value=100.0), \
                 mock.patch.object(
-                    combat_rules.random, 'uniform',
-                    side_effect=lambda low, high: (low + high) / 2.0), \
+                    combat_rules.random, 'gauss',
+                    side_effect=lambda mean, unused_sigma: mean), \
                 mock.patch.object(
                     critical_damage, 'propose_direct',
                     side_effect=lambda unused_target, unused_collisions,
@@ -4765,6 +4827,244 @@ class BattleProjectileTests(unittest.TestCase):
             0.75,
             resolved.call_args.kwargs['base_penetration_multiplier'])
         critical.assert_not_called()
+
+    def test_ap_and_apcr_ricochet_carry_screen_loss_from_actual_plate(self):
+        for shell_kind in ('ARMOR_PIERCING', 'ARMOR_PIERCING_CR'):
+            with self.subTest(shell_kind=shell_kind):
+                battle, unused_bigworld = _battle()
+                source = battle._server_entity(41)
+                target = types.SimpleNamespace(
+                    id=55, isStarted=True,
+                    typeDescriptor=types.SimpleNamespace(),
+                    position=_Vector((6.0, 1.0, 0.0)),
+                    isAlive=lambda: True)
+                battle._records['bot:17'] = {
+                    'engine_id': 55, 'network_id': 17, 'kind': 'bot',
+                    'local': False, 'ready': True,
+                    'state': {'health': 1000, 'alive': True}}
+                battle._server_entity = lambda entity_id: (
+                    source if entity_id == 41 else
+                    target if entity_id == 55 else None)
+                event = _event()
+                event['source_shot']['shell']['kind'] = shell_kind
+                event['source_shot']['shell']['caliber'] = 105.0
+                event['source_shot']['piercingPower'] = [220.0, 220.0]
+                meta = battle._projectile_wire_meta(event)
+                battle._projectile_meta[meta['projectile_id']] = meta
+                screen = types.SimpleNamespace(
+                    dist=5.0, hitAngleCos=1.0,
+                    matInfo=types.SimpleNamespace(
+                        armor=20.0, vehicleDamageFactor=0.0),
+                    compName='vehicleChassis')
+                hull = types.SimpleNamespace(
+                    dist=6.0, hitAngleCos=math.cos(math.radians(75.0)),
+                    matInfo=types.SimpleNamespace(
+                        armor=155.0, vehicleDamageFactor=1.0),
+                    compName='vehicleHull')
+                evidence = types.SimpleNamespace(
+                    collision=hull,
+                    worldNormal=_Vector((-1.0, 0.0, 0.0)))
+                battle._projectile_terminal_data[meta['projectile_id']] = {
+                    'target_key': 'bot:17',
+                    'collisions': [screen, hull],
+                    'collision_evidence': [evidence],
+                    # Native collision space may be offset from the visual
+                    # world trajectory for a swept moving-target sample.
+                    'query': (_Vector((100.0, 1.0, 0.0)),
+                              _Vector((110.0, 1.0, 0.0))),
+                    'trajectory_query': {
+                        'start': (0.0, 1.0, 0.0),
+                        'end': (12.0, 1.0, 0.0),
+                        'absolute_start': 0.0,
+                        'absolute_end': 1.2,
+                    },
+                    'impact': (6.0, 1.0, 0.0),
+                    'piercing_loss': 0.0,
+                    'penetration_factor': 1.0,
+                }
+                state = {
+                    'key': meta['projectile_id'],
+                    'start': (0.0, 1.0, 0.0),
+                    'position': (6.0, 1.0, 0.0),
+                    'velocity': (10.0, 0.0, 0.0),
+                    'gravity': (0.0, -0.000001, 0.0),
+                    'elapsed': 0.6,
+                    'distance': 6.0,
+                    'payload': {'range_origin': (0.0, 0.0, 0.0)},
+                }
+                sender = mock.Mock(side_effect=(False, True))
+                battle.client.send_projectile_ricochet = sender
+
+                # A rejected write retains one byte-equivalent proposal for
+                # retry instead of remapping the plate against newer state.
+                self.assertFalse(battle._projectile_terminal(
+                    state, {'reason': 'impact'}))
+                first = sender.call_args_list[0]
+                meta['awaiting_ricochet'] = False
+                self.assertTrue(battle._submit_projectile_ricochet(meta))
+
+                self.assertEqual(first, sender.call_args_list[1])
+                args = first.args
+                kwargs = first.kwargs
+                self.assertEqual(720, args[3])
+                self.assertAlmostEqual(7.2, args[4][0])
+                self.assertAlmostEqual(7.198, args[5][0], places=5)
+                self.assertLess(args[6][0], 0.0)
+                self.assertEqual(0.75, args[7])
+                self.assertEqual(0, args[8]['shot_result'])
+                self.assertEqual(6.0, args[8]['x'])
+                self.assertAlmostEqual(7.2, kwargs['checked_distance'])
+                self.assertEqual(20.0, kwargs['piercing_loss'])
+
+    def test_ricochet_without_a_screen_keeps_the_existing_frontier(self):
+        battle, unused_bigworld = _battle()
+        source = battle._server_entity(41)
+        target = types.SimpleNamespace(
+            id=55, isStarted=True, typeDescriptor=types.SimpleNamespace(),
+            position=_Vector((6.0, 1.0, 0.0)), isAlive=lambda: True)
+        battle._records['bot:17'] = {
+            'engine_id': 55, 'network_id': 17, 'kind': 'bot',
+            'local': False, 'ready': True,
+            'state': {'health': 1000, 'alive': True}}
+        battle._server_entity = lambda entity_id: (
+            source if entity_id == 41 else
+            target if entity_id == 55 else None)
+        event = _event()
+        event['source_shot']['shell']['caliber'] = 105.0
+        meta = battle._projectile_wire_meta(event)
+        meta['piercing_loss'] = 3.0
+        battle._projectile_meta[meta['projectile_id']] = meta
+        hull = types.SimpleNamespace(
+            dist=5.0, hitAngleCos=math.cos(math.radians(75.0)),
+            matInfo=types.SimpleNamespace(
+                armor=155.0, vehicleDamageFactor=1.0),
+            compName='vehicleHull')
+        battle._projectile_terminal_data[meta['projectile_id']] = {
+            'target_key': 'bot:17', 'collisions': [hull],
+            'collision_evidence': [types.SimpleNamespace(
+                collision=hull,
+                worldNormal=_Vector((-1.0, 0.0, 0.0)))],
+            'query': (_Vector((100.0, 1.0, 0.0)),
+                      _Vector((110.0, 1.0, 0.0))),
+            'trajectory_query': {
+                'start': (0.0, 1.0, 0.0),
+                'end': (12.0, 1.0, 0.0),
+                'absolute_start': 0.0,
+                'absolute_end': 1.2,
+            },
+            'impact': (6.0, 1.0, 0.0),
+            'piercing_loss': 3.0,
+            'penetration_factor': 1.0,
+        }
+        state = {
+            'key': meta['projectile_id'],
+            'start': (0.0, 1.0, 0.0),
+            'position': (6.0, 1.0, 0.0),
+            'velocity': (10.0, 0.0, 0.0),
+            'gravity': (0.0, -0.000001, 0.0),
+            'elapsed': 0.6, 'distance': 6.0,
+            'payload': {'range_origin': (0.0, 0.0, 0.0)},
+        }
+
+        self.assertTrue(battle._projectile_terminal(
+            state, {'reason': 'impact'}))
+
+        args, kwargs = battle.client.ricochets[0]
+        self.assertEqual(600, args[3])
+        self.assertEqual([6.0, 1.0, 0.0], args[4])
+        self.assertAlmostEqual(5.998, args[5][0], places=5)
+        self.assertEqual(6.0, kwargs['checked_distance'])
+        self.assertEqual(3.0, kwargs['piercing_loss'])
+
+    def test_extended_plate_maps_past_the_query_and_obeys_both_limits(self):
+        for limit, continues in ((None, True), ('range', False),
+                                 ('time', False)):
+            with self.subTest(limit=limit):
+                battle, unused_bigworld = _battle()
+                source = battle._server_entity(41)
+                target = types.SimpleNamespace(
+                    id=55, isStarted=True,
+                    typeDescriptor=types.SimpleNamespace(),
+                    position=_Vector((9.0, 0.0, 0.0)),
+                    isAlive=lambda: True)
+                battle._records['bot:17'] = {
+                    'engine_id': 55, 'network_id': 17, 'kind': 'bot',
+                    'local': False, 'ready': True,
+                    'state': {'health': 1000, 'alive': True}}
+                battle._server_entity = lambda entity_id: (
+                    source if entity_id == 41 else
+                    target if entity_id == 55 else None)
+                event = _event()
+                event['source_shot']['shell']['caliber'] = 105.0
+                event['source_shot']['piercingPower'] = [220.0, 220.0]
+                if limit == 'range':
+                    event['maxDistance'] = 13.0
+                    event['source_shot']['maxDistance'] = 13.0
+                if limit == 'time':
+                    event['max_time_ms'] = 1400
+                meta = battle._projectile_wire_meta(event)
+                battle._projectile_meta[meta['projectile_id']] = meta
+                screen = types.SimpleNamespace(
+                    dist=0.9, hitAngleCos=1.0,
+                    matInfo=types.SimpleNamespace(
+                        armor=20.0, vehicleDamageFactor=0.0),
+                    compName='vehicleChassis')
+                hull = types.SimpleNamespace(
+                    dist=1.4, hitAngleCos=math.cos(math.radians(75.0)),
+                    matInfo=types.SimpleNamespace(
+                        armor=155.0, vehicleDamageFactor=1.0),
+                    compName='vehicleHull')
+                evidence = (
+                    types.SimpleNamespace(
+                        collision=screen, worldNormal=None),
+                    types.SimpleNamespace(
+                        collision=hull,
+                        worldNormal=_Vector((-1.0, 0.0, 0.0))))
+                battle._projectile_vehicle_collisions = mock.Mock(
+                    return_value=((screen, hull), evidence))
+                battle._projectile_terminal_data[meta['projectile_id']] = {
+                    'target_key': 'bot:17', 'collisions': [screen],
+                    'collision_evidence': [evidence[0]],
+                    'query': (_Vector((0.0, 0.0, 0.0)),
+                              _Vector((1.0, 0.0, 0.0))),
+                    'trajectory_query': {
+                        'start': (0.0, 0.0, 0.0),
+                        'end': (10.0, 0.0, 0.0),
+                        'absolute_start': 0.0,
+                        'absolute_end': 1.0,
+                    },
+                    'impact': (9.0, 0.0, 0.0),
+                    'piercing_loss': 0.0,
+                    'penetration_factor': 1.0,
+                }
+                state = {
+                    'key': meta['projectile_id'],
+                    'start': (0.0, 0.0, 0.0),
+                    'position': (9.0, 0.0, 0.0),
+                    'velocity': (10.0, 0.0, 0.0),
+                    'gravity': (0.0, -0.000001, 0.0),
+                    'elapsed': 0.9, 'distance': 9.0,
+                    'payload': {'range_origin': (0.0, 0.0, 0.0)},
+                }
+
+                self.assertTrue(battle._projectile_terminal(
+                    state, {'reason': 'impact'}))
+
+                self.assertEqual(1, battle._projectile_vehicle_collisions.
+                                 call_count)
+                if continues:
+                    self.assertEqual(1, len(battle.client.ricochets))
+                    self.assertEqual([], battle.client.resolutions)
+                    args, kwargs = battle.client.ricochets[0]
+                    self.assertEqual(1400, args[3])
+                    self.assertAlmostEqual(14.0, args[4][0])
+                    self.assertAlmostEqual(13.998, args[5][0], places=5)
+                    self.assertAlmostEqual(14.0,
+                                           kwargs['checked_distance'])
+                    self.assertEqual(20.0, kwargs['piercing_loss'])
+                else:
+                    self.assertEqual([], battle.client.ricochets)
+                    self.assertEqual(1, len(battle.client.resolutions))
 
     def test_ap_direct_hit_requeries_the_full_late_hit_trace_budget(self):
         battle, unused_bigworld = _battle()
@@ -5002,6 +5302,8 @@ class BattleProjectileTests(unittest.TestCase):
                         combat_rules, 'damage', return_value=0), \
                     mock.patch('random.uniform',
                                side_effect=lambda low, high: low), \
+                    mock.patch('random.gauss',
+                               side_effect=lambda mean, sigma: mean - 2.5 * sigma), \
                     mock.patch('random.random', return_value=0.0):
                 effect = battle._projectile_direct_effect(
                     meta, {'start': (0.0, 1.0, 0.0), 'distance': 10.0},
@@ -5173,8 +5475,8 @@ class BattleProjectileTests(unittest.TestCase):
                             combat_rules, 'he_nominal_armor',
                             return_value=100.0), \
                         mock.patch.object(
-                            combat_rules.random, 'uniform',
-                            return_value=312.7) as uniform, \
+                            combat_rules.random, 'gauss',
+                            return_value=312.7) as gaussian, \
                         mock.patch.object(
                             critical_damage, 'propose_direct',
                             side_effect=lambda unused_target,
@@ -5192,7 +5494,7 @@ class BattleProjectileTests(unittest.TestCase):
                 else:
                     self.assertEqual(potential, effect['potential_damage'])
                 self.assertEqual(
-                    (390.0 * 0.75, 390.0 * 1.25), uniform.call_args.args)
+                    (390.0, 39.0), gaussian.call_args.args)
 
     def test_overlay_edited_shell_saturates_instead_of_losing_the_shot(self):
         battle, unused_bigworld = _battle()
@@ -5206,7 +5508,9 @@ class BattleProjectileTests(unittest.TestCase):
             'state': {'health': 1000, 'alive': True}}
         battle._server_entity = lambda entity_id: (
             source if entity_id == 41 else target if entity_id == 55 else None)
-        meta = battle._projectile_wire_meta(_event())
+        event = _event()
+        event['source_shot']['shell']['damage'] = [8000.0, 165.0]
+        meta = battle._projectile_wire_meta(event)
         collision = types.SimpleNamespace(
             dist=10.0, hitAngleCos=1.0, matInfo=object(), compName='hull')
         terminal = {
@@ -5223,7 +5527,7 @@ class BattleProjectileTests(unittest.TestCase):
                 mock.patch.object(
                     combat_rules, 'he_nominal_armor', return_value=100.0), \
                 mock.patch.object(
-                    combat_rules.random, 'uniform', return_value=9000.0):
+                    combat_rules.random, 'gauss', return_value=9000.0):
             effect = battle._projectile_direct_effect(
                 meta, {'start': (0.0, 1.0, 0.0), 'distance': 10.0},
                 terminal)

--- a/tests/test_port_0922_battle_projectiles.py
+++ b/tests/test_port_0922_battle_projectiles.py
@@ -1124,7 +1124,7 @@ class BattleProjectileTests(unittest.TestCase):
                         int(shell_kind == 'HIGH_EXPLOSIVE'),
                         battle._projectile_splash_effects.call_count)
 
-    def test_track_only_contact_blasts_hull_for_he_but_not_solid_shot(self):
+    def test_track_only_contact_cannot_invent_hull_damage(self):
         for shell_kind in ('HIGH_EXPLOSIVE', 'ARMOR_PIERCING'):
             with self.subTest(shell=shell_kind):
                 battle, unused_world, target_key, state = (
@@ -1161,10 +1161,7 @@ class BattleProjectileTests(unittest.TestCase):
                         meta, state, terminal_data)
 
                 self.assertEqual(1, effect['shot_result'])
-                if shell_kind == 'HIGH_EXPLOSIVE':
-                    self.assertGreater(effect['damage'], 0)
-                else:
-                    self.assertEqual(0, effect['damage'])
+                self.assertEqual(0, effect['damage'])
 
     def test_native_factory_exposes_unblended_projectile_matrix(self):
         canonical_matrix = object()
@@ -5067,7 +5064,7 @@ class BattleProjectileTests(unittest.TestCase):
         self.assertEqual(390, effect['damage'])
         battle._projectile_frozen_target.assert_called_once_with(
             target, collision_pose)
-        self.assertIs(frozen_descriptor, nominal.call_args.args[1])
+        nominal.assert_not_called()
         self.assertIs(frozen_target, critical.call_args.args[0])
 
     def test_he_direct_hit_uses_the_finite_explosion_cone(self):
@@ -5107,7 +5104,9 @@ class BattleProjectileTests(unittest.TestCase):
                 combat_rules, 'resolve_armor_contact',
                 return_value={'result': 1}), \
                 mock.patch.object(
-                    combat_rules, 'he_nominal_armor', return_value=100.0), \
+                    battle, '_projectile_he_blast_contact', return_value={
+                        'damage': 200, 'collisions': (collision,),
+                        'direction': (1.0, 0.0, 0.0)}), \
                 mock.patch.object(
                     combat_rules, 'damage', return_value=200), \
                 mock.patch.object(
@@ -5257,15 +5256,17 @@ class BattleProjectileTests(unittest.TestCase):
         meta = battle._projectile_wire_meta(event)
 
         with mock.patch.object(
-                combat_rules, 'he_splash_damage', return_value=90), \
+                battle, '_projectile_he_blast_contact', return_value={
+                    'damage': 90, 'collisions': (),
+                    'direction': (1.0, 0.0, 0.0)}), \
                 mock.patch.object(
                     critical_damage, 'propose_explosion',
                     return_value=(90, None, None)):
             effects = battle._projectile_splash_effects(
                 meta, (9.0, 1.0, 0.0), 'player:7')
 
-        # Splash rolls its own distance-attenuated quantity and the server
-        # excludes splash from blocked damage, so it publishes no roll.
+        # The server excludes splash from blocked damage, so it publishes no
+        # potential-damage statistic.
         self.assertEqual(1, len(effects))
         self.assertEqual(90, effects[0]['damage'])
         self.assertNotIn('potential_damage', effects[0])

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -6642,12 +6642,9 @@ class BattleRuntimeContractTests(unittest.TestCase):
             11, descriptor, _Vector(), (0.0, 0.0, 0.0),
             {'health': 500})
 
-        with mock.patch.object(
-                combat_rules, 'he_hull_armor',
-                side_effect=AssertionError('global hull fallback used')):
-            armor = battle._native_ram_vehicle_armor(
-                vehicle, vehicle.matrix, _Vector(0.0, 0.0, 3.5),
-                (0.0, -1.0))
+        armor = battle._native_ram_vehicle_armor(
+            vehicle, vehicle.matrix, _Vector(0.0, 0.0, 3.5),
+            (0.0, -1.0))
 
         self.assertIsNone(armor)
 

--- a/tests/test_port_0922_combat_rules.py
+++ b/tests/test_port_0922_combat_rules.py
@@ -100,7 +100,7 @@ class CombatRulesTests(unittest.TestCase):
 
         factor = combat_rules.sample_penetration_factor(low_roll)
         self.assertEqual(0.75, factor)
-        self.assertEqual([(1.0, 0.1)], draws)
+        self.assertEqual([(1.0, 1.0 / 12.0)], draws)
         self.assertEqual(
             30.0, combat_rules.sampled_piercing(
                 _shot(piercing=(40.0, 40.0)), 10.0, factor, 0.0))
@@ -166,7 +166,7 @@ class CombatRulesTests(unittest.TestCase):
             random_gauss=one_roll)
 
         self.assertEqual(2, result[0])
-        self.assertEqual([(1.0, 0.1)], draws)
+        self.assertEqual([(1.0, 1.0 / 12.0)], draws)
 
     def test_two_caliber_normalization_has_an_exact_boundary(self):
         armor = 60.0
@@ -364,10 +364,10 @@ class CombatRulesTests(unittest.TestCase):
 
         low = combat_rules.damage(
             shot, 2, 100.0,
-            random_gauss=lambda mean, sigma: mean - 2.5 * sigma)
+            random_gauss=lambda mean, sigma: mean - 3.0 * sigma)
         high = combat_rules.damage(
             shot, 2, 100.0,
-            random_gauss=lambda mean, sigma: mean + 2.5 * sigma)
+            random_gauss=lambda mean, sigma: mean + 3.0 * sigma)
 
         self.assertEqual(300, low)
         self.assertEqual(500, high)
@@ -382,10 +382,10 @@ class CombatRulesTests(unittest.TestCase):
                 shot.shell.damage = (400.0, 165.0)
                 low = combat_rules.damage(
                     shot, 2, 100.0,
-                    random_gauss=lambda mean, sigma: mean - 2.5 * sigma)
+                    random_gauss=lambda mean, sigma: mean - 3.0 * sigma)
                 high = combat_rules.damage(
                     shot, 2, 100.0,
-                    random_gauss=lambda mean, sigma: mean + 2.5 * sigma)
+                    random_gauss=lambda mean, sigma: mean + 3.0 * sigma)
 
                 self.assertEqual(300, low)
                 self.assertEqual(500, high)

--- a/tests/test_port_0922_combat_rules.py
+++ b/tests/test_port_0922_combat_rules.py
@@ -76,7 +76,7 @@ class CombatRulesTests(unittest.TestCase):
         result = combat_rules.penetration(
             _shot(piercing=(200.0, 100.0), maximum=500.0),
             500.0, 1.0, 1.0,
-            random_uniform=lambda unused_low, unused_high: 1.0)
+            random_gauss=lambda mean, unused_sigma: mean)
 
         self.assertEqual(1, result[0])
         self.assertEqual(0.0, result[2])
@@ -100,7 +100,7 @@ class CombatRulesTests(unittest.TestCase):
 
         factor = combat_rules.sample_penetration_factor(low_roll)
         self.assertEqual(0.75, factor)
-        self.assertEqual([(0.75, 1.25)], draws)
+        self.assertEqual([(1.0, 0.1)], draws)
         self.assertEqual(
             30.0, combat_rules.sampled_piercing(
                 _shot(piercing=(40.0, 40.0)), 10.0, factor, 0.0))
@@ -112,7 +112,7 @@ class CombatRulesTests(unittest.TestCase):
                 dist=10.0, hitAngleCos=1.0, matInfo=hull,
                 compName='vehicleHull'),),
             pierce_loss=5.0, penetration_factor=factor,
-            random_uniform=lambda unused_low, unused_high: self.fail(
+            random_gauss=lambda unused_low, unused_high: self.fail(
                 'vehicle resolution must not draw penetration again'))
 
         self.assertEqual(2, result[0])
@@ -163,10 +163,10 @@ class CombatRulesTests(unittest.TestCase):
             _shot(piercing=(100.0, 100.0)), 50.0,
             (_collision(5.0, 1.0, screen, 'vehicleChassis'),
              _collision(5.2, 1.0, hull)),
-            random_uniform=one_roll)
+            random_gauss=one_roll)
 
         self.assertEqual(2, result[0])
-        self.assertEqual([(0.75, 1.25)], draws)
+        self.assertEqual([(1.0, 0.1)], draws)
 
     def test_two_caliber_normalization_has_an_exact_boundary(self):
         armor = 60.0
@@ -240,7 +240,7 @@ class CombatRulesTests(unittest.TestCase):
         result = combat_rules.penetration(
             _shot(kind='HOLLOW_CHARGE', piercing=(400.0, 400.0)),
             50.0, 60.0, 0.30,
-            random_uniform=lambda unused_low, unused_high: 1.0)
+            random_gauss=lambda mean, unused_sigma: mean)
 
         self.assertEqual(2, result[0])
 
@@ -355,7 +355,7 @@ class CombatRulesTests(unittest.TestCase):
 
         value = combat_rules.damage(
             shot, 1, 100.0,
-            random_uniform=lambda low, high: (low + high) * 0.5)
+            random_gauss=lambda mean, unused_sigma: mean)
 
         self.assertEqual(70, value)
 
@@ -364,10 +364,10 @@ class CombatRulesTests(unittest.TestCase):
 
         low = combat_rules.damage(
             shot, 2, 100.0,
-            random_uniform=lambda minimum, unused_maximum: minimum)
+            random_gauss=lambda mean, sigma: mean - 2.5 * sigma)
         high = combat_rules.damage(
             shot, 2, 100.0,
-            random_uniform=lambda unused_minimum, maximum: maximum)
+            random_gauss=lambda mean, sigma: mean + 2.5 * sigma)
 
         self.assertEqual(300, low)
         self.assertEqual(500, high)
@@ -382,10 +382,10 @@ class CombatRulesTests(unittest.TestCase):
                 shot.shell.damage = (400.0, 165.0)
                 low = combat_rules.damage(
                     shot, 2, 100.0,
-                    random_uniform=lambda minimum, unused_maximum: minimum)
+                    random_gauss=lambda mean, sigma: mean - 2.5 * sigma)
                 high = combat_rules.damage(
                     shot, 2, 100.0,
-                    random_uniform=lambda unused_minimum, maximum: maximum)
+                    random_gauss=lambda mean, sigma: mean + 2.5 * sigma)
 
                 self.assertEqual(300, low)
                 self.assertEqual(500, high)
@@ -400,7 +400,7 @@ class CombatRulesTests(unittest.TestCase):
 
         result = combat_rules.resolve_hull_hit(
             _shot(piercing=(120.0, 120.0)), 50.0, collisions,
-            random_uniform=lambda unused_low, unused_high: 1.0)
+            random_gauss=lambda mean, unused_sigma: mean)
 
         self.assertEqual(1, result[0])
         # The 90 mm shell triggers the two-calibre normalization rule on the
@@ -601,7 +601,7 @@ class CombatRulesTests(unittest.TestCase):
         result = combat_rules.resolve_hull_hit(
             _shot(piercing=(160.0, 160.0)), 50.0, collisions,
             pierce_loss=50.0,
-            random_uniform=lambda unused_low, unused_high: 1.0)
+            random_gauss=lambda mean, unused_sigma: mean)
 
         self.assertEqual(1, result[0])
         self.assertEqual(70.0, result[3])
@@ -615,10 +615,10 @@ class CombatRulesTests(unittest.TestCase):
         shot = _shot(piercing=(160.0, 160.0), damage=240.0)
         clear = combat_rules.resolve_hull_hit(
             shot, 50.0, collisions,
-            random_uniform=lambda unused_low, unused_high: 1.0)
+            random_gauss=lambda mean, unused_sigma: mean)
         crossed = combat_rules.resolve_hull_hit(
             shot, 50.0, collisions,
-            random_uniform=lambda unused_low, unused_high: 1.0,
+            random_gauss=lambda mean, unused_sigma: mean,
             pierce_loss=25.0)
 
         self.assertEqual(2, clear[0])
@@ -626,10 +626,10 @@ class CombatRulesTests(unittest.TestCase):
         self.assertEqual(
             combat_rules.damage(
                 shot, clear[0], 50.0,
-                random_uniform=lambda unused_low, unused_high: 1.0),
+                random_gauss=lambda mean, unused_sigma: mean),
             combat_rules.damage(
                 shot, crossed[0], 50.0,
-                random_uniform=lambda unused_low, unused_high: 1.0))
+                random_gauss=lambda mean, unused_sigma: mean))
 
     def test_collision_adapter_rejects_incomplete_1513_result(self):
         collision = types.SimpleNamespace(
@@ -777,13 +777,13 @@ class CombatRulesTests(unittest.TestCase):
             kind='HIGH_EXPLOSIVE', damage=400.0,
             explosion_radius=10.0)
 
-        uniform = lambda low, high: (low + high) * 0.5
+        mean_roll = lambda mean, unused_sigma: mean
         center = combat_rules.he_splash_damage(
-            shot, 0.0, 0.0, random_uniform=uniform)
+            shot, 0.0, 0.0, random_gauss=mean_roll)
         middle = combat_rules.he_splash_damage(
-            shot, 50.0, 0.5, random_uniform=uniform)
+            shot, 50.0, 0.5, random_gauss=mean_roll)
         edge = combat_rules.he_splash_damage(
-            shot, 0.0, 1.0, random_uniform=uniform)
+            shot, 0.0, 1.0, random_gauss=mean_roll)
 
         self.assertTrue(combat_rules.is_he(shot))
         self.assertEqual(10.0, combat_rules.he_radius(shot))
@@ -794,16 +794,16 @@ class CombatRulesTests(unittest.TestCase):
     def test_spall_liner_scales_the_he_armour_absorption_term(self):
         shot = _shot(
             kind='HIGH_EXPLOSIVE', damage=400.0, explosion_radius=10.0)
-        uniform = lambda low, high: (low + high) * 0.5
+        mean_roll = lambda mean, unused_sigma: mean
 
         bare = combat_rules.he_splash_damage(
-            shot, 50.0, 0.0, random_uniform=uniform)
+            shot, 50.0, 0.0, random_gauss=mean_roll)
         lined = combat_rules.he_splash_damage(
-            shot, 50.0, 0.0, random_uniform=uniform, spall_coefficient=1.5)
+            shot, 50.0, 0.0, random_gauss=mean_roll, spall_coefficient=1.5)
         direct_bare = combat_rules.damage(
-            shot, 1, 50.0, random_uniform=uniform)
+            shot, 1, 50.0, random_gauss=mean_roll)
         direct_lined = combat_rules.damage(
-            shot, 1, 50.0, random_uniform=uniform, spall_coefficient=1.5)
+            shot, 1, 50.0, random_gauss=mean_roll, spall_coefficient=1.5)
 
         # 400 * 0.5 - 1.3 * 50 * spall
         self.assertEqual(135, bare)
@@ -814,13 +814,13 @@ class CombatRulesTests(unittest.TestCase):
     def test_he_absorption_ignores_an_absent_or_invalid_spall_factor(self):
         shot = _shot(
             kind='HIGH_EXPLOSIVE', damage=400.0, explosion_radius=10.0)
-        uniform = lambda low, high: (low + high) * 0.5
+        mean_roll = lambda mean, unused_sigma: mean
         baseline = combat_rules.he_splash_damage(
-            shot, 50.0, 0.0, random_uniform=uniform)
+            shot, 50.0, 0.0, random_gauss=mean_roll)
 
         for value in (None, 'x', float('nan'), float('inf'), 0.0, -2.0, 0.5):
             self.assertEqual(baseline, combat_rules.he_splash_damage(
-                shot, 50.0, 0.0, random_uniform=uniform,
+                shot, 50.0, 0.0, random_gauss=mean_roll,
                 spall_coefficient=value), value)
 
     def test_spall_coefficient_reads_the_1513_descriptor_default(self):
@@ -848,7 +848,7 @@ class CombatRulesTests(unittest.TestCase):
 
         value = combat_rules.he_splash_damage(
             shot, 50.0, 0.5,
-            random_uniform=lambda low, high: (low + high) * 0.5)
+            random_gauss=lambda mean, unused_sigma: mean)
 
         self.assertEqual((0.6, 1.0, 0.2), combat_rules.he_factors(shot))
         self.assertEqual(110, value)

--- a/tests/test_port_0922_combat_rules.py
+++ b/tests/test_port_0922_combat_rules.py
@@ -853,7 +853,7 @@ class CombatRulesTests(unittest.TestCase):
         self.assertEqual((0.6, 1.0, 0.2), combat_rules.he_factors(shot))
         self.assertEqual(110, value)
 
-    def test_he_hull_armor_reads_native_1513_component_attributes(self):
+    def test_he_missing_contact_does_not_borrow_descriptor_armor(self):
         material = types.SimpleNamespace(
             armor=35.0, vehicleDamageFactor=1.0)
 
@@ -865,7 +865,123 @@ class CombatRulesTests(unittest.TestCase):
 
         descriptor = types.SimpleNamespace(hull=Hull())
 
-        self.assertEqual(35.0, combat_rules._offh_he_hull_armor(descriptor))
+        self.assertIsNone(combat_rules.he_nominal_armor((), descriptor))
+
+    def test_he_blast_stops_at_first_structural_plate_not_weaker_backside(self):
+        first = _material(100.0)
+        weaker_backside = _material(10.0)
+        result = combat_rules.he_blast_contact(
+            _shot(kind='HIGH_EXPLOSIVE', damage=400.0,
+                  explosion_radius=10.0),
+            (0.0, 0.0, 0.0), (0.0, 0.0, 0.0), (10.0, 0.0, 0.0),
+            (_collision(2.0, 1.0, weaker_backside),
+             _collision(1.0, 1.0, first)), 400.0)
+
+        self.assertIs(first, result['collision'].matInfo)
+        self.assertEqual(100.0, result['nominal_armor'])
+        self.assertEqual(56, result['damage'])
+        self.assertEqual((1.0, 0.0, 0.0), result['point'])
+
+    def test_he_blast_accepts_zero_armour_structural_contact(self):
+        collision = _collision(0.0, 1.0, _material(0.0))
+
+        result = combat_rules.he_blast_contact(
+            _shot(kind='HIGH_EXPLOSIVE', damage=400.0,
+                  explosion_radius=10.0),
+            (0.0, 0.0, 0.0), (0.0, 0.0, 0.0), (10.0, 0.0, 0.0),
+            (collision,), 400.0)
+
+        self.assertEqual(0.0, result['nominal_armor'])
+        self.assertEqual(200, result['damage'])
+        self.assertEqual((collision,), result['collisions'])
+
+    def test_he_blast_requires_native_structural_evidence(self):
+        shot = _shot(kind='HIGH_EXPLOSIVE', damage=400.0,
+                     explosion_radius=10.0)
+        external = _collision(0.0, 1.0, _material(20.0, 0.0))
+        missing_material = _collision(1.0, 1.0, None)
+
+        self.assertIsNone(combat_rules.he_blast_contact(
+            shot, (0.0, 0.0, 0.0), (0.0, 0.0, 0.0),
+            (10.0, 0.0, 0.0), (external, missing_material), 400.0))
+        self.assertIsNone(combat_rules.he_blast_contact(
+            shot, (0.0, 0.0, 0.0), (0.0, 0.0, 0.0),
+            (10.0, 0.0, 0.0), (), 400.0))
+
+    def test_he_blast_missing_armour_is_not_a_zero_armour_plate(self):
+        collision = _collision(1.0, 1.0, types.SimpleNamespace(
+            vehicleDamageFactor=1.0))
+        self.assertIsNone(combat_rules.he_blast_contact(
+            _shot(kind='HIGH_EXPLOSIVE', explosion_radius=4.0),
+            (0.0, 0.0, 0.0), (0.0, 0.0, 0.0), (4.0, 0.0, 0.0),
+            (collision,), 400.0))
+
+    def test_he_blast_uses_structural_point_distance_after_external_screen(self):
+        screen = _collision(0.001, 1.0, _material(20.0, 0.0),
+                            'vehicleChassis')
+        hull = _collision(5.0, 1.0, _material(0.0), 'vehicleHull')
+        result = combat_rules.he_blast_contact(
+            _shot(kind='HIGH_EXPLOSIVE', damage=400.0,
+                  explosion_radius=10.0),
+            (0.0, 0.0, 0.0), (0.0, 0.0, 0.0), (10.0, 0.0, 0.0),
+            (hull, screen), 400.0)
+
+        self.assertEqual(5.0, result['distance'])
+        self.assertEqual(130, result['damage'])
+        self.assertEqual((screen, hull), result['collisions'])
+
+    def test_he_blast_allows_upstream_query_start_and_tolerance_backstep(self):
+        hull = _collision(4.9995, 1.0, _material(0.0))
+        result = combat_rules.he_blast_contact(
+            _shot(kind='HIGH_EXPLOSIVE', damage=400.0,
+                  explosion_radius=10.0),
+            (5.0, 0.0, 0.0), (0.0, 0.0, 0.0), (10.0, 0.0, 0.0),
+            (hull,), 400.0)
+
+        self.assertAlmostEqual(0.0005, result['distance'])
+        self.assertEqual((1.0, 0.0, 0.0), result['direction'])
+
+    def test_he_blast_rejects_structural_hit_outside_radius(self):
+        result = combat_rules.he_blast_contact(
+            _shot(kind='HIGH_EXPLOSIVE', damage=400.0,
+                  explosion_radius=4.0),
+            (0.0, 0.0, 0.0), (0.0, 0.0, 0.0), (10.0, 0.0, 0.0),
+            (_collision(4.001, 1.0, _material(0.0)),), 400.0)
+
+        self.assertIsNone(result)
+
+    def test_he_blast_reuses_caller_roll_without_random_sampling(self):
+        original_uniform = combat_rules.random.uniform
+        combat_rules.random.uniform = lambda *unused: self.fail(
+            'HE contact must use the caller-owned rolled damage')
+        try:
+            result = combat_rules.he_blast_contact(
+                _shot(kind='HIGH_EXPLOSIVE', damage=400.0,
+                      explosion_radius=10.0),
+                (0.0, 0.0, 0.0), (0.0, 0.0, 0.0),
+                (10.0, 0.0, 0.0),
+                (_collision(0.0, 1.0, _material(0.0)),), 321.0)
+        finally:
+            combat_rules.random.uniform = original_uniform
+
+        self.assertEqual(160, result['damage'])
+
+    def test_he_blast_material_can_opt_out_of_spall_liner(self):
+        lined = _collision(0.0, 1.0, _material(50.0))
+        opt_out = _collision(
+            0.0, 1.0, _material(50.0, useAntifragmentationLining=False))
+        shot = _shot(kind='HIGH_EXPLOSIVE', damage=400.0,
+                     explosion_radius=10.0)
+
+        lined_result = combat_rules.he_blast_contact(
+            shot, (0.0, 0.0, 0.0), (0.0, 0.0, 0.0),
+            (10.0, 0.0, 0.0), (lined,), 400.0, 1.5)
+        opt_out_result = combat_rules.he_blast_contact(
+            shot, (0.0, 0.0, 0.0), (0.0, 0.0, 0.0),
+            (10.0, 0.0, 0.0), (opt_out,), 400.0, 1.5)
+
+        self.assertEqual(102, lined_result['damage'])
+        self.assertEqual(135, opt_out_result['damage'])
 
 
 if __name__ == '__main__':

--- a/tests/test_port_0922_critical_damage.py
+++ b/tests/test_port_0922_critical_damage.py
@@ -1534,7 +1534,7 @@ class TrackWheelDamageTests(unittest.TestCase):
 
     def setUp(self):
         armor_roll = mock.patch(
-            'random.gauss', side_effect=lambda mean, sigma: mean - 2.5 * sigma)
+            'random.gauss', side_effect=lambda mean, sigma: mean - 3.0 * sigma)
         armor_roll.start()
         self.addCleanup(armor_roll.stop)
         self.player = types.SimpleNamespace(

--- a/tests/test_port_0922_critical_damage.py
+++ b/tests/test_port_0922_critical_damage.py
@@ -1490,7 +1490,7 @@ _FRONT_BOUND = _HALF_LENGTH - _FRONT_WHEEL
 _REAR_BOUND = _REAR_WHEEL - _HALF_LENGTH
 _T110E4_SHELL = {'damage': (750.0, 210.0), 'kind': 'ARMOR_PIERCING',
                  'caliber': 155.0}
-# random.uniform is pinned to its low bound in these tests, so the armour roll
+# Both channel samplers are pinned to their low bounds, so the armour roll
 # is 562.5 and the device roll 157.5. A mean-based mock could not tell the two
 # laws apart: 750 / 3 is exactly the 250 HP pool.
 _ARMOR_ROLL = 750.0 * 0.75
@@ -1533,6 +1533,10 @@ class TrackWheelDamageTests(unittest.TestCase):
     """Update 6.4 leading/rearmost wheel zones on the exact #1513 law."""
 
     def setUp(self):
+        armor_roll = mock.patch(
+            'random.gauss', side_effect=lambda mean, sigma: mean - 2.5 * sigma)
+        armor_roll.start()
+        self.addCleanup(armor_roll.stop)
         self.player = types.SimpleNamespace(
             playerVehicleID=999,
             arena=types.SimpleNamespace(onVehicleKilled=lambda *args: None),

--- a/tests/test_port_0922_gun_mechanics.py
+++ b/tests/test_port_0922_gun_mechanics.py
@@ -244,7 +244,7 @@ class GunMechanicsParityTests(unittest.TestCase):
 
         self.assertEqual(2.0, state.reload_time)
 
-    def test_scatter_uses_0922_two_sigma_barrel_plane_distribution(self):
+    def test_scatter_uses_legacy_two_sigma_barrel_plane_distribution(self):
         state = GunState(_descriptor())
         calls = []
 

--- a/tests/test_port_0922_he_blast_runtime.py
+++ b/tests/test_port_0922_he_blast_runtime.py
@@ -245,7 +245,7 @@ class HEBlastSurfaceRuntimeTests(unittest.TestCase):
                 mock.patch.object(
                     battle, '_projectile_he_world_visible', visible), \
                 mock.patch.object(
-                    random, 'uniform',
+                    random, 'gauss',
                     side_effect=AssertionError('surface search must not roll')):
             contact = battle._projectile_he_blast_contact(
                 _meta(), record, target, _shot(), (0.0, 0.0, 0.0),
@@ -363,7 +363,7 @@ class HEBlastEffectRuntimeTests(unittest.TestCase):
 
     def _direct_fixture(self, kind='HIGH_EXPLOSIVE'):
         battle, unused_bigworld = _runtime()
-        shot = _shot(kind=kind)
+        shot = _shot(kind=kind, damage=400.0)
         meta = _meta(shot)
         source = types.SimpleNamespace(id=41, typeDescriptor=types.SimpleNamespace(
             gun=types.SimpleNamespace(shots=[])))
@@ -416,7 +416,7 @@ class HEBlastEffectRuntimeTests(unittest.TestCase):
 
         with mock.patch.object(
                 combat_rules, 'resolve_armor_contact', return_value=contact), \
-                mock.patch.object(random, 'uniform', return_value=400.0), \
+                mock.patch.object(random, 'gauss', return_value=400.0), \
                 mock.patch.object(
                     battle, '_projectile_he_blast_contact',
                     return_value=blast) as blast_contact, \
@@ -454,7 +454,7 @@ class HEBlastEffectRuntimeTests(unittest.TestCase):
 
         with mock.patch.object(
                 combat_rules, 'resolve_armor_contact', return_value=contact), \
-                mock.patch.object(random, 'uniform', return_value=400.0), \
+                mock.patch.object(random, 'gauss', return_value=400.0), \
                 mock.patch.object(
                     battle, '_projectile_he_blast_contact',
                     side_effect=AssertionError(
@@ -484,7 +484,7 @@ class HEBlastEffectRuntimeTests(unittest.TestCase):
                 {'BigWorld': bigworld_module, 'Math': math_module}), \
                 mock.patch.object(
                 combat_rules, 'resolve_armor_contact', return_value=contact), \
-                mock.patch.object(random, 'uniform', return_value=400.0), \
+                mock.patch.object(random, 'gauss', return_value=400.0), \
                 mock.patch.object(
                     battle, '_projectile_he_blast_contact', return_value=None), \
                 mock.patch.object(
@@ -534,7 +534,7 @@ class HEBlastEffectRuntimeTests(unittest.TestCase):
             'gravity': (0.0, 0.0, 0.0),
         }
 
-        with mock.patch.object(random, 'uniform', return_value=640.0) as roll, \
+        with mock.patch.object(random, 'gauss', return_value=640.0) as roll, \
                 mock.patch.object(
                     battle, '_projectile_he_blast_contact',
                     return_value=blast) as blast_contact, \
@@ -587,7 +587,7 @@ class HEBlastEffectRuntimeTests(unittest.TestCase):
             'gravity': (0.0, 0.0, 0.0),
         }
 
-        with mock.patch.object(random, 'uniform') as roll, \
+        with mock.patch.object(random, 'gauss') as roll, \
                 mock.patch.object(
                     battle, '_projectile_he_blast_contact') as blast_contact:
             effects = battle._projectile_splash_effects(

--- a/tests/test_port_0922_he_blast_runtime.py
+++ b/tests/test_port_0922_he_blast_runtime.py
@@ -1,0 +1,670 @@
+import math
+from pathlib import Path
+import random
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CLIENT_SCRIPTS = ROOT / 'src' / 'res' / 'scripts' / 'client'
+sys.path.insert(0, str(CLIENT_SCRIPTS))
+
+from gui.mods.offline_lan_0922 import battle_runtime as battle_runtime_module  # noqa: E402
+from gui.mods.offline_lan_0922 import combat_rules, critical_damage  # noqa: E402
+from gui.mods.offline_lan_0922.battle_runtime import BattleRuntime  # noqa: E402
+
+
+def _xyz(value):
+    return tuple(float(value[index]) for index in range(3))
+
+
+class _Vector(object):
+
+    def __init__(self, value=(0.0, 0.0, 0.0), y=None, z=None):
+        if y is not None and z is not None:
+            value = (value, y, z)
+        try:
+            value = (value.x, value.y, value.z)
+        except AttributeError:
+            pass
+        self.x, self.y, self.z = map(float, value)
+
+    def __getitem__(self, index):
+        return (self.x, self.y, self.z)[index]
+
+    def __add__(self, other):
+        return _Vector((self.x + other.x, self.y + other.y,
+                        self.z + other.z))
+
+    def __sub__(self, other):
+        return _Vector((self.x - other.x, self.y - other.y,
+                        self.z - other.z))
+
+    def __neg__(self):
+        return self.scale(-1.0)
+
+    @property
+    def length(self):
+        return math.sqrt(self.x * self.x + self.y * self.y +
+                         self.z * self.z)
+
+    def scale(self, value):
+        return _Vector((self.x * value, self.y * value, self.z * value))
+
+    def normalise(self):
+        length = self.length
+        if length:
+            self.x /= length
+            self.y /= length
+            self.z /= length
+
+
+class _Matrix(object):
+
+    def __init__(self, other=None):
+        self.translation = _Vector(getattr(other, 'translation', _Vector()))
+        self.yaw = getattr(other, 'yaw', 0.0)
+        self.pitch = getattr(other, 'pitch', 0.0)
+        self.roll = getattr(other, 'roll', 0.0)
+
+    def setIdentity(self):
+        self.translation = _Vector()
+        self.yaw = self.pitch = self.roll = 0.0
+
+    def setRotateYPR(self, values):
+        self.yaw, self.pitch, self.roll = map(float, values)
+
+    def setRotateY(self, value):
+        self.yaw = float(value)
+
+    def setRotateX(self, value):
+        self.pitch = float(value)
+
+    def setTranslate(self, value):
+        self.translation = _Vector(value)
+
+    def postMultiply(self, unused_other):
+        return None
+
+    def preMultiply(self, unused_other):
+        return None
+
+    def invert(self):
+        self.translation = self.translation.scale(-1.0)
+
+    def applyPoint(self, value):
+        return _Vector(value) + self.translation
+
+
+class _BigWorld(object):
+
+    def __init__(self):
+        self.wall_x = None
+        self.calls = []
+
+    def wg_collideSegment(self, space_id, start, end, mask,
+                          collision_filter=None):
+        self.calls.append((space_id, start, end, mask, collision_filter))
+        if self.wall_x is None:
+            return None
+        if abs(end.x - start.x) <= 1.0e-9:
+            return None
+        low = min(start.x, end.x)
+        high = max(start.x, end.x)
+        if not low <= self.wall_x <= high:
+            return None
+        fraction = (self.wall_x - start.x) / (end.x - start.x)
+        return (_Vector((
+            self.wall_x,
+            start.y + (end.y - start.y) * fraction,
+            start.z + (end.z - start.z) * fraction)), None)
+
+
+class _Material(object):
+
+    def __init__(self, armor, factor):
+        self.armor = float(armor)
+        self.vehicleDamageFactor = float(factor)
+        self.useAntifragmentationLining = True
+
+
+def _collision(distance, armor, factor=1.0, component='vehicleHull'):
+    return types.SimpleNamespace(
+        dist=float(distance), hitAngleCos=1.0,
+        matInfo=_Material(armor, factor), compName=component)
+
+
+def _descriptor():
+    empty_tester = types.SimpleNamespace(
+        bbox=(_Vector((-1.0, -1.0, -1.0)),
+              _Vector((1.0, 1.0, 1.0)), None),
+        localHitTest=lambda unused_start, unused_end: ())
+    chassis = types.SimpleNamespace(
+        itemTypeName='vehicleChassis', hitTester=empty_tester,
+        materials={}, hullPosition=_Vector())
+    hull = types.SimpleNamespace(
+        itemTypeName='vehicleHull', hitTester=empty_tester,
+        materials={1: _Material(20.0, 1.0)},
+        turretPositions=(_Vector(),))
+    turret = types.SimpleNamespace(
+        itemTypeName='vehicleTurret', hitTester=empty_tester,
+        materials={1: _Material(30.0, 1.0)}, gunPosition=_Vector())
+    gun = types.SimpleNamespace(
+        itemTypeName='vehicleGun', hitTester=empty_tester, materials={})
+    return types.SimpleNamespace(
+        chassis=chassis, hull=hull, turret=turret, gun=gun,
+        miscAttrs={}, type=types.SimpleNamespace(crewRoles=()))
+
+
+def _target(entity_id=55, position=(0.0, 0.0, 0.0)):
+    descriptor = _descriptor()
+    matrix = _Matrix()
+    matrix.translation = _Vector(position)
+    return types.SimpleNamespace(
+        id=entity_id, isStarted=True, typeDescriptor=descriptor,
+        position=_Vector(position), matrix=matrix,
+        appearance=types.SimpleNamespace(
+            turretMatrix=_Matrix(), gunMatrix=_Matrix()),
+        isAlive=lambda: True, health=1000,
+        devices_hp={}, _destroyed_devices=set(), _crew_ko=set(),
+        is_on_fire=False,
+        getComponents=lambda: ())
+
+
+def _shot(kind='HIGH_EXPLOSIVE', radius=10.0, damage=1000.0):
+    return {
+        'maxDistance': 720.0,
+        'piercingPower': (60.0, 60.0),
+        'shell': {
+            'kind': kind, 'caliber': 122.0,
+            'damage': (float(damage), 150.0),
+            'explosionRadius': float(radius),
+        },
+    }
+
+
+def _runtime():
+    bigworld = _BigWorld()
+    runtime = types.SimpleNamespace(
+        bigworld=bigworld,
+        math=types.SimpleNamespace(Vector3=_Vector, Matrix=_Matrix))
+    battle = BattleRuntime(runtime)
+    battle._avatar = types.SimpleNamespace(spaceID=1)
+    battle._destructibles = None
+    battle._worker_mode = True
+    return battle, bigworld
+
+
+def _record(network_id=17, native_remote=True):
+    return {
+        'engine_id': 55, 'network_id': network_id, 'kind': 'bot',
+        'local': False, 'native_remote': bool(native_remote), 'ready': True,
+        'state': {'health': 1000, 'alive': True},
+    }
+
+
+def _meta(shot=None):
+    return {
+        'projectile_id': 'player:7:1',
+        'shooter_kind': 'player', 'shooter_id': 7,
+        'source_shot': shot or _shot(),
+        'presentation_offsets': {},
+        'base_penetration_multiplier': 1.0,
+    }
+
+
+class HEBlastSurfaceRuntimeTests(unittest.TestCase):
+
+    def test_surface_search_selects_best_visible_real_hit_after_blocked_best(self):
+        battle, unused_bigworld = _runtime()
+        target = _target()
+        record = _record()
+        body_matrix = object()
+        battle._projectile_vehicle_matrices = mock.Mock(
+            return_value=(body_matrix, body_matrix))
+        thin = _collision(4.001, 20.0)
+        thick = _collision(2.001, 100.0)
+
+        def collide(unused_target, unused_matrix, unused_start, end,
+                    unused_math, chassis_matrix=None):
+            self.assertIs(body_matrix, chassis_matrix)
+            return (thin,) if end.x > 9.0 else (thick,)
+
+        visible = mock.Mock(side_effect=lambda unused_start, point,
+                                               unused_burst: point[0] < 1.0)
+        with mock.patch.object(
+                battle_runtime_module,
+                'vehicle_blast_probe_points_at_matrix',
+                return_value=(_Vector((1.0, 0.0, 0.0)),
+                              _Vector((0.0, 1.0, 0.0)))), \
+                mock.patch.object(
+                    battle_runtime_module, 'collide_vehicle_at_matrix',
+                    side_effect=collide) as native_collide, \
+                mock.patch.object(
+                    battle, '_projectile_he_world_visible', visible), \
+                mock.patch.object(
+                    random, 'uniform',
+                    side_effect=AssertionError('surface search must not roll')):
+            contact = battle._projectile_he_blast_contact(
+                _meta(), record, target, _shot(), (0.0, 0.0, 0.0),
+                1000.0, state={})
+
+        self.assertIs(thick, contact['collision'])
+        self.assertEqual(100.0, contact['nominal_armor'])
+        self.assertEqual((thick,), contact['collisions'])
+        self.assertEqual(2, native_collide.call_count)
+        self.assertEqual(2, visible.call_count)
+        self.assertGreater(visible.call_args_list[0].args[1][0], 3.9)
+        self.assertLess(visible.call_args_list[1].args[1][0], 0.01)
+
+    def test_surface_search_keeps_screen_prefix_and_never_fabricates_hull_armor(self):
+        battle, unused_bigworld = _runtime()
+        target = _target()
+        record = _record()
+        screen = _collision(1.001, 40.0, factor=0.0,
+                            component='vehicleChassis')
+        hull = _collision(2.001, 35.0)
+        seed = (_Vector((-0.001, 0.0, 0.0)),
+                _Vector((10.0, 0.0, 0.0)), (screen, hull))
+
+        with mock.patch.object(
+                battle_runtime_module,
+                'vehicle_blast_probe_points_at_matrix', return_value=()), \
+                mock.patch.object(
+                    battle, '_projectile_he_world_visible', return_value=True):
+            contact = battle._projectile_he_blast_contact(
+                _meta(), record, target, _shot(), (0.0, 0.0, 0.0),
+                1000.0, state={}, seed=seed)
+
+        self.assertIs(hull, contact['collision'])
+        self.assertEqual((screen, hull), contact['collisions'])
+        self.assertAlmostEqual(2.0, contact['distance'], places=6)
+
+        with mock.patch.object(
+                battle_runtime_module,
+                'vehicle_blast_probe_points_at_matrix', return_value=()):
+            missing = battle._projectile_he_blast_contact(
+                _meta(), record, target, _shot(), (0.0, 0.0, 0.0),
+                1000.0, state={}, seed=(seed[0], seed[1], (screen,)))
+
+        self.assertIsNone(missing)
+
+    def test_native_surface_inside_radius_is_hit_when_vehicle_origin_is_outside(self):
+        battle, bigworld = _runtime()
+        target = _target(position=(5.0, 0.0, 0.0))
+        hull = target.typeDescriptor.hull
+        hull.materials = {1: _Material(20.0, 1.0)}
+
+        def plane_hit(start, end):
+            delta = end - start
+            if abs(delta.x) < 1.0e-9:
+                return ()
+            fraction = (-2.5 - start.x) / delta.x
+            if not 0.0 <= fraction <= 1.0:
+                return ()
+            point = start + delta.scale(fraction)
+            if abs(point.y) > 1.0 or abs(point.z) > 1.0:
+                return ()
+            return ((delta.length * fraction, None, 1.0, 1),)
+
+        hull.hitTester = types.SimpleNamespace(
+            bbox=(_Vector((-2.5, -1.0, -1.0)),
+                  _Vector((2.5, 1.0, 1.0)), None),
+            localHitTest=plane_hit)
+        shot = _shot(radius=3.0, damage=390.0)
+        record = _record(native_remote=False)
+
+        # Exercise the bbox directions, component adapter, HE law and scenery
+        # query together. Only the native localHitTest plane itself is a fake.
+        contact = battle._projectile_he_blast_contact(
+            _meta(shot), record, target, shot, (0.0, 0.0, 0.0), 390.0)
+
+        self.assertIsNotNone(contact)
+        self.assertAlmostEqual(2.5, contact['distance'])
+        self.assertGreater(contact['damage'], 0)
+        bigworld.wall_x = 2.0
+        blocked = battle._projectile_he_blast_contact(
+            _meta(shot), record, target, shot, (0.0, 0.0, 0.0), 390.0)
+        self.assertIsNone(blocked)
+        bigworld.wall_x = None
+        hull.hitTester.localHitTest = lambda unused_start, unused_end: ()
+        missing = battle._projectile_he_blast_contact(
+            _meta(shot), record, target, shot, (0.0, 0.0, 0.0), 390.0)
+        self.assertIsNone(missing)
+
+    def test_scene_origin_stays_on_incoming_side_and_real_wall_blocks(self):
+        battle, bigworld = _runtime()
+        state = {
+            'elapsed': 0.5,
+            'velocity': (10.0, 0.0, 0.0),
+            'gravity': (0.0, 0.0, 0.0),
+        }
+        burst = _Vector((5.0, 1.0, 0.0))
+
+        scene_start = battle._projectile_he_scene_origin(burst, state)
+
+        self.assertLess(scene_start.x, burst.x)
+        self.assertAlmostEqual(0.002, burst.x - scene_start.x, places=9)
+        bigworld.wall_x = 6.0
+        self.assertFalse(battle._projectile_he_world_visible(
+            scene_start, (8.0, 1.0, 0.0), burst))
+        bigworld.wall_x = None
+        self.assertTrue(battle._projectile_he_world_visible(
+            scene_start, (8.0, 1.0, 0.0), burst))
+        calls = len(bigworld.calls)
+        self.assertTrue(battle._projectile_he_world_visible(
+            scene_start, (5.0005, 1.0, 0.0), burst))
+        self.assertEqual(calls, len(bigworld.calls))
+
+
+class HEBlastEffectRuntimeTests(unittest.TestCase):
+
+    def _direct_fixture(self, kind='HIGH_EXPLOSIVE'):
+        battle, unused_bigworld = _runtime()
+        shot = _shot(kind=kind)
+        meta = _meta(shot)
+        source = types.SimpleNamespace(id=41, typeDescriptor=types.SimpleNamespace(
+            gun=types.SimpleNamespace(shots=[])))
+        target = _target()
+        record = _record()
+        battle._records = {
+            'player:7': {
+                'engine_id': 41, 'network_id': 7, 'kind': 'player',
+                'local': False, 'ready': True,
+                'state': {'health': 1000, 'alive': True}},
+            'bot:17': record,
+        }
+        battle._server_entity = lambda entity_id: (
+            source if entity_id == 41 else target if entity_id == 55 else None)
+        collision = _collision(5.0, 120.0)
+        terminal = {
+            'target_key': 'bot:17', 'collisions': (collision,),
+            'collision_evidence': (),
+            'query': (_Vector((0.0, 1.0, 0.0)),
+                      _Vector((8.0, 1.0, 0.0))),
+            'impact': (5.0, 1.0, 0.0),
+            'piercing_loss': 0.0, 'penetration_factor': 1.0,
+        }
+        state = {
+            'start': (0.0, 1.0, 0.0),
+            'payload': {'range_origin': (0.0, 0.0, 0.0)},
+            'distance': 5.0, 'elapsed': 0.5,
+            'velocity': (10.0, 0.0, 0.0),
+            'gravity': (0.0, 0.0, 0.0),
+        }
+        battle._install_critical_equipment_effects = mock.Mock()
+        battle._projectile_damage_sticker = mock.Mock(return_value=None)
+        return battle, meta, target, collision, terminal, state
+
+    def test_nonpenetrating_direct_he_uses_blast_contact_geometry(self):
+        (battle, meta, target, collision,
+         terminal, state) = self._direct_fixture()
+        screen = _collision(0.5, 20.0, factor=0.0,
+                            component='vehicleChassis')
+        weak_hull = _collision(1.5, 25.0)
+        blast = {
+            'damage': 240, 'nominal_armor': 25.0, 'distance': 1.5,
+            'point': (6.5, 1.0, 0.0), 'direction': (1.0, 0.0, 0.0),
+            'collision': weak_hull, 'collisions': (screen, weak_hull),
+        }
+        contact = {
+            'result': 1, 'layer': 'structural', 'distance': 5.0,
+            'component': 'vehicleHull',
+        }
+
+        with mock.patch.object(
+                combat_rules, 'resolve_armor_contact', return_value=contact), \
+                mock.patch.object(random, 'uniform', return_value=400.0), \
+                mock.patch.object(
+                    battle, '_projectile_he_blast_contact',
+                    return_value=blast) as blast_contact, \
+                mock.patch.object(
+                    critical_damage, 'propose_explosion',
+                    return_value=(240, None, {})) as critical:
+            effect = battle._projectile_direct_effect(meta, state, terminal)
+
+        self.assertEqual(240, effect['damage'])
+        self.assertEqual(1, effect['shot_result'])
+        self.assertEqual(400, effect['potential_damage'])
+        self.assertIs(True, effect['structural_armor_hit'])
+        args = blast_contact.call_args.args
+        self.assertIs(target, args[2])
+        self.assertEqual(400.0, args[5])
+        self.assertIs(state, blast_contact.call_args.kwargs['state'])
+        seed = blast_contact.call_args.kwargs['seed']
+        self.assertEqual((collision,), seed[2])
+        self.assertEqual(
+            combat_rules.collision_layers((screen, weak_hull)),
+            critical.call_args.args[1])
+        self.assertEqual((5.0, 1.0, 0.0),
+                         _xyz(critical.call_args.args[2]))
+        self.assertEqual((1.0, 0.0, 0.0),
+                         _xyz(critical.call_args.args[3]))
+        self.assertIs(True, critical.call_args.kwargs['allow_interior'])
+
+    def test_penetrating_he_keeps_full_direct_damage_without_surface_search(self):
+        battle, meta, unused_target, unused_collision, terminal, state = \
+            self._direct_fixture()
+        contact = {
+            'result': 2, 'layer': 'structural', 'distance': 5.0,
+            'component': 'vehicleHull',
+        }
+
+        with mock.patch.object(
+                combat_rules, 'resolve_armor_contact', return_value=contact), \
+                mock.patch.object(random, 'uniform', return_value=400.0), \
+                mock.patch.object(
+                    battle, '_projectile_he_blast_contact',
+                    side_effect=AssertionError(
+                        'penetrating HE must keep the direct path')), \
+                mock.patch.object(
+                    critical_damage, 'propose_explosion',
+                    return_value=(400, None, {})):
+            effect = battle._projectile_direct_effect(meta, state, terminal)
+
+        self.assertEqual(400, effect['damage'])
+        self.assertEqual(2, effect['shot_result'])
+        self.assertEqual(400, effect['potential_damage'])
+
+    def test_nonpenetrating_he_without_proved_structural_surface_is_zero_damage(self):
+        battle, meta, unused_target, collision, terminal, state = \
+            self._direct_fixture()
+        contact = {
+            'result': 1, 'layer': 'external', 'distance': 5.0,
+            'component': 'vehicleChassis',
+        }
+        bigworld_module = types.SimpleNamespace(
+            player=lambda: types.SimpleNamespace(playerVehicleID=-1))
+        math_module = types.SimpleNamespace(Vector3=_Vector)
+
+        with mock.patch.dict(
+                sys.modules,
+                {'BigWorld': bigworld_module, 'Math': math_module}), \
+                mock.patch.object(
+                combat_rules, 'resolve_armor_contact', return_value=contact), \
+                mock.patch.object(random, 'uniform', return_value=400.0), \
+                mock.patch.object(
+                    battle, '_projectile_he_blast_contact', return_value=None), \
+                mock.patch.object(
+                    critical_damage, '_offh_internal_cone_hits') as cone:
+            effect = battle._projectile_direct_effect(meta, state, terminal)
+
+        self.assertIsNotNone(effect)
+        self.assertEqual(0, effect['damage'])
+        self.assertEqual(1, effect['shot_result'])
+        self.assertIs(False, effect['structural_armor_hit'])
+        cone.assert_not_called()
+
+    def test_splash_uses_one_roll_and_the_collision_time_target_pose(self):
+        battle, unused_bigworld = _runtime()
+        shot = _shot(radius=4.0, damage=800.0)
+        meta = _meta(shot)
+        meta['presentation_offsets'] = {'bot:17': 0.25}
+        source = types.SimpleNamespace(id=41, typeDescriptor=types.SimpleNamespace(
+            gun=types.SimpleNamespace(shots=[])))
+        # The live origin is far outside the radius. Only the historical native
+        # surface chosen by the worker is eligible.
+        target = _target(position=(100.0, 0.0, 0.0))
+        record = _record()
+        battle._records = {
+            'player:7': {
+                'engine_id': 41, 'network_id': 7, 'kind': 'player',
+                'local': False, 'ready': True,
+                'state': {'health': 1000, 'alive': True}},
+            'bot:17': record,
+        }
+        battle._server_entity = lambda entity_id: (
+            source if entity_id == 41 else target if entity_id == 55 else None)
+        pose = battle._projectile_plain_pose((3.5, 0.0, 0.0))
+        frozen = _target(position=(3.5, 0.0, 0.0))
+        battle._projectile_historic_pose = mock.Mock(return_value=pose)
+        battle._projectile_frozen_target = mock.Mock(return_value=frozen)
+        battle._install_critical_equipment_effects = mock.Mock()
+        structural = _collision(3.5, 20.0)
+        blast = {
+            'damage': 120, 'nominal_armor': 20.0, 'distance': 3.5,
+            'point': (3.5, 0.0, 0.0), 'direction': (1.0, 0.0, 0.0),
+            'collision': structural, 'collisions': (structural,),
+        }
+        state = {
+            'cursor_time': 2.0, 'elapsed': 2.0,
+            'velocity': (10.0, 0.0, 0.0),
+            'gravity': (0.0, 0.0, 0.0),
+        }
+
+        with mock.patch.object(random, 'uniform', return_value=640.0) as roll, \
+                mock.patch.object(
+                    battle, '_projectile_he_blast_contact',
+                    return_value=blast) as blast_contact, \
+                mock.patch.object(
+                    critical_damage, 'propose_explosion',
+                    return_value=(120, None, {})) as critical:
+            effects = battle._projectile_splash_effects(
+                meta, (0.0, 0.0, 0.0), None, state=state)
+
+        self.assertEqual(1, roll.call_count)
+        self.assertEqual(640.0, blast_contact.call_args.args[5])
+        self.assertIs(state, blast_contact.call_args.kwargs['state'])
+        self.assertEqual(pose, blast_contact.call_args.kwargs['pose'])
+        battle._projectile_historic_pose.assert_called_once_with(
+            'bot:17', 1.75)
+        battle._projectile_frozen_target.assert_called_with(target, pose)
+        self.assertIs(frozen, critical.call_args.args[0])
+        self.assertEqual(
+            combat_rules.collision_layers((structural,)),
+            critical.call_args.args[1])
+        self.assertEqual((0.0, 0.0, 0.0),
+                         _xyz(critical.call_args.args[2]))
+        self.assertEqual((1.0, 0.0, 0.0),
+                         _xyz(critical.call_args.args[3]))
+        self.assertEqual(120, effects[0]['damage'])
+        self.assertEqual(3.5, effects[0]['target_x'])
+        self.assertEqual(0.0, effects[0]['target_y'])
+        self.assertEqual(0.0, effects[0]['target_z'])
+
+    def test_splash_missing_collision_time_pose_skips_only_that_target(self):
+        battle, unused_bigworld = _runtime()
+        shot = _shot(radius=4.0)
+        meta = _meta(shot)
+        source = types.SimpleNamespace(id=41, typeDescriptor=types.SimpleNamespace(
+            gun=types.SimpleNamespace(shots=[])))
+        target = _target(position=(1.0, 0.0, 0.0))
+        battle._records = {
+            'player:7': {
+                'engine_id': 41, 'network_id': 7, 'kind': 'player',
+                'local': False, 'ready': True,
+                'state': {'health': 1000, 'alive': True}},
+            'bot:17': _record(),
+        }
+        battle._server_entity = lambda entity_id: (
+            source if entity_id == 41 else target if entity_id == 55 else None)
+        battle._projectile_historic_pose = mock.Mock(return_value=None)
+        state = {
+            'cursor_time': 2.0, 'elapsed': 2.0,
+            'velocity': (10.0, 0.0, 0.0),
+            'gravity': (0.0, 0.0, 0.0),
+        }
+
+        with mock.patch.object(random, 'uniform') as roll, \
+                mock.patch.object(
+                    battle, '_projectile_he_blast_contact') as blast_contact:
+            effects = battle._projectile_splash_effects(
+                meta, (0.0, 0.0, 0.0), None, state=state)
+
+        self.assertEqual([], effects)
+        roll.assert_not_called()
+        blast_contact.assert_not_called()
+
+    def test_moving_target_terminal_shares_combat_burst_and_keeps_visual_impact(self):
+        battle, meta, unused_target, collision, data, state = self._direct_fixture()
+        meta.update({'is_he': True, 'origin': (0.0, 1.0, 0.0),
+                     'max_time_ms': 1000, 'max_distance': 100.0})
+        data['impact'] = (6.0, 1.0, 0.0)
+        state.update({'key': (meta['projectile_id'], 0),
+                      'position': data['impact']})
+        battle._projectile_meta = {meta['projectile_id']: meta}
+        battle._projectile_terminal_data = {meta['projectile_id']: data}
+        battle._submit_projectile_resolution = mock.Mock(return_value=True)
+        blast = {'damage': 120, 'collisions': (collision,),
+                 'direction': (1.0, 0.0, 0.0)}
+        with mock.patch.object(
+                battle, '_projectile_he_blast_contact',
+                return_value=blast) as direct_blast, \
+                mock.patch.object(
+                    battle, '_projectile_splash_effects',
+                    return_value=[]) as splash, \
+                mock.patch.object(
+                    critical_damage, 'propose_explosion',
+                    return_value=(120, None, {})):
+            self.assertTrue(battle._projectile_terminal_impl(
+                state, {'reason': 'impact'}))
+
+        self.assertEqual((5.0, 1.0, 0.0), direct_blast.call_args.args[4])
+        self.assertEqual(direct_blast.call_args.args[4],
+                         splash.call_args.args[1])
+        self.assertEqual((6.0, 1.0, 0.0),
+                         splash.call_args.kwargs['visual_impact'])
+        self.assertEqual(6.0, meta['pending_resolution']['direct']['x'])
+        self.assertEqual((6.0, 1.0, 0.0),
+                         meta['pending_resolution']['impact'])
+
+    def test_penetrating_he_terminal_does_not_add_external_splash(self):
+        battle, unused_bigworld = _runtime()
+        projectile_id = 'player:7:1'
+        meta = _meta()
+        meta.update({
+            'is_he': True, 'origin': (0.0, 0.0, 0.0),
+            'max_time_ms': 1000, 'max_distance': 100.0,
+        })
+        data = {
+            'impact': (5.0, 1.0, 0.0), 'target_key': 'bot:17',
+        }
+        state = {
+            'key': (projectile_id, 0), 'position': data['impact'],
+            'elapsed': 0.5, 'distance': 5.0,
+            'velocity': (10.0, 0.0, 0.0),
+            'gravity': (0.0, 0.0, 0.0),
+        }
+        direct = {'damage': 400, 'shot_result': 2}
+        battle._projectile_meta = {projectile_id: meta}
+        battle._projectile_terminal_data = {projectile_id: data}
+        battle._projectile_direct_effect = mock.Mock(return_value=direct)
+        battle._projectile_splash_effects = mock.Mock(
+            side_effect=AssertionError(
+                'penetrating HE must not burst outside the direct victim'))
+        battle._submit_projectile_resolution = mock.Mock(return_value=True)
+
+        result = battle._projectile_terminal_impl(
+            state, {'reason': 'impact'})
+
+        self.assertIs(True, result)
+        battle._projectile_splash_effects.assert_not_called()
+        pending = meta['pending_resolution']
+        self.assertIs(direct, pending['direct'])
+        self.assertEqual([], pending['splash'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_port_0922_he_geometry.py
+++ b/tests/test_port_0922_he_geometry.py
@@ -1,0 +1,268 @@
+import math
+from pathlib import Path
+import sys
+import types
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CLIENT_SCRIPTS = ROOT / 'src' / 'res' / 'scripts' / 'client'
+sys.path.insert(0, str(CLIENT_SCRIPTS))
+
+from gui.mods.offline_lan_0922.entities.remote_vehicle import (  # noqa: E402
+    vehicle_blast_probe_points_at_matrix)
+
+
+class _Vector(object):
+
+    def __init__(self, x=0.0, y=0.0, z=0.0):
+        if not isinstance(x, (int, float)):
+            try:
+                x, y, z = x[0], x[1], x[2]
+            except (TypeError, IndexError):
+                x, y, z = x.x, x.y, x.z
+        self.x = float(x)
+        self.y = float(y)
+        self.z = float(z)
+
+    def __getitem__(self, index):
+        return (self.x, self.y, self.z)[index]
+
+    def __add__(self, other):
+        return _Vector(self.x + other.x, self.y + other.y, self.z + other.z)
+
+    def __sub__(self, other):
+        return _Vector(self.x - other.x, self.y - other.y, self.z - other.z)
+
+    def __neg__(self):
+        return _Vector(-self.x, -self.y, -self.z)
+
+
+class _Matrix(object):
+    """Small rigid Math.Matrix fake with the transforms used by this helper."""
+
+    def __init__(self, other=None):
+        if other is None:
+            self._rotation = ((1.0, 0.0, 0.0),
+                              (0.0, 1.0, 0.0),
+                              (0.0, 0.0, 1.0))
+            self.translation = _Vector()
+        else:
+            self._rotation = tuple(tuple(row) for row in other._rotation)
+            self.translation = _Vector(other.translation)
+        self.yaw = getattr(other, 'yaw', 0.0)
+        self.pitch = getattr(other, 'pitch', 0.0)
+
+    @staticmethod
+    def _multiply(left, right):
+        return tuple(tuple(sum(left[row][mid] * right[mid][column]
+                               for mid in range(3))
+                           for column in range(3))
+                     for row in range(3))
+
+    @staticmethod
+    def _apply(rotation, point):
+        return _Vector(
+            sum(rotation[0][axis] * (point.x, point.y, point.z)[axis]
+                for axis in range(3)),
+            sum(rotation[1][axis] * (point.x, point.y, point.z)[axis]
+                for axis in range(3)),
+            sum(rotation[2][axis] * (point.x, point.y, point.z)[axis]
+                for axis in range(3)))
+
+    def setIdentity(self):
+        self.__init__()
+
+    def setTranslate(self, value):
+        self._rotation = ((1.0, 0.0, 0.0),
+                          (0.0, 1.0, 0.0),
+                          (0.0, 0.0, 1.0))
+        self.translation = _Vector(value)
+
+    def setRotateY(self, value):
+        cosine = math.cos(value)
+        sine = math.sin(value)
+        self._rotation = ((cosine, 0.0, sine),
+                          (0.0, 1.0, 0.0),
+                          (-sine, 0.0, cosine))
+        self.translation = _Vector()
+        self.yaw = float(value)
+
+    def setRotateX(self, value):
+        cosine = math.cos(value)
+        sine = math.sin(value)
+        self._rotation = ((1.0, 0.0, 0.0),
+                          (0.0, cosine, -sine),
+                          (0.0, sine, cosine))
+        self.translation = _Vector()
+        self.pitch = float(value)
+
+    def postMultiply(self, other):
+        self.translation = self._apply(self._rotation, other.translation) + \
+            self.translation
+        self._rotation = self._multiply(self._rotation, other._rotation)
+
+    def preMultiply(self, other):
+        self.translation = self._apply(other._rotation, self.translation) + \
+            other.translation
+        self._rotation = self._multiply(other._rotation, self._rotation)
+
+    def invert(self):
+        rotation = tuple(tuple(self._rotation[column][row]
+                               for column in range(3)) for row in range(3))
+        self.translation = -self._apply(rotation, self.translation)
+        self._rotation = rotation
+
+    def applyPoint(self, point):
+        return self._apply(self._rotation, _Vector(point)) + self.translation
+
+
+class _Tester(object):
+
+    def __init__(self, lower, upper, callable_test=True):
+        self.bbox = (_Vector(lower), _Vector(upper), None)
+        if callable_test:
+            self.localHitTest = self._local_hit_test
+
+    def _local_hit_test(self, unused_start, unused_end):
+        raise AssertionError('blast candidate generation must not ray-test')
+
+
+def _component(name, lower=None, upper=None, factor=1.0,
+               callable_test=True, armor=0.0):
+    tester = None if lower is None else _Tester(lower, upper, callable_test)
+    return types.SimpleNamespace(
+        itemTypeName=name, hitTester=tester,
+        materials={1: types.SimpleNamespace(
+            armor=armor, vehicleDamageFactor=factor)})
+
+
+def _vehicle(chassis, hull, turret, gun, hull_offset=(0.0, 0.0, 0.0),
+             turret_offset=(0.0, 0.0, 0.0), gun_offset=(0.0, 0.0, 0.0),
+             turret_yaw=0.0, gun_pitch=0.0):
+    chassis.hullPosition = _Vector(hull_offset)
+    hull.turretPositions = (_Vector(turret_offset),)
+    turret.gunPosition = _Vector(gun_offset)
+    descriptor = types.SimpleNamespace(
+        chassis=chassis, hull=hull, turret=turret, gun=gun)
+    appearance = types.SimpleNamespace(
+        turretMatrix=_pose_matrix(turret_yaw), gunMatrix=_pitch_matrix(gun_pitch))
+    return types.SimpleNamespace(typeDescriptor=descriptor, appearance=appearance)
+
+
+def _pose_matrix(yaw):
+    matrix = _Matrix()
+    matrix.setRotateY(yaw)
+    return matrix
+
+
+def _pitch_matrix(pitch):
+    matrix = _Matrix()
+    matrix.setRotateX(pitch)
+    return matrix
+
+
+def _xyz(point):
+    return (round(point.x, 9), round(point.y, 9), round(point.z, 9))
+
+
+class HEBlastGeometryTest(unittest.TestCase):
+
+    def setUp(self):
+        self.math = types.SimpleNamespace(Vector3=_Vector, Matrix=_Matrix)
+
+    def _empty_component(self, name):
+        return _component(name, None, None)
+
+    def test_rotated_offset_hull_uses_surface_inside_radius_not_vehicle_origin(self):
+        chassis = self._empty_component('vehicleChassis')
+        hull = _component('vehicleHull', (0.0, 0.0, 0.0), (2.0, 2.0, 2.0),
+                          armor=0.0)
+        vehicle = _vehicle(
+            chassis, hull, self._empty_component('vehicleTurret'),
+            self._empty_component('vehicleGun'), hull_offset=(1.0, 0.0, 0.0))
+        vehicle_matrix = _pose_matrix(math.pi / 2.0)
+        vehicle_matrix.translation = _Vector(10.0, 2.0, -4.0)
+        burst = _Vector(11.1, 3.0, -5.0)
+
+        points = vehicle_blast_probe_points_at_matrix(
+            vehicle, vehicle_matrix, burst, 0.25, self.math)
+
+        self.assertIn((11.0, 3.0, -5.0), tuple(_xyz(point) for point in points))
+        self.assertGreater(
+            math.sqrt((burst.x - vehicle_matrix.translation.x) ** 2 +
+                      (burst.y - vehicle_matrix.translation.y) ** 2 +
+                      (burst.z - vehicle_matrix.translation.z) ** 2), 0.25)
+
+    def test_turret_offset_and_chassis_matrix_keep_their_distinct_roots(self):
+        chassis = _component('vehicleChassis', (0.0, 0.0, 0.0),
+                             (1.0, 1.0, 1.0))
+        hull = self._empty_component('vehicleHull')
+        turret = _component('vehicleTurret', (0.0, 0.0, 0.0),
+                            (1.0, 1.0, 1.0))
+        vehicle = _vehicle(
+            chassis, hull, turret, self._empty_component('vehicleGun'),
+            hull_offset=(1.0, 0.0, 0.0), turret_offset=(0.0, 2.0, 0.0),
+            turret_yaw=0.5)
+        body = _Matrix()
+        body.translation = _Vector(10.0, 0.0, 0.0)
+        chassis_root = _Matrix()
+        chassis_root.translation = _Vector(-10.0, 0.0, 0.0)
+
+        turret_points = vehicle_blast_probe_points_at_matrix(
+            vehicle, body, _Vector(11.4, 2.5, 0.4), 0.2, self.math,
+            chassis_matrix=chassis_root)
+        chassis_points = vehicle_blast_probe_points_at_matrix(
+            vehicle, body, _Vector(-9.9, 0.5, 0.5), 0.2, self.math,
+            chassis_matrix=chassis_root)
+
+        self.assertIn((11.389342956, 2.5, 0.380492411),
+                      tuple(_xyz(point) for point in turret_points))
+        self.assertIn((-10.0, 0.5, 0.5),
+                      tuple(_xyz(point) for point in chassis_points))
+
+    def test_external_only_missing_bbox_and_noncallable_tester_do_not_produce_points(self):
+        chassis = _component('vehicleChassis', (0.0, 0.0, 0.0),
+                             (1.0, 1.0, 1.0), factor=0.0)
+        hull = _component('vehicleHull', (0.0, 0.0, 0.0),
+                          (1.0, 1.0, 1.0), callable_test=False)
+        turret = self._empty_component('vehicleTurret')
+        gun = _component('vehicleGun', (0.0, 0.0, 0.0), (1.0, 1.0, 1.0),
+                         factor=0.0)
+        vehicle = _vehicle(chassis, hull, turret, gun)
+
+        points = vehicle_blast_probe_points_at_matrix(
+            vehicle, _Matrix(), _Vector(0.5, 0.5, 0.5), 1.0, self.math)
+
+        self.assertEqual((), points)
+
+    def test_zero_armour_structural_bbox_is_kept_and_candidates_are_bounded(self):
+        hull = _component('vehicleHull', (-1.0, -1.0, -1.0),
+                          (2.0, 3.0, 4.0), armor=0.0, factor=1.0)
+        vehicle = _vehicle(
+            self._empty_component('vehicleChassis'), hull,
+            self._empty_component('vehicleTurret'),
+            self._empty_component('vehicleGun'))
+
+        points = vehicle_blast_probe_points_at_matrix(
+            vehicle, _Matrix(), _Vector(0.23, 0.41, 0.67), 1.0, self.math)
+
+        self.assertEqual(13, len(points))
+        self.assertEqual(len(points), len(set(_xyz(point) for point in points)))
+
+    def test_bbox_lower_distance_rejects_out_of_radius_component(self):
+        hull = _component('vehicleHull', (10.0, 0.0, 0.0),
+                          (12.0, 2.0, 2.0))
+        vehicle = _vehicle(
+            self._empty_component('vehicleChassis'), hull,
+            self._empty_component('vehicleTurret'),
+            self._empty_component('vehicleGun'))
+
+        points = vehicle_blast_probe_points_at_matrix(
+            vehicle, _Matrix(), _Vector(0.0, 1.0, 1.0), 9.99, self.math)
+
+        self.assertEqual((), points)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_port_0922_shell_randomization.py
+++ b/tests/test_port_0922_shell_randomization.py
@@ -1,0 +1,125 @@
+"""Check the public shell-roll reconstruction against an independent CDF.
+
+These tests establish the chosen truncated normal law. They cannot identify
+the unpublished #1513 server's precise generator or outlier policy.
+"""
+
+import math
+from pathlib import Path
+import random
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / 'src' / 'res' / 'scripts' / 'client'))
+from gui.mods.offline_lan_0922 import combat_rules, device_damage
+
+
+def _normal_cdf(value):
+    return 0.5 * (1.0 + math.erf(value / math.sqrt(2.0)))
+
+
+def _factor_cdf(value):
+    lower, upper = _normal_cdf(-2.5), _normal_cdf(2.5)
+    return (_normal_cdf((value - 1.0) / 0.1) - lower) / (upper - lower)
+
+
+class ShellRandomizationTests(unittest.TestCase):
+
+    def test_public_interval_and_nonuniform_density(self):
+        generator = random.Random(1513)
+        factors = [combat_rules.sample_penetration_factor(generator.gauss)
+                   for unused in range(100000)]
+        self.assertGreaterEqual(min(factors), 0.75)
+        self.assertLessEqual(max(factors), 1.25)
+        for lower, upper in ((0.75, 0.80), (0.95, 1.05), (1.20, 1.25)):
+            with self.subTest(interval=(lower, upper)):
+                observed = sum(lower <= value < upper for value in factors)
+                expected = _factor_cdf(upper) - _factor_cdf(lower)
+                self.assertAlmostEqual(expected, observed / len(factors),
+                                       delta=0.004)
+        # Old uniform sampling gives 20%, whereas the specified normal
+        # interval gives about 38.8%. This catches a flat RNG regression.
+        central = sum(0.95 <= value <= 1.05 for value in factors)
+        self.assertGreater(central / len(factors), 0.37)
+
+    def test_outliers_are_resampled_without_endpoint_pileup(self):
+        draws = mock.Mock(side_effect=(0.5, 1.5, 1.02))
+        self.assertEqual(1.02, combat_rules.sample_penetration_factor(draws))
+        self.assertEqual([mock.call(1.0, 0.1)] * 3, draws.call_args_list)
+        for invalid in (float('inf'), float('nan')):
+            with self.assertRaises(ValueError):
+                combat_rules.sample_shell_value(invalid)
+            with self.assertRaises(ValueError):
+                combat_rules.sample_penetration_factor(
+                    lambda unused_mean, unused_sigma: invalid)
+
+    def test_vehicle_damage_and_track_armor_channel_share_the_same_roll_law(self):
+        shell = {'damage': (400.0, 165.0), 'kind': 'ARMOR_PIERCING'}
+        shot = {'shell': shell}
+        # Two discarded outliers, then a legal full precision damage roll.
+        with mock.patch.object(combat_rules.random, 'gauss',
+                               side_effect=(200.0, 600.0, 333.7)) as draw:
+            rolled = combat_rules.shell_damage_roll(shot)
+        self.assertEqual(333.7, rolled)
+        self.assertEqual([mock.call(400.0, 40.0)] * 3, draw.call_args_list)
+        with mock.patch.object(combat_rules.random, 'gauss',
+                               side_effect=AssertionError('must reuse roll')):
+            self.assertEqual(333, combat_rules.damage(
+                shot, 2, 100.0, rolled_damage=rolled))
+            self.assertEqual(0, combat_rules.damage(
+                shot, 1, 100.0, rolled_damage=rolled))
+        with mock.patch.object(combat_rules.random, 'gauss',
+                               return_value=333.7) as draw:
+            self.assertEqual(333.7, device_damage.module_damage_roll(shell, 0))
+        draw.assert_called_once_with(400.0, 40.0)
+
+    def test_he_direct_and_splash_damage_draw_from_the_same_distribution(self):
+        shot = {'shell': {'damage': (400.0, 165.0),
+                          'kind': 'HIGH_EXPLOSIVE'}}
+        for direct in (True, False):
+            with self.subTest(direct=direct), mock.patch.object(
+                    combat_rules.random, 'gauss', return_value=400.0) as draw:
+                damage = (combat_rules.damage(shot, 1, 100.0) if direct else
+                          combat_rules.he_splash_damage(shot, 100.0, 0.0))
+                self.assertEqual(70, damage)
+                draw.assert_called_once_with(400.0, 40.0)
+
+    def test_type59_track_and_sloped_hull_show_both_probability_errors(self):
+        # Descriptor-derived Type 59 values: 20 mm track ignores hit angle,
+        # followed by a 100 mm hull at 60 degrees. Both verdicts go through
+        # the production layer resolver; probabilities use the independent CDF.
+        track = types.SimpleNamespace(
+            armor=20.0, vehicleDamageFactor=0.0, useHitAngle=False,
+            mayRicochet=False, kind=10, collideOnceOnly=True)
+        hull = types.SimpleNamespace(armor=100.0, vehicleDamageFactor=1.0)
+        collisions = [types.SimpleNamespace(
+            dist=distance, hitAngleCos=0.5, matInfo=material, compName=component)
+            for distance, material, component in (
+                (1.0, track, 'vehicleChassis'), (1.2, hull, 'vehicleHull'))]
+        for kind, mean, normalization in (
+                ('ARMOR_PIERCING', 181.0, 5.0),
+                ('ARMOR_PIERCING_CR', 241.0, 2.0)):
+            with self.subTest(kind=kind):
+                effective = 100.0 / math.cos(math.radians(60 - normalization))
+                threshold = (20.0 + effective) / mean
+                shot = {'piercingPower': (mean, mean), 'maxDistance': 720.0,
+                        'shell': {'kind': kind, 'caliber': 100.0}}
+                for factor, expected in ((threshold - 1e-5, 1),
+                                         (threshold + 1e-5, 2)):
+                    contact = combat_rules.resolve_armor_contact(
+                        shot, 50.0, collisions, penetration_factor=factor)
+                    self.assertEqual(expected, contact['result'])
+                corrected = 1.0 - _factor_cdf(threshold)
+                old_uniform = (1.25 - threshold) / 0.5
+                if kind == 'ARMOR_PIERCING':
+                    self.assertGreater(old_uniform - corrected, 0.12)
+                else:
+                    self.assertGreater(corrected - old_uniform, 0.14)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_port_0922_shell_randomization.py
+++ b/tests/test_port_0922_shell_randomization.py
@@ -23,8 +23,8 @@ def _normal_cdf(value):
 
 
 def _factor_cdf(value):
-    lower, upper = _normal_cdf(-2.5), _normal_cdf(2.5)
-    return (_normal_cdf((value - 1.0) / 0.1) - lower) / (upper - lower)
+    lower, upper = _normal_cdf(-3.0), _normal_cdf(3.0)
+    return (_normal_cdf((value - 1.0) * 12.0) - lower) / (upper - lower)
 
 
 class ShellRandomizationTests(unittest.TestCase):
@@ -42,14 +42,14 @@ class ShellRandomizationTests(unittest.TestCase):
                 self.assertAlmostEqual(expected, observed / len(factors),
                                        delta=0.004)
         # Old uniform sampling gives 20%, whereas the specified normal
-        # interval gives about 38.8%. This catches a flat RNG regression.
+        # interval gives about 45.3%. This catches a flat RNG regression.
         central = sum(0.95 <= value <= 1.05 for value in factors)
-        self.assertGreater(central / len(factors), 0.37)
+        self.assertGreater(central / len(factors), 0.44)
 
     def test_outliers_are_resampled_without_endpoint_pileup(self):
         draws = mock.Mock(side_effect=(0.5, 1.5, 1.02))
         self.assertEqual(1.02, combat_rules.sample_penetration_factor(draws))
-        self.assertEqual([mock.call(1.0, 0.1)] * 3, draws.call_args_list)
+        self.assertEqual([mock.call(1.0, 1.0 / 12.0)] * 3, draws.call_args_list)
         for invalid in (float('inf'), float('nan')):
             with self.assertRaises(ValueError):
                 combat_rules.sample_shell_value(invalid)
@@ -65,7 +65,7 @@ class ShellRandomizationTests(unittest.TestCase):
                                side_effect=(200.0, 600.0, 333.7)) as draw:
             rolled = combat_rules.shell_damage_roll(shot)
         self.assertEqual(333.7, rolled)
-        self.assertEqual([mock.call(400.0, 40.0)] * 3, draw.call_args_list)
+        self.assertEqual([mock.call(400.0, 400.0 / 12.0)] * 3, draw.call_args_list)
         with mock.patch.object(combat_rules.random, 'gauss',
                                side_effect=AssertionError('must reuse roll')):
             self.assertEqual(333, combat_rules.damage(
@@ -75,7 +75,7 @@ class ShellRandomizationTests(unittest.TestCase):
         with mock.patch.object(combat_rules.random, 'gauss',
                                return_value=333.7) as draw:
             self.assertEqual(333.7, device_damage.module_damage_roll(shell, 0))
-        draw.assert_called_once_with(400.0, 40.0)
+        draw.assert_called_once_with(400.0, 400.0 / 12.0)
 
     def test_he_direct_and_splash_damage_draw_from_the_same_distribution(self):
         shot = {'shell': {'damage': (400.0, 165.0),
@@ -86,7 +86,7 @@ class ShellRandomizationTests(unittest.TestCase):
                 damage = (combat_rules.damage(shot, 1, 100.0) if direct else
                           combat_rules.he_splash_damage(shot, 100.0, 0.0))
                 self.assertEqual(70, damage)
-                draw.assert_called_once_with(400.0, 40.0)
+                draw.assert_called_once_with(400.0, 400.0 / 12.0)
 
     def test_type59_track_and_sloped_hull_show_both_probability_errors(self):
         # Descriptor-derived Type 59 values: 20 mm track ignores hit angle,

--- a/tests/test_port_0922_simulation_worker.py
+++ b/tests/test_port_0922_simulation_worker.py
@@ -856,7 +856,7 @@ class SimulationWorkerStateTests(unittest.TestCase):
         self.assertFalse(player.participating)
         self.assertIs(worker, state.simulation_worker)
         self.assertEqual('battle', state.phase)
-        self.assertEqual(2, state.battle_result['winner'])
+        self.assertEqual(3 - player.team, state.battle_result['winner'])
         self.assertEqual('team_eliminated', state.battle_result['reason'])
         receipts = [
             receipt for receipt in state.result_receipts.values()
@@ -918,7 +918,7 @@ class SimulationWorkerStateTests(unittest.TestCase):
         self.assertFalse(reset)
         self.assertIs(worker, state.simulation_worker)
         self.assertIsNotNone(state.battle_result)
-        self.assertEqual(2, state.battle_result['winner'])
+        self.assertEqual(3 - player.team, state.battle_result['winner'])
         self.assertEqual('team_eliminated',
                          state.battle_result['reason'])
         receipt = next(

--- a/tests/test_port_0922_solid_collision_oracle.py
+++ b/tests/test_port_0922_solid_collision_oracle.py
@@ -1,0 +1,485 @@
+"""Independent row-vector geometry oracle for solid-shell vehicle hits.
+
+The production collision adapter is intentionally exercised through its public
+entrypoint.  Expected component-local rays use the small affine oracle below,
+not the fake Math.Matrix implementation that the production code receives.
+"""
+
+import math
+from pathlib import Path
+import sys
+import types
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CLIENT_SCRIPTS = ROOT / 'src' / 'res' / 'scripts' / 'client'
+sys.path.insert(0, str(CLIENT_SCRIPTS))
+
+from gui.mods.offline_lan_0922.battle_runtime import BattleRuntime
+from gui.mods.offline_lan_0922.entities.remote_vehicle import \
+    collide_vehicle_at_matrix
+
+
+EPSILON = 1.0e-8
+
+
+class Vector(object):
+
+    def __init__(self, value=(0.0, 0.0, 0.0), y=None, z=None):
+        if y is not None and z is not None:
+            value = (value, y, z)
+        try:
+            value = (value.x, value.y, value.z)
+        except AttributeError:
+            pass
+        self.x, self.y, self.z = [float(entry) for entry in value]
+
+    def __getitem__(self, index):
+        return (self.x, self.y, self.z)[index]
+
+    def __add__(self, other):
+        return Vector((self.x + other.x, self.y + other.y,
+                       self.z + other.z))
+
+    def __sub__(self, other):
+        return Vector((self.x - other.x, self.y - other.y,
+                       self.z - other.z))
+
+    def __neg__(self):
+        return Vector((-self.x, -self.y, -self.z))
+
+    @property
+    def length(self):
+        return math.sqrt(self.x * self.x + self.y * self.y +
+                         self.z * self.z)
+
+    def normalise(self):
+        length = self.length
+        if length:
+            self.x /= length
+            self.y /= length
+            self.z /= length
+
+
+def _identity():
+    return ((1.0, 0.0, 0.0, 0.0),
+            (0.0, 1.0, 0.0, 0.0),
+            (0.0, 0.0, 1.0, 0.0),
+            (0.0, 0.0, 0.0, 1.0))
+
+
+def _oracle_multiply(left, right):
+    """Multiply affine matrices for points represented as row vectors."""
+    return tuple(tuple(sum(left[row][mid] * right[mid][column]
+                           for mid in range(4))
+                       for column in range(4)) for row in range(4))
+
+
+def _oracle_translation(value):
+    x, y, z = value
+    return ((1.0, 0.0, 0.0, 0.0),
+            (0.0, 1.0, 0.0, 0.0),
+            (0.0, 0.0, 1.0, 0.0),
+            (float(x), float(y), float(z), 1.0))
+
+
+def _oracle_yaw(angle):
+    cosine = math.cos(angle)
+    sine = math.sin(angle)
+    return ((cosine, 0.0, -sine, 0.0),
+            (0.0, 1.0, 0.0, 0.0),
+            (sine, 0.0, cosine, 0.0),
+            (0.0, 0.0, 0.0, 1.0))
+
+
+def _oracle_pitch(angle):
+    cosine = math.cos(angle)
+    sine = math.sin(angle)
+    return ((1.0, 0.0, 0.0, 0.0),
+            (0.0, cosine, -sine, 0.0),
+            (0.0, sine, cosine, 0.0),
+            (0.0, 0.0, 0.0, 1.0))
+
+
+def _oracle_roll(angle):
+    cosine = math.cos(angle)
+    sine = math.sin(angle)
+    return ((cosine, -sine, 0.0, 0.0),
+            (sine, cosine, 0.0, 0.0),
+            (0.0, 0.0, 1.0, 0.0),
+            (0.0, 0.0, 0.0, 1.0))
+
+
+def _oracle_ypr(yaw, pitch, roll):
+    return _oracle_multiply(
+        _oracle_multiply(_oracle_yaw(yaw), _oracle_pitch(pitch)),
+        _oracle_roll(roll))
+
+
+def _oracle_pose(yaw, pitch, roll, translation):
+    return _oracle_multiply(_oracle_ypr(yaw, pitch, roll),
+                            _oracle_translation(translation))
+
+
+def _oracle_inverse_rigid(matrix):
+    rotation = tuple(tuple(matrix[row][column] for row in range(3))
+                     for column in range(3))
+    translation = matrix[3][:3]
+    inverse_translation = tuple(-sum(
+        translation[row] * rotation[row][column] for row in range(3))
+                                for column in range(3))
+    return ((rotation[0][0], rotation[0][1], rotation[0][2], 0.0),
+            (rotation[1][0], rotation[1][1], rotation[1][2], 0.0),
+            (rotation[2][0], rotation[2][1], rotation[2][2], 0.0),
+            (inverse_translation[0], inverse_translation[1],
+             inverse_translation[2], 1.0))
+
+
+def _oracle_point(matrix, point):
+    x, y, z = point
+    return tuple(x * matrix[0][column] + y * matrix[1][column] +
+                 z * matrix[2][column] + matrix[3][column]
+                 for column in range(3))
+
+
+def _oracle_length(vector):
+    return math.sqrt(sum(value * value for value in vector))
+
+
+def _oracle_subtract(left, right):
+    return tuple(left[index] - right[index] for index in range(3))
+
+
+def _oracle_dot(left, right):
+    return sum(left[index] * right[index] for index in range(3))
+
+
+class Matrix(object):
+    """Test double for the native API, deliberately separate from oracle."""
+
+    def __init__(self, other=None):
+        if isinstance(other, Matrix):
+            self._values = tuple(tuple(row) for row in other._values)
+            self.yaw, self.pitch, self.roll = other.yaw, other.pitch, other.roll
+        else:
+            self._values = _identity()
+            self.yaw = self.pitch = self.roll = 0.0
+
+    @staticmethod
+    def _product(left, right):
+        return tuple(tuple(sum(left[row][mid] * right[mid][column]
+                               for mid in range(4))
+                           for column in range(4)) for row in range(4))
+
+    @property
+    def translation(self):
+        return Vector(self._values[3][:3])
+
+    @translation.setter
+    def translation(self, value):
+        value = Vector(value)
+        rows = [list(row) for row in self._values]
+        rows[3][0:3] = (value.x, value.y, value.z)
+        self._values = tuple(tuple(row) for row in rows)
+
+    def setIdentity(self):
+        self._values = _identity()
+        self.yaw = self.pitch = self.roll = 0.0
+
+    def setTranslate(self, value):
+        value = Vector(value)
+        self._values = ((1.0, 0.0, 0.0, 0.0),
+                        (0.0, 1.0, 0.0, 0.0),
+                        (0.0, 0.0, 1.0, 0.0),
+                        (value.x, value.y, value.z, 1.0))
+        self.yaw = self.pitch = self.roll = 0.0
+
+    def setRotateY(self, value):
+        value = float(value)
+        cosine, sine = math.cos(value), math.sin(value)
+        self._values = ((cosine, 0.0, -sine, 0.0),
+                        (0.0, 1.0, 0.0, 0.0),
+                        (sine, 0.0, cosine, 0.0),
+                        (0.0, 0.0, 0.0, 1.0))
+        self.yaw, self.pitch, self.roll = value, 0.0, 0.0
+
+    def setRotateX(self, value):
+        value = float(value)
+        cosine, sine = math.cos(value), math.sin(value)
+        self._values = ((1.0, 0.0, 0.0, 0.0),
+                        (0.0, cosine, -sine, 0.0),
+                        (0.0, sine, cosine, 0.0),
+                        (0.0, 0.0, 0.0, 1.0))
+        self.yaw, self.pitch, self.roll = 0.0, value, 0.0
+
+    def setRotateYPR(self, value):
+        self.yaw, self.pitch, self.roll = [float(entry) for entry in value]
+        yaw = Matrix()
+        yaw.setRotateY(self.yaw)
+        pitch = Matrix()
+        pitch.setRotateX(self.pitch)
+        cosine, sine = math.cos(self.roll), math.sin(self.roll)
+        roll = ((cosine, -sine, 0.0, 0.0),
+                (sine, cosine, 0.0, 0.0),
+                (0.0, 0.0, 1.0, 0.0),
+                (0.0, 0.0, 0.0, 1.0))
+        self._values = Matrix._product(
+            Matrix._product(yaw._values, pitch._values), roll)
+
+    def postMultiply(self, other):
+        self._values = Matrix._product(self._values, other._values)
+
+    def preMultiply(self, other):
+        self._values = Matrix._product(other._values, self._values)
+
+    def invert(self):
+        rotation = tuple(tuple(self._values[row][column]
+                               for row in range(3))
+                         for column in range(3))
+        translation = self._values[3][:3]
+        inverse = tuple(-sum(translation[row] * rotation[row][column]
+                             for row in range(3)) for column in range(3))
+        self._values = ((rotation[0][0], rotation[0][1], rotation[0][2], 0.0),
+                        (rotation[1][0], rotation[1][1], rotation[1][2], 0.0),
+                        (rotation[2][0], rotation[2][1], rotation[2][2], 0.0),
+                        (inverse[0], inverse[1], inverse[2], 1.0))
+
+    def applyPoint(self, value):
+        value = Vector(value)
+        return Vector(tuple(value[0] * self._values[0][column] +
+                            value[1] * self._values[1][column] +
+                            value[2] * self._values[2][column] +
+                            self._values[3][column] for column in range(3)))
+
+    def applyVector(self, value):
+        value = Vector(value)
+        return Vector(tuple(value[0] * self._values[0][column] +
+                            value[1] * self._values[1][column] +
+                            value[2] * self._values[2][column]
+                            for column in range(3)))
+
+
+class _PlaneHitTester(object):
+    """A non-axis-aligned local plane that reports the native four-tuple."""
+
+    def __init__(self, normal, plane_point, material_kind):
+        length = _oracle_length(normal)
+        self.normal = tuple(value / length for value in normal)
+        self.offset = _oracle_dot(self.normal, plane_point)
+        self.material_kind = material_kind
+        self.calls = []
+
+    def localHitTest(self, start, end):
+        start = tuple(start)
+        end = tuple(end)
+        self.calls.append((start, end))
+        direction = _oracle_subtract(end, start)
+        denominator = _oracle_dot(self.normal, direction)
+        if abs(denominator) <= EPSILON:
+            return ()
+        fraction = (self.offset - _oracle_dot(self.normal, start)) / denominator
+        if fraction < 0.0 or fraction > 1.0:
+            return ()
+        distance = _oracle_length(direction) * fraction
+        cosine = abs(denominator) / _oracle_length(direction)
+        return ((distance, Vector(self.normal), cosine, self.material_kind),)
+
+
+def _near_point(test, actual, expected):
+    for index in range(3):
+        test.assertAlmostEqual(expected[index], actual[index], places=7)
+
+
+def _component_oracle(body, chassis, hull_offset, turret_offset, gun_offset,
+                      turret_yaw, gun_pitch):
+    hull = _oracle_translation(tuple(-value for value in hull_offset))
+    turret = _oracle_multiply(
+        _oracle_translation(tuple(-hull_offset[index] - turret_offset[index]
+                                  for index in range(3))),
+        _oracle_yaw(-turret_yaw))
+    gun = _oracle_multiply(
+        turret, _oracle_multiply(_oracle_translation(
+            tuple(-value for value in gun_offset)), _oracle_pitch(-gun_pitch)))
+    return (('vehicleChassis', chassis, _identity()),
+            ('vehicleHull', body, hull),
+            ('vehicleTurret', body, turret),
+            ('vehicleGun', body, gun))
+
+
+def _local_ray(root, component, start, end):
+    world_to_root = _oracle_inverse_rigid(root)
+    transform = _oracle_multiply(world_to_root, component)
+    return (_oracle_point(transform, start), _oracle_point(transform, end))
+
+
+def _point_on_ray(start, end, fraction):
+    return tuple(start[index] + (end[index] - start[index]) * fraction
+                 for index in range(3))
+
+
+def _descriptor_for_ray(component_oracle, start, end, fractions):
+    components = []
+    normals = ((0.51, -0.22, 0.83), (-0.37, 0.91, 0.17),
+               (0.62, 0.48, -0.59), (-0.71, 0.33, 0.62))
+    materials = []
+    rays = {}
+    for index, (name, root, component) in enumerate(component_oracle):
+        local_start, local_end = _local_ray(root, component, start, end)
+        ray_point = _point_on_ray(local_start, local_end, fractions[index])
+        tester = _PlaneHitTester(normals[index], ray_point, 40 + index)
+        material = types.SimpleNamespace(name='material-%d' % index)
+        components.append(types.SimpleNamespace(
+            itemTypeName=name, hitTester=tester,
+            materials={40 + index: material}))
+        materials.append(material)
+        rays[name] = (local_start, local_end)
+    descriptor = types.SimpleNamespace(
+        chassis=components[0], hull=components[1], turret=components[2],
+        gun=components[3])
+    descriptor.chassis.hullPosition = Vector(HULL_OFFSET)
+    descriptor.hull.turretPositions = (Vector(TURRET_OFFSET),)
+    descriptor.turret.gunPosition = Vector(GUN_OFFSET)
+    descriptor.gun.staticTurretYaw = STATIC_TURRET_YAW
+    descriptor.gun.staticPitch = STATIC_GUN_PITCH
+    return descriptor, rays, tuple(materials)
+
+
+HULL_OFFSET = (1.4, -0.8, 2.1)
+TURRET_OFFSET = (-0.6, 1.7, 0.9)
+GUN_OFFSET = (0.5, 0.4, 1.3)
+STATIC_TURRET_YAW = 0.47
+STATIC_GUN_PITCH = -0.28
+START = (-20.0, -15.0, -25.0)
+END = (28.0, 15.0, 22.0)
+FRACTIONS = (0.79, 0.21, 0.52, 0.67)
+
+
+class SolidCollisionOracleTests(unittest.TestCase):
+
+    def _matrix(self, yaw, pitch, roll, translation):
+        matrix = Matrix()
+        matrix.setRotateYPR((yaw, pitch, roll))
+        matrix.translation = Vector(translation)
+        return matrix
+
+    def _expected_collisions(self, component_oracle, fractions, materials):
+        length = _oracle_length(_oracle_subtract(END, START))
+        expected = []
+        for index, (name, unused_root, unused_component) in enumerate(
+                component_oracle):
+            local_start, local_end = _local_ray(
+                unused_root, unused_component, START, END)
+            direction = _oracle_subtract(local_end, local_start)
+            normal = ((0.51, -0.22, 0.83), (-0.37, 0.91, 0.17),
+                      (0.62, 0.48, -0.59), (-0.71, 0.33, 0.62))[index]
+            cosine = abs(_oracle_dot(normal, direction)) / (
+                _oracle_length(normal) * _oracle_length(direction))
+            expected.append((length * fractions[index], cosine,
+                             materials[index], name))
+        return sorted(expected, key=lambda item: item[0])
+
+    def test_collision_uses_row_vector_component_chain_and_separate_chassis(self):
+        body = _oracle_pose(0.63, -0.31, 0.22, (13.0, -4.0, 8.0))
+        chassis = _oracle_pose(-0.23, 0.16, -0.19, (11.0, -4.7, 7.5))
+        chain = _component_oracle(
+            body, chassis, HULL_OFFSET, TURRET_OFFSET, GUN_OFFSET,
+            STATIC_TURRET_YAW, STATIC_GUN_PITCH)
+        descriptor, expected_rays, materials = _descriptor_for_ray(
+            chain, START, END, FRACTIONS)
+        vehicle = types.SimpleNamespace(
+            typeDescriptor=descriptor,
+            appearance=types.SimpleNamespace(
+                turretMatrix=self._matrix(STATIC_TURRET_YAW, 0.0, 0.0,
+                                          (0.0, 0.0, 0.0)),
+                gunMatrix=self._matrix(0.0, STATIC_GUN_PITCH, 0.0,
+                                       (0.0, 0.0, 0.0))))
+
+        collisions = collide_vehicle_at_matrix(
+            vehicle, self._matrix(0.63, -0.31, 0.22, (13.0, -4.0, 8.0)),
+            Vector(START), Vector(END),
+            types.SimpleNamespace(Vector3=Vector, Matrix=Matrix),
+            chassis_matrix=self._matrix(-0.23, 0.16, -0.19,
+                                        (11.0, -4.7, 7.5)))
+
+        for component in (descriptor.chassis, descriptor.hull,
+                          descriptor.turret, descriptor.gun):
+            actual_start, actual_end = component.hitTester.calls[0]
+            expected_start, expected_end = expected_rays[component.itemTypeName]
+            _near_point(self, actual_start, expected_start)
+            _near_point(self, actual_end, expected_end)
+        expected = self._expected_collisions(chain, FRACTIONS, materials)
+        self.assertEqual([item[3] for item in expected],
+                         [item.compName for item in collisions])
+        for actual, wanted in zip(collisions, expected):
+            self.assertAlmostEqual(wanted[0], actual.dist, places=7)
+            self.assertAlmostEqual(wanted[1], actual.hitAngleCos, places=7)
+            self.assertIs(wanted[2], actual.matInfo)
+
+        # This is a mutation-killer: swapping turret postMultiply to a
+        # preMultiply changes a translated, rotated point by metres.  The
+        # expected point is from the independent row-vector oracle above.
+        wrong_turret = _oracle_multiply(
+            _oracle_yaw(-STATIC_TURRET_YAW), _oracle_translation(
+                tuple(-HULL_OFFSET[index] - TURRET_OFFSET[index]
+                      for index in range(3))))
+        wrong_turret_start, unused_end = _local_ray(
+            body, wrong_turret, START, END)
+        correct_turret_start = expected_rays['vehicleTurret'][0]
+        self.assertGreater(_oracle_length(_oracle_subtract(
+            correct_turret_start, wrong_turret_start)), 0.5)
+        self.assertGreater(_oracle_length(_oracle_subtract(
+            tuple(descriptor.turret.hitTester.calls[0][0]),
+            wrong_turret_start)), 0.5)
+
+        # Using the body base for the chassis is another plausible mutation.
+        body_chassis_start, unused_end = _local_ray(
+            body, _identity(), START, END)
+        actual_chassis_start = descriptor.chassis.hitTester.calls[0][0]
+        self.assertGreater(_oracle_length(_oracle_subtract(
+            tuple(actual_chassis_start), body_chassis_start)), 0.5)
+
+    def test_frozen_target_uses_historical_pose_and_static_angles_for_hits(self):
+        body = _oracle_pose(0.63, -0.31, 0.22, (13.0, -4.0, 8.0))
+        # A frozen historic pose has one body matrix.  The first tuple's root
+        # therefore differs from the live hydraulic-chassis case above.
+        chain = _component_oracle(
+            body, body, HULL_OFFSET, TURRET_OFFSET, GUN_OFFSET,
+            STATIC_TURRET_YAW, STATIC_GUN_PITCH)
+        descriptor, expected_rays, materials = _descriptor_for_ray(
+            chain, START, END, FRACTIONS)
+        target = types.SimpleNamespace(typeDescriptor=descriptor)
+        runtime = types.SimpleNamespace(
+            math=types.SimpleNamespace(Vector3=Vector, Matrix=Matrix))
+        battle = object.__new__(BattleRuntime)
+        battle._runtime = runtime
+        pose = {
+            'x': 13.0, 'y': -4.0, 'z': 8.0,
+            'yaw': 0.63, 'pitch': -0.31, 'roll': 0.22,
+            # These values must not override the installed static gun data.
+            'turret_yaw': -1.17, 'gun_pitch': 0.91,
+        }
+
+        frozen = battle._projectile_frozen_target(target, pose)
+        collisions = collide_vehicle_at_matrix(
+            frozen, frozen.matrix, Vector(START), Vector(END), runtime.math)
+
+        self.assertAlmostEqual(STATIC_TURRET_YAW,
+                               frozen.appearance.turretMatrix.yaw)
+        self.assertAlmostEqual(STATIC_GUN_PITCH,
+                               frozen.appearance.gunMatrix.pitch)
+        _near_point(self, frozen.matrix.applyPoint(Vector((1.2, -0.4, 2.3))),
+                    _oracle_point(body, (1.2, -0.4, 2.3)))
+        for component in (descriptor.chassis, descriptor.hull,
+                          descriptor.turret, descriptor.gun):
+            actual_start, actual_end = component.hitTester.calls[0]
+            expected_start, expected_end = expected_rays[component.itemTypeName]
+            _near_point(self, actual_start, expected_start)
+            _near_point(self, actual_end, expected_end)
+        expected = self._expected_collisions(chain, FRACTIONS, materials)
+        self.assertEqual([item[3] for item in expected],
+                         [item.compName for item in collisions])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_port_0922_solid_hit_pipeline.py
+++ b/tests/test_port_0922_solid_hit_pipeline.py
@@ -1,0 +1,318 @@
+"""End-to-end AP/APCR collision checks against an analytic moving plane.
+
+This deliberately reaches BattleRuntime's chord and direct-effect paths.  The
+only fake collision primitive is a declared local BSP-plane boundary; its
+intersection is checked independently in world space below.
+"""
+
+import math
+from pathlib import Path
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CLIENT_SCRIPTS = ROOT / 'src' / 'res' / 'scripts' / 'client'
+TESTS = ROOT / 'tests'
+sys.path.insert(0, str(CLIENT_SCRIPTS))
+sys.path.insert(0, str(TESTS))
+
+from gui.mods.offline_lan_0922 import combat_rules, critical_damage, lan_client
+from gui.mods.offline_lan_0922.battle_runtime import BattleRuntime
+import test_port_0922_solid_collision_oracle as row_oracle
+
+
+Vector = row_oracle.Vector
+Matrix = row_oracle.Matrix
+
+START = (0.0, 1.0, 0.0)
+END = (40.0, 1.0, 0.0)
+YAW = 0.63
+HULL_OFFSET = (0.9, -0.2, 0.7)
+PLANE_POINT = (0.4, 0.35, -0.6)
+PLANE_NORMAL = (0.51, -0.22, 0.83)
+PENETRATION_FACTOR = 1.19
+DAMAGE_ROLL = 333.7
+
+
+class _PipelineVector(Vector):
+    """The production chord also needs the native Vector3 scale helper."""
+
+    def __add__(self, other):
+        return _PipelineVector((self.x + other.x, self.y + other.y,
+                                self.z + other.z))
+
+    def __sub__(self, other):
+        return _PipelineVector((self.x - other.x, self.y - other.y,
+                                self.z - other.z))
+
+    def scale(self, value):
+        return _PipelineVector((self.x * value, self.y * value,
+                                self.z * value))
+
+
+def _subtract(left, right):
+    return tuple(left[index] - right[index] for index in range(3))
+
+
+def _add(left, right):
+    return tuple(left[index] + right[index] for index in range(3))
+
+
+def _scale(vector, amount):
+    return tuple(value * amount for value in vector)
+
+
+def _dot(left, right):
+    return sum(left[index] * right[index] for index in range(3))
+
+
+def _length(vector):
+    return math.sqrt(_dot(vector, vector))
+
+
+def _normalised(vector):
+    length = _length(vector)
+    return tuple(value / length for value in vector)
+
+
+class _PlaneHitTester(object):
+    """Analytic stand-in for one native component-local BSP plane."""
+
+    def __init__(self, normal, point, material_kind):
+        self.normal = _normalised(normal)
+        self.offset = _dot(self.normal, point)
+        self.material_kind = material_kind
+        self.calls = []
+
+    def localHitTest(self, start, end):
+        start = tuple(start)
+        end = tuple(end)
+        self.calls.append((start, end))
+        direction = _subtract(end, start)
+        divisor = _dot(self.normal, direction)
+        if abs(divisor) <= 1.0e-10:
+            return ()
+        fraction = (self.offset - _dot(self.normal, start)) / divisor
+        if fraction < 0.0 or fraction > 1.0:
+            return ()
+        return ((fraction * _length(direction), Vector(self.normal),
+                 abs(divisor) / _length(direction), self.material_kind),)
+
+
+class _BigWorld(object):
+
+    def wg_collideSegment(self, unused_space, unused_start, unused_end,
+                          unused_mask):
+        return None
+
+
+def _plain_pose(position, yaw):
+    return BattleRuntime._projectile_plain_pose(
+        position, {'yaw': yaw, 'pitch': 0.0, 'roll': 0.0,
+                   'turret_yaw': 0.0, 'gun_pitch': 0.0})
+
+
+def _world_plane(yaw):
+    """Return the plane's root offset and world normal without test Matrix."""
+    rotation = row_oracle._oracle_ypr(yaw, 0.0, 0.0)
+    inverse = row_oracle._oracle_inverse_rigid(rotation)
+    root_point = _add(HULL_OFFSET, PLANE_POINT)
+    rotated_point = row_oracle._oracle_point(rotation, root_point)
+    local_normal = _normalised(PLANE_NORMAL)
+    # For row-vector positions p_world = p_local * R, plane normals use
+    # R^-1 * n.  This is intentionally not Matrix.applyVector().
+    world_normal = tuple(sum(inverse[row][column] * local_normal[column]
+                             for column in range(3)) for row in range(3))
+    return rotated_point, _normalised(world_normal)
+
+
+def _moving_plane_solution(target_start, target_delta, yaw):
+    """Solve n·(P0+f*dP-Q0-f*dQ-R*p)=0 for the projectile fraction."""
+    plane_offset, normal = _world_plane(yaw)
+    projectile_delta = _subtract(END, START)
+    relative_origin = _subtract(_subtract(START, target_start), plane_offset)
+    relative_delta = _subtract(projectile_delta, target_delta)
+    fraction = -_dot(normal, relative_origin) / _dot(normal, relative_delta)
+    impact = _add(START, _scale(projectile_delta, fraction))
+    relative_cosine = abs(_dot(normal, relative_delta)) / _length(relative_delta)
+    return fraction, impact, relative_cosine
+
+
+def _material(armor):
+    return types.SimpleNamespace(
+        armor=float(armor), vehicleDamageFactor=1.0,
+        checkCaliberForRichet=False, collideOnceOnly=False,
+        kind=71, useAntifragmentationLining=True)
+
+
+def _descriptor(tester, material):
+    chassis = types.SimpleNamespace(
+        itemTypeName='vehicleChassis', hullPosition=Vector(HULL_OFFSET))
+    hull = types.SimpleNamespace(
+        itemTypeName='vehicleHull',
+        turretPositions=(Vector((0.0, 0.0, 0.0)),), hitTester=tester,
+        materials={71: material})
+    turret = types.SimpleNamespace(itemTypeName='vehicleTurret',
+                                   gunPosition=Vector((0.0, 0.0, 0.0)))
+    gun = types.SimpleNamespace(itemTypeName='vehicleGun',
+                                staticTurretYaw=None, staticPitch=None)
+    return types.SimpleNamespace(
+        chassis=chassis, hull=hull, turret=turret, gun=gun,
+        hasSiegeMode=False, isPitchHullAimingAvailable=False)
+
+
+class SolidHitPipelineTests(unittest.TestCase):
+
+    def _battle(self):
+        runtime = types.SimpleNamespace(
+            bigworld=_BigWorld(), math=types.SimpleNamespace(
+                Vector3=_PipelineVector, Matrix=Matrix))
+        battle = object.__new__(BattleRuntime)
+        battle._runtime = runtime
+        battle._avatar = types.SimpleNamespace(spaceID=1)
+        battle._records = {}
+        battle._projectile_meta = {}
+        battle._projectile_terminal_data = {}
+        battle._projectile_position_history = []
+        battle._projectile_historic_pose_cache = {}
+        battle._projectile_spatial_bins = None
+        battle._projectile_destructible_context = None
+        battle._projectile_scan_count = 0
+        battle._projectile_candidate_count = 0
+        battle._worker_mode = True
+        battle._projectile_current_positions = {}
+        battle._destructibles = None
+        battle._equipment_state = None
+        return battle
+
+    def _run_first_hit(self, shooter_kind, shell_kind, target_delta):
+        expected_fraction, expected_impact, expected_cosine = \
+            _moving_plane_solution(TARGET_START, target_delta, YAW)
+        self.assertGreater(expected_fraction, 0.1)
+        self.assertLess(expected_fraction, 0.9)
+
+        # The fixed factor crosses this plate; an implicit 1.0 factor does
+        # not.  The contact's reported piercing value below catches a second
+        # random draw or a lost launch factor as well.
+        expected_piercing = 200.0 * PENETRATION_FACTOR
+        material = _material(expected_piercing * 0.90 * expected_cosine)
+        tester = _PlaneHitTester(PLANE_NORMAL, PLANE_POINT, 71)
+        descriptor = _descriptor(tester, material)
+        target = types.SimpleNamespace(
+            id=42, isStarted=True, isTurretDetached=False,
+            typeDescriptor=descriptor, position=Vector(TARGET_START),
+            isAlive=lambda: True)
+        source = types.SimpleNamespace(id=41, typeDescriptor=None)
+        battle = self._battle()
+        source_key = '%s:7' % shooter_kind
+        target_key = 'bot:8'
+        projectile_id = '%s:7:1' % shooter_kind
+        battle._records[source_key] = {
+            'engine_id': 41, 'network_id': 7, 'kind': shooter_kind,
+            'local': False, 'ready': True,
+            'state': {'health': 100, 'alive': True}}
+        battle._records[target_key] = {
+            'engine_id': 42, 'network_id': 8, 'kind': 'bot',
+            'local': False, 'ready': True,
+            'state': {'health': 1000, 'alive': True}}
+        battle._server_entity = lambda entity_id: (
+            source if entity_id == 41 else target if entity_id == 42 else None)
+        shot = {
+            'maxDistance': 100.0, 'piercingPower': (200.0, 200.0),
+            'deadeye': False,
+            'shell': {'kind': shell_kind, 'caliber': 105.0,
+                      'damage': (300.0, 100.0), 'explosionRadius': 0.0},
+        }
+        battle._projectile_meta[projectile_id] = {
+            'projectile_id': projectile_id, 'shooter_kind': shooter_kind,
+            'shooter_id': 7, 'source_shot': shot, 'shell_index': 0,
+            'penetration_factor': PENETRATION_FACTOR, 'piercing_loss': 0.0,
+            'base_penetration_multiplier': 1.0, 'is_he': False,
+        }
+        source_pose = _plain_pose(START, 0.0)
+        for fraction in (0.0, 1.0):
+            target_position = _add(TARGET_START,
+                                   _scale(target_delta, fraction))
+            battle._sample_projectile_positions(
+                fraction, {source_key: source_pose,
+                           target_key: _plain_pose(target_position, YAW)})
+        state = {
+            'key': projectile_id, 'start': START,
+            'payload': {'range_origin': START}, 'distance': 0.0,
+            'elapsed': 0.0,
+        }
+
+        terminal = battle._projectile_chord(
+            state, START, END, 0.0, 1.0)
+        self.assertEqual('impact', terminal['reason'])
+        terminal_data = battle._projectile_terminal_data[projectile_id]
+        for axis in range(3):
+            self.assertAlmostEqual(expected_impact[axis],
+                                   terminal_data['impact'][axis], places=6)
+        collision = terminal_data['collisions'][0]
+        self.assertEqual('vehicleHull', collision.compName)
+        self.assertIs(material, collision.matInfo)
+        self.assertAlmostEqual(expected_cosine, collision.hitAngleCos,
+                               places=7)
+        self.assertEqual(1, len(tester.calls))
+
+        # Current/spawn pose and yaw mutations have different analytic roots.
+        # The moving case proves the chord solves against relative travel,
+        # rather than pinning collision to either endpoint pose.
+        if _length(target_delta) > 0.0:
+            spawn_fraction, unused_impact, unused_cosine = \
+                _moving_plane_solution(TARGET_START, (0.0, 0.0, 0.0), YAW)
+            self.assertGreater(abs(expected_fraction - spawn_fraction), 0.01)
+        wrong_yaw_fraction, unused_impact, unused_cosine = \
+            _moving_plane_solution(TARGET_START, target_delta, 0.0)
+        self.assertGreater(abs(expected_fraction - wrong_yaw_fraction), 0.02)
+
+        with mock.patch('random.gauss', return_value=DAMAGE_ROLL) as roll, \
+                mock.patch.object(
+                    critical_damage, 'propose_direct',
+                    side_effect=lambda unused_target, unused_layers,
+                    unused_start, unused_end, damage, unused_shell,
+                    unused_attacker, **unused_kwargs: (damage, None, {})):
+            effect = battle._projectile_direct_effect(
+                battle._projectile_meta[projectile_id], state, terminal_data)
+
+        self.assertEqual(2, effect['shot_result'])
+        self.assertEqual(int(DAMAGE_ROLL), effect['damage'])
+        self.assertEqual(int(DAMAGE_ROLL), effect['potential_damage'])
+        roll.assert_called_once_with(300.0, 30.0)
+        self.assertTrue(effect['structural_armor_hit'])
+        self.assertIsNotNone(lan_client._strict_projectile_effect(effect))
+        contact = terminal_data['armor_contact']
+        self.assertIs(material, contact['material'])
+        self.assertEqual('vehicleHull', contact['component'])
+        self.assertAlmostEqual(expected_cosine, contact['angle_cos'], places=7)
+        self.assertAlmostEqual(expected_piercing, contact['piercing'], places=7)
+        self.assertEqual(2, contact['result'])
+
+    def test_ap_and_apcr_first_hit_pipeline_for_player_and_bot(self):
+        for shooter_kind in ('player', 'bot'):
+            for shell_kind in ('ARMOR_PIERCING', 'ARMOR_PIERCING_CR'):
+                for label, target_delta in (
+                        ('stationary', (0.0, 0.0, 0.0)),
+                        ('constant_velocity', (0.0, 0.0, 4.0))):
+                    with self.subTest(shooter=shooter_kind, shell=shell_kind,
+                                      target_motion=label):
+                        self._run_first_hit(
+                            shooter_kind, shell_kind, target_delta)
+
+
+# The root position is selected from the independent analytic equation so
+# every parameterized target is hit at the same in-chord fraction.
+_OFFSET, _NORMAL = _world_plane(YAW)
+_WANTED_FRACTION = 0.47
+_PROJECTILE_DELTA = _subtract(END, START)
+TARGET_START = _subtract(
+    _subtract(_add(START, _scale(_PROJECTILE_DELTA, _WANTED_FRACTION)),
+              _scale((0.0, 0.0, 4.0), _WANTED_FRACTION)), _OFFSET)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_port_0922_solid_hit_pipeline.py
+++ b/tests/test_port_0922_solid_hit_pipeline.py
@@ -282,7 +282,7 @@ class SolidHitPipelineTests(unittest.TestCase):
         self.assertEqual(2, effect['shot_result'])
         self.assertEqual(int(DAMAGE_ROLL), effect['damage'])
         self.assertEqual(int(DAMAGE_ROLL), effect['potential_damage'])
-        roll.assert_called_once_with(300.0, 30.0)
+        roll.assert_called_once_with(300.0, 25.0)
         self.assertTrue(effect['structural_armor_hit'])
         self.assertIsNotNone(lan_client._strict_projectile_effect(effect))
         contact = terminal_data['armor_contact']


### PR DESCRIPTION
Ordinary shots sampled penetration and armour damage uniformly across +/-25%, overproducing unusually high and low rolls. This change uses the post-8.6 three-sigma normal model (standard deviation = descriptor mean / 12), keeps the descriptor mean and +/-25% limits, freezes penetration across obstacles and armour layers, and publishes the exact damage roll consumed.

- AP/APCR ricochet continuations retain penetration spent on external plates. Their origin, time and distance come from the actual ricochet plate mapped from the moving-target query to the projectile trajectory. Later destructibles use the continuation's retained penetration multiplier.
- HE blast damage uses reachable native structural contacts, surface distance and static-world occlusion, with one damage roll per victim. Missing surfaces no longer select a vehicle-wide minimum plate, and penetrating HE does not create an external splash burst.
- Independent affine and moving-plane tests exercise ordinary player/Bot AP/APCR collision, incidence, material selection, penetration and effect serialization. The stock penetration preview, normalization and material flag rules are unchanged. The public wiki and available preview bytecode disagree on enhanced two-calibre normalization; this retains the client formula without claiming closed-server equivalence.

The sigma parameter follows [WG's versioned 8.6 explanation](https://wot-news.com/track/post/ru/HuKoguM/1369231089), which explicitly changes damage and penetration from two to three sigma, and the [8.6 release notes](https://worldoftanks.com/en/news/general-news/86-update-notes/), which confirm fewer extreme rolls. [The 2017 staff statement](https://wot-news.com/track/post/eu/MrConway/1497292760) still describes nonuniform RNG. Out-of-interval resampling remains an explicit reconstruction assumption; the published cutoff does not expose its exact algorithm.

Aiming dispersion remains an unresolved version gap: the retained 8.6 radial model gives about 16.3% in the central tenth of the radius, while [the historical 9.6 change](https://lesta.ru/support/ru/products/mt/article/35718/) reduced this to about 10%. The official 3,000-shot diagrams do not specify a complete sampling law. This PR does not implement guessed ring weights or claim exact retail accuracy. HE contact sampling is bounded; dynamic vehicle/wreck occlusion and exact Windows collision/gameplay behaviour also remain unproved.

Validation on `d6a37c96342325d3b23b995bc227446165c92cd9`:

- 340 focused tests passed: shell randomization, armour rules, projectile runtime, critical damage, gun mechanics, independent ordinary collision/hit pipeline and HE geometry/runtime. The statistical test uses 100,000 draws and an independent three-sigma CDF.
- All 91 client Python sources compile with CPython 2.7.18.
- Full CI: 3654 client tests passed; 480 launcher tests passed with 2 platform-dependent skips; the Python 2.7 wotmod build validated 105 archive members.
- All three jobs passed on this exact commit: Windows server, client tests/package, and Windows launcher. [CI run](https://github.com/pengw0048/wot-offline-battles/actions/runs/33969513857).
