### PR TITLE
Improve Bot tactics and complete multiplayer team communication

### DIFF
--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -640,23 +640,37 @@ not inferred from another 0.9.22 build:
 | goodies, vehicle rotation, recycle bin, ranked, badges, New Year | Readable empty caches exist. `groupLocks` contains both directly indexed lists, the ranked helper can directly index an empty `ranked` cache, and `ClientNewYear` plus the New Year controller accept the empty sync/goodie mappings without fabricated event data. |
 | `Shop` / `ShopRequester` / `RefSystem` | Mandatory `sellPriceFactor`; all directly read item/goodie collections; currency-mapped `paidRemovalCost`; exact berth, slot, and free-XP tuple arities; and the four-key disabled referral configuration, including integer `posByXPinTeam = 0`. |
 | `DossierCache` / `DossierRequester` | The stream body is the exact `(revision, dossierChanges)` pair; an empty change list completes synchronization without fabricating dossier data. |
-| `ClientChat` and BW Chat2 | The legacy `ClientChat.chatCommandFromClient` mailbox remains a one-way no-op so `CHAT_COMMANDS` indices are never misreported as `CHAT_ACTIONS`. The battle Avatar's BW Chat2 mailbox now translates the reviewed fixed tactical commands to reliable LAN messages and returns validated team broadcasts through the stock Chat2 receive path. |
+| `ClientChat` and BW Chat2 | The legacy `ClientChat.chatCommandFromClient` mailbox remains a one-way no-op so `CHAT_COMMANDS` indices are never misreported as `CHAT_ACTIONS`. The battle Avatar's BW Chat2 mailbox translates stock team text and all 18 fixed battle messages to reliable LAN messages, then returns validated same-team broadcasts through the stock Chat2 receive path. |
 | initial server settings / lobby controllers / `ClientRanked` | `file_server`, regional settings, the four-item roaming tuple and the directly indexed two-item `wallet` retain their native shapes; roaming item 3 is the host list consumed by `predefined_hosts`, while `ranked_config` is present and explicitly disabled because `ClientRanked` indexes it directly. `elenSettings` and the server-owned tutorial are explicitly disabled because their exact missing-section defaults start unsupported event-board or tutorial GUI lifecycles. |
 
-The BW Chat2 adapter is limited to the fixed commands present in the reviewed
+The BW Chat2 adapter covers the complete fixed-message range in the reviewed
 archive: `HELPME=23`, `FOLLOWME=24`, `ATTACK=25`, `BACKTOBASE=26`,
-`POSITIVE=27`, `NEGATIVE=28`, `ATTENTIONTOCELL=29`, `ATTACKENEMY=31`,
-`TURNBACK=32`, `HELPMEEX=33`, `SUPPORTMEWITHFIRE=34`, and `STOP=36`. It does
-not add free text, speech recognition, or synthetic SPG and reload-state
-orders. CPython 2.7 marshal and disassembly
-confirm the outgoing chain from `RadialMenu.onAction` through
-`ChatCommandsController` and `BattleChatCommandHandler.send` to
+`POSITIVE=27`, `NEGATIVE=28`, `ATTENTIONTOCELL=29`, `SPG_AIM_AREA=30`,
+`ATTACKENEMY=31`, `TURNBACK=32`, `HELPMEEX=33`,
+`SUPPORTMEWITHFIRE=34`, `RELOADINGGUN=35`, `STOP=36`,
+`RELOADING_CASSETE=37`, `RELOADING_READY=38`,
+`RELOADING_READY_CASSETE=39`, and `RELOADING_UNAVAILABLE=40`. These are
+stock messages; the adapter adds neither arbitrary command names nor speech
+recognition. CPython 2.7 marshal and disassembly confirm the outgoing chain
+from `RadialMenu.onAction` through `ChatCommandsController` and
+`BattleChatCommandHandler.send` to
 `Avatar.base.messenger_onActionByClient_chat2(actionID, requestID, args)`, and
 the inverse server path through
 `Avatar.messenger_onActionByServer_chat2(actionID, requestID, args)`. The
 argument mapping has exactly `int32Arg1`, `int64Arg1`, `floatArg1`, `strArg1`,
 and `strArg2`; `int32Arg1` carries the target vehicle entity id or minimap cell,
 while `int64Arg1` carries the sender account DBID on reception.
+
+The SPG area producer packs exactly `<fffif` into the 20-byte `strArg1`:
+desired world `x/y/z`, integer cell index, and reload time. Its consumer
+unpacks the same layout for the stun-area marker, minimap cell text and optional
+reloading text. The SPG target form of `ATTACKENEMY` carries the target entity
+id in `int32Arg1` and reload time in `floatArg1`. Reload messages use
+`floatArg1` for positive remaining seconds and `int32Arg1` for positive
+cassette quantity: `RELOADING_CASSETE` has both,
+`RELOADING_READY_CASSETE` has quantity only, and the ordinary ready/unavailable
+forms have default arguments. These status messages are same-team information
+broadcasts and do not create Bot orders.
 
 Targeted commands retain their stock relationship: `FOLLOWME`, `TURNBACK`,
 `HELPMEEX`, and `STOP` address a living ally, while `ATTACKENEMY` and
@@ -680,6 +694,42 @@ controller registers its event consumers on `startControl` and removes them on
 `stopControl`. The LAN adapter adds current-Avatar and current-round fences,
 clears pending request identities during Avatar teardown, and ignores duplicate
 or late acknowledgements and relays.
+
+Team text uses stock actions `INIT_BATTLE_CHAT=19`,
+`DEINIT_BATTLE_CHAT=20`, `BROADCAST_BATTLE_MESSAGE=21`, and
+`ON_BATTLE_MESSAGE_BROADCAST=22`. Outgoing TEAM messages carry channel marker
+`int32Arg1=0` and text in `strArg1`; `int32Arg1=1` is COMMON and is rejected
+locally because the LAN service is same-team only. The Chinese client applies
+a three-second text cooldown. Its outgoing filter strips, performs its own
+runtime's NFKC normalization, slices to 140 characters, UTF-8 encodes, and
+collapses byte-string whitespace. On the supported 32-bit Windows Python 2.7
+runtime that slice counts UTF-16 code units. LAN validation checks valid
+non-blank Unicode and the 140-unit bound without applying NFKC a second time:
+Python 2.7's Unicode database and a modern server runtime can normalize the
+same character differently. Incoming `ArenaMessageVO` preserves Unicode, and
+the locked stock incoming filter performs the single HTML escape for `&`, `<`,
+`>`, double quote and apostrophe. The server relays raw plaintext; the adapter
+passes Unicode rather than invoking the consumer's lossy byte decode fallback.
+
+Action 19 carries a level-1 zlib-compressed protocol-2 pickle of an empty
+history list. It creates both TEAM and COMMON channel controllers. A second
+stock gate is also required: `_EntityChatHandler` starts disabled and queues
+every action 22 message until `onUsersListReceived` contains `IGNORED` or
+`IGNORED_TMP`. Retail produces that event from XMPP cache restore, successful
+contacts sequence initialization, or its battle retry fallback. The offline
+account has no dependable XMPP producer, so the adapter publishes only those
+two roster-ready tags after action 19. It does not clear or replace users,
+ignored state, or mute state. Teardown sends action 20 before stock GUI exit;
+partial initialization retains teardown ownership and both start/close paths
+are idempotent.
+
+The stock provider calls the base mailbox synchronously and only appends the
+request id to its response deque after that call returns. A local rejection or
+LAN admission failure is therefore returned through a zero-delay BigWorld
+callback. The callback validates the current Avatar and adapter generation;
+chat teardown rotates the generation so a late response cannot reach the
+retiring UI or a replacement battle. A later LAN acknowledgement can respond
+directly because the stock request has already been registered.
 
 For `ATTENTIONTOCELL`, the exact archive computes
 `cellIndex = column * 10 + row`. With arena bounds

--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -640,8 +640,64 @@ not inferred from another 0.9.22 build:
 | goodies, vehicle rotation, recycle bin, ranked, badges, New Year | Readable empty caches exist. `groupLocks` contains both directly indexed lists, the ranked helper can directly index an empty `ranked` cache, and `ClientNewYear` plus the New Year controller accept the empty sync/goodie mappings without fabricated event data. |
 | `Shop` / `ShopRequester` / `RefSystem` | Mandatory `sellPriceFactor`; all directly read item/goodie collections; currency-mapped `paidRemovalCost`; exact berth, slot, and free-XP tuple arities; and the four-key disabled referral configuration, including integer `posByXPinTeam = 0`. |
 | `DossierCache` / `DossierRequester` | The stream body is the exact `(revision, dossierChanges)` pair; an empty change list completes synchronization without fabricating dossier data. |
-| `ClientChat` and BW Chat2 | Both client mailboxes exist. Offline chat commands are accepted as one-way no-ops: `CHAT_COMMANDS` indices are never echoed as `CHAT_ACTIONS`, and no malformed partial action is delivered to `ClientChat.onChatAction`. |
+| `ClientChat` and BW Chat2 | The legacy `ClientChat.chatCommandFromClient` mailbox remains a one-way no-op so `CHAT_COMMANDS` indices are never misreported as `CHAT_ACTIONS`. The battle Avatar's BW Chat2 mailbox now translates the reviewed fixed tactical commands to reliable LAN messages and returns validated team broadcasts through the stock Chat2 receive path. |
 | initial server settings / lobby controllers / `ClientRanked` | `file_server`, regional settings, the four-item roaming tuple and the directly indexed two-item `wallet` retain their native shapes; roaming item 3 is the host list consumed by `predefined_hosts`, while `ranked_config` is present and explicitly disabled because `ClientRanked` indexes it directly. `elenSettings` and the server-owned tutorial are explicitly disabled because their exact missing-section defaults start unsupported event-board or tutorial GUI lifecycles. |
+
+The BW Chat2 adapter is limited to the fixed commands present in the reviewed
+archive: `HELPME=23`, `FOLLOWME=24`, `ATTACK=25`, `BACKTOBASE=26`,
+`POSITIVE=27`, `NEGATIVE=28`, `ATTENTIONTOCELL=29`, `ATTACKENEMY=31`,
+`TURNBACK=32`, `HELPMEEX=33`, `SUPPORTMEWITHFIRE=34`, and `STOP=36`. It does
+not add free text, speech recognition, or synthetic SPG and reload-state
+orders. CPython 2.7 marshal and disassembly
+confirm the outgoing chain from `RadialMenu.onAction` through
+`ChatCommandsController` and `BattleChatCommandHandler.send` to
+`Avatar.base.messenger_onActionByClient_chat2(actionID, requestID, args)`, and
+the inverse server path through
+`Avatar.messenger_onActionByServer_chat2(actionID, requestID, args)`. The
+argument mapping has exactly `int32Arg1`, `int64Arg1`, `floatArg1`, `strArg1`,
+and `strArg2`; `int32Arg1` carries the target vehicle entity id or minimap cell,
+while `int64Arg1` carries the sender account DBID on reception.
+
+Targeted commands retain their stock relationship: `FOLLOWME`, `TURNBACK`,
+`HELPMEEX`, and `STOP` address a living ally, while `ATTACKENEMY` and
+`SUPPORTMEWITHFIRE` address a living enemy. `FOLLOWME` asks that ally to follow
+the sender. The four ally-targeted actions retain the stock private filter, so
+only sender and receiver render them after the same-team relay; enemy-targeted
+actions retain their public markers. Every reviewed command has a five-second
+stock cooldown except `ATTENTIONTOCELL`, whose cooldown is 0.5 seconds. The
+adapter resolves the stock BigWorld entity id to a separate LAN identity kind
+and logical id before transmission, then performs the reverse mapping for
+display; account DBIDs are resolved independently and are never assumed to
+equal entity ids. A same-team server broadcast owns the original stock command
+display, marker, and sound. Its acknowledgement closes the stock request and
+may display one assigned Bot's stock `POSITIVE` reply. Expiry, issuer death or
+departure, round completion, and replacement at the bounded command-history
+limit are cancellation terminals, not claims that a Bot completed the order.
+
+The stock BW Chat2 provider enables and flushes its action queue only in battle
+scope, and disables and clears it on scope exit. The stock chat-command
+controller registers its event consumers on `startControl` and removes them on
+`stopControl`. The LAN adapter adds current-Avatar and current-round fences,
+clears pending request identities during Avatar teardown, and ignores duplicate
+or late acknowledgements and relays.
+
+For `ATTENTIONTOCELL`, the exact archive computes
+`cellIndex = column * 10 + row`. With arena bounds
+`(bottomLeft(x, z), upperRight(x, z))`, its stock marker point is
+`x = bottomLeft.x + column * width / 10` and
+`z = upperRight.z - row * height / 10`; this is the cell's northwest boundary,
+with a placeholder `y = 0`. Bot navigation instead targets the center of the
+same proven cell bounds. The worker selects a passable point within that cell,
+preferring dry ground, and obtains its height from the baked navigation data. The stock minimap feedback path creates the cell flash, runs its
+animation, and plays the `minimap_attention` sound.
+
+The candidate inspected during this review contained a loose `scripts.pkg` and
+executable rather than a complete client root. `tools/inspect_client.py`
+therefore rejected it because the required `version.xml`, `paths.xml`, packaged
+archive path, entity definitions, and assets were unavailable. The bytecode
+results above prove the contract of that actual local archive. They do not
+independently prove its regional build identity, native UI rendering, audio,
+or lifecycle behavior on the Chinese HD `0.9.22.0.1 #1513` Windows client.
 
 The controller chain itself was enumerated from `game_control.__init__` and
 `new_year.__init__`. `NewYearController` is invoked first, followed by the

--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ whose profile changed after it started must be restarted first.
   shared contacts to route, take cover, pick targets and choose ammunition,
   including SPG arcs. Navigation and foliage data ship for all 41 supported
   standard-battle maps.
+- Stock battle commands can direct nearby allied Bots: request help, name a
+  target, ask a Bot to follow or stop, return to base, or ping a minimap cell.
+  At most two Bots accept a general request; a named ally command addresses
+  that Bot. An accepting Bot replies through the stock team-message system.
+  Orders expire after 15 seconds and yield to urgent defense and survival.
+  Minimap requests choose passable ground inside the cell; following Bots
+  leave room behind the player. Native menu, marker and sound presentation
+  still needs acceptance on the supported Windows client.
 - Automatically generated Bot lineups contain no self-propelled artillery.
   Player vehicles and manually assigned Bot lineups remain unrestricted;
   tank destroyers are not artillery and remain in the automatic pool.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ whose profile changed after it started must be restarted first.
   shared contacts to route, take cover, pick targets and choose ammunition,
   including SPG arcs. Navigation and foliage data ship for all 41 supported
   standard-battle maps.
+- Team text chat, minimap pings and fixed battle messages are relayed to
+  human teammates, including the sender, independently from Bot responses.
+  Text and pings remain available during the countdown and after the sender's
+  tank is destroyed; a team with no living Bots can still communicate.
+  Text uses the stock team
+  channel, formatting and cooldown. Reload, cassette and SPG aim-area messages
+  preserve the status supplied by the stock client. Common/all-team chat is
+  not supported.
 - Stock battle commands can direct nearby allied Bots: request help, name a
   target, ask a Bot to follow or stop, return to base, or ping a minimap cell.
   At most two Bots accept a general request; a named ally command addresses

--- a/server/lan_battle_server.py
+++ b/server/lan_battle_server.py
@@ -192,6 +192,7 @@ ROUND_SCOPED_MESSAGE_TYPES = frozenset((
     "player_environment", "landing_observation",
     "track_repair",
     "equipment_intent",
+    "team_command",
 ))
 MODERN_VISIBLE_MESSAGE_TYPES = frozenset((
     "input", "fire_intent", "landing_observation", "start_battle",
@@ -201,6 +202,7 @@ MODERN_VISIBLE_MESSAGE_TYPES = frozenset((
     "ping", "leave",
     "track_repair",
     "equipment_intent",
+    "team_command",
 ))
 # The elected #1513 authority uses the same bounded in-process manager.  The
 # server must never admit more durable launches than a takeover client can
@@ -215,6 +217,21 @@ PROJECTILE_MAX_DESTRUCTIBLES = 64
 PROJECTILE_MAX_LIFETIME_MS = 20000
 PLAYER_FIRE_INTENT_MAX_PENDING = 1
 PLAYER_FIRE_INTENT_HISTORY = 64
+TEAM_COMMAND_HISTORY = 64
+TEAM_COMMAND_TTL_TICKS = int(15 * TICK_HZ)
+TEAM_COMMAND_MAX_RECIPIENTS = 2
+TEAM_COMMANDS = frozenset((
+    "ATTACK", "BACKTOBASE", "HELPME", "FOLLOWME", "TURNBACK",
+    "HELPMEEX", "STOP", "ATTACKENEMY", "SUPPORTMEWITHFIRE",
+    "ATTENTIONTOCELL", "POSITIVE", "NEGATIVE",
+))
+TEAM_COMMAND_ENEMY_TARGETS = frozenset((
+    "ATTACKENEMY", "SUPPORTMEWITHFIRE",
+))
+TEAM_COMMAND_ALLY_TARGETS = frozenset((
+    "FOLLOWME", "TURNBACK", "HELPMEEX", "STOP",
+))
+TEAM_COMMAND_CELL_TARGETS = frozenset(("ATTENTIONTOCELL",))
 # One trigger-edge presentation entry per live Bot identity (1..30).
 PLAYER_PRESENTATION_LEDGER_FIELDS = frozenset((
     "bot_id", "bot_state_revision", "presentation_time_us"))
@@ -1821,6 +1838,11 @@ class Player(_EndpointSendMixin):
         default_factory=OrderedDict, repr=False)
     equipment_intent_result: dict = field(default_factory=lambda: {
         "intent_seq": 0, "accepted": False, "reason": ""})
+    team_command_seq: int = 0
+    team_command_fingerprints: OrderedDict = field(
+        default_factory=OrderedDict, repr=False)
+    team_command_acks: OrderedDict = field(
+        default_factory=OrderedDict, repr=False)
     combat_fire_elapsed: float = 0.0
     combat_fire_timer: float = 0.0
     fire_attacker_kind: str = ""
@@ -1993,6 +2015,7 @@ class BattleState:
         # snapshot timestamps and recreate a presentation hold.
         self.motion_time_offset_us = 0
         self.bot_orders = {"revision": 0, "orders": []}
+        self.team_commands = OrderedDict()
         self._next_bot_planner_tick = 0
         self.bot_reported_hits = set()
         self.bot_reported_rams = set()
@@ -2891,6 +2914,7 @@ class BattleState:
     def _reset_round(self):
         """Return connected players to a clean waiting-room round."""
         self.phase = "waiting"
+        self._clear_team_commands_locked("round_complete")
         self.round_id += 1
         self.tick = 0
         self.map_name = self._choose_map(self._active_map_pool())
@@ -2909,6 +2933,9 @@ class BattleState:
             player.equipment_intent_fingerprints.clear()
             player.equipment_intent_result = {
                 "intent_seq": 0, "accepted": False, "reason": ""}
+            player.team_command_seq = 0
+            player.team_command_fingerprints.clear()
+            player.team_command_acks.clear()
             player.combat_fire_elapsed = 0.0
             player.combat_fire_timer = 0.0
             player.fire_attacker_kind = ""
@@ -3006,6 +3033,7 @@ class BattleState:
         self.motion_time_offset_us = 0
         self.bot_planner.reset()
         self.bot_orders = {"revision": 0, "orders": []}
+        self.team_commands = OrderedDict()
         self._next_bot_planner_tick = 0
         self.bot_reported_hits = set()
         self.bot_reported_rams = set()
@@ -4477,6 +4505,29 @@ class BattleState:
                         return False
                     shooter_ids.append(bot_id)
                 contact["shootable_by_bot_ids"] = sorted(shooter_ids)
+                # A threat is advisory native geometry: a malformed row must
+                # not make an otherwise valid observation batch fail or give
+                # a visible client a way to evict the worker.  It is useful
+                # only while the enemy contact is currently visible, and can
+                # name only live Bots on the observing team.
+                if "threatened_bot_ids" in contact:
+                    threatened_ids = []
+                    raw_threatened = contact.get("threatened_bot_ids")
+                    if isinstance(raw_threatened, (list, tuple)):
+                        for raw_bot_id in raw_threatened:
+                            try:
+                                bot_id = _exact_int(
+                                    raw_bot_id, 1, PROJECTILE_MAX_ID)
+                            except ValueError:
+                                continue
+                            bot = known_bots.get(bot_id)
+                            if (bot is None or not bot.get("alive") or
+                                    int(bot.get("team", 0)) != observing_team or
+                                    bot_id in threatened_ids):
+                                continue
+                            threatened_ids.append(bot_id)
+                    contact["threatened_bot_ids"] = sorted(
+                        threatened_ids if contact["visible"] else ())
                 fresh = bool(bot_observer_ids or observer_ids)
                 if stale_contact and not fresh:
                     continue
@@ -4543,6 +4594,306 @@ class BattleState:
             spotted = frozenset(direct_spots[player_id])
             self.player_spotted[int(player_id)] = spotted
         return True
+
+    @staticmethod
+    def _team_command_fingerprint(message):
+        """Return an idempotence key after the wire shape was checked."""
+        return json.dumps(message, sort_keys=True, separators=(",", ":"),
+                          ensure_ascii=True)
+
+    def _active_team_commands_locked(self):
+        """Return only current commands whose issuer can still direct Bots."""
+        active = []
+        expired = []
+        for command_id, command in self.team_commands.items():
+            issuer = self.players.get(command["issuer_id"])
+            code = None
+            if self.tick >= command["expires_tick"]:
+                code = "expired"
+            elif issuer is None or not issuer.connected:
+                code = "issuer_disconnected"
+            elif not issuer.participating:
+                code = "issuer_left"
+            elif not issuer.alive:
+                code = "issuer_dead"
+            elif issuer.team != command["team"]:
+                code = "issuer_changed"
+            if code is not None:
+                expired.append((command_id, issuer, code))
+                continue
+            active.append(dict(command))
+        for command_id, issuer, code in expired:
+            command = self.team_commands.get(command_id)
+            self.team_commands.pop(command_id, None)
+            if command is not None:
+                self._publish_team_command_terminal(issuer, command, code)
+        if expired:
+            # The next tick must rebuild immediately, so an order cannot
+            # outlive a dead issuer until the ordinary planner cadence.
+            self._next_bot_planner_tick = min(
+                self._next_bot_planner_tick, self.tick)
+        return active
+
+    @staticmethod
+    def _team_command_terminal(command, code):
+        """Project a one-shot end state without claiming Bot execution."""
+        message = {
+            "type": "team_command_terminal",
+            "protocol": PROTOCOL_VERSION,
+            "round_id": int(command["round_id"]),
+            "command_id": command["command_id"],
+            "command_seq": int(command["command_seq"]),
+            "command": command["command"],
+            "code": str(code),
+            "recipient_bot_ids": list(command["recipient_bot_ids"]),
+        }
+        if "target_id" in command:
+            message["target_id"] = int(command["target_id"])
+        if "target_kind" in command:
+            message["target_kind"] = command["target_kind"]
+        if "cell_index" in command:
+            message["cell_index"] = int(command["cell_index"])
+        return message
+
+    def _publish_team_command_terminal(self, issuer, command, code):
+        if issuer is not None and issuer.connected:
+            issuer.offer_reliable(self._team_command_terminal(command, code))
+
+    def _clear_team_commands_locked(self, code):
+        for command_id, command in list(self.team_commands.items()):
+            issuer = self.players.get(command["issuer_id"])
+            self.team_commands.pop(command_id, None)
+            self._publish_team_command_terminal(issuer, command, code)
+
+    def publish_team_command(self, acknowledgement):
+        """Relay an admitted stock command to current teammates only."""
+        with self.lock:
+            if not acknowledgement or not acknowledgement.get("accepted"):
+                return False
+            team = acknowledgement.get("team")
+            command = acknowledgement.get("command")
+            if team not in (1, 2) or command not in TEAM_COMMANDS:
+                return False
+            message = {
+                "type": "team_command",
+                "protocol": PROTOCOL_VERSION,
+                "round_id": self.round_id,
+                "command_seq": acknowledgement.get("command_seq"),
+                "command": command,
+                "issuer_id": acknowledgement.get("issuer_id"),
+                "team": team,
+            }
+            for field in ("target_kind", "target_id", "cell_index"):
+                if field in acknowledgement:
+                    message[field] = acknowledgement[field]
+            recipients = tuple(
+                player for player in self.players.values()
+                if player.connected and player.participating and
+                player.team == team)
+        for recipient in recipients:
+            if not recipient.offer_reliable(message):
+                self.remove_player(recipient.player_id, expected=recipient)
+        return True
+
+    def _team_command_bots_locked(self, team):
+        """Return live canonical Bots for one team with their current poses."""
+        result = []
+        for identity in self.bot_manifest:
+            bot_id = int(identity.get("id", 0))
+            state = self.bot_states.get(bot_id)
+            if (state is None or not state.get("alive") or
+                    int(identity.get("team", 0)) != team):
+                continue
+            row = dict(state)
+            row["id"] = bot_id
+            row["team"] = team
+            result.append(row)
+        return result
+
+    def _team_command_ack(self, player, message, accepted, code,
+                          command=None, recipients=(), expires_tick=0):
+        """Build the one observable terminal receipt for a radio request."""
+        ack = {
+            "type": "team_command_ack",
+            "protocol": PROTOCOL_VERSION,
+            "round_id": self.round_id,
+            "command_seq": message.get("command_seq"),
+            "accepted": bool(accepted),
+            "code": str(code),
+            "recipient_bot_ids": list(recipients),
+            "expires_tick": int(expires_tick),
+            "issuer_id": int(player.player_id),
+            "team": int(player.team),
+        }
+        if command is not None:
+            ack["command"] = command
+        if "target_id" in message:
+            ack["target_id"] = message["target_id"]
+        if "target_kind" in message:
+            ack["target_kind"] = message["target_kind"]
+        if "cell_index" in message:
+            ack["cell_index"] = message["cell_index"]
+        return ack
+
+    def submit_team_command(self, player_id, message):
+        """Admit one fixed #1513 team command for a bounded Bot subset.
+
+        The visible client owns only the command intent.  The server fences
+        its round, sender, target visibility and selected recipients before
+        the native worker's planner sees the resulting short-lived order.
+        """
+        with self.lock:
+            player = self.players.get(player_id)
+            if player is None or not player.connected:
+                return None
+            if (not self._message_round_matches(message) or
+                    not self._combat_accepting() or self.battle_result is not None
+                    or not player.participating or not player.alive):
+                return self._team_command_ack(
+                    player, message, False, "inactive_round")
+            command = message.get("command")
+            if not isinstance(command, str) or command not in TEAM_COMMANDS:
+                return self._team_command_ack(
+                    player, message, False, "unknown_command")
+            base_fields = set(("type", "round_id", "command_seq", "command"))
+            if command in TEAM_COMMAND_ENEMY_TARGETS | TEAM_COMMAND_ALLY_TARGETS:
+                expected_fields = base_fields | set(("target_id", "target_kind"))
+            elif command in TEAM_COMMAND_CELL_TARGETS:
+                expected_fields = base_fields | set(("cell_index",))
+            else:
+                expected_fields = base_fields
+            if set(message) != expected_fields:
+                return self._team_command_ack(
+                    player, message, False, "invalid_shape", command)
+            try:
+                sequence = _exact_int(
+                    message.get("command_seq"), 1, PROJECTILE_MAX_ID)
+            except ValueError:
+                sequence = None
+            if sequence is None:
+                return self._team_command_ack(
+                    player, message, False, "invalid_sequence", command)
+            fingerprint = self._team_command_fingerprint(message)
+            previous = player.team_command_fingerprints.get(sequence)
+            if previous is not None:
+                if previous == fingerprint:
+                    return dict(player.team_command_acks[sequence])
+                return self._team_command_ack(
+                    player, message, False, "sequence_conflict", command)
+            if sequence <= player.team_command_seq:
+                return self._team_command_ack(
+                    player, message, False, "stale_sequence", command)
+
+            bots = self._team_command_bots_locked(player.team)
+            target_id = None
+            target_marker = None
+            if command in TEAM_COMMAND_ENEMY_TARGETS:
+                try:
+                    target_id = _exact_int(
+                        message.get("target_id"), 1, PROJECTILE_MAX_ID)
+                except ValueError:
+                    target_id = None
+                wire_target_kind = message.get("target_kind")
+                if wire_target_kind == "human":
+                    target = self.players.get(target_id)
+                    valid_target = bool(
+                        target is not None and target.connected and
+                        target.participating and target.alive)
+                    target_marker = ("player", target_id)
+                    target_kind = "human"
+                elif wire_target_kind == "bot":
+                    target = self.bot_states.get(target_id)
+                    valid_target = bool(
+                        target is not None and target.get("alive"))
+                    target_marker = ("bot", target_id)
+                    target_kind = "bot"
+                else:
+                    target = None
+                    valid_target = False
+                    target_marker = None
+                if (target_id is None or not valid_target or
+                        int(target.team if wire_target_kind == "human"
+                            else target.get("team", 0)) == player.team):
+                    return self._team_command_ack(
+                        player, message, False, "invalid_enemy", command)
+                if target_marker not in self.player_spotted.get(
+                        player.player_id, frozenset()):
+                    return self._team_command_ack(
+                        player, message, False, "enemy_not_visible", command)
+            elif command in TEAM_COMMAND_ALLY_TARGETS:
+                try:
+                    target_id = _exact_int(
+                        message.get("target_id"), 1, PROJECTILE_MAX_ID)
+                except ValueError:
+                    target_id = None
+                if message.get("target_kind") != "bot":
+                    return self._team_command_ack(
+                        player, message, False, "invalid_ally", command)
+                bots = [bot for bot in bots if bot["id"] == target_id]
+                if not bots:
+                    return self._team_command_ack(
+                        player, message, False, "invalid_ally", command)
+            elif command in TEAM_COMMAND_CELL_TARGETS:
+                try:
+                    cell_index = _exact_int(message.get("cell_index"), 0, 99)
+                except ValueError:
+                    cell_index = None
+                if cell_index is None:
+                    return self._team_command_ack(
+                        player, message, False, "invalid_cell", command)
+            if not bots:
+                return self._team_command_ack(
+                    player, message, False, "no_eligible_bot", command)
+
+            def sort_key(bot):
+                bot_id = bot["id"]
+                sees_target = target_marker in self.bot_spotted.get(
+                    bot_id, frozenset())
+                return (0 if sees_target else 1,
+                        round(math.hypot(float(bot.get("x", 0.0)) - player.x,
+                                         float(bot.get("z", 0.0)) - player.z), 6),
+                        bot_id)
+
+            bots.sort(key=sort_key)
+            recipients = [bot["id"] for bot in bots[:TEAM_COMMAND_MAX_RECIPIENTS]]
+            expires_tick = self.tick + TEAM_COMMAND_TTL_TICKS
+            command_id = "%d:%d:%d" % (
+                self.round_id, player.player_id, sequence)
+            order = {
+                "command_id": command_id,
+                "command_seq": int(sequence),
+                "round_id": int(self.round_id),
+                "command": command,
+                "team": int(player.team),
+                "issuer_id": int(player.player_id),
+                "issued_tick": int(self.tick),
+                "expires_tick": int(expires_tick),
+                "recipient_bot_ids": recipients,
+            }
+            if target_id is not None:
+                order["target_id"] = int(target_id)
+                if command in TEAM_COMMAND_ENEMY_TARGETS:
+                    order["target_kind"] = target_kind
+            if command in TEAM_COMMAND_CELL_TARGETS:
+                order["cell_index"] = int(cell_index)
+            self.team_commands[command_id] = order
+            while len(self.team_commands) > TEAM_COMMAND_HISTORY:
+                unused_id, retired = self.team_commands.popitem(last=False)
+                self._publish_team_command_terminal(
+                    self.players.get(retired['issuer_id']), retired, 'superseded')
+            ack = self._team_command_ack(
+                player, message, True, "accepted", command, recipients,
+                expires_tick)
+            player.team_command_seq = sequence
+            player.team_command_fingerprints[sequence] = fingerprint
+            player.team_command_acks[sequence] = dict(ack)
+            while len(player.team_command_fingerprints) > TEAM_COMMAND_HISTORY:
+                stale_sequence, unused = player.team_command_fingerprints.popitem(
+                    last=False)
+                player.team_command_acks.pop(stale_sequence, None)
+            self._next_bot_planner_tick = min(
+                self._next_bot_planner_tick, self.tick)
+            return ack
 
     @staticmethod
     def _ordinary_bot_burst(fire_seq, shell_index):
@@ -11713,6 +12064,19 @@ class BattleState:
                     "x": round(x, 3), "y": 0.0, "z": round(z, 3),
                 })
             capture_bases[str(team)] = values
+        arena_bounds = None
+        raw_bounds = self._map_rule_data().get("bounds")
+        if isinstance(raw_bounds, (list, tuple)) and len(raw_bounds) == 4:
+            try:
+                min_x, min_z, max_x, max_z = (
+                    float(value) for value in raw_bounds)
+            except (TypeError, ValueError):
+                pass
+            else:
+                if (all(math.isfinite(value) for value in
+                        (min_x, min_z, max_x, max_z)) and
+                        min_x < max_x and min_z < max_z):
+                    arena_bounds = (min_x, min_z, max_x, max_z)
         return {
             "bases": dict((str(team), [dict(point) for point in
                                         self.capture_threat_bases.get(
@@ -11723,6 +12087,7 @@ class BattleState:
                 for team in (1, 2)),
             "contributors": contributors,
             "capture_bases": capture_bases,
+            "arena_bounds": arena_bounds,
         }
 
     def tick_once(self, dt):
@@ -11814,17 +12179,24 @@ class BattleState:
             self._tick_player_drowning(dt)
             self._tick_player_overturn(dt)
             self._expire_projectiles()
+            # Death, a leave, and command expiry may happen between planner
+            # cadences. Prune before deciding whether this tick needs a new
+            # order set, so no stale radio request survives the next frame.
+            if self.team_commands:
+                self._active_team_commands_locked()
             # Observation and damage handlers update planner memory as their
             # messages arrive. Only the full-roster synthesis is throttled;
             # authoritative events and snapshots continue every tick below.
             if (self.battle_result is None and
                     self.tick >= self._next_bot_planner_tick):
+                team_orders = self._active_team_commands_locked()
                 self.bot_orders = self.bot_planner.build_orders(
                     self.bot_manifest, list(self.bot_states.values()),
                     [self._public_player(p, include_outfits=False)
                      for p in self.players.values()
                      if p.connected and p.participating],
-                    time.monotonic(), self._bot_defense_context())
+                    time.monotonic(), self._bot_defense_context(),
+                    team_orders=team_orders)
                 self._next_bot_planner_tick = (
                     self.tick + BOT_PLANNER_INTERVAL_TICKS)
             # Freeze the one current clock sample shared by this tick's durable
@@ -12902,6 +13274,28 @@ class ClientHandler(socketserver.BaseRequestHandler):
                                     "EQUIPMENT INTENT rejected sender=%d seq=%s" % (
                                         player.player_id,
                                         message.get("intent_seq")))
+                        elif message_type == "team_command":
+                            acknowledgement = server.state.submit_team_command(
+                                player.player_id, message)
+                            if acknowledgement is not None:
+                                if acknowledgement.get("accepted"):
+                                    server.state.publish_team_command(
+                                        acknowledgement)
+                                player.send(acknowledgement)
+                            if (acknowledgement is None or
+                                    not acknowledgement.get("accepted")):
+                                _server_log_limited(
+                                    "team-command:%d:%s" % (
+                                        player.player_id,
+                                        acknowledgement.get("code")
+                                        if acknowledgement else "missing"),
+                                    "TEAM COMMAND rejected sender=%d command=%s "
+                                    "seq=%s code=%s" % (
+                                        player.player_id,
+                                        message.get("command"),
+                                        message.get("command_seq"),
+                                        acknowledgement.get("code")
+                                        if acknowledgement else "missing"))
                         elif message_type == "landing_observation":
                             if not server.state.submit_landing_observation(
                                     player.player_id, message):

--- a/server/lan_battle_server.py
+++ b/server/lan_battle_server.py
@@ -193,6 +193,7 @@ ROUND_SCOPED_MESSAGE_TYPES = frozenset((
     "track_repair",
     "equipment_intent",
     "team_command",
+    "team_chat",
 ))
 MODERN_VISIBLE_MESSAGE_TYPES = frozenset((
     "input", "fire_intent", "landing_observation", "start_battle",
@@ -203,6 +204,7 @@ MODERN_VISIBLE_MESSAGE_TYPES = frozenset((
     "track_repair",
     "equipment_intent",
     "team_command",
+    "team_chat",
 ))
 # The elected #1513 authority uses the same bounded in-process manager.  The
 # server must never admit more durable launches than a takeover client can
@@ -218,12 +220,18 @@ PROJECTILE_MAX_LIFETIME_MS = 20000
 PLAYER_FIRE_INTENT_MAX_PENDING = 1
 PLAYER_FIRE_INTENT_HISTORY = 64
 TEAM_COMMAND_HISTORY = 64
+TEAM_CHAT_HISTORY = 64
+# The exact #1513 stock text limit is measured in UTF-16 code units.  Keep the
+# LAN admission finite while preserving every accepted Unicode string unchanged.
+TEAM_CHAT_MAX_CHARACTERS = 140
 TEAM_COMMAND_TTL_TICKS = int(15 * TICK_HZ)
 TEAM_COMMAND_MAX_RECIPIENTS = 2
 TEAM_COMMANDS = frozenset((
     "ATTACK", "BACKTOBASE", "HELPME", "FOLLOWME", "TURNBACK",
     "HELPMEEX", "STOP", "ATTACKENEMY", "SUPPORTMEWITHFIRE",
-    "ATTENTIONTOCELL", "POSITIVE", "NEGATIVE",
+    "ATTENTIONTOCELL", "POSITIVE", "NEGATIVE", "SPG_AIM_AREA",
+    "RELOADINGGUN", "RELOADING_CASSETE", "RELOADING_READY",
+    "RELOADING_READY_CASSETE", "RELOADING_UNAVAILABLE",
 ))
 TEAM_COMMAND_ENEMY_TARGETS = frozenset((
     "ATTACKENEMY", "SUPPORTMEWITHFIRE",
@@ -232,6 +240,13 @@ TEAM_COMMAND_ALLY_TARGETS = frozenset((
     "FOLLOWME", "TURNBACK", "HELPMEEX", "STOP",
 ))
 TEAM_COMMAND_CELL_TARGETS = frozenset(("ATTENTIONTOCELL",))
+TEAM_COMMAND_PURE_BROADCAST = frozenset((
+    "POSITIVE", "NEGATIVE", "SPG_AIM_AREA", "RELOADINGGUN",
+    "RELOADING_CASSETE", "RELOADING_READY", "RELOADING_READY_CASSETE",
+    "RELOADING_UNAVAILABLE",
+))
+TEAM_COMMAND_AIM_POINT_LOW = (-5000.0, -5000.0, -5000.0)
+TEAM_COMMAND_AIM_POINT_HIGH = (5000.0, 5000.0, 5000.0)
 # One trigger-edge presentation entry per live Bot identity (1..30).
 PLAYER_PRESENTATION_LEDGER_FIELDS = frozenset((
     "bot_id", "bot_state_revision", "presentation_time_us"))
@@ -1843,6 +1858,17 @@ class Player(_EndpointSendMixin):
         default_factory=OrderedDict, repr=False)
     team_command_acks: OrderedDict = field(
         default_factory=OrderedDict, repr=False)
+    team_command_publications: OrderedDict = field(
+        default_factory=OrderedDict, repr=False)
+    team_chat_seq: int = 0
+    team_chat_fingerprints: OrderedDict = field(
+        default_factory=OrderedDict, repr=False)
+    team_chat_acks: OrderedDict = field(
+        default_factory=OrderedDict, repr=False)
+    team_chat_teams: OrderedDict = field(
+        default_factory=OrderedDict, repr=False)
+    team_chat_publications: OrderedDict = field(
+        default_factory=OrderedDict, repr=False)
     combat_fire_elapsed: float = 0.0
     combat_fire_timer: float = 0.0
     fire_attacker_kind: str = ""
@@ -2936,6 +2962,12 @@ class BattleState:
             player.team_command_seq = 0
             player.team_command_fingerprints.clear()
             player.team_command_acks.clear()
+            player.team_command_publications.clear()
+            player.team_chat_seq = 0
+            player.team_chat_fingerprints.clear()
+            player.team_chat_acks.clear()
+            player.team_chat_teams.clear()
+            player.team_chat_publications.clear()
             player.combat_fire_elapsed = 0.0
             player.combat_fire_timer = 0.0
             player.fire_attacker_kind = ""
@@ -4674,22 +4706,44 @@ class BattleState:
             command = acknowledgement.get("command")
             if team not in (1, 2) or command not in TEAM_COMMANDS:
                 return False
+            try:
+                issuer_id = _exact_int(acknowledgement.get("issuer_id"),
+                                       1, PROJECTILE_MAX_ID)
+                sequence = _exact_int(acknowledgement.get("command_seq"),
+                                      1, PROJECTILE_MAX_ID)
+            except ValueError:
+                return False
+            issuer = self.players.get(issuer_id)
+            if (issuer is None or not issuer.connected or
+                    not issuer.participating or issuer.team != team or
+                    acknowledgement.get("round_id") != self.round_id):
+                return False
+            fingerprint = issuer.team_command_fingerprints.get(sequence)
+            cached_ack = issuer.team_command_acks.get(sequence)
+            if (fingerprint is None or cached_ack != acknowledgement):
+                return False
+            if issuer.team_command_publications.get(sequence) == fingerprint:
+                return True
             message = {
                 "type": "team_command",
                 "protocol": PROTOCOL_VERSION,
                 "round_id": self.round_id,
-                "command_seq": acknowledgement.get("command_seq"),
+                "command_seq": sequence,
                 "command": command,
-                "issuer_id": acknowledgement.get("issuer_id"),
+                "issuer_id": issuer_id,
                 "team": team,
             }
-            for field in ("target_kind", "target_id", "cell_index"):
+            for field in ("target_kind", "target_id", "cell_index",
+                          "aim_point", "reload_time", "quantity"):
                 if field in acknowledgement:
                     message[field] = acknowledgement[field]
             recipients = tuple(
                 player for player in self.players.values()
                 if player.connected and player.participating and
                 player.team == team)
+            issuer.team_command_publications[sequence] = fingerprint
+            while len(issuer.team_command_publications) > TEAM_COMMAND_HISTORY:
+                issuer.team_command_publications.popitem(last=False)
         for recipient in recipients:
             if not recipient.offer_reliable(message):
                 self.remove_player(recipient.player_id, expected=recipient)
@@ -4710,13 +4764,23 @@ class BattleState:
             result.append(row)
         return result
 
+    def _team_command_bot_identity_locked(self, bot_id):
+        """Return the roster identity for a message target without requiring life."""
+        for identity in self.bot_manifest:
+            try:
+                if int(identity.get("id", 0)) == int(bot_id):
+                    return identity
+            except (AttributeError, TypeError, ValueError):
+                continue
+        return None
+
     def _team_command_ack(self, player, message, accepted, code,
                           command=None, recipients=(), expires_tick=0):
         """Build the one observable terminal receipt for a radio request."""
         ack = {
             "type": "team_command_ack",
             "protocol": PROTOCOL_VERSION,
-            "round_id": self.round_id,
+            "round_id": message.get("round_id"),
             "command_seq": message.get("command_seq"),
             "accepted": bool(accepted),
             "code": str(code),
@@ -4731,24 +4795,46 @@ class BattleState:
             ack["target_id"] = message["target_id"]
         if "target_kind" in message:
             ack["target_kind"] = message["target_kind"]
-        if "cell_index" in message:
-            ack["cell_index"] = message["cell_index"]
+        for field in ("cell_index", "aim_point", "reload_time", "quantity"):
+            if field in message:
+                ack[field] = message[field]
         return ack
 
-    def submit_team_command(self, player_id, message):
-        """Admit one fixed #1513 team command for a bounded Bot subset.
+    def _team_chat_ack(self, player, message, accepted, code):
+        return {
+            "type": "team_chat_ack",
+            "protocol": PROTOCOL_VERSION,
+            "round_id": message.get("round_id"),
+            "chat_seq": message.get("chat_seq"),
+            "accepted": bool(accepted),
+            "code": str(code),
+        }
 
-        The visible client owns only the command intent.  The server fences
-        its round, sender, target visibility and selected recipients before
-        the native worker's planner sees the resulting short-lived order.
+    @staticmethod
+    def _valid_team_chat_text(value):
+        """Bound plain Unicode without reimplementing stock normalization."""
+        if not isinstance(value, str) or not value or not value.strip():
+            return False
+        try:
+            value.encode("utf-8")
+            utf16_units = len(value.encode("utf-16-le")) // 2
+        except UnicodeError:
+            return False
+        return utf16_units <= TEAM_CHAT_MAX_CHARACTERS
+
+    def submit_team_command(self, player_id, message):
+        """Relay a valid stock command and optionally admit a Bot order.
+
+        Team communication is valid independently from whether any Bot can
+        act on it.  Only a living sender's currently actionable request is
+        copied into the planner-owned, short-lived order set.
         """
         with self.lock:
             player = self.players.get(player_id)
             if player is None or not player.connected:
                 return None
             if (not self._message_round_matches(message) or
-                    not self._combat_accepting() or self.battle_result is not None
-                    or not player.participating or not player.alive):
+                    self.phase != "battle" or not player.participating):
                 return self._team_command_ack(
                     player, message, False, "inactive_round")
             command = message.get("command")
@@ -4758,11 +4844,25 @@ class BattleState:
             base_fields = set(("type", "round_id", "command_seq", "command"))
             if command in TEAM_COMMAND_ENEMY_TARGETS | TEAM_COMMAND_ALLY_TARGETS:
                 expected_fields = base_fields | set(("target_id", "target_kind"))
+                if command == "ATTACKENEMY":
+                    expected_fields = expected_fields | set(("reload_time",))
             elif command in TEAM_COMMAND_CELL_TARGETS:
                 expected_fields = base_fields | set(("cell_index",))
+            elif command == "SPG_AIM_AREA":
+                expected_fields = base_fields | set((
+                    "aim_point", "cell_index", "reload_time"))
+            elif command in ("RELOADINGGUN", "RELOADING_CASSETE"):
+                expected_fields = base_fields | set(("reload_time",))
+                if command == "RELOADING_CASSETE":
+                    expected_fields.add("quantity")
+            elif command == "RELOADING_READY_CASSETE":
+                expected_fields = base_fields | set(("quantity",))
             else:
                 expected_fields = base_fields
-            if set(message) != expected_fields:
+            actual_fields = set(message)
+            if (actual_fields != expected_fields and not
+                    (command == "ATTACKENEMY" and
+                     actual_fields == expected_fields - set(("reload_time",)))):
                 return self._team_command_ack(
                     player, message, False, "invalid_shape", command)
             try:
@@ -4784,9 +4884,35 @@ class BattleState:
                 return self._team_command_ack(
                     player, message, False, "stale_sequence", command)
 
-            bots = self._team_command_bots_locked(player.team)
+            live_bots = self._team_command_bots_locked(player.team)
             target_id = None
             target_marker = None
+            target_kind = None
+            if (command in ("SPG_AIM_AREA", "RELOADINGGUN",
+                            "RELOADING_CASSETE") or
+                    (command == "ATTACKENEMY" and
+                     "reload_time" in message)):
+                try:
+                    reload_time = _bounded_float(
+                        message.get("reload_time"), 0.0, 3600.0,
+                        inclusive_low=command in ("ATTACKENEMY", "SPG_AIM_AREA"))
+                except (TypeError, ValueError, OverflowError):
+                    return self._team_command_ack(
+                        player, message, False, "invalid_reload_time", command)
+            if command in ("RELOADING_CASSETE", "RELOADING_READY_CASSETE"):
+                try:
+                    quantity = _exact_int(message.get("quantity"), 1, 255)
+                except (TypeError, ValueError, OverflowError):
+                    return self._team_command_ack(
+                        player, message, False, "invalid_quantity", command)
+            if command == "SPG_AIM_AREA":
+                try:
+                    aim_point = _bounded_vector(
+                        message.get("aim_point"), TEAM_COMMAND_AIM_POINT_LOW,
+                        TEAM_COMMAND_AIM_POINT_HIGH)
+                except (TypeError, ValueError, OverflowError):
+                    return self._team_command_ack(
+                        player, message, False, "invalid_aim_point", command)
             if command in TEAM_COMMAND_ENEMY_TARGETS:
                 try:
                     target_id = _exact_int(
@@ -4798,42 +4924,46 @@ class BattleState:
                     target = self.players.get(target_id)
                     valid_target = bool(
                         target is not None and target.connected and
-                        target.participating and target.alive)
+                        target.participating and target.team != player.team)
                     target_marker = ("player", target_id)
                     target_kind = "human"
                 elif wire_target_kind == "bot":
-                    target = self.bot_states.get(target_id)
+                    target = self._team_command_bot_identity_locked(target_id)
                     valid_target = bool(
-                        target is not None and target.get("alive"))
+                        target is not None and
+                        int(target.get("team", 0)) != player.team)
                     target_marker = ("bot", target_id)
                     target_kind = "bot"
                 else:
                     target = None
                     valid_target = False
                     target_marker = None
-                if (target_id is None or not valid_target or
-                        int(target.team if wire_target_kind == "human"
-                            else target.get("team", 0)) == player.team):
+                if target_id is None or not valid_target:
                     return self._team_command_ack(
                         player, message, False, "invalid_enemy", command)
-                if target_marker not in self.player_spotted.get(
-                        player.player_id, frozenset()):
-                    return self._team_command_ack(
-                        player, message, False, "enemy_not_visible", command)
             elif command in TEAM_COMMAND_ALLY_TARGETS:
                 try:
                     target_id = _exact_int(
                         message.get("target_id"), 1, PROJECTILE_MAX_ID)
                 except ValueError:
                     target_id = None
-                if message.get("target_kind") != "bot":
+                target_kind = message.get("target_kind")
+                if target_kind == "human":
+                    target = self.players.get(target_id)
+                    valid_target = bool(
+                        target is not None and target.connected and
+                        target.participating and target.team == player.team)
+                elif target_kind == "bot":
+                    target = self._team_command_bot_identity_locked(target_id)
+                    valid_target = bool(
+                        target is not None and
+                        int(target.get("team", 0)) == player.team)
+                else:
+                    valid_target = False
+                if target_id is None or not valid_target:
                     return self._team_command_ack(
                         player, message, False, "invalid_ally", command)
-                bots = [bot for bot in bots if bot["id"] == target_id]
-                if not bots:
-                    return self._team_command_ack(
-                        player, message, False, "invalid_ally", command)
-            elif command in TEAM_COMMAND_CELL_TARGETS:
+            elif command in TEAM_COMMAND_CELL_TARGETS or command == "SPG_AIM_AREA":
                 try:
                     cell_index = _exact_int(message.get("cell_index"), 0, 99)
                 except ValueError:
@@ -4841,46 +4971,69 @@ class BattleState:
                 if cell_index is None:
                     return self._team_command_ack(
                         player, message, False, "invalid_cell", command)
-            if not bots:
-                return self._team_command_ack(
-                    player, message, False, "no_eligible_bot", command)
+            recipients = []
+            expires_tick = 0
+            # Social stock calls are presentation-only.  A dead sender can
+            # still communicate, but it cannot direct the hidden worker.
+            can_order = (player.alive and self._combat_accepting() and
+                         self.battle_result is None and
+                         command not in TEAM_COMMAND_PURE_BROADCAST)
+            if can_order and command in TEAM_COMMAND_ENEMY_TARGETS:
+                if target_kind == "human":
+                    target_live = bool(getattr(target, "alive", False))
+                else:
+                    target_live = bool(
+                        self.bot_states.get(target_id, {}).get("alive"))
+                if (not target_live or target_marker not in
+                        self.player_spotted.get(player.player_id, frozenset())):
+                    can_order = False
+            if can_order:
+                bots = list(live_bots)
+                if command in TEAM_COMMAND_ALLY_TARGETS:
+                    bots = (bots if target_kind == "bot" else [])
+                    bots = [bot for bot in bots if bot["id"] == target_id]
 
-            def sort_key(bot):
-                bot_id = bot["id"]
-                sees_target = target_marker in self.bot_spotted.get(
-                    bot_id, frozenset())
-                return (0 if sees_target else 1,
-                        round(math.hypot(float(bot.get("x", 0.0)) - player.x,
-                                         float(bot.get("z", 0.0)) - player.z), 6),
-                        bot_id)
+                def sort_key(bot):
+                    bot_id = bot["id"]
+                    sees_target = target_marker in self.bot_spotted.get(
+                        bot_id, frozenset())
+                    return (0 if sees_target else 1,
+                            round(math.hypot(float(bot.get("x", 0.0)) - player.x,
+                                             float(bot.get("z", 0.0)) - player.z), 6),
+                            bot_id)
 
-            bots.sort(key=sort_key)
-            recipients = [bot["id"] for bot in bots[:TEAM_COMMAND_MAX_RECIPIENTS]]
-            expires_tick = self.tick + TEAM_COMMAND_TTL_TICKS
-            command_id = "%d:%d:%d" % (
-                self.round_id, player.player_id, sequence)
-            order = {
-                "command_id": command_id,
-                "command_seq": int(sequence),
-                "round_id": int(self.round_id),
-                "command": command,
-                "team": int(player.team),
-                "issuer_id": int(player.player_id),
-                "issued_tick": int(self.tick),
-                "expires_tick": int(expires_tick),
-                "recipient_bot_ids": recipients,
-            }
-            if target_id is not None:
-                order["target_id"] = int(target_id)
-                if command in TEAM_COMMAND_ENEMY_TARGETS:
-                    order["target_kind"] = target_kind
-            if command in TEAM_COMMAND_CELL_TARGETS:
-                order["cell_index"] = int(cell_index)
-            self.team_commands[command_id] = order
-            while len(self.team_commands) > TEAM_COMMAND_HISTORY:
-                unused_id, retired = self.team_commands.popitem(last=False)
-                self._publish_team_command_terminal(
-                    self.players.get(retired['issuer_id']), retired, 'superseded')
+                bots.sort(key=sort_key)
+                recipients = [bot["id"]
+                              for bot in bots[:TEAM_COMMAND_MAX_RECIPIENTS]]
+                if recipients:
+                    expires_tick = self.tick + TEAM_COMMAND_TTL_TICKS
+                    command_id = "%d:%d:%d" % (
+                        self.round_id, player.player_id, sequence)
+                    order = {
+                        "command_id": command_id,
+                        "command_seq": int(sequence),
+                        "round_id": int(self.round_id),
+                        "command": command,
+                        "team": int(player.team),
+                        "issuer_id": int(player.player_id),
+                        "issued_tick": int(self.tick),
+                        "expires_tick": int(expires_tick),
+                        "recipient_bot_ids": recipients,
+                    }
+                    if target_id is not None:
+                        order["target_id"] = int(target_id)
+                        if command in TEAM_COMMAND_ENEMY_TARGETS:
+                            order["target_kind"] = target_kind
+                    if command in TEAM_COMMAND_CELL_TARGETS:
+                        order["cell_index"] = int(cell_index)
+                    self.team_commands[command_id] = order
+                    while len(self.team_commands) > TEAM_COMMAND_HISTORY:
+                        unused_id, retired = self.team_commands.popitem(last=False)
+                        self._publish_team_command_terminal(
+                            self.players.get(retired['issuer_id']), retired,
+                            'superseded')
+                    self._next_bot_planner_tick = min(
+                        self._next_bot_planner_tick, self.tick)
             ack = self._team_command_ack(
                 player, message, True, "accepted", command, recipients,
                 expires_tick)
@@ -4891,9 +5044,100 @@ class BattleState:
                 stale_sequence, unused = player.team_command_fingerprints.popitem(
                     last=False)
                 player.team_command_acks.pop(stale_sequence, None)
-            self._next_bot_planner_tick = min(
-                self._next_bot_planner_tick, self.tick)
             return ack
+
+    def submit_team_chat(self, player_id, message):
+        """Admit one plain stock team-chat line without touching battle state."""
+        with self.lock:
+            player = self.players.get(player_id)
+            if player is None or not player.connected:
+                return None
+            if (not self._message_round_matches(message) or
+                    self.phase != "battle" or not player.participating):
+                return self._team_chat_ack(
+                    player, message, False, "inactive_round")
+            if set(message) != set(("type", "round_id", "chat_seq", "text")):
+                return self._team_chat_ack(
+                    player, message, False, "invalid_shape")
+            try:
+                sequence = _exact_int(message.get("chat_seq"), 1,
+                                      PROJECTILE_MAX_ID)
+            except ValueError:
+                sequence = None
+            text = message.get("text")
+            if sequence is None or not self._valid_team_chat_text(text):
+                return self._team_chat_ack(
+                    player, message, False,
+                    "invalid_sequence" if sequence is None else "invalid_text")
+            fingerprint = self._team_command_fingerprint(message)
+            previous = player.team_chat_fingerprints.get(sequence)
+            if previous is not None:
+                if previous == fingerprint:
+                    return dict(player.team_chat_acks[sequence])
+                return self._team_chat_ack(
+                    player, message, False, "sequence_conflict")
+            if sequence <= player.team_chat_seq:
+                return self._team_chat_ack(
+                    player, message, False, "stale_sequence")
+            ack = self._team_chat_ack(player, message, True, "accepted")
+            player.team_chat_seq = sequence
+            player.team_chat_fingerprints[sequence] = fingerprint
+            player.team_chat_acks[sequence] = dict(ack)
+            player.team_chat_teams[sequence] = int(player.team)
+            while len(player.team_chat_fingerprints) > TEAM_CHAT_HISTORY:
+                stale_sequence, unused = player.team_chat_fingerprints.popitem(
+                    last=False)
+                player.team_chat_acks.pop(stale_sequence, None)
+                player.team_chat_teams.pop(stale_sequence, None)
+            return ack
+
+    def publish_team_chat(self, player_id, acknowledgement):
+        """Reliably relay one admitted plain-text message to its sender's team."""
+        with self.lock:
+            if not acknowledgement or not acknowledgement.get("accepted"):
+                return False
+            try:
+                issuer_id = _exact_int(player_id, 1, PROJECTILE_MAX_ID)
+                sequence = _exact_int(acknowledgement.get("chat_seq"), 1,
+                                      PROJECTILE_MAX_ID)
+            except ValueError:
+                return False
+            issuer = self.players.get(issuer_id)
+            if (issuer is None or not issuer.connected or
+                    not issuer.participating or
+                    acknowledgement.get("round_id") != self.round_id):
+                return False
+            fingerprint = issuer.team_chat_fingerprints.get(sequence)
+            cached_ack = issuer.team_chat_acks.get(sequence)
+            team = issuer.team_chat_teams.get(sequence)
+            if (fingerprint is None or cached_ack != acknowledgement or
+                    team not in (1, 2) or issuer.team != team):
+                return False
+            if issuer.team_chat_publications.get(sequence) == fingerprint:
+                return True
+            text = json.loads(fingerprint).get("text")
+            if not isinstance(text, str):
+                return False
+            message = {
+                "type": "team_chat",
+                "protocol": PROTOCOL_VERSION,
+                "round_id": self.round_id,
+                "chat_seq": sequence,
+                "issuer_id": issuer_id,
+                "team": team,
+                "text": text,
+            }
+            recipients = tuple(
+                player for player in self.players.values()
+                if player.connected and player.participating and
+                player.team == team)
+            issuer.team_chat_publications[sequence] = fingerprint
+            while len(issuer.team_chat_publications) > TEAM_CHAT_HISTORY:
+                issuer.team_chat_publications.popitem(last=False)
+        for recipient in recipients:
+            if not recipient.offer_reliable(message):
+                self.remove_player(recipient.player_id, expected=recipient)
+        return True
 
     @staticmethod
     def _ordinary_bot_burst(fire_seq, shell_index):
@@ -13294,6 +13538,26 @@ class ClientHandler(socketserver.BaseRequestHandler):
                                         player.player_id,
                                         message.get("command"),
                                         message.get("command_seq"),
+                                        acknowledgement.get("code")
+                                        if acknowledgement else "missing"))
+                        elif message_type == "team_chat":
+                            acknowledgement = server.state.submit_team_chat(
+                                player.player_id, message)
+                            if acknowledgement is not None:
+                                if acknowledgement.get("accepted"):
+                                    server.state.publish_team_chat(
+                                        player.player_id, acknowledgement)
+                                player.send(acknowledgement)
+                            if (acknowledgement is None or
+                                    not acknowledgement.get("accepted")):
+                                _server_log_limited(
+                                    "team-chat:%d:%s" % (
+                                        player.player_id,
+                                        acknowledgement.get("code")
+                                        if acknowledgement else "missing"),
+                                    "TEAM CHAT rejected sender=%d seq=%s code=%s" % (
+                                        player.player_id,
+                                        message.get("chat_seq"),
                                         acknowledgement.get("code")
                                         if acknowledgement else "missing"))
                         elif message_type == "landing_observation":

--- a/server/server_bot_ai.py
+++ b/server/server_bot_ai.py
@@ -405,9 +405,9 @@ class BotPlanner(object):
             return result
         ordered = sorted(
             (value for value in team_orders if isinstance(value, dict)),
-            key=lambda value: (
-                _integer(value.get("issued_tick")),
-                str(value.get("command_id") or "")))
+            # Stable sorting preserves the server's admission order within a
+            # tick. Lexicographic command IDs put sequence 9 after 10.
+            key=lambda value: _integer(value.get("issued_tick")))
         for raw in ordered:
             command = str(raw.get("command") or "")
             if (command not in TEAM_ORDER_COMMANDS or

--- a/server/server_bot_ai.py
+++ b/server/server_bot_ai.py
@@ -60,6 +60,14 @@ RECENT_ATTACKER_SCORE_BONUS = 140.0
 LOW_HEALTH_BASE_FRACTION = 0.18
 CROSSFIRE_MIN_ANGLE = math.radians(55.0)
 CROSSFIRE_MAX_DISTANCE = 360.0
+TEAM_ORDER_COMMANDS = frozenset((
+    "ATTACK", "BACKTOBASE", "HELPME", "FOLLOWME", "TURNBACK",
+    "HELPMEEX", "STOP", "ATTACKENEMY", "SUPPORTMEWITHFIRE",
+    "ATTENTIONTOCELL", "POSITIVE", "NEGATIVE",
+))
+TEAM_ORDER_ENEMY_COMMANDS = frozenset((
+    "ATTACKENEMY", "SUPPORTMEWITHFIRE",
+))
 
 
 def _number(value, default=0.0):
@@ -248,6 +256,10 @@ class BotPlanner(object):
             previous = self._contacts[observing_team].get(contact_key)
             if visible:
                 position = _point(raw)
+                threatened = raw.get("threatened_bot_ids")
+                threatened = (self._bot_id_list(threatened)
+                              if isinstance(threatened, (list, tuple))
+                              else None)
                 self._contacts[observing_team][contact_key] = {
                     "id": target_id,
                     "target_kind": target_kind,
@@ -261,10 +273,14 @@ class BotPlanner(object):
                     "armor": max(0.0, _number(raw.get("armor"), 0.0)),
                     "shootable_by_bot_ids": self._bot_id_list(
                         raw.get("shootable_by_bot_ids")),
+                    # Positive incoming-fire evidence. None means this pair
+                    # was not sampled; an empty list is still not a global
+                    # proof that the team is safe.
+                    "threatened_bot_ids": threatened,
                 }
                 accepted += 1
                 if accepted_visibility is not None:
-                    accepted_visibility.append({
+                    accepted_contact = {
                         "observing_team": observing_team,
                         "target_kind": target_kind,
                         "target_id": target_id,
@@ -278,10 +294,15 @@ class BotPlanner(object):
                             raw.get("visible_by_player_ids")),
                         "shootable_by_bot_ids": self._bot_id_list(
                             raw.get("shootable_by_bot_ids")),
-                    })
+                    }
+                    if threatened is not None:
+                        accepted_contact["threatened_bot_ids"] = list(
+                            threatened)
+                    accepted_visibility.append(accepted_contact)
             elif previous is not None:
                 previous["visible"] = False
                 previous["shootable_by_bot_ids"] = []
+                previous["threatened_bot_ids"] = []
                 accepted += 1
                 if accepted_visibility is not None:
                     accepted_visibility.append({
@@ -295,6 +316,7 @@ class BotPlanner(object):
                         "visible_by_bot_ids": [],
                         "visible_by_player_ids": [],
                         "shootable_by_bot_ids": [],
+                        "threatened_bot_ids": [],
                     })
         return accepted
 
@@ -374,8 +396,218 @@ class BotPlanner(object):
             accepted += 1
         return accepted
 
+    @staticmethod
+    def _team_orders_by_bot(team_orders, bots):
+        """Index the newest structurally live server-admitted order per Bot."""
+        live = dict((bot["id"], bot) for bot in bots)
+        result = {}
+        if not isinstance(team_orders, (list, tuple)):
+            return result
+        ordered = sorted(
+            (value for value in team_orders if isinstance(value, dict)),
+            key=lambda value: (
+                _integer(value.get("issued_tick")),
+                str(value.get("command_id") or "")))
+        for raw in ordered:
+            command = str(raw.get("command") or "")
+            if (command not in TEAM_ORDER_COMMANDS or
+                    _integer(raw.get("expires_tick")) <=
+                    _integer(raw.get("issued_tick"))):
+                continue
+            recipients = raw.get("recipient_bot_ids")
+            if not isinstance(recipients, (list, tuple)):
+                continue
+            for raw_bot_id in recipients:
+                bot_id = _integer(raw_bot_id)
+                bot = live.get(bot_id)
+                if (bot is None or
+                        bot["team"] != _integer(raw.get("team"))):
+                    continue
+                result[bot_id] = dict(raw)
+        return result
+
+    @staticmethod
+    def _team_order_focus(team_order, bot, contacts):
+        if (not isinstance(team_order, dict) or
+                team_order.get("command") not in
+                TEAM_ORDER_ENEMY_COMMANDS):
+            return None
+        target_kind = str(team_order.get("target_kind") or "")
+        if target_kind == "player":
+            target_kind = "human"
+        target_id = _integer(team_order.get("target_id"))
+        for contact in contacts or ():
+            if ((str(contact.get("target_kind") or ""),
+                 _integer(contact.get("id"))) !=
+                    (target_kind, target_id)):
+                continue
+            if (contact.get("visible") and
+                    bot["id"] in (contact.get(
+                        "shootable_by_bot_ids") or ()) and
+                    BotPlanner._weapon_can_recover(bot)):
+                return contact
+        return None
+
+    @staticmethod
+    def _mark_flank_suppressors(assignments, bots):
+        """Fence each local flank group with an assigned covering shooter."""
+        bot_by_id = dict((bot["id"], bot) for bot in bots)
+        groups = {}
+        for bot_id, contact in assignments.items():
+            bot = bot_by_id.get(bot_id)
+            if (bot is None or contact.get("movement_lease") or
+                    not BotPlanner._weapon_ready(bot)):
+                continue
+            key = (str(contact.get("target_kind") or ""),
+                   _integer(contact.get("id")))
+            groups.setdefault(key, []).append(bot)
+        result = dict(assignments)
+        for key, shooters in groups.items():
+            if len(shooters) < 2:
+                continue
+            contact = assignments[shooters[0]["id"]]
+            tx = _number(contact.get("position", {}).get("x"))
+            tz = _number(contact.get("position", {}).get("z"))
+
+            def hold_key(ally):
+                profile = ally.get("profile") if isinstance(
+                    ally.get("profile"), dict) else {}
+                roles = profile.get("roles") if isinstance(
+                    profile.get("roles"), dict) else {}
+                state = ally.get("state") if isinstance(
+                    ally.get("state"), dict) else {}
+                return (_number(roles.get("flanker")), math.hypot(
+                    _number(state.get("x")) - tx,
+                    _number(state.get("z")) - tz), ally["id"])
+
+            suppressor_id = min(shooters, key=hold_key)["id"]
+            assigned_ids = [ally["id"] for ally in shooters]
+            for ally in shooters:
+                marked = dict(result[ally["id"]])
+                marked["assigned_shooter_ids"] = list(assigned_ids)
+                marked["flank_suppressor_bot_ids"] = [suppressor_id]
+                result[ally["id"]] = marked
+        return result
+
+    @staticmethod
+    def _apply_team_order(order, bot, team_order, players, defense):
+        """Overlay one admitted radio intent without inventing target data."""
+        if not isinstance(team_order, dict):
+            return order
+        command = str(team_order.get("command") or "")
+        if command not in TEAM_ORDER_COMMANDS:
+            return order
+        order["team_command_id"] = str(team_order.get("command_id") or "")
+        order["team_command"] = command
+        if "cell_index" in team_order:
+            order["team_command_cell_index"] = _integer(
+                team_order.get("cell_index"))
+
+        # Radio intent cannot cancel an already selected local survival action
+        # or an urgent base response. The command remains visible in the order
+        # so its bounded admission is observable without claiming execution.
+        protected_modes = (
+            "base_defense", "low_health_retreat", "low_health_defend",
+            "under_fire_withdraw", "under_fire_hold",
+            "crossfire_withdraw", "crossfire_hold", "take_cover",
+            "cover_hold", "cover_peek", "cover_return", "withdraw",
+        )
+        if order.get("combat_mode") in protected_modes:
+            return order
+
+        state = bot.get("state") if isinstance(bot.get("state"), dict) else {}
+        if command == "STOP":
+            order["combat_mode"] = "team_stop"
+            order["move_position"] = _point(state)
+            order["throttle_override"] = 0.0
+            return order
+        if command == "TURNBACK":
+            order["combat_mode"] = "team_turnback"
+            order["move_position"] = dict(order["route_anchor"])
+            order["face_position"] = dict(order["route_anchor"])
+            order["throttle_override"] = None
+            return order
+        if command == "BACKTOBASE":
+            bases = (defense.get("capture_bases")
+                     if isinstance(defense, dict) else None)
+            points = BotPlanner._defense_points(bases, bot["team"])
+            if points:
+                base = min(points, key=lambda value: math.hypot(
+                    value["point"]["x"] - _number(state.get("x")),
+                    value["point"]["z"] - _number(state.get("z"))))
+                order["combat_mode"] = "team_back_to_base"
+                order["move_position"] = dict(base["point"])
+                order["face_position"] = dict(base["point"])
+                order["throttle_override"] = None
+            return order
+        if command == "ATTENTIONTOCELL":
+            raw_bounds = (defense.get("arena_bounds")
+                          if isinstance(defense, dict) else None)
+            try:
+                bounds = tuple(float(value) for value in raw_bounds)
+            except (TypeError, ValueError, OverflowError):
+                bounds = ()
+            cell_index = team_order.get("cell_index")
+            if (len(bounds) == 4 and
+                    all(math.isfinite(value) for value in bounds) and
+                    bounds[0] < bounds[2] and bounds[1] < bounds[3] and
+                    isinstance(cell_index, int) and
+                    not isinstance(cell_index, bool) and
+                    0 <= cell_index <= 99):
+                column, row = divmod(cell_index, 10)
+                cell_width = (bounds[2] - bounds[0]) / 10.0
+                cell_height = (bounds[3] - bounds[1]) / 10.0
+                cell_min_x = bounds[0] + column * cell_width
+                cell_max_x = cell_min_x + cell_width
+                cell_max_z = bounds[3] - row * cell_height
+                cell_min_z = cell_max_z - cell_height
+                point = {
+                    "x": round((cell_min_x + cell_max_x) * 0.5, 3),
+                    # The worker's navigator resolves terrain. Preserve the
+                    # current live altitude instead of guessing target ground.
+                    "y": round(_number(state.get("y")), 3),
+                    "z": round((cell_min_z + cell_max_z) * 0.5, 3),
+                }
+                order["combat_mode"] = "team_attention_cell"
+                order["move_position"] = point
+                order["move_area_bounds"] = [
+                    round(cell_min_x, 3), round(cell_min_z, 3),
+                    round(cell_max_x, 3), round(cell_max_z, 3),
+                ]
+                order["face_position"] = dict(point)
+                order["throttle_override"] = None
+            return order
+        if command in ("HELPME", "HELPMEEX", "FOLLOWME"):
+            issuer_id = _integer(team_order.get("issuer_id"))
+            issuer = next((value for value in (players or ())
+                           if _integer(value.get("id")) == issuer_id and
+                           _integer(value.get("team")) == bot["team"] and
+                           value.get("alive", True) and
+                           value.get("world_pose") is True), None)
+            if issuer is not None:
+                point = _point(issuer)
+                # A tactical escort keeps room for both hulls instead of
+                # continually asking the driver to occupy the human's centre.
+                recipients = team_order.get("recipient_bot_ids") or [bot["id"]]
+                slot = recipients.index(bot["id"]) if bot["id"] in recipients else 0
+                lateral = (slot - (len(recipients) - 1) * 0.5) * 12.0
+                yaw = _number(issuer.get("yaw"))
+                point["x"] += -math.sin(yaw) * 18.0 + math.cos(yaw) * lateral
+                point["z"] += -math.cos(yaw) * 18.0 - math.sin(yaw) * lateral
+                order["combat_mode"] = "team_follow"
+                order["move_position"] = point
+                order["face_position"] = dict(point)
+                order["throttle_override"] = None
+            return order
+        if command == "ATTACK" and order.get("target_id") is None:
+            order["combat_mode"] = "team_attack"
+        # Enemy-target commands retain the ordinary locally proved target and
+        # firing checks. Cell and social commands remain explicit markers for
+        # the worker/UI until a validated world point or response exists.
+        return order
+
     def build_orders(self, manifest, bot_states, players, now,
-                     defense=None):
+                     defense=None, team_orders=None):
         known_targets = self.known_targets(bot_states, players)
         contacts = self._prune_contacts(known_targets, now)
         bots = self._alive_bots(manifest, bot_states)
@@ -387,6 +619,7 @@ class BotPlanner(object):
                          for team in (1, 2))
         capture_targets = dict((team, self._capture_target(defense, team))
                                for team in (1, 2))
+        team_order_by_bot = self._team_orders_by_bot(team_orders, bots)
         orders = []
         for team in (1, 2):
             team_bots = sorted((bot for bot in bots if bot["team"] == team),
@@ -401,6 +634,14 @@ class BotPlanner(object):
             assignments = self._prioritize_base_invaders(
                 team, team_bots, contacts[team], assignments,
                 defenders.get(team, {}), defense)
+            for bot in team_bots:
+                commanded_focus = self._team_order_focus(
+                    team_order_by_bot.get(bot["id"]), bot, contacts[team])
+                if (commanded_focus is not None and
+                        bot["id"] not in defenders.get(team, {})):
+                    assignments[bot["id"]] = commanded_focus
+            assignments = self._mark_flank_suppressors(
+                assignments, team_bots)
             for index, bot in enumerate(team_bots):
                 order = self._order_for(
                     bot, index, len(team_bots), assignments.get(bot["id"]),
@@ -408,7 +649,9 @@ class BotPlanner(object):
                     defenders.get(team, {}).get(bot["id"]), team_axis,
                     team_bots, capture_targets[team],
                     not bool(contacts[team]) and bot["id"] in capture_ids)
-                base = defenders.get(team, {}).get(bot["id"])
+                self._apply_team_order(
+                    order, bot, team_order_by_bot.get(bot["id"]),
+                    players, defense)
                 orders.append(order)
         orders.sort(key=lambda value: value["id"])
         payload = {"orders": orders}
@@ -599,6 +842,33 @@ class BotPlanner(object):
                         (critical.get("destroyed") or ()))
         return not destroyed.intersection((
             "engineHealth", "leftTrackHealth", "rightTrackHealth"))
+
+    @staticmethod
+    def _route_donor_eligible(bot):
+        """Require current pose and mobility for a route reassignment."""
+        state = bot.get("state") if isinstance(bot.get("state"), dict) else {}
+        if state.get("world_pose") is not True:
+            return False
+        critical = state.get("critical")
+        critical = critical if isinstance(critical, dict) else {}
+        destroyed = set(str(value) for value in
+                        (critical.get("destroyed") or ()))
+        return not destroyed.intersection((
+            "engineHealth", "leftTrackHealth", "rightTrackHealth"))
+
+    @staticmethod
+    def _route_line_contributor(bot, contacts):
+        """Count mobility, or proved fire from an immobilized line holder."""
+        if BotPlanner._route_donor_eligible(bot):
+            return True
+        state = bot.get("state") if isinstance(bot.get("state"), dict) else {}
+        if (state.get("world_pose") is not True or
+                not BotPlanner._weapon_ready(bot)):
+            return False
+        return any(
+            contact.get("visible") and
+            bot["id"] in (contact.get("shootable_by_bot_ids") or ())
+            for contact in (contacts or ()))
 
     @staticmethod
     def _defense_points(raw, team):
@@ -1030,6 +1300,62 @@ class BotPlanner(object):
         return limit
 
     @staticmethod
+    def _selected_shell_damage(bot, contact):
+        """Return nominal damage for the descriptor-backed selected round."""
+        profile = bot.get("profile") if isinstance(
+            bot.get("profile"), dict) else {}
+        shells = profile.get("shells")
+        if not isinstance(shells, list) or not shells:
+            return None
+        state = bot.get("state") if isinstance(bot.get("state"), dict) else {}
+        shell_index = BotPlanner._shell_index(
+            profile, contact, BotPlanner._personality(bot["id"]), state)
+        for shell in shells:
+            if _integer(shell.get("index"), -1) != shell_index:
+                continue
+            damage = _number(shell.get("damage"), -1.0)
+            return damage if damage > 0.0 else None
+        return None
+
+    @staticmethod
+    def _reserve_focus(reservations, key, bot, contact):
+        reservation = reservations.setdefault(key, {
+            "count": 0,
+            "nominal_damage": 0.0,
+            "smallest_shot": None,
+            "unknown_damage": False,
+        })
+        damage = BotPlanner._selected_shell_damage(bot, contact)
+        reservation["count"] += 1
+        if damage is None:
+            reservation["unknown_damage"] = True
+            return
+        reservation["nominal_damage"] += damage
+        smallest = reservation.get("smallest_shot")
+        reservation["smallest_shot"] = (
+            damage if smallest is None else min(_number(smallest), damage))
+
+    @staticmethod
+    def _focus_saturated(reservations, key, contact, distance):
+        reservation = reservations.get(key)
+        if not isinstance(reservation, dict):
+            return False
+        count = max(0, _integer(reservation.get("count")))
+        if distance <= CLOSE_THREAT_DISTANCE:
+            return count >= BotPlanner._focus_limit(contact, distance)
+        if reservation.get("unknown_damage"):
+            return count >= BotPlanner._focus_limit(contact, distance)
+        smallest = reservation.get("smallest_shot")
+        if smallest is None or count < 2:
+            return False
+        # Descriptor damage is nominal and the live roll is random. Reserve
+        # one complete additional shot instead of treating the nominal sum as
+        # a guaranteed kill. Projectile physics remains owned by the worker.
+        covered_damage = (_number(reservation.get("nominal_damage")) -
+                          _number(smallest))
+        return covered_damage >= max(1.0, _number(contact.get("health"), 1.0))
+
+    @staticmethod
     def _engagement_range(bot, contact):
         """Keep nearby combat primary without pulling an entire team off-route."""
         profile = bot.get("profile") if isinstance(bot.get("profile"), dict) else {}
@@ -1152,14 +1478,17 @@ class BotPlanner(object):
 
     @staticmethod
     def _ally_support_score(bot, team_bots, focus):
-        """Return nearby and forward ally support on a normalized scale."""
+        """Return nearby support which can currently fire on this contact."""
         bx = _number(bot["state"].get("x"))
         bz = _number(bot["state"].get("z"))
         tx = _number(focus.get("position", {}).get("x"))
         tz = _number(focus.get("position", {}).get("z"))
+        shooters = set(_integer(value) for value in
+                       (focus.get("shootable_by_bot_ids") or ()))
         score = 0.0
         for ally in team_bots or ():
-            if ally["id"] == bot["id"]:
+            if (ally["id"] == bot["id"] or ally["id"] not in shooters or
+                    not BotPlanner._weapon_ready(ally)):
                 continue
             state = ally.get("state") if isinstance(
                 ally.get("state"), dict) else {}
@@ -1180,14 +1509,14 @@ class BotPlanner(object):
 
     @staticmethod
     def _crossfire_risk(bot, contacts):
-        """Estimate multi-direction exposure from current visible headings."""
+        """Estimate exposure only from explicit enemy-to-bot firing lanes."""
         bx = _number(bot["state"].get("x"))
         bz = _number(bot["state"].get("z"))
         bearings = []
         for contact in contacts:
             if (not contact.get("visible") or
-                    bot["id"] not in contact.get(
-                        "shootable_by_bot_ids", ())):
+                    bot["id"] not in (
+                        contact.get("threatened_bot_ids", ()) or ())):
                 continue
             dx = _number(contact.get("position", {}).get("x")) - bx
             dz = _number(contact.get("position", {}).get("z")) - bz
@@ -1195,6 +1524,9 @@ class BotPlanner(object):
             if distance <= 1.0 or distance > CROSSFIRE_MAX_DISTANCE:
                 continue
             bearings.append(math.atan2(dx, dz))
+        if len(bearings) < 2:
+            # Unknown and incomplete pair sampling is not evidence of safety.
+            return None
         best = 0.0
         for first_index, first in enumerate(bearings):
             for second in bearings[first_index + 1:]:
@@ -1472,10 +1804,10 @@ class BotPlanner(object):
                 continue
             contact = previous_candidate[2]
             key = (contact.get("target_kind"), contact["id"])
-            if reservations.get(key, 0) >= self._focus_limit(
-                    contact, previous_candidate[3]):
+            if self._focus_saturated(
+                    reservations, key, contact, previous_candidate[3]):
                 continue
-            reservations[key] = reservations.get(key, 0) + 1
+            self._reserve_focus(reservations, key, bot, contact)
             assigned[bot["id"]] = contact
             if lease_expired:
                 previous["until"] = _number(now) + TARGET_LEASE_SECONDS
@@ -1485,10 +1817,10 @@ class BotPlanner(object):
             if bot["id"] in assigned:
                 continue
             key = (contact.get("target_kind"), contact["id"])
-            if reservations.get(key, 0) >= self._focus_limit(
-                    contact, distance):
+            if self._focus_saturated(
+                    reservations, key, contact, distance):
                 continue
-            reservations[key] = reservations.get(key, 0) + 1
+            self._reserve_focus(reservations, key, bot, contact)
             assigned[bot["id"]] = contact
             self._target_assignments[bot["id"]] = {
                 "target": key,
@@ -1728,6 +2060,8 @@ class BotPlanner(object):
         for bot in bots:
             if str(bot.get("profile", {}).get("class_tag") or "") == "SPG":
                 continue
+            if not self._route_line_contributor(bot, contacts):
+                continue
             assignment = self._route_assignments.get(bot["id"], {})
             route = assignment.get("route") if isinstance(assignment, dict) else None
             if not isinstance(route, dict):
@@ -1759,6 +2093,10 @@ class BotPlanner(object):
             if bot["id"] in protected_ids:
                 continue
             if str(bot.get("profile", {}).get("class_tag") or "") == "SPG":
+                continue
+            # An immobilized tank may still hold a firing lane, so it remains
+            # in counts above. It cannot satisfy a movement reassignment.
+            if not self._route_donor_eligible(bot):
                 continue
             assignment = self._route_assignments.get(bot["id"], {})
             current = assignment.get("route") if isinstance(assignment, dict) else None
@@ -1923,7 +2261,46 @@ class BotPlanner(object):
         return _point(waypoints[max(0, index - 1)])
 
     @staticmethod
-    def _flank_point(bot, contact, desired_range):
+    def _flank_shooters(contact, team_bots):
+        shooter_ids = set(_integer(value) for value in
+                          (contact.get("shootable_by_bot_ids") or ()))
+        assigned_ids = contact.get("assigned_shooter_ids")
+        if isinstance(assigned_ids, (list, tuple)):
+            shooter_ids.intersection_update(
+                _integer(value) for value in assigned_ids)
+        return [ally for ally in (team_bots or ())
+                if ally["id"] in shooter_ids and
+                BotPlanner._weapon_ready(ally)]
+
+    @staticmethod
+    def _should_flank(bot, contact, team_bots):
+        """Keep a firing element in place and move only half the shooters."""
+        shooters = BotPlanner._flank_shooters(contact, team_bots)
+        if len(shooters) < 2:
+            return False
+        if bot["id"] in (contact.get("flank_suppressor_bot_ids") or ()):
+            return False
+        candidates = []
+        for ally in shooters:
+            profile = ally.get("profile") if isinstance(
+                ally.get("profile"), dict) else {}
+            roles = profile.get("roles") if isinstance(
+                profile.get("roles"), dict) else {}
+            initiative = BotPlanner._personality(ally["id"])["initiative"]
+            flanker = _number(roles.get("flanker"))
+            if flanker < 0.68 or initiative <= 0.42:
+                continue
+            candidates.append((flanker, initiative, -ally["id"], ally["id"]))
+        if not candidates:
+            return False
+        moving_count = max(1, len(shooters) // 2)
+        moving_ids = set(value[-1] for value in
+                         sorted(candidates, reverse=True)[:moving_count])
+        return bot["id"] in moving_ids and len(moving_ids) < len(shooters)
+
+    @staticmethod
+    def _flank_point(bot, contact, desired_range, team_bots=None):
+        """Choose the side which opens the widest angle from current guns."""
         bx = _number(bot["state"].get("x"))
         bz = _number(bot["state"].get("z"))
         tx = contact["position"]["x"]
@@ -1931,12 +2308,32 @@ class BotPlanner(object):
         dx, dz = bx - tx, bz - tz
         length = math.hypot(dx, dz) or 1.0
         dx, dz = dx / length, dz / length
-        side = -1.0 if bot["id"] % 2 else 1.0
-        return _point({
-            "x": tx + dx * desired_range * 0.72 + dz * min(95.0, desired_range * 0.38) * side,
-            "y": contact["position"].get("y", 0.0),
-            "z": tz + dz * desired_range * 0.72 - dx * min(95.0, desired_range * 0.38) * side,
-        })
+        offset = min(95.0, desired_range * 0.38)
+        candidates = []
+        for side in (-1.0, 1.0):
+            point = _point({
+                "x": tx + dx * desired_range * 0.72 + dz * offset * side,
+                "y": contact["position"].get("y", 0.0),
+                "z": tz + dz * desired_range * 0.72 - dx * offset * side,
+            })
+            bearing = math.atan2(point["x"] - tx, point["z"] - tz)
+            separations = []
+            for ally in BotPlanner._flank_shooters(contact, team_bots):
+                if ally["id"] == bot["id"]:
+                    continue
+                state = ally.get("state") if isinstance(
+                    ally.get("state"), dict) else {}
+                ally_dx = _number(state.get("x")) - tx
+                ally_dz = _number(state.get("z")) - tz
+                if math.hypot(ally_dx, ally_dz) <= 1.0:
+                    continue
+                ally_bearing = math.atan2(ally_dx, ally_dz)
+                separations.append(abs(
+                    (bearing - ally_bearing + math.pi) %
+                    (math.pi * 2.0) - math.pi))
+            angle = min(separations) if separations else 0.0
+            candidates.append((angle, -side, point))
+        return max(candidates, key=lambda value: value[:2])[2]
 
     @staticmethod
     def _shell_index(profile, contact, personality, state=None):
@@ -2489,7 +2886,8 @@ class BotPlanner(object):
                 order, bot, profile, personality)
             return order
 
-        if crossfire_risk >= 0.35 and support_score < 0.70:
+        if (crossfire_risk is not None and crossfire_risk >= 0.35 and
+                support_score < 0.70):
             self._engage_anchors.pop(bot["id"], None)
             self._combat_states.pop(bot["id"], None)
             if (distance <= fire_range * 1.15 and
@@ -2534,6 +2932,16 @@ class BotPlanner(object):
             return order
 
         self._retreat_states.pop(bot["id"], None)
+        if (distance > close_limit and distance <= fire_range and
+                self._should_flank(bot, focus, team_bots or ())):
+            self._engage_anchors.pop(bot["id"], None)
+            self._combat_states.pop(bot["id"], None)
+            self._cover_states.pop(bot["id"], None)
+            order["combat_mode"] = "flank"
+            order["move_position"] = self._flank_point(
+                bot, focus, desired_range, team_bots or ())
+            order["throttle_override"] = 0.78
+            return order
         advance_score = (
             personality["aggression"] * 0.85 +
             personality["initiative"] * 0.30 +
@@ -2604,11 +3012,6 @@ class BotPlanner(object):
                 self._engage_anchors[bot["id"]] = anchor_state
             order["move_position"] = dict(anchor_state["position"])
             order["throttle_override"] = 0.0
-        elif roles.get("flanker", 0.0) >= 0.68 and personality["initiative"] > 0.42:
-            self._engage_anchors.pop(bot["id"], None)
-            order["combat_mode"] = "flank"
-            order["move_position"] = self._flank_point(bot, focus, desired_range)
-            order["throttle_override"] = 0.78
         else:
             order["combat_mode"] = "engage"
             target_key = (focus.get("target_kind"), focus["id"])

--- a/server/server_bot_ai.py
+++ b/server/server_bot_ai.py
@@ -51,6 +51,7 @@ CLOSE_THREAT_FOCUS_LIMIT = 4
 ROUTE_REBALANCE_SECONDS = 4.0
 ROUTE_LEASE_SECONDS = 6.0
 MAX_BASE_DEFENDERS = 3
+BASE_DEFENSE_RELEASE_SECONDS = 3.0
 MAX_BASE_CAPTURERS = 3
 CAPTURE_STAGING_RADIUS = 30.0
 MIN_ROUTE_CLASS_AFFINITY = 0.20
@@ -518,7 +519,10 @@ class BotPlanner(object):
             if bot_id not in live_bots:
                 del self._artillery_anchors[bot_id]
         for bot_id, hit in list(self._recent_hits.items()):
+            attacker = (known_targets.get(hit.get("attacker"))
+                        if isinstance(hit, dict) else None)
             if (bot_id not in live_bots or not isinstance(hit, dict) or
+                    attacker is None or not attacker.get("alive") or
                     _number(now) - _number(hit.get("reported_at")) >
                     RECENT_HIT_SECONDS):
                 del self._recent_hits[bot_id]
@@ -648,6 +652,49 @@ class BotPlanner(object):
             return (0, eta + diversion, eta, bot["id"])
         return (1, eta - deadline, eta + diversion, bot["id"])
 
+    @staticmethod
+    def _defense_contributor_keys(defense, team):
+        if not isinstance(defense, dict):
+            return set()
+        contributor_map = defense.get("contributors")
+        contributor_map = (contributor_map
+                           if isinstance(contributor_map, dict) else {})
+        raw = contributor_map.get(str(team), contributor_map.get(team, ()))
+        result = set()
+        if not isinstance(raw, (list, tuple)):
+            return result
+        for value in raw:
+            if not isinstance(value, dict):
+                continue
+            kind = str(value.get("kind") or "")
+            vehicle_id = _integer(value.get("id"))
+            if kind in ("human", "bot") and vehicle_id > 0:
+                result.add((kind, vehicle_id))
+        return result
+
+    @staticmethod
+    def _defense_retention_key(bot, point, contacts, contributor_keys):
+        """Prefer an arrived responder which can stop the current capture."""
+        state = bot["state"]
+        distance = math.hypot(
+            point["x"] - _number(state.get("x")),
+            point["z"] - _number(state.get("z")))
+        can_engage = False
+        if (distance <= ROUTE_ARRIVAL_RADIUS and
+                BotPlanner._weapon_ready(bot)):
+            for contact in contacts or ():
+                key = (str(contact.get("target_kind") or ""),
+                       _integer(contact.get("id")))
+                if (key in contributor_keys and contact.get("visible") and
+                        bot["id"] in contact.get(
+                            "shootable_by_bot_ids", ())):
+                    can_engage = True
+                    break
+        speed = _number(bot.get("profile", {}).get("speed"))
+        cruise = _clamp(speed * 0.65, 4.0, 22.0)
+        eta = 3.0 + distance * 1.30 / cruise
+        return (0 if can_engage else 1, eta, bot["id"])
+
     def _update_base_defense(self, bots, contacts, defense, now):
         """Keep a small, stable responder group while an own base is invaded."""
         if not isinstance(defense, dict):
@@ -673,21 +720,23 @@ class BotPlanner(object):
             raw_state = raw_state if isinstance(raw_state, dict) else {}
             invaders = max(0, _integer(raw_state.get("invaders")))
             points = self._defense_points(bases, team)
+            contributor_keys = self._defense_contributor_keys(
+                defense, team)
             reserve_limit = (1 if len(live) == 1 else
                              max(0, len(live) - 1))
             if len(responders) > reserve_limit:
-                deadline = max(
-                    0.0, _number(raw_state.get("time_left")) - 2.0)
                 ranked = sorted(
-                    responders, key=lambda bot_id: self._defense_eta(
+                    responders, key=lambda bot_id:
+                    self._defense_retention_key(
                         live[bot_id], responders[bot_id]["point"],
-                        contacts.get(team, ()), deadline))
+                        contacts.get(team, ()), contributor_keys))
                 keep = set(ranked[:reserve_limit])
                 for bot_id in list(responders):
                     if bot_id not in keep:
                         del responders[bot_id]
 
             if invaders <= 0:
+                incident["release_since"] = None
                 if not responders:
                     incident["clear_since"] = None
                     incident["need"] = 0
@@ -709,8 +758,33 @@ class BotPlanner(object):
                     desired = 1
                 else:
                     desired = 0
-                incident["need"] = max(
-                    _integer(incident.get("need")), desired)
+                previous_need = max(
+                    0, _integer(incident.get("need")))
+                if desired >= previous_need:
+                    incident["need"] = desired
+                    incident["release_since"] = None
+                else:
+                    release_since = incident.get("release_since")
+                    if release_since is None:
+                        incident["release_since"] = _number(now)
+                    elif (_number(now) - _number(release_since) >=
+                          BASE_DEFENSE_RELEASE_SECONDS):
+                        incident["need"] = max(
+                            desired, previous_need - 1)
+                        incident["release_since"] = _number(now)
+
+                keep_limit = min(
+                    _integer(incident.get("need")), reserve_limit)
+                if len(responders) > keep_limit:
+                    ranked = sorted(
+                        responders, key=lambda bot_id:
+                        self._defense_retention_key(
+                            live[bot_id], responders[bot_id]["point"],
+                            contacts.get(team, ()), contributor_keys))
+                    keep = set(ranked[:keep_limit])
+                    for bot_id in list(responders):
+                        if bot_id not in keep:
+                            del responders[bot_id]
 
                 point_by_id = dict((value["id"], value) for value in points)
                 for bot_id, record in list(responders.items()):
@@ -894,19 +968,7 @@ class BotPlanner(object):
                                   defenders, defense):
         if not defenders or not isinstance(defense, dict):
             return assignments
-        contributor_map = defense.get("contributors")
-        contributor_map = (contributor_map
-                           if isinstance(contributor_map, dict) else {})
-        raw = contributor_map.get(str(team), contributor_map.get(team, ()))
-        contributor_keys = set()
-        if isinstance(raw, (list, tuple)):
-            for value in raw:
-                if not isinstance(value, dict):
-                    continue
-                kind = str(value.get("kind") or "")
-                vehicle_id = _integer(value.get("id"))
-                if kind in ("human", "bot") and vehicle_id > 0:
-                    contributor_keys.add((kind, vehicle_id))
+        contributor_keys = self._defense_contributor_keys(defense, team)
         if not contributor_keys:
             return assignments
         result = dict(assignments)
@@ -1000,6 +1062,82 @@ class BotPlanner(object):
             self._recent_hits.pop(_integer(bot_id), None)
             return None
         return hit
+
+    @staticmethod
+    def _weapon_can_recover(bot):
+        """Return whether current inventory can eventually supply a shot."""
+        state = bot.get("state") if isinstance(bot.get("state"), dict) else {}
+        remaining = state.get("ammo_remaining")
+        return bool(
+            isinstance(remaining, (list, tuple)) and
+            sum(max(0, _integer(value)) for value in remaining) > 0)
+
+    @staticmethod
+    def _weapon_ready(bot):
+        """Return whether this Bot can turn a firing lane into a current shot."""
+        if not BotPlanner._weapon_can_recover(bot):
+            return False
+        state = bot.get("state") if isinstance(bot.get("state"), dict) else {}
+        critical = state.get("critical")
+        critical = critical if isinstance(critical, dict) else {}
+        if "gunHealth" in set(str(value) for value in
+                              (critical.get("destroyed") or ())):
+            return False
+        remaining = state.get("ammo_remaining")
+        if isinstance(remaining, (list, tuple)):
+            loaded = _integer(state.get("shell_index"), -1)
+            if (loaded < 0 or loaded >= len(remaining) or
+                    _integer(remaining[loaded]) <= 0):
+                return False
+
+        # A burst which is already in flight owns its remaining rounds even
+        # though the ordinary loaded-shell snapshot is reload-pending.
+        if state.get("burst_active"):
+            return True
+        if state.get("ammo_reload_pending") is True:
+            return False
+        if "clip" in state and _integer(state.get("clip")) <= 0:
+            return False
+        if ("reload_time" in state and
+                _number(state.get("reload_time")) > 0.0):
+            return False
+        return True
+
+    @staticmethod
+    def _magazine_has_followup(bot):
+        """Return whether an exposed magazine or burst still has a next shot."""
+        state = bot.get("state") if isinstance(bot.get("state"), dict) else {}
+        if state.get("burst_active"):
+            return True
+        if (_integer(state.get("clip_size"), 1) <= 1 or
+                _integer(state.get("clip")) <= 0):
+            return False
+        remaining = state.get("ammo_remaining")
+        return bool(
+            isinstance(remaining, (list, tuple)) and
+            sum(max(0, _integer(value)) for value in remaining) > 0)
+
+    def _hit_requires_withdrawal(self, bot, hit, threat, team_bots):
+        """Escalate damage only when it is material or cannot be answered."""
+        if not isinstance(hit, dict):
+            return False
+        state = bot.get("state") if isinstance(bot.get("state"), dict) else {}
+        max_health = max(1.0, _number(state.get("max_health"), 1.0))
+        if (_number(hit.get("damage")) / max_health >=
+                LOW_HEALTH_BASE_FRACTION):
+            return True
+        if isinstance(threat, dict):
+            shooters = threat.get("shootable_by_bot_ids") or ()
+            if (threat.get("visible") and bot["id"] in shooters and
+                    self._weapon_ready(bot)):
+                return False
+            armed_support = [
+                ally for ally in (team_bots or ())
+                if (ally["id"] in shooters and self._weapon_ready(ally))
+            ]
+            return self._ally_support_score(
+                bot, armed_support, threat) < 0.70
+        return True
 
     def _recent_threat_contact(self, bot, contacts, now):
         hit = self._recent_hit(bot["id"], now)
@@ -1240,7 +1378,9 @@ class BotPlanner(object):
                 sort_key = (
                     score, bot["id"], str(contact.get("target_kind") or ""),
                     contact["id"], distance)
-                candidate = (sort_key, bot, contact, distance)
+                candidate = (
+                    sort_key, bot, contact, distance,
+                    self._weapon_ready(bot))
                 candidates.append(candidate)
                 by_bot.setdefault(bot["id"], []).append(candidate)
 
@@ -1258,9 +1398,12 @@ class BotPlanner(object):
                 # empty.  Keep the unexpired movement lease, while the order's
                 # fire flag still follows the current (negative) lane sample.
                 leased_contact = None
-                leased_distance = 0.0
+                cover_state = self._cover_states.get(bot["id"])
+                cover_target = (cover_state.get("target")
+                                if isinstance(cover_state, dict) else None)
                 if (isinstance(previous, dict) and
-                        _number(now) < _number(previous.get("until"))):
+                        (_number(now) < _number(previous.get("until")) or
+                         cover_target == previous.get("target"))):
                     bx = _number(bot["state"].get("x"))
                     bz = _number(bot["state"].get("z"))
                     for contact in contacts:
@@ -1274,16 +1417,16 @@ class BotPlanner(object):
                         if distance <= self._engagement_range(bot, contact):
                             leased_contact = dict(contact)
                             leased_contact["movement_lease"] = True
-                            leased_distance = distance
                             break
                 if leased_contact is not None:
-                    key = (leased_contact.get("target_kind"),
-                           leased_contact["id"])
-                    if reservations.get(key, 0) < self._focus_limit(
-                            leased_contact, leased_distance):
-                        reservations[key] = reservations.get(key, 0) + 1
-                        assigned[bot["id"]] = leased_contact
+                    if not self._weapon_can_recover(bot):
+                        self._target_assignments.pop(bot["id"], None)
                         continue
+                    if cover_target == previous.get("target"):
+                        previous["until"] = (
+                            _number(now) + TARGET_LEASE_SECONDS)
+                    assigned[bot["id"]] = leased_contact
+                    continue
                 self._target_assignments.pop(bot["id"], None)
                 continue
             if not isinstance(previous, dict):
@@ -1297,6 +1440,15 @@ class BotPlanner(object):
                     break
             if previous_candidate is None:
                 self._target_assignments.pop(bot["id"], None)
+                continue
+            if not previous_candidate[4]:
+                if self._weapon_can_recover(bot):
+                    contact = dict(previous_candidate[2])
+                    contact["movement_lease"] = True
+                    assigned[bot["id"]] = contact
+                    previous["until"] = _number(now) + TARGET_LEASE_SECONDS
+                else:
+                    self._target_assignments.pop(bot["id"], None)
                 continue
             best_score = bot_candidates[0][0][0]
             lease_expired = _number(now) >= _number(previous.get("until"))
@@ -1328,7 +1480,8 @@ class BotPlanner(object):
             if lease_expired:
                 previous["until"] = _number(now) + TARGET_LEASE_SECONDS
         for (unused_sort_key, bot, contact, distance) in sorted(
-                candidates, key=lambda value: value[0]):
+                (candidate[:4] for candidate in candidates
+                 if candidate[4]), key=lambda value: value[0]):
             if bot["id"] in assigned:
                 continue
             key = (contact.get("target_kind"), contact["id"])
@@ -1336,6 +1489,25 @@ class BotPlanner(object):
                     contact, distance):
                 continue
             reservations[key] = reservations.get(key, 0) + 1
+            assigned[bot["id"]] = contact
+            self._target_assignments[bot["id"]] = {
+                "target": key,
+                "until": _number(now) + TARGET_LEASE_SECONDS,
+            }
+        # Reloading and repairable vehicles still need one tactical contact
+        # for spacing, withdrawal and cover.  Add that movement-only lease
+        # after every current shooter has competed for the focus cap, so it
+        # cannot displace fire that is actually available.
+        for bot in bots:
+            if bot["id"] in assigned or not self._weapon_can_recover(bot):
+                continue
+            bot_candidates = sorted(
+                by_bot.get(bot["id"], ()), key=lambda value: value[0])
+            if not bot_candidates or bot_candidates[0][4]:
+                continue
+            contact = dict(bot_candidates[0][2])
+            contact["movement_lease"] = True
+            key = (contact.get("target_kind"), contact["id"])
             assigned[bot["id"]] = contact
             self._target_assignments[bot["id"]] = {
                 "target": key,
@@ -2002,14 +2174,30 @@ class BotPlanner(object):
             state["face_position"] = _point(
                 order.get("face_position") or focus["position"])
         elif (phase == "hold" and not urgent and not hold_only and
-              _number(now) >= _number(state.get("phase_until"))):
+              _number(now) >= _number(state.get("phase_until")) and
+              self._weapon_ready(bot)):
             phase = "peek"
             self._begin_cover_phase(state, phase, now, peek_distance)
+            state["peek_fire_seq"] = _integer(
+                bot.get("state", {}).get("fire_seq"))
         elif phase == "peek" and peek_distance <= 4.5:
+            bot_state = bot.get("state") if isinstance(
+                bot.get("state"), dict) else {}
+            fire_seq = _integer(bot_state.get("fire_seq"))
+            shot_advanced = fire_seq > _integer(
+                state.get("peek_fire_seq"), fire_seq)
             if _number(state.get("phase_until")) <= 0.0:
                 state["phase_until"] = (_number(now) + 1.0 +
                                         personality["aggression"] * 1.8)
-            elif _number(now) >= _number(state.get("phase_until")):
+            if shot_advanced and self._magazine_has_followup(bot):
+                state["peek_fire_seq"] = fire_seq
+                state["phase_until"] = (
+                    _number(now) + max(
+                        _number(bot_state.get("reload_time")),
+                        1.0 + personality["aggression"] * 1.8))
+            elif (shot_advanced or
+                  (not bot_state.get("burst_active") and
+                   _number(now) >= _number(state.get("phase_until")))):
                 phase = "return"
                 self._begin_cover_phase(
                     state, phase, now, cover_distance)
@@ -2067,7 +2255,8 @@ class BotPlanner(object):
         order["target_kind"] = contact.get("target_kind")
         order["aim_position"] = dict(contact["position"])
         order["face_position"] = dict(contact["position"])
-        order["fire_allowed"] = bool(fire_allowed)
+        order["fire_allowed"] = bool(
+            fire_allowed and BotPlanner._weapon_ready(bot))
         order["shell_index"] = BotPlanner._shell_index(
             profile, contact, personality, bot.get("state"))
 
@@ -2161,6 +2350,8 @@ class BotPlanner(object):
             LOW_HEALTH_BASE_FRACTION + personality["caution"] * 0.18)
         recent_hit = self._recent_hit(bot["id"], now)
         threat_contact = self._recent_threat_contact(bot, contacts, now)
+        withdraw_after_hit = self._hit_requires_withdrawal(
+            bot, recent_hit, threat_contact, team_bots)
         order = {
             "id": bot["id"],
             "team": bot["team"],
@@ -2233,7 +2424,7 @@ class BotPlanner(object):
                 self._apply_retreat_order(
                     order, bot, retreat_point, move, now,
                     "low_health_retreat", "low_health_defend")
-            elif recent_hit is not None:
+            elif withdraw_after_hit:
                 self._apply_retreat_order(
                     order, bot, retreat_point, move, now,
                     "under_fire_withdraw", "under_fire_hold")
@@ -2277,7 +2468,7 @@ class BotPlanner(object):
                 order, bot, profile, personality)
             return order
 
-        if recent_hit is not None:
+        if withdraw_after_hit:
             cover_focus = threat_contact or focus
             cover_observers = cover_focus.get("shootable_by_bot_ids")
             self._set_target(
@@ -2315,10 +2506,16 @@ class BotPlanner(object):
             return order
 
         if not locally_shootable:
-            if (focus.get("movement_lease") and
-                    self._apply_leased_movement_order(
-                        order, bot, focus)):
-                return order
+            if focus.get("movement_lease"):
+                if (bot["id"] in self._cover_states and
+                        self._apply_cover_order(
+                            order, bot, focus, personality, now)):
+                    self._engage_anchors.pop(bot["id"], None)
+                    self._combat_states.pop(bot["id"], None)
+                    return order
+                if self._apply_leased_movement_order(
+                        order, bot, focus):
+                    return order
             self._engage_anchors.pop(bot["id"], None)
             self._combat_states.pop(bot["id"], None)
             self._retreat_states.pop(bot["id"], None)

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/server.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/server.py
@@ -293,7 +293,11 @@ class FakeServer(object):
         return True
 
     def messenger_onActionByClient_chat2(self, action_id, request_id, args):
-        """Accept the enabled #1513 BW_CHAT2 provider's one-way mailbox."""
+        """Forward chat2 when a scoped battle-radio adapter is attached."""
+        adapter = self._context.get('battle_radio')
+        handler = getattr(adapter, 'handle_client_action', None)
+        if callable(handler):
+            return bool(handler(action_id, request_id, args))
         return True
 
     def update_context(self, values):

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/server.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/server.py
@@ -293,7 +293,7 @@ class FakeServer(object):
         return True
 
     def messenger_onActionByClient_chat2(self, action_id, request_id, args):
-        """Forward chat2 when a scoped battle-radio adapter is attached."""
+        """Forward Chat2 when a scoped battle adapter is attached."""
         adapter = self._context.get('battle_radio')
         handler = getattr(adapter, 'handle_client_action', None)
         if callable(handler):

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
@@ -34,6 +34,16 @@ BLOCKED_STEP_REPLAN_SECONDS = 1.0
 BLOCKED_STEP_REPLAN_VERDICTS = 4
 BLOCKED_STEP_EDGE_TTL = 12.0
 BLOCKED_STEP_EDGE_PENALTY = 240.0
+# LocalDriver deliberately owns short-lived contact recovery, but displacement
+# alone cannot detect a tank that rocks or circles without advancing its route.
+# Track progress towards the navigator's stable local target and, after a long
+# grace, make only this bot avoid the unproductive edge for one replan.
+MACRO_PROGRESS_METRES = 0.20
+MACRO_STALL_SECONDS = 12.0
+MACRO_TARGET_CHANGE_METRES = 2.0
+MACRO_EDGE_TTL = 4.0
+MACRO_EDGE_PENALTY = 240.0
+PENDING_INTENT_PROGRESS_METRES = 0.20
 # A controlled ford admits LocalDriver's first avoidance branch, and no wider.
 CONTROLLED_SHALLOW_YAW_WINDOW = FIRST_CANDIDATE_OFFSET + 0.03
 # The commit side sees an integrated hull yaw rather than the candidate the
@@ -385,6 +395,15 @@ class TerrainGrid(object):
 				return True
 		return False
 
+	def path_has_edge_penalty(self, path, edge_penalties):
+		if not edge_penalties:
+			return False
+		for index in range(len(path) - 1):
+			if any(edge in edge_penalties for edge in
+					self._edge_keys_for_segment(path[index], path[index + 1])):
+				return True
+		return False
+
 	def _ground(self, x, z, hint_y):
 		if not self._inside(x, z):
 			return None
@@ -643,7 +662,8 @@ class TerrainGrid(object):
 		return penalty
 
 	def safe_local_target(self, current, goal, now, avoid_points=None,
-			side_preference=1.0):
+			side_preference=1.0, edge_penalties=None,
+			minimum_offset=0.0):
 		"""Choose one short, fully probed detour when the global search fails.
 
 		This is deliberately not a direct-to-goal fallback. Every candidate must
@@ -665,6 +685,8 @@ class TerrainGrid(object):
 		best = None
 		for distance in distances:
 			for offset in offsets:
+				if abs(offset) < max(0.0, float(minimum_offset)):
+					continue
 				yaw = desired_yaw + offset
 				x = float(current[0]) + math.sin(yaw) * distance
 				z = float(current[2]) + math.cos(yaw) * distance
@@ -673,6 +695,11 @@ class TerrainGrid(object):
 					continue
 				candidate = (x, y, z)
 				if not self.dry_segment_clear(current, candidate, now):
+					continue
+				if (edge_penalties and any(
+						edge in edge_penalties
+						for edge in self._edge_keys_for_segment(
+							current, candidate))):
 					continue
 				cell = self.cell_for(candidate)
 				score = (_distance_2d(candidate, goal) + abs(offset) * 3.5 +
@@ -683,23 +710,25 @@ class TerrainGrid(object):
 		return best[2] if best is not None else None
 
 	def plan(self, start, goal, avoid_points=None, max_expansions=1600, now=0.0,
-			prefer_clearance=True, edge_penalties=None):
+			prefer_clearance=True, edge_penalties=None,
+			hard_edge_penalties=None):
 		"""Return a supported path synchronously (mainly for tests/tools)."""
 		search = self.begin_plan(
 			start, goal, avoid_points, max_expansions, now, prefer_clearance,
-			edge_penalties)
+			edge_penalties, hard_edge_penalties)
 		while not search.done:
 			search.step(256)
 		return search.result
 
 	def begin_plan(self, start, goal, avoid_points=None, max_expansions=1600,
-			now=0.0, prefer_clearance=False, edge_penalties=None):
+			now=0.0, prefer_clearance=False, edge_penalties=None,
+			hard_edge_penalties=None):
 		return _TerrainSearch(self._plan_steps(
 			start, goal, avoid_points, max_expansions, now,
-			bool(prefer_clearance), edge_penalties))
+			bool(prefer_clearance), edge_penalties, hard_edge_penalties))
 
 	def _plan_steps(self, start, goal, avoid_points, max_expansions, now,
-			prefer_clearance, edge_penalties):
+			prefer_clearance, edge_penalties, hard_edge_penalties):
 		start_cell = self.cell_for(start)
 		goal_cell = self.cell_for(goal)
 		if self.prebaked:
@@ -750,6 +779,10 @@ class TerrainGrid(object):
 				next_y = self._edge(current, current_y, next_cell)
 				if next_y is None:
 					continue
+				edge_key = tuple(sorted((current, next_cell)))
+				if (hard_edge_penalties and
+						edge_key in hard_edge_penalties):
+					continue
 				if offset_x and offset_z and not self.prebaked:
 					# Do not squeeze diagonally across a blocked corner.
 					if (self._edge(current, current_y,
@@ -771,8 +804,7 @@ class TerrainGrid(object):
 					slope_cost *= 1.25
 				local_penalty = 0.0
 				if edge_penalties:
-					local_penalty = float(edge_penalties.get(
-						tuple(sorted((current, next_cell))), 0.0))
+					local_penalty = float(edge_penalties.get(edge_key, 0.0))
 				new_cost = (cost_so_far[current] + run + slope_cost +
 				            self._penalty(
 				                next_cell, avoid_points, prefer_clearance) +
@@ -793,6 +825,11 @@ class TerrainGrid(object):
 					               (new_cost + heuristic, sequence, next_cell, new_cost))
 			yield None
 		if reached is None:
+			if hard_edge_penalties and closest == start_cell:
+				# A per-bot macro veto that leaves no forward progress is a real
+				# failed route, not a sparse-anchor success at the start cell.
+				yield ()
+				return
 			# Sparse strategic anchors are hand placed on a minimap. A point a few
 			# metres inside a building footprint, cliff lip or water edge must not
 			# invalidate an otherwise complete route. Use the nearest cell A* could
@@ -821,11 +858,15 @@ class TerrainGrid(object):
 		goal_y = self._ground(float(goal[0]), float(goal[2]), path[-1][1])
 		goal_point = (float(goal[0]), goal_y if goal_y is not None else path[-1][1],
 		              float(goal[2]))
-		if self.segment_clear(path[-1], goal_point):
+		if (self.segment_clear(path[-1], goal_point) and
+				not self.path_has_edge_penalty(
+					(path[-1], goal_point), hard_edge_penalties)):
 			path.append(goal_point)
-		yield self._smooth(tuple(path), now, prefer_clearance)
+		yield self._smooth(
+			tuple(path), now, prefer_clearance, hard_edge_penalties)
 
-	def _smooth(self, path, now=0.0, prefer_clearance=False):
+	def _smooth(self, path, now=0.0, prefer_clearance=False,
+			edge_penalties=None):
 		if len(path) < 3:
 			return path
 		result = [path[0]]
@@ -838,6 +879,10 @@ class TerrainGrid(object):
 						 path, index, furthest)) and
 						self.shortcut_preserves_climb_approach(
 						path, index, furthest) and
+						not (edge_penalties and any(
+							edge in edge_penalties for edge in
+							self._edge_keys_for_segment(
+								path[index], path[furthest]))) and
 						self.dry_segment_clear(
 							path[index], path[furthest], now)):
 					break
@@ -886,6 +931,8 @@ class TerrainNavigator(object):
 		self.search_times = {}
 		self.bot_states = {}
 		self.bot_failed_edges = {}
+		self.bot_macro_edges = {}
+		self.bot_direct_progress = {}
 		self.search_frame_time = None
 		self.housekeeping_time = None
 		self.search_next_key = None
@@ -964,6 +1011,11 @@ class TerrainNavigator(object):
 			'blocked_step_replans': sum(
 				int(state.get('blocked_step_replans', 0))
 				for state in self.bot_states.values()),
+			'macro_progress_replans': sum(
+				int(state.get('macro_progress_replans', 0))
+				for state in self.bot_states.values()) + sum(
+				int(state.get('replans', 0))
+				for state in self.bot_direct_progress.values()),
 		}
 
 	def _fallback_target(self, bot_id, current, goal, now, avoid_points, state,
@@ -988,7 +1040,8 @@ class TerrainNavigator(object):
 		if allow_safe_local:
 			fallback = self.grid.safe_local_target(
 				current, goal, now, avoid_points,
-				1.0 if (int(bot_id) % 2) else -1.0)
+				1.0 if (int(bot_id) % 2) else -1.0,
+				self._active_macro_edge_penalties(bot_id, now))
 			if fallback is not None:
 				state['last_target'] = tuple(fallback)
 				state['navigation_status'] = 'safe'
@@ -1003,7 +1056,8 @@ class TerrainNavigator(object):
 		return tuple(goal)
 
 	def _pending_target(self, bot_id, current, goal, now, state,
-			avoid_points=None):
+			avoid_points=None, allow_last_target=True,
+			immediate_safe_local=False):
 		"""Continue a proved local edge, else make bounded probed progress.
 
 		Returning the hull's own position is a complete stop: the driver reads it
@@ -1017,12 +1071,14 @@ class TerrainNavigator(object):
 		means the only safe action is to hold.
 		"""
 		last_target = state.get('last_target')
-		if last_target is not None:
+		if allow_last_target and last_target is not None:
 			last_target = tuple(last_target)
 			shallow = self.grid.segment_has_baked_hazard(
 				current, last_target, BAKED_SHALLOW_WATER)
 			controlled = state.get('controlled_shallow_target')
 			if (self.grid.segment_penalty(current, last_target, now) <= 0.0 and
+					not self._macro_edges_penalized(
+						bot_id, current, last_target, now) and
 					self.grid.segment_clear(current, last_target) and
 					(not shallow or controlled == last_target) and
 					_distance_2d(current, last_target) >
@@ -1036,10 +1092,12 @@ class TerrainNavigator(object):
 			started = float(now)
 			state['pending_since'] = started
 		if (goal is not None and
-				float(now) - float(started) >= PENDING_PROGRESS_SECONDS):
+				(immediate_safe_local or
+				 float(now) - float(started) >= PENDING_PROGRESS_SECONDS)):
 			fallback = self.grid.safe_local_target(
 				current, goal, now, avoid_points,
-				1.0 if (int(bot_id) % 2) else -1.0)
+				1.0 if (int(bot_id) % 2) else -1.0,
+				self._active_macro_edge_penalties(bot_id, now))
 			if fallback is not None:
 				state['last_target'] = tuple(fallback)
 				state['navigation_status'] = 'pending'
@@ -1051,6 +1109,170 @@ class TerrainNavigator(object):
 		state['target_is_terminal'] = False
 		self._set_fallback_mode(bot_id, 'pending')
 		return tuple(current)
+
+	@staticmethod
+	def _target_advances_new_intent(current, target, goal):
+		"""Whether an old local target remains useful for a new request."""
+		if target is None or goal is None:
+			return False
+		to_target_x = float(target[0]) - float(current[0])
+		to_target_z = float(target[2]) - float(current[2])
+		to_goal_x = float(goal[0]) - float(current[0])
+		to_goal_z = float(goal[2]) - float(current[2])
+		if (to_target_x * to_goal_x + to_target_z * to_goal_z) <= 0.0:
+			return False
+		return (_distance_2d(target, goal) +
+		        PENDING_INTENT_PROGRESS_METRES < _distance_2d(current, goal))
+
+	def _reset_macro_progress(self, state, current, target, now):
+		state['macro_progress_at'] = float(now)
+		state['macro_progress_position'] = tuple(current)
+		state['macro_progress_target'] = (
+			tuple(target) if target is not None else None)
+		state['macro_progress_path_key'] = state.get('path_key')
+		state['macro_progress_index'] = int(state.get('index', 0))
+
+	def observe_direct_target(self, bot_id, current, goal, path_key, now,
+			movement_intent=True):
+		"""Return a bounded local escape when a proved direct edge stalls."""
+		bot_id = int(bot_id)
+		path_identity = tuple(path_key)
+		state = self.bot_direct_progress.get(bot_id)
+		if state is None:
+			state = {'path_key': path_identity, 'target': tuple(goal),
+			         'position': tuple(current), 'progress_at': float(now),
+			         'replans': 0}
+			self.bot_direct_progress[bot_id] = state
+		if (state.get('path_key') != path_identity or
+				_distance_2d(state.get('target', goal), goal) >
+				MACRO_TARGET_CHANGE_METRES or not movement_intent or
+				_distance_2d(current, goal) <= WAYPOINT_ARRIVAL_RADIUS):
+			state['path_key'] = path_identity
+			state['target'] = tuple(goal)
+			state['position'] = tuple(current)
+			state['progress_at'] = float(now)
+			state.pop('escape_target', None)
+			state.pop('escape_until', None)
+			return None
+		escape = state.get('escape_target')
+		if escape is not None:
+			escape = tuple(escape)
+			if (float(now) < float(state.get('escape_until', now)) and
+					_distance_2d(current, escape) > WAYPOINT_ARRIVAL_RADIUS and
+					self.grid.dry_segment_clear(current, escape, now)):
+				return escape
+			state['target'] = tuple(goal)
+			state['position'] = tuple(current)
+			state['progress_at'] = float(now)
+			state.pop('escape_target', None)
+			state.pop('escape_until', None)
+			return None
+		target = tuple(state.get('target') or goal)
+		reference = tuple(state.get('position') or current)
+		progress = (_distance_2d(reference, target) -
+		            _distance_2d(current, target))
+		if progress >= MACRO_PROGRESS_METRES:
+			state['target'] = tuple(goal)
+			state['position'] = tuple(current)
+			state['progress_at'] = float(now)
+			return None
+		if (float(now) - float(state.get('progress_at', now)) <
+				MACRO_STALL_SECONDS):
+			return None
+		escape = self.grid.safe_local_target(
+			current, goal, now, None,
+			1.0 if (bot_id % 2) else -1.0,
+			None, FIRST_CANDIDATE_OFFSET)
+		state['target'] = tuple(goal)
+		state['position'] = tuple(current)
+		state['progress_at'] = float(now)
+		if escape is None:
+			return None
+		state['escape_target'] = tuple(escape)
+		state['escape_until'] = float(now) + MACRO_EDGE_TTL
+		state['replans'] = int(state.get('replans', 0)) + 1
+		return tuple(escape)
+
+	def _start_macro_replan(self, bot_id, state, current, target, now):
+		"""Reroute one bot without changing shared terrain or hazard state."""
+		escape = self.grid.safe_local_target(
+			current, target, now, None,
+			1.0 if (int(bot_id) % 2) else -1.0,
+			None, FIRST_CANDIDATE_OFFSET)
+		key = self.grid._edge_cells_for_segment(current, target)
+		if key is None and escape is None:
+			return False
+		if escape is not None:
+			state['macro_escape_target'] = tuple(escape)
+			state['macro_escape_until'] = float(now) + MACRO_EDGE_TTL
+		else:
+			macro_edges = self.bot_macro_edges.setdefault(int(bot_id), {})
+			macro_edges[key] = (
+				float(now) + MACRO_EDGE_TTL, MACRO_EDGE_PENALTY)
+		state['replan_generation'] = int(
+			state.get('replan_generation', 0)) + 1
+		state['macro_progress_replans'] = int(
+			state.get('macro_progress_replans', 0)) + 1
+		state['path_key'] = None
+		state['index'] = 0
+		state['recovery_start'] = tuple(current)
+		state['replan_active'] = escape is None
+		state['macro_replan_active'] = True
+		state['pending_since'] = float(now) - PENDING_PROGRESS_SECONDS
+		state.pop('controlled_shallow_target', None)
+		self._cancel_bot_searches(bot_id)
+		self._reset_macro_progress(state, current, target, now)
+		return True
+
+	def _finish_macro_replan(self, bot_id, state):
+		self.bot_macro_edges.pop(int(bot_id), None)
+		state.pop('macro_escape_target', None)
+		state.pop('macro_escape_until', None)
+		state['macro_replan_active'] = False
+		state['replan_active'] = False
+		state['recovery_start'] = None
+		state['path_key'] = None
+		state['index'] = 0
+		self._cancel_bot_searches(bot_id)
+
+	def _observe_macro_progress(self, bot_id, state, current, goal, now):
+		"""Observe progress along the issued path target, not arbitrary motion."""
+		target = state.get('last_target')
+		if (state.get('macro_replan_active') and
+				state.get('macro_escape_target') is None and
+				not self._active_macro_edge_penalties(bot_id, now)):
+			self._finish_macro_replan(bot_id, state)
+			self._reset_macro_progress(state, current, target, now)
+			return False
+		if (target is None or
+				_distance_2d(current, target) <= WAYPOINT_ARRIVAL_RADIUS or
+				_distance_2d(current, goal) <= WAYPOINT_ARRIVAL_RADIUS):
+			self._reset_macro_progress(state, current, target, now)
+			return False
+		tracked_target = state.get('macro_progress_target')
+		path_changed = (
+			state.get('macro_progress_path_key') != state.get('path_key') or
+			int(state.get('macro_progress_index', 0)) !=
+			int(state.get('index', 0)))
+		if (tracked_target is None or path_changed or
+				_distance_2d(tracked_target, target) >
+				MACRO_TARGET_CHANGE_METRES):
+			self._reset_macro_progress(state, current, target, now)
+			return False
+		reference = state.get('macro_progress_position') or current
+		progress = (_distance_2d(reference, target) -
+		            _distance_2d(current, target))
+		state['macro_progress_target'] = tuple(target)
+		if progress >= MACRO_PROGRESS_METRES:
+			if state.get('macro_replan_active'):
+				self._finish_macro_replan(bot_id, state)
+			self._reset_macro_progress(state, current, target, now)
+			return False
+		if (float(now) - float(state.get('macro_progress_at', now)) >=
+				MACRO_STALL_SECONDS):
+			return self._start_macro_replan(
+				bot_id, state, current, target, now)
+		return False
 
 	@staticmethod
 	def _path_owner(path_key):
@@ -1078,9 +1300,36 @@ class TerrainNavigator(object):
 			self.bot_failed_edges.pop(int(bot_id), None)
 		return result or None
 
+	def _active_macro_edge_penalties(self, bot_id, now):
+		if bot_id is None:
+			return None
+		failed = self.bot_macro_edges.get(int(bot_id))
+		if not failed:
+			return None
+		result = {}
+		for key, value in list(failed.items()):
+			if float(now) >= float(value[0]):
+				failed.pop(key, None)
+			else:
+				result[key] = float(value[1])
+		if not failed:
+			self.bot_macro_edges.pop(int(bot_id), None)
+		return result or None
+
+	def _active_planning_edge_penalties(self, bot_id, now):
+		result = dict(self._active_bot_edge_penalties(bot_id, now) or {})
+		result.update(self._active_macro_edge_penalties(bot_id, now) or {})
+		return result or None
+
+	def _macro_edges_penalized(self, bot_id, start, end, now):
+		penalties = self._active_macro_edge_penalties(bot_id, now)
+		return bool(penalties and any(
+			edge in penalties
+			for edge in self.grid._edge_keys_for_segment(start, end)))
+
 	def _bot_edges_penalized(self, bot_id, start, end, now):
 		"""True when this bot's own escalation covers any edge of the segment."""
-		penalties = self._active_bot_edge_penalties(bot_id, now)
+		penalties = self._active_planning_edge_penalties(bot_id, now)
 		return bool(penalties and any(
 			edge in penalties
 			for edge in self.grid._edge_keys_for_segment(start, end)))
@@ -1137,6 +1386,10 @@ class TerrainNavigator(object):
 		state['index'] = 0
 		state['recovery_start'] = tuple(current)
 		state['replan_active'] = True
+		state['macro_replan_active'] = False
+		self.bot_macro_edges.pop(bot_id, None)
+		state.pop('macro_escape_target', None)
+		state.pop('macro_escape_until', None)
 		state.pop('controlled_shallow_target', None)
 		self._cancel_bot_searches(bot_id)
 		return True
@@ -1291,6 +1544,8 @@ class TerrainNavigator(object):
 			self.grid.prune_failed_edges(now)
 			for bot_id in list(self.bot_failed_edges):
 				self._active_bot_edge_penalties(bot_id, now)
+			for bot_id in list(self.bot_macro_edges):
+				self._active_macro_edge_penalties(bot_id, now)
 			self.grid.trim_caches()
 
 	def _path(self, path_key, start, goal, now, avoid_points):
@@ -1310,9 +1565,13 @@ class TerrainNavigator(object):
 				owner, keep_key=key, kind=path_key[0])
 		if key in self.paths:
 			path = self.paths[key]
+			hard_edge_penalties = self._active_macro_edge_penalties(
+				owner, now)
 			# A probe can fail while distant chunks are still streaming. Successful
 			# paths are permanent for the battle; failed ones get another chance.
-			if path and not self.grid.path_has_penalty(path, now):
+			if (path and not self.grid.path_has_penalty(path, now) and
+					not self.grid.path_has_edge_penalty(
+						path, hard_edge_penalties)):
 				self.path_times[key] = float(now)
 				return key, path
 			if path:
@@ -1326,7 +1585,9 @@ class TerrainNavigator(object):
 				self.grid.clear_negative_cache()
 		search = self.searches.get(key)
 		if search is None:
-			edge_penalties = self._active_bot_edge_penalties(owner, now)
+			edge_penalties = self._active_planning_edge_penalties(owner, now)
+			hard_edge_penalties = self._active_macro_edge_penalties(
+				owner, now)
 			penalized_direct = bool(
 				edge_penalties and any(
 					edge in edge_penalties
@@ -1347,7 +1608,8 @@ class TerrainNavigator(object):
 				start, goal, avoid_points=None,
 				max_expansions=self.search_max_expansions, now=now,
 				prefer_clearance=self._prefers_baked_clearance(path_key),
-				edge_penalties=edge_penalties)
+				edge_penalties=edge_penalties,
+				hard_edge_penalties=hard_edge_penalties)
 			self.searches[key] = search
 			self.search_times[key] = float(now)
 		self._advance_searches(now)
@@ -1419,6 +1681,8 @@ class TerrainNavigator(object):
 			horizon = max(
 				self.grid.cell_size * 2.0, float(lookahead_distance))
 		prefer_clearance = self._prefers_baked_clearance(path_key)
+		edge_penalties = self._active_macro_edge_penalties(
+			self._path_owner(path_key), now)
 		for candidate in range(index + 1, limit):
 			if (horizon is not None and candidate > index + 1 and
 					_distance_2d(current, path[candidate]) > horizon):
@@ -1428,6 +1692,8 @@ class TerrainNavigator(object):
 						 path, index, candidate)) and
 					self.grid.live_shortcut_preserves_climb_approach(
 						current, path, index, candidate) and
+					not self.grid.path_has_edge_penalty(
+						(current, path[candidate]), edge_penalties) and
 					self.grid.dry_segment_clear(
 						current, path[candidate], now)):
 				lookahead = candidate
@@ -1436,9 +1702,11 @@ class TerrainNavigator(object):
 		return lookahead
 
 	def next_target(self, bot_id, current, goal, path_key, now,
-			anchor=None, avoid_points=None, lookahead_distance=None):
+			anchor=None, avoid_points=None, lookahead_distance=None,
+			movement_intent=True):
 		"""Return a terrain-safe local target, holding if no safe path is ready."""
 		bot_id = int(bot_id)
+		self.bot_direct_progress.pop(bot_id, None)
 		# Search progress is a navigator-wide frame task, not a cache-miss side
 		# effect. Once every active bot had a cached/partial path, _path() returned
 		# before advancing unrelated join and continuation jobs, leaving the whole
@@ -1454,6 +1722,13 @@ class TerrainNavigator(object):
 			         'planned_at': 0.0, 'navigation_status': 'pending',
 			         'target_is_terminal': False,
 			         'replan_generation': 0, 'replan_active': False,
+			         'macro_replan_active': False,
+			         'macro_progress_replans': 0,
+			         'macro_progress_at': float(now),
+			         'macro_progress_position': tuple(current),
+			         'macro_progress_target': None,
+			         'macro_progress_path_key': None,
+			         'macro_progress_index': 0,
 			         'blocked_step_replans': 0,
 			         'blocked_step_tracker': None,
 			         'blocked_step_escalated_until': 0.0}
@@ -1473,9 +1748,18 @@ class TerrainNavigator(object):
 			state['planned_goal'] = tuple(goal)
 			state['planned_at'] = float(now)
 		request_key = self._cache_key(path_key, goal)
-		if state.get('request_key') != request_key:
+		had_request = state.get('request_key') is not None
+		request_changed = state.get('request_key') != request_key
+		request_transition = bool(had_request and request_changed)
+		allow_pending_last_target = True
+		if request_changed:
 			# A new route segment or combat target is not evidence that the previous
-			# request stalled. Reset recovery before evaluating progress.
+			# request stalled. A locally safe old target may bridge an asynchronous
+			# search only when it still advances the new intent.
+			allow_pending_last_target = self._target_advances_new_intent(
+				current, state.get('last_target'), goal)
+			if not allow_pending_last_target:
+				state.pop('last_target', None)
 			self._cancel_bot_searches(bot_id)
 			state['request_key'] = request_key
 			state['path_key'] = None
@@ -1487,12 +1771,48 @@ class TerrainNavigator(object):
 			state['recovery_key'] = None
 			state['recovery_start'] = None
 			state['replan_active'] = False
-		if _distance_2d(current, state['last_position']) >= 2.0:
+			state['macro_replan_active'] = False
+			self.bot_macro_edges.pop(bot_id, None)
+			state.pop('macro_escape_target', None)
+			state.pop('macro_escape_until', None)
+			state.pop('pending_since', None)
+			# A shallow-water grant belongs to the exact A* request that selected it.
+			# The replacement request must prove its own ford before steering there.
+			state.pop('controlled_shallow_target', None)
+			self._reset_macro_progress(
+				state, current, state.get('last_target'), now)
+		elif movement_intent:
+			self._observe_macro_progress(bot_id, state, current, goal, now)
+		else:
+			# A tactical throttle hold may retain a distant movement order. Keep its
+			# route warm, but start any stall lease only after movement resumes.
+			if state.get('macro_replan_active'):
+				self._finish_macro_replan(bot_id, state)
+			self._reset_macro_progress(
+				state, current, state.get('last_target'), now)
+		escape = state.get('macro_escape_target')
+		if escape is not None:
+			escape = tuple(escape)
+			if (float(now) < float(state.get('macro_escape_until', now)) and
+					_distance_2d(current, escape) > WAYPOINT_ARRIVAL_RADIUS and
+					self.grid.dry_segment_clear(current, escape, now)):
+				state.pop('controlled_shallow_target', None)
+				state['last_target'] = escape
+				state['navigation_status'] = 'safe'
+				state['target_is_terminal'] = False
+				self._set_fallback_mode(bot_id, None)
+				return escape
+			self._finish_macro_replan(bot_id, state)
+			self._reset_macro_progress(
+				state, current, state.get('last_target'), now)
+		if (not state.get('macro_replan_active') and
+				_distance_2d(current, state['last_position']) >= 2.0):
 			state['last_position'] = tuple(current)
 			state['progress_time'] = float(now)
 			state['recovery'] = 0
 			state['recovery_until'] = 0.0
 			state['replan_active'] = False
+			state['recovery_start'] = None
 		plan_start = tuple(anchor or current)
 		if anchor is not None:
 			# Strategic route annotations are two-dimensional and LAN protocol v5
@@ -1518,7 +1838,9 @@ class TerrainNavigator(object):
 		key, path = self._path(effective_key, plan_start, goal, now,
 		                       None)
 		if path is None:
-			if self.grid.dry_segment_clear(current, goal, now):
+			if (self.grid.dry_segment_clear(current, goal, now) and
+					not self._macro_edges_penalized(
+						bot_id, current, goal, now)):
 				state.pop('controlled_shallow_target', None)
 				state['last_target'] = tuple(goal)
 				state['navigation_status'] = 'safe'
@@ -1526,9 +1848,12 @@ class TerrainNavigator(object):
 				self._set_fallback_mode(bot_id, 'safe_direct')
 				return tuple(goal)
 			return self._pending_target(
-				bot_id, current, goal, now, state, avoid_points)
+				bot_id, current, goal, now, state, avoid_points,
+				allow_pending_last_target, request_transition)
 		if not path:
-			if self.grid.dry_segment_clear(current, goal, now):
+			if (self.grid.dry_segment_clear(current, goal, now) and
+					not self._macro_edges_penalized(
+						bot_id, current, goal, now)):
 				state.pop('controlled_shallow_target', None)
 				state['last_target'] = tuple(goal)
 				state['navigation_status'] = 'safe'
@@ -1568,6 +1893,8 @@ class TerrainNavigator(object):
 		current_segment_shallow = self.grid.segment_has_baked_hazard(
 			current, path[index], BAKED_SHALLOW_WATER)
 		if (self.grid.segment_penalty(current, path[index], now) > 0.0 or
+				self._macro_edges_penalized(
+					bot_id, current, path[index], now) or
 				(current_segment_shallow and
 				 not self._planned_current_segment_clear(
 					 current, path, index, now,
@@ -1577,7 +1904,8 @@ class TerrainNavigator(object):
 			key, joined_path = self._path(join_key, current, goal, now, avoid_points)
 			if joined_path is None:
 				return self._pending_target(
-				bot_id, current, goal, now, state, avoid_points)
+					bot_id, current, goal, now, state, avoid_points,
+					allow_pending_last_target, request_transition)
 			if not joined_path:
 				# The cached strategic path is unusable from this hull's actual
 				# position and the join search has conclusively failed. Reuse the
@@ -1635,7 +1963,8 @@ class TerrainNavigator(object):
 				return selected
 			if continued is None:
 				return self._pending_target(
-				bot_id, current, goal, now, state, avoid_points)
+					bot_id, current, goal, now, state, avoid_points,
+					allow_pending_last_target, request_transition)
 			return self._fallback_target(
 				bot_id, current, goal, now, avoid_points, state, True)
 		selected = tuple(path[lookahead])

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/ai/tactical_geometry.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/ai/tactical_geometry.py
@@ -1,0 +1,81 @@
+"""Bounded, observation-owned geometry for advisory Bot tactics."""
+
+import math
+
+from gui.mods.offline_lan_0922 import shot_geometry
+
+
+class ProbeBudgetExhausted(Exception):
+    pass
+
+
+class RayBudget(object):
+    """Never turn an untested ray into evidence of cover or exposure."""
+
+    def __init__(self, probe, maximum=24):
+        self.probe = probe
+        self.remaining = maximum
+
+    def clear(self, start, end):
+        return bool(self.call(self.probe, start, end))
+
+    def call(self, probe, *args):
+        if self.remaining <= 0:
+            raise ProbeBudgetExhausted()
+        self.remaining -= 1
+        return probe(*args)
+
+
+def body_samples(descriptor):
+    """Keep hull/turret centres and both hull sides, in descriptor frames."""
+    samples = shot_geometry.vehicle_aim_samples(descriptor)
+    centres = [value for value in samples[:2]]
+    sides = [value for value in samples[2:] if value[0] == 'hull'][:2]
+    return tuple(centres + sides)
+
+
+def exposure(samples, pose, threats, clear):
+    """Return the worst observed direction's sampled visible body fraction.
+
+    This is a geometric score, not a probability of being hit. The caller
+    supplies observed enemy gun origins; no live hidden entity pose is read.
+    """
+    if not samples or not threats:
+        return None
+    points = [shot_geometry.vehicle_aim_point(sample, pose)
+              for sample in samples]
+    return max(sum(1.0 for point in points if clear(origin, point)) /
+               len(points) for origin in threats)
+
+
+def search_offsets(width, length, phase):
+    """Rotate a local search around the whole vehicle, including its flanks."""
+    radius = max(width, length) * 2.0
+    offsets = [(0.0, 0.0)]
+    for scale in (1.0, 2.0):
+        for index in range(8):
+            angle = index * math.pi / 4.0
+            offsets.append((math.cos(angle) * radius * scale,
+                            math.sin(angle) * radius * scale))
+    start = int(phase) % len(offsets)
+    return tuple(offsets[start:] + offsets[:start])
+
+
+def relevant_threats(source_position, focus, observed, maximum=2):
+    """Prioritize the focus and a distinct nearby observed firing direction."""
+    focus_key = (focus.get('kind'), focus.get('network_id', focus.get('id')))
+    result = [focus]
+    fx, unused_y, fz = focus['position']
+    main = math.atan2(fx - source_position[0], fz - source_position[2])
+    ranked = []
+    for key, value in observed:
+        if key == focus_key:
+            continue
+        x, unused_y, z = value['position']
+        distance = math.hypot(x - source_position[0], z - source_position[2])
+        bearing = math.atan2(x - source_position[0], z - source_position[2])
+        separation = abs((bearing - main + math.pi) % (2.0 * math.pi) - math.pi)
+        ranked.append((-(1.0 + separation) / max(1.0, distance), key, value))
+    ranked.sort(key=lambda value: (value[0], value[1]))
+    result.extend(value[2] for value in ranked[:max(0, maximum - 1)])
+    return result

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -15,7 +15,8 @@ import traceback
 
 from gui.mods.offline_lan_0922.ai import maps as tactical_maps
 from gui.mods.offline_lan_0922.ai import planner as bot_planner
-from gui.mods.offline_lan_0922.ai.cover import score_candidates
+from gui.mods.offline_lan_0922.ai import tactical_geometry
+from gui.mods.offline_lan_0922.ai.driver import gun_yaw_limits
 from gui.mods.offline_lan_0922.artillery_controller import \
     ArtilleryController
 from gui.mods.offline_lan_0922.authority_worker_probe import \
@@ -1249,6 +1250,28 @@ class _LANInputSender(object):
         self.aim_pitch = 0.0
         self.aim_point = None
         self.handbrake = False
+
+    def send_team_command(self, request):
+        owner = self.owner
+        if (owner._worker_mode or owner._avatar is None or
+                not owner._battle_live or not isinstance(request, dict)):
+            return False
+        target_kind = target_id = None
+        stock_id = request.get('stock_target_id')
+        if stock_id is not None:
+            matching = [record for record in owner._records.values()
+                        if record.get('engine_id') == stock_id and
+                        record.get('ready') and not record.get('tombstone')]
+            if len(matching) != 1:
+                return False
+            record = matching[0]
+            if record.get('kind') not in ('bot', 'player'):
+                return False
+            target_kind = 'human' if record['kind'] == 'player' else 'bot'
+            target_id = record.get('network_id')
+        return owner.client.send_team_command(
+            request.get('command'), target_kind=target_kind,
+            target_id=target_id, cell_index=request.get('cell_index'))
 
     def align_aim(self, turret_yaw=0.0, gun_pitch=0.0):
         """Seed the world-space LAN aim from the attached native gun."""
@@ -2856,6 +2879,7 @@ class BattleRuntime(object):
             commands = self._runtime.account_commands
             self._server = AvatarServerBridge(
                 self._avatar, self._binding, builder, self._sender,
+                radio_player_getter=self._runtime.bigworld.player,
                 account_commands=(commands.CMD_GET_AVATAR_SYNC,
                                   commands.CMD_ADD_INT_USER_SETTINGS,
                                   commands.CMD_DEL_INT_USER_SETTINGS),
@@ -3069,6 +3093,7 @@ class BattleRuntime(object):
                 vehicle_selector=self._select_bot_vehicle,
                 visibility_probe=self._bot_visibility,
                 firing_lane_probe=self._bot_firing_lane,
+                incoming_lane_probe=self._bot_incoming_lane,
                 friendly_lane_probe=self._bot_friendly_firing_lane,
                 direct_launch_origin_probe=self._bot_direct_launch_origin,
                 direct_aim_point_probe=self._bot_aim_point,
@@ -3267,6 +3292,78 @@ class BattleRuntime(object):
             self._publish_reload_event(
                 self._gun_state.reload_time,
                 self._gun_state.reload_duration, force=True)
+        return True
+
+    def _radio_message_current(self, message):
+        return (not self._worker_mode and self._avatar is not None and
+                self._server is not None and isinstance(message, dict) and
+                message.get('round_id') == self._start_message.get('round_id'))
+
+    def _radio_identity(self, kind, network_id):
+        record_kind = 'player' if kind == 'human' else 'bot'
+        try:
+            record = self._records.get('%s:%d' % (record_kind, int(network_id)))
+        except (TypeError, ValueError, OverflowError):
+            return None
+        if not record or record.get('tombstone') or not record.get('ready'):
+            return None
+        entity_id = record.get('engine_id')
+        arena = getattr(self._avatar, 'arena', None)
+        info = (getattr(arena, 'vehicles', {}) or {}).get(entity_id)
+        if not isinstance(info, dict) or not info.get('accountDBID'):
+            return None
+        return entity_id, info['accountDBID']
+
+    def on_team_command_ack(self, message):
+        if not self._radio_message_current(message):
+            return False
+        responders = []
+        for bot_id in message.get('recipient_bot_ids') or ():
+            identity = self._radio_identity('bot', bot_id)
+            if identity is not None:
+                responders.append(identity[1])
+        return self._server.receive_team_command_ack(
+            message.get('command_seq'), message.get('accepted'), responders)
+
+    def on_team_command(self, message):
+        if (not self._radio_message_current(message) or
+                message.get('team') != self.client.team):
+            return False
+        # The same-team relay owns the command echo for every player.
+        # Admission receipts only close the request and publish the Bot reply.
+        issuer = self._radio_identity('human', message.get('issuer_id'))
+        if issuer is None:
+            return False
+        target_id = None
+        if 'target_id' in message:
+            target = self._radio_identity(message.get('target_kind'),
+                                          message['target_id'])
+            if target is None:
+                return False
+            target_id = target[0]
+        seen = getattr(self, '_radio_seen', {})
+        key = (message['round_id'], message['issuer_id'])
+        if message['command_seq'] <= seen.get(key, 0):
+            return False
+        result = self._server.receive_team_command(
+            message.get('command'), issuer[1], target_id,
+            message.get('cell_index'))
+        if result:
+            seen[key] = message['command_seq']
+            self._radio_seen = seen
+        return result
+
+    def on_team_command_terminal(self, message):
+        if not self._radio_message_current(message):
+            return False
+        seen = getattr(self, '_radio_terminals', set())
+        key = (message['round_id'], message['command_seq'])
+        if key in seen:
+            return False
+        seen.add(key)
+        self._radio_terminals = seen
+        sys.stdout.write('[Offline LAN 0.9.22] BOT ORDER END seq=%s command=%s reason=%s\n' % (
+            message['command_seq'], message.get('command'), message.get('code')))
         return True
 
     def on_battle_live(self, message):
@@ -5201,86 +5298,224 @@ class BattleRuntime(object):
                 abs(height - point[1]), 2.5)))
         return maximum
 
+    def _observed_vehicle_descriptor(self, target):
+        kind = 'player' if target.get('kind') == 'human' else 'bot'
+        network_id = target.get('network_id', target.get('id'))
+        record = self._records.get('%s:%d' % (kind, int(network_id)))
+        if not record or record.get('tombstone') or not record.get('ready'):
+            return None
+        entity = self._server_entity(record.get('engine_id'))
+        if entity is None or not getattr(entity, 'isStarted', False):
+            return None
+        # Descriptors are static content. The entity's omniscient matrix,
+        # reload, ammunition and current gun angles are never read here.
+        return getattr(entity, 'typeDescriptor', None)
+
+    def _observed_gun_origin(self, target):
+        descriptor = self._observed_vehicle_descriptor(target)
+        if descriptor is None:
+            return None
+        yaw = target.get('yaw', 0.0)
+        origin, unused_direction = shot_geometry.shot_origin_and_direction(
+            descriptor, _xyz(target.get('position', target)), yaw, target.get('pitch', 0.0),
+            target.get('roll', 0.0), target.get(
+                'turret_yaw', target.get('aim_yaw', yaw) - yaw),
+            target.get('gun_pitch', 0.0))
+        return origin
+
+    def _tactical_ray_clear(self, start, end):
+        return self._runtime.bigworld.wg_collideSegment(
+            self._avatar.spaceID, self._vector(start),
+            self._vector(end), 128) is None
+
+    def _bot_incoming_lane(self, source, target):
+        """Probe enemy gun -> own body, never infer it from the reverse ray."""
+        try:
+            own = dict(source, kind='bot', network_id=source['id'])
+            descriptor = self._observed_vehicle_descriptor(own)
+            origin = self._observed_gun_origin(target)
+            if descriptor is None or origin is None:
+                return None
+            samples = shot_geometry.vehicle_aim_samples(descriptor)[:2]
+            if not samples:
+                return None
+            return any(self._tactical_ray_clear(
+                origin, shot_geometry.vehicle_aim_point(sample, source))
+                for sample in samples)
+        except Exception:
+            return None
+
+    def _cover_surface_pose(self, source, point, descriptor, ground=None):
+        plane = self._sample_ground_plane(point, source.get('yaw', 0.0),
+                                          descriptor, ground_probe=ground)
+        if plane is None or math.degrees(math.atan(
+                plane['slope_tangent'])) > 24.0:
+            return None
+        pose = dict(source)
+        pose.update(position=(point[0], plane['center_y'], point[2]),
+                    pitch=plane['pitch'], roll=plane['roll'])
+        return pose
+
+    def _cover_gun_lane(self, pose, descriptor, target, clear):
+        """Prove a peek from the installed gun envelope and physical pivot."""
+        target_descriptor = self._observed_vehicle_descriptor(target)
+        if target_descriptor is None:
+            return False
+        yaw = pose.get('yaw', 0.0)
+        origin, unused = shot_geometry.shot_origin_and_direction(
+            descriptor, pose['position'], yaw, pose.get('pitch', 0.0),
+            pose.get('roll', 0.0), pose.get('turret_yaw', 0.0),
+            pose.get('gun_pitch', 0.0))
+        for sample in shot_geometry.vehicle_aim_samples(target_descriptor)[:2]:
+            point = shot_geometry.vehicle_aim_point(sample, target)
+            direction = tuple(point[i] - origin[i] for i in range(3))
+            turret_yaw, pitch = shot_geometry.world_direction_to_local_gun_angles(
+                direction, yaw, pose.get('pitch', 0.0), pose.get('roll', 0.0))
+            limits = BotRuntime._effective_gun_pitch_limits(
+                pose, descriptor, turret_yaw)
+            yaw_min, yaw_max, unused = gun_yaw_limits(descriptor)
+            if (limits is None or not limits[0] <= pitch <= limits[1] or
+                    not yaw_min <= turret_yaw <= yaw_max):
+                continue
+            aimed_origin, unused = shot_geometry.shot_origin_and_direction(
+                descriptor, pose['position'], yaw, pose.get('pitch', 0.0),
+                pose.get('roll', 0.0), turret_yaw, pitch)
+            if clear(aimed_origin, point):
+                return True
+        return False
+
     def _sample_bot_cover(self, source, target, route_position,
                           ally_positions, segment_clear):
-        """Port the 0.8.2 four-point cover fan through #1513 ray probes."""
-        current = _xyz(source)
-        target_position = target.get('position') or _xyz(target)
-        dx = current[0] - float(target_position[0])
-        dz = current[2] - float(target_position[2])
-        length = math.sqrt(dx * dx + dz * dz)
-        if length < 2.0 or not callable(segment_clear):
+        """Search cover with at most 40 direct native queries per job.
+
+        Rotate the candidate fan between normal staggered cover jobs. Geometry
+        is advisory: actual navigation, body support and final fire retain their
+        independent native proofs. Incomplete probes never produce a candidate.
+        """
+        if not callable(segment_clear) or self._bots is None:
             return ()
-        away_x, away_z = dx / length, dz / length
-        right_x, right_z = away_z, -away_x
+        current = _xyz(source)
+        own = dict(source, kind='bot', network_id=source['id'])
+        descriptor = self._observed_vehicle_descriptor(own)
+        if descriptor is None:
+            return ()
+        samples = tactical_geometry.body_samples(descriptor)
+        if not samples:
+            return ()
+        bbox = _field(_field(_field(descriptor, 'hull'), 'hitTester'), 'bbox')
+        width = float(bbox[1][0]) - float(bbox[0][0])
+        length = float(bbox[1][2]) - float(bbox[0][2])
+        if min(width, length) <= 0.0:
+            return ()
+        observed = []
+        for key, remembered in self._bots._visible_target_poses.items():
+            if (key[0] != source.get('team') or
+                    self._bots._team_spot_time_left(key, self._clock()) <= 0.0):
+                continue
+            value = dict(remembered, kind=key[1], network_id=key[2])
+            observed.append(((key[1], key[2]), value))
+        threats = tactical_geometry.relevant_threats(current, target, observed)
+        origins = []
+        for threat in threats:
+            origin = self._observed_gun_origin(threat)
+            if origin is None:
+                return ()
+            origins.append(origin)
+        record = self._records.get('bot:%d' % source['id'])
+        phase = record.get('cover_search_phase', 0)
+        record['cover_search_phase'] = phase + 1
+        offsets = tactical_geometry.search_offsets(width, length, phase)
+        # Budget includes vertical ground rays and water queries as well as
+        # exposure. Grid traversal retains its existing independent budget.
+        budget = tactical_geometry.RayBudget(self._tactical_ray_clear, 40)
+        ground_cache = {}
+        def ground_at(x, z, hint):
+            key = (x, z, hint)
+            if key not in ground_cache:
+                ground_cache[key] = budget.call(self._cover_ground, x, z, hint)
+            return ground_cache[key]
+        target_position = _xyz(target.get('position', target))
+        dx, dz = (current[0] - target_position[0],
+                  current[2] - target_position[2])
+        distance = math.hypot(dx, dz)
+        if distance < 2.0:
+            return ()
+        away = (dx / distance, dz / distance)
+        right = (away[1], -away[0])
         route = _xyz(route_position)
         route_dx, route_dz = route[0] - current[0], route[2] - current[2]
-        route_length = math.sqrt(route_dx * route_dx + route_dz * route_dz)
+        route_length = math.hypot(route_dx, route_dz)
         candidates = []
-        for away, lateral in ((0.0, 0.0), (14.0, 0.0),
-                              (10.0, 13.0), (10.0, -13.0)):
-            x = current[0] + away_x * away + right_x * lateral
-            z = current[2] + away_z * away + right_z * lateral
-            ground = self._cover_ground(x, z, current[1])
-            if ground is None:
-                continue
-            point = (x, ground, z)
-            water_depth = self._water_depth(point)
-            if (water_depth > BOT_WATER_AVOID_DEPTH or
-                    not segment_clear(current, point)):
-                continue
-            occluded = not self._has_los(point, target_position)
-            if not occluded:
-                continue
-            slope = self._cover_slope(point)
-            if slope > 24.0:
-                continue
-            peek = None
-            for side in (-1.0, 1.0):
-                peek_x = point[0] + right_x * side * 6.5 - away_x * 2.0
-                peek_z = point[2] + right_z * side * 6.5 - away_z * 2.0
-                peek_y = self._cover_ground(peek_x, peek_z, point[1])
-                if peek_y is None:
+        # Ground/path work is bounded too, even when every point has no ground.
+        for backward, lateral in offsets[:4]:
+            try:
+                point = (current[0] + away[0] * backward + right[0] * lateral,
+                         current[1],
+                         current[2] + away[1] * backward + right[1] * lateral)
+                ground = ground_at(point[0], point[2], point[1])
+                if ground is None:
                     continue
-                peek_point = (peek_x, peek_y, peek_z)
-                if (self._water_depth(peek_point) <=
-                        BOT_WATER_AVOID_DEPTH and
-                        segment_clear(point, peek_point) and
-                        self._has_los(peek_point, target_position)):
-                    peek = peek_point
+                point = (point[0], ground, point[2])
+                water_depth = budget.call(self._water_depth, point)
+                if (water_depth > BOT_WATER_AVOID_DEPTH or
+                        not segment_clear(current, point)):
+                    continue
+                pose = self._cover_surface_pose(source, point, descriptor, ground_at)
+                if pose is None:
+                    continue
+                try:
+                    hidden = tactical_geometry.exposure(samples, pose, origins,
+                                                        budget.clear)
+                    if hidden is None or hidden > 0.5:
+                        continue
+                    side = -1.0 if phase % 2 else 1.0
+                    peek = (point[0] + right[0] * width * 1.5 * side,
+                            point[1],
+                            point[2] + right[1] * width * 1.5 * side)
+                    peek_ground = ground_at(peek[0], peek[2], peek[1])
+                    if peek_ground is None:
+                        continue
+                    peek = (peek[0], peek_ground, peek[2])
+                    if (budget.call(self._water_depth, peek) > BOT_WATER_AVOID_DEPTH or
+                            not segment_clear(point, peek) or
+                            not segment_clear(peek, point)):
+                        continue
+                    peek_pose = self._cover_surface_pose(source, peek, descriptor, ground_at)
+                    if peek_pose is None or not self._cover_gun_lane(
+                            peek_pose, descriptor, target, budget.clear):
+                        continue
+                    exposed = tactical_geometry.exposure(samples, peek_pose,
+                                                         origins, budget.clear)
+                    midpoint = tuple((current[i] + point[i]) * 0.5 for i in range(3))
+                    mid_pose = dict(pose, position=midpoint)
+                    approach = tactical_geometry.exposure(samples[:2], mid_pose,
+                                                          origins, budget.clear)
+                except tactical_geometry.ProbeBudgetExhausted:
                     break
-            move_dx, move_dz = point[0] - current[0], point[2] - current[2]
-            move_length = math.sqrt(move_dx * move_dx + move_dz * move_dz)
-            alignment = 0.5
-            if move_length > 0.1 and route_length > 0.1:
-                dot = ((move_dx / move_length) * (route_dx / route_length) +
-                       (move_dz / move_length) * (route_dz / route_length))
-                alignment = max(0.0, min(1.0, (dot + 1.0) * 0.5))
-            nearby = sum(1 for ally in (ally_positions or ())
-                         if 0.5 < _distance_2d(point, ally) < 13.0)
-            candidate = {
-                'id': '%s:%d:%d' % (
-                    source.get('id'), int(round(point[0] / 4.0)),
-                    int(round(point[2] / 4.0))),
-                'position': point,
-                'travel_distance': _distance_2d(point, current),
-                'route_alignment': alignment,
-                'enemy_occlusion': 1.0,
-                'exposure': 0.12,
-                'slope': slope,
-                'water': max(0.0, min(1.0, water_depth)),
-                'ally_congestion': max(0.0, min(1.0, nearby / 3.0)),
-                'peek_feasible': peek is not None,
-                'escape_feasible': True,
-            }
-            if peek is not None:
-                candidate['peek_position'] = peek
-            candidates.append(candidate)
-        ranked = score_candidates(candidates)
-        for candidate in ranked:
-            for key in ('breakdown', 'reasons', 'rank', 'score'):
-                candidate.pop(key, None)
-        return tuple(ranked)
+                move_dx, move_dz = point[0] - current[0], point[2] - current[2]
+                travel = math.hypot(move_dx, move_dz)
+                alignment = 0.5
+                if travel > 0.1 and route_length > 0.1:
+                    alignment = max(0.0, min(1.0, 0.5 + 0.5 * (
+                        move_dx * route_dx + move_dz * route_dz) /
+                        (travel * route_length)))
+                nearby = sum(1 for ally in (ally_positions or ())
+                             if 0.5 < _distance_2d(point, ally) < 13.0)
+                candidates.append({
+                    'id': '%s:%d:%d:%d' % (source['id'],
+                        int(round(point[0] / 4.0)), int(round(point[2] / 4.0)), side),
+                    'position': point, 'peek_position': peek,
+                    'travel_distance': travel, 'route_alignment': alignment,
+                    'enemy_occlusion': 1.0 - hidden,
+                    'exposure': (hidden + exposed + approach) / 3.0,
+                    'slope': math.degrees(max(abs(pose['pitch']), abs(pose['roll']))),
+                    'water': water_depth,
+                    'ally_congestion': min(1.0, nearby / 3.0),
+                    'peek_feasible': True, 'escape_feasible': True,
+                })
+            except tactical_geometry.ProbeBudgetExhausted:
+                break
+        return tuple(candidates)
 
     def local_pose(self):
         # The copied 0.8.2 integrator owns this pose.  #1513's stock camera,
@@ -15277,8 +15512,10 @@ class BattleRuntime(object):
         self._ready_sent = True
         return True
 
-    def _sample_ground_plane(self, position, yaw, descriptor=None):
+    def _sample_ground_plane(self, position, yaw, descriptor=None,
+                             ground_probe=None):
         """Fit one continuous terrain plane under the local suspension."""
+        ground = ground_probe or self._ground_y
         length = 5.0
         width = 3.0
         try:
@@ -15294,19 +15531,19 @@ class BattleRuntime(object):
         half_length = length * 0.5
         half_width = width * 0.5
         sin_yaw, cos_yaw = math.sin(yaw), math.cos(yaw)
-        front_y = self._ground_y(
+        front_y = ground(
             position[0] + sin_yaw * half_length,
             position[2] + cos_yaw * half_length, position[1])
-        rear_y = self._ground_y(
+        rear_y = ground(
             position[0] - sin_yaw * half_length,
             position[2] - cos_yaw * half_length, position[1])
-        right_y = self._ground_y(
+        right_y = ground(
             position[0] + cos_yaw * half_width,
             position[2] - sin_yaw * half_width, position[1])
-        left_y = self._ground_y(
+        left_y = ground(
             position[0] - cos_yaw * half_width,
             position[2] + sin_yaw * half_width, position[1])
-        center_y = self._ground_y(
+        center_y = ground(
             position[0], position[2], position[1])
         if None in (front_y, rear_y, right_y, left_y, center_y):
             return None
@@ -18345,6 +18582,52 @@ class BattleRuntime(object):
         except Exception:
             return None
 
+    def _bot_aim_damage_score(self, descriptor, entry, source, target,
+                              origin, point):
+        """Rank a tested sample with the existing #1513 armour resolver.
+
+        The midpoint penetration/damage rolls make this an advisory nominal
+        estimate. It neither samples nor commits the real projectile's RNG.
+        """
+        try:
+            target_descriptor = entry['descriptor']
+            for name in ('chassis', 'hull', 'turret', 'gun'):
+                tester = _field(_field(target_descriptor, name), 'hitTester')
+                if not callable(getattr(tester, 'localHitTest', None)):
+                    return None
+            yaw = target.get('yaw', 0.0)
+            matrix = self._runtime.math.Matrix()
+            matrix.setRotateYPR((yaw, target.get('pitch', 0.0),
+                                 target.get('roll', 0.0)))
+            position = self._vector(_xyz(target.get('position', target)))
+            matrix.translation = position
+            appearance = _ProjectileCollisionAppearance(
+                self._runtime.math, target_descriptor,
+                target.get('turret_yaw', target.get('aim_yaw', yaw) - yaw),
+                target.get('gun_pitch', 0.0))
+            proxy = _ProjectileCollisionTarget(
+                None, target_descriptor, matrix, position, appearance,
+                self._runtime.math)
+            collisions = collide_vehicle_at_matrix(
+                proxy, matrix, self._vector(origin), self._vector(point),
+                self._runtime.math)
+            if not collisions:
+                return None
+            shot = self._descriptor_shot(descriptor, source.get('shell_index', 0))
+            distance = math.sqrt(sum((point[i] - origin[i]) ** 2 for i in range(3)))
+            contact = combat_rules.resolve_armor_contact(
+                shot, distance, collisions, penetration_factor=1.0)
+            if contact is None:
+                return None
+            if contact['layer'] != 'structural' and not combat_rules.is_he(shot):
+                return 0.0
+            nominal = combat_rules.he_nominal_armor(collisions, target_descriptor)
+            return float(combat_rules.damage(
+                shot, contact['result'], nominal,
+                random_uniform=lambda minimum, maximum: (minimum + maximum) * 0.5))
+        except Exception:
+            return None
+
     def _bot_firing_lane(self, source, target):
         """Select a real exposed part with at most two static rays per job."""
         profile = source.get('profile')
@@ -18392,14 +18675,26 @@ class BattleRuntime(object):
                 if samples[index] not in attempts:
                     attempts.append(samples[index])
             entry['selected'] = None
+            best = None
+            best_score = None
             for sample in attempts:
                 point = shot_geometry.vehicle_aim_point(sample, target)
                 hit = self._runtime.bigworld.wg_collideSegment(
                     self._avatar.spaceID, self._vector(origin),
                     self._vector(point), 128)
-                if hit is None:
-                    entry['selected'] = sample
-                    return True
+                if hit is not None:
+                    continue
+                score = self._bot_aim_damage_score(
+                    descriptor, entry, source, target, origin, point)
+                if best is None or (score is not None and
+                        best_score is not None and score > best_score):
+                    best, best_score = sample, score
+                # Missing material evidence cannot authorize a weak-spot
+                # claim. Preserve the exposed-part behaviour in that case.
+                if score is None:
+                    break
+            entry['selected'] = best
+            return best is not None
         except Exception:
             if entry is not None:
                 entry['selected'] = None

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -3071,6 +3071,7 @@ class BattleRuntime(object):
                 firing_lane_probe=self._bot_firing_lane,
                 friendly_lane_probe=self._bot_friendly_firing_lane,
                 direct_launch_origin_probe=self._bot_direct_launch_origin,
+                direct_aim_point_probe=self._bot_aim_point,
                 ballistic_solution_probe=self._bot_ballistic_solution,
                 artillery_launch_probe=self._bot_artillery_launch,
                 artillery_friendly_lane_probe=(
@@ -18280,8 +18281,72 @@ class BattleRuntime(object):
             'foliage_bonus': foliage_bonus,
         }
 
+    def _bot_aim_context(self, source, target):
+        """Keep candidate ownership on the current source/target records."""
+        if not isinstance(target, dict) or not target.get('alive', True):
+            return None
+        try:
+            source_key = 'bot:%d' % int(source['id'])
+            kind = 'player' if target.get('kind') == 'human' else 'bot'
+            target_key = '%s:%d' % (
+                kind, int(target.get('network_id', target.get('id'))))
+        except (KeyError, TypeError, ValueError, OverflowError):
+            return None
+        source_record = self._records.get(source_key)
+        target_record = self._records.get(target_key)
+        if (source_record is None or target_record is None or
+                source_record.get('tombstone') or
+                target_record.get('tombstone') or
+                not source_record.get('ready') or
+                not target_record.get('ready')):
+            return None
+        source_entity = self._server_entity(source_record.get('engine_id'))
+        target_entity = self._server_entity(target_record.get('engine_id'))
+        if (source_entity is None or target_entity is None or
+                not getattr(source_entity, 'isStarted', False) or
+                not getattr(target_entity, 'isStarted', False)):
+            return None
+        descriptor = getattr(target_entity, 'typeDescriptor', None)
+        source_descriptor = getattr(source_entity, 'typeDescriptor', None)
+        if descriptor is None or source_descriptor is None:
+            return None
+        candidates = source_record.setdefault('bot_aim_targets', {})
+        entry = candidates.get(target_key)
+        geometry_ready = tuple(
+            _field(_field(_field(descriptor, name), 'hitTester'),
+                   'bbox') is not None for name in ('hull', 'turret'))
+        if (entry is None or entry['record'] is not target_record or
+                entry['descriptor'] is not descriptor or
+                entry['geometry_ready'] != geometry_ready):
+            entry = {'record': target_record, 'descriptor': descriptor,
+                     'samples': shot_geometry.vehicle_aim_samples(descriptor),
+                     'geometry_ready': geometry_ready,
+                     'cursor': 0, 'selected': None}
+            candidates[target_key] = entry
+        return source_record, source_descriptor, entry
+
+    def _bot_aim_point(self, source, target):
+        """Project the selected part at the supplied, visibility-owned pose."""
+        try:
+            context = self._bot_aim_context(source, target)
+            if context is None:
+                return None
+            entry = context[2]
+            sample = entry['selected']
+            if sample is None:
+                return None
+            return {
+                'aim_position': shot_geometry.vehicle_aim_point(sample, target),
+                # Replacing an entity or descriptor invalidates a solved shot,
+                # even when the replacement happens to have the same bbox.
+                'aim_token': (id(entry['record']), id(entry['descriptor']),
+                              sample),
+            }
+        except Exception:
+            return None
+
     def _bot_firing_lane(self, source, target):
-        """Probe static space between, rather than inside, two vehicle hulls."""
+        """Select a real exposed part with at most two static rays per job."""
         profile = source.get('profile')
         profile = profile if isinstance(profile, dict) else {}
         if str(profile.get('class_tag') or '') == 'SPG':
@@ -18292,29 +18357,53 @@ class BattleRuntime(object):
             ready, solution = self._artillery.request(
                 source, target, descriptor, shell_index, self._clock())
             return bool(ready and solution is not None)
-        source_position = _xyz(source)
-        target_position = target.get('position') or _xyz(target)
-        dx = target_position[0] - source_position[0]
-        dz = target_position[2] - source_position[2]
-        distance = math.sqrt(dx * dx + dz * dz)
-        # Keep a short but real world segment between close hulls. Treating the
-        # absence of the default eight-metre middle section as clear let tanks
-        # on opposite sides of a thin wall enter engage/hold and fire forever.
-        clearance = min(4.0, max(0.0, (distance - 0.75) * 0.5))
-        for target_height in (1.5, 2.2):
-            segment = bot_planner.trimmed_sight_segment(
-                source_position, target_position, 2.5, target_height,
-                clearance, clearance)
-            if segment is None:
+        entry = None
+        try:
+            context = self._bot_aim_context(source, target)
+            if context is None:
                 return False
-            if not segment:
+            record, descriptor, entry = context
+            samples = entry['samples']
+            if not samples:
                 return False
-            start, end = segment
-            hit = self._runtime.bigworld.wg_collideSegment(
-                self._avatar.spaceID,
-                self._vector(start), self._vector(end), 128)
-            if hit is None:
-                return True
+            pose_key = (id(descriptor), self._last_frame_time,
+                        source.get('fire_seq', 0)) + tuple(source.get(name, 0.0)
+                for name in ('x', 'y', 'z', 'yaw', 'pitch', 'roll',
+                             'aim_yaw', 'turret_yaw', 'gun_pitch'))
+            cached = record.get('bot_lane_origin')
+            origin = cached[1] if cached and cached[0] == pose_key else None
+            if origin is None:
+                origin = self._bot_direct_launch_origin(
+                    source, descriptor, source.get('shell_index', 0),
+                    int(source.get('fire_seq', 0)) + 1, 0.0, 0.0, 0.0)
+                if origin is None:
+                    entry['selected'] = None
+                    return False
+                record['bot_lane_origin'] = (pose_key, origin)
+            selected = entry['selected']
+            attempts = [selected] if selected is not None else []
+            # Keep a still-clear part stable. On blockage, rotate through the
+            # remaining bbox samples across the existing bounded lane jobs.
+            visited = 0
+            while len(attempts) < 2 and visited < len(samples):
+                index = entry['cursor'] % len(samples)
+                entry['cursor'] = (index + 1) % len(samples)
+                visited += 1
+                if samples[index] not in attempts:
+                    attempts.append(samples[index])
+            entry['selected'] = None
+            for sample in attempts:
+                point = shot_geometry.vehicle_aim_point(sample, target)
+                hit = self._runtime.bigworld.wg_collideSegment(
+                    self._avatar.spaceID, self._vector(origin),
+                    self._vector(point), 128)
+                if hit is None:
+                    entry['selected'] = sample
+                    return True
+        except Exception:
+            if entry is not None:
+                entry['selected'] = None
+            return False
         return False
 
     def _bot_friendly_path_verdict(

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -1254,7 +1254,7 @@ class _LANInputSender(object):
     def send_team_command(self, request):
         owner = self.owner
         if (owner._worker_mode or owner._avatar is None or
-                not owner._battle_live or not isinstance(request, dict)):
+                owner.state != 'running' or not isinstance(request, dict)):
             return False
         target_kind = target_id = None
         stock_id = request.get('stock_target_id')
@@ -1271,7 +1271,15 @@ class _LANInputSender(object):
             target_id = record.get('network_id')
         return owner.client.send_team_command(
             request.get('command'), target_kind=target_kind,
-            target_id=target_id, cell_index=request.get('cell_index'))
+            target_id=target_id, cell_index=request.get('cell_index'),
+            details=request.get('details'))
+
+    def send_team_chat(self, request):
+        owner = self.owner
+        if (owner._worker_mode or owner._avatar is None or
+                owner.state != 'running' or not isinstance(request, dict)):
+            return False
+        return owner.client.send_team_chat(request.get('text'))
 
     def align_aim(self, turret_yaw=0.0, gun_pitch=0.0):
         """Seed the world-space LAN aim from the attached native gun."""
@@ -3191,6 +3199,11 @@ class BattleRuntime(object):
                 self._remember_ram_bot_snapshot(self._last_snapshot)
             self.state = 'running'
             if not self._worker_mode:
+                # Stock __startGUI has registered the battle messenger before
+                # setClientReady reaches this boundary. Initialize channels
+                # after that owner exists and before our shared load barrier.
+                self._run_optional_feature(
+                    'team chat initialization', self._server.start_team_chat)
                 self._bind_local_arcade_camera()
                 self._run_optional_feature(
                     'engine RPM presentation', self._publish_rpm,
@@ -3295,7 +3308,8 @@ class BattleRuntime(object):
         return True
 
     def _radio_message_current(self, message):
-        return (not self._worker_mode and self._avatar is not None and
+        return (self.state == 'running' and not self._worker_mode and
+                self._avatar is not None and
                 self._server is not None and isinstance(message, dict) and
                 message.get('round_id') == self._start_message.get('round_id'))
 
@@ -3325,7 +3339,31 @@ class BattleRuntime(object):
         return self._server.receive_team_command_ack(
             message.get('command_seq'), message.get('accepted'), responders)
 
+    def on_team_chat_ack(self, message):
+        if not self._radio_message_current(message):
+            return False
+        return self._server.receive_team_chat_ack(
+            message.get('chat_seq'), message.get('accepted'))
+
+    def on_team_chat(self, message):
+        if (not self._radio_message_current(message) or
+                message.get('team') != self.client.team):
+            return False
+        issuer = self._radio_identity('human', message.get('issuer_id'))
+        if issuer is None:
+            return False
+        seen = getattr(self, '_team_chat_seen', {})
+        key = (message['round_id'], message['issuer_id'])
+        if message['chat_seq'] <= seen.get(key, 0):
+            return False
+        result = self._server.receive_team_chat(message.get('text'), issuer[1])
+        if result:
+            seen[key] = message['chat_seq']
+            self._team_chat_seen = seen
+        return result
+
     def on_team_command(self, message):
+        from gui.mods.offline_lan_0922.tactical_radio import COMMAND_DETAIL_FIELDS
         if (not self._radio_message_current(message) or
                 message.get('team') != self.client.team):
             return False
@@ -3345,9 +3383,14 @@ class BattleRuntime(object):
         key = (message['round_id'], message['issuer_id'])
         if message['command_seq'] <= seen.get(key, 0):
             return False
+        required, optional = COMMAND_DETAIL_FIELDS.get(
+            message.get('command'), ((), ()))
+        details = dict((field, message[field]) for field in required + optional
+                       if field in message)
+        extra = {'details': details} if details else {}
         result = self._server.receive_team_command(
             message.get('command'), issuer[1], target_id,
-            message.get('cell_index'))
+            message.get('cell_index'), **extra)
         if result:
             seen[key] = message['command_seq']
             self._radio_seen = seen
@@ -21902,13 +21945,21 @@ class BattleRuntime(object):
     def _quiesce_native_presentations(self):
         """Release battle-scoped native visuals before Hangar takes over."""
         cleanup_error = None
+        if self._server is not None:
+            try:
+                # Close channel controllers while the current Avatar and
+                # battle GUI still own them, before onBecomeNonPlayer.
+                self._server.close_team_chat()
+            except Exception as error:
+                cleanup_error = error
         try:
             # BigWorld.target.clear() synchronously reaches stock targetBlur.
             # Run it before any GUI, trigger, edge or remote-entity owner can
             # be retired; PlayerAvatar.onBecomeNonPlayer clears it too late.
             self._runtime.compatibility.clear_target_focus()
         except Exception as error:
-            cleanup_error = error
+            if cleanup_error is None:
+                cleanup_error = error
         try:
             self._release_postmortem_visibility()
         except Exception as error:
@@ -22018,6 +22069,9 @@ class BattleRuntime(object):
         self._unusable_vehicles_reported = set()
         self._records = {}
         self._records_revision += 1
+        self._radio_seen = {}
+        self._radio_terminals = set()
+        self._team_chat_seen = {}
         _release_layout_caches()
         if self._map_create_attempted:
             creator = self._runtime.offline_map_creator

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -101,9 +101,12 @@ MAX_WORKER_SHOT_LANE_PAIRS_PER_FRAME = 16
 # visibility, planning, ballistics and observation serialisation consume.  In
 # particular, do not clone a complete Bot authority state for every enemy
 # observer pair.
-_TARGET_DYNAMIC_FIELDS = (
-    'team', 'alive', 'health', 'max_health',
-    'x', 'y', 'z', 'yaw', 'speed', 'velocity', 'fire_seq', 'critical',
+_TARGET_POSE_FIELDS = (
+    'x', 'y', 'z', 'yaw', 'pitch', 'roll', 'aim_yaw', 'turret_yaw',
+    'gun_pitch', 'speed', 'velocity',
+)
+_TARGET_DYNAMIC_FIELDS = _TARGET_POSE_FIELDS + (
+    'team', 'alive', 'health', 'max_health', 'fire_seq', 'critical',
 )
 _HUMAN_TARGET_STATIC_FIELDS = (
     'vehicle', 'vehicle_compact_descr', 'effective_params',
@@ -1886,6 +1889,7 @@ class BotRuntime(object):
                  vehicle_selector=None, visibility_probe=None,
                  firing_lane_probe=None, friendly_lane_probe=None,
                  direct_launch_origin_probe=None,
+                 direct_aim_point_probe=None,
                  ballistic_solution_probe=None,
                  artillery_launch_probe=None,
                  artillery_friendly_lane_probe=None,
@@ -1902,6 +1906,9 @@ class BotRuntime(object):
         self.local_player_id = local_player_id
         self.descriptor_resolver = descriptor_resolver or (lambda unused: {})
         self.player_descriptor_resolver = player_descriptor_resolver
+        # Production resolves the same descriptor-local part selected by the
+        # bounded firing-lane queue. None retains the engine-free test seam.
+        self.direct_aim_point_probe = direct_aim_point_probe
         self.direction_probe = self._adapt_direction_probe(
             direction_probe or (lambda *unused: True))
         self.adapter_factory = adapter_factory or BotAdapter
@@ -4835,6 +4842,14 @@ class BotRuntime(object):
     def _copy_target_fields(raw, names):
         return dict((name, raw[name]) for name in names if name in raw)
 
+    @staticmethod
+    def _target_pose_snapshot(target):
+        remembered = BotRuntime._copy_target_fields(target, _TARGET_POSE_FIELDS)
+        remembered['position'] = _position(target)
+        for name in ('x', 'y', 'z', 'yaw', 'speed'):
+            remembered.setdefault(name, 0.0)
+        return remembered
+
     def _human_observation_target(
             self, raw, tick_cache=None, player_id=None):
         if player_id is None:
@@ -4951,14 +4966,7 @@ class BotRuntime(object):
                     continue
                 entry[3].add(source['id'])
                 team_visibility[key] = True
-                remembered = {
-                    'position': _position(target),
-                    'x': target.get('x', 0.0),
-                    'y': target.get('y', 0.0),
-                    'z': target.get('z', 0.0),
-                    'yaw': target.get('yaw', 0.0),
-                    'speed': target.get('speed', 0.0),
-                }
+                remembered = self._target_pose_snapshot(target)
                 self._visible_target_poses[key] = remembered
                 entry[2].update(remembered)
                 duration = spotting.SPOT_MEMORY_SECONDS
@@ -4991,18 +4999,15 @@ class BotRuntime(object):
             key = (source_team, target.get('kind'),
                    int(target.get('network_id', 0)))
             if target['fresh_visible']:
-                remembered = {
-                    'position': _position(target),
-                    'x': target.get('x', 0.0),
-                    'y': target.get('y', 0.0),
-                    'z': target.get('z', 0.0),
-                    'yaw': target.get('yaw', 0.0),
-                    'speed': target.get('speed', 0.0),
-                }
+                remembered = self._target_pose_snapshot(target)
                 self._visible_target_poses[key] = remembered
                 target.update(remembered)
                 return True
             remembered = self._visible_target_poses.get(key)
+            # Discard every live pose field first: an old observation can lack
+            # articulation or velocity that the current hidden entity has.
+            for name in _TARGET_POSE_FIELDS:
+                target.pop(name, None)
             if remembered is None:
                 # The server treats a first hidden sample as a valid no-op.
                 # Publish a shape-complete neutral record, but never expose
@@ -5080,7 +5085,7 @@ class BotRuntime(object):
         if live is not None:
             if target.get('fresh_visible') is True:
                 target['position'] = _position(live)
-                pose_fields = ('x', 'y', 'z', 'yaw', 'speed')
+                pose_fields = _TARGET_POSE_FIELDS
             else:
                 pose_fields = ()
             for name in (('alive', 'health', 'max_health', 'team') +
@@ -6510,17 +6515,30 @@ class BotRuntime(object):
         direct_target = bool(
             direct_close and callable(direct) and
             not direct_penalized and direct(position, goal, now))
+        # Short, clear routes still need the navigator's progress monitor:
+        # local motion alone cannot distinguish travel from oscillation.
+        throttle_override = strategic.get('throttle_override')
+        driver = getattr(self.adapter, 'driver', None)
+        driver_state = getattr(driver, 'states', {}).get(int(bot_id), {})
+        movement_intent = bool(
+            (throttle_override is None or float(throttle_override) > 0.0)
+            and not driver_state.get('traffic_waiting', False)
+            and int(bot_id) not in self._artillery_intents
+            and int(bot_id) not in self._artillery_reproofs)
         if direct_target:
-            target = tuple(goal)
+            escape = self.navigator.observe_direct_target(
+                bot_id, position, goal, path_key, now, movement_intent)
+            target = tuple(escape or goal)
         else:
             target = self.navigator.next_target(
                 bot_id, position, goal, path_key, now,
-                anchor, avoid, lookahead_distance)
+                anchor, avoid, lookahead_distance,
+                movement_intent=movement_intent)
         terminal = getattr(self.navigator, 'target_is_terminal', None)
         state['navigation_stop_at_target'] = bool(
             stop_at_goal and
-            (direct_target or
-             (callable(terminal) and terminal(bot_id))))
+            ((direct_target and tuple(target) == tuple(goal)) or
+             (not direct_target and callable(terminal) and terminal(bot_id))))
         if mode in ('route', 'advance') and anchor is None:
             target = self._route_lane_target(
                 bot_id, position, goal, target, strategic, now)
@@ -7562,11 +7580,25 @@ class BotRuntime(object):
         start = self._exact_shot_origin(state, descriptor, shell_index)
         if start is None:
             return None
-        target_position = _point(
-            target.get('position'), _position(target))
-        target_position = (
-            target_position[0], target_position[1] + 1.0,
-            target_position[2])
+        aim_token = None
+        if callable(self.direct_aim_point_probe):
+            selected = self.direct_aim_point_probe(state, target)
+            if not isinstance(selected, dict):
+                return None
+            try:
+                target_position = _water_sensor_vector(
+                    selected['aim_position'], 3, 'bot aim point')
+                aim_token = selected['aim_token']
+            except (KeyError, TypeError, ValueError):
+                return None
+        else:
+            # The logical runtime has no target model. BattleRuntime always
+            # supplies the exact part-selection seam above, including failure.
+            target_position = _point(
+                target.get('position'), _position(target))
+            target_position = (
+                target_position[0], target_position[1] + 1.0,
+                target_position[2])
         solution = ballistics.ballistic_intercept(
             start, target_position, self._target_velocity(target),
             speed, gravity, -math.pi * 0.5, math.pi * 0.5)
@@ -7589,7 +7621,20 @@ class BotRuntime(object):
             # the exact frozen muzzle instead of crossing the native
             # HP_gunFire boundary a second time for the identical pose.
             '_origin': start,
+            '_aim_token': aim_token,
         }
+
+    def _direct_aim_matches(self, state, target, solution):
+        """A lane refresh may select a new part after this tick's gun slew."""
+        if not callable(self.direct_aim_point_probe):
+            return True
+        selected = self.direct_aim_point_probe(state, target)
+        matches = bool(
+            isinstance(selected, dict) and isinstance(solution, dict) and
+            selected.get('aim_token') == solution.get('_aim_token'))
+        if not matches:
+            self._ballistic_solution_cache.pop(int(state['id']), None)
+        return matches
 
     @staticmethod
     def _artillery_target_identity(target):
@@ -9560,14 +9605,7 @@ class BotRuntime(object):
                 team_visibility[key] = bool(
                     fresh_visible or team_visibility.get(key, False))
                 if fresh_visible:
-                    remembered = {
-                        'position': _position(observed_target),
-                        'x': observed_target.get('x', 0.0),
-                        'y': observed_target.get('y', 0.0),
-                        'z': observed_target.get('z', 0.0),
-                        'yaw': observed_target.get('yaw', 0.0),
-                        'speed': observed_target.get('speed', 0.0),
-                    }
+                    remembered = self._target_pose_snapshot(observed_target)
                     self._visible_target_poses[key] = remembered
                     observed_target.update(remembered)
                 if collect_observation:
@@ -10249,7 +10287,7 @@ class BotRuntime(object):
                                 self._probe_finished(1, probe_started)
                         lane_clear, lane_verdict = \
                             self._friendly_lane_verdict(lane_value)
-                else:
+                elif self._direct_aim_matches(state, target, ballistic_solution):
                     launch_preview = self._direct_launch_preview(
                         state, descriptor, state['shell_index'], gun_state,
                         ballistic_solution)

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -32,6 +32,12 @@ from gui.mods.offline_lan_0922 import tank_collision
 from gui.mods.offline_lan_0922 import vehicle_physics
 
 
+try:
+    _STRING_TYPES = (basestring,)
+except NameError:
+    _STRING_TYPES = (str,)
+
+
 OBSERVATION_SECONDS = 0.40
 # The logical runtime keeps its mature 30 Hz default for engine-free callers.
 # Production hidden workers explicitly select the lower-cost 10 Hz control and
@@ -1902,7 +1908,8 @@ class BotRuntime(object):
                  world_receipt_probe=None, probe_timing_seconds=0.0,
                  water_depth_probe=None, ram_contact_probe=None,
                  bot_equipment_resolver=None,
-                 destructible_body_scan=None, control_seconds=None):
+                 destructible_body_scan=None, control_seconds=None,
+                 incoming_lane_probe=None):
         self.local_player_id = local_player_id
         self.descriptor_resolver = descriptor_resolver or (lambda unused: {})
         self.player_descriptor_resolver = player_descriptor_resolver
@@ -1921,6 +1928,9 @@ class BotRuntime(object):
         # Keeping an explicit seam also makes it impossible for a stale team
         # spot to stand in for a current clear barrel lane.
         self.firing_lane_probe = firing_lane_probe or self.visibility_probe
+        self.incoming_lane_probe = incoming_lane_probe
+        self._incoming_lanes = {}
+        self._incoming_lane_budget = 0
         # Dynamic allied hulls are deliberately outside the cached static-world
         # lane.  Production checks this seam again at every final fire attempt.
         self.friendly_lane_probe = self._adapt_friendly_lane_probe(
@@ -2896,6 +2906,8 @@ class BotRuntime(object):
             self._ballistic_solution_cache = {}
             self._friendly_repositions = {}
             self._shot_los_cache = {}
+            self._incoming_lanes = {}
+            self._incoming_lane_budget = 0
             self._shot_los_deadlines = {}
             self._reset_shot_lane_work()
             self._reset_shot_lane_diagnostics()
@@ -2991,6 +3003,8 @@ class BotRuntime(object):
             self._visibility_fire = {}
             self._visibility_still = {}
             self._shot_los_cache = {}
+            self._incoming_lanes = {}
+            self._incoming_lane_budget = 0
             self._shot_los_deadlines = {}
             self._reset_shot_lane_work()
             self._reset_shot_lane_diagnostics()
@@ -3985,12 +3999,16 @@ class BotRuntime(object):
                 if order.get(name) is not None:
                     order[name] = _number(order[name])
             for name in ('id', 'team', 'target_id', 'route_index',
-                         'shell_index', 'cover_id'):
+                         'shell_index'):
                 if order.get(name) is not None:
                     try:
                         order[name] = int(order[name])
                     except (TypeError, ValueError, OverflowError):
                         return False
+            if order.get('cover_id') is not None:
+                cover_id = order['cover_id']
+                if not isinstance(cover_id, _STRING_TYPES) or len(cover_id) > 80:
+                    return False
             accepted[bot_id] = order
         previous = self._server_orders
         changed_ids = set(previous).union(accepted)
@@ -6450,6 +6468,37 @@ class BotRuntime(object):
         bot_state['_route_lane_offset'] = 0.0
         return selected
 
+    def _radio_ground_goal(self, bot_id, position, goal, strategic, grid):
+        """Choose a dry baked point in a requested minimap cell once per order."""
+        area = strategic.get('move_area_bounds')
+        if not getattr(grid, 'prebaked', False) or not isinstance(area, (list, tuple)) or len(area) != 4:
+            return None
+        key = (strategic.get('team_command_id'), tuple(area))
+        own = self.states.get(int(bot_id), {})
+        cached = own.get('_radio_ground_goal')
+        if cached is not None and cached[0] == key:
+            return cached[1]
+        minimum = grid.cell_for((area[0], position[1], area[1]))
+        maximum = grid.cell_for((area[2], position[1], area[3]))
+        candidates = []
+        # This is a bounded pure-data scan of one tenth of each map axis.
+        for z in range(minimum[1], maximum[1] + 1):
+            for x in range(minimum[0], maximum[0] + 1):
+                cell = (x, z)
+                if grid._baked_index(cell) is None:
+                    continue
+                point = grid.point_for(cell, grid._baked_cell_height(cell))
+                if not (area[0] <= point[0] <= area[2] and area[1] <= point[2] <= area[3]):
+                    continue
+                if grid.point_has_baked_hazard(point, BAKED_FATAL_HAZARDS):
+                    continue
+                shallow = grid.point_has_baked_hazard(point, BAKED_SHALLOW_WATER)
+                candidates.append((bool(shallow), _distance(point, goal), cell, point))
+        candidates.sort(key=lambda value: value[:3])
+        result = candidates[0][3] if candidates else None
+        own['_radio_ground_goal'] = (key, result)
+        return result
+
     def _navigation_target(self, bot_id, position, goal, strategic, state):
         mode = strategic.get('combat_mode', 'route')
         stop_at_goal = mode not in ('route', 'advance')
@@ -6457,6 +6506,14 @@ class BotRuntime(object):
             state['navigation_stop_at_target'] = stop_at_goal
             return goal
         grid = getattr(self.navigator, 'grid', None)
+        if strategic.get('move_area_bounds') is not None:
+            grounded = self._radio_ground_goal(bot_id, position, goal, strategic, grid)
+            if grounded is None:
+                # No proved destination is a local unfulfilled order, never an
+                # invented ground height or a whole-round simulation failure.
+                state['navigation_stop_at_target'] = True
+                return position
+            goal = grounded
         now = state.get('now', 0.0)
         route_index = int(strategic.get('route_index', 0))
         if mode == 'base_defense':
@@ -8223,6 +8280,22 @@ class BotRuntime(object):
             if self._shot_los_key(source, target) != key:
                 self._shot_lane_work_set.discard(key)
                 return False
+            # Only this direct-spot-gated queue may inspect incoming geometry.
+            # One extra pair per control callback keeps advisory threat work
+            # bounded independently of the final-shot safety checks.
+            if (self._incoming_lane_budget and
+                    callable(self.incoming_lane_probe)):
+                self._incoming_lane_budget -= 1
+                probe_started = self._probe_started()
+                self._probe_totals[1] += 1
+                try:
+                    incoming = self.incoming_lane_probe(source, target)
+                except Exception:
+                    incoming = None
+                finally:
+                    self._probe_finished(1, probe_started)
+                if incoming is not None:
+                    self._incoming_lanes[key] = (now, bool(incoming))
             # Count identities resolved at service time separately from the
             # native budget. A distant pure-data rejection is still one
             # bounded job even though it consumes no collision ray.
@@ -8409,6 +8482,35 @@ class BotRuntime(object):
         remain complete on every latency-sensitive observation.
         """
         packed = []
+        incoming_by_target = {}
+        maximum_age = SHOT_LANE_REFRESH_SECONDS + self._control_seconds
+        for lane_key, receipt in tuple(self._incoming_lanes.items()):
+            source = self.states.get(lane_key[0])
+            if (source is None or not source.get('alive', True) or
+                    now - receipt[0] > maximum_age):
+                self._incoming_lanes.pop(lane_key, None)
+                continue
+            if receipt[1]:
+                target_key = (int(source.get('team', 0)),) + lane_key[1:]
+                incoming_by_target.setdefault(target_key, []).append(lane_key[0])
+        # A fresh enemy Bot's outgoing receipt already has the required
+        # enemy-muzzle -> own-body direction. Reuse that geometry only when
+        # this team currently observes the enemy below. This avoids another
+        # full-roster native scan and never reverses our own outgoing ray.
+        for lane_key, receipt in self._shot_los_cache.items():
+            enemy_id, target_kind, own_id = lane_key
+            if target_kind != 'bot' or not receipt[1] or now - receipt[0] > maximum_age:
+                continue
+            enemy = self.states.get(enemy_id)
+            own = self.states.get(own_id)
+            if (enemy is None or own is None or
+                    not enemy.get('alive', True) or not own.get('alive', True) or
+                    enemy.get('team') == own.get('team') or
+                    (enemy.get('profile') or {}).get('class_tag') == 'SPG'):
+                continue
+            key = (int(own.get('team', 0)), 'bot', enemy_id)
+            if key in aggregate:
+                incoming_by_target.setdefault(key, []).append(own_id)
         for key in sorted(aggregate):
             row = aggregate[key]
             target_visible, shootable, observed_target = row[:3]
@@ -8451,6 +8553,9 @@ class BotRuntime(object):
                 # means team-spotted without a local firing lane; the server
                 # rejects omission rather than guessing.
                 'shootable_by_bot_ids': sorted(shootable),
+                # Positive evidence only: an absent id is unknown, not safe.
+                'threatened_bot_ids': sorted(set(
+                    incoming_by_target.get(key, ()))) if fresh else [],
                 'x': _number(observed_target.get('x')),
                 'y': _number(observed_target.get('y')),
                 'z': _number(observed_target.get('z')),
@@ -9276,6 +9381,7 @@ class BotRuntime(object):
         """Advance one stable authority substep and preserve its events."""
         publish = bool(self._publish_control_this_step)
         refresh_control = bool(self._refresh_control_this_step)
+        self._incoming_lane_budget = 1 if refresh_control else 0
         step_duration_us = max(
             1, int(round(float(frame_step) * 1000000.0)))
         step_start_time_us = self._sample_time_us
@@ -10399,14 +10505,28 @@ class BotRuntime(object):
                 self._cover_queue[0]
             if now + 1e-9 >= ready_at:
                 del self._cover_queue[0]
+                current_source = self.states.get(int(bot_id))
+                target_key = (source.get('team'), target.get('kind', 'human'),
+                              int(target.get('network_id', 0)))
+                remembered = self._visible_target_poses.get(target_key)
+                current = (current_source is not None and
+                           current_source.get('alive', True) and
+                           current_source.get('team') == source.get('team') and
+                           remembered is not None and
+                           self._team_spot_time_left(target_key, now) > 0.0)
+                if current:
+                    source = _copy_runtime_state(current_source)
+                    target = dict(target)
+                    target.update(remembered)
                 try:
                     self._probe_totals[2] += 1
                     probe_started = self._probe_started()
                     try:
-                        candidates = self.cover_probe(
+                        candidates = (self.cover_probe(
                             source, target, route, allies,
                             (self.navigator.grid.segment_clear
                              if self.navigator is not None else None))
+                                      if current else ())
                     finally:
                         self._probe_finished(2, probe_started)
                 except Exception:

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/entities/avatar_server.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/entities/avatar_server.py
@@ -25,6 +25,8 @@ try:
 except ImportError:
     import pickle as _pickle
 
+from gui.mods.offline_lan_0922.tactical_radio import BattleRadioAdapter
+
 
 class AvatarBridgeError(RuntimeError):
     pass
@@ -114,7 +116,8 @@ class AvatarServerBridge(object):
                  on_ready=None, on_leave=None,
                  on_vehicle_enter=None, on_viewpoint_switch=None,
                  on_monitor_vehicle_devices=None,
-                 initial_period='battle', initial_period_seconds=0.0):
+                 initial_period='battle', initial_period_seconds=0.0,
+                 radio_player_getter=None):
         self._avatar = avatar
         self._binding = entity_binding
         self._builder = property_builder
@@ -143,6 +146,8 @@ class AvatarServerBridge(object):
         self._client_context = ''
         self._destroyed = False
         self._leave_requested = False
+        self._battle_radio = BattleRadioAdapter(
+            avatar, lan_sender, player_getter=radio_player_getter)
 
     def prepareVehicleEnter(self, vehicle):
         """Install client-server pose state before stock local entry runs."""
@@ -494,6 +499,29 @@ class AvatarServerBridge(object):
     def makeDenunciation(self, violator_id, topic_id, violator_kind):
         return None
 
+    def messenger_onActionByClient_chat2(self, action_id, request_id, args):
+        """Forward one exact #1513 fixed battle command to the LAN server."""
+        if self._destroyed:
+            return False
+        return self._battle_radio.handle_client_action(
+            action_id, request_id, args)
+
+    def receive_team_command_ack(self, command_seq, accepted,
+                                 responder_account_dbids=None):
+        """Complete and present one LAN team-command acknowledgement."""
+        if self._destroyed:
+            return False
+        return self._battle_radio.receive_ack(
+            command_seq, accepted, responder_account_dbids)
+
+    def receive_team_command(self, command, sender_account_dbid,
+                             target_id=None, cell_index=None):
+        """Present one server-validated teammate command through stock UI."""
+        if self._destroyed:
+            return False
+        return self._battle_radio.receive_command(
+            command, sender_account_dbid, target_id, cell_index)
+
     def banUnbanUser(self, account_dbid, restriction_type, ban_period,
                      reason, is_ban):
         return None
@@ -593,6 +621,7 @@ class AvatarServerBridge(object):
         if self._destroyed and self._vehicle_id is None:
             return False
         self._destroyed = True
+        self._battle_radio.close()
         if self._vehicle_id is None:
             self._vehicle_enter_states = {}
             return False

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/entities/avatar_server.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/entities/avatar_server.py
@@ -500,11 +500,36 @@ class AvatarServerBridge(object):
         return None
 
     def messenger_onActionByClient_chat2(self, action_id, request_id, args):
-        """Forward one exact #1513 fixed battle command to the LAN server."""
+        """Forward one reviewed #1513 Chat2 action to the LAN server."""
         if self._destroyed:
             return False
         return self._battle_radio.handle_client_action(
             action_id, request_id, args)
+
+    def start_team_chat(self):
+        """Initialize both stock arena channels after Avatar GUI startup."""
+        if self._destroyed:
+            return False
+        return self._battle_radio.start_team_chat()
+
+    def close_team_chat(self):
+        """Deinitialize stock arena channels before Avatar GUI teardown."""
+        if self._destroyed:
+            return False
+        return self._battle_radio.close_team_chat()
+
+    def receive_team_chat_ack(self, chat_seq, accepted):
+        """Complete one outgoing stock team-text request."""
+        if self._destroyed:
+            return False
+        return self._battle_radio.receive_chat_ack(chat_seq, accepted)
+
+    def receive_team_chat(self, text, sender_account_dbid):
+        """Present one server-validated teammate text through stock UI."""
+        if self._destroyed:
+            return False
+        return self._battle_radio.receive_team_chat(
+            text, sender_account_dbid)
 
     def receive_team_command_ack(self, command_seq, accepted,
                                  responder_account_dbids=None):
@@ -515,12 +540,12 @@ class AvatarServerBridge(object):
             command_seq, accepted, responder_account_dbids)
 
     def receive_team_command(self, command, sender_account_dbid,
-                             target_id=None, cell_index=None):
+                             target_id=None, cell_index=None, details=None):
         """Present one server-validated teammate command through stock UI."""
         if self._destroyed:
             return False
         return self._battle_radio.receive_command(
-            command, sender_account_dbid, target_id, cell_index)
+            command, sender_account_dbid, target_id, cell_index, details)
 
     def banUnbanUser(self, account_dbid, restriction_type, ban_period,
                      reason, is_ban):

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
@@ -163,7 +163,8 @@ ORDERED_RECEIVE_TYPES = STATE_BARRIER_TYPES | frozenset((
     'battle_receipt', 'fire_intent', 'fire_intent_result',
     'landing_observation_result',
     'player_destructible_contact',
-    'player_destructible_contact_result'))
+    'player_destructible_contact_result', 'team_command',
+    'team_command_ack', 'team_command_terminal'))
 SERVER_STATE_TYPES = frozenset((
     'welcome', 'roster', 'battle_start', 'battle_live', 'start_denied',
     'team_denied', 'team_size_denied', 'bot_tier_mode_denied', 'snapshot',
@@ -171,7 +172,8 @@ SERVER_STATE_TYPES = frozenset((
     'battle_receipt', 'player_destructible_contact'))
 RECOVERABLE_RUNTIME_TYPES = frozenset((
     'snapshot', 'events', 'bot_observation',
-    'landing_observation_result'))
+    'landing_observation_result', 'team_command', 'team_command_ack',
+    'team_command_terminal'))
 
 
 def _monotonic_time():
@@ -1718,6 +1720,8 @@ class LANClient(object):
         self._fire_seq = 0
         self._fire_intent_seq = 0
         self._equipment_intent_seq = 0
+        self._team_command_seq = 0
+        self._team_command_round = None
         self._input_seq = 0
         self._input_seq_round = None
         self._landing_observation_seq = 0
@@ -3285,6 +3289,38 @@ class LANClient(object):
                 return False
             message['human_ram_armors'] = human_ram_armors
         return self._send(message)
+
+    def send_team_command(self, command, target_kind=None, target_id=None,
+                          cell_index=None):
+        from gui.mods.offline_lan_0922.tactical_radio import (
+            COMMAND_IDS_BY_NAME, COMMAND_SPECS)
+        if (not self.ready or self.phase != 'battle' or
+                self.is_bot_authority() or command not in COMMAND_IDS_BY_NAME):
+            return False
+        relation = COMMAND_SPECS[COMMAND_IDS_BY_NAME[command]][1]
+        message = {'type': 'team_command', 'round_id': self.round_id,
+                   'command': command}
+        if relation in ('ally', 'enemy'):
+            target_id = _projectile_int_range(target_id, 1, MAX_PROJECTILE_ID)
+            if target_kind not in ('bot', 'human') or target_id is None:
+                return False
+            message.update(target_kind=target_kind, target_id=target_id)
+        elif relation == 'cell':
+            cell_index = _projectile_int_range(cell_index, 0, 99)
+            if cell_index is None:
+                return False
+            message['cell_index'] = cell_index
+        if self._team_command_round != self.round_id:
+            self._team_command_round = self.round_id
+            self._team_command_seq = 0
+        sequence = self._team_command_seq + 1
+        if sequence > MAX_PROJECTILE_ID:
+            return False
+        message['command_seq'] = sequence
+        if not self._send(message):
+            return False
+        self._team_command_seq = sequence
+        return sequence
 
     def send_bot_observation(self, contacts, affordances=None):
         if not self.is_bot_authority():
@@ -4908,6 +4944,44 @@ class LANClient(object):
                 self.authority_epoch = events_authority_epoch
             if events_server_time is not None:
                 self.server_time_ms = events_server_time
+        elif kind in ('team_command', 'team_command_ack', 'team_command_terminal'):
+            if self._runtime_round_disposition(kind, message, 'invalid team command') is None:
+                return
+            from gui.mods.offline_lan_0922.tactical_radio import (
+                COMMAND_IDS_BY_NAME, COMMAND_SPECS)
+            command = _safe_text(message.get('command'), '', 40)
+            valid = (_projectile_int_range(message.get('command_seq'),
+                                           1, MAX_PROJECTILE_ID) is not None)
+            if kind != 'team_command_ack' or message.get('accepted'):
+                valid = valid and command in COMMAND_IDS_BY_NAME
+            if kind == 'team_command':
+                valid = (valid and message.get('team') == self.team and
+                         _projectile_int_range(message.get('issuer_id'),
+                                               1, MAX_PROJECTILE_ID) is not None)
+                if valid:
+                    relation = COMMAND_SPECS[COMMAND_IDS_BY_NAME[command]][1]
+                    if relation == 'cell':
+                        valid = _projectile_int_range(message.get('cell_index'), 0, 99) is not None
+                    elif relation in ('ally', 'enemy'):
+                        valid = (message.get('target_kind') in ('bot', 'human') and
+                                 _projectile_int_range(message.get('target_id'),
+                                                       1, MAX_PROJECTILE_ID) is not None)
+            else:
+                recipients = message.get('recipient_bot_ids')
+                valid = (valid and isinstance(recipients, (list, tuple)) and
+                         len(recipients) <= 30 and
+                         all(_projectile_int_range(value, 1, MAX_PROJECTILE_ID)
+                             is not None for value in recipients) and
+                         len(set(recipients)) == len(recipients))
+                if kind == 'team_command_ack':
+                    valid = valid and isinstance(message.get('accepted'), bool)
+                else:
+                    valid = valid and message.get('code') in (
+                        'expired', 'issuer_dead', 'issuer_left', 'round_complete',
+                        'superseded')
+            if self.phase != 'battle' or not valid:
+                self._ignore_runtime_payload(kind, 'invalid_team_command', message)
+                return
         elif kind == 'bot_observation':
             round_id = self._runtime_round_disposition(
                 kind, message, 'invalid bot observation message')
@@ -4956,6 +5030,12 @@ class LANClient(object):
                     contact.get('visible_by_player_ids')) and
                 (not bool(contact.get('fresh')) or
                  bool(contact.get('visible'))) and
+                ('threatened_bot_ids' not in contact or (
+                    isinstance(contact.get('threatened_bot_ids'), (list, tuple)) and
+                    all(_projectile_int_range(value, 1, MAX_PROJECTILE_ID) is not None
+                        for value in contact['threatened_bot_ids']) and
+                    len(set(contact['threatened_bot_ids'])) == len(contact['threatened_bot_ids']) and
+                    (bool(contact.get('fresh')) or not contact['threatened_bot_ids']))) and
                 (bool(contact.get('fresh')) or
                  not contact.get('shootable_by_bot_ids'))
                 for contact in (contacts or ()))

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
@@ -164,7 +164,7 @@ ORDERED_RECEIVE_TYPES = STATE_BARRIER_TYPES | frozenset((
     'landing_observation_result',
     'player_destructible_contact',
     'player_destructible_contact_result', 'team_command',
-    'team_command_ack', 'team_command_terminal'))
+    'team_command_ack', 'team_command_terminal', 'team_chat', 'team_chat_ack'))
 SERVER_STATE_TYPES = frozenset((
     'welcome', 'roster', 'battle_start', 'battle_live', 'start_denied',
     'team_denied', 'team_size_denied', 'bot_tier_mode_denied', 'snapshot',
@@ -173,7 +173,7 @@ SERVER_STATE_TYPES = frozenset((
 RECOVERABLE_RUNTIME_TYPES = frozenset((
     'snapshot', 'events', 'bot_observation',
     'landing_observation_result', 'team_command', 'team_command_ack',
-    'team_command_terminal'))
+    'team_command_terminal', 'team_chat', 'team_chat_ack'))
 
 
 def _monotonic_time():
@@ -1722,6 +1722,8 @@ class LANClient(object):
         self._equipment_intent_seq = 0
         self._team_command_seq = 0
         self._team_command_round = None
+        self._team_chat_seq = 0
+        self._team_chat_round = None
         self._input_seq = 0
         self._input_seq_round = None
         self._landing_observation_seq = 0
@@ -3291,21 +3293,27 @@ class LANClient(object):
         return self._send(message)
 
     def send_team_command(self, command, target_kind=None, target_id=None,
-                          cell_index=None):
+                          cell_index=None, details=None):
         from gui.mods.offline_lan_0922.tactical_radio import (
-            COMMAND_IDS_BY_NAME, COMMAND_SPECS)
+            COMMAND_IDS_BY_NAME, COMMAND_SPECS, validate_command_details)
         if (not self.ready or self.phase != 'battle' or
-                self.is_bot_authority() or command not in COMMAND_IDS_BY_NAME):
+                self.is_bot_authority() or
+                not isinstance(command, string_types) or
+                command not in COMMAND_IDS_BY_NAME):
             return False
         relation = COMMAND_SPECS[COMMAND_IDS_BY_NAME[command]][1]
+        details = {} if details is None else details
+        if not validate_command_details(command, details):
+            return False
         message = {'type': 'team_command', 'round_id': self.round_id,
                    'command': command}
+        message.update(details)
         if relation in ('ally', 'enemy'):
             target_id = _projectile_int_range(target_id, 1, MAX_PROJECTILE_ID)
             if target_kind not in ('bot', 'human') or target_id is None:
                 return False
             message.update(target_kind=target_kind, target_id=target_id)
-        elif relation == 'cell':
+        elif relation in ('cell', 'aim_area'):
             cell_index = _projectile_int_range(cell_index, 0, 99)
             if cell_index is None:
                 return False
@@ -3320,6 +3328,26 @@ class LANClient(object):
         if not self._send(message):
             return False
         self._team_command_seq = sequence
+        return sequence
+
+    def send_team_chat(self, text):
+        from gui.mods.offline_lan_0922.tactical_radio import (
+            is_valid_team_chat_text)
+        if (not self.ready or self.phase != 'battle' or
+                self.is_bot_authority()):
+            return False
+        if not is_valid_team_chat_text(text):
+            return False
+        if self._team_chat_round != self.round_id:
+            self._team_chat_round = self.round_id
+            self._team_chat_seq = 0
+        sequence = self._team_chat_seq + 1
+        if sequence > MAX_PROJECTILE_ID:
+            return False
+        if not self._send({'type': 'team_chat', 'round_id': self.round_id,
+                           'chat_seq': sequence, 'text': text}):
+            return False
+        self._team_chat_seq = sequence
         return sequence
 
     def send_bot_observation(self, contacts, affordances=None):
@@ -4944,26 +4972,57 @@ class LANClient(object):
                 self.authority_epoch = events_authority_epoch
             if events_server_time is not None:
                 self.server_time_ms = events_server_time
+        elif kind in ('team_chat', 'team_chat_ack'):
+            from gui.mods.offline_lan_0922.tactical_radio import (
+                is_valid_team_chat_text)
+            valid = (self.phase == 'battle' and self.round_id is not None and
+                     _exact_int(message.get('round_id')) == self.round_id and
+                     _projectile_int_range(message.get('chat_seq'),
+                                           1, MAX_PROJECTILE_ID) is not None)
+            if kind == 'team_chat':
+                valid = (valid and _exact_int(message.get('team')) == self.team and
+                         _projectile_int_range(message.get('issuer_id'),
+                                               1, MAX_PROJECTILE_ID) is not None and
+                         is_valid_team_chat_text(message.get('text')))
+            else:
+                valid = (valid and isinstance(message.get('accepted'), bool) and
+                         isinstance(message.get('code'), string_types))
+            if not valid:
+                self._ignore_runtime_payload(kind, 'invalid_team_chat', message)
+                return
         elif kind in ('team_command', 'team_command_ack', 'team_command_terminal'):
-            if self._runtime_round_disposition(kind, message, 'invalid team command') is None:
+            # A mistimed communication is local to that message. It cannot
+            # change the round lineage or stop a healthy battle transport.
+            if (self.round_id is None or
+                    _exact_int(message.get('round_id')) != self.round_id):
+                self._ignore_runtime_payload(kind, 'invalid_round', message)
                 return
             from gui.mods.offline_lan_0922.tactical_radio import (
-                COMMAND_IDS_BY_NAME, COMMAND_SPECS)
+                COMMAND_IDS_BY_NAME, COMMAND_SPECS, COMMAND_DETAIL_FIELDS,
+                validate_command_details)
             command = _safe_text(message.get('command'), '', 40)
             valid = (_projectile_int_range(message.get('command_seq'),
                                            1, MAX_PROJECTILE_ID) is not None)
             if kind != 'team_command_ack' or message.get('accepted'):
                 valid = valid and command in COMMAND_IDS_BY_NAME
             if kind == 'team_command':
-                valid = (valid and message.get('team') == self.team and
+                valid = (valid and _exact_int(message.get('team')) == self.team and
                          _projectile_int_range(message.get('issuer_id'),
                                                1, MAX_PROJECTILE_ID) is not None)
                 if valid:
                     relation = COMMAND_SPECS[COMMAND_IDS_BY_NAME[command]][1]
-                    if relation == 'cell':
-                        valid = _projectile_int_range(message.get('cell_index'), 0, 99) is not None
+                    required, optional = COMMAND_DETAIL_FIELDS.get(
+                        command, ((), ()))
+                    details = dict((field, message[field]) for field in
+                                   required + optional
+                                   if field in message)
+                    valid = validate_command_details(command, details)
+                    if relation in ('cell', 'aim_area'):
+                        valid = (valid and _projectile_int_range(
+                            message.get('cell_index'), 0, 99) is not None)
                     elif relation in ('ally', 'enemy'):
-                        valid = (message.get('target_kind') in ('bot', 'human') and
+                        valid = (valid and
+                                 message.get('target_kind') in ('bot', 'human') and
                                  _projectile_int_range(message.get('target_id'),
                                                        1, MAX_PROJECTILE_ID) is not None)
             else:

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/lan_session.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/lan_session.py
@@ -2227,6 +2227,27 @@ class LANSession(object):
                     self._battle_runtime is None):
                 return
             self._battle_runtime.on_bot_observation(message)
+        elif kind == 'team_command_ack':
+            round_id = _message_value(message, 'round_id')
+            if (not self._battle_started or
+                    round_id != self._active_round_id or
+                    self._battle_runtime is None):
+                return
+            self._battle_runtime.on_team_command_ack(message)
+        elif kind == 'team_command':
+            round_id = _message_value(message, 'round_id')
+            if (not self._battle_started or
+                    round_id != self._active_round_id or
+                    self._battle_runtime is None):
+                return
+            self._battle_runtime.on_team_command(message)
+        elif kind == 'team_command_terminal':
+            round_id = _message_value(message, 'round_id')
+            if (not self._battle_started or
+                    round_id != self._active_round_id or
+                    self._battle_runtime is None):
+                return
+            self._battle_runtime.on_team_command_terminal(message)
         elif kind == 'battle_failed':
             self._on_battle_failed(message)
         elif kind == 'battle_receipt':

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/lan_session.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/lan_session.py
@@ -2234,6 +2234,16 @@ class LANSession(object):
                     self._battle_runtime is None):
                 return
             self._battle_runtime.on_team_command_ack(message)
+        elif kind in ('team_chat', 'team_chat_ack'):
+            round_id = _message_value(message, 'round_id')
+            if (not self._battle_started or
+                    round_id != self._active_round_id or
+                    self._battle_runtime is None):
+                return
+            if kind == 'team_chat':
+                self._battle_runtime.on_team_chat(message)
+            else:
+                self._battle_runtime.on_team_chat_ack(message)
         elif kind == 'team_command':
             round_id = _message_value(message, 'round_id')
             if (not self._battle_started or

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/shot_geometry.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/shot_geometry.py
@@ -19,6 +19,8 @@ __all__ = (
     'shot_origin_and_direction',
     'transform_vehicle_point',
     'transform_vehicle_vector',
+    'vehicle_aim_point',
+    'vehicle_aim_samples',
     'world_direction_to_local_gun_angles',
 )
 
@@ -129,6 +131,71 @@ def transform_vehicle_point(point, position, yaw, pitch=0.0, roll=0.0):
     position = _vector3(position, 'vehicle position')
     return _add(position, transform_vehicle_vector(
         point, yaw, pitch, roll))
+
+
+def vehicle_aim_samples(descriptor):
+    """Return bounded hull/turret samples in their reviewed #1513 frames.
+
+    Quarter-box centres sample partial exposure without inventing a vehicle
+    height. Missing geometry contributes no candidate. These are aiming
+    hypotheses, not armour plates or proof that a projectile penetrates.
+    """
+    chassis = _field(descriptor, 'chassis')
+    hull = _field(descriptor, 'hull')
+    try:
+        hull_mount = _vector3(_field(chassis, 'hullPosition'),
+                              'chassis.hullPosition')
+    except (TypeError, ValueError):
+        return ()
+    components = [('hull', hull, hull_mount, 0.0)]
+    try:
+        turret_mount = _add(hull_mount, _vector3(
+            _field(hull, 'turretPositions')[0], 'hull.turretPositions[0]'))
+        static_yaw = _field(_field(descriptor, 'gun'), 'staticTurretYaw')
+        if static_yaw is not None:
+            static_yaw = _finite_number(static_yaw, 'staticTurretYaw')
+        components.append(('turret', _field(descriptor, 'turret'),
+                           turret_mount, static_yaw))
+    except (TypeError, ValueError, IndexError, KeyError):
+        pass
+    centres = []
+    edges = []
+    for name, component, mount, static_yaw in components:
+        try:
+            bbox = _field(_field(component, 'hitTester'), 'bbox')
+            lower = _vector3(bbox[0], 'aim bbox minimum')
+            upper = _vector3(bbox[1], 'aim bbox maximum')
+            if any(upper[axis] <= lower[axis] for axis in range(3)):
+                continue
+        except (TypeError, ValueError, IndexError, KeyError):
+            continue
+        centre = tuple((lower[axis] + upper[axis]) * 0.5
+                       for axis in range(3))
+        centres.append((name, mount, centre, static_yaw))
+        for axis, sign in ((0, -1.0), (0, 1.0), (1, 1.0)):
+            point = list(centre)
+            point[axis] += (upper[axis] - lower[axis]) * 0.25 * sign
+            edges.append((name, mount, tuple(point), static_yaw))
+    return tuple(centres + edges)
+
+
+def vehicle_aim_point(sample, pose):
+    """Resolve a retained part sample against the current observed pose."""
+    name, mount, point, static_yaw = sample
+    yaw = _finite_number(pose.get('yaw', 0.0), 'target yaw')
+    if name == 'turret':
+        turret_yaw = (static_yaw if static_yaw is not None else
+                      pose.get('turret_yaw',
+                               pose.get('aim_yaw', yaw) - yaw))
+        point = _rotate_y(point, _finite_number(turret_yaw, 'target turret'))
+    elif name != 'hull':
+        raise ValueError('unknown aim component')
+    position = pose.get('position')
+    if position is None:
+        position = (pose['x'], pose['y'], pose['z'])
+    return transform_vehicle_point(
+        _add(mount, point), position, yaw,
+        pose.get('pitch', 0.0), pose.get('roll', 0.0))
 
 
 def _mount_offsets(descriptor, turret_index):

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/tactical_radio.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/tactical_radio.py
@@ -1,15 +1,31 @@
-"""Bridge the exact #1513 fixed battle commands to the LAN protocol.
+"""Bridge the reviewed #1513 team chat and commands to the LAN protocol.
 
-The stock client owns command selection, cooldowns, chat formatting, sounds,
-vehicle markers, and minimap feedback.  This adapter only translates the
-reviewed command payload at the missing base-mailbox boundary and sends
-accepted server results back through ``Avatar.messenger_onActionByServer_chat2``.
+The stock client owns text entry, normalization, cooldowns, chat formatting,
+sounds, vehicle markers, and minimap feedback.  This adapter only translates
+the reviewed payloads at the missing base-mailbox boundary and sends accepted
+server results back through ``Avatar.messenger_onActionByServer_chat2``.
 """
+
+try:
+    import cPickle as _pickle
+except ImportError:
+    import pickle as _pickle
+import unicodedata
+import zlib
+import struct
 
 try:
     _INTEGER_TYPES = (int, long)
 except NameError:
     _INTEGER_TYPES = (int,)
+try:
+    _UNICODE_TYPE = unicode
+    _BYTE_STRING_TYPE = str
+    _BINARY_TYPES = (str, bytearray)
+except NameError:
+    _UNICODE_TYPE = str
+    _BYTE_STRING_TYPE = bytes
+    _BINARY_TYPES = (bytes, bytearray)
 
 
 RESPONSE_SUCCESS_ACTION_ID = 0
@@ -17,14 +33,25 @@ RESPONSE_FAILURE_ACTION_ID = 1
 GENERIC_ERROR_ID = 1
 MAX_STOCK_REQUEST_ID = 32766
 
+TEAM_CHAT_INIT_ACTION_ID = 19
+TEAM_CHAT_DEINIT_ACTION_ID = 20
+TEAM_CHAT_SEND_ACTION_ID = 21
+TEAM_CHAT_RECEIVE_ACTION_ID = 22
+MAX_TEAM_CHAT_LENGTH = 140
+MAX_TEAM_CHAT_UTF16_UNITS = MAX_TEAM_CHAT_LENGTH
+
 TARGET_NONE = None
 TARGET_ALLY = 'ally'
 TARGET_ENEMY = 'enemy'
 TARGET_CELL = 'cell'
+TARGET_AIM_AREA = 'aim_area'
+
+MAX_COMMAND_RELOAD_TIME = 3600.0
+MAX_COMMAND_QUANTITY = 255
+COMMAND_AIM_POINT_LOW = (-5000.0, -5000.0, -5000.0)
+COMMAND_AIM_POINT_HIGH = (5000.0, 5000.0, 5000.0)
 
 # ``BATTLE_CHAT_COMMANDS`` action IDs from the reviewed local #1513 archive.
-# Reload/SPG status commands are intentionally outside the tactical order
-# surface: their payloads describe transient gun state rather than Bot intent.
 COMMAND_SPECS = {
     23: ('HELPME', TARGET_NONE),
     24: ('FOLLOWME', TARGET_ALLY),
@@ -33,17 +60,165 @@ COMMAND_SPECS = {
     27: ('POSITIVE', TARGET_NONE),
     28: ('NEGATIVE', TARGET_NONE),
     29: ('ATTENTIONTOCELL', TARGET_CELL),
+    30: ('SPG_AIM_AREA', TARGET_AIM_AREA),
     31: ('ATTACKENEMY', TARGET_ENEMY),
     32: ('TURNBACK', TARGET_ALLY),
     33: ('HELPMEEX', TARGET_ALLY),
     34: ('SUPPORTMEWITHFIRE', TARGET_ENEMY),
+    35: ('RELOADINGGUN', TARGET_NONE),
     36: ('STOP', TARGET_ALLY),
+    37: ('RELOADING_CASSETE', TARGET_NONE),
+    38: ('RELOADING_READY', TARGET_NONE),
+    39: ('RELOADING_READY_CASSETE', TARGET_NONE),
+    40: ('RELOADING_UNAVAILABLE', TARGET_NONE),
 }
 COMMAND_IDS_BY_NAME = dict(
     (spec[0], action_id) for action_id, spec in COMMAND_SPECS.items())
 
+# Value shape is ``(required fields, optional fields)``.  Cell and entity
+# targets remain top-level adapter fields because they already have dedicated
+# LAN projection paths.
+COMMAND_DETAIL_FIELDS = {
+    'SPG_AIM_AREA': (('aim_point', 'reload_time'), ()),
+    'ATTACKENEMY': ((), ('reload_time',)),
+    'RELOADINGGUN': (('reload_time',), ()),
+    'RELOADING_CASSETE': (('reload_time', 'quantity'), ()),
+    'RELOADING_READY_CASSETE': (('quantity',), ()),
+}
+
 _MESSAGE_ARG_NAMES = (
     'int32Arg1', 'int64Arg1', 'floatArg1', 'strArg1', 'strArg2')
+
+
+def _unicode_text(value):
+    if isinstance(value, _UNICODE_TYPE):
+        return value
+    if isinstance(value, _BINARY_TYPES):
+        try:
+            return value.decode('utf-8')
+        except (UnicodeDecodeError, UnicodeEncodeError):
+            return None
+    return None
+
+
+def normalize_team_chat_text(value):
+    """Return the stock outgoing filter's canonical JSON Unicode text."""
+    if isinstance(value, _UNICODE_TYPE):
+        stripped = value.strip()
+    elif isinstance(value, _BINARY_TYPES):
+        stripped = value.strip()
+    else:
+        return None
+    text = _unicode_text(stripped)
+    if text is None:
+        return None
+    try:
+        text = unicodedata.normalize('NFKC', text)
+        # The supported 32-bit Windows CPython 2.7 build uses narrow Unicode,
+        # so the stock slice counts UTF-16 code units.  Reproduce that limit
+        # on wide-Unicode audit and server interpreters as well.
+        utf16 = text.encode('utf-16-le')
+        utf16 = utf16[:MAX_TEAM_CHAT_UTF16_UNITS * 2]
+        text = utf16.decode('utf-16-le')
+        # The exact Python 2 filter encodes after truncation, then collapses
+        # whitespace on the UTF-8 byte string.
+        encoded = text.encode('utf-8')
+        encoded = b' '.join(encoded.split())
+        text = encoded.decode('utf-8')
+    except (TypeError, UnicodeDecodeError, UnicodeEncodeError):
+        return None
+    return text if text else None
+
+
+def is_valid_team_chat_text(value):
+    """Validate plaintext without re-normalizing it under the host UCD."""
+    if not isinstance(value, _UNICODE_TYPE):
+        return False
+    try:
+        utf16 = value.encode('utf-16-le')
+        value.encode('utf-8')
+    except (UnicodeDecodeError, UnicodeEncodeError):
+        return False
+    units = len(utf16) // 2
+    return bool(value.strip()) and 0 < units <= MAX_TEAM_CHAT_UTF16_UNITS
+
+
+def _bounded_number(value, minimum, maximum, inclusive_minimum=True):
+    if isinstance(value, bool) or not isinstance(
+            value, _INTEGER_TYPES + (float,)):
+        return None
+    try:
+        result = float(value)
+    except (OverflowError, TypeError, ValueError):
+        return None
+    if result != result or result in (float('inf'), float('-inf')):
+        return None
+    if ((inclusive_minimum and result < minimum) or
+            (not inclusive_minimum and result <= minimum) or
+            result > maximum):
+        return None
+    return result
+
+
+def validate_command_details(command, details):
+    """Validate optional LAN fields derived from exact stock command args."""
+    if command not in COMMAND_IDS_BY_NAME:
+        return False
+    fields = COMMAND_DETAIL_FIELDS.get(command)
+    if fields is None:
+        return details is None or details == {}
+    required, optional = fields
+    if details is None:
+        details = {}
+    if not isinstance(details, dict):
+        return False
+    keys = set(details)
+    if not set(required).issubset(keys) or not keys.issubset(
+            set(required + optional)):
+        return False
+    if 'reload_time' in details:
+        inclusive = command in ('SPG_AIM_AREA', 'ATTACKENEMY')
+        if _bounded_number(
+                details['reload_time'], 0.0, MAX_COMMAND_RELOAD_TIME,
+                inclusive_minimum=inclusive) is None:
+            return False
+    if 'quantity' in details:
+        if _exact_int(
+                details['quantity'], 1, MAX_COMMAND_QUANTITY) is None:
+            return False
+    if 'aim_point' in details:
+        point = details['aim_point']
+        if not isinstance(point, (list, tuple)) or len(point) != 3:
+            return False
+        for value, minimum, maximum in zip(
+                point, COMMAND_AIM_POINT_LOW, COMMAND_AIM_POINT_HIGH):
+            if _bounded_number(value, minimum, maximum) is None:
+                return False
+    return True
+
+
+def _empty_arena_history():
+    # ``ArenaHistoryIterator`` calls z_loads whenever strArg1 exists.  The
+    # stock five-key mapping therefore needs a real compressed empty list;
+    # its ordinary empty-string default would produce a non-iterable None.
+    return zlib.compress(_pickle.dumps([], 2), 1)
+
+
+def _notify_stock_ignore_lists_ready():
+    """Release the stock arena-message queue after offline chat startup."""
+    from messenger.m_constants import USER_TAG
+    from messenger.proto.events import g_messengerEvents
+
+    # ArenaChatHandler only needs completion of the two ignore rosters.  This
+    # event preserves cached user entities and their existing tags; it does not
+    # claim that unrelated friends or muted rosters were refreshed.
+    g_messengerEvents.users.onUsersListReceived(set((
+        USER_TAG.IGNORED, USER_TAG.IGNORED_TMP)))
+
+
+def _schedule_next_frame(delay, callback):
+    import BigWorld
+    return BigWorld.callback(delay, callback)
 
 
 def _exact_int(value, minimum=None, maximum=None, allow_integral_float=False):
@@ -77,24 +252,168 @@ def _message_args(int32_arg=0, int64_arg=0, float_arg=0,
     }
 
 
+def _stock_args_are_default(args, allowed=()):
+    allowed = set(allowed)
+    if ('int32Arg1' not in allowed and
+            _exact_int(args.get('int32Arg1')) != 0):
+        return False
+    if ('int64Arg1' not in allowed and
+            _exact_int(args.get('int64Arg1')) != 0):
+        return False
+    if ('floatArg1' not in allowed and
+            _bounded_number(args.get('floatArg1'), 0.0, 0.0) is None):
+        return False
+    for name in ('strArg1', 'strArg2'):
+        if name not in allowed and args.get(name) not in ('', u'', b''):
+            return False
+    return True
+
+
+def _stock_command_details(action_id, args):
+    """Return ``(details, packed_cell)`` or ``None`` for invalid stock args."""
+    command, relation = COMMAND_SPECS[action_id]
+    allowed = []
+    if relation in (TARGET_ALLY, TARGET_ENEMY, TARGET_CELL):
+        allowed.append('int32Arg1')
+    if action_id in (31, 35, 37):
+        allowed.append('floatArg1')
+    if action_id in (37, 39):
+        allowed.append('int32Arg1')
+    if action_id == 30:
+        allowed.append('strArg1')
+    if not _stock_args_are_default(args, allowed):
+        return None
+
+    details = {}
+    packed_cell = None
+    if action_id == 30:
+        record = args.get('strArg1')
+        if not isinstance(record, _BYTE_STRING_TYPE):
+            return None
+        try:
+            x, y, z, packed_cell, reload_time = struct.unpack(
+                '<fffif', record)
+        except (TypeError, ValueError, struct.error):
+            return None
+        packed_cell = _exact_int(packed_cell, 0, 99)
+        details = {
+            'aim_point': [float(x), float(y), float(z)],
+            'reload_time': float(reload_time),
+        }
+    elif action_id == 31:
+        reload_time = _bounded_number(
+            args.get('floatArg1'), 0.0, MAX_COMMAND_RELOAD_TIME)
+        if reload_time is None:
+            return None
+        if reload_time > 0.0:
+            details['reload_time'] = reload_time
+    elif action_id in (35, 37):
+        reload_time = _bounded_number(
+            args.get('floatArg1'), 0.0, MAX_COMMAND_RELOAD_TIME,
+            inclusive_minimum=False)
+        if reload_time is None:
+            return None
+        details['reload_time'] = reload_time
+        if action_id == 37:
+            quantity = _exact_int(
+                args.get('int32Arg1'), 1, MAX_COMMAND_QUANTITY)
+            if quantity is None:
+                return None
+            details['quantity'] = quantity
+    elif action_id == 39:
+        quantity = _exact_int(
+            args.get('int32Arg1'), 1, MAX_COMMAND_QUANTITY)
+        if quantity is None:
+            return None
+        details['quantity'] = quantity
+    if packed_cell is None and action_id == 30:
+        return None
+    if not validate_command_details(command, details):
+        return None
+    return details, packed_cell
+
+
 class BattleRadioAdapter(object):
     """Own one Avatar's fixed-command translation and response lifecycle."""
 
-    def __init__(self, avatar, lan_sender, player_getter=None):
+    def __init__(self, avatar, lan_sender, player_getter=None,
+                 users_ready_notifier=None, callback_scheduler=None):
         self._avatar = avatar
         self._lan_sender = lan_sender
         self._player_getter = player_getter
         self._pending = {}
+        self._pending_chat = {}
+        self._team_chat_started = False
+        self._users_ready_notifier = (
+            users_ready_notifier or _notify_stock_ignore_lists_ready)
+        self._callback_scheduler = (
+            callback_scheduler or _schedule_next_frame)
+        self._callback_generation = object()
         self._closed = False
+
+    def start_team_chat(self):
+        """Create the stock TEAM and COMMON arena channels exactly once."""
+        if not self._is_current_avatar() or self._team_chat_started:
+            return False
+        self._team_chat_started = True
+        try:
+            self._publish_action(
+                TEAM_CHAT_INIT_ACTION_ID, 0,
+                _message_args(str_arg1=_empty_arena_history()))
+            # Retail receives this event from XMPP contacts cache/sequence
+            # startup or its retry fallback.  The offline account has none of
+            # those producers; without it action 22 stays queued forever.
+            self._users_ready_notifier()
+        except Exception:
+            # ArenaChatHandler marks itself initialized before creating its
+            # two channels.  Retain teardown ownership if the second channel
+            # or its synchronous controller event raises.
+            raise
+        return True
+
+    def close_team_chat(self):
+        """Remove the stock arena channels before Avatar GUI teardown."""
+        # This is the runtime's actual presentation-retirement boundary.
+        # Fence queued rejection callbacks and forget requests before action 20
+        # can synchronously run stock channel-destroy listeners.
+        self._callback_generation = object()
+        self._pending = {}
+        self._pending_chat = {}
+        if not self._team_chat_started:
+            return False
+        if not self._is_current_avatar():
+            self._team_chat_started = False
+            return False
+        try:
+            self._publish_action(
+                TEAM_CHAT_DEINIT_ACTION_ID, 0, _message_args())
+        except Exception:
+            # ``leave`` removes TEAM and COMMON sequentially.  A retry is
+            # required when a synchronous destroy listener fails in between.
+            raise
+        self._team_chat_started = False
+        return True
 
     def close(self):
         if self._closed:
             return False
+        try:
+            self.close_team_chat()
+        except Exception:
+            # Channel presentation is already retiring.  A late stock GUI
+            # failure must not retain the Avatar or its LAN request identities.
+            pass
         self._closed = True
+        # Native cancellation is unnecessary: rotating this token makes every
+        # already-scheduled response harmless after teardown.
+        self._callback_generation = object()
         self._pending = {}
+        self._pending_chat = {}
         self._avatar = None
         self._lan_sender = None
         self._player_getter = None
+        self._users_ready_notifier = None
+        self._callback_scheduler = None
         return True
 
     def handle_client_action(self, action_id, request_id, args):
@@ -106,22 +425,38 @@ class BattleRadioAdapter(object):
         # its zero low bound at the exact high-bound wrap.  The stock response
         # dictionary simply ignores that untracked zero id.
         request_id = _exact_int(request_id, 0, MAX_STOCK_REQUEST_ID)
-        spec = COMMAND_SPECS.get(action_id)
-        if spec is None or request_id is None or not isinstance(args, dict):
+        is_supported = (action_id == TEAM_CHAT_SEND_ACTION_ID or
+                        action_id in COMMAND_SPECS)
+        if request_id is None:
             return False
-        if set(args) != set(_MESSAGE_ARG_NAMES):
+        if not isinstance(args, dict) or set(args) != set(_MESSAGE_ARG_NAMES):
+            if is_supported:
+                self._defer_response(request_id, False)
+            return False
+        if action_id == TEAM_CHAT_SEND_ACTION_ID:
+            return self._handle_team_chat(request_id, args)
+        spec = COMMAND_SPECS.get(action_id)
+        if spec is None:
             return False
 
         command, target_kind = spec
+        parsed_details = _stock_command_details(action_id, args)
+        if parsed_details is None:
+            self._defer_response(request_id, False)
+            return False
+        details, packed_cell = parsed_details
         request = {
             'command': command,
             'stock_action_id': action_id,
             'stock_request_id': request_id,
         }
+        if details:
+            request['details'] = details
         if target_kind in (TARGET_ALLY, TARGET_ENEMY):
             target_id = _exact_int(args.get('int32Arg1'), 1)
             if target_id is None or not self._valid_target(
                     target_id, target_kind):
+                self._defer_response(request_id, False)
                 return False
             # The stock id is a BigWorld entity id.  ``_LANInputSender`` owns
             # the current BattleRuntime record map and must translate it to a
@@ -134,19 +469,46 @@ class BattleRadioAdapter(object):
             cell_index = _exact_int(
                 args.get('int32Arg1'), 0, 99, allow_integral_float=True)
             if cell_index is None:
+                self._defer_response(request_id, False)
                 return False
             request['cell_index'] = cell_index
+        elif target_kind == TARGET_AIM_AREA:
+            request['cell_index'] = packed_cell
 
         sender = getattr(self._lan_sender, 'send_team_command', None)
         if not callable(sender):
             raise AttributeError('LAN sender.send_team_command')
         command_seq = _exact_int(sender(dict(request)), 1)
         if command_seq is None:
-            self._publish_response(request_id, False)
+            self._defer_response(request_id, False)
             return False
         if command_seq in self._pending:
             raise RuntimeError('duplicate team command sequence')
         self._pending[command_seq] = request
+        return True
+
+    def _handle_team_chat(self, request_id, args):
+        if (not self._team_chat_started or
+                _exact_int(args.get('int32Arg1')) != 0 or
+                _exact_int(args.get('int64Arg1')) != 0 or
+                args.get('floatArg1') not in (0, 0.0) or
+                args.get('strArg2') not in ('', u'')):
+            self._defer_response(request_id, False)
+            return False
+        text = normalize_team_chat_text(args.get('strArg1'))
+        if text is None:
+            self._defer_response(request_id, False)
+            return False
+        sender = getattr(self._lan_sender, 'send_team_chat', None)
+        if not callable(sender):
+            raise AttributeError('LAN sender.send_team_chat')
+        chat_seq = _exact_int(sender({'text': text}), 1)
+        if chat_seq is None:
+            self._defer_response(request_id, False)
+            return False
+        if chat_seq in self._pending_chat:
+            raise RuntimeError('duplicate team chat sequence')
+        self._pending_chat[chat_seq] = request_id
         return True
 
     def receive_ack(self, command_seq, accepted,
@@ -174,11 +536,40 @@ class BattleRadioAdapter(object):
                 break
         return True
 
-    def receive_command(self, command, sender_account_dbid, target_id=None,
-                        cell_index=None):
-        """Publish one validated team command through the stock receive path."""
-        if not self._is_current_avatar() or command not in COMMAND_IDS_BY_NAME:
+    def receive_chat_ack(self, chat_seq, accepted):
+        """Complete one stock text request without duplicating its relay."""
+        if not self._is_current_avatar() or not isinstance(accepted, bool):
             return False
+        chat_seq = _exact_int(chat_seq, 1)
+        request_id = self._pending_chat.pop(chat_seq, None)
+        if request_id is None:
+            return False
+        self._publish_response(request_id, accepted)
+        return True
+
+    def receive_team_chat(self, text, sender_account_dbid):
+        """Publish one valid same-team plaintext message through stock UI."""
+        if (not self._is_current_avatar() or
+                not self._team_chat_started or
+                not is_valid_team_chat_text(text)):
+            return False
+        sender_account_dbid = _exact_int(sender_account_dbid, 1)
+        if (sender_account_dbid is None or
+                not self._valid_sender(sender_account_dbid)):
+            return False
+        self._publish_action(
+            TEAM_CHAT_RECEIVE_ACTION_ID, 0,
+            _message_args(int32_arg=0, int64_arg=sender_account_dbid,
+                          str_arg1=text))
+        return True
+
+    def receive_command(self, command, sender_account_dbid, target_id=None,
+                        cell_index=None, details=None):
+        """Publish one validated team command through the stock receive path."""
+        if (not self._is_current_avatar() or
+                not validate_command_details(command, details)):
+            return False
+        details = details or {}
         sender_account_dbid = _exact_int(sender_account_dbid, 1)
         if (sender_account_dbid is None or
                 not self._valid_sender(sender_account_dbid)):
@@ -186,6 +577,8 @@ class BattleRadioAdapter(object):
         action_id = COMMAND_IDS_BY_NAME[command]
         unused_name, target_kind = COMMAND_SPECS[action_id]
         int32_arg = 0
+        float_arg = 0.0
+        str_arg1 = ''
         if target_kind in (TARGET_ALLY, TARGET_ENEMY):
             target_id = _exact_int(target_id, 1)
             if target_id is None or not self._valid_target(
@@ -198,28 +591,53 @@ class BattleRadioAdapter(object):
             if cell_index is None:
                 return False
             int32_arg = cell_index
+        elif target_kind == TARGET_AIM_AREA:
+            cell_index = _exact_int(
+                cell_index, 0, 99, allow_integral_float=True)
+            if cell_index is None or target_id is not None:
+                return False
+            point = details['aim_point']
+            str_arg1 = struct.pack(
+                '<fffif', float(point[0]), float(point[1]), float(point[2]),
+                cell_index, float(details['reload_time']))
         elif target_id is not None or cell_index is not None:
             return False
 
-        callback = getattr(
-            self._avatar, 'messenger_onActionByServer_chat2', None)
-        if not callable(callback):
-            raise AttributeError(
-                'Avatar.messenger_onActionByServer_chat2')
-        callback(action_id, 0, _message_args(
-            int32_arg=int32_arg, int64_arg=sender_account_dbid))
+        if 'reload_time' in details and action_id != 30:
+            float_arg = float(details['reload_time'])
+        if 'quantity' in details:
+            int32_arg = details['quantity']
+
+        self._publish_action(action_id, 0, _message_args(
+            int32_arg=int32_arg, int64_arg=sender_account_dbid,
+            float_arg=float_arg, str_arg1=str_arg1))
         return True
 
     def _publish_response(self, request_id, accepted):
+        action_id = (RESPONSE_SUCCESS_ACTION_ID if accepted else
+                     RESPONSE_FAILURE_ACTION_ID)
+        error_id = 0 if accepted else GENERIC_ERROR_ID
+        self._publish_action(
+            action_id, request_id, _message_args(int32_arg=error_id))
+
+    def _defer_response(self, request_id, accepted):
+        """Respond after stock has registered the synchronous request ID."""
+        generation = self._callback_generation
+
+        def publish():
+            if (generation is self._callback_generation and
+                    self._is_current_avatar()):
+                self._publish_response(request_id, accepted)
+
+        self._callback_scheduler(0.0, publish)
+
+    def _publish_action(self, action_id, request_id, args):
         callback = getattr(
             self._avatar, 'messenger_onActionByServer_chat2', None)
         if not callable(callback):
             raise AttributeError(
                 'Avatar.messenger_onActionByServer_chat2')
-        action_id = (RESPONSE_SUCCESS_ACTION_ID if accepted else
-                     RESPONSE_FAILURE_ACTION_ID)
-        error_id = 0 if accepted else GENERIC_ERROR_ID
-        callback(action_id, request_id, _message_args(int32_arg=error_id))
+        callback(action_id, request_id, args)
 
     def _is_current_avatar(self):
         if self._closed or self._avatar is None:

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/tactical_radio.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/tactical_radio.py
@@ -1,0 +1,273 @@
+"""Bridge the exact #1513 fixed battle commands to the LAN protocol.
+
+The stock client owns command selection, cooldowns, chat formatting, sounds,
+vehicle markers, and minimap feedback.  This adapter only translates the
+reviewed command payload at the missing base-mailbox boundary and sends
+accepted server results back through ``Avatar.messenger_onActionByServer_chat2``.
+"""
+
+try:
+    _INTEGER_TYPES = (int, long)
+except NameError:
+    _INTEGER_TYPES = (int,)
+
+
+RESPONSE_SUCCESS_ACTION_ID = 0
+RESPONSE_FAILURE_ACTION_ID = 1
+GENERIC_ERROR_ID = 1
+MAX_STOCK_REQUEST_ID = 32766
+
+TARGET_NONE = None
+TARGET_ALLY = 'ally'
+TARGET_ENEMY = 'enemy'
+TARGET_CELL = 'cell'
+
+# ``BATTLE_CHAT_COMMANDS`` action IDs from the reviewed local #1513 archive.
+# Reload/SPG status commands are intentionally outside the tactical order
+# surface: their payloads describe transient gun state rather than Bot intent.
+COMMAND_SPECS = {
+    23: ('HELPME', TARGET_NONE),
+    24: ('FOLLOWME', TARGET_ALLY),
+    25: ('ATTACK', TARGET_NONE),
+    26: ('BACKTOBASE', TARGET_NONE),
+    27: ('POSITIVE', TARGET_NONE),
+    28: ('NEGATIVE', TARGET_NONE),
+    29: ('ATTENTIONTOCELL', TARGET_CELL),
+    31: ('ATTACKENEMY', TARGET_ENEMY),
+    32: ('TURNBACK', TARGET_ALLY),
+    33: ('HELPMEEX', TARGET_ALLY),
+    34: ('SUPPORTMEWITHFIRE', TARGET_ENEMY),
+    36: ('STOP', TARGET_ALLY),
+}
+COMMAND_IDS_BY_NAME = dict(
+    (spec[0], action_id) for action_id, spec in COMMAND_SPECS.items())
+
+_MESSAGE_ARG_NAMES = (
+    'int32Arg1', 'int64Arg1', 'floatArg1', 'strArg1', 'strArg2')
+
+
+def _exact_int(value, minimum=None, maximum=None, allow_integral_float=False):
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, _INTEGER_TYPES):
+        result = int(value)
+    elif allow_integral_float and isinstance(value, float):
+        if value != value or value in (float('inf'), float('-inf')):
+            return None
+        result = int(value)
+        if float(result) != value:
+            return None
+    else:
+        return None
+    if minimum is not None and result < minimum:
+        return None
+    if maximum is not None and result > maximum:
+        return None
+    return result
+
+
+def _message_args(int32_arg=0, int64_arg=0, float_arg=0,
+                  str_arg1='', str_arg2=''):
+    return {
+        'int32Arg1': int32_arg,
+        'int64Arg1': int64_arg,
+        'floatArg1': float_arg,
+        'strArg1': str_arg1,
+        'strArg2': str_arg2,
+    }
+
+
+class BattleRadioAdapter(object):
+    """Own one Avatar's fixed-command translation and response lifecycle."""
+
+    def __init__(self, avatar, lan_sender, player_getter=None):
+        self._avatar = avatar
+        self._lan_sender = lan_sender
+        self._player_getter = player_getter
+        self._pending = {}
+        self._closed = False
+
+    def close(self):
+        if self._closed:
+            return False
+        self._closed = True
+        self._pending = {}
+        self._avatar = None
+        self._lan_sender = None
+        self._player_getter = None
+        return True
+
+    def handle_client_action(self, action_id, request_id, args):
+        """Translate one stock mailbox call into one reliable LAN request."""
+        if not self._is_current_avatar():
+            return False
+        action_id = _exact_int(action_id)
+        # ``SequenceIDGenerator`` normally yields a positive id but resets to
+        # its zero low bound at the exact high-bound wrap.  The stock response
+        # dictionary simply ignores that untracked zero id.
+        request_id = _exact_int(request_id, 0, MAX_STOCK_REQUEST_ID)
+        spec = COMMAND_SPECS.get(action_id)
+        if spec is None or request_id is None or not isinstance(args, dict):
+            return False
+        if set(args) != set(_MESSAGE_ARG_NAMES):
+            return False
+
+        command, target_kind = spec
+        request = {
+            'command': command,
+            'stock_action_id': action_id,
+            'stock_request_id': request_id,
+        }
+        if target_kind in (TARGET_ALLY, TARGET_ENEMY):
+            target_id = _exact_int(args.get('int32Arg1'), 1)
+            if target_id is None or not self._valid_target(
+                    target_id, target_kind):
+                return False
+            # The stock id is a BigWorld entity id.  ``_LANInputSender`` owns
+            # the current BattleRuntime record map and must translate it to a
+            # wire ``target_kind`` + network ``target_id`` pair.
+            request['target_relation'] = target_kind
+            request['stock_target_id'] = target_id
+        elif target_kind == TARGET_CELL:
+            # ``makeCellIndex`` uses a float dimension and therefore returns
+            # values such as 23.0 before the retail INT32 mailbox coerces it.
+            cell_index = _exact_int(
+                args.get('int32Arg1'), 0, 99, allow_integral_float=True)
+            if cell_index is None:
+                return False
+            request['cell_index'] = cell_index
+
+        sender = getattr(self._lan_sender, 'send_team_command', None)
+        if not callable(sender):
+            raise AttributeError('LAN sender.send_team_command')
+        command_seq = _exact_int(sender(dict(request)), 1)
+        if command_seq is None:
+            self._publish_response(request_id, False)
+            return False
+        if command_seq in self._pending:
+            raise RuntimeError('duplicate team command sequence')
+        self._pending[command_seq] = request
+        return True
+
+    def receive_ack(self, command_seq, accepted,
+                    responder_account_dbids=None):
+        """Complete a sent request and render one deterministic Bot reply."""
+        if not self._is_current_avatar() or not isinstance(accepted, bool):
+            return False
+        command_seq = _exact_int(command_seq, 1)
+        request = self._pending.pop(command_seq, None)
+        if request is None:
+            return False
+        self._publish_response(request['stock_request_id'], accepted)
+        if not accepted:
+            return True
+
+        # The reliable same-team broadcast owns the stock command echo.  The
+        # acknowledgement only closes the request and presents one assigned
+        # Bot's positive response, so delivery order cannot duplicate the
+        # issuer's command in chat or on the minimap.
+        for account_dbid in responder_account_dbids or ():
+            account_dbid = _exact_int(account_dbid, 1)
+            if (account_dbid is not None and
+                    self._valid_sender(account_dbid)):
+                self.receive_command('POSITIVE', account_dbid)
+                break
+        return True
+
+    def receive_command(self, command, sender_account_dbid, target_id=None,
+                        cell_index=None):
+        """Publish one validated team command through the stock receive path."""
+        if not self._is_current_avatar() or command not in COMMAND_IDS_BY_NAME:
+            return False
+        sender_account_dbid = _exact_int(sender_account_dbid, 1)
+        if (sender_account_dbid is None or
+                not self._valid_sender(sender_account_dbid)):
+            return False
+        action_id = COMMAND_IDS_BY_NAME[command]
+        unused_name, target_kind = COMMAND_SPECS[action_id]
+        int32_arg = 0
+        if target_kind in (TARGET_ALLY, TARGET_ENEMY):
+            target_id = _exact_int(target_id, 1)
+            if target_id is None or not self._valid_target(
+                    target_id, target_kind):
+                return False
+            int32_arg = target_id
+        elif target_kind == TARGET_CELL:
+            cell_index = _exact_int(
+                cell_index, 0, 99, allow_integral_float=True)
+            if cell_index is None:
+                return False
+            int32_arg = cell_index
+        elif target_id is not None or cell_index is not None:
+            return False
+
+        callback = getattr(
+            self._avatar, 'messenger_onActionByServer_chat2', None)
+        if not callable(callback):
+            raise AttributeError(
+                'Avatar.messenger_onActionByServer_chat2')
+        callback(action_id, 0, _message_args(
+            int32_arg=int32_arg, int64_arg=sender_account_dbid))
+        return True
+
+    def _publish_response(self, request_id, accepted):
+        callback = getattr(
+            self._avatar, 'messenger_onActionByServer_chat2', None)
+        if not callable(callback):
+            raise AttributeError(
+                'Avatar.messenger_onActionByServer_chat2')
+        action_id = (RESPONSE_SUCCESS_ACTION_ID if accepted else
+                     RESPONSE_FAILURE_ACTION_ID)
+        error_id = 0 if accepted else GENERIC_ERROR_ID
+        callback(action_id, request_id, _message_args(int32_arg=error_id))
+
+    def _is_current_avatar(self):
+        if self._closed or self._avatar is None:
+            return False
+        if self._player_getter is None:
+            return True
+        try:
+            return self._player_getter() is self._avatar
+        except (AttributeError, ReferenceError):
+            return False
+
+    def _player_vehicle_id(self):
+        return _exact_int(getattr(self._avatar, 'playerVehicleID', None), 1)
+
+    def _vehicle_info(self, vehicle_id):
+        arena = getattr(self._avatar, 'arena', None)
+        vehicles = getattr(arena, 'vehicles', None)
+        if not isinstance(vehicles, dict):
+            return None
+        info = vehicles.get(vehicle_id)
+        return info if isinstance(info, dict) else None
+
+    def _valid_sender(self, account_dbid):
+        info = None
+        arena = getattr(self._avatar, 'arena', None)
+        vehicles = getattr(arena, 'vehicles', None)
+        if isinstance(vehicles, dict):
+            for candidate in vehicles.values():
+                if (isinstance(candidate, dict) and
+                        _exact_int(candidate.get('accountDBID'), 1) ==
+                        account_dbid):
+                    info = candidate
+                    break
+        own_team = _exact_int(getattr(self._avatar, 'team', None), 1, 2)
+        return bool(info is not None and own_team is not None and
+                    _exact_int(info.get('team'), 1, 2) == own_team)
+
+    def _valid_target(self, vehicle_id, target_kind):
+        info = self._vehicle_info(vehicle_id)
+        own_team = _exact_int(getattr(self._avatar, 'team', None), 1, 2)
+        target_team = (_exact_int(info.get('team'), 1, 2)
+                       if info is not None else None)
+        if (own_team is None or target_team is None or
+                not info.get('isAlive', True)):
+            return False
+        if target_kind == TARGET_ALLY:
+            return (target_team == own_team and
+                    vehicle_id != self._player_vehicle_id())
+        if target_kind == TARGET_ENEMY:
+            return target_team != own_team
+        return False

--- a/tests/test_port_0922_ai.py
+++ b/tests/test_port_0922_ai.py
@@ -781,6 +781,86 @@ class BotAiPortTests(unittest.TestCase):
         self.assertEqual(current, held)
         self.assertEqual('pending', navigator.fallback_modes[7])
 
+    def test_new_pending_request_reuses_only_a_target_that_advances_it(self):
+        graph = self._baked_graph(7, 7, blocked=((3, 5),))
+        navigator = TerrainNavigator(
+            lambda *unused: None, baked_graph=graph)
+        current = (22.0, 0.0, 32.0)
+        old_goal = (22.0, 0.0, 36.0)
+        new_goal = (22.0, 0.0, 44.0)
+
+        old_target = navigator.next_target(
+            11, current, old_goal, ('route', 1, 'near-north'), 1.0)
+        selected = navigator.next_target(
+            11, current, new_goal, ('route', 1, 'far-north'), 1.1)
+
+        self.assertEqual(old_goal, old_target)
+        self.assertEqual(old_target, selected)
+        self.assertEqual('pending', navigator.bot_states[11][
+            'navigation_status'])
+        self.assertTrue(navigator.searches)
+
+    def test_new_pending_request_immediately_replaces_opposed_old_target(self):
+        graph = self._baked_graph(7, 7, blocked=((3, 2),))
+        navigator = TerrainNavigator(
+            lambda *unused: None, baked_graph=graph)
+        current = (22.0, 0.0, 32.0)
+        old_goal = (22.0, 0.0, 36.0)
+        new_goal = (22.0, 0.0, 20.0)
+
+        old_target = navigator.next_target(
+            11, current, old_goal, ('route', 1, 'north'), 1.0)
+        old_request = navigator.bot_states[11]['request_key']
+        selected = navigator.next_target(
+            11, current, new_goal, ('route', 1, 'south'), 1.1)
+        state = navigator.bot_states[11]
+
+        self.assertEqual(old_goal, old_target)
+        self.assertNotEqual(old_request, state['request_key'])
+        self.assertEqual('pending', state['navigation_status'])
+        self.assertTrue(navigator.searches)
+        self.assertNotEqual(current, selected)
+        self.assertNotEqual(old_target, selected)
+        self.assertLess(_distance_2d(selected, new_goal),
+                        _distance_2d(current, new_goal))
+        self.assertTrue(navigator.grid.dry_segment_clear(
+            current, selected, 1.1))
+
+    def test_opposed_old_target_stays_retired_after_no_safe_first_step(self):
+        graph = self._baked_graph(7, 7, blocked=((3, 2),))
+        navigator = TerrainNavigator(
+            lambda *unused: None, baked_graph=graph)
+        current = (22.0, 0.0, 32.0)
+        old_goal = (22.0, 0.0, 36.0)
+        new_goal = (22.0, 0.0, 20.0)
+        old_target = navigator.next_target(
+            11, current, old_goal, ('route', 1, 'north'), 1.0)
+        safe_local_target = navigator.grid.safe_local_target
+        safe_calls = [0]
+
+        def delayed_safe_local(*args, **kwargs):
+            safe_calls[0] += 1
+            if safe_calls[0] == 1:
+                return None
+            return safe_local_target(*args, **kwargs)
+
+        navigator._path = lambda *unused: (('pending-south',), None)
+        navigator.grid.safe_local_target = delayed_safe_local
+        first = navigator.next_target(
+            11, current, new_goal, ('route', 1, 'south'), 1.1)
+        second = navigator.next_target(
+            11, current, new_goal, ('route', 1, 'south'), 1.2)
+        third = navigator.next_target(
+            11, current, new_goal, ('route', 1, 'south'), 1.8)
+
+        self.assertEqual(old_goal, old_target)
+        self.assertEqual(current, first)
+        self.assertNotEqual(old_target, second)
+        self.assertEqual(current, second)
+        self.assertNotEqual(old_target, third)
+        self.assertLess(_distance_2d(third, new_goal),
+                        _distance_2d(current, new_goal))
+
     def test_completed_route_target_restarts_the_pending_grace(self):
         """A real routed target ends the episode; a probed step does not."""
         navigator = self._pending_navigator()
@@ -1122,6 +1202,190 @@ class BotAiPortTests(unittest.TestCase):
             1, navigator.bot_states[11]['blocked_step_replans'])
         self.assertEqual(0, navigator.bot_states[12].get(
             'blocked_step_replans', 0))
+
+    def test_macro_hard_edge_expires_and_restores_the_only_corridor(self):
+        navigator = TerrainNavigator(
+            lambda *unused: None, baked_graph=self._baked_graph(5, 1))
+        current = (14.0, 0.0, 20.0)
+        goal = (26.0, 0.0, 20.0)
+        edge = ((1, 0), (2, 0))
+        navigator.bot_failed_edges[31] = {
+            edge: (20.0, 240.0),
+        }
+        navigator.bot_macro_edges[31] = {
+            edge: (5.0, 240.0),
+        }
+
+        blocked = navigator.grid.plan(
+            current, goal, now=1.0,
+            edge_penalties=navigator._active_planning_edge_penalties(31, 1.0),
+            hard_edge_penalties=navigator._active_macro_edge_penalties(31, 1.0))
+        restored = navigator.grid.plan(
+            current, goal, now=5.1,
+            edge_penalties=navigator._active_planning_edge_penalties(31, 5.1),
+            hard_edge_penalties=navigator._active_macro_edge_penalties(31, 5.1))
+
+        self.assertEqual((), blocked)
+        self.assertTrue(restored)
+        self.assertTrue(navigator.grid.path_has_edge_penalty(restored, {edge: 1.0}))
+        self.assertNotIn(31, navigator.bot_macro_edges)
+
+    def test_macro_progress_replans_a_shuffling_bot_without_shared_penalty(self):
+        graph = self._baked_graph(7, 7)
+        hazards_before = tuple(graph['hazards'])
+        navigator = TerrainNavigator(
+            lambda *unused: None, baked_graph=graph)
+        goal = (34.0, 0.0, 32.0)
+        route_key = ('route', 1, 'east')
+        old_target = None
+        rerouted = None
+        now = 1.0
+
+        for step in range(64):
+            current = (14.1 if step & 1 else 14.0, 0.0, 32.0)
+            selected = navigator.next_target(
+                21, current, goal, route_key, now)
+            if old_target is None and selected != current:
+                old_target = selected
+            if (navigator.bot_states[21]['macro_progress_replans'] and
+                    selected not in (current, old_target)):
+                rerouted = selected
+                break
+            now += 0.25
+
+        self.assertEqual(goal, old_target)
+        self.assertIsNotNone(rerouted)
+        self.assertNotEqual(old_target, rerouted)
+        self.assertEqual(1, navigator.bot_states[21][
+            'macro_progress_replans'])
+        self.assertEqual(rerouted, navigator.bot_states[21].get(
+            'macro_escape_target'))
+        self.assertEqual(goal, navigator.next_target(
+            22, (14.0, 0.0, 32.0), goal, route_key, now))
+        self.assertNotIn(22, navigator.bot_macro_edges)
+        self.assertFalse(navigator.grid._failed_edges)
+        self.assertEqual(hazards_before, tuple(navigator.grid._baked_hazards))
+
+    def test_runtime_near_goal_direct_path_still_observes_macro_progress(self):
+        from gui.mods.offline_lan_0922.bot_runtime import BotRuntime
+
+        runtime = BotRuntime(1)
+        runtime.adapter = BotAdapter('04_himmelsdorf', 1)
+        runtime.navigator = TerrainNavigator(
+            lambda *unused: None, baked_graph=self._baked_graph(7, 7))
+        runtime.states = {41: {'id': 41, 'team': 1}}
+        goal = (26.0, 0.0, 32.0)
+        strategic = {'combat_mode': 'engage', 'target_id': 91}
+        first = None
+        rerouted = None
+        now = 1.0
+        driver_state = {'now': now, 'speed': 0.0}
+
+        for step in range(64):
+            current = (14.1 if step & 1 else 14.0, 0.0, 32.0)
+            driver_state['now'] = now
+            selected = runtime._navigation_target(
+                41, current, goal, strategic,
+                driver_state)
+            if first is None:
+                first = selected
+            state = runtime.navigator.bot_direct_progress.get(41, {})
+            if (state.get('replans') and
+                    selected not in (current, first)):
+                rerouted = selected
+                break
+            now += 0.25
+
+        self.assertEqual(goal, first)
+        self.assertIsNotNone(rerouted)
+        self.assertEqual(1, runtime.navigator.bot_direct_progress[41][
+            'replans'])
+        self.assertFalse(driver_state['navigation_stop_at_target'])
+
+    def test_runtime_hold_and_traffic_wait_pause_macro_progress_lease(self):
+        from gui.mods.offline_lan_0922.bot_runtime import BotRuntime
+
+        runtime = BotRuntime(1)
+        runtime.adapter = BotAdapter('04_himmelsdorf', 1)
+        runtime.navigator = TerrainNavigator(
+            lambda *unused: None, baked_graph=self._baked_graph(7, 7))
+        runtime.states = {
+            42: {'id': 42, 'team': 1},
+            43: {'id': 43, 'team': 1},
+            44: {'id': 44, 'team': 1},
+        }
+        current = (14.0, 0.0, 32.0)
+        goal = (26.0, 0.0, 32.0)
+        arrived_goal = (15.0, 0.0, 32.0)
+        held = {
+            'combat_mode': 'engage', 'target_id': 92,
+            'throttle_override': 0.0,
+        }
+        moving = {'combat_mode': 'engage', 'target_id': 93}
+        traffic_state = runtime.adapter.driver._state(43, 1, current)
+        traffic_state['traffic_waiting'] = True
+
+        for step in range(64):
+            now = 1.0 + step * 0.25
+            runtime._navigation_target(
+                42, current, goal, held, {'now': now, 'speed': 0.0})
+            runtime._navigation_target(
+                43, current, goal, moving, {'now': now, 'speed': 0.0})
+            arrived = runtime._navigation_target(
+                44, current, arrived_goal, moving,
+                {'now': now, 'speed': 0.0})
+        traffic_state['traffic_waiting'] = False
+        runtime._navigation_target(
+            42, current, goal, moving, {'now': 17.0, 'speed': 0.0})
+        runtime._navigation_target(
+            43, current, goal, moving, {'now': 17.0, 'speed': 0.0})
+
+        self.assertEqual(0, runtime.navigator.bot_direct_progress[42][
+            'replans'])
+        self.assertEqual(0, runtime.navigator.bot_direct_progress[43][
+            'replans'])
+        self.assertEqual(arrived_goal, arrived)
+        self.assertEqual(0, runtime.navigator.bot_direct_progress[44][
+            'replans'])
+
+    def test_macro_progress_accepts_slow_waypoint_detour_and_tactical_hold(self):
+        navigator = TerrainNavigator(lambda *unused: 0.0)
+        navigator.grid.segment_clear = lambda *unused: True
+        navigator.grid.segment_penalty = lambda *unused: 0.0
+        navigator.grid.segment_has_baked_hazard = lambda *unused: False
+        detour = ((0.0, 0.0, 0.0),
+                  (0.0, 0.0, 20.0),
+                  (20.0, 0.0, 20.0),
+                  (20.0, 0.0, 0.0))
+        navigator._path = lambda key, *unused: (key, detour)
+        navigator._lookahead_index = (
+            lambda current, path, index, *unused: index)
+        now = 1.0
+
+        for step in range(64):
+            current = (0.0, 0.0, float(step) * 0.05)
+            selected = navigator.next_target(
+                31, current, detour[-1], ('route', 1, 'detour'), now)
+            self.assertEqual(detour[1], selected)
+            now += 0.25
+
+        self.assertGreater(_distance_2d(current, detour[-1]),
+                           _distance_2d(detour[0], detour[-1]))
+
+        hold = detour[0]
+        for step in range(64):
+            navigator.next_target(
+                32, hold, detour[-1], ('hold', 1), now + step * 0.25,
+                movement_intent=False)
+        resumed = navigator.next_target(
+            32, hold, detour[-1], ('hold', 1), now + 16.0,
+            movement_intent=True)
+
+        self.assertEqual(0, navigator.bot_states[31][
+            'macro_progress_replans'])
+        self.assertEqual(0, navigator.bot_states[32][
+            'macro_progress_replans'])
+        self.assertEqual(detour[1], resumed)
 
     def test_shore_ford_episode_crosses_instead_of_oscillating(self):
         open_cells = set(((0, 2), (1, 2), (2, 2), (3, 2)))

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -10452,8 +10452,62 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertTrue(result['collision'])
         soft.assert_not_called()
 
-    def test_bot_firing_lane_trims_hulls_and_tries_two_target_heights(self):
+    def _bot_lane_scene(self, target_kind='bot'):
         runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        descriptor = _Descriptor()
+        descriptor.hull.turretPositions = (_Vector(0.0, 1.4, 0.0),)
+        runtime.bigworld.entities.update({
+            10: types.SimpleNamespace(isStarted=True,
+                                      typeDescriptor=_Descriptor()),
+            20: types.SimpleNamespace(isStarted=True,
+                                      typeDescriptor=descriptor),
+        })
+        target_key = 'player:2' if target_kind == 'human' else 'bot:12'
+        battle._records = {
+            'bot:11': {'engine_id': 10, 'ready': True},
+            target_key: {'engine_id': 20, 'ready': True},
+        }
+        battle._bot_direct_launch_origin = lambda *unused: (0.0, 2.5, 0.0)
+        source = {'id': 11, 'x': 0.0, 'y': 0.0, 'z': 0.0, 'yaw': 0.0}
+        target = {'id': 12, 'network_id': 2 if target_kind == 'human' else 12,
+                  'kind': target_kind, 'position': (0.0, 0.0, 100.0),
+                  'yaw': 0.0, 'alive': True}
+        return runtime, battle, source, target, descriptor
+
+    def test_bot_exposed_turret_selection_drives_the_actual_ballistic_aim(self):
+        runtime, battle, source, target, descriptor = self._bot_lane_scene()
+        rays = []
+
+        def wall(unused_space_id, start, end, unused_mask):
+            rays.append((start, end))
+            height = start.y + (end.y - start.y) * 90.0 / end.z
+            return (_Vector(0.0, height, 90.0),) if height < 1.8 else None
+
+        runtime.bigworld.wg_collideSegment = wall
+        self.assertTrue(battle._bot_firing_lane(source, target))
+        self.assertEqual(2, len(rays))
+        self.assertAlmostEqual(1.2, rays[0][1].y)
+        self.assertAlmostEqual(2.2, rays[1][1].y)
+        selected = battle._bot_aim_point(source, target)
+        self.assertAlmostEqual(2.2, selected['aim_position'][1])
+
+        bots = bot_runtime.BotRuntime(
+            1, direct_launch_origin_probe=battle._bot_direct_launch_origin,
+            direct_aim_point_probe=battle._bot_aim_point)
+        solution = bots._local_ballistic_solution(source, target, descriptor, 0)
+        self.assertIsNotNone(solution)
+        self.assertAlmostEqual(2.2, solution['aim_position'][1])
+        speed = descriptor.gun.shots[0].speed
+        gravity = descriptor.gun.shots[0].gravity
+        time_at_wall = 90.0 / (speed * math.cos(solution['pitch']))
+        height = (2.5 - speed * math.sin(solution['pitch']) * time_at_wall -
+                  gravity * time_at_wall ** 2 * 0.5)
+        self.assertGreater(height, 1.8)
+
+    def test_bot_firing_lane_rotates_real_samples_with_two_ray_budget(self):
+        runtime, battle, source, target, unused = self._bot_lane_scene()
         rays = []
 
         def collide(unused_space_id, start, end, unused_mask):
@@ -10461,26 +10515,24 @@ class BattleRuntimeContractTests(unittest.TestCase):
             return (_Vector(start.x + 1.0, start.y, start.z),)
 
         runtime.bigworld.wg_collideSegment = collide
-        battle = BattleRuntime(runtime)
-        battle._avatar = runtime.bigworld.avatar
-        source = {'x': 0.0, 'y': 0.0, 'z': 0.0}
-        target = {'position': (0.0, 0.0, 100.0)}
-
         self.assertFalse(battle._bot_firing_lane(source, target))
-
         self.assertEqual(2, len(rays))
-        self.assertEqual({1.5, 2.2}, {round(end.y, 1)
-                                     for unused, end in rays})
-        self.assertTrue(all(round(start.z, 1) == 4.0
+        self.assertFalse(battle._bot_firing_lane(source, target))
+        self.assertEqual(4, len(rays))
+        self.assertTrue(any(end.x != 0.0 for unused, end in rays))
+        self.assertTrue(all(round(start.z, 1) == 0.0
                             for start, unused in rays))
-        self.assertTrue(all(round(end.z, 1) == 96.0
+        self.assertTrue(all(round(end.z, 1) == 100.0
                             for unused, end in rays))
-
+        self.assertIsNone(battle._bot_aim_point(source, target))
         runtime.bigworld.wg_collideSegment = lambda *unused: None
         self.assertTrue(battle._bot_firing_lane(source, target))
+        selected = battle._bot_aim_point(source, target)
+        self.assertTrue(battle._bot_firing_lane(source, target))
+        self.assertEqual(selected, battle._bot_aim_point(source, target))
 
     def test_bot_firing_lane_probes_close_targets_instead_of_assuming_clear(self):
-        runtime = _runtime()
+        runtime, battle, source, target, unused = self._bot_lane_scene()
         rays = []
 
         def wall(unused_space_id, start, end, unused_mask):
@@ -10488,10 +10540,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
             return (_Vector(start.x, start.y, start.z + 0.25),)
 
         runtime.bigworld.wg_collideSegment = wall
-        battle = BattleRuntime(runtime)
-        battle._avatar = runtime.bigworld.avatar
-        source = {'x': 0.0, 'y': 0.0, 'z': 0.0}
-        target = {'position': (0.0, 0.0, 8.0)}
+        target['position'] = (0.0, 0.0, 8.0)
 
         self.assertFalse(battle._bot_firing_lane(source, target))
         self.assertEqual(2, len(rays))
@@ -10499,6 +10548,53 @@ class BattleRuntimeContractTests(unittest.TestCase):
 
         runtime.bigworld.wg_collideSegment = lambda *unused: None
         self.assertTrue(battle._bot_firing_lane(source, target))
+
+    def test_bot_aim_lifecycle_and_observed_pose_for_human_and_bot_targets(self):
+        for kind in ('human', 'bot'):
+            runtime, battle, source, target, descriptor = self._bot_lane_scene(kind)
+            runtime.bigworld.wg_collideSegment = lambda *unused: None
+            entity = runtime.bigworld.entities[20]
+            entity.isStarted = False
+            self.assertFalse(battle._bot_firing_lane(source, target))
+            entity.isStarted = True
+            hull_bbox = descriptor.hull.hitTester.bbox
+            turret_bbox = descriptor.turret.hitTester.bbox
+            descriptor.hull.hitTester.bbox = None
+            descriptor.turret.hitTester.bbox = None
+            self.assertFalse(battle._bot_firing_lane(source, target))
+            descriptor.hull.hitTester.bbox = hull_bbox
+            descriptor.turret.hitTester.bbox = turret_bbox
+            self.assertTrue(battle._bot_firing_lane(source, target))
+            first = battle._bot_aim_point(source, target)
+            # A hidden/live entity position is not an observation. The supplied
+            # target pose alone owns where the retained sample is projected.
+            entity.position = _Vector(500.0, 500.0, 500.0)
+            self.assertEqual(first, battle._bot_aim_point(source, target))
+            target['position'] = (10.0, 3.0, 80.0)
+            moved = battle._bot_aim_point(source, target)
+            self.assertEqual(first['aim_token'], moved['aim_token'])
+            self.assertAlmostEqual(4.2, moved['aim_position'][1])
+            key = 'player:2' if kind == 'human' else 'bot:12'
+            battle._records[key] = dict(battle._records[key])
+            self.assertIsNone(battle._bot_aim_point(source, target))
+            self.assertTrue(battle._bot_firing_lane(source, target))
+            self.assertNotEqual(first['aim_token'],
+                                battle._bot_aim_point(source, target)['aim_token'])
+            battle._records[key]['tombstone'] = True
+            self.assertIsNone(battle._bot_aim_point(source, target))
+
+    def test_bot_aim_missing_muzzle_or_failed_native_ray_revokes_selection(self):
+        runtime, battle, source, target, unused = self._bot_lane_scene()
+        runtime.bigworld.wg_collideSegment = lambda *unused: None
+        self.assertTrue(battle._bot_firing_lane(source, target))
+        runtime.bigworld.wg_collideSegment = mock.Mock(side_effect=RuntimeError('BSP'))
+        self.assertFalse(battle._bot_firing_lane(source, target))
+        self.assertIsNone(battle._bot_aim_point(source, target))
+        runtime.bigworld.wg_collideSegment = mock.Mock(return_value=None)
+        battle._last_frame_time = 1.0
+        battle._bot_direct_launch_origin = lambda *unused: None
+        self.assertFalse(battle._bot_firing_lane(source, target))
+        runtime.bigworld.wg_collideSegment.assert_not_called()
 
     def test_bot_friendly_lane_uses_the_frozen_dispersed_parabola(self):
         runtime = _runtime()

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -806,6 +806,7 @@ class _Avatar(object):
         self.shot_results = []
         self.dispersion_queries = []
         self.battle_events = []
+        self.chat_actions = []
         self.responses = []
         self.misc_statuses = []
         self.cancelWaitingForShot = mock.Mock()
@@ -867,6 +868,14 @@ class _Avatar(object):
                                          with_shot=0):
         self.dispersion_queries.append((turret_rotation_speed, with_shot))
         return [0.25, 0.125]
+
+    def messenger_onActionByServer_chat2(self, action_id, request_id, args):
+        if action_id == 19:
+            # The real handler/controller registration happens in
+            # Avatar.__startGUI, before the native client-ready callback.
+            if not self._offlineLANInitComplete or not self.playerVehicleID:
+                raise RuntimeError('battle messenger is not ready')
+        self.chat_actions.append((action_id, request_id, dict(args)))
 
     def set_playerVehicleID(self, previous):
         self.previous_vehicle_id = previous
@@ -9491,10 +9500,19 @@ class BattleRuntimeContractTests(unittest.TestCase):
             type(runtime.app_loader).__dict__['showBattlePage'])
         self.assertEqual('newer', runtime.app_loader.showBattlePage())
 
-    def test_map_to_native_vehicle_to_ready_lifecycle(self):
+    @mock.patch('gui.mods.offline_lan_0922.tactical_radio.'
+                '_notify_stock_ignore_lists_ready')
+    def test_map_to_native_vehicle_to_ready_lifecycle(self, notify_users):
         runtime = _runtime()
         runtime.bigworld.defer_vehicle_entry = True
         battle = BattleRuntime(runtime)
+
+        def users_ready():
+            self.assertEqual('running', battle.state)
+            self.assertEqual([19], [entry[0] for entry in
+                                    runtime.bigworld.avatar.chat_actions])
+
+        notify_users.side_effect = users_ready
         client = _Client()
         start = {
             'round_id': 1, 'map': '01_karelia', 'bot_authority_id': 1,
@@ -9509,6 +9527,8 @@ class BattleRuntimeContractTests(unittest.TestCase):
 
         self.assertEqual('loading_entities', battle.state)
         self.assertIsNotNone(battle._server.vehicle_id)
+        self.assertEqual([], runtime.bigworld.avatar.chat_actions)
+        notify_users.assert_not_called()
         self.assertEqual(
             battle._server.vehicle_id,
             runtime.bigworld.avatar.playerVehicleID)
@@ -9533,7 +9553,12 @@ class BattleRuntimeContractTests(unittest.TestCase):
 
         self.assertEqual('running', battle.state)
         self.assertEqual(1, runtime.bigworld.avatar.vehicle_changed)
+        self.assertEqual([19], [entry[0] for entry in
+                                runtime.bigworld.avatar.chat_actions])
         self.assertFalse(battle._server.setClientReady())
+        self.assertFalse(battle._server.start_team_chat())
+        self.assertEqual(1, len(runtime.bigworld.avatar.chat_actions))
+        notify_users.assert_called_once_with()
         self.assertEqual(500, runtime.bigworld.entity(
             battle._server.vehicle_id).health)
 
@@ -24248,6 +24273,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
         calls = []
 
         def retire():
+            server.close_team_chat.assert_called_once_with()
             calls.append('retire')
 
         def destroy():

--- a/tests/test_port_0922_bot_runtime.py
+++ b/tests/test_port_0922_bot_runtime.py
@@ -7169,6 +7169,73 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertLessEqual(solution['pitch'], 0.15)
         self.assertGreater(solution['flight_time'], 0.25)
 
+    def test_selected_part_aim_is_led_and_missing_geometry_blocks_solution(self):
+        selection = [{'aim_position': (0.0, 3.0, 300.0), 'aim_token': ('turret',)}]
+        runtime = self.module.BotRuntime(
+            1, direct_aim_point_probe=lambda *unused: selection[0])
+        state = {'id': 11, 'x': 0.0, 'y': 0.0, 'z': 0.0}
+        target = {'position': (0.0, 0.0, 300.0),
+                  'yaw': math.pi * 0.5, 'speed': 20.0}
+        solution = runtime._local_ballistic_solution(
+            state, target, _combat_descriptor(), 0)
+        self.assertIsNotNone(solution)
+        self.assertAlmostEqual(3.0, solution['aim_position'][1])
+        self.assertGreater(solution['aim_position'][0], 1.0)
+        self.assertEqual(('turret',), solution['_aim_token'])
+        self.assertTrue(runtime._direct_aim_matches(state, target, solution))
+        runtime._ballistic_solution_cache[11] = ('cached',)
+        selection[0] = {'aim_position': (0.0, 1.5, 300.0), 'aim_token': ('hull',)}
+        self.assertFalse(runtime._direct_aim_matches(state, target, solution))
+        self.assertNotIn(11, runtime._ballistic_solution_cache)
+        for missing in (None, {'aim_position': (0, float('nan'), 300)}):
+            selection[0] = missing
+            self.assertIsNone(runtime._local_ballistic_solution(
+                state, target, _combat_descriptor(), 0))
+
+    def test_lane_part_change_after_slew_defers_only_new_shot_admission(self):
+        selection = [{'aim_position': (0.0, 1.0, 100.0), 'aim_token': ('hull',)}]
+
+        def lane(*unused):
+            selection[0] = {'aim_position': (0.0, 2.2, 100.0),
+                            'aim_token': ('turret',)}
+            return True
+
+        command = {
+            'target_yaw': 0.0, 'throttle': 0.0, 'turn': 0.0,
+            'shell_index': 0, 'fire_allowed': True,
+            'target_id': self.module.HUMAN_TARGET_ID_BASE + 2,
+            'fire_range': 500.0, 'combat_mode': 'engage',
+            'aim_position': (0.0, 1.0, 100.0),
+            'face_position': (0.0, 1.0, 100.0),
+            'move_position': (0.0, 0.0, 0.0),
+            'recovery_mode': 'arrived', 'movement_intent': False,
+        }
+        runtime = self.module.BotRuntime(
+            1, descriptor_resolver=lambda unused: _combat_descriptor(
+                reload_time=0.01, clip=(1,)),
+            adapter_factory=lambda *unused, **kwargs: _FixedAdapter(command),
+            direction_probe=lambda *unused: {'clear': True, 'slope': 0.0},
+            visibility_probe=lambda *unused: True,
+            firing_lane_probe=lane,
+            direct_aim_point_probe=lambda *unused: selection[0],
+            ground_probe=lambda *unused: 0.0,
+            physics_ground_probe=lambda *unused: 0.0,
+            spawn_resolver=_spawn_resolver, baked_graph=_graph())
+        runtime.battle_start(self.start)
+        runtime._next_observation = 100.0
+        runtime._next_shot_lane_refresh = 100.0
+        runtime._next_cover_refresh = 100.0
+        player = _admit_player({'id': 2, 'team': 1, 'alive': True,
+                                'x': 0.0, 'y': 0.0, 'z': 100.0})
+        runtime.states[11].update(x=0.0, y=0.0, z=0.0, yaw=0.0)
+        blocked = runtime.update(0.2, 1.0, players=[player])[0]['bots'][0]
+        self.assertEqual(0, blocked['fire_seq'])
+        self.assertNotIn(11, runtime._ballistic_solution_cache)
+        fired = runtime.update(0.2, 1.2, players=[player])[0]['bots'][0]
+        self.assertEqual(1, fired['fire_seq'])
+        self.assertTrue(runtime.states[11]['gun_aligned'])
+        self.assertLess(fired['gun_pitch'], 0.0)
+
     def test_spg_requires_a_client_proved_arc_and_accepts_low_root_fallback(self):
         descriptor = _combat_descriptor()
         target = {
@@ -12559,7 +12626,8 @@ class BotRuntimeTests(unittest.TestCase):
             'id': 2, 'team': 2, 'alive': True,
             'vehicle': 'ussr:R11_MS-1',
             'x': 10.0, 'y': 1.0, 'z': 100.0,
-            'yaw': 0.2, 'speed': 4.0, 'health': 900,
+            'yaw': 0.2, 'pitch': 0.1, 'roll': -0.1,
+            'turret_yaw': 0.4, 'speed': 4.0, 'health': 900,
             'max_health': 1000,
         })
         unused_contacts, lookup = runtime._contacts_for(
@@ -12567,9 +12635,12 @@ class BotRuntimeTests(unittest.TestCase):
         planner_id = self.module.HUMAN_TARGET_ID_BASE + 2
         self.assertEqual((10.0, 1.0, 100.0),
                          lookup[planner_id]['position'])
+        self.assertEqual((0.1, -0.1, 0.4), tuple(
+            lookup[planner_id][name] for name in ('pitch', 'roll', 'turret_yaw')))
 
         visible[0] = False
         player.update(x=80.0, y=2.0, z=240.0, yaw=1.2,
+                      pitch=0.3, roll=0.2, turret_yaw=-0.5,
                       speed=20.0, health=700)
         contacts, lookup = runtime._contacts_for(source, [player], 1.1)
         hidden_human = lookup[planner_id]
@@ -12587,6 +12658,13 @@ class BotRuntimeTests(unittest.TestCase):
             refreshed_human['z'], refreshed_human['yaw'],
             refreshed_human['speed']))
         self.assertEqual(700, refreshed_human['health'])
+        self.assertEqual((0.1, -0.1, 0.4), tuple(
+            refreshed_human[name] for name in ('pitch', 'roll', 'turret_yaw')))
+        visible[0] = True
+        unused, fresh_lookup = runtime._contacts_for(source, [player], 1.15)
+        self.assertEqual((0.3, 0.2, -0.5), tuple(
+            fresh_lookup[planner_id][name]
+            for name in ('pitch', 'roll', 'turret_yaw')))
 
         bot = {
             'id': 12, 'team': 2, 'alive': True,
@@ -13651,11 +13729,16 @@ class BotRuntimeTests(unittest.TestCase):
                 return True
 
         class Navigator(object):
+            @staticmethod
+            def observe_direct_target(*unused):
+                return None
+
             grid = Grid()
             bot_states = {}
 
             def next_target(self, bot_id, position, goal, path_key, now,
-                            anchor, avoid, lookahead_distance=None):
+                            anchor, avoid, lookahead_distance=None,
+                            movement_intent=True):
                 calls.append((bot_id, goal, path_key, anchor))
                 # The navigation result is deliberately unrelated to the
                 # macro goal. A post-A* translation would change this tuple.
@@ -14170,12 +14253,17 @@ class BotRuntimeTests(unittest.TestCase):
                 return True
 
         class Navigator(object):
+            @staticmethod
+            def observe_direct_target(*unused):
+                return None
+
             def __init__(self):
                 self.grid = Grid()
                 self.bot_states = {}
 
             def next_target(self, bot_id, position, goal, path_key, now,
-                            anchor, avoid, lookahead_distance=None):
+                            anchor, avoid, lookahead_distance=None,
+                            movement_intent=True):
                 calls.append((goal, path_key))
                 self.bot_states[bot_id] = {
                     'navigation_status': 'blocked',
@@ -14633,14 +14721,21 @@ class BotRuntimeTests(unittest.TestCase):
                 return self.allow_direct
 
         class Navigator(object):
+            @staticmethod
+            def observe_direct_target(*unused):
+                return None
+
             def __init__(self):
                 self.grid = Grid()
                 self.penalized = False
                 self.penalty_calls = []
 
             def next_target(self, bot_id, position, goal, path_key, now,
-                            anchor, avoid, lookahead_distance=None):
+                            anchor, avoid, lookahead_distance=None,
+                            movement_intent=True):
                 calls.append(('planned', bot_id, path_key))
+                if self.grid.allow_direct and not self.penalized:
+                    return tuple(goal)
                 return (4.0, 0.0, 8.0)
 
             @staticmethod
@@ -14705,8 +14800,13 @@ class BotRuntimeTests(unittest.TestCase):
         calls = []
 
         class Navigator(object):
+            @staticmethod
+            def observe_direct_target(*unused):
+                return None
+
             def next_target(self, bot_id, position, goal, path_key, now,
-                            anchor, avoid, lookahead_distance=None):
+                            anchor, avoid, lookahead_distance=None,
+                            movement_intent=True):
                 calls.append(path_key)
                 return goal
 
@@ -14726,6 +14826,27 @@ class BotRuntimeTests(unittest.TestCase):
             ('local', 11, 'base_defense', '1:0'),
             ('local', 11, 'base_defense', '1:0'),
         ], calls)
+
+    def test_artillery_proof_hold_does_not_accumulate_macro_stall_time(self):
+        runtime = self.module.BotRuntime(1, baked_graph=_graph())
+        runtime.navigator = self.module.TerrainNavigator(
+            lambda *unused: None, baked_graph=_graph())
+        runtime.states = {11: {'id': 11, 'team': 1}}
+        current = (0.0, 0.0, 0.0)
+        goal = (0.0, 0.0, 100.0)
+        strategic = {'combat_mode': 'artillery_deploy', 'target_id': 21}
+        for pending in (runtime._artillery_intents, runtime._artillery_reproofs):
+            pending[11] = {'created': 1.0}
+            for now in range(1, 31):
+                runtime._navigation_target(
+                    11, current, goal, strategic, {'now': float(now)})
+            self.assertEqual(0, runtime.navigator.bot_states[11][
+                'macro_progress_replans'])
+            pending.clear()
+            runtime._navigation_target(
+                11, current, goal, strategic, {'now': 30.1})
+            self.assertEqual(0, runtime.navigator.bot_states[11][
+                'macro_progress_replans'])
 
     def test_planner_selects_near_fast_stable_base_defenders(self):
         planner = BotPlanner()
@@ -14841,6 +14962,10 @@ class BotRuntimeTests(unittest.TestCase):
             'x': 400.0, 'y': 0.0, 'z': 0.0,
             'health': 1000, 'max_health': 1000,
         }]
+        for state in states:
+            state.update(ammo_remaining=[40], shell_index=0,
+                         ammo_reload_pending=False, reload_time=0.0,
+                         clip=1, clip_size=1, burst_active=False)
         enemy = {'id': 2, 'team': 2, 'alive': True}
         self.assertEqual(1, planner.report_contacts([{
             'observing_team': 1, 'target_kind': 'human',
@@ -14976,6 +15101,10 @@ class BotRuntimeTests(unittest.TestCase):
                 'world_pose': True, 'x': x, 'y': 0.0, 'z': 0.0,
                 'health': 1000, 'max_health': 1000,
             })
+        for state in states:
+            state.update(ammo_remaining=[40], shell_index=0,
+                         ammo_reload_pending=False, reload_time=0.0,
+                         clip=1, clip_size=1, burst_active=False)
         enemies = [
             {'id': 2, 'team': 2, 'alive': True},
             {'id': 3, 'team': 2, 'alive': True},
@@ -15296,7 +15425,7 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertFalse(orders[11]['fire_allowed'])
         self.assertEqual(2, orders[12]['target_id'])
         self.assertEqual('human', orders[12]['target_kind'])
-        self.assertTrue(orders[12]['fire_allowed'])
+        self.assertFalse(orders[12]['fire_allowed'])
 
         payload = planner.build_orders(
             manifest, bot_states, [enemy], 1.0)
@@ -15305,9 +15434,16 @@ class BotRuntimeTests(unittest.TestCase):
             'bot_orders': payload['orders'],
         }))
         # Team spotting does not pull bot 11 off its route. Bot 12 owns the
-        # current firing lane and remains the only assigned shooter.
+        # current firing lane and becomes the sole shooter after reloading.
         for index in range(4):
-            runtime.update(.06, 1.21 + index * .21, players=[enemy])
+            now = 1.21 + index * .21
+            runtime.update(.06, now, players=[enemy])
+            payload = planner.build_orders(
+                manifest, list(runtime.states.values()), [enemy], now)
+            runtime._apply_orders({
+                'bot_order_revision': payload['revision'],
+                'bot_orders': payload['orders'],
+            })
         self.assertEqual(0, runtime.states[11]['fire_seq'])
         self.assertGreater(runtime.states[12]['fire_seq'], 0)
 
@@ -15371,6 +15507,21 @@ class BotRuntimeTests(unittest.TestCase):
         yaws = []
         turns = []
         for frame in range(750):
+            if frame and frame % 50 == 0:
+                now = 1.0 + frame * 0.02
+                bot_states = [dict(runtime.states[11])]
+                planner.report_contacts([{
+                    'observing_team': 1, 'target_kind': 'human',
+                    'target_id': 2, 'target_team': 2,
+                    'visible': True, 'shootable_by_bot_ids': [11],
+                    'x': 0.0, 'y': 0.0, 'z': 20.0,
+                    'health': 1000, 'max_health': 1000,
+                }], planner.known_targets(bot_states, [enemy]), now)
+                payload = planner.build_orders(manifest, bot_states, [enemy], now)
+                runtime._apply_orders({
+                    'bot_order_revision': payload['revision'],
+                    'bot_orders': payload['orders'],
+                })
             runtime.update(0.02, 1.0 + frame * 0.02,
                            players=[enemy])
             yaws.append(runtime.states[11]['yaw'])
@@ -15401,6 +15552,10 @@ class BotRuntimeTests(unittest.TestCase):
             'id': 11, 'team': 1, 'alive': True,
             'x': 0.0, 'y': 0.0, 'z': 0.0, 'yaw': 0.0,
         }]
+        for state in bot_states:
+            state.update(ammo_remaining=[40], shell_index=0,
+                         ammo_reload_pending=False, reload_time=0.0,
+                         clip=1, clip_size=1, burst_active=False)
         enemy = {
             'id': 2, 'team': 2, 'alive': True,
             'x': 0.0, 'y': 0.0, 'z': 150.0,
@@ -16123,6 +16278,7 @@ class BotRuntimeTests(unittest.TestCase):
         observation_batches = 0
         observation_times = []
         per_frame_lane_probes = []
+        ready_order_batches = 0
 
         # Drive the runtime at 50 FPS for 120 seconds. Periodic firing-lane
         # refreshes and current-fire safety checks share one frame budget.
@@ -16175,13 +16331,17 @@ class BotRuntimeTests(unittest.TestCase):
                     self.assertIn(order['id'],
                                   contact['shootable_by_bot_ids'])
             if len(runtime._shot_los_cache) == 420:
-                self.assertEqual(2, targeted)
-                self.assertEqual(2, firing)
-            else:
-                self.assertLessEqual(targeted, 2)
-                self.assertLessEqual(firing, targeted)
+                # Reload and empty ammunition now affect permission even when
+                # a lane exists. Only the two clear observers may be targeted.
+                self.assertTrue(all(order['id'] in (11, 25)
+                                    for order in orders
+                                    if order['target_id'] is not None))
+            self.assertLessEqual(targeted, 2)
+            self.assertLessEqual(firing, targeted)
+            ready_order_batches += int(firing > 0)
 
         self.assertTrue(observation_times)
+        self.assertGreater(ready_order_batches, 0)
         self.assertLessEqual(
             observation_times[0],
             1.0 + self.module.PUBLICATION_SECONDS + 0.02 + 1e-6)

--- a/tests/test_port_0922_entities.py
+++ b/tests/test_port_0922_entities.py
@@ -2,6 +2,7 @@ import importlib.util
 import inspect
 from pathlib import Path
 import pickle
+import sys
 import types
 import unittest
 from unittest import mock
@@ -14,6 +15,8 @@ RUNTIME_PATH = (ROOT / 'src' / 'res' / 'scripts' /
                 'entities' / 'runtime.py')
 BINDING_PATH = RUNTIME_PATH.parent / 'bigworld_binding.py'
 AVATAR_BRIDGE_PATH = RUNTIME_PATH.parent / 'avatar_server.py'
+CLIENT_SCRIPTS = ROOT / 'src' / 'res' / 'scripts' / 'client'
+sys.path.insert(0, str(CLIENT_SCRIPTS))
 
 
 def _runtime_module():
@@ -1177,6 +1180,7 @@ class AvatarServerBridgeTests(unittest.TestCase):
             'setRemoteCamera': 1,
             'switchObserverFPVControlMode': 1,
             'sendStateToOwnClient': 0,
+            'messenger_onActionByClient_chat2': 3,
         }
 
         for name, wire_count in expected_wire_args.items():

--- a/tests/test_port_0922_lan_session.py
+++ b/tests/test_port_0922_lan_session.py
@@ -200,6 +200,9 @@ class _BattleRuntime(object):
         self.events = []
         self.rosters = []
         self.observations = []
+        self.team_command_acks = []
+        self.team_commands = []
+        self.team_command_terminals = []
         self.restore_pending = False
 
     def start(self, config, message=None, lan_client=None,
@@ -224,6 +227,15 @@ class _BattleRuntime(object):
 
     def on_bot_observation(self, message):
         self.observations.append(message)
+
+    def on_team_command_ack(self, message):
+        self.team_command_acks.append(message)
+
+    def on_team_command(self, message):
+        self.team_commands.append(message)
+
+    def on_team_command_terminal(self, message):
+        self.team_command_terminals.append(message)
 
     def stop(self, show_login=True, restore_account=True):
         self.stopped.append(show_login)
@@ -1759,6 +1771,24 @@ class LANSessionTests(unittest.TestCase):
         self.emit('bot_observation', dict(current, round_id=6))
 
         self.assertEqual([current], self.battle_runtime.observations)
+
+    def test_only_active_round_team_command_messages_reach_runtime(self):
+        self.emit('battle_start', {
+            'round_id': 7, 'map': '01_karelia', 'players': [{
+                'id': 'p1', 'x': 1, 'y': 2, 'z': 3,
+                'vehicle': 'ussr:T-34'}]})
+        messages = (
+            ('team_command_ack', self.battle_runtime.team_command_acks),
+            ('team_command', self.battle_runtime.team_commands),
+            ('team_command_terminal',
+             self.battle_runtime.team_command_terminals),
+        )
+
+        for kind, received in messages:
+            current = {'type': kind, 'round_id': 7}
+            self.emit(kind, current)
+            self.emit(kind, dict(current, round_id=6))
+            self.assertEqual([current], received)
 
     def test_local_avatar_leave_retires_round_and_waits_for_server_reset(self):
         first = {

--- a/tests/test_port_0922_lan_session.py
+++ b/tests/test_port_0922_lan_session.py
@@ -203,6 +203,8 @@ class _BattleRuntime(object):
         self.team_command_acks = []
         self.team_commands = []
         self.team_command_terminals = []
+        self.team_chats = []
+        self.team_chat_acks = []
         self.restore_pending = False
 
     def start(self, config, message=None, lan_client=None,
@@ -236,6 +238,12 @@ class _BattleRuntime(object):
 
     def on_team_command_terminal(self, message):
         self.team_command_terminals.append(message)
+
+    def on_team_chat(self, message):
+        self.team_chats.append(message)
+
+    def on_team_chat_ack(self, message):
+        self.team_chat_acks.append(message)
 
     def stop(self, show_login=True, restore_account=True):
         self.stopped.append(show_login)
@@ -1778,6 +1786,8 @@ class LANSessionTests(unittest.TestCase):
                 'id': 'p1', 'x': 1, 'y': 2, 'z': 3,
                 'vehicle': 'ussr:T-34'}]})
         messages = (
+            ('team_chat', self.battle_runtime.team_chats),
+            ('team_chat_ack', self.battle_runtime.team_chat_acks),
             ('team_command_ack', self.battle_runtime.team_command_acks),
             ('team_command', self.battle_runtime.team_commands),
             ('team_command_terminal',

--- a/tests/test_port_0922_radio_integration.py
+++ b/tests/test_port_0922_radio_integration.py
@@ -1,0 +1,85 @@
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / 'src/res/scripts/client'))
+from gui.mods.offline_lan_0922.lan_client import LANClient, ORDERED_RECEIVE_TYPES
+from gui.mods.offline_lan_0922.battle_runtime import _LANInputSender
+import test_port_0922_battle_runtime as fixtures
+
+
+class RadioIntegrationTests(unittest.TestCase):
+    def setUp(self):
+        self.client = LANClient('127.0.0.1', 28782, 'P', 'ussr:R11_MS-1')
+        self.client.ready = True
+        self.client.running = True
+        self.client.phase = 'battle'
+        self.client.round_id = 7
+        self.client.player_id = 1
+        self.client.team = 1
+        self.client.bot_authority_id = -1
+        self.sent = []
+        self.client._send = lambda value: self.sent.append(value) or True
+
+    def test_wire_is_ordered_and_sequence_is_scoped_to_round(self):
+        self.assertEqual(1, self.client.send_team_command('FOLLOWME', 'bot', 1))
+        self.assertEqual('bot', self.sent[-1]['target_kind'])
+        self.assertEqual(2, self.client.send_team_command('ATTENTIONTOCELL', cell_index=23))
+        self.assertFalse(self.client.send_team_command('ATTENTIONTOCELL', cell_index=100))
+        self.client.round_id = 8
+        self.assertEqual(1, self.client.send_team_command('HELPME'))
+        self.assertEqual(8, self.sent[-1]['round_id'])
+        self.assertTrue({'team_command', 'team_command_ack', 'team_command_terminal'} <= ORDERED_RECEIVE_TYPES)
+
+    def test_malformed_wrong_team_and_old_round_radio_do_not_end_battle(self):
+        received = []
+        self.client.on_event = lambda kind, value: received.append(kind)
+        message = dict(type='team_command', protocol=5, round_id=7, command='HELPME',
+                       command_seq=1, issuer_id=1, team=1)
+        self.client._handle_message(message)
+        self.assertEqual(['team_command'], received)
+        for change in ({'round_id': 6}, {'team': 2}, {'command': []}, {'command_seq': True}):
+            self.client._handle_message(dict(message, **change))
+        self.assertEqual(['team_command'], received)
+        self.assertTrue(self.client.running)
+        self.assertIsNone(self.client.last_error)
+
+    def test_engine_network_and_account_id_domains_stay_separate(self):
+        runtime, battle, unused, unused_target, unused_descriptor = (
+            fixtures.BattleRuntimeContractTests()._bot_lane_scene())
+        battle.client = self.client
+        battle._worker_mode = False
+        battle._battle_live = True
+        battle._start_message = {'round_id': 7}
+        battle._server = mock.Mock()
+        battle._records = {
+            'player:1': dict(kind='player', network_id=1, engine_id=101, ready=True),
+            'bot:1': dict(kind='bot', network_id=1, engine_id=201, ready=True),
+        }
+        battle._avatar.arena = types.SimpleNamespace(vehicles={
+            101: {'accountDBID': 10001, 'team': 1},
+            201: {'accountDBID': 20001, 'team': 1},
+        })
+        sender = _LANInputSender(battle)
+        self.assertEqual(1, sender.send_team_command(dict(
+            command='FOLLOWME', stock_target_id=201, target_relation='ally')))
+        self.assertEqual(('bot', 1), (self.sent[-1]['target_kind'], self.sent[-1]['target_id']))
+        message = dict(type='team_command', round_id=7, command_seq=1, issuer_id=1,
+                       team=1, command='FOLLOWME', target_kind='bot', target_id=1)
+        self.assertTrue(battle.on_team_command(message))
+        battle._server.receive_team_command.assert_called_once_with('FOLLOWME', 10001, 201, None)
+        self.assertFalse(battle.on_team_command(message))
+        self.assertTrue(battle.on_team_command_ack(dict(
+            round_id=7, command_seq=1, accepted=True, recipient_bot_ids=[1])))
+        battle._server.receive_team_command_ack.assert_called_once_with(1, True, [20001])
+        self.assertFalse(battle.on_team_command_ack(dict(
+            round_id=6, command_seq=1, accepted=True, recipient_bot_ids=[1])))
+        battle._records['bot:1']['tombstone'] = True
+        self.assertFalse(sender.send_team_command(dict(command='FOLLOWME', stock_target_id=201)))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_port_0922_radio_integration.py
+++ b/tests/test_port_0922_radio_integration.py
@@ -41,7 +41,8 @@ class RadioIntegrationTests(unittest.TestCase):
                        command_seq=1, issuer_id=1, team=1)
         self.client._handle_message(message)
         self.assertEqual(['team_command'], received)
-        for change in ({'round_id': 6}, {'team': 2}, {'command': []}, {'command_seq': True}):
+        for change in ({'round_id': 6}, {'round_id': 8}, {'team': 2},
+                       {'command': []}, {'command_seq': True}):
             self.client._handle_message(dict(message, **change))
         self.assertEqual(['team_command'], received)
         self.assertTrue(self.client.running)
@@ -52,6 +53,7 @@ class RadioIntegrationTests(unittest.TestCase):
             fixtures.BattleRuntimeContractTests()._bot_lane_scene())
         battle.client = self.client
         battle._worker_mode = False
+        battle.state = 'running'
         battle._battle_live = True
         battle._start_message = {'round_id': 7}
         battle._server = mock.Mock()
@@ -79,6 +81,156 @@ class RadioIntegrationTests(unittest.TestCase):
             round_id=6, command_seq=1, accepted=True, recipient_bot_ids=[1])))
         battle._records['bot:1']['tombstone'] = True
         self.assertFalse(sender.send_team_command(dict(command='FOLLOWME', stock_target_id=201)))
+
+    def test_chat_and_commands_can_be_sent_during_countdown(self):
+        unused, battle, unused_source, unused_target, unused_descriptor = (
+            fixtures.BattleRuntimeContractTests()._bot_lane_scene())
+        battle.client = self.client
+        battle._worker_mode = False
+        battle.state = 'running'
+        battle._battle_live = False
+        sender = _LANInputSender(battle)
+
+        self.assertEqual(1, sender.send_team_chat({'text': u'Hold here'}))
+        self.assertEqual(1, sender.send_team_command(
+            {'command': 'ATTENTIONTOCELL', 'cell_index': 12}))
+        for state in ('loading_entities', 'stopping', 'idle'):
+            battle.state = state
+            self.assertFalse(sender.send_team_chat({'text': u'Late'}))
+            self.assertFalse(sender.send_team_command({'command': 'HELPME'}))
+        battle.state = 'running'
+        battle._worker_mode = True
+        self.assertFalse(sender.send_team_chat({'text': u'Worker'}))
+
+    def test_chat_sequence_is_independent_and_restarts_at_round_boundary(self):
+        text = u'\u961f\u53cb,\u8bf7\u63a9\u62a4 <A1> & B2'
+        self.assertEqual(1, self.client.send_team_chat(text))
+        self.assertEqual(text, self.sent[-1]['text'])
+        self.assertEqual(1, self.client.send_team_command('HELPME'))
+        self.assertEqual(2, self.client.send_team_chat(text))
+        self.client._send = lambda unused: False
+        self.assertFalse(self.client.send_team_chat(text))
+        self.client._send = lambda value: self.sent.append(value) or True
+        self.assertEqual(3, self.client.send_team_chat(text))
+        self.client.round_id = 8
+        self.assertEqual(1, self.client.send_team_chat(text))
+        self.assertEqual(8, self.sent[-1]['round_id'])
+        self.assertTrue({'team_chat', 'team_chat_ack'} <= ORDERED_RECEIVE_TYPES)
+
+    def test_invalid_chat_never_disconnects_or_mutates_round(self):
+        from gui.mods.offline_lan_0922.tactical_radio import MAX_TEAM_CHAT_LENGTH
+        received = []
+        self.client.on_event = lambda kind, value: received.append((kind, value))
+        message = dict(type='team_chat', protocol=5, round_id=7,
+                       chat_seq=1, issuer_id=1, team=1, text=u'Hello')
+        invalid = ({'round_id': 6}, {'round_id': 8}, {'round_id': True},
+                   {'team': 2}, {'team': True}, {'issuer_id': True},
+                   {'chat_seq': True}, {'text': []}, {'text': ''},
+                   {'text': 'x' * (MAX_TEAM_CHAT_LENGTH + 1)},
+                   {'text': u'\ud800'})
+        for change in invalid:
+            self.client._handle_message(dict(message, **change))
+        self.assertEqual([], received)
+        self.assertTrue(self.client.running)
+        self.assertIsNone(self.client.last_error)
+        self.assertEqual(7, self.client.round_id)
+        self.client._handle_message(message)
+        self.assertEqual([('team_chat', message)], received)
+        ack = dict(type='team_chat_ack', protocol=5, round_id=7,
+                   chat_seq=1, accepted=True, code='accepted')
+        self.client._handle_message(ack)
+        self.assertEqual(('team_chat_ack', ack), received[-1])
+        for change in ({'chat_seq': 0}, {'accepted': 1}, {'code': []}):
+            self.client._handle_message(dict(ack, **change))
+        self.assertEqual(2, len(received))
+
+    def test_stock_reload_and_spg_details_survive_wire_and_runtime(self):
+        details = {'aim_point': [125.0, 42.0, -270.0], 'reload_time': 8.25}
+        self.assertEqual(1, self.client.send_team_command(
+            'SPG_AIM_AREA', cell_index=42, details=details))
+        wire = self.sent[-1]
+        self.assertEqual(details['aim_point'], wire['aim_point'])
+        self.assertEqual(8.25, wire['reload_time'])
+        received = []
+        self.client.on_event = lambda kind, value: received.append(value)
+        broadcast = dict(wire, protocol=5, issuer_id=1, team=1)
+        self.client._handle_message(broadcast)
+        self.assertEqual([broadcast], received)
+        for change in ({'reload_time': float('nan')},
+                       {'aim_point': [0.0, 0.0]}, {'cell_index': 100}):
+            self.client._handle_message(dict(broadcast, **change))
+        self.assertEqual([broadcast], received)
+        self.assertTrue(self.client.running)
+
+        unused, battle, unused_source, unused_target, unused_descriptor = (
+            fixtures.BattleRuntimeContractTests()._bot_lane_scene())
+        battle.client = self.client
+        battle.state = 'running'
+        battle._worker_mode = False
+        battle._start_message = {'round_id': 7}
+        battle._server = mock.Mock()
+        battle._records = {
+            'player:1': dict(kind='player', network_id=1, engine_id=101,
+                             ready=True),
+        }
+        battle._avatar.arena = types.SimpleNamespace(vehicles={
+            101: {'accountDBID': 10001, 'team': 1},
+        })
+        self.assertTrue(battle.on_team_command(broadcast))
+        battle._server.receive_team_command.assert_called_once_with(
+            'SPG_AIM_AREA', 10001, None, 42, details=details)
+        self.assertEqual(2, _LANInputSender(battle).send_team_command(dict(
+            command='RELOADING_CASSETE',
+            details={'reload_time': 4.5, 'quantity': 3})))
+        self.assertEqual(4.5, self.sent[-1]['reload_time'])
+        self.assertEqual(3, self.sent[-1]['quantity'])
+
+    def test_targeted_command_cannot_bypass_reload_validation(self):
+        received = []
+        self.client.on_event = lambda kind, value: received.append(value)
+        broadcast = dict(type='team_command', round_id=7, command_seq=1,
+                         command='ATTACKENEMY', issuer_id=1, team=1,
+                         target_kind='human', target_id=2, reload_time=3.75)
+        for value in (float('nan'), -1.0, True, '3.75'):
+            self.client._handle_message(dict(broadcast, reload_time=value))
+        self.assertEqual([], received)
+        self.client._handle_message(broadcast)
+        self.assertEqual([broadcast], received)
+
+    def test_chat_display_resolves_dead_teammate_dbid_and_echoes_once(self):
+        unused, battle, unused_source, unused_target, unused_descriptor = (
+            fixtures.BattleRuntimeContractTests()._bot_lane_scene())
+        battle.client = self.client
+        battle._worker_mode = False
+        battle.state = 'running'
+        battle._start_message = {'round_id': 7}
+        battle._server = mock.Mock()
+        battle._records = {
+            'player:1': dict(kind='player', network_id=1, engine_id=101,
+                             ready=True, state={'alive': False}),
+        }
+        battle._avatar.arena = types.SimpleNamespace(vehicles={
+            101: {'accountDBID': 10001, 'team': 1, 'isAlive': False},
+        })
+        message = dict(type='team_chat', round_id=7, chat_seq=1,
+                       issuer_id=1, team=1, text=u'Cover our base')
+
+        self.assertTrue(battle.on_team_chat(message))
+        battle._server.receive_team_chat.assert_called_once_with(
+            u'Cover our base', 10001)
+        self.assertFalse(battle.on_team_chat(message))
+        for change in ({'round_id': 6}, {'team': 2}, {'issuer_id': 999}):
+            self.assertFalse(battle.on_team_chat(dict(message, **change)))
+        self.assertTrue(battle.on_team_chat_ack(dict(
+            round_id=7, chat_seq=1, accepted=True)))
+        battle._server.receive_team_chat_ack.assert_called_once_with(1, True)
+        self.assertFalse(battle.on_team_chat_ack(dict(
+            round_id=6, chat_seq=1, accepted=True)))
+        self.assertEqual(1, battle._server.receive_team_chat.call_count)
+        battle.state = 'stopping'
+        self.assertFalse(battle.on_team_chat(dict(message, chat_seq=2)))
+        self.assertFalse(battle.on_team_chat_ack(dict(
+            round_id=7, chat_seq=2, accepted=True)))
 
 
 if __name__ == '__main__':

--- a/tests/test_port_0922_server_bot_ai.py
+++ b/tests/test_port_0922_server_bot_ai.py
@@ -76,8 +76,36 @@ def _state(bot_id, team, x, z):
         'yaw': 0.0,
         'health': 1000,
         'max_health': 1000,
+        'fire_seq': 0,
+        'shell_index': 0,
+        'next_shell_index': 0,
+        'ammo_remaining': [20],
+        'ammo_reload_pending': False,
+        'reload_time': 0.0,
+        'reload_duration': 20.0,
+        'clip': 1,
+        'clip_size': 1,
+        'burst_active': False,
         'critical': {},
     }
+
+
+def _weapon_state(raw, reload_time=0.0, clip=1, clip_size=1,
+                  ammunition=(20,), reload_pending=False, fire_seq=0,
+                  burst_active=False):
+    raw.update({
+        'fire_seq': int(fire_seq),
+        'shell_index': 0,
+        'next_shell_index': 0,
+        'ammo_remaining': list(ammunition),
+        'ammo_reload_pending': bool(reload_pending),
+        'reload_time': float(reload_time),
+        'reload_duration': 20.0,
+        'clip': int(clip),
+        'clip_size': int(clip_size),
+        'burst_active': bool(burst_active),
+    })
+    return raw
 
 
 def _contact(target_id, x, z, observers, class_tag='mediumTank'):
@@ -318,6 +346,433 @@ class ServerBotTacticsTests(unittest.TestCase):
             self.manifest, self.states, players, 3.1)['orders'][0]
         self.assertIsNone(expired['target_id'])
         self.assertEqual('route', expired['combat_mode'])
+
+    def test_ready_shooter_preempts_a_reloading_target_lease(self):
+        planner = BotPlanner()
+        manifest = [
+            _bot(11, 1, 0, self.route, 'mediumTank'),
+            _bot(12, 1, 1, self.route, 'mediumTank'),
+        ]
+        states = [
+            _weapon_state(_state(11, 1, 0, 0)),
+            _weapon_state(_state(12, 1, 20, 0)),
+        ]
+        contact = _contact(2, 0, 240, [11, 12])
+        contact.update({'health': 500, 'max_health': 1000})
+        players = self._report(planner, [contact])
+
+        first = dict((order['id'], order) for order in
+                     planner.build_orders(
+                         manifest, states, players, 1.0)['orders'])
+        self.assertEqual(2, first[11]['target_id'])
+        self.assertIsNone(first[12]['target_id'])
+
+        states[0].update({
+            'reload_time': 8.0,
+            'ammo_reload_pending': True,
+        })
+        ready_only = _contact(2, 0, 240, [12])
+        ready_only.update({'health': 500, 'max_health': 1000})
+        self.assertEqual(1, planner.report_contacts(
+            [ready_only], planner.known_targets(states, players), 1.5))
+        reallocated = dict((order['id'], order) for order in
+                           planner.build_orders(
+                               manifest, states, players, 1.5)['orders'])
+
+        self.assertEqual(2, reallocated[11]['target_id'])
+        self.assertFalse(reallocated[11]['fire_allowed'])
+        self.assertEqual(first[11]['combat_mode'],
+                         reallocated[11]['combat_mode'])
+        self.assertEqual(first[11]['move_position'],
+                         reallocated[11]['move_position'])
+        self.assertEqual(2, reallocated[12]['target_id'])
+        self.assertTrue(reallocated[12]['fire_allowed'])
+
+    def test_unavailable_weapons_do_not_consume_focus_capacity(self):
+        unavailable_states = (
+            (True, _weapon_state(
+                _state(11, 1, 0, 0), reload_time=8.0,
+                reload_pending=True)),
+            (True, _weapon_state(
+                _state(11, 1, 0, 0), reload_time=20.0,
+                clip=0, clip_size=3, reload_pending=True)),
+            (False, _weapon_state(
+                _state(11, 1, 0, 0), ammunition=(0,))),
+            (True, _weapon_state(_state(11, 1, 0, 0))),
+        )
+        unavailable_states[-1][1]['critical'] = {
+            'destroyed': ['gunHealth'],
+        }
+
+        for keeps_movement_target, unavailable in unavailable_states:
+            with self.subTest(state=unavailable):
+                planner = BotPlanner()
+                manifest = [
+                    _bot(11, 1, 0, self.route, 'mediumTank'),
+                    _bot(12, 1, 1, self.route, 'mediumTank'),
+                ]
+                states = [
+                    unavailable,
+                    _weapon_state(_state(12, 1, 20, 0)),
+                ]
+                contact = _contact(2, 0, 240, [11, 12])
+                contact.update({'health': 500, 'max_health': 1000})
+                players = self._report(planner, [contact])
+
+                orders = dict((order['id'], order) for order in
+                              planner.build_orders(
+                                  manifest, states, players, 1.0)['orders'])
+
+                if keeps_movement_target:
+                    self.assertEqual(2, orders[11]['target_id'])
+                    self.assertFalse(orders[11]['fire_allowed'])
+                else:
+                    self.assertIsNone(orders[11]['target_id'])
+                    self.assertEqual('route', orders[11]['combat_mode'])
+                    self.assertNotEqual(
+                        {'x': 0.0, 'y': 0.0, 'z': 0.0},
+                        orders[11]['move_position'])
+                self.assertEqual(2, orders[12]['target_id'])
+                self.assertTrue(orders[12]['fire_allowed'])
+
+    def test_reloading_vehicle_uses_a_new_close_threat_for_withdrawal(self):
+        planner = BotPlanner()
+        states = [_weapon_state(
+            _state(11, 1, 0, 0), reload_time=8.0,
+            reload_pending=True)]
+        contact = _contact(2, 0, 20, [11])
+        players = self._report(planner, [contact])
+
+        order = planner.build_orders(
+            self.manifest, states, players, 1.0)['orders'][0]
+
+        self.assertEqual(2, order['target_id'])
+        self.assertEqual('withdraw', order['combat_mode'])
+        self.assertFalse(order['fire_allowed'])
+
+    def test_exhausted_weapon_releases_an_old_lease(self):
+        planner = BotPlanner()
+        manifest = [
+            _bot(11, 1, 0, self.route, 'mediumTank'),
+            _bot(12, 1, 1, self.route, 'mediumTank'),
+        ]
+        states = [
+            _weapon_state(_state(11, 1, 0, 0)),
+            _weapon_state(_state(12, 1, 20, 0)),
+        ]
+        contact = _contact(2, 0, 240, [11, 12])
+        contact.update({'health': 500, 'max_health': 1000})
+        players = self._report(planner, [contact])
+        first = dict((order['id'], order) for order in
+                     planner.build_orders(
+                         manifest, states, players, 1.0)['orders'])
+        self.assertEqual(2, first[11]['target_id'])
+
+        states[0].update({
+            'ammo_remaining': [0],
+            'clip': 0,
+        })
+        ready_only = _contact(2, 0, 240, [12])
+        ready_only.update({'health': 500, 'max_health': 1000})
+        self.assertEqual(1, planner.report_contacts(
+            [ready_only], planner.known_targets(states, players), 1.5))
+        orders = dict((order['id'], order) for order in
+                      planner.build_orders(
+                          manifest, states, players, 1.5)['orders'])
+
+        self.assertIsNone(orders[11]['target_id'])
+        self.assertNotIn(11, planner._target_assignments)
+        self.assertEqual(2, orders[12]['target_id'])
+        self.assertTrue(orders[12]['fire_allowed'])
+
+    def test_cover_movement_lease_does_not_reserve_a_firing_slot(self):
+        planner = BotPlanner()
+        manifest = [
+            _bot(11, 1, 0, self.route, 'mediumTank'),
+            _bot(12, 1, 1, self.route, 'mediumTank'),
+        ]
+        states = [
+            _weapon_state(_state(11, 1, 0, 0)),
+            _weapon_state(_state(12, 1, 20, 0)),
+        ]
+        initial_contact = _contact(2, 0, 150, [11])
+        initial_contact.update({'health': 500, 'max_health': 1000})
+        players = self._report(planner, [initial_contact])
+        self.assertEqual(1, planner.report_affordances(
+            [_cover_report(11, 2)], planner.known_bots(manifest, states),
+            planner.known_targets(states, players), 1.0))
+        approach = dict((order['id'], order) for order in
+                        planner.build_orders(
+                            manifest, states, players, 1.0)['orders'])
+        self.assertEqual('take_cover', approach[11]['combat_mode'])
+        states[0].update(approach[11]['move_position'])
+
+        ready_only = _contact(2, 0, 150, [12])
+        ready_only.update({'health': 500, 'max_health': 1000})
+        self.assertEqual(1, planner.report_contacts(
+            [ready_only], planner.known_targets(states, players), 2.0))
+        holding = dict((order['id'], order) for order in
+                       planner.build_orders(
+                           manifest, states, players, 2.0)['orders'])
+
+        self.assertEqual('cover_hold', holding[11]['combat_mode'])
+        self.assertFalse(holding[11]['fire_allowed'])
+        self.assertEqual(2, holding[12]['target_id'])
+        self.assertTrue(holding[12]['fire_allowed'])
+
+        peeking = dict((order['id'], order) for order in
+                       planner.build_orders(
+                           manifest, states, players, 4.0)['orders'])
+        self.assertEqual('cover_peek', peeking[11]['combat_mode'])
+        self.assertFalse(peeking[11]['fire_allowed'])
+        self.assertEqual(2, peeking[12]['target_id'])
+        self.assertTrue(peeking[12]['fire_allowed'])
+
+    def test_destroyed_gun_keeps_its_movement_lease_until_repaired(self):
+        planner = BotPlanner()
+        manifest = [
+            _bot(11, 1, 0, self.route, 'mediumTank'),
+            _bot(12, 1, 1, self.route, 'mediumTank'),
+        ]
+        states = [
+            _weapon_state(_state(11, 1, 0, 0)),
+            _weapon_state(_state(12, 1, 20, 0)),
+        ]
+        contact = _contact(2, 0, 240, [11, 12])
+        contact.update({'health': 500, 'max_health': 1000})
+        players = self._report(planner, [contact])
+        first = dict((order['id'], order) for order in
+                     planner.build_orders(
+                         manifest, states, players, 1.0)['orders'])
+        self.assertEqual(2, first[11]['target_id'])
+
+        states[0]['critical'] = {'destroyed': ['gunHealth']}
+        self.assertEqual(1, planner.report_contacts(
+            [contact], planner.known_targets(states, players), 1.5))
+        destroyed = dict((order['id'], order) for order in
+                         planner.build_orders(
+                             manifest, states, players, 1.5)['orders'])
+        self.assertEqual(2, destroyed[11]['target_id'])
+        self.assertFalse(destroyed[11]['fire_allowed'])
+        self.assertEqual(first[11]['move_position'],
+                         destroyed[11]['move_position'])
+        self.assertEqual(2, destroyed[12]['target_id'])
+        self.assertTrue(destroyed[12]['fire_allowed'])
+
+        states[0]['critical'] = {'destroyed': []}
+        self.assertEqual(1, planner.report_contacts(
+            [contact], planner.known_targets(states, players), 19.6))
+        repaired = dict((order['id'], order) for order in
+                        planner.build_orders(
+                            manifest, states, players, 19.6)['orders'])
+        self.assertEqual(2, repaired[11]['target_id'])
+        self.assertTrue(repaired[11]['fire_allowed'])
+        self.assertIsNone(repaired[12]['target_id'])
+
+    def test_active_burst_keeps_focus_while_reload_is_pending(self):
+        planner = BotPlanner()
+        manifest = [
+            _bot(11, 1, 0, self.route, 'mediumTank'),
+            _bot(12, 1, 1, self.route, 'mediumTank'),
+        ]
+        states = [
+            _weapon_state(
+                _state(11, 1, 0, 0), reload_time=1.0,
+                clip=2, clip_size=3, reload_pending=True,
+                fire_seq=1, burst_active=True),
+            _weapon_state(_state(12, 1, 20, 0)),
+        ]
+        contact = _contact(2, 0, 240, [11, 12])
+        contact.update({'health': 500, 'max_health': 1000})
+        players = self._report(planner, [contact])
+
+        orders = dict((order['id'], order) for order in
+                      planner.build_orders(
+                          manifest, states, players, 1.0)['orders'])
+
+        self.assertEqual(2, orders[11]['target_id'])
+        self.assertTrue(orders[11]['fire_allowed'])
+        self.assertIsNone(orders[12]['target_id'])
+
+    def test_minor_answerable_hit_does_not_force_withdrawal(self):
+        planner = BotPlanner()
+        self.states[0] = _weapon_state(self.states[0])
+        contact = _contact(2, 0, 150, [11])
+        players = self._report(planner, [contact])
+        self.assertTrue(planner.report_damage(
+            11, 'player', 2, 1, 1.1))
+
+        order = planner.build_orders(
+            self.manifest, self.states, players, 1.1)['orders'][0]
+
+        self.assertEqual(2, order['target_id'])
+        self.assertTrue(order['fire_allowed'])
+        self.assertNotIn(order['combat_mode'], (
+            'under_fire_withdraw', 'under_fire_hold'))
+
+    def test_minor_unanswerable_hit_uses_nearby_support(self):
+        contact = _contact(2, 0, 50, [12])
+        players = [{'id': 2, 'team': 2, 'alive': True}]
+
+        unsupported = BotPlanner()
+        solo_states = [_weapon_state(_state(11, 1, 0, 0))]
+        self.assertEqual(1, unsupported.report_contacts(
+            [contact], unsupported.known_targets(solo_states, players), 1.0))
+        self.assertTrue(unsupported.report_damage(
+            11, 'player', 2, 1, 1.1))
+        solo = unsupported.build_orders(
+            self.manifest, solo_states, players, 1.1)['orders'][0]
+        self.assertEqual('under_fire_withdraw', solo['combat_mode'])
+
+        supported = BotPlanner()
+        manifest = [
+            _bot(11, 1, 0, self.route, 'mediumTank'),
+            _bot(12, 1, 1, self.route, 'mediumTank'),
+        ]
+        states = [
+            _weapon_state(_state(11, 1, 0, 0)),
+            _weapon_state(_state(12, 1, 0, 0)),
+        ]
+        self.assertEqual(1, supported.report_contacts(
+            [contact], supported.known_targets(states, players), 1.0))
+        self.assertTrue(supported.report_damage(
+            11, 'player', 2, 1, 1.1))
+        orders = dict((order['id'], order) for order in
+                      supported.build_orders(
+                          manifest, states, players, 1.1)['orders'])
+
+        self.assertEqual('route', orders[11]['combat_mode'])
+        self.assertEqual(2, orders[11]['target_id'])
+        self.assertFalse(orders[11]['fire_allowed'])
+        self.assertEqual(2, orders[12]['target_id'])
+        self.assertTrue(orders[12]['fire_allowed'])
+
+        for unavailable in ('no_lane', 'empty', 'destroyed'):
+            with self.subTest(unavailable=unavailable):
+                planner = BotPlanner()
+                ally = _weapon_state(_state(12, 1, 0, 0))
+                shooters = [12]
+                if unavailable == 'no_lane':
+                    shooters = []
+                elif unavailable == 'empty':
+                    ally.update({'ammo_remaining': [0], 'clip': 0})
+                else:
+                    ally['critical'] = {'destroyed': ['gunHealth']}
+                blocked_contact = _contact(2, 0, 50, shooters)
+                blocked_states = [
+                    _weapon_state(_state(11, 1, 0, 0)), ally,
+                ]
+                self.assertEqual(1, planner.report_contacts(
+                    [blocked_contact], planner.known_targets(
+                        blocked_states, players), 1.0))
+                self.assertTrue(planner.report_damage(
+                    11, 'player', 2, 1, 1.1))
+
+                blocked = dict((order['id'], order) for order in
+                               planner.build_orders(
+                                   manifest, blocked_states, players,
+                                   1.1)['orders'])
+
+                self.assertEqual(
+                    'under_fire_withdraw', blocked[11]['combat_mode'])
+
+    def test_dead_recent_attacker_is_cleared_before_ordering(self):
+        planner = BotPlanner()
+        contact = _contact(2, 0, 150, [11])
+        players = self._report(planner, [contact])
+        self.assertTrue(planner.report_damage(
+            11, 'player', 2, 240, 1.1))
+        players[0]['alive'] = False
+
+        order = planner.build_orders(
+            self.manifest, self.states, players, 1.2)['orders'][0]
+
+        self.assertNotIn(11, planner._recent_hits)
+        self.assertIsNone(order['target_id'])
+        self.assertEqual('route', order['combat_mode'])
+
+    def test_cover_waits_for_reload_and_completes_the_exposed_magazine(self):
+        planner = BotPlanner()
+        self.states[0] = _weapon_state(
+            self.states[0], clip=3, clip_size=3)
+        contact = _contact(2, 0, 150, [11])
+        players = self._report(planner, [contact])
+        known_bots = planner.known_bots(self.manifest, self.states)
+        known_targets = planner.known_targets(self.states, players)
+        self.assertEqual(1, planner.report_affordances(
+            [_cover_report(11, 2)], known_bots, known_targets, 1.0))
+
+        approach = planner.build_orders(
+            self.manifest, self.states, players, 1.0)['orders'][0]
+        self.assertEqual('take_cover', approach['combat_mode'])
+        self.states[0].update(approach['move_position'])
+        self.states[0].update({
+            'reload_time': 10.0,
+            'ammo_reload_pending': True,
+        })
+        holding = planner.build_orders(
+            self.manifest, self.states, players, 2.0)['orders'][0]
+        self.assertEqual('cover_hold', holding['combat_mode'])
+
+        self.states[0]['reload_time'] = 8.0
+        blocked_contact = _contact(2, 0, 150, [])
+        self.assertEqual(1, planner.report_contacts(
+            [blocked_contact], planner.known_targets(
+                self.states, players), 4.0))
+        blocked = planner.build_orders(
+            self.manifest, self.states, players, 4.0)['orders'][0]
+        self.assertEqual('cover_hold', blocked['combat_mode'])
+        self.assertFalse(blocked['fire_allowed'])
+
+        self.states[0].update({
+            'reload_time': 0.0,
+            'ammo_reload_pending': False,
+        })
+        peeking = planner.build_orders(
+            self.manifest, self.states, players, 4.1)['orders'][0]
+        self.assertEqual('cover_peek', peeking['combat_mode'])
+        self.assertFalse(peeking['fire_allowed'])
+        self.states[0].update(peeking['move_position'])
+        at_peek = planner.build_orders(
+            self.manifest, self.states, players, 4.2)['orders'][0]
+        self.assertEqual('cover_peek', at_peek['combat_mode'])
+
+        self.states[0].update({
+            'fire_seq': 1,
+            'clip': 2,
+            'ammo_remaining': [19],
+            'reload_time': 0.8,
+            'reload_duration': 1.0,
+            'ammo_reload_pending': True,
+        })
+        followup = planner.build_orders(
+            self.manifest, self.states, players, 4.3)['orders'][0]
+        self.assertEqual('cover_peek', followup['combat_mode'])
+
+        self.states[0].update({
+            'fire_seq': 2,
+            'clip': 1,
+            'ammo_remaining': [18],
+            'reload_time': 0.8,
+            'reload_duration': 1.0,
+            'ammo_reload_pending': True,
+            'burst_active': True,
+        })
+        bursting = planner.build_orders(
+            self.manifest, self.states, players, 4.4)['orders'][0]
+        self.assertEqual('cover_peek', bursting['combat_mode'])
+
+        self.states[0].update({
+            'fire_seq': 3,
+            'clip': 0,
+            'ammo_remaining': [17],
+            'reload_time': 20.0,
+            'reload_duration': 20.0,
+            'burst_active': False,
+        })
+        returning = planner.build_orders(
+            self.manifest, self.states, players, 4.5)['orders'][0]
+        self.assertEqual('cover_return', returning['combat_mode'])
 
     def test_cover_lease_outlives_full_roster_refresh_cycle(self):
         planner = BotPlanner()
@@ -1084,6 +1539,108 @@ class ServerBotArtilleryTests(unittest.TestCase):
         self.assertEqual('1:0', order['defense_base_id'])
         self.assertEqual({'x': 0.0, 'y': 0.0, 'z': 0.0},
                          order['move_position'])
+
+    def test_base_defense_releases_one_excess_responder_per_delay(self):
+        planner = BotPlanner()
+        route = _route('defense-lane', [
+            (0, -100, False), (0, 100, False), (0, 500, False),
+        ])
+        manifest = [
+            _bot(11 + index, 1, index, route, 'mediumTank')
+            for index in range(4)
+        ]
+        states = [
+            _state(bot['id'], 1, index * 20, 0)
+            for index, bot in enumerate(manifest)
+        ]
+        defense = {
+            'bases': {'1': [
+                {'id': '1:0', 'x': 0.0, 'y': 0.0, 'z': -100.0},
+            ]},
+            'states': {'1': {
+                'points': 20,
+                'time_left': 60.0,
+                'invaders': 3,
+                'stopped': False,
+            }},
+            'contributors': {'1': []},
+        }
+
+        first = planner.build_orders(
+            manifest, states, [], 1.0, defense)['orders']
+        first_ids = {order['id'] for order in first
+                     if order['combat_mode'] == 'base_defense'}
+        self.assertEqual(3, len(first_ids))
+
+        defense['states']['1']['invaders'] = 1
+        delayed = planner.build_orders(
+            manifest, states, [], 2.0, defense)['orders']
+        delayed_ids = {order['id'] for order in delayed
+                       if order['combat_mode'] == 'base_defense'}
+        self.assertEqual(first_ids, delayed_ids)
+
+        reduced_once = planner.build_orders(
+            manifest, states, [], 5.1, defense)['orders']
+        reduced_once_ids = {order['id'] for order in reduced_once
+                            if order['combat_mode'] == 'base_defense'}
+        self.assertEqual(2, len(reduced_once_ids))
+        self.assertTrue(reduced_once_ids < first_ids)
+
+        reduced_twice = planner.build_orders(
+            manifest, states, [], 8.2, defense)['orders']
+        reduced_twice_ids = {order['id'] for order in reduced_twice
+                             if order['combat_mode'] == 'base_defense'}
+        self.assertEqual(1, len(reduced_twice_ids))
+        self.assertTrue(reduced_twice_ids < reduced_once_ids)
+
+    def test_base_defense_keeps_an_arrived_responder_firing_on_capturer(self):
+        planner = BotPlanner()
+        route = _route('defense-lane', [
+            (0, -100, False), (0, 100, False), (0, 500, False),
+        ])
+        manifest = [
+            _bot(11 + index, 1, index, route, 'mediumTank')
+            for index in range(3)
+        ]
+        states = [
+            _weapon_state(_state(bot['id'], 1, 0, -100))
+            for bot in manifest
+        ]
+        defense = {
+            'bases': {'1': [
+                {'id': '1:0', 'x': 0.0, 'y': 0.0, 'z': -100.0},
+            ]},
+            'states': {'1': {
+                'points': 20,
+                'time_left': 60.0,
+                'invaders': 2,
+                'stopped': False,
+            }},
+            'contributors': {'1': [
+                {'kind': 'human', 'id': 2},
+            ]},
+        }
+        initial = planner.build_orders(
+            manifest, states, [], 1.0, defense)['orders']
+        initial_ids = {order['id'] for order in initial
+                       if order['combat_mode'] == 'base_defense'}
+        self.assertEqual({11, 12}, initial_ids)
+
+        player = {'id': 2, 'team': 2, 'alive': True}
+        contact = _contact(2, 0, -80, [11])
+        self.assertEqual(1, planner.report_contacts(
+            [contact], planner.known_targets(states, [player]), 2.0))
+        defense['states']['1']['invaders'] = 1
+        planner.build_orders(manifest, states, [player], 2.0, defense)
+        reduced = planner.build_orders(
+            manifest, states, [player], 5.1, defense)['orders']
+        retained_ids = {order['id'] for order in reduced
+                        if order['combat_mode'] == 'base_defense'}
+
+        self.assertEqual({11}, retained_ids)
+        retained = next(order for order in reduced if order['id'] == 11)
+        self.assertEqual(2, retained['target_id'])
+        self.assertTrue(retained['fire_allowed'])
 
     def test_spg_is_never_a_pressured_route_donor(self):
         planner = BotPlanner()

--- a/tests/test_port_0922_server_bot_ai.py
+++ b/tests/test_port_0922_server_bot_ai.py
@@ -165,7 +165,7 @@ class _CountingPlanner(object):
         self.build_ticks = []
         self.reset_count = 0
 
-    def build_orders(self, *unused_args):
+    def build_orders(self, *unused_args, **unused_kwargs):
         self.build_ticks.append(self.state.tick)
         return {"revision": len(self.build_ticks), "orders": []}
 
@@ -1132,6 +1132,8 @@ class ServerBotTacticsTests(unittest.TestCase):
             _contact(2, -130, 130, [11]),
             _contact(3, 130, 130, [11]),
         ]
+        for contact in contacts:
+            contact['threatened_bot_ids'] = [11]
         players = self._report(planner, contacts)
 
         order = planner.build_orders(
@@ -1141,6 +1143,335 @@ class ServerBotTacticsTests(unittest.TestCase):
         self.assertGreaterEqual(planner._crossfire_risk(
             live_bot, list(planner._contacts[1].values())), 0.35)
         self.assertEqual('crossfire_withdraw', order['combat_mode'])
+
+    def test_outgoing_firing_lanes_do_not_claim_incoming_crossfire(self):
+        planner = BotPlanner()
+        contacts = [
+            _contact(2, -130, 130, [11]),
+            _contact(3, 130, 130, [11]),
+        ]
+        players = self._report(planner, contacts)
+
+        order = planner.build_orders(
+            self.manifest, self.states, players, 1.0)['orders'][0]
+        live_bot = planner._alive_bots(self.manifest, self.states)[0]
+
+        self.assertIsNone(planner._crossfire_risk(
+            live_bot, list(planner._contacts[1].values())))
+        self.assertNotIn(order['combat_mode'], (
+            'crossfire_withdraw', 'crossfire_hold'))
+
+    def test_support_requires_a_ready_weapon_and_current_firing_lane(self):
+        contact = _contact(2, 0, 380, [12], 'heavyTank')
+        player = {'id': 2, 'team': 2, 'alive': True}
+        manifest = [
+            _bot(12, 1, 0, self.route, 'mediumTank', {'support': 1.0}),
+            _bot(13, 1, 1, self.route, 'mediumTank', {'support': 1.0}),
+        ]
+        for bot in manifest:
+            bot['profile'].update({
+                'dominant_role': 'support', 'desired_range': 200.0,
+                'fire_range': 520.0,
+            })
+
+        for reason in ('no_lane', 'reloading'):
+            with self.subTest(reason=reason):
+                planner = BotPlanner()
+                states = [
+                    _weapon_state(_state(12, 1, 0, 0)),
+                    _weapon_state(_state(13, 1, 5, 0)),
+                ]
+                sample = dict(contact)
+                if reason == 'reloading':
+                    sample['shootable_by_bot_ids'] = [12, 13]
+                    states[1].update({
+                        'reload_time': 8.0,
+                        'ammo_reload_pending': True,
+                    })
+                self.assertEqual(1, planner.report_contacts(
+                    [sample], planner.known_targets(states, [player]), 1.0))
+
+                orders = dict((value['id'], value) for value in
+                              planner.build_orders(
+                                  manifest, states, [player], 1.0)['orders'])
+
+                self.assertEqual('support_hold', orders[12]['combat_mode'])
+
+    def test_focus_capacity_uses_selected_shell_damage_with_a_spare_shot(self):
+        planner = BotPlanner()
+        manifest = [
+            _bot(bot_id, 1, bot_id, self.route, 'mediumTank')
+            for bot_id in (11, 12, 13, 14)
+        ]
+        for bot in manifest:
+            bot['profile']['shells'] = [{
+                'index': 0,
+                'kind': 'ARMOR_PIERCING',
+                'penetration': 200.0,
+                'damage': 800.0,
+            }]
+        states = [
+            _weapon_state(_state(bot['id'], 1, 0, 0))
+            for bot in manifest
+        ]
+        contact = _contact(2, 0, 200, [11, 12, 13, 14])
+        contact.update({
+            'health': 1600,
+            'max_health': 2000,
+            'armor': 100.0,
+        })
+        player = {'id': 2, 'team': 2, 'alive': True}
+        self.assertEqual(1, planner.report_contacts(
+            [contact], planner.known_targets(states, [player]), 1.0))
+
+        orders = planner.build_orders(
+            manifest, states, [player], 1.0)['orders']
+
+        self.assertEqual(3, sum(order['target_id'] == 2
+                                for order in orders))
+
+    def test_flanker_uses_ally_geometry_and_leaves_one_shooter_holding(self):
+        planner = BotPlanner()
+        manifest = [
+            _bot(12, 1, 0, self.route, 'mediumTank', {
+                'support': 1.0, 'flanker': 0.1,
+            }),
+            _bot(14, 1, 1, self.route, 'mediumTank', {
+                'support': 0.1, 'flanker': 1.0,
+            }),
+        ]
+        for bot in manifest:
+            bot['profile'].update({
+                'dominant_role': 'support', 'desired_range': 160.0,
+                'fire_range': 520.0,
+            })
+        states = [
+            _weapon_state(_state(12, 1, -80, -180)),
+            _weapon_state(_state(14, 1, 0, -230)),
+        ]
+        contact = _contact(2, 0, 0, [12, 14])
+        contact.update({'health': 2000, 'max_health': 2000})
+        player = {'id': 2, 'team': 2, 'alive': True}
+        self.assertEqual(1, planner.report_contacts(
+            [contact], planner.known_targets(states, [player]), 1.0))
+
+        orders = dict((order['id'], order) for order in
+                      planner.build_orders(
+                          manifest, states, [player], 1.0)['orders'])
+
+        self.assertEqual('flank', orders[14]['combat_mode'])
+        self.assertGreater(orders[14]['move_position']['x'], 0.0)
+        self.assertNotEqual('flank', orders[12]['combat_mode'])
+        self.assertTrue(orders[12]['fire_allowed'])
+
+    def test_radio_enemy_focus_still_requires_the_recipient_firing_lane(self):
+        planner = BotPlanner()
+        contacts = [
+            _contact(2, 0, 35, [11]),
+            _contact(3, 0, 180, [11]),
+        ]
+        players = self._report(planner, contacts)
+        team_order = {
+            'command_id': '1:1:1',
+            'command': 'ATTACKENEMY',
+            'team': 1,
+            'issuer_id': 1,
+            'issued_tick': 100,
+            'expires_tick': 200,
+            'recipient_bot_ids': [11],
+            'target_kind': 'player',
+            'target_id': 3,
+        }
+
+        commanded = planner.build_orders(
+            self.manifest, self.states, players, 1.0,
+            team_orders=[team_order])['orders'][0]
+        self.assertEqual(3, commanded['target_id'])
+        self.assertEqual('ATTACKENEMY', commanded['team_command'])
+
+        blocked = dict(contacts[1])
+        blocked['shootable_by_bot_ids'] = []
+        self.assertEqual(1, planner.report_contacts(
+            [blocked], planner.known_targets(self.states, players), 1.1))
+        fallback = planner.build_orders(
+            self.manifest, self.states, players, 1.1,
+            team_orders=[team_order])['orders'][0]
+
+        self.assertEqual(2, fallback['target_id'])
+
+    def test_radio_movement_orders_use_validated_live_positions(self):
+        issuer = {
+            'id': 1, 'team': 1, 'alive': True, 'world_pose': True,
+            'x': 45.0, 'y': 2.0, 'z': 60.0,
+        }
+        base_order = {
+            'command_id': '1:1:1',
+            'team': 1,
+            'issuer_id': 1,
+            'issued_tick': 100,
+            'expires_tick': 200,
+            'recipient_bot_ids': [11],
+        }
+        cases = (
+            ('FOLLOWME', 'team_follow',
+             {'x': 45.0, 'y': 2.0, 'z': 42.0}),
+            ('STOP', 'team_stop',
+             {'x': 0.0, 'y': 0.0, 'z': 0.0}),
+            ('TURNBACK', 'team_turnback',
+             {'x': 0.0, 'y': 0.0, 'z': 0.0}),
+        )
+
+        for command, mode, point in cases:
+            with self.subTest(command=command):
+                planner = BotPlanner()
+                team_order = dict(base_order, command=command)
+                order = planner.build_orders(
+                    self.manifest, self.states, [issuer], 1.0,
+                    team_orders=[team_order])['orders'][0]
+
+                self.assertEqual(mode, order['combat_mode'])
+                self.assertEqual(point, order['move_position'])
+
+    def test_radio_order_cannot_cross_team_or_invalid_tick_window(self):
+        invalid_orders = [{
+            'command_id': '1:1:1',
+            'command': 'STOP',
+            'team': team,
+            'issuer_id': 1,
+            'issued_tick': issued,
+            'expires_tick': expires,
+            'recipient_bot_ids': [11],
+        } for team, issued, expires in ((2, 100, 200), (1, 200, 200))]
+
+        order = BotPlanner().build_orders(
+            self.manifest, self.states, [], 1.0,
+            team_orders=invalid_orders)['orders'][0]
+
+        self.assertEqual('route', order['combat_mode'])
+        self.assertNotIn('team_command', order)
+
+    def test_radio_back_to_base_uses_the_canonical_capture_base(self):
+        team_order = {
+            'command_id': '1:1:1',
+            'command': 'BACKTOBASE',
+            'team': 1,
+            'issuer_id': 1,
+            'issued_tick': 100,
+            'expires_tick': 200,
+            'recipient_bot_ids': [11],
+        }
+        defense = {
+            'capture_bases': {
+                '1': [{'id': '1:0', 'x': -25.0, 'y': 0.0, 'z': -450.0}],
+            },
+        }
+
+        order = BotPlanner().build_orders(
+            self.manifest, self.states, [], 1.0, defense,
+            team_orders=[team_order])['orders'][0]
+
+        self.assertEqual('team_back_to_base', order['combat_mode'])
+        self.assertEqual(
+            {'x': -25.0, 'y': 0.0, 'z': -450.0},
+            order['move_position'])
+
+    def test_radio_cell_order_is_forwarded_without_inventing_a_world_point(self):
+        team_order = {
+            'command_id': '1:1:1',
+            'command': 'ATTENTIONTOCELL',
+            'team': 1,
+            'issuer_id': 1,
+            'issued_tick': 100,
+            'expires_tick': 200,
+            'recipient_bot_ids': [11],
+            'cell_index': 38,
+        }
+
+        order = BotPlanner().build_orders(
+            self.manifest, self.states, [], 1.0,
+            team_orders=[team_order])['orders'][0]
+
+        self.assertEqual('ATTENTIONTOCELL', order['team_command'])
+        self.assertEqual(38, order['team_command_cell_index'])
+        self.assertEqual('route', order['combat_mode'])
+
+    def test_radio_cell_order_moves_to_the_proved_grid_cell_center(self):
+        team_order = {
+            'command_id': '1:1:1',
+            'command': 'ATTENTIONTOCELL',
+            'team': 1,
+            'issuer_id': 1,
+            'issued_tick': 100,
+            'expires_tick': 200,
+            'recipient_bot_ids': [11],
+            'cell_index': 38,
+        }
+        defense = {'arena_bounds': [-500.0, -500.0, 500.0, 500.0]}
+
+        order = BotPlanner().build_orders(
+            self.manifest, self.states, [], 1.0, defense,
+            team_orders=[team_order])['orders'][0]
+
+        self.assertEqual('team_attention_cell', order['combat_mode'])
+        self.assertEqual(
+            {'x': -150.0, 'y': 0.0, 'z': -350.0},
+            order['move_position'])
+        self.assertEqual(
+            [-200.0, -400.0, -100.0, -300.0],
+            order['move_area_bounds'])
+
+    def test_radio_does_not_override_local_survival(self):
+        planner = BotPlanner()
+        contact = _contact(2, 0, 150, [11])
+        players = self._report(planner, [contact])
+        self.states[0]['health'] = 100
+        team_order = {
+            'command_id': '1:1:1',
+            'command': 'STOP',
+            'team': 1,
+            'issuer_id': 1,
+            'issued_tick': 100,
+            'expires_tick': 200,
+            'recipient_bot_ids': [11],
+        }
+
+        order = planner.build_orders(
+            self.manifest, self.states, players, 1.0,
+            team_orders=[team_order])['orders'][0]
+
+        self.assertEqual('low_health_retreat', order['combat_mode'])
+        self.assertEqual('STOP', order['team_command'])
+
+    def test_radio_does_not_override_an_urgent_base_responder(self):
+        defense = {
+            'bases': {'1': [
+                {'id': '1:0', 'x': 0.0, 'y': 0.0, 'z': -100.0},
+            ]},
+            'states': {'1': {
+                'points': 20, 'time_left': 60.0,
+                'invaders': 1, 'stopped': False,
+            }},
+            'contributors': {'1': []},
+            'capture_bases': {'1': [
+                {'id': '1:0', 'x': 0.0, 'y': 0.0, 'z': -100.0},
+            ]},
+        }
+        team_order = {
+            'command_id': '1:1:1',
+            'command': 'STOP',
+            'team': 1,
+            'issuer_id': 1,
+            'issued_tick': 100,
+            'expires_tick': 200,
+            'recipient_bot_ids': [11],
+        }
+
+        order = BotPlanner().build_orders(
+            self.manifest, self.states, [], 1.0, defense,
+            team_orders=[team_order])['orders'][0]
+
+        self.assertEqual('base_defense', order['combat_mode'])
+        self.assertEqual('STOP', order['team_command'])
 
     def test_nearby_ally_changes_cautious_support_advance_score(self):
         contact = _contact(2, 0, 380, [12, 13], 'heavyTank')
@@ -1696,6 +2027,77 @@ class ServerBotArtilleryTests(unittest.TestCase):
         self.assertEqual('b', orders[13]['route_id'])
         self.assertEqual(1, sum(
             orders[bot_id]['route_id'] == 'b' for bot_id in (12, 14)))
+
+    def test_immobile_line_holders_count_but_cannot_be_route_donors(self):
+        source = _route('source', [
+            (-100, 0, False), (-100, 100, False), (-100, 500, False),
+        ])
+        target = _route('target', [
+            (100, 0, False), (100, 100, False), (100, 500, False),
+        ])
+        enemy = {'id': 2, 'team': 2, 'alive': True}
+        conditions = (
+            ('no_pose', {'world_pose': False}, [11], None),
+            ('engine', {'critical': {'destroyed': ['engineHealth']}},
+             [11], 12),
+            ('left_track', {
+                'critical': {'destroyed': ['leftTrackHealth']}},
+             [11], 12),
+            ('right_track', {
+                'critical': {'destroyed': ['rightTrackHealth']}},
+             [11], 12),
+            ('damaged_engine', {'critical': {
+                'destroyed': [],
+                'devices': [{
+                    'name': 'engineHealth', 'state': 'critical',
+                }],
+            }}, [11], 11),
+            ('damaged_track', {'critical': {
+                'destroyed': [],
+                'devices': [{
+                    'name': 'rightTrackHealth', 'state': 'critical',
+                }],
+            }}, [11], 11),
+            ('track_without_lane', {
+                'critical': {'destroyed': ['leftTrackHealth']}},
+             [], None),
+        )
+
+        for unused_name, state_change, observers, donor_id in conditions:
+            with self.subTest(condition=unused_name):
+                planner = BotPlanner()
+                manifest = [
+                    _bot(11, 1, 0, source, 'mediumTank', {
+                        'support': 1.0, 'flanker': 1.0,
+                    }),
+                    _bot(12, 1, 1, source, 'heavyTank', {
+                        'support': 0.0, 'flanker': 0.0,
+                        'brawler': 1.0,
+                    }),
+                    _bot(13, 1, 2, target, 'mediumTank', {
+                        'support': 0.5,
+                    }),
+                ]
+                states = [
+                    _weapon_state(_state(11, 1, -100, 0)),
+                    _weapon_state(_state(12, 1, -100, 0)),
+                    _weapon_state(_state(13, 1, 100, 0)),
+                ]
+                states[0].update(state_change)
+                contact = _contact(2, 100, 250, observers)
+                self.assertEqual(1, planner.report_contacts(
+                    [contact], planner.known_targets(states, [enemy]), 1.0))
+
+                orders = dict((order['id'], order) for order in
+                              planner.build_orders(
+                                  manifest, states, [enemy], 1.0)['orders'])
+
+                self.assertEqual(
+                    'target' if donor_id == 11 else 'source',
+                    orders[11]['route_id'])
+                self.assertEqual(
+                    'target' if donor_id == 12 else 'source',
+                    orders[12]['route_id'])
 
     def test_rebalance_keeps_scouts_off_an_incompatible_heavy_lane(self):
         planner = BotPlanner()

--- a/tests/test_port_0922_server_capture.py
+++ b/tests/test_port_0922_server_capture.py
@@ -143,6 +143,14 @@ class ServerCaptureTests(unittest.TestCase):
                 {'id': '2:0', 'x': 500.0, 'y': 0.0, 'z': 0.0},
             ],
         }, context['capture_bases'])
+        self.assertEqual((-500.0, -500.0, 500.0, 500.0),
+                         context['arena_bounds'])
+
+    def test_defense_context_omits_invalid_tactical_bounds(self):
+        state = self._state()
+        state._map_rule_data = lambda: {'bounds': (0.0, 0.0, float('nan'), 1.0)}
+
+        self.assertIsNone(state._bot_defense_context()['arena_bounds'])
 
     def test_first_live_bot_publication_preserves_manifest_world_pose(self):
         state = self._state()

--- a/tests/test_port_0922_shot_geometry.py
+++ b/tests/test_port_0922_shot_geometry.py
@@ -196,6 +196,46 @@ class ShotGeometryTest(unittest.TestCase):
                 ValueError, 'invalid activeTurretPosition'):
             shot_geometry.compute_barrel_local_point(descriptor, 0.0, 0.0)
 
+    def test_aim_samples_use_part_bounds_and_current_articulated_pose(self):
+        descriptor = _mode_descriptor(SIEGE_VEHICLES[0])
+        descriptor.turret.hitTester = _Tester((0.0, 0.0, 0.0), (2.0, 2.0, 4.0))
+        samples = shot_geometry.vehicle_aim_samples(descriptor)
+        self.assertEqual(8, len(samples))
+        self.assertEqual(('hull', 'turret'), tuple(s[0] for s in samples[:2]))
+        pose = {'position': (10.0, 20.0, 30.0), 'yaw': math.pi / 2.0,
+                'turret_yaw': -math.pi / 2.0}
+        self.assertVectorAlmostEqual(
+            (9.9, 21.3, 29.8), shot_geometry.vehicle_aim_point(samples[0], pose))
+        # The current #1513 compound uses the first turret mount, even on a
+        # descriptor with a different active barrel mount.
+        self.assertVectorAlmostEqual(
+            (11.2, 22.8, 31.65), shot_geometry.vehicle_aim_point(samples[1], pose))
+        posed = dict(pose, pitch=0.2, roll=-0.3)
+        self.assertNotEqual(shot_geometry.vehicle_aim_point(samples[1], pose),
+                            shot_geometry.vehicle_aim_point(samples[1], posed))
+        self.assertVectorAlmostEqual(
+            shot_geometry.transform_vehicle_point(
+                (-1.65, 2.8, 1.2), posed['position'], posed['yaw'], 0.2, -0.3),
+            shot_geometry.vehicle_aim_point(samples[1], posed))
+
+    def test_fixed_turret_aim_ignores_unavailable_articulation(self):
+        descriptor = _mode_descriptor(SIEGE_VEHICLES[0])
+        descriptor.gun.staticTurretYaw = math.pi
+        descriptor.turret.hitTester = _Tester((0.0, 0.0, 0.0), (2.0, 2.0, 4.0))
+        sample = shot_geometry.vehicle_aim_samples(descriptor)[1]
+        self.assertVectorAlmostEqual(
+            (-0.65, 2.8, -1.8), shot_geometry.vehicle_aim_point(
+                sample, {'x': 0, 'y': 0, 'z': 0, 'turret_yaw': 0.7}))
+
+    def test_missing_or_invalid_aim_geometry_has_no_invented_part(self):
+        descriptor = _mode_descriptor(SIEGE_VEHICLES[0])
+        descriptor.turret.hitTester.bbox = None
+        self.assertEqual({'hull'},
+                         {s[0] for s in shot_geometry.vehicle_aim_samples(descriptor)})
+        descriptor.hull.hitTester.bbox = (
+            _Vector(0.0, 0.0, 0.0), _Vector(float('nan'), 1.0, 2.0))
+        self.assertEqual((), shot_geometry.vehicle_aim_samples(descriptor))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_port_0922_tactical_geometry.py
+++ b/tests/test_port_0922_tactical_geometry.py
@@ -1,0 +1,163 @@
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / 'src/res/scripts/client'))
+from gui.mods.offline_lan_0922.ai import tactical_geometry as geometry
+from gui.mods.offline_lan_0922 import bot_runtime
+import test_port_0922_battle_runtime as fixtures
+
+
+class TacticalGeometryTests(unittest.TestCase):
+    def scene(self):
+        return fixtures.BattleRuntimeContractTests()._bot_lane_scene()
+
+    def test_exposure_distinguishes_hull_down_from_side_crossfire(self):
+        unused, unused_battle, source, unused_target, descriptor = self.scene()
+        samples = geometry.body_samples(descriptor)
+        source['position'] = (0.0, 0.0, 0.0)
+        front = (0.0, 2.5, 100.0)
+        side = (100.0, 2.5, 0.0)
+        clear = lambda origin, point: origin == side or point[1] > 1.8
+        covered = geometry.exposure(samples, source, [front], clear)
+        self.assertGreater(covered, 0.0)
+        self.assertLess(covered, 1.0)
+        self.assertEqual(1.0, geometry.exposure(samples, source, [front, side], clear))
+
+    def test_budget_exhaustion_never_becomes_safe_cover(self):
+        unused, unused_battle, source, unused_target, descriptor = self.scene()
+        budget = geometry.RayBudget(lambda *unused: False, 1)
+        with self.assertRaises(geometry.ProbeBudgetExhausted):
+            geometry.exposure(geometry.body_samples(descriptor), source,
+                              [(0.0, 2.0, 100.0)], budget.clear)
+        self.assertEqual(0, budget.remaining)
+
+    def test_search_covers_both_flanks_and_scales_with_vehicle(self):
+        small = geometry.search_offsets(2.0, 4.0, 0)
+        large = geometry.search_offsets(4.0, 8.0, 0)
+        self.assertEqual(17, len(small))
+        self.assertTrue(any(value[1] < -1.0 for value in small))
+        self.assertTrue(any(value[1] > 1.0 for value in small))
+        self.assertEqual(small[1:], geometry.search_offsets(2, 4, 1)[:-1])
+        self.assertEqual(tuple(v * 2 for v in small[1]), large[1])
+
+    def test_incoming_probe_uses_observed_enemy_origin_not_live_entity_pose(self):
+        runtime, battle, source, target, unused = self.scene()
+        rays = []
+        runtime.bigworld.wg_collideSegment = lambda space, start, end, mask: (
+            rays.append((tuple(start), tuple(end))) or None)
+        runtime.bigworld.entities[20].position = fixtures._Vector(900, 900, 900)
+        self.assertTrue(battle._bot_incoming_lane(source, target))
+        self.assertLessEqual(len(rays), 2)
+        self.assertAlmostEqual(100.0, rays[0][0][2])
+        self.assertAlmostEqual(0.0, rays[0][1][2])
+        target['position'] = (50.0, 0.0, 80.0)
+        self.assertTrue(battle._bot_incoming_lane(source, target))
+        self.assertAlmostEqual(50.0, rays[-1][0][0])
+        runtime.bigworld.entities[20].isStarted = False
+        self.assertIsNone(battle._bot_incoming_lane(source, target))
+
+    def test_nominal_damage_selects_better_clear_part_with_existing_ray_bound(self):
+        runtime, battle, source, target, unused = self.scene()
+        rays = []
+        runtime.bigworld.wg_collideSegment = lambda *args: rays.append(args) or None
+        battle._bot_aim_damage_score = lambda d, e, s, t, o, p: 100.0 if p[1] > 1.8 else 0.0
+        self.assertTrue(battle._bot_firing_lane(source, target))
+        self.assertEqual(2, len(rays))
+        self.assertGreater(battle._bot_aim_point(source, target)['aim_position'][1], 1.8)
+
+    def test_nominal_damage_does_not_sample_projectile_rng_or_live_angles(self):
+        runtime, battle, source, target, descriptor = self.scene()
+        for name in ('chassis', 'hull', 'turret', 'gun'):
+            getattr(descriptor, name).hitTester.localHitTest = lambda *unused: ()
+        source_descriptor = runtime.bigworld.entities[10].typeDescriptor
+        collisions = [types.SimpleNamespace(dist=100.0,
+            hitAngleCos=1.0, matInfo={'armor': 20.0, 'vehicleDamageFactor': 1.0},
+            compName='hull')]
+        with mock.patch.object(fixtures.battle_runtime_module, 'collide_vehicle_at_matrix', return_value=collisions) as collide:
+            with mock.patch('random.uniform', side_effect=AssertionError('real RNG')):
+                score = battle._bot_aim_damage_score(source_descriptor,
+                    {'descriptor': descriptor}, source, target,
+                    (0.0, 2.0, 0.0), (0.0, 1.2, 100.0))
+        self.assertIsNotNone(score)
+        self.assertGreater(score, 0.0)
+        self.assertAlmostEqual(100.0, collide.call_args[0][1].translation.z)
+
+    def test_cover_job_counts_ground_and_water_queries_and_requires_return_path(self):
+        runtime, battle, source, target, unused = self.scene()
+        source['team'] = 1
+        battle._bots = types.SimpleNamespace(_visible_target_poses={})
+        calls = []
+        def ground(x, z, hint):
+            calls.append('ground')
+            return 0.0
+        def water(point):
+            calls.append('water')
+            return -1.0
+        def ray(start, end):
+            calls.append('ray')
+            return end[2] > 90.0 or abs(end[0]) > 2.0
+        battle._cover_ground = ground
+        battle._water_depth = water
+        battle._tactical_ray_clear = ray
+        candidates = battle._sample_bot_cover(source, target, (0, 0, 50), (), lambda *unused: True)
+        self.assertTrue(candidates)
+        self.assertLessEqual(len(calls), 40)
+        self.assertIn('ground', calls)
+        self.assertIn('water', calls)
+        self.assertTrue(any(value['exposure'] > 0.12 for value in candidates))
+        calls[:] = []
+        battle._records['bot:11']['cover_search_phase'] = 0
+        def no_return(start, end):
+            return not (abs(start[0]) > 2.0 and abs(end[0]) < 1.0)
+        self.assertFalse(battle._sample_bot_cover(source, target, (0, 0, 50), (), no_return))
+        self.assertLessEqual(len(calls), 40)
+
+    def test_incoming_reuses_enemy_receipt_only_for_a_fresh_local_observation(self):
+        bots = bot_runtime.BotRuntime(1)
+        bots.states = {11: {'id': 11, 'team': 1, 'alive': True},
+                       21: {'id': 21, 'team': 2, 'alive': True}}
+        target = {'team': 2, 'x': 0, 'y': 0, 'z': 100}
+        key = (1, 'bot', 21)
+        bots._visible_target_poses[key] = dict(target)
+        bots._team_spot_time_left = lambda *unused: 5.0
+        aggregate = {key: [True, {11}, dict(target), set(), {11}]}
+        bots._shot_los_cache[(11, 'bot', 21)] = (1.0, True)
+        self.assertEqual([], bots._pack_observations(aggregate, 1.0)[0]['threatened_bot_ids'])
+        bots._shot_los_cache[(21, 'bot', 11)] = (1.0, True)
+        self.assertEqual([11], bots._pack_observations(aggregate, 1.0)[0]['threatened_bot_ids'])
+        aggregate[key][4] = set()
+        self.assertEqual([], bots._pack_observations(aggregate, 1.0)[0]['threatened_bot_ids'])
+        aggregate[key][4] = {11}
+        self.assertEqual([], bots._pack_observations(aggregate, 3.0)[0]['threatened_bot_ids'])
+
+    def test_cover_identity_survives_server_order_admission(self):
+        bots = bot_runtime.BotRuntime(1)
+        order = {'id': 11, 'team': 1, 'cover_id': '11:-2:7:-1',
+                 'move_position': {'x': 0, 'y': 0, 'z': 12}}
+        self.assertTrue(bots._apply_orders({'bot_order_revision': 1, 'bot_orders': [order]}))
+        self.assertEqual(order['cover_id'], bots._server_orders[11]['cover_id'])
+
+    def test_radio_cell_uses_dry_baked_ground_instead_of_blocked_centre(self):
+        from gui.mods.offline_lan_0922.ai.navigation import TerrainGrid
+        from test_port_0922_ai import BotAiPortTests
+        graph = BotAiPortTests._baked_graph(9, 9, blocked=((4, 4),))
+        grid = TerrainGrid(None, baked_graph=graph)
+        bots = bot_runtime.BotRuntime(1)
+        bots.states[11] = {'id': 11}
+        goal = grid.point_for((4, 4), 900.0)
+        first, last = grid.point_for((2, 2), 0), grid.point_for((6, 6), 0)
+        strategic = {'team_command_id': '1:1:1', 'move_area_bounds':
+                     (first[0], first[2], last[0], last[2])}
+        resolved = bots._radio_ground_goal(11, (0, 0, 0), goal, strategic, grid)
+        self.assertIsNotNone(resolved)
+        self.assertNotEqual(grid.cell_for(goal), grid.cell_for(resolved))
+        self.assertEqual(0.0, resolved[1])
+        self.assertTrue(first[0] <= resolved[0] <= last[0])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_port_0922_tactical_radio.py
+++ b/tests/test_port_0922_tactical_radio.py
@@ -1,8 +1,12 @@
 import importlib.util
 from pathlib import Path
+import pickle
+import struct
 import sys
 import types
 import unittest
+from unittest import mock
+import zlib
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -14,13 +18,14 @@ from gui.mods.offline_lan_0922.account_rpc.server import FakeServer
 from gui.mods.offline_lan_0922.entities.avatar_server import AvatarServerBridge
 
 
-def _args(int32_arg=0):
+def _args(int32_arg=0, int64_arg=0, float_arg=0.0,
+          str_arg1='', str_arg2=''):
     return {
         'int32Arg1': int32_arg,
-        'int64Arg1': 0,
-        'floatArg1': 0.0,
-        'strArg1': '',
-        'strArg2': '',
+        'int64Arg1': int64_arg,
+        'floatArg1': float_arg,
+        'strArg1': str_arg1,
+        'strArg2': str_arg2,
     }
 
 
@@ -48,15 +53,35 @@ class _Avatar(object):
         self.chat2.append((action_id, request_id, args))
 
 
+class _FailingAvatar(_Avatar):
+    def __init__(self):
+        super().__init__()
+        self.fail_once = set()
+
+    def messenger_onActionByServer_chat2(self, action_id, request_id, args):
+        super().messenger_onActionByServer_chat2(
+            action_id, request_id, args)
+        if action_id in self.fail_once:
+            self.fail_once.remove(action_id)
+            raise RuntimeError('stock channel listener failed')
+
+
 class _Sender(object):
     def __init__(self):
         self.requests = []
         self.next_sequence = 40
+        self.chat_requests = []
+        self.next_chat_sequence = 70
 
     def send_team_command(self, request):
         self.requests.append(request)
         self.next_sequence += 1
         return self.next_sequence
+
+    def send_team_chat(self, request):
+        self.chat_requests.append(request)
+        self.next_chat_sequence += 1
+        return self.next_chat_sequence
 
 
 class BattleRadioAdapterTests(unittest.TestCase):
@@ -64,8 +89,14 @@ class BattleRadioAdapterTests(unittest.TestCase):
         self.avatar = _Avatar()
         self.sender = _Sender()
         self.current = self.avatar
+        self.stock_ready = []
+        self.scheduled = []
         self.adapter = tactical_radio.BattleRadioAdapter(
-            self.avatar, self.sender, lambda: self.current)
+            self.avatar, self.sender, lambda: self.current,
+            users_ready_notifier=lambda: self.stock_ready.append(
+                tuple(item[0] for item in self.avatar.chat2)),
+            callback_scheduler=lambda delay, callback: self.scheduled.append(
+                (delay, callback)))
 
     def test_exact_fixed_command_contract_is_pinned(self):
         self.assertEqual({
@@ -76,11 +107,17 @@ class BattleRadioAdapterTests(unittest.TestCase):
             27: ('POSITIVE', None),
             28: ('NEGATIVE', None),
             29: ('ATTENTIONTOCELL', 'cell'),
+            30: ('SPG_AIM_AREA', 'aim_area'),
             31: ('ATTACKENEMY', 'enemy'),
             32: ('TURNBACK', 'ally'),
             33: ('HELPMEEX', 'ally'),
             34: ('SUPPORTMEWITHFIRE', 'enemy'),
+            35: ('RELOADINGGUN', None),
             36: ('STOP', 'ally'),
+            37: ('RELOADING_CASSETE', None),
+            38: ('RELOADING_READY', None),
+            39: ('RELOADING_READY_CASSETE', None),
+            40: ('RELOADING_UNAVAILABLE', None),
         }, tactical_radio.COMMAND_SPECS)
 
     def test_stock_target_id_stays_explicit_until_runtime_maps_it(self):
@@ -188,6 +225,263 @@ class BattleRadioAdapterTests(unittest.TestCase):
         self.assertEqual((1, 12, 1),
                          (action_id, request_id, args['int32Arg1']))
 
+    def test_stock_team_chat_contract_and_normalization_are_pinned(self):
+        self.assertEqual(19, tactical_radio.TEAM_CHAT_INIT_ACTION_ID)
+        self.assertEqual(20, tactical_radio.TEAM_CHAT_DEINIT_ACTION_ID)
+        self.assertEqual(21, tactical_radio.TEAM_CHAT_SEND_ACTION_ID)
+        self.assertEqual(22, tactical_radio.TEAM_CHAT_RECEIVE_ACTION_ID)
+        self.assertEqual(140, tactical_radio.MAX_TEAM_CHAT_LENGTH)
+        self.assertEqual(
+            'A hello 世界',
+            tactical_radio.normalize_team_chat_text(
+                '  Ａ\t hello   世界  '.encode('utf-8')))
+        self.assertEqual(
+            '<b>& raw',
+            tactical_radio.normalize_team_chat_text(' <b>&  raw '))
+        self.assertIsNone(
+            tactical_radio.normalize_team_chat_text(b'\xff'))
+        self.assertIsNone(
+            tactical_radio.normalize_team_chat_text('\ud800'))
+        # U+1F16A normalizes differently under the host's modern UCD and the
+        # target Python 2.7 UCD.  Wire validation must preserve it unchanged.
+        self.assertTrue(tactical_radio.is_valid_team_chat_text('\U0001f16a'))
+        self.assertFalse(tactical_radio.is_valid_team_chat_text('   '))
+        self.assertFalse(tactical_radio.is_valid_team_chat_text('\ud800'))
+
+    def test_stock_text_limit_counts_windows_utf16_code_units(self):
+        self.assertEqual(
+            'a' * 138 + '\U0001f600',
+            tactical_radio.normalize_team_chat_text(
+                'a' * 138 + '\U0001f600'))
+        self.assertIsNone(tactical_radio.normalize_team_chat_text(
+            'a' * 139 + '\U0001f600'))
+        self.assertEqual(
+            'a' * 140,
+            tactical_radio.normalize_team_chat_text('a' * 141))
+
+    def test_team_chat_start_and_close_use_stock_arena_actions(self):
+        self.assertTrue(self.adapter.start_team_chat())
+        self.assertFalse(self.adapter.start_team_chat())
+        self.assertEqual([(19,)], self.stock_ready)
+        action_id, request_id, args = self.avatar.chat2[-1]
+        self.assertEqual((19, 0), (action_id, request_id))
+        self.assertEqual([], pickle.loads(zlib.decompress(args['strArg1'])))
+        self.assertTrue(self.adapter.close_team_chat())
+        self.assertFalse(self.adapter.close_team_chat())
+        self.assertEqual((20, 0), self.avatar.chat2[-1][:2])
+
+    def test_partial_stock_init_retains_deinit_ownership(self):
+        avatar = _FailingAvatar()
+        avatar.fail_once.add(19)
+        adapter = tactical_radio.BattleRadioAdapter(
+            avatar, self.sender, lambda: avatar,
+            users_ready_notifier=lambda: None,
+            callback_scheduler=lambda delay, callback: callback())
+        with self.assertRaisesRegex(
+                RuntimeError, 'stock channel listener failed'):
+            adapter.start_team_chat()
+        self.assertFalse(adapter.start_team_chat())
+        self.assertTrue(adapter.close_team_chat())
+        self.assertEqual([19, 20], [item[0] for item in avatar.chat2])
+
+    def test_users_ready_failure_retains_deinit_ownership(self):
+        avatar = _Avatar()
+
+        def fail_users_ready():
+            raise RuntimeError('stock users listener failed')
+
+        adapter = tactical_radio.BattleRadioAdapter(
+            avatar, self.sender, lambda: avatar,
+            users_ready_notifier=fail_users_ready,
+            callback_scheduler=lambda delay, callback: callback())
+        with self.assertRaisesRegex(
+                RuntimeError, 'stock users listener failed'):
+            adapter.start_team_chat()
+        self.assertFalse(adapter.start_team_chat())
+        self.assertTrue(adapter.close_team_chat())
+        self.assertEqual([19, 20], [item[0] for item in avatar.chat2])
+
+    def test_partial_stock_deinit_can_be_retried(self):
+        avatar = _FailingAvatar()
+        adapter = tactical_radio.BattleRadioAdapter(
+            avatar, self.sender, lambda: avatar,
+            users_ready_notifier=lambda: None,
+            callback_scheduler=lambda delay, callback: callback())
+        self.assertTrue(adapter.start_team_chat())
+        avatar.fail_once.add(20)
+        with self.assertRaisesRegex(
+                RuntimeError, 'stock channel listener failed'):
+            adapter.close_team_chat()
+        self.assertTrue(adapter.close_team_chat())
+        self.assertEqual([19, 20, 20], [item[0] for item in avatar.chat2])
+
+    def test_stock_team_text_is_sent_and_acknowledged_without_local_echo(self):
+        self.assertTrue(self.adapter.start_team_chat())
+        self.avatar.chat2 = []
+        self.assertTrue(self.adapter.handle_client_action(
+            21, 15, _args(str_arg1='hello  team')))
+        self.assertEqual([{'text': 'hello team'}],
+                         self.sender.chat_requests)
+        self.assertEqual([], self.avatar.chat2)
+        self.assertTrue(self.adapter.receive_chat_ack(71, True))
+        self.assertEqual((0, 15), self.avatar.chat2[-1][:2])
+        self.assertFalse(self.adapter.receive_chat_ack(71, True))
+
+    def test_common_text_is_rejected_instead_of_relabelled_as_team(self):
+        self.assertTrue(self.adapter.start_team_chat())
+        self.avatar.chat2 = []
+        self.assertFalse(self.adapter.handle_client_action(
+            21, 16, _args(int32_arg=1, str_arg1='common')))
+        self.assertEqual([], self.sender.chat_requests)
+        self.assertEqual([], self.avatar.chat2)
+        self.assertEqual(1, len(self.scheduled))
+        self.assertEqual(0.0, self.scheduled[0][0])
+        self.scheduled.pop(0)[1]()
+        self.assertEqual((1, 16, 1), (
+            self.avatar.chat2[-1][0], self.avatar.chat2[-1][1],
+            self.avatar.chat2[-1][2]['int32Arg1']))
+
+    def test_same_team_text_relay_uses_stock_inbound_filter_path(self):
+        self.assertTrue(self.adapter.start_team_chat())
+        self.avatar.chat2 = []
+        self.assertTrue(self.adapter.receive_team_chat('<b>& raw', 99002))
+        action_id, request_id, args = self.avatar.chat2[-1]
+        self.assertEqual((22, 0, 0, 99002, '<b>& raw'), (
+            action_id, request_id, args['int32Arg1'],
+            args['int64Arg1'], args['strArg1']))
+        self.assertFalse(self.adapter.receive_team_chat('enemy', 9003))
+        self.assertTrue(self.adapter.receive_team_chat('  changed', 99002))
+
+    def test_command_detail_schema_and_bounds_are_explicit(self):
+        self.assertEqual({
+            'SPG_AIM_AREA': (('aim_point', 'reload_time'), ()),
+            'ATTACKENEMY': ((), ('reload_time',)),
+            'RELOADINGGUN': (('reload_time',), ()),
+            'RELOADING_CASSETE': (
+                ('reload_time', 'quantity'), ()),
+            'RELOADING_READY_CASSETE': (('quantity',), ()),
+        }, tactical_radio.COMMAND_DETAIL_FIELDS)
+        self.assertTrue(tactical_radio.validate_command_details(
+            'ATTACKENEMY', {}))
+        self.assertTrue(tactical_radio.validate_command_details(
+            'ATTACKENEMY', {'reload_time': 0.0}))
+        self.assertTrue(tactical_radio.validate_command_details(
+            'RELOADING_CASSETE', {
+                'reload_time': 1.0, 'quantity': 255}))
+        self.assertFalse(tactical_radio.validate_command_details(
+            'RELOADINGGUN', {'reload_time': 0.0}))
+        self.assertFalse(tactical_radio.validate_command_details(
+            'RELOADING_READY_CASSETE', {'quantity': 256}))
+        self.assertFalse(tactical_radio.validate_command_details(
+            'SPG_AIM_AREA', {
+                'aim_point': [5001.0, 0.0, 0.0], 'reload_time': 0.0}))
+        self.assertFalse(tactical_radio.validate_command_details(
+            'ATTACKENEMY', {'reload_time': 10 ** 10000}))
+
+    def test_spg_and_reload_stock_payloads_project_to_details(self):
+        record = struct.pack('<fffif', 12.5, -3.0, 99.25, 47, 8.0)
+        self.assertTrue(self.adapter.handle_client_action(
+            30, 21, _args(str_arg1=record)))
+        request = self.sender.requests[-1]
+        self.assertEqual(('SPG_AIM_AREA', 47), (
+            request['command'], request['cell_index']))
+        self.assertEqual([12.5, -3.0, 99.25],
+                         request['details']['aim_point'])
+        self.assertEqual(8.0, request['details']['reload_time'])
+
+        self.assertTrue(self.adapter.handle_client_action(
+            31, 22, _args(int32_arg=201, float_arg=6.0)))
+        self.assertEqual({'reload_time': 6.0},
+                         self.sender.requests[-1]['details'])
+        self.assertTrue(self.adapter.handle_client_action(
+            35, 23, _args(float_arg=12.0)))
+        self.assertTrue(self.adapter.handle_client_action(
+            37, 24, _args(int32_arg=3, float_arg=11.0)))
+        self.assertTrue(self.adapter.handle_client_action(
+            38, 25, _args()))
+        self.assertTrue(self.adapter.handle_client_action(
+            39, 26, _args(int32_arg=2)))
+        self.assertTrue(self.adapter.handle_client_action(
+            40, 27, _args()))
+        self.assertEqual([
+            ('RELOADINGGUN', {'reload_time': 12.0}),
+            ('RELOADING_CASSETE', {'reload_time': 11.0, 'quantity': 3}),
+            ('RELOADING_READY', None),
+            ('RELOADING_READY_CASSETE', {'quantity': 2}),
+            ('RELOADING_UNAVAILABLE', None),
+        ], [(item['command'], item.get('details'))
+            for item in self.sender.requests[-5:]])
+
+    def test_details_rebuild_exact_stock_payloads_on_receive(self):
+        details = {'aim_point': [1.5, 2.5, -3.5], 'reload_time': 7.0}
+        self.assertTrue(self.adapter.receive_command(
+            'SPG_AIM_AREA', 99002, cell_index=64, details=details))
+        action_id, unused_request_id, args = self.avatar.chat2[-1]
+        self.assertEqual(30, action_id)
+        self.assertEqual((1.5, 2.5, -3.5, 64, 7.0),
+                         struct.unpack('<fffif', args['strArg1']))
+        self.assertEqual(99002, args['int64Arg1'])
+
+        self.assertTrue(self.adapter.receive_command(
+            'RELOADING_CASSETE', 99002,
+            details={'reload_time': 9.0, 'quantity': 4}))
+        action_id, unused_request_id, args = self.avatar.chat2[-1]
+        self.assertEqual((37, 4, 9.0), (
+            action_id, args['int32Arg1'], args['floatArg1']))
+        self.assertFalse(self.adapter.receive_command(
+            'SPG_AIM_AREA', 99002, cell_index=64,
+            details={'aim_point': [1.0, 2.0, 3.0]}))
+
+    def test_deferred_rejection_is_fenced_by_avatar_and_close(self):
+        self.assertTrue(self.adapter.start_team_chat())
+        self.avatar.chat2 = []
+        self.assertFalse(self.adapter.handle_client_action(
+            21, 17, _args(int32_arg=1, str_arg1='common')))
+        unused_delay, callback = self.scheduled.pop()
+        self.current = _Avatar()
+        callback()
+        self.assertEqual([], self.avatar.chat2)
+
+        self.current = self.avatar
+        self.assertFalse(self.adapter.handle_client_action(
+            21, 18, _args(int32_arg=1, str_arg1='common')))
+        unused_delay, callback = self.scheduled.pop()
+        self.adapter.close()
+        self.avatar.chat2 = []
+        callback()
+        self.assertEqual([], self.avatar.chat2)
+
+    def test_lan_send_failure_is_deferred_until_stock_registers_request(self):
+        self.assertTrue(self.adapter.start_team_chat())
+        self.avatar.chat2 = []
+        self.sender.send_team_chat = lambda request: False
+        self.assertFalse(self.adapter.handle_client_action(
+            21, 18, _args(str_arg1='not admitted')))
+        self.assertEqual([], self.avatar.chat2)
+        self.assertEqual(1, len(self.scheduled))
+        self.scheduled.pop()[1]()
+        self.assertEqual((1, 18), self.avatar.chat2[-1][:2])
+
+    def test_stock_users_ready_event_only_completes_ignore_rosters(self):
+        received = []
+        user_tag = types.SimpleNamespace(
+            IGNORED='ignored', IGNORED_TMP='ignored_tmp')
+        messenger = types.ModuleType('messenger')
+        constants = types.ModuleType('messenger.m_constants')
+        constants.USER_TAG = user_tag
+        proto = types.ModuleType('messenger.proto')
+        events = types.ModuleType('messenger.proto.events')
+        events.g_messengerEvents = types.SimpleNamespace(
+            users=types.SimpleNamespace(
+                onUsersListReceived=lambda tags: received.append(tags)))
+        with mock.patch.dict(sys.modules, {
+                'messenger': messenger,
+                'messenger.m_constants': constants,
+                'messenger.proto': proto,
+                'messenger.proto.events': events}):
+            tactical_radio._notify_stock_ignore_lists_ready()
+        self.assertEqual([{'ignored', 'ignored_tmp'}], received)
+
 
 class _UnusedBinding(object):
     pass
@@ -201,9 +495,16 @@ class RadioMailboxIntegrationTests(unittest.TestCase):
     def test_avatar_bridge_owns_real_battle_mailbox_and_teardown(self):
         avatar = _Avatar()
         sender = _Sender()
-        bridge = AvatarServerBridge(
-            avatar, _UnusedBinding(), _UnusedBuilder(), sender)
-
+        with mock.patch.object(
+                tactical_radio, '_notify_stock_ignore_lists_ready'):
+            bridge = AvatarServerBridge(
+                avatar, _UnusedBinding(), _UnusedBuilder(), sender)
+            self.assertTrue(bridge.start_team_chat())
+        self.assertTrue(bridge.messenger_onActionByClient_chat2(
+            21, 19, _args(str_arg1='team text')))
+        self.assertTrue(bridge.receive_team_chat_ack(71, True))
+        self.assertTrue(bridge.receive_team_chat('relay', 9002))
+        self.assertTrue(bridge.close_team_chat())
         self.assertTrue(bridge.messenger_onActionByClient_chat2(
             29, 20, _args(44.0)))
         self.assertEqual(44, sender.requests[-1]['cell_index'])

--- a/tests/test_port_0922_tactical_radio.py
+++ b/tests/test_port_0922_tactical_radio.py
@@ -1,0 +1,227 @@
+import importlib.util
+from pathlib import Path
+import sys
+import types
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CLIENT_SCRIPTS = ROOT / 'src' / 'res' / 'scripts' / 'client'
+sys.path.insert(0, str(CLIENT_SCRIPTS))
+
+from gui.mods.offline_lan_0922 import tactical_radio
+from gui.mods.offline_lan_0922.account_rpc.server import FakeServer
+from gui.mods.offline_lan_0922.entities.avatar_server import AvatarServerBridge
+
+
+def _args(int32_arg=0):
+    return {
+        'int32Arg1': int32_arg,
+        'int64Arg1': 0,
+        'floatArg1': 0.0,
+        'strArg1': '',
+        'strArg2': '',
+    }
+
+
+class _Avatar(object):
+    def __init__(self):
+        self.playerVehicleID = 101
+        self.team = 1
+        self.arena = types.SimpleNamespace(vehicles={
+            101: {
+                'team': 1, 'isAlive': True, 'accountDBID': 9001},
+            102: {
+                'team': 1, 'isAlive': True, 'accountDBID': 9002},
+            103: {
+                'team': 1, 'isAlive': True, 'accountDBID': 99002},
+            104: {
+                'team': 1, 'isAlive': False, 'accountDBID': 99003},
+            201: {
+                'team': 2, 'isAlive': True, 'accountDBID': 9003},
+            202: {
+                'team': 2, 'isAlive': False, 'accountDBID': 9004},
+        })
+        self.chat2 = []
+
+    def messenger_onActionByServer_chat2(self, action_id, request_id, args):
+        self.chat2.append((action_id, request_id, args))
+
+
+class _Sender(object):
+    def __init__(self):
+        self.requests = []
+        self.next_sequence = 40
+
+    def send_team_command(self, request):
+        self.requests.append(request)
+        self.next_sequence += 1
+        return self.next_sequence
+
+
+class BattleRadioAdapterTests(unittest.TestCase):
+    def setUp(self):
+        self.avatar = _Avatar()
+        self.sender = _Sender()
+        self.current = self.avatar
+        self.adapter = tactical_radio.BattleRadioAdapter(
+            self.avatar, self.sender, lambda: self.current)
+
+    def test_exact_fixed_command_contract_is_pinned(self):
+        self.assertEqual({
+            23: ('HELPME', None),
+            24: ('FOLLOWME', 'ally'),
+            25: ('ATTACK', None),
+            26: ('BACKTOBASE', None),
+            27: ('POSITIVE', None),
+            28: ('NEGATIVE', None),
+            29: ('ATTENTIONTOCELL', 'cell'),
+            31: ('ATTACKENEMY', 'enemy'),
+            32: ('TURNBACK', 'ally'),
+            33: ('HELPMEEX', 'ally'),
+            34: ('SUPPORTMEWITHFIRE', 'enemy'),
+            36: ('STOP', 'ally'),
+        }, tactical_radio.COMMAND_SPECS)
+
+    def test_stock_target_id_stays_explicit_until_runtime_maps_it(self):
+        self.assertTrue(self.adapter.handle_client_action(
+            24, 7, _args(102)))
+        self.assertEqual({
+            'command': 'FOLLOWME',
+            'stock_action_id': 24,
+            'stock_request_id': 7,
+            'stock_target_id': 102,
+            'target_relation': 'ally',
+        }, self.sender.requests[-1])
+        self.assertNotIn('target_id', self.sender.requests[-1])
+        self.assertNotIn('target_kind', self.sender.requests[-1])
+
+        self.assertTrue(self.adapter.handle_client_action(
+            31, 8, _args(201)))
+        self.assertEqual('enemy',
+                         self.sender.requests[-1]['target_relation'])
+        self.assertEqual(201,
+                         self.sender.requests[-1]['stock_target_id'])
+
+    def test_minimap_float_cell_is_normalized_like_int32_mailbox(self):
+        self.assertTrue(self.adapter.handle_client_action(
+            29, 9, _args(23.0)))
+        self.assertEqual(23, self.sender.requests[-1]['cell_index'])
+        self.assertFalse(self.adapter.handle_client_action(
+            29, 10, _args(23.5)))
+        self.assertFalse(self.adapter.handle_client_action(
+            29, 11, _args(100)))
+
+    def test_target_relation_and_alive_state_are_checked_before_send(self):
+        self.assertFalse(self.adapter.handle_client_action(
+            24, 1, _args(201)))
+        self.assertFalse(self.adapter.handle_client_action(
+            31, 2, _args(102)))
+        self.assertFalse(self.adapter.handle_client_action(
+            31, 3, _args(202)))
+        self.assertFalse(self.adapter.handle_client_action(
+            24, 4, _args(101)))
+        self.assertEqual([], self.sender.requests)
+
+    def test_ack_uses_account_dbid_for_stock_dispatch(self):
+        self.assertTrue(self.adapter.handle_client_action(
+            24, 7, _args(102)))
+
+        self.assertTrue(self.adapter.receive_ack(41, True, [99002]))
+
+        self.assertEqual(2, len(self.avatar.chat2))
+        response, reply = self.avatar.chat2
+        self.assertEqual((0, 7), response[:2])
+        self.assertEqual((27, 0), reply[:2])
+        self.assertEqual(99002, reply[2]['int64Arg1'])
+
+    def test_same_team_broadcast_owns_the_original_stock_echo(self):
+        self.assertTrue(self.adapter.receive_command(
+            'FOLLOWME', 9001, target_id=102))
+        action_id, request_id, args = self.avatar.chat2[-1]
+        self.assertEqual((24, 0, 9001, 102), (
+            action_id, request_id, args['int64Arg1'], args['int32Arg1']))
+
+    def test_stock_argument_mapping_must_have_the_exact_five_keys(self):
+        incomplete = _args()
+        incomplete.pop('strArg2')
+        self.assertFalse(self.adapter.handle_client_action(
+            25, 2, incomplete))
+        extended = _args()
+        extended['extra'] = 1
+        self.assertFalse(self.adapter.handle_client_action(
+            25, 3, extended))
+
+    def test_stock_zero_request_id_wrap_still_sends_the_command(self):
+        self.assertTrue(self.adapter.handle_client_action(25, 0, _args()))
+        self.assertEqual(0, self.sender.requests[-1]['stock_request_id'])
+        self.assertTrue(self.adapter.receive_ack(41, True, []))
+        self.assertEqual((0, 0), self.avatar.chat2[-1][:2])
+
+    def test_dispatcher_does_not_assume_account_dbid_equals_entity_id(self):
+        self.assertTrue(self.adapter.receive_command('POSITIVE', 99002))
+        self.assertEqual(99002, self.avatar.chat2[-1][2]['int64Arg1'])
+        self.assertFalse(self.adapter.receive_command('POSITIVE', 103))
+
+    def test_validated_teammate_broadcast_survives_a_death_update_race(self):
+        self.assertTrue(self.adapter.receive_command('POSITIVE', 99003))
+        self.assertEqual(99003, self.avatar.chat2[-1][2]['int64Arg1'])
+
+    def test_late_or_cross_avatar_ack_is_contained(self):
+        self.assertTrue(self.adapter.handle_client_action(
+            25, 5, _args()))
+        self.current = _Avatar()
+        self.assertFalse(self.adapter.receive_ack(41, True, [9002]))
+        self.assertEqual([], self.avatar.chat2)
+        self.current = self.avatar
+        self.adapter.close()
+        self.assertFalse(self.adapter.receive_ack(41, True, [9002]))
+        self.assertFalse(self.adapter.handle_client_action(
+            25, 6, _args()))
+
+    def test_rejection_completes_stock_request_without_command_echo(self):
+        self.assertTrue(self.adapter.handle_client_action(
+            25, 12, _args()))
+        self.assertTrue(self.adapter.receive_ack(41, False, []))
+        self.assertEqual(1, len(self.avatar.chat2))
+        action_id, request_id, args = self.avatar.chat2[0]
+        self.assertEqual((1, 12, 1),
+                         (action_id, request_id, args['int32Arg1']))
+
+
+class _UnusedBinding(object):
+    pass
+
+
+class _UnusedBuilder(object):
+    pass
+
+
+class RadioMailboxIntegrationTests(unittest.TestCase):
+    def test_avatar_bridge_owns_real_battle_mailbox_and_teardown(self):
+        avatar = _Avatar()
+        sender = _Sender()
+        bridge = AvatarServerBridge(
+            avatar, _UnusedBinding(), _UnusedBuilder(), sender)
+
+        self.assertTrue(bridge.messenger_onActionByClient_chat2(
+            29, 20, _args(44.0)))
+        self.assertEqual(44, sender.requests[-1]['cell_index'])
+        self.assertFalse(bridge.destroy())
+        self.assertFalse(bridge.receive_team_command_ack(41, True, [9002]))
+
+    def test_account_mailbox_delegates_only_when_adapter_is_scoped(self):
+        calls = []
+        adapter = types.SimpleNamespace(
+            handle_client_action=lambda *args: calls.append(args) or True)
+        player = types.SimpleNamespace()
+        server = FakeServer(lambda: player, callback=lambda *args: None,
+                            context={'battle_radio': adapter})
+
+        self.assertTrue(server.messenger_onActionByClient_chat2(
+            25, 4, _args()))
+        self.assertEqual([(25, 4, _args())], calls)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_port_0922_team_chat_transport.py
+++ b/tests/test_port_0922_team_chat_transport.py
@@ -1,0 +1,365 @@
+import json
+from pathlib import Path
+import socket
+import sys
+import threading
+import unittest
+
+
+TEST_ROOT = Path(__file__).resolve().parent
+SERVER_ROOT = TEST_ROOT.parent / 'server'
+sys.path.insert(0, str(TEST_ROOT))
+sys.path.insert(0, str(SERVER_ROOT))
+
+import lan_battle_server as server_module  # noqa: E402
+from lan_battle_server import (  # noqa: E402
+    BattleState, CLIENT_BUILD_0922, ClientHandler, ThreadedTCPServer,
+)
+from effective_params_fixture import effective_params  # noqa: E402
+
+
+class _Peer(object):
+    def __init__(self, address):
+        self.socket = socket.create_connection(address, timeout=2.0)
+        self.socket.settimeout(2.0)
+        self.stream = self.socket.makefile('rwb')
+
+    def send(self, message):
+        payload = json.dumps(
+            message, ensure_ascii=False, separators=(',', ':')) + '\n'
+        self.stream.write(payload.encode('utf-8'))
+        self.stream.flush()
+
+    def receive_until_all(self, predicates, limit=64):
+        matched = [False] * len(predicates)
+        messages = []
+        for _unused in range(limit):
+            line = self.stream.readline()
+            if not line:
+                raise AssertionError('connection closed before message barrier')
+            message = json.loads(line.decode('utf-8'))
+            messages.append(message)
+            for index, predicate in enumerate(predicates):
+                if not matched[index] and predicate(message):
+                    matched[index] = True
+            if all(matched):
+                return messages
+        raise AssertionError('message barrier was not reached: %r' % messages)
+
+    def receive_until(self, predicate, limit=64):
+        return self.receive_until_all((predicate,), limit=limit)
+
+    def close(self):
+        try:
+            self.socket.shutdown(socket.SHUT_RDWR)
+        except OSError:
+            pass
+        try:
+            self.stream.close()
+        except OSError:
+            pass
+        try:
+            self.socket.close()
+        except OSError:
+            pass
+
+
+def _player_hello(name, account_key, team):
+    return {
+        'type': 'hello',
+        'protocol': server_module.PROTOCOL_VERSION,
+        'client_build': CLIENT_BUILD_0922,
+        'capabilities': list(server_module.MODERN_CLIENT_REQUIRED_CAPABILITIES),
+        'name': name,
+        'account_key': account_key,
+        'requested_team': team,
+        'vehicle': 'ussr:R11_MS-1',
+        'max_health': 90,
+        'vehicle_compact_descr': 'dGVzdA==',
+        'effective_params': effective_params(),
+    }
+
+
+def _type(kind):
+    return lambda message: message.get('type') == kind
+
+
+def _chat(kind, issuer_id, sequence):
+    return lambda message: (
+        message.get('type') == kind and
+        message.get('issuer_id') == issuer_id and
+        message.get('chat_seq') == sequence)
+
+
+def _chat_ack(sequence):
+    return lambda message: (
+        message.get('type') == 'team_chat_ack' and
+        message.get('chat_seq') == sequence)
+
+
+def _command(kind, issuer_id, sequence):
+    return lambda message: (
+        message.get('type') == kind and
+        message.get('issuer_id') == issuer_id and
+        message.get('command_seq') == sequence)
+
+
+def _command_ack(sequence):
+    return lambda message: (
+        message.get('type') == 'team_command_ack' and
+        message.get('command_seq') == sequence)
+
+
+class TeamChatTransportTests(unittest.TestCase):
+    def setUp(self):
+        self.state = BattleState(
+            map_name='01_karelia', max_players=3,
+            team1_size=2, team2_size=1)
+        self.server = ThreadedTCPServer(
+            ('127.0.0.1', 0), ClientHandler)
+        self.server.game_server = type(
+            'GameServer', (), {'state': self.state})()
+        self.thread = threading.Thread(target=self.server.serve_forever)
+        self.thread.daemon = True
+        self.thread.start()
+        self.peers = []
+
+    def tearDown(self):
+        for peer in self.peers:
+            peer.close()
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(2.0)
+
+    def _connect(self, name, account_key, team):
+        peer = _Peer(self.server.server_address)
+        self.peers.append(peer)
+        peer.send(_player_hello(name, account_key, team))
+        messages = peer.receive_until(_type('welcome'))
+        welcome = next(
+            message for message in messages if message.get('type') == 'welcome')
+        self.assertEqual(team, welcome['team'])
+        return peer, welcome['player_id']
+
+    def _connect_teams(self):
+        sender, sender_id = self._connect('Sender', 'chat_sender', 1)
+        teammate, teammate_id = self._connect('Teammate', 'chat_teammate', 1)
+        opponent, opponent_id = self._connect('Opponent', 'chat_opponent', 2)
+        for sequence, peer in enumerate((sender, teammate, opponent), 1):
+            peer.send({'type': 'ping', 'seq': sequence})
+            peer.receive_until(
+                lambda message, expected=sequence:
+                message.get('type') == 'pong' and
+                message.get('seq') == expected)
+        with self.state.lock:
+            self.state.phase = 'battle'
+        self.assertEqual([], self.state.bot_manifest)
+        return sender, sender_id, teammate, teammate_id, opponent, opponent_id
+
+    def test_unicode_chat_reaches_sender_and_team_without_bots_or_enemy_leak(self):
+        (sender, sender_id, teammate, unused_teammate_id,
+         opponent, unused_opponent_id) = self._connect_teams()
+        with self.state.lock:
+            self.state.players[sender_id].alive = False
+
+        text = '守住 E7! 装填中, 等等我...'
+        sender.send({
+            'type': 'team_chat',
+            'round_id': self.state.round_id,
+            'chat_seq': 1,
+            'text': text,
+        })
+        sender_messages = sender.receive_until_all((
+            _chat('team_chat', sender_id, 1), _chat_ack(1)))
+        teammate_messages = teammate.receive_until(
+            _chat('team_chat', sender_id, 1))
+
+        broadcast = next(
+            message for message in sender_messages
+            if _chat('team_chat', sender_id, 1)(message))
+        self.assertEqual({
+            'type': 'team_chat',
+            'protocol': server_module.PROTOCOL_VERSION,
+            'round_id': self.state.round_id,
+            'chat_seq': 1,
+            'issuer_id': sender_id,
+            'team': 1,
+            'text': text,
+        }, broadcast)
+        self.assertEqual(broadcast, next(
+            message for message in teammate_messages
+            if _chat('team_chat', sender_id, 1)(message)))
+        acknowledgement = next(
+            message for message in sender_messages if _chat_ack(1)(message))
+        self.assertEqual({
+            'type': 'team_chat_ack',
+            'protocol': server_module.PROTOCOL_VERSION,
+            'round_id': self.state.round_id,
+            'chat_seq': 1,
+            'accepted': True,
+            'code': 'accepted',
+        }, acknowledgement)
+
+        opponent.send({'type': 'ping', 'seq': 701})
+        opponent_messages = opponent.receive_until(
+            lambda message: message.get('type') == 'pong' and
+            message.get('seq') == 701)
+        self.assertFalse(any(
+            _chat('team_chat', sender_id, 1)(message)
+            for message in opponent_messages))
+
+    def test_map_command_reaches_human_team_without_bots(self):
+        (sender, sender_id, teammate, unused_teammate_id,
+         opponent, unused_opponent_id) = self._connect_teams()
+        with self.state.lock:
+            self.state.players[sender_id].alive = False
+
+        sender.send({
+            'type': 'team_command',
+            'round_id': self.state.round_id,
+            'command_seq': 1,
+            'command': 'ATTENTIONTOCELL',
+            'cell_index': 42,
+        })
+        sender_messages = sender.receive_until_all((
+            _command('team_command', sender_id, 1), _command_ack(1)))
+        teammate_messages = teammate.receive_until(
+            _command('team_command', sender_id, 1))
+
+        publication = next(
+            message for message in sender_messages
+            if _command('team_command', sender_id, 1)(message))
+        self.assertEqual(42, publication['cell_index'])
+        self.assertEqual('ATTENTIONTOCELL', publication['command'])
+        self.assertEqual(1, publication['team'])
+        self.assertEqual(publication, next(
+            message for message in teammate_messages
+            if _command('team_command', sender_id, 1)(message)))
+        acknowledgement = next(
+            message for message in sender_messages
+            if _command_ack(1)(message))
+        self.assertTrue(acknowledgement['accepted'])
+        self.assertEqual('accepted', acknowledgement['code'])
+        self.assertEqual([], acknowledgement['recipient_bot_ids'])
+        self.assertEqual(0, acknowledgement['expires_tick'])
+
+        opponent.send({'type': 'ping', 'seq': 702})
+        opponent_messages = opponent.receive_until(
+            lambda message: message.get('type') == 'pong' and
+            message.get('seq') == 702)
+        self.assertFalse(any(
+            _command('team_command', sender_id, 1)(message)
+            for message in opponent_messages))
+
+    def test_duplicate_and_wrong_shape_are_local_and_transport_survives(self):
+        (sender, sender_id, teammate, teammate_id,
+         unused_opponent, unused_opponent_id) = self._connect_teams()
+        request = {
+            'type': 'team_chat',
+            'round_id': self.state.round_id,
+            'chat_seq': 1,
+            'text': 'First line.',
+        }
+        sender.send(request)
+        sender.receive_until_all((
+            _chat('team_chat', sender_id, 1), _chat_ack(1)))
+        teammate.receive_until(_chat('team_chat', sender_id, 1))
+
+        sender.send(request)
+        duplicate_messages = sender.receive_until(_chat_ack(1))
+        self.assertFalse(any(
+            _chat('team_chat', sender_id, 1)(message)
+            for message in duplicate_messages))
+        duplicate_ack = next(
+            message for message in duplicate_messages if _chat_ack(1)(message))
+        self.assertTrue(duplicate_ack['accepted'])
+
+        teammate.send({
+            'type': 'team_chat',
+            'round_id': self.state.round_id,
+            'chat_seq': 1,
+            'text': 'Publication barrier.',
+        })
+        teammate_messages = teammate.receive_until_all((
+            _chat('team_chat', teammate_id, 1), _chat_ack(1)))
+        self.assertFalse(any(
+            _chat('team_chat', sender_id, 1)(message)
+            for message in teammate_messages))
+
+        sender.send({
+            'type': 'team_chat',
+            'round_id': self.state.round_id,
+            'chat_seq': 2,
+            'text': 'Bad shape.',
+            'unexpected': True,
+        })
+        sender.send({
+            'type': 'team_chat',
+            'round_id': self.state.round_id,
+            'chat_seq': 3,
+            'text': 'Still connected.',
+        })
+        recovery_messages = sender.receive_until_all((
+            lambda message: _chat_ack(2)(message) and
+            not message.get('accepted') and
+            message.get('code') == 'invalid_shape',
+            _chat('team_chat', sender_id, 3),
+            lambda message: _chat_ack(3)(message) and
+            message.get('accepted')))
+        self.assertFalse(any(
+            message.get('type') == 'team_chat' and
+            message.get('issuer_id') == sender_id and
+            message.get('chat_seq') == 2
+            for message in recovery_messages))
+        self.assertTrue(self.state.players[sender_id].connected)
+
+    def test_old_round_message_cannot_enter_the_reset_round(self):
+        (sender, sender_id, teammate, unused_teammate_id,
+         unused_opponent, unused_opponent_id) = self._connect_teams()
+        old_round = self.state.round_id
+        sender.send({
+            'type': 'team_chat',
+            'round_id': old_round,
+            'chat_seq': 1,
+            'text': 'Old accepted line.',
+        })
+        sender.receive_until_all((
+            _chat('team_chat', sender_id, 1), _chat_ack(1)))
+        teammate.receive_until(_chat('team_chat', sender_id, 1))
+
+        with self.state.lock:
+            self.state._reset_round()
+            self.state.phase = 'battle'
+            new_round = self.state.round_id
+        self.assertEqual(old_round + 1, new_round)
+
+        sender.send({
+            'type': 'team_chat',
+            'round_id': old_round,
+            'chat_seq': 2,
+            'text': 'Stale in the new round.',
+        })
+        sender.send({
+            'type': 'team_chat',
+            'round_id': new_round,
+            'chat_seq': 1,
+            'text': 'Current round barrier.',
+        })
+        sender_messages = sender.receive_until_all((
+            lambda message: _chat('team_chat', sender_id, 1)(message) and
+            message.get('round_id') == new_round,
+            lambda message: _chat_ack(1)(message) and
+            message.get('round_id') == new_round))
+        teammate_messages = teammate.receive_until(
+            lambda message: _chat('team_chat', sender_id, 1)(message) and
+            message.get('round_id') == new_round)
+        observed = sender_messages + teammate_messages
+        self.assertFalse(any(
+            message.get('type') == 'team_chat' and
+            (message.get('round_id') == old_round or
+             message.get('text') == 'Stale in the new round.')
+            for message in observed))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_port_0922_team_commands.py
+++ b/tests/test_port_0922_team_commands.py
@@ -74,6 +74,17 @@ class TeamCommandTests(unittest.TestCase):
         self.assertFalse(ack['accepted'])
         self.assertEqual('unknown_command', ack['code'])
 
+    def test_same_tick_commands_keep_admission_order_across_sequence_digits(self):
+        from server_bot_ai import BotPlanner
+        first = self.state.submit_team_command(1, self._message('HELPME', sequence=9))
+        second = self.state.submit_team_command(1, self._message('ATTACK', sequence=10))
+        self.assertTrue(first['accepted'] and second['accepted'])
+        orders = self.state._active_team_commands_locked()
+        bots = [{'id': 11, 'team': 1}, {'id': 12, 'team': 1}]
+        selected = BotPlanner._team_orders_by_bot(orders, bots)
+        self.assertEqual('ATTACK', selected[11]['command'])
+        self.assertEqual(10, selected[11]['command_seq'])
+
     def test_accepts_stock_cell_command_for_nearest_bounded_bots(self):
         ack = self.state.submit_team_command(
             1, self._message('ATTENTIONTOCELL', cell_index=38))

--- a/tests/test_port_0922_team_commands.py
+++ b/tests/test_port_0922_team_commands.py
@@ -1,0 +1,189 @@
+import sys
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / 'server'))
+
+from lan_battle_server import (
+    BattleState, CLIENT_BUILD_0922, Player, PREBATTLE_SECONDS, TICK_HZ,
+    SIMULATION_WORKER_AUTHORITY_ID)
+
+
+class _Socket(object):
+    def sendall(self, unused_payload):
+        pass
+
+
+class _Planner(object):
+    def __init__(self):
+        self.team_orders = []
+
+    def reset(self):
+        pass
+
+    def build_orders(self, *unused_args, **kwargs):
+        self.team_orders.append(kwargs.get('team_orders'))
+        return {'revision': len(self.team_orders), 'orders': []}
+
+
+class TeamCommandTests(unittest.TestCase):
+    def setUp(self):
+        self.state = BattleState(map_name='01_karelia')
+        self.state.client_build = CLIENT_BUILD_0922
+        self.state.phase = 'battle'
+        self.state.tick = int(round(PREBATTLE_SECONDS * TICK_HZ))
+        self.sender = Player(1, _Socket(), ('127.0.0.1', 1), team=1,
+                             x=0.0, z=0.0)
+        self.enemy = Player(2, _Socket(), ('127.0.0.1', 2), team=2,
+                            x=200.0, z=0.0)
+        self.state.players = {1: self.sender, 2: self.enemy}
+        self.state.bot_authority_id = SIMULATION_WORKER_AUTHORITY_ID
+        self.state.bot_manifest_authority_id = SIMULATION_WORKER_AUTHORITY_ID
+        self.state.bot_manifest = [
+            {'id': 11, 'team': 1}, {'id': 12, 'team': 1},
+            {'id': 21, 'team': 2},
+        ]
+        self.state.bot_states = {
+            11: {'id': 11, 'team': 1, 'alive': True, 'x': 20.0, 'z': 0.0},
+            12: {'id': 12, 'team': 1, 'alive': True, 'x': 40.0, 'z': 0.0},
+            21: {'id': 21, 'team': 2, 'alive': True, 'x': 180.0, 'z': 0.0},
+        }
+
+    def _message(self, command, sequence=1, **fields):
+        message = {
+            'type': 'team_command', 'round_id': self.state.round_id,
+            'command_seq': sequence, 'command': command,
+        }
+        message.update(fields)
+        return message
+
+    def test_history_eviction_publishes_a_terminal_receipt(self):
+        from unittest import mock
+        sent = []
+        self.sender.offer_reliable = lambda message: sent.append(message) or True
+        with mock.patch('lan_battle_server.TEAM_COMMAND_HISTORY', 1):
+            self.assertTrue(self.state.submit_team_command(1, self._message('HELPME'))['accepted'])
+            self.assertTrue(self.state.submit_team_command(1, self._message('ATTACK', sequence=2))['accepted'])
+        self.assertEqual('superseded', sent[-1]['code'])
+        self.assertEqual(1, sent[-1]['command_seq'])
+
+    def test_unhashable_command_is_rejected_locally(self):
+        ack = self.state.submit_team_command(1, self._message([]))
+        self.assertFalse(ack['accepted'])
+        self.assertEqual('unknown_command', ack['code'])
+
+    def test_accepts_stock_cell_command_for_nearest_bounded_bots(self):
+        ack = self.state.submit_team_command(
+            1, self._message('ATTENTIONTOCELL', cell_index=38))
+
+        self.assertTrue(ack['accepted'])
+        self.assertEqual('accepted', ack['code'])
+        self.assertEqual([11, 12], ack['recipient_bot_ids'])
+        orders = self.state._active_team_commands_locked()
+        self.assertEqual(1, len(orders))
+        self.assertEqual('ATTENTIONTOCELL', orders[0]['command'])
+        self.assertEqual(38, orders[0]['cell_index'])
+        self.assertGreater(orders[0]['expires_tick'], self.state.tick)
+
+    def test_enemy_command_requires_sender_current_direct_spot(self):
+        message = self._message(
+            'ATTACKENEMY', target_id=2, target_kind='human')
+        rejected = self.state.submit_team_command(1, message)
+        self.assertFalse(rejected['accepted'])
+        self.assertEqual('enemy_not_visible', rejected['code'])
+
+        self.state.player_spotted[1] = frozenset((('player', 2),))
+        self.state.bot_spotted[12] = frozenset((('player', 2),))
+        accepted = self.state.submit_team_command(1, message)
+
+        self.assertTrue(accepted['accepted'])
+        self.assertEqual([12, 11], accepted['recipient_bot_ids'])
+        order = self.state._active_team_commands_locked()[0]
+        self.assertEqual('human', order['target_kind'])
+        self.assertEqual(2, order['target_id'])
+
+    def test_ally_order_is_directed_only_to_the_named_live_bot(self):
+        ack = self.state.submit_team_command(
+            1, self._message('FOLLOWME', target_id=12, target_kind='bot'))
+
+        self.assertTrue(ack['accepted'])
+        self.assertEqual([12], ack['recipient_bot_ids'])
+        self.assertEqual([12], self.state._active_team_commands_locked()[0]
+                         ['recipient_bot_ids'])
+
+    def test_sender_death_clears_command_before_next_planning_cycle(self):
+        sent = []
+        self.sender.offer_reliable = lambda message: sent.append(message) or True
+        self.assertTrue(self.state.submit_team_command(
+            1, self._message('HELPME'))['accepted'])
+        self.sender.alive = False
+
+        self.assertEqual([], self.state._active_team_commands_locked())
+        self.assertEqual({}, self.state.team_commands)
+        self.assertEqual('team_command_terminal', sent[-1]['type'])
+        self.assertEqual('issuer_dead', sent[-1]['code'])
+
+    def test_duplicate_sequence_replays_same_ack_but_conflict_is_rejected(self):
+        message = self._message('ATTACK')
+        accepted = self.state.submit_team_command(1, message)
+
+        self.assertEqual(
+            accepted, self.state.submit_team_command(1, dict(message)))
+        rejected = self.state.submit_team_command(
+            1, self._message('HELPME', sequence=1))
+        self.assertFalse(rejected['accepted'])
+        self.assertEqual('sequence_conflict', rejected['code'])
+
+    def test_planner_gets_only_active_validated_team_orders(self):
+        planner = _Planner()
+        self.state.bot_planner = planner
+        self.assertTrue(self.state.submit_team_command(
+            1, self._message('BACKTOBASE'))['accepted'])
+
+        self.state.tick_once(1.0 / TICK_HZ)
+
+        self.assertEqual(1, len(planner.team_orders))
+        self.assertEqual('BACKTOBASE', planner.team_orders[0][0]['command'])
+
+    def test_accepted_command_is_relayed_only_to_the_sender_team(self):
+        teammate = Player(3, _Socket(), ('127.0.0.1', 3), team=1)
+        self.state.players[3] = teammate
+        deliveries = {1: [], 2: [], 3: []}
+        for player_id, player in self.state.players.items():
+            player.offer_reliable = (
+                lambda message, player_id=player_id:
+                deliveries[player_id].append(message) or True)
+        ack = self.state.submit_team_command(
+            1, self._message('ATTENTIONTOCELL', cell_index=31))
+
+        self.assertTrue(self.state.publish_team_command(ack))
+        self.assertEqual('team_command', deliveries[1][0]['type'])
+        self.assertEqual('ATTENTIONTOCELL', deliveries[3][0]['command'])
+        self.assertEqual(31, deliveries[3][0]['cell_index'])
+        self.assertEqual([], deliveries[2])
+
+    def test_threatened_bot_ids_are_cleaned_without_rejecting_contact(self):
+        relay = self.state.update_bot_observation(
+            SIMULATION_WORKER_AUTHORITY_ID, {
+                'type': 'bot_observation', 'round_id': self.state.round_id,
+                'contacts': [{
+                    'observing_team': 1, 'target_kind': 'human',
+                    'target_id': 2, 'target_team': 2,
+                    'visible': True, 'fresh': True, 'time_left': 10.0,
+                    'visible_by_bot_ids': [11],
+                    'visible_by_player_ids': [],
+                    'shootable_by_bot_ids': [11],
+                    'threatened_bot_ids': [11, 12, 21, 'bad', 11],
+                }], 'affordances': [],
+            })
+
+        self.assertIsInstance(relay, dict)
+        self.assertEqual(
+            [11, 12], self.state.bot_planner._contacts[1][
+                ('human', 2)]['threatened_bot_ids'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_port_0922_team_commands.py
+++ b/tests/test_port_0922_team_commands.py
@@ -8,7 +8,7 @@ sys.path.insert(0, str(ROOT / 'server'))
 
 from lan_battle_server import (
     BattleState, CLIENT_BUILD_0922, Player, PREBATTLE_SECONDS, TICK_HZ,
-    SIMULATION_WORKER_AUTHORITY_ID)
+    SIMULATION_WORKER_AUTHORITY_ID, TEAM_CHAT_MAX_CHARACTERS)
 
 
 class _Socket(object):
@@ -98,16 +98,19 @@ class TeamCommandTests(unittest.TestCase):
         self.assertEqual(38, orders[0]['cell_index'])
         self.assertGreater(orders[0]['expires_tick'], self.state.tick)
 
-    def test_enemy_command_requires_sender_current_direct_spot(self):
+    def test_enemy_message_broadcasts_without_a_spot_but_only_spotted_order_reaches_bot(self):
         message = self._message(
             'ATTACKENEMY', target_id=2, target_kind='human')
-        rejected = self.state.submit_team_command(1, message)
-        self.assertFalse(rejected['accepted'])
-        self.assertEqual('enemy_not_visible', rejected['code'])
+        accepted_message = self.state.submit_team_command(1, message)
+        self.assertTrue(accepted_message['accepted'])
+        self.assertEqual([], accepted_message['recipient_bot_ids'])
+        self.assertEqual([], self.state._active_team_commands_locked())
 
         self.state.player_spotted[1] = frozenset((('player', 2),))
         self.state.bot_spotted[12] = frozenset((('player', 2),))
-        accepted = self.state.submit_team_command(1, message)
+        accepted = self.state.submit_team_command(
+            1, self._message('ATTACKENEMY', sequence=2,
+                             target_id=2, target_kind='human'))
 
         self.assertTrue(accepted['accepted'])
         self.assertEqual([12, 11], accepted['recipient_bot_ids'])
@@ -174,6 +177,231 @@ class TeamCommandTests(unittest.TestCase):
         self.assertEqual('ATTENTIONTOCELL', deliveries[3][0]['command'])
         self.assertEqual(31, deliveries[3][0]['cell_index'])
         self.assertEqual([], deliveries[2])
+
+    def test_social_command_broadcasts_but_never_creates_bot_order(self):
+        teammate = Player(3, _Socket(), ('127.0.0.1', 3), team=1)
+        self.state.players[3] = teammate
+        deliveries = {1: [], 2: [], 3: []}
+        for player_id, player in self.state.players.items():
+            player.offer_reliable = (
+                lambda message, player_id=player_id:
+                deliveries[player_id].append(message) or True)
+
+        ack = self.state.submit_team_command(1, self._message('POSITIVE'))
+
+        self.assertTrue(ack['accepted'])
+        self.assertEqual([], ack['recipient_bot_ids'])
+        self.assertEqual([], self.state._active_team_commands_locked())
+        self.assertTrue(self.state.publish_team_command(ack))
+        self.assertTrue(self.state.publish_team_command(ack))
+        self.assertEqual(1, len(deliveries[1]))
+        self.assertEqual('POSITIVE', deliveries[3][0]['command'])
+        self.assertEqual([], deliveries[2])
+
+    def test_cell_message_reaches_human_team_with_no_live_bot(self):
+        self.state.bot_states[11]['alive'] = False
+        self.state.bot_states[12]['alive'] = False
+        teammate = Player(3, _Socket(), ('127.0.0.1', 3), team=1)
+        self.state.players[3] = teammate
+        messages = []
+        teammate.offer_reliable = lambda message: messages.append(message) or True
+
+        ack = self.state.submit_team_command(
+            1, self._message('ATTENTIONTOCELL', cell_index=31))
+
+        self.assertTrue(ack['accepted'])
+        self.assertEqual([], ack['recipient_bot_ids'])
+        self.assertTrue(self.state.publish_team_command(ack))
+        self.assertEqual(31, messages[0]['cell_index'])
+        self.assertEqual([], self.state._active_team_commands_locked())
+
+    def test_human_ally_target_and_dead_sender_broadcast_without_bot_order(self):
+        teammate = Player(3, _Socket(), ('127.0.0.1', 3), team=1)
+        self.state.players[3] = teammate
+        messages = []
+        teammate.offer_reliable = lambda message: messages.append(message) or True
+        self.sender.alive = False
+
+        follow = self.state.submit_team_command(
+            1, self._message('FOLLOWME', target_kind='human', target_id=3))
+        cell = self.state.submit_team_command(
+            1, self._message('ATTENTIONTOCELL', sequence=2, cell_index=4))
+
+        self.assertTrue(follow['accepted'] and cell['accepted'])
+        self.assertEqual([], follow['recipient_bot_ids'])
+        self.assertEqual([], cell['recipient_bot_ids'])
+        self.assertTrue(self.state.publish_team_command(follow))
+        self.assertTrue(self.state.publish_team_command(cell))
+        self.assertEqual(['FOLLOWME', 'ATTENTIONTOCELL'],
+                         [message['command'] for message in messages])
+        self.assertEqual([], self.state._active_team_commands_locked())
+
+    def _chat_message(self, text, sequence=1):
+        return {
+            'type': 'team_chat', 'round_id': self.state.round_id,
+            'chat_seq': sequence, 'text': text,
+        }
+
+    def test_team_chat_is_canonical_unicode_and_idempotently_broadcast(self):
+        teammate = Player(3, _Socket(), ('127.0.0.1', 3), team=1)
+        self.state.players[3] = teammate
+        deliveries = {1: [], 2: [], 3: []}
+        for player_id, player in self.state.players.items():
+            player.offer_reliable = (
+                lambda message, player_id=player_id:
+                deliveries[player_id].append(message) or True)
+        self.sender.alive = False
+        message = self._chat_message(u'队友 <注意> & 伏击')
+
+        ack = self.state.submit_team_chat(1, message)
+
+        self.assertTrue(ack['accepted'])
+        self.assertTrue(self.state.publish_team_chat(1, ack))
+        self.assertTrue(self.state.publish_team_chat(1, ack))
+        self.assertEqual(1, len(deliveries[1]))
+        self.assertEqual(message['text'], deliveries[3][0]['text'])
+        self.assertEqual([], deliveries[2])
+        self.assertEqual(ack, self.state.submit_team_chat(1, dict(message)))
+
+    def test_team_chat_rejects_blank_invalid_unicode_and_overlong_text_locally(self):
+        self.assertEqual('invalid_text', self.state.submit_team_chat(
+            1, self._chat_message(''))['code'])
+        self.assertEqual('invalid_text', self.state.submit_team_chat(
+            1, self._chat_message(' \t '))['code'])
+        self.assertEqual('invalid_text', self.state.submit_team_chat(
+            1, self._chat_message(u'\ud800'))['code'])
+
+    def test_team_chat_uses_stock_utf16_unit_limit(self):
+        self.assertTrue(self.state.submit_team_chat(
+            1, self._chat_message(u'😀' * 70))['accepted'])
+        self.assertEqual('invalid_text', self.state.submit_team_chat(
+            1, self._chat_message(u'😀' * 71, sequence=2))['code'])
+
+    def test_team_chat_preserves_stock_unicode_across_server_unicode_versions(self):
+        text = u'\U0001f16a'
+        ack = self.state.submit_team_chat(1, self._chat_message(text))
+        deliveries = []
+        self.sender.offer_reliable = lambda message: deliveries.append(message) or True
+
+        self.assertTrue(ack['accepted'])
+        self.assertTrue(self.state.publish_team_chat(1, ack))
+        self.assertEqual(text, deliveries[0]['text'])
+
+    def test_stale_or_rebound_acknowledgements_cannot_publish(self):
+        command_ack = self.state.submit_team_command(self.sender.player_id,
+                                                     self._message('HELPME'))
+        chat_ack = self.state.submit_team_chat(
+            self.sender.player_id, self._chat_message('hold'))
+        deliveries = []
+        self.sender.offer_reliable = lambda message: deliveries.append(message) or True
+
+        self.state.round_id += 1
+        self.assertFalse(self.state.publish_team_command(command_ack))
+        self.assertFalse(self.state.publish_team_chat(self.sender.player_id,
+                                                      chat_ack))
+        self.assertEqual([], deliveries)
+
+        self.state.round_id -= 1
+        altered_command = dict(command_ack, recipient_bot_ids=[])
+        altered_chat = dict(chat_ack, code='invalid_text')
+        self.assertFalse(self.state.publish_team_command(altered_command))
+        self.assertFalse(self.state.publish_team_chat(self.sender.player_id,
+                                                      altered_chat))
+        self.assertEqual([], deliveries)
+
+    def test_old_round_rejections_cannot_alias_current_round_sequence_one(self):
+        self.state.round_id = 8
+        stale_command = self._message('HELPME', sequence=1)
+        stale_command['round_id'] = 7
+        stale_chat = self._chat_message('old', sequence=1)
+        stale_chat['round_id'] = 7
+
+        command_rejection = self.state.submit_team_command(1, stale_command)
+        chat_rejection = self.state.submit_team_chat(1, stale_chat)
+        command_current = self.state.submit_team_command(
+            1, self._message('HELPME', sequence=1))
+        chat_current = self.state.submit_team_chat(
+            1, self._chat_message('current', sequence=1))
+
+        self.assertFalse(command_rejection['accepted'])
+        self.assertFalse(chat_rejection['accepted'])
+        self.assertEqual(7, command_rejection['round_id'])
+        self.assertEqual(7, chat_rejection['round_id'])
+        self.assertTrue(command_current['accepted'])
+        self.assertTrue(chat_current['accepted'])
+        self.assertEqual(8, command_current['round_id'])
+        self.assertEqual(8, chat_current['round_id'])
+
+    def test_dead_enemy_can_be_displayed_but_never_becomes_bot_focus(self):
+        self.enemy.alive = False
+        self.state.player_spotted[1] = frozenset((('player', 2),))
+
+        ack = self.state.submit_team_command(
+            1, self._message('ATTACKENEMY', target_kind='human', target_id=2))
+
+        self.assertTrue(ack['accepted'])
+        self.assertEqual([], ack['recipient_bot_ids'])
+        self.assertEqual([], self.state._active_team_commands_locked())
+
+    def test_all_stock_information_commands_relay_without_bot_orders(self):
+        teammate = Player(3, _Socket(), ('127.0.0.1', 3), team=1)
+        self.state.players[3] = teammate
+        deliveries = []
+        teammate.offer_reliable = lambda message: deliveries.append(message) or True
+        messages = (
+            self._message('SPG_AIM_AREA', aim_point=[4999.75, -2000.0, -4999.25],
+                          cell_index=0, reload_time=0.0),
+            self._message('RELOADINGGUN', sequence=2, reload_time=2.5),
+            self._message('RELOADING_CASSETE', sequence=3, reload_time=2.5,
+                          quantity=7),
+            self._message('RELOADING_READY', sequence=4),
+            self._message('RELOADING_READY_CASSETE', sequence=5, quantity=7),
+            self._message('RELOADING_UNAVAILABLE', sequence=6),
+        )
+
+        for message in messages:
+            ack = self.state.submit_team_command(1, message)
+            self.assertTrue(ack['accepted'])
+            self.assertEqual([], ack['recipient_bot_ids'])
+            self.assertTrue(self.state.publish_team_command(ack))
+
+        self.assertEqual([message['command'] for message in messages],
+                         [message['command'] for message in deliveries])
+        self.assertEqual(messages[0]['aim_point'], deliveries[0]['aim_point'])
+        self.assertEqual(0.0, deliveries[0]['reload_time'])
+        self.assertEqual(7, deliveries[2]['quantity'])
+        self.assertEqual([], self.state._active_team_commands_locked())
+
+    def test_reload_metadata_is_validated_relayed_and_not_a_bot_order_field(self):
+        self.state.player_spotted[1] = frozenset((('player', 2),))
+        ack = self.state.submit_team_command(
+            1, self._message('ATTACKENEMY', target_kind='human', target_id=2,
+                             reload_time=0.0))
+
+        self.assertTrue(ack['accepted'])
+        self.assertEqual(0.0, ack['reload_time'])
+        order = self.state._active_team_commands_locked()[0]
+        self.assertNotIn('reload_time', order)
+
+        invalid = self.state.submit_team_command(
+            1, self._message('SPG_AIM_AREA', sequence=2,
+                             aim_point=[0.0, 0.0, 0.0], cell_index=100,
+                             reload_time=0.0))
+        invalid_reload = self.state.submit_team_command(
+            1, self._message('RELOADINGGUN', sequence=2, reload_time=True))
+        invalid_quantity = self.state.submit_team_command(
+            1, self._message('RELOADING_READY_CASSETE', sequence=2,
+                             quantity=256))
+        invalid_aim = self.state.submit_team_command(
+            1, self._message('SPG_AIM_AREA', sequence=2,
+                             aim_point=[float('nan'), 0.0, 0.0], cell_index=0,
+                             reload_time=0.0))
+
+        self.assertFalse(invalid['accepted'])
+        self.assertEqual('invalid_cell', invalid['code'])
+        self.assertEqual('invalid_reload_time', invalid_reload['code'])
+        self.assertEqual('invalid_quantity', invalid_quantity['code'])
+        self.assertEqual('invalid_aim_point', invalid_aim['code'])
 
     def test_threatened_bot_ids_are_cleaned_without_rejecting_contact(self):
         relay = self.state.update_bot_observation(


### PR DESCRIPTION
Team text never reached the offline battle mailbox, and minimap pings were rejected when no Bot could accept an order. This change connects the stock team-chat UI and all 18 fixed battle messages to reliable same-team broadcasts. Human teammates can communicate independently from Bot participation; actionable commands also guide the improved Bot planner.

This draft is stacked on #53 (`fix/0922-ai-combat-decisions`). Merge that prerequisite first, then retarget this PR to `main`.

- Initialize stock arena channels after Avatar GUI readiness and complete the missing ignore-roster readiness event without clearing cached users or mute state. Close channels before GUI retirement. Delay local rejection callbacks until stock has registered the request ID.
- Relay team text, minimap cells, human-targeted ally messages, reload/cassette status, and SPG aim-area data. Preserve client-owned text normalization, incoming HTML escaping, cooldowns, and status values. Text and pings remain available during countdown and after the sender dies. Common/all-team text is outside the same-team service.
- Keep round-scoped sequences, reliable ordering, duplicate suppression, and separate engine IDs, LAN IDs, and account DBIDs. Stale rejections retain the request's round ID and cannot settle a new round's request. Invalid messages are contained locally. Text validation preserves Unicode across Python 2.7 and Python 3 without applying a different Unicode normalization database.
- Only actionable commands from living players enter the Bot planner. A named Bot is addressed directly; general requests select at most two. Social/status messages and commands addressed to human allies create no Bot order. Accepted Bot orders get a stock acknowledgement, expire after 15 seconds, and yield to urgent defense or survival.
- Resolve map requests to passable baked ground within the chosen cell and leave following space behind the player. Search vehicle-sized cover using observed gun origins, body exposure, gun envelopes, approach exposure, and checked return paths, under a shared native-query budget. Fix string cover IDs being rejected as integers by the worker.
- Rank exposed aim samples with the existing armor resolver and nominal damage, without consuming projectile RNG. Evaluate ready allied guns, incoming-lane evidence, damage saturation, and coordinated flank directions. Physically immobile vehicles cannot become reinforcement donors; yellow damage alone does not exclude them.

Validation for `6661e12732cef584444b415036150a38466f0bf6`:

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -p 'test_*.py'`: all 3,733 tests passed locally and in CI. This includes production TCP-handler tests with three peers, same-team isolation, sender echo, death/countdown behavior, replay suppression, invalid messages, and round transitions.
- Launcher suite: 480 tests run successfully, with 2 expected skips.
- All 93 client modules compile with CPython 2.7.18. Executed local archive code objects confirm Unicode handling, stock HTML escaping, and the ignore-roster receive gate.
- [CI for this exact commit](https://github.com/pengw0048/wot-offline-battles/actions/runs/33970031855) passed Windows server build/startup/protocol checks, the Python 2.7 client build, validation of 107 package members, and Windows launcher build/startup checks. The [push run](https://github.com/pengw0048/wot-offline-battles/actions/runs/33970030298) also passed.

The cover search examines the focus plus one additional observed enemy direction and rotates a bounded local candidate fan. Aim ranking compares at most two samples per existing lane job. These bounds do not establish Windows frame pacing or complete tactical awareness.

The loose local `scripts.pkg` was inspected with Python 2.7 marshal/dis. `tools/inspect_client.py` cannot certify a full client because the available root lacks regional metadata and the installed resource layout. Native acceptance remains outstanding on Chinese HD 0.9.22.0.1 #1513: two-client text display, minimap flashes, stock markers/sounds, repeated battle entry/exit, cover/following behavior, and frame pacing. This remains a draft, without a release or gameplay acceptance claim.
