### PR TITLE
Advance projectile visuals with stock native ballistics

### DIFF
--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -1194,13 +1194,41 @@ the authority manifest arrived.
 
 The exact relative-aim call treats the point as relative coordinates. Stopping
 gun tracking reconstructs world aim from the current hull yaw. A local shot
-uses the public `gunRotator.getCurShotPosition()` boundary, performs client
-map/vehicle collision and armor checks, and reports the proposed hit to the
-server. The echoed server shot event calls `Vehicle.showShooting()` with the
+freezes the public `gunRotator.getCurShotPosition()` ray in its fire intent;
+the hidden worker performs map/vehicle collision and armour checks and reports
+the proposed result to the server. The echoed shot event calls
+`Vehicle.showShooting()` with the
 descriptor's positive `gun.burst[0]` and the authoritative flag. Exact #1513
 then cancels the local Avatar's shot-wait callback; zero is not a single-shot
 sentinel and leaves the native firing extra unbounded. Remote events use the
 same finite presentation without claiming prediction.
+
+Canonical shell visuals use the stock #1513 `ProjectileMover` after the worker's
+launch is admitted. `PlayerAvatar.__startWaitingForShot` still owns the stock
+120--200 ms predicted-muzzle timeout; a tracer starts only from the canonical
+launch or an active snapshot, with the admitted muzzle/velocity and the current
+on-screen `HP_gunFire` as stock's separate, 20 m-guarded visual start. A late
+first snapshot seeds the checked trajectory pose. Once started, the stock
+`PyBallisticsSimulator` motor owns cosmetic flight: progress snapshots neither
+clamp nor rewrite it, and no Python Servo competes for its pose. The worker
+continues to own every collision, damage, ricochet and terminal verdict.
+
+The presenter binds the mover to the loaded space before `add`, reserves its
+logical shot identity before native creation can re-enter, and deduplicates that
+identity even if the native motor expires before the worker result. Canonical
+rows disable stock `fireMissedTrigger`; their `__notifyProjectileHit` path is
+scoped out so only the worker terminal emits the existing input/flock/missed
+feedback once. Terminal events call stock `hide` or `explode`, while a ricochet
+retires the old native id and starts a new one with stock `hold`. `hide` owns its
+negative-id row and particle tail; capacity counts both active and tail rows
+without detaching a live native motor. A late world terminal can use stock's
+unknown-id explosion without recreating a tracer. Round reset and teardown
+destroy the mover before forgetting its ids. A failed native teardown retains
+that owner and stops further cosmetic admission. The ABI/lifecycle audits pin
+the relevant calls and private-row consumers. Exact Windows acceptance must
+still establish native rendering, collision appearance, tail lifetime, late
+terminal correction and frame pacing; local tests only establish the adapter's
+ownership and worker-authority boundaries.
 
 A hit vehicle also receives retail's hull shot impulse. Exact #1513
 `Vehicle.showDamageFromShot` builds the first decoded hit point's world-space

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -9831,7 +9831,6 @@ class BattleRuntime(object):
                 'trigger': float(pending.get('sent_wall', now_wall)),
                 'shown': None,
                 'cursor_logs': 0,
-                'moving_logged': False,
             })
         self._local_fire_intent = None
         return True
@@ -9994,9 +9993,9 @@ class BattleRuntime(object):
                         ('_offlineLANShotMaxDistance',
                          event.get('maxDistance')),
                         ('_offlineLANProjectileID', projectile_id),
-                        # RemoteVehicle.showShooting still owns the muzzle and
-                        # recoil call.  The factory-backed controlled tracer
-                        # above is the sole flight owner.
+                        # RemoteVehicle.showShooting owns muzzle and recoil.
+                        # The factory-backed native tracer above is the sole
+                        # cosmetic flight owner.
                         ('_offlineLANCanonicalTracerOwned', True)):
                     setattr(entity, name, value)
                     transient_names.append(name)
@@ -10065,7 +10064,7 @@ class BattleRuntime(object):
         if self._projectile_epoch == epoch:
             return True
         # An authority epoch fences every projectile presentation as well as
-        # its simulator state.  Drop the old controlled tracers without using
+        # its simulator state.  Drop the old native tracers without using
         # their terminal path: a worker handoff is neither a hit nor a miss
         # and must not emit impact feedback or a world explosion.
         self._reset_projectile_visuals()
@@ -11033,7 +11032,7 @@ class BattleRuntime(object):
 
     def _ensure_projectile_visual(self, normalized, now,
                                   visual_start=None):
-        """Create one tracer and monotonically extend its confirmed frontier."""
+        """Start one native visual per segment, independent of cursor cadence."""
         if self._worker_mode:
             return False
         if self._remote_factory is None or not isinstance(normalized, dict):
@@ -11042,10 +11041,9 @@ class BattleRuntime(object):
         if projectile_id in self._projectile_visual_terminals:
             return False
         confirmed_elapsed = self._projectile_visual_age(normalized)
-        existing_visual = self._projectile_visual_meta.get(
-            projectile_id)
-        if (existing_visual is not None and
-                int(existing_visual.get('ricochet_count', 0)) !=
+        visual = self._projectile_visual_meta.get(projectile_id)
+        if (visual is not None and
+                int(visual.get('ricochet_count', 0)) !=
                 normalized['ricochet_count']):
             meta = self._projectile_meta.get(projectile_id)
             if meta is not None:
@@ -11053,79 +11051,39 @@ class BattleRuntime(object):
             self._stop_projectile_visual(
                 projectile_id, {
                     'impact': list(normalized['segment_origin']),
-                    'resolved_time_ms': normalized[
-                        'segment_start_time_ms'],
+                    'resolved_time_ms': normalized['segment_start_time_ms'],
                 })
-            existing_visual = None
-        elif existing_visual is not None:
-            # Snapshots may be duplicated or arrive after an older one.  They
-            # can only move the display fence forward and must never relaunch
-            # a tracer that this canonical segment already owns. A failed
-            # initial creation owns no resource, so it may retry at the newest
-            # confirmed pose without manufacturing an unconfirmed flight.
-            existing_visual['confirmed_elapsed'] = max(
-                float(existing_visual.get('confirmed_elapsed', 0.0)),
-                confirmed_elapsed)
+            visual = None
+        elif visual is not None:
+            # Only a failed initial creation may try the newest checked pose.
+            # A running (or naturally expired) native tracer owns its complete
+            # visual flight until the worker sends a terminal or ricochet.
             timeline = self._fire_timeline.get(str(projectile_id))
-            if (timeline is not None and
-                    timeline.get('shown') is not None and
+            if (timeline is not None and timeline.get('shown') is not None and
                     int(timeline.get('cursor_logs', 0)) < 8):
-                timeline['cursor_logs'] = int(
-                    timeline.get('cursor_logs', 0)) + 1
-                wall = _PROFILE_CLOCK()
+                timeline['cursor_logs'] = int(timeline.get('cursor_logs', 0)) + 1
                 sys.stdout.write(
                     '[Offline LAN 0.9.22] FIRE CURSOR projectile=%s '
-                    'confirmed_ms=%.0f display_ms=%.0f '
+                    'confirmed_ms=%.0f native_started=%d '
                     'since_trigger_ms=%.0f\n' % (
-                        projectile_id,
-                        existing_visual['confirmed_elapsed'] * 1000.0,
-                        float(existing_visual.get(
-                            'display_elapsed', 0.0)) * 1000.0,
-                        max(0.0, wall - timeline['trigger']) * 1000.0))
-            if (existing_visual.get('active', False) and
-                    existing_visual.get('first_frontier_pending', False)):
-                if existing_visual['confirmed_elapsed'] <= 0.0:
-                    return True
-                return self._catch_up_first_projectile_frontier(
-                    projectile_id, existing_visual, now)
-            if (existing_visual.get('active', False) or
-                    not existing_visual.get('admitted', True) or
-                    not existing_visual.get('launch_retryable', False)):
-                return bool(existing_visual.get('active', False))
-
+                        projectile_id, confirmed_elapsed * 1000.0,
+                        int(bool(visual.get('active'))),
+                        max(0.0, _PROFILE_CLOCK() -
+                            timeline['trigger']) * 1000.0))
+            if (visual.get('active', False) or
+                    not visual.get('admitted', True)):
+                return bool(visual.get('active', False))
         descriptor = self._projectile_source_descriptor(normalized)
         if descriptor is None:
             return False
-        gravity = normalized['gravity']
-        if existing_visual is None:
-            display_elapsed = confirmed_elapsed
+        if visual is None:
             visual = {
                 'origin': tuple(normalized['segment_origin']),
                 'velocity': tuple(normalized['segment_velocity']),
-                'gravity': gravity,
-                'segment_start_time_ms': normalized[
-                    'segment_start_time_ms'],
+                'gravity': normalized['gravity'],
+                'segment_start_time_ms': normalized['segment_start_time_ms'],
                 'ricochet_count': normalized['ricochet_count'],
-                'display_elapsed': display_elapsed,
-                'confirmed_elapsed': confirmed_elapsed,
-                'last_frame': float(now),
                 'active': False,
-                'launch_retryable': True,
-                'first_frontier_pending': bool(
-                    normalized['ricochet_count'] == 0 and
-                    confirmed_elapsed <= 0.0),
-                'visual_start': (
-                    tuple(visual_start) if
-                    normalized['ricochet_count'] == 0 and
-                    confirmed_elapsed <= 0.0 and
-                    visual_start is not None else None),
-                'first_frontier_min_distance_sq': (
-                    sum((float(visual_start[index]) -
-                         float(normalized['segment_origin'][index])) ** 2
-                        for index in range(3)) if
-                    normalized['ricochet_count'] == 0 and
-                    confirmed_elapsed <= 0.0 and
-                    visual_start is not None else 0.0),
             }
             self._projectile_visual_meta[projectile_id] = visual
             record = self._records.get('%s:%s' % (
@@ -11133,201 +11091,51 @@ class BattleRuntime(object):
             attacker_id = int(record.get('engine_id', 0) or 0) \
                 if record is not None else 0
             if attacker_id <= 0:
-                # Presentation attribution survives a disconnected shooter;
-                # its canonical network id is still stable for this shot.
                 attacker_id = int(normalized['shooter_id'])
             visual['attacker_id'] = attacker_id
             visual['admitted'] = self._admit_projectile_visual(
                 attacker_id, projectile_id, now)
-        else:
-            visual = existing_visual
-            display_elapsed = float(visual['confirmed_elapsed'])
-            visual['display_elapsed'] = display_elapsed
-            visual['last_frame'] = float(now)
-            attacker_id = int(visual['attacker_id'])
-            if display_elapsed > 0.0:
-                # A failed zero-age creation owns no native tracer. Retry at
-                # the confirmed trajectory pose instead of a stale muzzle.
-                visual['first_frontier_pending'] = False
-                visual['visual_start'] = None
-                visual['first_frontier_min_distance_sq'] = 0.0
-
-        admitted = bool(visual.get('admitted', True))
-        if not admitted:
+        if (not visual.get('admitted', True) or
+                not self._optional_feature_enabled('projectile visual launch')):
             return False
-        if not self._optional_feature_enabled('projectile visual launch'):
-            return False
+        # A late first snapshot starts at its checked trajectory pose. Once
+        # installed, stock PyBallisticsSimulator advances the motor locally;
+        # checked_through_ms is no longer a per-frame presentation fence.
+        gravity = normalized['gravity']
         reference_origin = trajectory_position(
             normalized['segment_origin'], normalized['segment_velocity'],
-            (0.0, -gravity, 0.0), display_elapsed)
+            (0.0, -gravity, 0.0), confirmed_elapsed)
         reference_velocity = (
             normalized['segment_velocity'][0],
-            normalized['segment_velocity'][1] - gravity * display_elapsed,
+            normalized['segment_velocity'][1] - gravity * confirmed_elapsed,
             normalized['segment_velocity'][2])
+        if confirmed_elapsed > 0.0 or normalized['ricochet_count']:
+            visual_start = None
         try:
             visual['active'] = bool(
                 self._remote_factory.play_projectile_tracer(
-                descriptor, normalized['shell_index'],
-                normalized['segment_origin'],
-                normalized['segment_velocity'], gravity, max(
-                    0.001, normalized['max_distance'] -
-                    normalized['checked_distance']),
-                attacker_id, projectile_id, reference_origin,
-                reference_velocity,
-                is_ricochet=bool(normalized['ricochet_count']),
-                visual_start=visual.get('visual_start')))
-            visual['launch_retryable'] = not visual['active']
+                    descriptor, normalized['shell_index'],
+                    normalized['segment_origin'],
+                    normalized['segment_velocity'], gravity, max(
+                        0.001, normalized['max_distance'] -
+                        normalized['checked_distance']),
+                    visual['attacker_id'], projectile_id, reference_origin,
+                    reference_velocity,
+                    is_ricochet=bool(normalized['ricochet_count']),
+                    visual_start=visual_start))
+            timeline = self._fire_timeline.get(str(projectile_id))
+            if visual['active'] and timeline is not None:
+                # This records the hand-off, not the unobserved native frame
+                # at which a particle first becomes visible on Windows.
+                sys.stdout.write(
+                    '[Offline LAN 0.9.22] FIRE TRACER STARTED '
+                    'projectile=%s since_trigger_ms=%.0f path=native\n' % (
+                        projectile_id, max(0.0, _PROFILE_CLOCK() -
+                            timeline['trigger']) * 1000.0))
             return visual['active']
         except Exception as error:
-            self._warn_optional_failure(
-                'projectile visual launch', error)
+            self._warn_optional_failure('projectile visual launch', error)
             return False
-
-    def _catch_up_first_projectile_frontier(self, projectile_id, visual,
-                                             now):
-        """Move a muzzle-started tracer once its safe cursor clears the bridge."""
-        if (not visual.get('active', False) or
-                not visual.get('first_frontier_pending', False)):
-            return bool(visual.get('active', False))
-        confirmed_elapsed = max(
-            0.0, float(visual.get('confirmed_elapsed', 0.0)))
-        if confirmed_elapsed <= 0.0:
-            visual['last_frame'] = max(
-                float(visual.get('last_frame', now)), float(now))
-            return True
-        callback = getattr(
-            self._remote_factory, 'update_projectile_visual', None)
-        if (not callable(callback) or not self._optional_feature_enabled(
-                'projectile visual update')):
-            return True
-        position, velocity = self._projectile_visual_pose(
-            visual, confirmed_elapsed)
-        origin = visual['origin']
-        confirmed_distance_sq = sum(
-            (float(position[index]) - float(origin[index])) ** 2
-            for index in range(3))
-        if (confirmed_distance_sq + 1.0e-9 < float(visual.get(
-                'first_frontier_min_distance_sq', 0.0))):
-            # A very fast tank and a very early worker receipt can put the
-            # first safe cursor behind the current-muzzle bridge. Keep the
-            # tracer at that muzzle until the canonical path is at least as
-            # far from the stale launch origin; never visibly snap back to it.
-            visual['last_frame'] = max(
-                float(visual.get('last_frame', now)), float(now))
-            return True
-        try:
-            visible = bool(callback(
-                projectile_id, position, velocity=velocity))
-        except Exception as error:
-            self._warn_optional_failure(
-                'projectile visual update', error)
-            visible = False
-        if not visible:
-            visual['active'] = False
-            visual['launch_retryable'] = False
-            return False
-        visual['display_elapsed'] = confirmed_elapsed
-        visual['last_frame'] = float(now)
-        visual['first_frontier_pending'] = False
-        visual['visual_start'] = None
-        visual['first_frontier_min_distance_sq'] = 0.0
-        timeline = self._fire_timeline.get(str(projectile_id))
-        if (timeline is not None and timeline.get('shown') is not None and
-                not timeline.get('moving_logged', False)):
-            timeline['moving_logged'] = True
-            wall = _PROFILE_CLOCK()
-            sys.stdout.write(
-                '[Offline LAN 0.9.22] FIRE TRACER MOVING '
-                'projectile=%s since_trigger_ms=%.0f '
-                'since_shown_ms=%.0f confirmed_ms=%.0f\n' % (
-                    projectile_id,
-                    max(0.0, wall - timeline['trigger']) * 1000.0,
-                    max(0.0, wall - timeline['shown']) * 1000.0,
-                    confirmed_elapsed * 1000.0))
-        return True
-
-    @staticmethod
-    def _projectile_visual_pose(visual, elapsed=None):
-        """Return the controlled position and velocity at one segment age."""
-        if elapsed is None:
-            elapsed = float(visual.get('display_elapsed', 0.0))
-        gravity = float(visual['gravity'])
-        position = trajectory_position(
-            visual['origin'], visual['velocity'],
-            (0.0, -gravity, 0.0), elapsed)
-        velocity = (
-            visual['velocity'][0],
-            visual['velocity'][1] - gravity * elapsed,
-            visual['velocity'][2])
-        return position, velocity
-
-    def _advance_projectile_visuals(self, now):
-        """Advance visible tracers without crossing a confirmed worker cursor."""
-        if (self._worker_mode or self._remote_factory is None or
-                not self._projectile_visual_meta or
-                not self._optional_feature_enabled(
-                    'projectile visual update')):
-            return False
-        callback = getattr(
-            self._remote_factory, 'update_projectile_visual', None)
-        if not callable(callback):
-            return False
-        frame = float(now)
-        advanced = False
-        for projectile_id, visual in tuple(
-                self._projectile_visual_meta.items()):
-            if (not visual.get('active', False) or
-                    not visual.get('admitted', True)):
-                continue
-            previous_frame = float(visual.get('last_frame', frame))
-            if visual.get('first_frontier_pending', False):
-                if self._catch_up_first_projectile_frontier(
-                        projectile_id, visual, frame):
-                    advanced = advanced or not visual.get(
-                        'first_frontier_pending', False)
-                continue
-            dt = max(0.0, frame - previous_frame)
-            visual['last_frame'] = max(previous_frame, frame)
-            previous_elapsed = max(
-                0.0, float(visual.get('display_elapsed', 0.0)))
-            confirmed_elapsed = max(
-                previous_elapsed,
-                float(visual.get('confirmed_elapsed', previous_elapsed)))
-            display_elapsed = min(
-                previous_elapsed + dt, confirmed_elapsed)
-            visual['display_elapsed'] = display_elapsed
-            position, velocity = self._projectile_visual_pose(
-                visual, display_elapsed)
-            try:
-                visible = bool(callback(
-                    projectile_id, position, velocity=velocity))
-            except Exception as error:
-                self._warn_optional_failure(
-                    'projectile visual update', error)
-                visible = False
-            if not visible:
-                # A lost native resource must not be recreated from a later
-                # snapshot at a different point in the same segment.
-                visual['active'] = False
-                visual['launch_retryable'] = False
-                continue
-            if display_elapsed > previous_elapsed:
-                timeline = self._fire_timeline.get(str(projectile_id))
-                if (timeline is not None and
-                        timeline.get('shown') is not None and
-                        not timeline.get('moving_logged', False)):
-                    timeline['moving_logged'] = True
-                    wall = _PROFILE_CLOCK()
-                    sys.stdout.write(
-                        '[Offline LAN 0.9.22] FIRE TRACER MOVING '
-                        'projectile=%s since_trigger_ms=%.0f '
-                        'since_shown_ms=%.0f confirmed_ms=%.0f\n' % (
-                            projectile_id,
-                            max(0.0, wall - timeline['trigger']) * 1000.0,
-                            max(0.0, wall - timeline['shown']) * 1000.0,
-                            confirmed_elapsed * 1000.0))
-            advanced = advanced or display_elapsed > previous_elapsed
-        return advanced
 
     def _reset_projectile_visuals(self):
         """Fence an epoch change without manufacturing terminal feedback."""
@@ -11955,7 +11763,6 @@ class BattleRuntime(object):
         self._projectile_perf = {}
         self._projectile_scan_count = 0
         self._projectile_candidate_count = 0
-        self._advance_projectile_visuals(now)
         if self._projectiles is None:
             return False
         self._flush_pending_projectile_resolutions()

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/entities/native_remote_vehicle.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/entities/native_remote_vehicle.py
@@ -1071,12 +1071,6 @@ class NativeRemoteVehicleFactory(object):
         return self._shot_presenter.stop_canonical(
             projectile_id, end_position, explosion, missed)
 
-    def update_projectile_visual(self, projectile_id, position,
-                                 velocity=None):
-        """Move a tracer to the latest hidden-worker-confirmed cursor."""
-        return self._shot_presenter.update_canonical(
-            projectile_id, position, velocity)
-
     def reset_projectile_visuals(self):
         """Release the old epoch's visuals while keeping the factory live."""
         return self._shot_presenter.reset_canonical()

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/entities/remote_vehicle.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/entities/remote_vehicle.py
@@ -320,14 +320,9 @@ class _RemoteShotPresenter(object):
     """Shared #1513 tracer and gun-recoil resources for remote vehicles.
 
     Muzzle flash and shot sound stay on the stock ``ShowShooting`` extra.
-    Canonical projectile motion is already resolved by the hidden worker, so
-    its tracer is a stock projectile model attached to a ``BigWorld.Servo``
-    over a Python-owned matrix.  Only authoritative positions may move that
-    matrix.  ``ProjectileMover`` remains a lazy owner for its reviewed
-    unknown-id world-explosion path and the non-ledgered legacy presentation
-    fallback; canonical tank and SPG shell tracers never enter its native
-    free-running ballistics simulator. Combat-equipment artillery descriptors
-    are outside the standard-battle catalog and fail closed on this ledger.
+    ProjectileMover owns continuous cosmetic flight after an admitted launch.
+    The hidden worker retains collision, damage and terminal authority; its
+    progress receipts never reposition a running native motor.
     """
 
     _STOCK_VISUAL_START_MAX_DIFF = PROJECTILE_VISUAL_START_MAX_DIFF
@@ -338,9 +333,6 @@ class _RemoteShotPresenter(object):
     _VISUAL_REFILL_PER_SECOND = 5.0
     _MAX_ACTIVE_PER_ATTACKER = 24
     _MAX_ACTIVE_TOTAL = 128
-    # Stock ProjectileMover keeps the stopped projectile effect alive for
-    # this long before detachAllFrom/delMotor/delModel.
-    _TERMINAL_TAIL_SECONDS = 2.0
 
     def __init__(self, bigworld, math_module, model_assembler, space_id):
         self._bigworld = bigworld
@@ -350,9 +342,6 @@ class _RemoteShotPresenter(object):
         self._mover = None
         self._next_shot_id = 1000000
         self._projectile_shots = {}
-        self._projectile_order = []
-        self._projectile_tails = {}
-        self._projectile_tail_order = []
         self._visual_budgets = {}
         self._visual_admissions = {}
         self._failure_stages = set()
@@ -398,6 +387,8 @@ class _RemoteShotPresenter(object):
                 self._VISUAL_BURST_CAPACITY,
                 tokens + elapsed * self._VISUAL_REFILL_PER_SECOND)
         admitted = tokens >= 1.0 - 1.0e-9
+        if admitted and key is not None and self._mover is not None:
+            admitted = self._ensure_visual_capacity(self._mover, attacker_id)
         if admitted:
             tokens = max(0.0, tokens - 1.0)
         self._visual_budgets[attacker_id] = (tokens, moment)
@@ -549,350 +540,120 @@ class _RemoteShotPresenter(object):
                        projectile_id=None, reference_position=None,
                        reference_velocity=None, is_ricochet=False,
                        visual_start=None):
-        """Create one tracer whose pose is owned by authoritative updates.
+        """Start one stock native tracer from the admitted launch segment.
 
-        The origin and velocity belong to the authoritative launch event.
-        They must never be recomputed from the vehicle's presentation pose,
-        which may already have advanced by the time a relay event arrives.
-        ``reference_position`` and ``reference_velocity`` are the latest
-        hidden-worker-confirmed cursor when a launch arrives late.  No
-        ballistic motor is created here, so the tracer cannot run ahead of
-        that cursor while the next collision receipt is pending.
-        ``visual_start`` is the separate current-muzzle pose used by stock
-        #1513 presentation; its exact 20 m guard never changes the launch or
-        confirmed-reference trajectory.
+        The worker still owns collision and every terminal verdict. After this
+        call, ProjectileMover owns the visual motor; later progress receipts
+        cannot pause, rewind or restart it. A late first snapshot supplies the
+        checked reference pose, while the launch event may use the current
+        on-screen muzzle as stock's separate startPoint.
         """
         if self._closed or not self._launches_enabled:
             return False
         shot = self._shot_at(descriptor, shell_index)
         shell = _component_value(shot, 'shell')
         effects_index = _component_value(shell, 'effectsIndex')
-        if shot is None or shell is None or effects_index is None:
-            return False
-        launch_start = self._finite_vector(origin)
-        reference_start = (
-            launch_start if reference_position is None else
-            self._finite_vector(reference_position))
-        requested_visual_start = self._finite_vector(visual_start)
-        if requested_visual_start is not None and reference_start is not None:
-            try:
-                offset_sq = sum(
-                    (getattr(requested_visual_start, name) -
-                     getattr(reference_start, name)) ** 2
-                    for name in ('x', 'y', 'z'))
-                if offset_sq > self._STOCK_VISUAL_START_MAX_DIFF ** 2:
-                    # Exact #1513 ProjectileMover.add falls all the way back
-                    # to refStartPoint; it does not clamp the offset to 20 m.
-                    requested_visual_start = reference_start
-            except Exception:
-                requested_visual_start = reference_start
-        initial_position = (reference_start if requested_visual_start is None
-                            else requested_visual_start)
-        visual_velocity = self._finite_vector(
+        reference_start = self._finite_vector(
+            origin if reference_position is None else reference_position)
+        reference_speed = self._finite_vector(
             velocity if reference_velocity is None else reference_velocity)
+        start = (reference_start if visual_start is None else
+                 self._finite_vector(visual_start))
         gravity = self._finite_float(gravity)
         maximum = self._finite_float(max_distance)
         try:
             attacker_id = int(attacker_id)
+            projectile_id = (str(projectile_id)
+                             if projectile_id is not None else '')
         except (TypeError, ValueError, OverflowError):
             return False
-        if projectile_id is None:
-            return False
-        try:
-            projectile_id = str(projectile_id)
-        except Exception:
-            return False
-        if not projectile_id or len(projectile_id) > 128:
+        if (shot is None or shell is None or effects_index is None or
+                reference_start is None or reference_speed is None or
+                start is None or gravity is None or maximum is None or
+                gravity < 0.0 or maximum <= 0.0 or attacker_id <= 0 or
+                not projectile_id or len(projectile_id) > 128):
             return False
         existing = self._projectile_shots.get(projectile_id)
         if existing is not None:
-            if not existing.get('creation_failed', False):
-                return existing['visual_id']
-            try:
-                released = self._release_controlled(existing)
-            except Exception as error:
-                released = False
-                self._report_failure(
-                    'failed tracer creation cleanup retry', error)
-            if not released:
-                return False
-            self._remove_projectile_mapping(projectile_id)
-        if (launch_start is None or reference_start is None or
-                initial_position is None or
-                visual_velocity is None or gravity is None or
-                maximum is None or gravity < 0.0 or maximum <= 0.0 or
-                attacker_id <= 0):
-            return False
-        entry = None
+            return (existing['visual_id'] if existing.get('started') and
+                    not existing.get('terminal_failed') else False)
         try:
             from items import vehicles
             effects_descr = vehicles.g_cache.shotEffects[effects_index]
             if effects_descr is None:
                 return False
-            try:
-                artillery = effects_descr.get('artilleryID') is not None
-            except AttributeError:
-                return False
-            if artillery:
-                # #1513 builds artilleryID only for the Env_Artillery/strike
-                # effect family, which the standard-battle catalog excludes.
-                # PySalvo exposes neither a confirmed-pose update nor a
-                # per-projectile stop boundary, so never admit one onto the
-                # canonical ledger. Ordinary tank and SPG effects provide the
-                # controllable projectile tuple handled below.
+            if effects_descr.get('artilleryID') is not None:
+                # PySalvo has no reviewed per-shot terminal boundary. The
+                # standard tank/SPG catalog uses the ordinary projectile tuple.
                 self._visual_admissions.pop(projectile_id, None)
                 self._report_failure(
                     'canonical combat-equipment artillery rejected')
                 return False
-            try:
-                projectile = effects_descr['projectile']
-                model_name, own_model_name, projectile_effects = projectile
-            except (KeyError, TypeError, ValueError):
+            if not self.admit_visual(attacker_id, projectile_id):
                 return False
-            attach = getattr(projectile_effects, 'attachTo', None)
-            detach = getattr(projectile_effects, 'detachFrom', None)
-            detach_all = getattr(projectile_effects, 'detachAllFrom', None)
-            if (not callable(attach) or not callable(detach) or
-                    not callable(detach_all)):
+            mover = self._projectile_mover()
+            if mover is None or not self._ensure_visual_capacity(
+                    mover, attacker_id):
                 return False
+            visual_id = self._take_unused_shot_id(mover)
             player = self._bigworld.player()
-            add_model = getattr(player, 'addModel', None)
-            del_model = getattr(player, 'delModel', None)
-            model_factory = getattr(self._bigworld, 'Model', None)
-            servo_factory = getattr(self._bigworld, 'Servo', None)
-            if (player is None or not callable(add_model) or
-                    not callable(del_model) or not callable(model_factory) or
-                    not callable(servo_factory)):
+            camera = self._bigworld.camera()
+            camera_position = self._finite_vector(camera.position)
+            if camera_position is None:
                 return False
-            try:
-                player_vehicle_id = int(player.playerVehicleID)
-            except (AttributeError, TypeError, ValueError, OverflowError):
-                player_vehicle_id = 0
-            own_shot = attacker_id == player_vehicle_id
-            selected_name = own_model_name if own_shot else model_name
-            if not selected_name:
-                return False
-            if (not self.admit_visual(attacker_id, projectile_id) or
-                    not self._ensure_visual_capacity(attacker_id)):
-                return False
-            visual_id = self._next_shot_id
-            self._next_shot_id += 1
-            pose = self._math.Matrix()
-            self._write_projectile_pose(
-                pose, initial_position, visual_velocity)
-            model = model_factory(selected_name)
-            servo = servo_factory(pose)
             entry = {
                 'visual_id': visual_id,
-                'model': model,
-                'servo': servo,
-                'pose': pose,
                 'effects_descr': effects_descr,
-                'projectile_effects': projectile_effects,
-                'effects_data': {},
                 'attacker_id': attacker_id,
-                'position': initial_position,
-                'velocity': visual_velocity,
-                'in_scene': False,
-                'motor_attached': False,
-                'flying_attached': False,
-                'effects_cleared': False,
-                'kind': 'controlled',
-                'ricochet': bool(is_ricochet),
-                'own_shot': own_shot,
+                'own_shot': attacker_id == int(player.playerVehicleID),
                 'input_hit_notified': False,
                 'flock_hit_notified': False,
                 'missed_notified': False,
-                'creation_failed': False,
+                'started': False,
                 'terminal': False,
-                'release_scheduled': False,
             }
-            add_model(model)
-            entry['in_scene'] = True
-            model.addMotor(servo)
-            entry['motor_attached'] = True
-            # This matches stock ProjectileMover: the model mesh is hidden,
-            # while the attached ``flying`` effect owns the visible tracer.
-            model.visible = False
-            model.visibleAttachments = True
-            attach(
-                model, entry['effects_data'], 'flying',
-                isPlayerVehicle=own_shot, isArtillery=False)
-            entry['flying_attached'] = True
+            # Native addProjectile may re-enter Python. Publish the identity
+            # before entering stock, and retain it if partial creation fails.
             self._projectile_shots[projectile_id] = entry
-            self._projectile_order.append(projectile_id)
-            self._notify_projectile_launch(initial_position)
+            try:
+                mover.add(
+                    visual_id, effects_descr, gravity, reference_start,
+                    reference_speed, start, maximum, attacker_id,
+                    camera_position)
+            except Exception:
+                self._launches_enabled = False
+                raise
+            native = mover._ProjectileMover__projectiles.get(visual_id)
+            if native is None:
+                # Stock add returns before model creation when the native
+                # simulator refuses a projectile. No model needs retirement.
+                self._projectile_shots.pop(projectile_id, None)
+                self._report_failure('native add rejected')
+                return False
+            # Native range expiry is cosmetic, not an authoritative miss. The
+            # worker's terminal below owns input/flock and missed feedback.
+            native['fireMissedTrigger'] = False
+            native['_offlineLANCanonical'] = True
+            entry['started'] = True
+            if is_ricochet:
+                mover.hold(visual_id)
             return visual_id
         except Exception as error:
-            if entry is not None:
-                try:
-                    released = self._release_controlled(entry)
-                except Exception as cleanup_error:
-                    released = False
-                    self._report_failure(
-                        'failed tracer creation cleanup', cleanup_error)
-                if not released:
-                    entry['creation_failed'] = True
-                    self._projectile_shots[projectile_id] = entry
-                    if projectile_id not in self._projectile_order:
-                        self._projectile_order.append(projectile_id)
-            self._report_failure('controlled tracer creation', error)
+            self._report_failure('native tracer creation', error)
             return False
 
-    def _ensure_visual_capacity(self, attacker_id):
-        """Retire oldest visuals before scene resources grow unbounded."""
-        while True:
-            attacker_active = sum(
-                1 for entry in self._projectile_shots.values()
-                if entry.get('attacker_id') == attacker_id) + sum(
-                    1 for entry in self._projectile_tails.values()
-                    if entry.get('attacker_id') == attacker_id)
-            total_active = (
-                len(self._projectile_shots) + len(self._projectile_tails))
-            if (attacker_active < self._MAX_ACTIVE_PER_ATTACKER and
-                    total_active < self._MAX_ACTIVE_TOTAL):
-                return True
-            require_attacker = (
-                attacker_active >= self._MAX_ACTIVE_PER_ATTACKER)
-            tail_candidate = None
-            for visual_id in tuple(self._projectile_tail_order):
-                entry = self._projectile_tails.get(visual_id)
-                if entry is None:
-                    self._remove_tail_order(visual_id)
-                    continue
-                if (require_attacker and
-                        entry.get('attacker_id') != attacker_id):
-                    continue
-                tail_candidate = visual_id
-                break
-            if tail_candidate is not None:
-                if not self._retire_tail_for_pressure(tail_candidate):
-                    self._launches_enabled = False
-                    return False
-                continue
-            candidate = None
-            for projectile_id in tuple(self._projectile_order):
-                entry = self._projectile_shots.get(projectile_id)
-                if entry is None:
-                    self._remove_projectile_order(projectile_id)
-                    continue
-                if (require_attacker and
-                        entry.get('attacker_id') != attacker_id):
-                    continue
-                candidate = projectile_id
-                break
-            if candidate is None:
-                return False
-            if not self._retire_for_pressure(candidate):
-                # A failed scene teardown is the exact moment to stop adding
-                # cosmetic work. Authority continues without this presenter.
-                self._launches_enabled = False
-                return False
+    def _ensure_visual_capacity(self, mover, attacker_id):
+        """Count stock's active and negative-id tail owners before admission.
 
-    def _retire_tail_for_pressure(self, visual_id):
-        entry = self._projectile_tails.get(visual_id)
-        if entry is None:
-            self._remove_tail_order(visual_id)
-            return True
-        try:
-            released = self._release_controlled(entry)
-        except Exception as error:
-            released = False
-            self._report_failure('controlled tracer tail pressure', error)
-        if not released:
-            return False
-        self._remove_tail_mapping(visual_id)
-        return True
-
-    def _retire_for_pressure(self, projectile_id):
-        entry = self._projectile_shots.get(projectile_id)
-        if entry is None:
-            return True
-        if entry.get('kind') == 'controlled':
-            try:
-                released = self._release_controlled(entry)
-            except Exception as error:
-                released = False
-                self._report_failure(
-                    'controlled tracer active pressure', error)
-            if not released:
-                return False
-        attacker_id = entry.get('attacker_id', 0)
-        self._remove_projectile_mapping(projectile_id)
-        if attacker_id > 0:
-            self._visual_admissions[projectile_id] = (attacker_id, False)
-        return True
-
-    def _remove_projectile_mapping(self, projectile_id):
-        self._projectile_shots.pop(projectile_id, None)
-        self._remove_projectile_order(projectile_id)
-
-    def _remove_projectile_order(self, projectile_id):
-        try:
-            self._projectile_order.remove(projectile_id)
-        except ValueError:
-            pass
-
-    def _remove_tail_mapping(self, visual_id):
-        self._projectile_tails.pop(visual_id, None)
-        self._remove_tail_order(visual_id)
-
-    def _remove_tail_order(self, visual_id):
-        try:
-            self._projectile_tail_order.remove(visual_id)
-        except ValueError:
-            pass
-
-    def update_canonical(self, projectile_id, position, velocity=None):
-        """Move one tracer only to a hidden-worker-confirmed cursor."""
-        if self._closed or projectile_id is None:
-            return False
-        try:
-            projectile_id = str(projectile_id)
-        except Exception:
-            return False
-        entry = self._projectile_shots.get(projectile_id)
-        point = self._finite_vector(position)
-        if (entry is None or entry.get('kind') != 'controlled' or
-                entry.get('creation_failed', False) or
-                entry.get('terminal', False) or point is None):
-            return False
-        direction = entry.get('velocity')
-        if velocity is not None:
-            direction = self._finite_vector(velocity)
-            if direction is None:
-                return False
-        try:
-            self._write_projectile_pose(entry['pose'], point, direction)
-        except Exception as error:
-            self._report_failure('controlled tracer update', error)
-            return False
-        entry['position'] = point
-        entry['velocity'] = direction
-        return True
-
-    def _write_projectile_pose(self, pose, position, velocity):
-        """Write the stock projectile's +Z axis along its current velocity."""
-        if pose is None or position is None:
-            raise RuntimeError('controlled projectile pose is unavailable')
-        if velocity is not None and velocity.length > 1.0e-9:
-            horizontal = math.sqrt(
-                velocity.x * velocity.x + velocity.z * velocity.z)
-            yaw = math.atan2(velocity.x, velocity.z)
-            pitch = -math.atan2(velocity.y, horizontal)
-            pose.setRotateYPR((yaw, pitch, 0.0))
-        pose.translation = position
-
-    def _notify_projectile_launch(self, position):
-        """Preserve the stock projectile disturbance notification."""
-        try:
-            import FlockManager
-            manager = FlockManager.getManager()
-            callback = getattr(manager, 'onProjectile', None)
-            if callable(callback):
-                callback(position)
-        except Exception as error:
-            self._report_failure('projectile launch notification', error)
+        Native expiry frees capacity through ProjectileMover's own callback.
+        Do not detach a live native motor or reset unrelated shots to make
+        room for another cosmetic resource.
+        """
+        native = mover._ProjectileMover__projectiles
+        return (len(native) < self._MAX_ACTIVE_TOTAL and sum(
+            1 for entry in native.values()
+            if entry.get('attackerID') == attacker_id) <
+            self._MAX_ACTIVE_PER_ATTACKER)
 
     def _notify_projectile_hit(self, entry, position):
         """Preserve #1513 input and flock feedback before visual teardown."""
@@ -944,270 +705,100 @@ class _RemoteShotPresenter(object):
             self._report_failure('projectile miss notification', error)
             return False
 
-    def _release_controlled(self, entry):
-        """Detach every controlled tracer owner in a retry-safe order."""
-        effects = entry.get('projectile_effects')
-        data = entry.get('effects_data')
-        model = entry.get('model')
-        servo = entry.get('servo')
-        if entry.get('flying_attached'):
-            callback = getattr(effects, 'detachFrom', None)
-            if not callable(callback):
-                return False
-            callback(data, 'stopFlying')
-            entry['flying_attached'] = False
-        if not entry.get('effects_cleared'):
-            callback = getattr(effects, 'detachAllFrom', None)
-            if not callable(callback):
-                return False
-            callback(data, False)
-            entry['effects_cleared'] = True
-        if entry.get('motor_attached'):
-            callback = getattr(model, 'delMotor', None)
-            if not callable(callback):
-                return False
-            callback(servo)
-            entry['motor_attached'] = False
-        if entry.get('in_scene'):
-            player = self._bigworld.player()
-            callback = getattr(player, 'delModel', None)
-            if not callable(callback):
-                return False
-            callback(model)
-            entry['in_scene'] = False
-        return True
-
-    def _schedule_controlled_release(self, entry):
-        """Keep the stopped stock effect for its reviewed two-second tail."""
-        if entry.get('release_scheduled', False):
-            return True
-        visual_id = entry['visual_id']
-        callback = getattr(self._bigworld, 'callback', None)
-        if not callable(callback):
-            self._launches_enabled = False
-            self._report_failure(
-                'controlled tracer tail scheduling', RuntimeError(
-                    '#1513 BigWorld.callback is unavailable'))
-            return False
-
-        def release():
-            current = self._projectile_tails.get(visual_id)
-            if current is not entry:
-                return
-            entry['release_scheduled'] = False
-            try:
-                released = self._release_controlled(entry)
-            except Exception as error:
-                released = False
-                self._report_failure(
-                    'controlled tracer tail cleanup', error)
-            if released:
-                self._remove_tail_mapping(visual_id)
-            else:
-                # A retained scene owner cannot be bounded safely by later
-                # cosmetic work. Battle authority remains unaffected.
-                self._launches_enabled = False
-
-        entry['release_scheduled'] = True
-        try:
-            callback(self._TERMINAL_TAIL_SECONDS, release)
-        except Exception as error:
-            entry['release_scheduled'] = False
-            self._launches_enabled = False
-            self._report_failure(
-                'controlled tracer tail scheduling', error)
-            return False
-        return True
-
-    def reset_canonical(self, recycle_mover=True):
-        """Release one epoch's visuals without permanently closing us.
-
-        Controlled tracers are detached individually. The lazy stock mover is
-        also recycled to retire its tracked legacy ballistics and callbacks;
-        a later legacy shot or world explosion creates a fresh space-bound
-        mover. This does not claim a per-shot stop contract for PySalvo,
-        which never enters the canonical projectile ledger.
-        """
-        failed = False
-        for projectile_id in tuple(self._projectile_order):
-            entry = self._projectile_shots.get(projectile_id)
-            if entry is None:
-                self._remove_projectile_order(projectile_id)
-                continue
-            if entry.get('kind') != 'controlled':
-                self._remove_projectile_mapping(projectile_id)
-                continue
-            try:
-                released = self._release_controlled(entry)
-            except Exception as error:
-                released = False
-                self._report_failure('controlled tracer reset', error)
-            if released:
-                self._remove_projectile_mapping(projectile_id)
-            else:
-                failed = True
-        for visual_id in tuple(self._projectile_tail_order):
-            entry = self._projectile_tails.get(visual_id)
-            if entry is None:
-                self._remove_tail_order(visual_id)
-                continue
-            try:
-                released = self._release_controlled(entry)
-            except Exception as error:
-                released = False
-                self._report_failure('controlled tracer tail reset', error)
-            if released:
-                self._remove_tail_mapping(visual_id)
-            else:
-                failed = True
+    def reset_canonical(self):
+        """Destroy the old native simulator before forgetting its shot IDs."""
         mover = self._mover
-        if recycle_mover and mover is not None:
-            callback = getattr(mover, 'destroy', None)
-            if not callable(callback):
-                failed = True
-            else:
-                try:
-                    callback()
-                except Exception as error:
-                    failed = True
-                    self._report_failure('projectile mover reset', error)
-                else:
-                    self._mover = None
-        if not failed:
-            self._visual_budgets = {}
-            self._visual_admissions = {}
-        else:
-            # Retained native owners cannot be correlated safely with the
-            # next authority epoch. Keep combat running, but fail closed for
-            # later cosmetic launches in this battle.
-            self._launches_enabled = False
-        return not failed
+        if mover is not None:
+            try:
+                mover.destroy()
+            except Exception as error:
+                self._launches_enabled = False
+                self._report_failure('projectile mover reset', error)
+                return False
+            self._mover = None
+        self._projectile_shots = {}
+        self._visual_budgets = {}
+        self._visual_admissions = {}
+        return True
 
     def _take_unused_shot_id(self, mover):
-        """Reserve one increasing id not owned by native or canonical state."""
-        active = getattr(mover, '_ProjectileMover__projectiles', None)
-        mapped = set(
-            entry['visual_id'] for entry in self._projectile_shots.values())
-        mapped.update(self._projectile_tails)
+        """Reserve an increasing identity across active and stopped motors."""
+        native = mover._ProjectileMover__projectiles
+        mapped = set(entry['visual_id'] for entry in
+                     self._projectile_shots.values())
         while True:
             shot_id = self._next_shot_id
             self._next_shot_id += 1
-            if shot_id in mapped:
-                continue
-            if isinstance(active, dict) and shot_id in active:
-                continue
-            return shot_id
+            if (shot_id not in mapped and shot_id not in native and
+                    -shot_id not in native):
+                return shot_id
 
     def stop_canonical(self, projectile_id, end_position,
                        explosion=None, missed=False):
-        """Pin and stop one tracer, then retire its stock terminal tail.
+        """Forward exactly one worker terminal to the stock visual owner.
 
-        ``explosion`` carries ``(effectsDescr, effectMaterial, velocityDir)``
-        for a terminal on the world.  The controlled tracer is moved to the
-        impact before its flying state is stopped. Its scene owners stay for
-        the reviewed stock tail interval, then release asynchronously. A lazy
-        ProjectileMover receives an unused id solely
-        for the exact #1513 unknown-id material-explosion branch; it never
-        owns or advances this tracer.
+        Native expiry can precede a delayed worker verdict. Keep the logical
+        entry until that verdict so expiry never relaunches a tracer or loses
+        its feedback. Stock's unknown-id explosion still handles a late world
+        hit, and hide owns its negative-id motor and stopped particle tail.
         """
         if self._closed or projectile_id is None:
             return False
-        try:
-            projectile_id = str(projectile_id)
-        except Exception:
-            return False
-        entry = self._projectile_shots.get(projectile_id)
+        projectile_id = str(projectile_id)
         end = self._finite_vector(end_position)
-        if entry is None:
-            # A visual can fail or be pressure-retired before a world
-            # terminal arrives. Unknown ids preserve only the material hit
-            # effect, without creating a late tracer. Denied visuals must not
-            # bypass their admission.
-            admission = self._visual_admissions.pop(projectile_id, None)
-            if (admission is None or not admission[1] or end is None or
-                    not explosion):
-                return False
-            mover = self._projectile_mover()
-            if mover is None:
-                return False
-            shot_id = self._take_unused_shot_id(mover)
-            return self._explode_canonical(
-                mover, shot_id, end, explosion)
         if end is None:
             return False
-        if entry.get('kind') != 'controlled':
+        entry = self._projectile_shots.get(projectile_id)
+        admission = self._visual_admissions.get(projectile_id)
+        if entry is None:
+            if admission is None or not admission[1] or not explosion:
+                return False
+            self._visual_admissions.pop(projectile_id, None)
+            mover = self._projectile_mover()
+            return bool(mover is not None and self._explode_canonical(
+                mover, self._take_unused_shot_id(mover), end, explosion))
+        if not entry.get('started'):
+            # Partial stock creation has no safe per-shot recovery contract.
+            # Retain its owner for reset, without retrying another native add.
             return False
-        delayed_release = False
-        if entry.get('creation_failed', False):
-            try:
-                released = self._release_controlled(entry)
-            except Exception as error:
-                self._report_failure(
-                    'failed tracer creation terminal cleanup', error)
-                return False
-            if not released:
-                return False
-        else:
-            direction = entry.get('velocity')
-            if explosion:
-                try:
-                    unused_descr, unused_material, direction = explosion
-                except (TypeError, ValueError):
-                    direction = entry.get('velocity')
-            direction = self._finite_vector(direction)
-            if direction is None:
-                direction = entry.get('velocity')
-            try:
-                # Pinning is deliberately the first native-visible action.
-                self._write_projectile_pose(entry['pose'], end, direction)
-                entry['position'] = end
-                entry['velocity'] = direction
-                if missed:
-                    self._notify_projectile_missed(entry)
-                self._notify_projectile_hit(entry, end)
-                if entry.get('flying_attached'):
-                    callback = getattr(
-                        entry.get('projectile_effects'), 'detachFrom', None)
-                    if not callable(callback):
-                        raise RuntimeError(
-                            '#1513 projectile stopFlying is unavailable')
-                    callback(entry.get('effects_data'), 'stopFlying')
-                    entry['flying_attached'] = False
-                entry['terminal'] = True
-                self._remove_projectile_mapping(projectile_id)
-                visual_id = entry['visual_id']
-                self._projectile_tails[visual_id] = entry
-                self._projectile_tail_order.append(visual_id)
-                delayed_release = self._schedule_controlled_release(
-                    entry)
-                released = False
-            except Exception as error:
-                self._report_failure('controlled tracer terminal', error)
-                return False
-        if released:
-            self._remove_projectile_mapping(projectile_id)
-        retirement_safe = bool(released or delayed_release)
-        admission = self._visual_admissions.pop(projectile_id, None)
-        if not explosion or admission is None or not admission[1]:
-            return retirement_safe
-        mover = self._projectile_mover()
+        mover = self._mover
         if mover is None:
-            return retirement_safe
-        shot_id = self._take_unused_shot_id(mover)
+            return False
+        visual_id = entry['visual_id']
         try:
-            self._explode_canonical(mover, shot_id, end, explosion)
-        except Exception:
-            # Visual ownership is already safely retired. The explosion path
-            # reports and disables itself without resurrecting the tracer.
-            pass
-        return retirement_safe
+            if not entry.get('terminal'):
+                native = mover._ProjectileMover__projectiles
+                if explosion:
+                    # A failed material effect is local to presentation. The
+                    # fallback hide still retires an active tracer at the
+                    # authoritative endpoint without fabricating a new hit.
+                    exploded = self._explode_canonical(
+                        mover, visual_id, end, explosion)
+                    if not exploded and visual_id in native:
+                        mover.hide(visual_id, end)
+                elif visual_id in native:
+                    mover.hide(visual_id, end)
+                entry['terminal'] = True
+            if missed:
+                self._notify_projectile_missed(entry)
+            self._notify_projectile_hit(entry, end)
+        except Exception as error:
+            # A ricochet may reuse the logical projectile id. If its previous
+            # motor could not retire, never report that motor as the new
+            # segment. Other projectiles remain independent.
+            entry['terminal_failed'] = True
+            self._report_failure('native tracer terminal', error)
+            return False
+        self._projectile_shots.pop(projectile_id, None)
+        self._visual_admissions.pop(projectile_id, None)
+        return True
 
     def _explode_canonical(self, mover, shot_id, end, explosion):
         """Play the retail ground explosion for one world terminal.
 
-        The id is deliberately absent from ProjectileMover's private map.
-        Exact #1513 then constructs only a temporary effect dictionary and
-        calls its material-explosion helper directly.
+        An active id follows stock's native terminal path. If the motor
+        already expired, #1513 constructs a temporary effect dictionary and
+        plays the material explosion without resurrecting a tracer.
         """
         if not explosion or not self._explosions_enabled:
             return False
@@ -1271,12 +862,24 @@ class _RemoteShotPresenter(object):
             return None
 
     def _projectile_mover(self):
-        if (self._mover is None and not self._closed and
-                self._explosions_enabled):
+        if self._mover is None and not self._closed:
             mover = None
             try:
                 from ProjectileMover import ProjectileMover
-                mover = ProjectileMover()
+
+                class CanonicalProjectileMover(ProjectileMover):
+                    def _ProjectileMover__notifyProjectileHit(
+                            inner, position, projectile):
+                        # hide/explode invoke this Python method. Canonical
+                        # feedback is emitted once below, including when a
+                        # native lifetime ended before the worker's verdict.
+                        if projectile.get('_offlineLANCanonical'):
+                            return
+                        notify = (
+                            ProjectileMover._ProjectileMover__notifyProjectileHit)
+                        return notify(inner, position, projectile)
+
+                mover = CanonicalProjectileMover()
                 set_space_id = getattr(mover, 'setSpaceID', None)
                 if not callable(set_space_id):
                     raise RuntimeError(
@@ -1371,36 +974,12 @@ class _RemoteShotPresenter(object):
 
     def destroy(self):
         self._closed = True
-        first_error = None
-        try:
-            if not self.reset_canonical(recycle_mover=False):
-                first_error = RuntimeError(
-                    'controlled projectile visual cleanup failed')
-        except Exception as error:
-            first_error = error
-        mover = self._mover
-        if mover is not None:
-            callback = getattr(mover, 'destroy', None)
-            if not callable(callback):
-                if first_error is None:
-                    first_error = RuntimeError(
-                        '#1513 ProjectileMover has no destroy lifecycle')
-            else:
-                try:
-                    callback()
-                except Exception as error:
-                    if first_error is None:
-                        first_error = error
-                else:
-                    self._mover = None
-        if first_error is not None:
-            raise first_error
-        self._projectile_shots = {}
-        self._projectile_order = []
-        self._projectile_tails = {}
-        self._projectile_tail_order = []
-        self._visual_budgets = {}
-        self._visual_admissions = {}
+        if self._mover is not None:
+            # Preserve the original exception for the enclosing entity/arena
+            # cleanup, which must still restore its other owners on failure.
+            self._mover.destroy()
+            self._mover = None
+        self.reset_canonical()
 
 
 class _RemoteFilter(object):
@@ -2993,12 +2572,6 @@ class RemoteVehicleFactory(object):
         """Retire one canonical tracer after a server terminal event."""
         return self._shot_presenter.stop_canonical(
             projectile_id, end_position, explosion, missed)
-
-    def update_projectile_visual(self, projectile_id, position,
-                                 velocity=None):
-        """Move a tracer to the latest hidden-worker-confirmed cursor."""
-        return self._shot_presenter.update_canonical(
-            projectile_id, position, velocity)
 
     def reset_projectile_visuals(self):
         """Release the old epoch's visuals while keeping the factory live."""

--- a/tests/test_audit_native_resource_ownership.py
+++ b/tests/test_audit_native_resource_ownership.py
@@ -85,6 +85,43 @@ class NativeResourceOwnershipAuditTests(unittest.TestCase):
             AUDIT.audit_acquisition_inventory(
                 source_root, approved_acquisitions=approved)
 
+    def test_nested_subclass_cannot_hide_native_mover_acquisition(self):
+        source_root = self._synthetic_root('''
+            from ProjectileMover import ProjectileMover as NativeMover
+
+            def unreviewed_tracer():
+                class CanonicalMover(NativeMover):
+                    pass
+                return CanonicalMover()
+        ''')
+
+        with self.assertRaisesRegex(
+                ValueError,
+                r'synthetic\.py:unreviewed_tracer ProjectileMover '
+                r'acquisitions=1 expected=0'):
+            AUDIT.audit_acquisition_inventory(
+                source_root, approved_acquisitions=())
+
+    def test_module_subclass_acquisition_is_counted_in_calling_function(self):
+        source_root = self._synthetic_root('''
+            from ProjectileMover import ProjectileMover
+
+            class BaseMover(ProjectileMover):
+                pass
+
+            class CanonicalMover(BaseMover):
+                pass
+
+            def reviewed():
+                return CanonicalMover()
+        ''')
+
+        report = AUDIT.audit_acquisition_inventory(
+            source_root,
+            approved_acquisitions=(
+                ('synthetic.py', 'reviewed', 'ProjectileMover', 1),))
+        self.assertEqual(1, report['approvedAcquisitionSites'])
+
     def test_ownership_commit_before_initialization_violates_order(self):
         tree = ast.parse(textwrap.dedent('''
             def setup(self):

--- a/tests/test_port_0922_battle_projectiles.py
+++ b/tests/test_port_0922_battle_projectiles.py
@@ -112,8 +112,8 @@ class _Client(object):
         return int(args[2])
 
 
-class _ControlledTracerFactory(object):
-    """Stateful fake for the one controlled visual owned by each projectile."""
+class _NativeTracerFactory(object):
+    """Native motor stand-in; no Python position-update method is exposed."""
 
     def __init__(self, admitted=True, order=None, fail_plays=0,
                  reset_succeeds=True):
@@ -124,7 +124,6 @@ class _ControlledTracerFactory(object):
         self.active = {}
         self.play_attempts = []
         self.play_calls = []
-        self.update_calls = []
         self.stop_calls = []
         self.reset_calls = 0
 
@@ -141,7 +140,7 @@ class _ControlledTracerFactory(object):
             self.fail_plays -= 1
             return False
         if projectile_id in self.active:
-            raise AssertionError('controlled tracer was rebuilt')
+            raise AssertionError('native tracer was rebuilt')
         reference = (origin if reference_position is None else
                      reference_position)
         position = reference if visual_start is None else visual_start
@@ -156,22 +155,23 @@ class _ControlledTracerFactory(object):
             'position': tuple(float(value) for value in position),
             'velocity': tuple(float(value) for value in current_velocity),
             'visible': True,
+            'gravity': gravity,
             'ricochet': bool(is_ricochet),
         }
         self.active[projectile_id] = row
         self.play_calls.append((projectile_id, dict(row)))
         return 1000000 + len(self.play_calls)
 
-    def update_projectile_visual(
-            self, projectile_id, position, velocity=None):
-        row = self.active.get(projectile_id)
-        if row is None:
-            return False
-        row['position'] = tuple(float(value) for value in position)
-        if velocity is not None:
-            row['velocity'] = tuple(float(value) for value in velocity)
-        self.update_calls.append((projectile_id, dict(row)))
-        return bool(row['visible'])
+    def engine_frame(self, dt):
+        for row in self.active.values():
+            position, velocity = row['position'], row['velocity']
+            row['position'] = (
+                position[0] + velocity[0] * dt,
+                position[1] + velocity[1] * dt -
+                0.5 * row['gravity'] * dt * dt,
+                position[2] + velocity[2] * dt)
+            row['velocity'] = (
+                velocity[0], velocity[1] - row['gravity'] * dt, velocity[2])
 
     def stop_projectile_tracer(
             self, projectile_id, end_position, explosion=None,
@@ -1473,11 +1473,11 @@ class BattleProjectileTests(unittest.TestCase):
         self.assertEqual(10.0, battle._projectile_server_local_time)
         self.assertEqual(11000, battle._projectile_estimated_server_time(11.0))
 
-    def test_canonical_launch_creates_a_visible_controlled_tracer(self):
+    def test_late_first_snapshot_seeds_a_native_tracer_at_its_checked_pose(self):
         battle, unused_bigworld = _battle(now=1.0)
         source = battle._server_entity(41)
         source.showShooting = mock.Mock(return_value=True)
-        factory = _ControlledTracerFactory()
+        factory = _NativeTracerFactory()
         battle._remote_factory = factory
         source_shot = dict(_event()['source_shot'])
         source_shot.update({
@@ -1503,14 +1503,13 @@ class BattleProjectileTests(unittest.TestCase):
         self.assertEqual((40.0, 8.2, 0.0), tracer['position'])
         visual = battle._projectile_visual_meta['player:7:1']
         self.assertTrue(visual['active'])
-        self.assertEqual(0.4, visual['display_elapsed'])
-        self.assertEqual(0.4, visual['confirmed_elapsed'])
-        self.assertEqual(1.0, visual['last_frame'])
+        self.assertEqual((40.0, 8.2, 0.0),
+                         factory.play_calls[0][1]['reference_position'])
         source.showShooting.assert_called_once_with(1, False)
         self.assertFalse(hasattr(
             source, '_offlineLANCanonicalTracerOwned'))
 
-    def test_bot_launch_uses_the_same_visible_controlled_tracer_path(self):
+    def test_bot_launch_uses_the_same_visible_native_tracer_path(self):
         battle, unused_bigworld = _battle(now=1.0)
         descriptor = battle._server_entity(41).typeDescriptor
         source = types.SimpleNamespace(
@@ -1525,7 +1524,7 @@ class BattleProjectileTests(unittest.TestCase):
         original_server_entity = battle._server_entity
         battle._server_entity = lambda entity_id: (
             source if entity_id == 77 else original_server_entity(entity_id))
-        factory = _ControlledTracerFactory()
+        factory = _NativeTracerFactory()
         battle._remote_factory = factory
         event = dict(
             _event(), attacker_bot=11, shooter_kind='bot', shooter_id=11,
@@ -1543,7 +1542,7 @@ class BattleProjectileTests(unittest.TestCase):
             battle._projectile_visual_meta['bot:11:1']['active'])
         source.showShooting.assert_called_once_with(1, False)
 
-    def test_zero_cursor_tracer_bridges_muzzle_to_confirmed_frontier(self):
+    def test_zero_cursor_native_tracer_flies_without_progress_and_never_rewinds(self):
         battle, unused_bigworld = _battle(now=0.0)
         battle.client.is_bot_authority = lambda: False
         source = battle._server_entity(41)
@@ -1556,103 +1555,48 @@ class BattleProjectileTests(unittest.TestCase):
         battle._runtime.math.Matrix = lambda value: value
         battle._runtime.cameras = types.SimpleNamespace(
             isPointOnScreen=mock.Mock(return_value=True))
-        factory = _ControlledTracerFactory()
+        factory = _NativeTracerFactory()
         battle._remote_factory = factory
         source_shot = dict(_event()['source_shot'])
         source_shot.update({
-            'speed': math.sqrt(10400.0),
-            'gravity': 10.0,
-            'maxDistance': 1000.0,
-        })
+            'speed': math.sqrt(10400.0), 'gravity': 10.0,
+            'maxDistance': 1000.0})
         event = dict(
             _event(), maxDistance=1000.0, max_time_ms=20000,
             source_shot=source_shot,
             velocity=[100.0, 20.0, 0.0],
             segment_velocity=[100.0, 20.0, 0.0], gravity=10.0,
             launch_server_time_ms=0)
-
         self.assertTrue(battle._show_shot(event))
-        visual = battle._projectile_visual_meta['player:7:1']
-        self.assertEqual(1, len(factory.play_calls))
-        self.assertEqual((15.0, 1.0, 0.0),
-                         factory.active['player:7:1']['position'])
-        self.assertEqual((0.0, 1.0, 0.0),
-                         factory.play_calls[0][1]['origin'])
-        self.assertEqual((0.0, 1.0, 0.0),
-                         factory.play_calls[0][1]['reference_position'])
-        self.assertEqual((15.0, 1.0, 0.0),
-                         factory.play_calls[0][1]['visual_start'])
-        self.assertTrue(visual['active'])
-        self.assertTrue(visual['first_frontier_pending'])
-        self.assertTrue(visual['admitted'])
-        self.assertEqual(0.0, visual['display_elapsed'])
-        self.assertEqual(0.0, visual['confirmed_elapsed'])
+        tracer = factory.active['player:7:1']
+        self.assertEqual((15.0, 1.0, 0.0), tracer['position'])
+        self.assertEqual((0.0, 1.0, 0.0), tracer['reference_position'])
         source.showShooting.assert_called_once_with(1, False)
 
-        for frame in (0.01, 0.02):
+        # The visible engine advances independently while the worker sends no
+        # progress at all. BattleRuntime must neither clamp nor replace it.
+        for frame in (0.1, 0.2):
+            factory.engine_frame(0.1)
             self.assertFalse(battle._advance_projectiles(frame))
-        self.assertEqual([], factory.update_calls)
-        self.assertEqual((15.0, 1.0, 0.0),
-                         factory.active['player:7:1']['position'])
+        self.assertAlmostEqual(35.0, tracer['position'][0])
+        self.assertEqual(0, battle._projectile_meta[
+            'player:7:1']['base_checked_ms'])
+        self.assertEqual(0, len(battle._projectiles))
 
-        early_progress = dict(event, checked_through_ms=10,
-                              checked_distance=1.0, piercing_loss=0.0)
-        early_normalized = battle._projectile_wire_meta(early_progress)
-        early_normalized['source_descriptor'] = source.typeDescriptor
-        battle._install_projectile_meta(early_normalized)
-        self.assertTrue(battle._ensure_projectile_visual(
-            early_normalized, 0.02))
-        self.assertEqual([], factory.update_calls)
-        self.assertEqual((15.0, 1.0, 0.0),
-                         factory.active['player:7:1']['position'])
-        self.assertTrue(visual['first_frontier_pending'])
-
-        progress = dict(event, checked_through_ms=400,
-                        checked_distance=40.0, piercing_loss=0.0)
-        normalized = battle._projectile_wire_meta(progress)
-        normalized['source_descriptor'] = source.typeDescriptor
-        battle._install_projectile_meta(normalized)
-        self.assertTrue(battle._ensure_projectile_visual(normalized, 0.02))
-        self.assertEqual(1, len(factory.play_calls))
-        tracer = factory.active['player:7:1']
-        self.assertEqual((40.0, 8.2, 0.0), tracer['position'])
-        self.assertEqual((40.0, 8.2, 0.0),
-                         factory.update_calls[0][1]['position'])
-        self.assertFalse(visual['first_frontier_pending'])
-        self.assertEqual(0.4, visual['display_elapsed'])
-
-        self.assertFalse(battle._advance_projectiles(0.1))
-        visual = battle._projectile_visual_meta['player:7:1']
-        tracer = factory.active['player:7:1']
-        self.assertTrue(visual['active'])
-        self.assertTrue(tracer['visible'])
-        self.assertLessEqual(
-            visual['display_elapsed'], visual['confirmed_elapsed'])
-        self.assertFalse(visual['first_frontier_pending'])
-        self.assertEqual(0.4, visual['display_elapsed'])
-        self.assertAlmostEqual(40.0, tracer['position'][0])
-        self.assertTrue(all(
-            row[1]['position'][0] >= 15.0 for row in factory.update_calls))
-
-        # A duplicate and then a regressing snapshot neither rebuilds the
-        # visible tracer nor lowers the already confirmed frontier.
-        self.assertTrue(battle._ensure_projectile_visual(normalized, 0.1))
-        regressed = dict(normalized, base_checked_ms=200)
-        self.assertTrue(battle._ensure_projectile_visual(regressed, 0.1))
-        self.assertEqual(1, len(factory.play_calls))
-        self.assertEqual(0.4, visual['confirmed_elapsed'])
-
-        # Even an arbitrarily large render stall clamps at the collision-free
-        # cursor.  The tracer remains present rather than being suppressed.
-        self.assertFalse(battle._advance_projectiles(30.0))
-        visual = battle._projectile_visual_meta['player:7:1']
-        tracer = factory.active['player:7:1']
-        self.assertTrue(visual['active'])
-        self.assertTrue(tracer['visible'])
-        self.assertEqual(0.4, visual['display_elapsed'])
-        self.assertLessEqual(
-            visual['display_elapsed'], visual['confirmed_elapsed'])
-        self.assertAlmostEqual(40.0, tracer['position'][0])
+        for checked in (10, 400, 400, 200):
+            progress = dict(event, checked_through_ms=checked,
+                            checked_distance=checked / 10.0, piercing_loss=0.0)
+            normalized = battle._projectile_wire_meta(progress)
+            normalized['source_descriptor'] = source.typeDescriptor
+            before = tracer['position']
+            self.assertTrue(battle._ensure_projectile_visual(normalized, 0.2))
+            self.assertEqual(before, tracer['position'])
+            self.assertEqual(1, len(factory.play_calls))
+        self.assertTrue(battle._stop_projectile_visual('player:7:1', {
+            'impact': [20.0, 1.0, 0.0], 'resolved_time_ms': 200,
+            'hit_vehicle': True}))
+        self.assertEqual((20.0, 1.0, 0.0), factory.stop_calls[0][1])
+        self.assertNotIn('player:7:1', factory.active)
 
     def test_zero_cursor_visual_start_requires_onscreen_muzzle(self):
         cases = (
@@ -1678,7 +1622,7 @@ class BattleProjectileTests(unittest.TestCase):
                     screen_check = mock.Mock(return_value=screen_result)
                 battle._runtime.cameras = types.SimpleNamespace(
                     isPointOnScreen=screen_check)
-                factory = _ControlledTracerFactory()
+                factory = _NativeTracerFactory()
                 battle._remote_factory = factory
 
                 self.assertTrue(battle._show_shot(_event()))
@@ -1689,7 +1633,7 @@ class BattleProjectileTests(unittest.TestCase):
                     factory.play_calls[0][1]['visual_start'])
                 self.assertTrue(
                     battle._projectile_visual_meta[
-                        'player:7:1']['first_frontier_pending'])
+                        'player:7:1']['active'])
 
     def test_failed_launch_stays_inactive_and_retries_under_runtime_ownership(self):
         battle, unused_bigworld = _battle(now=1.0)
@@ -1702,7 +1646,7 @@ class BattleProjectileTests(unittest.TestCase):
             return True
 
         source.showShooting = show_shooting
-        factory = _ControlledTracerFactory(fail_plays=1)
+        factory = _NativeTracerFactory(fail_plays=1)
         battle._remote_factory = factory
 
         self.assertTrue(battle._show_shot(_event()))
@@ -1710,7 +1654,6 @@ class BattleProjectileTests(unittest.TestCase):
         visual = battle._projectile_visual_meta['player:7:1']
         self.assertEqual([True], ownership)
         self.assertFalse(visual['active'])
-        self.assertTrue(visual['launch_retryable'])
         self.assertNotIn('player:7:1', factory.active)
         self.assertEqual(['player:7:1'], factory.play_attempts)
 
@@ -1745,7 +1688,7 @@ class BattleProjectileTests(unittest.TestCase):
         source = battle._server_entity(41)
         source.showShooting = mock.Mock(
             side_effect=RuntimeError('native muzzle failed'))
-        factory = _ControlledTracerFactory()
+        factory = _NativeTracerFactory()
         battle._remote_factory = factory
 
         first = _event()
@@ -1766,7 +1709,7 @@ class BattleProjectileTests(unittest.TestCase):
         battle, unused_bigworld = _battle()
         source = battle._server_entity(41)
         source.showShooting = mock.Mock(return_value=True)
-        factory = _ControlledTracerFactory()
+        factory = _NativeTracerFactory()
         battle._remote_factory = factory
         launch = _event()
         self.assertTrue(battle._show_shot(launch))
@@ -1795,7 +1738,7 @@ class BattleProjectileTests(unittest.TestCase):
                 battle, unused_bigworld = _battle()
                 source = battle._server_entity(41)
                 source.showShooting = mock.Mock(return_value=True)
-                factory = _ControlledTracerFactory()
+                factory = _NativeTracerFactory()
                 battle._remote_factory = factory
                 launch = _event()
                 self.assertTrue(battle._show_shot(launch))
@@ -1818,7 +1761,7 @@ class BattleProjectileTests(unittest.TestCase):
         battle, unused_bigworld = _battle()
         source = battle._server_entity(41)
         source.showShooting = mock.Mock(return_value=True)
-        factory = _ControlledTracerFactory(order=order)
+        factory = _NativeTracerFactory(order=order)
         battle._remote_factory = factory
         launch = _event()
         self.assertTrue(battle._show_shot(launch))
@@ -1842,7 +1785,7 @@ class BattleProjectileTests(unittest.TestCase):
         battle, unused_bigworld = _battle()
         source = battle._server_entity(41)
         source.showShooting = mock.Mock(return_value=True)
-        factory = _ControlledTracerFactory()
+        factory = _NativeTracerFactory()
         battle._remote_factory = factory
         launch = _event()
         self.assertTrue(battle._show_shot(launch))
@@ -1884,7 +1827,7 @@ class BattleProjectileTests(unittest.TestCase):
         battle._runtime.math.Matrix = lambda value: value
         battle._runtime.cameras = types.SimpleNamespace(
             isPointOnScreen=mock.Mock(return_value=True))
-        factory = _ControlledTracerFactory()
+        factory = _NativeTracerFactory()
         battle._remote_factory = factory
         launch = _event()
         self.assertTrue(battle._show_shot(launch))
@@ -1922,14 +1865,12 @@ class BattleProjectileTests(unittest.TestCase):
         visual = battle._projectile_visual_meta['player:7:1']
         self.assertTrue(visual['active'])
         self.assertEqual(1, visual['ricochet_count'])
-        self.assertEqual(0.0, visual['display_elapsed'])
-        self.assertEqual(0.0, visual['confirmed_elapsed'])
 
     def test_epoch_change_resets_old_tracers_without_terminal_feedback(self):
         battle, unused_bigworld = _battle()
         source = battle._server_entity(41)
         source.showShooting = mock.Mock(return_value=True)
-        factory = _ControlledTracerFactory()
+        factory = _NativeTracerFactory()
         battle._remote_factory = factory
         launch = _event()
         self.assertTrue(battle._show_shot(launch))
@@ -1948,7 +1889,7 @@ class BattleProjectileTests(unittest.TestCase):
         battle, unused_bigworld = _battle()
         source = battle._server_entity(41)
         source.showShooting = mock.Mock(return_value=True)
-        factory = _ControlledTracerFactory(reset_succeeds=False)
+        factory = _NativeTracerFactory(reset_succeeds=False)
         battle._remote_factory = factory
         battle._warn_optional_failure = mock.Mock(return_value=True)
         self.assertTrue(battle._show_shot(_event()))

--- a/tests/test_port_0922_projectile_visual_presenter.py
+++ b/tests/test_port_0922_projectile_visual_presenter.py
@@ -201,29 +201,128 @@ class _TriggerManager(object):
         self.triggers.append(trigger_type)
 
 
+class _NativeMotor(object):
+
+    def __init__(self, origin, velocity, start, gravity):
+        self.origin = _Vector(origin)
+        self.velocity = _Vector(velocity)
+        self.start = _Vector(start)
+        self.gravity = gravity
+        self.elapsed = 0.0
+
+    def advance(self, dt):
+        self.elapsed += dt
+        t = self.elapsed
+        return _Vector(self.start.x + self.velocity.x * t,
+                       self.start.y + self.velocity.y * t -
+                       0.5 * self.gravity * t * t,
+                       self.start.z + self.velocity.z * t)
+
+
 class _ProjectileMover(object):
+    """Exercise the reviewed stock guards, rows and ownership callbacks.
+
+    Motor stepping is a fake engine callback, not evidence of native physics
+    or Windows rendering. Its purpose is to expose competing Python writers.
+    """
 
     instances = []
     explode_error = None
     destroy_error = None
+    add_error = None
+    hide_error = None
+    reject_add = False
+    on_add = None
+    bigworld = None
 
     def __init__(self):
         self.calls = []
         self.explode_calls = []
+        self.hide_calls = []
+        self.hold_calls = []
         self.destroy_calls = 0
         self.space_ids = []
         self._ProjectileMover__projectiles = {}
         self.__class__.instances.append(self)
 
     def add(self, *args):
+        if not self.space_ids:
+            return
         self.calls.append(args)
-        if args[1].get('artilleryID') is None:
-            self._ProjectileMover__projectiles[args[0]] = object()
+        if self.__class__.on_add is not None:
+            self.__class__.on_add()
+        if self.__class__.add_error is not None:
+            raise self.__class__.add_error
+        if self.__class__.reject_add:
+            return
+        (shot_id, effects, gravity, origin, velocity, start,
+         maximum, attacker_id, camera_position) = args
+        if effects.get('artilleryID') is not None:
+            return
+        if sum((a - b) ** 2 for a, b in zip(_xyz(start), _xyz(origin))) > 400:
+            start = origin
+        own = attacker_id == self.bigworld.player().playerVehicleID
+        motor = _NativeMotor(origin, velocity, start, gravity)
+        model = self.bigworld.Model(effects['projectile'][int(own)])
+        model.position = _Vector(start)
+        row = {'model': model, 'motor': motor, 'effectsDescr': effects,
+               'showExplosion': False, 'fireMissedTrigger': own,
+               'autoScaleProjectile': own, 'attackerID': attacker_id,
+               'effectsData': {}}
+        self.bigworld.player().addModel(model)
+        model.addMotor(motor)
+        model.visible = False
+        model.visibleAttachments = True
+        effects['projectile'][2].attachTo(
+            model, row['effectsData'], 'flying',
+            isPlayerVehicle=own, isArtillery=False)
+        self._ProjectileMover__projectiles[shot_id] = row
+
+    def engine_frame(self, dt):
+        for shot_id, row in self._ProjectileMover__projectiles.items():
+            if shot_id > 0:
+                row['model'].position = row['motor'].advance(dt)
+
+    def _ProjectileMover__notifyProjectileHit(self, position, row):
+        self.bigworld.player().inputHandler.onProjectileHit(
+            position, row['effectsDescr']['caliber'],
+            row['autoScaleProjectile'])
 
     def explode(self, *args):
         self.explode_calls.append(args)
         if self.__class__.explode_error is not None:
             raise self.__class__.explode_error
+        row = self._ProjectileMover__projectiles.get(args[0])
+        if row is not None:
+            row['fireMissedTrigger'] = False
+            row['showExplosion'] = True
+            self._ProjectileMover__notifyProjectileHit(args[3], row)
+
+    def hide(self, shot_id, position):
+        if self.__class__.hide_error is not None:
+            raise self.__class__.hide_error
+        self.hide_calls.append((shot_id, position))
+        row = self._ProjectileMover__projectiles.pop(shot_id, None)
+        if row is not None:
+            self._ProjectileMover__projectiles[-shot_id] = row
+            row['fireMissedTrigger'] = False
+            row['showExplosion'] = False
+            self._ProjectileMover__notifyProjectileHit(position, row)
+
+    def hold(self, shot_id):
+        self.hold_calls.append(shot_id)
+
+    def expire(self, shot_id):
+        row = self._ProjectileMover__projectiles.pop(shot_id, None)
+        if row is None:
+            return
+        row['effectsDescr']['projectile'][2].detachAllFrom(row['effectsData'])
+        row['model'].delMotor(row['motor'])
+        self.bigworld.player().delModel(row['model'])
+        if row['fireMissedTrigger']:
+            import TriggersManager
+            TriggersManager.g_manager.fireTrigger(
+                TriggersManager.TRIGGER_TYPE.PLAYER_SHOT_MISSED)
 
     def setSpaceID(self, space_id):
         self.space_ids.append(space_id)
@@ -232,6 +331,10 @@ class _ProjectileMover(object):
         self.destroy_calls += 1
         if self.__class__.destroy_error is not None:
             raise self.__class__.destroy_error
+        for shot_id in list(self._ProjectileMover__projectiles):
+            # Stock destroy calls __delProjectile, not its expiry callback.
+            self._ProjectileMover__projectiles[shot_id]['fireMissedTrigger'] = False
+            self.expire(shot_id)
 
 
 def _descriptor(effects_index=7):
@@ -273,9 +376,14 @@ class ProjectileVisualPresenterTests(unittest.TestCase):
         _ProjectileMover.instances[:] = []
         _ProjectileMover.explode_error = None
         _ProjectileMover.destroy_error = None
+        _ProjectileMover.add_error = None
+        _ProjectileMover.hide_error = None
+        _ProjectileMover.reject_add = False
+        _ProjectileMover.on_add = None
         self.events = []
         _Matrix.events = self.events
         self.bigworld = _BigWorld(self.events)
+        _ProjectileMover.bigworld = self.bigworld
         self.math = types.SimpleNamespace(Vector3=_Vector, Matrix=_Matrix)
         self.effects, self.projectile_effects = _effects(self.events)
         self.flock = _FlockManager(self.events)
@@ -314,436 +422,293 @@ class ProjectileVisualPresenterTests(unittest.TestCase):
                 projectile_id, reference_position, reference_velocity,
                 is_ricochet, visual_start)
 
-    def test_player_and_bot_use_visible_stock_effects_on_controlled_servos(self):
+    def test_player_and_bot_use_space_bound_stock_native_motors(self):
         factory = self._factory()
-
-        player_visual = self._launch(factory, 'player:1', attacker_id=42)
-        bot_visual = self._launch(factory, 'bot:1', attacker_id=99)
-
-        self.assertEqual(1000000, player_visual)
-        self.assertEqual(1000001, bot_visual)
-        self.assertEqual([], _ProjectileMover.instances)
-        models = self.bigworld._player.models
-        self.assertEqual(
-            ['own-projectile.model', 'remote-projectile.model'],
-            [model.name for model in models])
-        self.assertTrue(all(model.visibleAttachments for model in models))
-        self.assertTrue(all(not model.visible for model in models))
-        self.assertTrue(all(len(model.motors) == 1 for model in models))
-        self.assertTrue(all(
-            isinstance(model.motors[0], _Servo) for model in models))
-        self.assertEqual((3.0, 4.0, 5.0),
-                         _xyz(models[0].motors[0].provider.translation))
-        calls = self.projectile_effects.attach_calls
-        self.assertEqual(['flying', 'flying'], [call[2] for call in calls])
-        self.assertEqual(
-            [True, False],
-            [call[3]['isPlayerVehicle'] for call in calls])
-        self.assertEqual([False, False],
-                         [call[3]['isArtillery'] for call in calls])
-
-    def test_non_ledgered_show_shooting_keeps_self_retiring_stock_tracer(self):
-        presenter = _RemoteShotPresenter(
-            self.bigworld, self.math, types.SimpleNamespace(), 7)
-        node = types.SimpleNamespace(translation=_Vector(4.0, 5.0, 6.0))
-        vehicle = types.SimpleNamespace(
-            id=99,
-            model=types.SimpleNamespace(node=mock.Mock(return_value=node)),
-            typeDescriptor=_descriptor(), _offlineLANShotIndex=0,
-            position=_Vector(), yaw=0.0, _aim_yaw=math.pi / 2.0,
-            _gun_pitch=-0.2)
-
-        with mock.patch.dict(sys.modules, _modules(self.effects)):
-            self.assertTrue(presenter.play_tracer(vehicle))
-
-        self.assertEqual([], self.bigworld._player.models)
-        mover = _ProjectileMover.instances[0]
-        self.assertEqual(1, len(mover.calls))
-        args = mover.calls[0]
-        self.assertIs(self.effects, args[1])
-        self.assertEqual((4.0, 5.0, 6.0), _xyz(args[3]))
-        self.assertEqual((4.0, 5.0, 6.0), _xyz(args[5]))
-        self.assertEqual(99, args[7])
-
-    def test_update_moves_same_pose_and_duplicate_launch_does_not_recreate(self):
-        factory = self._factory()
-        visual_id = self._launch(factory)
-        entry = factory._shot_presenter._projectile_shots['round:shot']
-        pose = entry['pose']
-        model = entry['model']
-
-        duplicate = self._launch(
-            factory, reference_position=(999.0, 999.0, 999.0))
-        self.assertTrue(factory.update_projectile_visual(
-            'round:shot', (11.0, 12.0, 13.0), (0.0, -4.0, 80.0)))
-
-        self.assertEqual(visual_id, duplicate)
-        self.assertIs(pose, model.motors[0].provider)
-        self.assertEqual((11.0, 12.0, 13.0), _xyz(pose.translation))
-        self.assertEqual(1, len(self.bigworld._player.models))
-        self.assertEqual(1, len(self.projectile_effects.attach_calls))
-        self.assertEqual([], _ProjectileMover.instances)
-
-    def test_visual_start_uses_stock_twenty_metre_guard(self):
-        factory = self._factory()
-        origin = (1.0, 2.0, 3.0)
-        reference = (51.0, 2.0, 3.0)
-
-        self.assertTrue(self._launch(
-            factory, projectile_id='edge:accepted', origin=origin,
-            reference_position=reference,
-            visual_start=(71.0, 2.0, 3.0)))
-        self.assertTrue(self._launch(
-            factory, projectile_id='edge:rejected', origin=origin,
-            reference_position=reference,
-            visual_start=(71.001, 2.0, 3.0)))
-
-        presenter = factory._shot_presenter
-        accepted = presenter._projectile_shots['edge:accepted']
-        rejected = presenter._projectile_shots['edge:rejected']
-        self.assertEqual(
-            (71.0, 2.0, 3.0), _xyz(accepted['pose'].translation))
-        self.assertEqual(reference, _xyz(rejected['pose'].translation))
-        self.assertEqual(
-            [(71.0, 2.0, 3.0), reference],
-            [_xyz(position) for position in self.flock.positions])
-
-    def test_terminal_pins_then_keeps_stock_tail_before_owner_cleanup(self):
-        factory = self._factory()
-        self._launch(factory)
-        model = self.bigworld._player.models[0]
-        self.events[:] = []
-
-        self.assertTrue(factory.stop_projectile_tracer(
-            'round:shot', (31.0, 7.0, -2.0)))
-
-        self.assertEqual(('pose', (31.0, 7.0, -2.0)), self.events[0])
-        self.assertLess(
-            self.events.index(('pose', (31.0, 7.0, -2.0))),
-            self.events.index(('hit', (31.0, 7.0, -2.0), 0.12, True)))
-        self.assertLess(
-            self.events.index(('hit', (31.0, 7.0, -2.0), 0.12, True)),
-            self.events.index(('detach', 'stopFlying')))
-        self.assertEqual(1, len(model.motors))
-        self.assertEqual([model], self.bigworld._player.models)
-        presenter = factory._shot_presenter
-        self.assertNotIn('round:shot', presenter._projectile_shots)
-        self.assertEqual(1, len(presenter._projectile_tails))
-        self.assertNotIn(
-            'round:shot', factory._shot_presenter._visual_admissions)
-        self.assertFalse(factory.stop_projectile_tracer(
-            'round:shot', (31.0, 7.0, -2.0)))
-        self.assertEqual([], _ProjectileMover.instances)
-        self.assertEqual(2, len(self.flock.positions))
-        self.assertEqual((31.0, 7.0, -2.0),
-                         _xyz(self.flock.positions[-1]))
-        self.assertEqual(1, len(self.bigworld._player.projectile_hits))
-        self.assertEqual(1, len(self.bigworld.callbacks))
-        self.assertEqual(2.0, self.bigworld.callbacks[0][0])
-        self.assertEqual([], self.projectile_effects.detach_all_calls)
-
-        self.bigworld.run_callbacks()
-
-        self.assertEqual([], model.motors)
-        self.assertEqual([], self.bigworld._player.models)
-        self.assertNotIn(
-            'round:shot', factory._shot_presenter._projectile_shots)
-        self.assertEqual({}, factory._shot_presenter._projectile_tails)
-        self.assertEqual(1, len(self.projectile_effects.detach_all_calls))
-
-    def test_world_terminal_cleans_tracer_then_uses_unknown_id_explosion(self):
-        factory = self._factory()
-        self._launch(factory, projectile_id='world:shot')
-        self.events[:] = []
-        explosion = (self.effects, 'ground', (2.0, -2.0, 0.0))
-
-        with mock.patch.dict(sys.modules, _modules(self.effects)):
-            self.assertTrue(factory.stop_projectile_tracer(
-                'world:shot', (12.0, 0.0, 3.0), explosion=explosion,
-                missed=True))
-
-        self.assertEqual(1, len(self.bigworld._player.models))
-        mover = _ProjectileMover.instances[0]
-        self.assertEqual([], mover.calls)
+        self.bigworld.Servo = mock.Mock(side_effect=AssertionError('second owner'))
+        first = self._launch(factory, 'player:1', attacker_id=42)
+        second = self._launch(factory, 'bot:2', attacker_id=77)
+        mover = factory._shot_presenter._mover
         self.assertEqual([7], mover.space_ids)
-        self.assertEqual(1, len(mover.explode_calls))
-        args = mover.explode_calls[0]
-        self.assertEqual(1000001, args[0])
-        self.assertNotIn(args[0], mover._ProjectileMover__projectiles)
-        self.assertEqual((12.0, 0.0, 3.0), _xyz(args[3]))
-        self.assertAlmostEqual(1.0, args[4].length)
-        self.assertEqual(['player-shot-missed'], self.triggers.triggers)
-        self.assertLess(
-            self.events.index(('detach', 'stopFlying')),
-            self.events.index(('callback', 2.0)))
+        self.assertEqual(2, len(mover.calls))
+        self.assertNotEqual(first, second)
+        self.bigworld.Servo.assert_not_called()
+        for shot_id, own in ((first, True), (second, False)):
+            row = mover._ProjectileMover__projectiles[shot_id]
+            self.assertIsInstance(row['motor'], _NativeMotor)
+            self.assertFalse(row['model'].visible)
+            self.assertTrue(row['model'].visibleAttachments)
+            self.assertFalse(row['fireMissedTrigger'])
+            self.assertTrue(row['_offlineLANCanonical'])
+            self.assertEqual(own, row['autoScaleProjectile'])
+        self.assertEqual('own-projectile.model', self.bigworld.player().models[0].name)
+        self.assertEqual('remote-projectile.model', self.bigworld.player().models[1].name)
+        self.assertEqual((3.0, 4.0, 5.0), _xyz(mover.calls[0][3]))
+        self.assertEqual((100.0, 10.0, 0.0), _xyz(mover.calls[0][4]))
+        self.assertEqual((91.0, 17.0, -4.0), _xyz(mover.calls[0][-1]))
 
-        self.bigworld.run_callbacks()
-        self.assertEqual([], self.bigworld._player.models)
-
-    def test_bot_world_terminal_does_not_fire_player_missed_trigger(self):
+    def test_native_flight_does_not_wait_for_a_worker_cursor(self):
         factory = self._factory()
-        self._launch(
-            factory, projectile_id='bot:world', attacker_id=99)
-
-        self.assertTrue(factory.stop_projectile_tracer(
-            'bot:world', (12.0, 0.0, 3.0), missed=True))
-
+        shot_id = self._launch(factory)
+        mover = factory._shot_presenter._mover
+        mover.engine_frame(0.4)
+        row = mover._ProjectileMover__projectiles[shot_id]
+        position = _xyz(row['model'].position)
+        self.assertGreater(position[0], 3.0)
+        self.assertEqual(shot_id, self._launch(factory))
+        self.assertEqual(1, len(mover.calls))
+        self.assertEqual(position, _xyz(row['model'].position))
+        self.assertFalse(hasattr(factory, 'update_projectile_visual'))
         self.assertEqual([], self.triggers.triggers)
 
-    def test_pending_world_terminal_preserves_explosion_without_late_tracer(self):
+    def test_current_muzzle_and_stock_distance_guard_do_not_change_reference(self):
+        for start, expected in (((8, 4, 5), (8, 4, 5)),
+                                ((24, 4, 5), (3, 4, 5))):
+            with self.subTest(start=start):
+                factory = self._factory()
+                shot_id = self._launch(factory, visual_start=start)
+                mover = factory._shot_presenter._mover
+                row = mover._ProjectileMover__projectiles[shot_id]
+                self.assertEqual(expected, _xyz(row['model'].position))
+                self.assertEqual((3, 4, 5), _xyz(row['motor'].origin))
+                factory.destroy_all()
+
+    def test_worker_vehicle_terminal_hides_at_its_endpoint_once(self):
+        factory = self._factory()
+        shot_id = self._launch(factory)
+        mover = factory._shot_presenter._mover
+        mover.engine_frame(0.8)
+        self.assertTrue(factory.stop_projectile_tracer('round:shot', (23, 2, 1)))
+        self.assertEqual([(shot_id, (23, 2, 1))], [
+            (key, _xyz(point)) for key, point in mover.hide_calls])
+        self.assertIn(-shot_id, mover._ProjectileMover__projectiles)
+        self.assertEqual(1, len(self.bigworld.player().projectile_hits))
+        self.assertEqual([], self.triggers.triggers)
+        self.assertFalse(factory.stop_projectile_tracer('round:shot', (23, 2, 1)))
+        mover.expire(-shot_id)
+        self.assertEqual([], self.bigworld.player().models)
+        self.assertEqual(1, len(self.bigworld.player().projectile_hits))
+
+    def test_world_terminal_uses_stock_explode_and_authoritative_feedback(self):
+        for attacker, missed_count in ((42, 1), (77, 0)):
+            with self.subTest(attacker=attacker):
+                self.triggers.triggers[:] = []
+                factory = self._factory()
+                shot_id = self._launch(factory, attacker_id=attacker)
+                mover = factory._shot_presenter._mover
+                self.assertTrue(factory.stop_projectile_tracer(
+                    'round:shot', (20, 0, 0),
+                    explosion=(self.effects, 'ground', (100, 0, 0)), missed=True))
+                self.assertEqual(shot_id, mover.explode_calls[0][0])
+                self.assertEqual((1, 0, 0), _xyz(mover.explode_calls[0][4]))
+                self.assertEqual([], mover.hide_calls)
+                self.assertEqual(missed_count, len(self.triggers.triggers))
+                factory.destroy_all()
+                self.assertEqual(missed_count, len(self.triggers.triggers))
+
+    def test_native_expiry_neither_reports_a_miss_nor_relaunches_on_retry(self):
+        factory = self._factory()
+        shot_id = self._launch(factory)
+        mover = factory._shot_presenter._mover
+        mover.expire(shot_id)
+        self.assertEqual([], self.triggers.triggers)
+        self.assertEqual([], self.bigworld.player().projectile_hits)
+        self.assertEqual(shot_id, self._launch(factory))
+        self.assertEqual(1, len(mover.calls))
+        self.assertTrue(factory.stop_projectile_tracer(
+            'round:shot', (100, 0, 0),
+            explosion=(self.effects, 'ground', (1, 0, 0)), missed=True))
+        self.assertEqual(shot_id, mover.explode_calls[0][0])
+        self.assertEqual({}, mover._ProjectileMover__projectiles)
+        self.assertEqual(1, len(self.triggers.triggers))
+        self.assertEqual(1, len(self.bigworld.player().projectile_hits))
+
+    def test_ricochet_gets_a_new_held_motor_and_old_tail_cannot_delete_it(self):
+        factory = self._factory()
+        first = self._launch(factory)
+        mover = factory._shot_presenter._mover
+        self.assertTrue(factory.stop_projectile_tracer('round:shot', (20, 0, 0)))
+        second = self._launch(factory, is_ricochet=True)
+        self.assertNotEqual(first, second)
+        self.assertEqual([second], mover.hold_calls)
+        mover.expire(-first)
+        self.assertIn(second, mover._ProjectileMover__projectiles)
+        self.assertEqual(second, factory._shot_presenter._projectile_shots[
+            'round:shot']['visual_id'])
+
+    def test_capacity_counts_native_tails_without_detaching_other_motors(self):
         factory = self._factory()
         presenter = factory._shot_presenter
-        self.assertTrue(factory.admit_projectile_visual(
-            42, 'pending:world', now=10.0))
+        presenter._MAX_ACTIVE_TOTAL = 1
+        first = self._launch(factory, 'first')
+        mover = presenter._mover
+        self.assertTrue(factory.stop_projectile_tracer('first', (20, 0, 0)))
+        self.assertFalse(self._launch(factory, 'second'))
+        self.assertIn(-first, mover._ProjectileMover__projectiles)
+        mover.expire(-first)
+        # Cosmetic denial is final for this shot, so freeing a tail cannot
+        # make an old launch suddenly appear seconds after its muzzle effect.
+        self.assertFalse(self._launch(factory, 'second'))
+        self.assertTrue(self._launch(factory, 'third'))
+        self.assertEqual([], self.triggers.triggers)
 
+    def test_non_ledgered_stock_tracer_keeps_its_original_feedback(self):
+        factory = self._factory()
         with mock.patch.dict(sys.modules, _modules(self.effects)):
-            self.assertTrue(factory.stop_projectile_tracer(
-                'pending:world', (12.0, 0.0, 3.0),
-                explosion=(self.effects, 'ground', (1.0, -1.0, 0.0))))
+            shot_id = factory._shot_presenter._play_legacy_tracer(
+                _descriptor(), 0, (1, 2, 3), (100, 0, 0), 9.81, 640, 42)
+        mover = factory._shot_presenter._mover
+        self.assertTrue(shot_id)
+        self.assertNotIn('_offlineLANCanonical',
+                         mover._ProjectileMover__projectiles[shot_id])
+        mover.hide(shot_id, _Vector(20, 2, 3))
+        self.assertEqual(1, len(self.bigworld.player().projectile_hits))
 
-        self.assertEqual([], self.bigworld._player.models)
-        mover = _ProjectileMover.instances[0]
-        self.assertEqual([], mover.calls)
-        self.assertEqual(1, len(mover.explode_calls))
-        self.assertNotIn('pending:world', presenter._visual_admissions)
-
-    def test_unmapped_terminal_cannot_bypass_visual_admission(self):
+    def test_reset_retires_native_owners_without_combat_feedback(self):
         factory = self._factory()
+        self._launch(factory)
+        mover = factory._shot_presenter._mover
+        self.assertTrue(factory.reset_projectile_visuals())
+        self.assertEqual(1, mover.destroy_calls)
+        self.assertEqual([], self.bigworld.player().models)
+        self.assertEqual([], self.bigworld.player().projectile_hits)
+        self.assertEqual([], self.triggers.triggers)
+        self.assertTrue(self._launch(factory, 'next-round'))
+        self.assertIsNot(mover, factory._shot_presenter._mover)
 
-        with mock.patch.dict(sys.modules, _modules(self.effects)):
-            self.assertFalse(factory.stop_projectile_tracer(
-                'unknown', (12.0, 0.0, 3.0),
-                explosion=(self.effects, 'ground', (1.0, -1.0, 0.0))))
-
-        self.assertEqual([], _ProjectileMover.instances)
-        self.assertEqual([], self.bigworld._player.models)
-
-    def test_pressure_retires_oldest_controlled_visual_without_native_rows(self):
-        presenter = _RemoteShotPresenter(
-            self.bigworld, self.math, types.SimpleNamespace(), 7)
-        with mock.patch.dict(sys.modules, _modules(self.effects)):
-            for index in range(25):
-                projectile_id = 'rapid:%d' % index
-                self.assertTrue(presenter.admit_visual(
-                    42, projectile_id, now=float(index)))
-                self.assertTrue(presenter.play_canonical(
-                    _descriptor(), 0, (float(index), 1.0, 0.0),
-                    (100.0, 0.0, 0.0), 9.81, 640.0, 42,
-                    projectile_id))
-
-        self.assertEqual(24, len(presenter._projectile_shots))
-        self.assertNotIn('rapid:0', presenter._projectile_shots)
-        self.assertIn('rapid:24', presenter._projectile_shots)
-        self.assertEqual(24, len(self.bigworld._player.models))
-        self.assertEqual([], _ProjectileMover.instances)
-        self.assertFalse(presenter._visual_admissions['rapid:0'][1])
-
-    def test_failed_terminal_detach_keeps_owner_for_retry(self):
+    def test_failed_reset_retains_native_owner_and_disables_new_cosmetics(self):
         factory = self._factory()
-        self._launch(factory, projectile_id='retry:terminal')
-        self.projectile_effects.detach_error = RuntimeError('detach failed')
+        self._launch(factory)
+        mover = factory._shot_presenter._mover
+        _ProjectileMover.destroy_error = RuntimeError('retirement failed')
+        with mock.patch('sys.stdout', new=io.StringIO()):
+            self.assertFalse(factory.reset_projectile_visuals())
+        self.assertIs(mover, factory._shot_presenter._mover)
+        self.assertFalse(self._launch(factory, 'next-shot'))
+        _ProjectileMover.destroy_error = None
+        self.assertTrue(factory.reset_projectile_visuals())
+        self.assertIsNone(factory._shot_presenter._mover)
+        self.assertEqual([], self.bigworld.player().models)
 
-        self.assertFalse(factory.stop_projectile_tracer(
-            'retry:terminal', (10.0, 1.0, 0.0)))
-        self.assertIn(
-            'retry:terminal', factory._shot_presenter._projectile_shots)
-        self.assertEqual(1, len(self.bigworld._player.models))
-
-        self.projectile_effects.detach_error = None
-        self.assertTrue(factory.stop_projectile_tracer(
-            'retry:terminal', (10.0, 1.0, 0.0)))
-        self.assertEqual(1, len(self.bigworld._player.models))
-        self.bigworld.run_callbacks()
-        self.assertEqual([], self.bigworld._player.models)
-
-    def test_ricochet_reuses_id_without_losing_old_tail_or_new_segment(self):
+    def test_native_add_rejection_can_retry_without_duplicate_resources(self):
         factory = self._factory()
-        self._launch(factory, projectile_id='reused:1')
-        self.assertTrue(factory.stop_projectile_tracer(
-            'reused:1', (10.0, 1.0, 0.0)))
+        _ProjectileMover.reject_add = True
+        with mock.patch('sys.stdout', new=io.StringIO()):
+            self.assertFalse(self._launch(factory))
+        self.assertEqual({}, factory._shot_presenter._projectile_shots)
+        self.assertEqual([], self.bigworld.player().models)
+        _ProjectileMover.reject_add = False
+        self.assertTrue(self._launch(factory))
+        self.assertEqual(1, len(self.bigworld.player().models))
 
-        self.assertTrue(self._launch(
-            factory, projectile_id='reused:1', is_ricochet=True,
-            reference_position=(10.0, 1.0, 0.0),
-            reference_velocity=(-80.0, 4.0, 0.0)))
-        replacement = factory._shot_presenter._projectile_shots['reused:1']
-        self.assertEqual(2, len(self.bigworld._player.models))
-        self.assertEqual(1, len(factory._shot_presenter._projectile_tails))
-        self.assertTrue(factory.update_projectile_visual(
-            'reused:1', (8.0, 1.1, 0.0), (-80.0, 3.0, 0.0)))
-
-        self.bigworld.run_callbacks()
-
-        self.assertIs(
-            replacement,
-            factory._shot_presenter._projectile_shots['reused:1'])
-        self.assertEqual([replacement['model']], self.bigworld._player.models)
-        self.assertEqual({}, factory._shot_presenter._projectile_tails)
-
-    def test_failed_creation_cleanup_keeps_owner_until_exact_retry(self):
+    def test_identity_is_installed_before_native_creation_can_reenter(self):
         factory = self._factory()
-        presenter = factory._shot_presenter
-        self.projectile_effects.attach_error = RuntimeError('attach failed')
-        self.bigworld._player.del_model_error = RuntimeError(
-            'delModel failed')
+        seen = []
+        _ProjectileMover.on_add = lambda: seen.append(dict(
+            factory._shot_presenter._projectile_shots['round:shot']))
+        self.assertTrue(self._launch(factory))
+        self.assertEqual(1, len(seen))
+        self.assertFalse(seen[0]['started'])
+        self.assertEqual(1000000, seen[0]['visual_id'])
 
-        self.assertFalse(self._launch(
-            factory, projectile_id='retry:creation'))
-
-        retained = presenter._projectile_shots['retry:creation']
-        self.assertTrue(retained['creation_failed'])
-        self.assertEqual(1, len(self.bigworld._player.models))
-
-        self.projectile_effects.attach_error = None
-        self.bigworld._player.del_model_error = None
-        self.assertTrue(self._launch(
-            factory, projectile_id='retry:creation'))
-
-        active = presenter._projectile_shots['retry:creation']
-        self.assertFalse(active['creation_failed'])
-        self.assertEqual(1, len(self.bigworld._player.models))
-        self.assertEqual(2, len(self.projectile_effects.attach_calls))
-
-    def test_reset_releases_epoch_visuals_and_presenter_can_launch_again(self):
+    def test_native_add_exception_retains_owner_without_retrying(self):
         factory = self._factory()
-        self._launch(factory, projectile_id='old:1')
-        self._launch(factory, projectile_id='old:2', attacker_id=99)
-
+        _ProjectileMover.add_error = RuntimeError('partial creation')
+        with mock.patch('sys.stdout', new=io.StringIO()):
+            self.assertFalse(self._launch(factory))
+        mover = factory._shot_presenter._mover
+        self.assertFalse(self._launch(factory))
+        self.assertEqual(1, len(mover.calls))
+        self.assertIn('round:shot', factory._shot_presenter._projectile_shots)
         self.assertTrue(factory.reset_projectile_visuals())
 
-        presenter = factory._shot_presenter
-        self.assertEqual({}, presenter._projectile_shots)
-        self.assertEqual({}, presenter._visual_admissions)
-        self.assertEqual([], self.bigworld._player.models)
-        self.assertTrue(self._launch(factory, projectile_id='new:1'))
-        self.assertEqual(1, len(self.bigworld._player.models))
-
-    def test_failed_epoch_reset_disables_later_cosmetic_launches(self):
+    def test_failed_terminal_cannot_reuse_old_motor_as_a_ricochet(self):
         factory = self._factory()
-        self._launch(factory, projectile_id='old:1')
-        presenter = factory._shot_presenter
-        self.bigworld._player.del_model_error = RuntimeError(
-            'delModel failed')
+        first = self._launch(factory)
+        mover = factory._shot_presenter._mover
+        _ProjectileMover.hide_error = RuntimeError('native hide failed')
+        with mock.patch('sys.stdout', new=io.StringIO()):
+            self.assertFalse(factory.stop_projectile_tracer(
+                'round:shot', (20, 0, 0)))
+        self.assertFalse(self._launch(factory, is_ricochet=True))
+        self.assertIn(first, mover._ProjectileMover__projectiles)
+        self.assertEqual([], mover.hold_calls)
+        self.assertTrue(self._launch(factory, 'independent-shot'))
+        _ProjectileMover.hide_error = None
+        self.assertTrue(factory.stop_projectile_tracer('round:shot', (20, 0, 0)))
 
-        self.assertFalse(factory.reset_projectile_visuals())
-        self.assertFalse(presenter._launches_enabled)
-
-        self.bigworld._player.del_model_error = None
-        self.assertFalse(self._launch(factory, projectile_id='new:1'))
-        self.assertNotIn('new:1', presenter._projectile_shots)
-
-    def test_canonical_combat_equipment_artillery_fails_closed(self):
-        artillery, unused_effects = _effects(self.events, artillery=True)
-        forged = dict(self.effects)
-        forged['artilleryID'] = 92
+    def test_material_effect_failure_still_hides_and_does_not_block_later_flight(self):
         factory = self._factory()
-        presenter = factory._shot_presenter
+        shot_id = self._launch(factory)
+        mover = factory._shot_presenter._mover
+        _ProjectileMover.explode_error = RuntimeError('material failure')
+        with mock.patch('sys.stdout', new=io.StringIO()):
+            self.assertTrue(factory.stop_projectile_tracer(
+                'round:shot', (20, 0, 0),
+                explosion=(self.effects, 'ground', (1, 0, 0))))
+        self.assertIn(-shot_id, mover._ProjectileMover__projectiles)
+        self.assertTrue(self._launch(factory, 'next-shot'))
+        self.assertEqual(2, len(mover.calls))
 
-        with mock.patch('sys.stdout', new_callable=io.StringIO) as output:
-            first = self._launch(
-                factory, projectile_id='artillery:1', effects=artillery)
-            forged_result = self._launch(
-                factory, projectile_id='artillery:forged', effects=forged)
-
-        self.assertFalse(first)
-        self.assertFalse(forged_result)
-        self.assertEqual([], self.bigworld._player.models)
-        self.assertEqual([], _ProjectileMover.instances)
-        self.assertEqual({}, presenter._projectile_shots)
-        self.assertNotIn('artillery:1', presenter._visual_admissions)
-        self.assertNotIn(
-            'artillery:forged', presenter._visual_admissions)
-        self.assertEqual(1, output.getvalue().count(
-            'canonical combat-equipment artillery rejected'))
-        self.assertFalse(factory.update_projectile_visual(
-            'artillery:1', (9.0, 8.0, 7.0)))
+    def test_unmapped_or_denied_terminal_does_not_fabricate_visuals(self):
+        factory = self._factory()
         self.assertFalse(factory.stop_projectile_tracer(
-            'artillery:1', (9.0, 8.0, 7.0)))
+            'unowned', (20, 0, 0),
+            explosion=(self.effects, 'ground', (1, 0, 0))))
+        self.assertIsNone(factory._shot_presenter._mover)
+        factory._shot_presenter._visual_admissions['denied'] = (42, False)
+        self.assertFalse(factory.stop_projectile_tracer(
+            'denied', (20, 0, 0),
+            explosion=(self.effects, 'ground', (1, 0, 0))))
 
-    def test_world_explosion_failure_does_not_disable_controlled_tracers(self):
+    def test_admitted_missing_tracer_keeps_late_world_explosion_without_add(self):
         factory = self._factory()
-        self._launch(factory, projectile_id='world:failed')
-        _ProjectileMover.explode_error = RuntimeError('explosion failed')
+        self.assertTrue(factory.admit_projectile_visual(42, 'admitted', 0.0))
         with mock.patch.dict(sys.modules, _modules(self.effects)):
             self.assertTrue(factory.stop_projectile_tracer(
-                'world:failed', (12.0, 0.0, 3.0),
-                explosion=(self.effects, 'ground', (1.0, -1.0, 0.0)),
-                missed=True))
+                'admitted', (20, 0, 0),
+                explosion=(self.effects, 'ground', (1, 0, 0))))
+        mover = factory._shot_presenter._mover
+        self.assertEqual([], mover.calls)
+        self.assertEqual(1, len(mover.explode_calls))
+        self.assertFalse(factory.stop_projectile_tracer(
+            'admitted', (20, 0, 0),
+            explosion=(self.effects, 'ground', (1, 0, 0))))
 
-        self.assertTrue(self._launch(factory, projectile_id='next:shot'))
-        self.assertEqual(2, len(self.bigworld._player.models))
-        self.bigworld.run_callbacks()
-        self.assertEqual(1, len(self.bigworld._player.models))
-        self.assertEqual([], _ProjectileMover.instances[0].calls)
-        self.assertEqual(['player-shot-missed'], self.triggers.triggers)
-
-    def test_invalid_launches_fail_before_scene_or_mover_acquisition(self):
+    def test_combat_equipment_artillery_is_not_admitted_to_native_shell_ledger(self):
         factory = self._factory()
-        with mock.patch.dict(sys.modules, _modules(self.effects)):
-            self.assertFalse(factory.play_projectile_tracer(
-                _descriptor(), 0, (float('nan'), 0.0, 0.0),
-                (1.0, 0.0, 0.0), 1.0, 10.0, 1, 'bad:point'))
-            self.assertFalse(factory.play_projectile_tracer(
-                _descriptor(), 0, (0.0, 0.0, 0.0),
-                (1.0, 0.0, 0.0), 1.0, 10.0, 1, None))
-
-        self.assertEqual([], self.bigworld._player.models)
-        self.assertEqual([], _ProjectileMover.instances)
-
-    def test_destroy_releases_controlled_and_lazy_native_owners_once(self):
-        factory = self._factory()
-        self._launch(factory, projectile_id='world:active')
-        with mock.patch.dict(sys.modules, _modules(self.effects)):
-            mover = factory._shot_presenter._projectile_mover()
-
-        factory.destroy_all()
-
-        self.assertEqual([], self.bigworld._player.models)
-        self.assertEqual(1, mover.destroy_calls)
-        self.assertFalse(self._launch(factory, projectile_id='late:shot'))
-
-    def test_failed_mover_destroy_retains_owner_for_exact_retry(self):
-        factory = self._factory()
-        with mock.patch.dict(sys.modules, _modules(self.effects)):
-            mover = factory._shot_presenter._projectile_mover()
-        _ProjectileMover.destroy_error = RuntimeError('destroy failed')
-
-        with self.assertRaisesRegex(RuntimeError, 'destroy failed'):
-            factory.destroy_all()
-
-        self.assertIs(mover, factory._shot_presenter._mover)
-        self.assertEqual(1, mover.destroy_calls)
-        _ProjectileMover.destroy_error = None
-        factory.destroy_all()
-        self.assertEqual(2, mover.destroy_calls)
+        effects, unused = _effects(self.events, artillery=True)
+        with mock.patch('sys.stdout', new=io.StringIO()):
+            self.assertFalse(self._launch(factory, effects=effects))
         self.assertIsNone(factory._shot_presenter._mover)
+        self.assertEqual([], self.bigworld.player().models)
 
-    def test_both_factory_implementations_expose_controlled_visual_lifecycle(self):
-        for factory_type in (RemoteVehicleFactory,
-                             NativeRemoteVehicleFactory):
-            self.assertTrue(callable(getattr(
-                factory_type, 'update_projectile_visual', None)))
-            self.assertTrue(callable(getattr(
-                factory_type, 'reset_projectile_visuals', None)))
+    def test_destroy_is_safe_twice_and_late_native_expiry_is_harmless(self):
+        factory = self._factory()
+        shot_id = self._launch(factory)
+        presenter = factory._shot_presenter
+        mover = presenter._mover
+        presenter.destroy()
+        presenter.destroy()
+        mover.expire(shot_id)
+        self.assertEqual(1, mover.destroy_calls)
+        self.assertEqual([], self.bigworld.player().models)
+        self.assertEqual([], self.triggers.triggers)
+        self.assertFalse(self._launch(factory, 'after-destroy'))
 
-    def test_both_factory_implementations_forward_visual_start(self):
-        visual_start = (7.0, 8.0, 9.0)
-        for factory_type in (RemoteVehicleFactory,
-                             NativeRemoteVehicleFactory):
-            with self.subTest(factory=factory_type.__name__):
-                factory = factory_type.__new__(factory_type)
+    def test_both_factories_forward_native_launch_and_terminal(self):
+        for cls in (RemoteVehicleFactory, NativeRemoteVehicleFactory):
+            with self.subTest(factory=cls.__name__):
+                factory = object.__new__(cls)
                 factory._shot_presenter = mock.Mock()
-                factory._shot_presenter.play_canonical.return_value = 17
-
-                self.assertEqual(17, factory.play_projectile_tracer(
-                    _descriptor(), 0, (1.0, 2.0, 3.0),
-                    (120.0, 20.0, 0.0), 9.81, 640.0, 42,
-                    'forwarded:1', (3.0, 4.0, 5.0),
-                    (100.0, 10.0, 0.0), False, visual_start))
-
-                self.assertEqual(
-                    visual_start,
-                    factory._shot_presenter.play_canonical.call_args.args[-1])
+                factory.play_projectile_tracer(
+                    'descriptor', 2, (1, 2, 3), (100, 0, 0), 9.81,
+                    400, 42, 'round:shot', (2, 2, 3), (100, 0, 0),
+                    False, (3, 2, 3))
+                factory._shot_presenter.play_canonical.assert_called_once_with(
+                    'descriptor', 2, (1, 2, 3), (100, 0, 0), 9.81,
+                    400, 42, 'round:shot', (2, 2, 3), (100, 0, 0),
+                    False, (3, 2, 3))
+                self.assertFalse(hasattr(factory, 'update_projectile_visual'))
 
 
 if __name__ == '__main__':

--- a/tests/test_port_0922_simulation_worker.py
+++ b/tests/test_port_0922_simulation_worker.py
@@ -856,7 +856,7 @@ class SimulationWorkerStateTests(unittest.TestCase):
         self.assertFalse(player.participating)
         self.assertIs(worker, state.simulation_worker)
         self.assertEqual('battle', state.phase)
-        self.assertEqual(2, state.battle_result['winner'])
+        self.assertEqual(3 - player.team, state.battle_result['winner'])
         self.assertEqual('team_eliminated', state.battle_result['reason'])
         receipts = [
             receipt for receipt in state.result_receipts.values()
@@ -918,7 +918,7 @@ class SimulationWorkerStateTests(unittest.TestCase):
         self.assertFalse(reset)
         self.assertIs(worker, state.simulation_worker)
         self.assertIsNotNone(state.battle_result)
-        self.assertEqual(2, state.battle_result['winner'])
+        self.assertEqual(3 - player.team, state.battle_result['winner'])
         self.assertEqual('team_eliminated',
                          state.battle_result['reason'])
         receipt = next(

--- a/tools/audit_client_abi.py
+++ b/tools/audit_client_abi.py
@@ -165,6 +165,7 @@ EXPECTED_ABI = {
             'refVelocity', 'startPoint', 'maxDistance', 'attackerID',
             'tracerCameraPos'),
         'ProjectileMover.hide': ('self', 'shotID', 'endPoint'),
+        'ProjectileMover.hold': ('self', 'shotID'),
         'ProjectileMover.explode': (
             'self', 'shotID', 'effectsDescr', 'effectMaterial', 'endPoint',
             'velocityDir'),
@@ -175,6 +176,9 @@ EXPECTED_ABI = {
         'ProjectileMover.__killProjectile': (
             'self', 'shotID', 'position', 'impactVelDir'),
         'ProjectileMover.__delProjectile': ('self', 'shotID'),
+        'ProjectileMover.__deleteProjectile': ('self', 'shotID'),
+        'ProjectileMover.__onCameraChanged': (
+            'self', 'cameraName', 'currentVehicleId'),
         'segmentMayHitEntity': ('entity', 'startPoint', 'endPoint'),
         'collideEntities': (
             'startPoint', 'endPoint', 'entities', 'skipGun'),
@@ -966,6 +970,9 @@ EXPECTED_CODE_LITERALS = {
             'showExplosion', 'fireMissedTrigger', 'autoScaleProjectile',
             'attackerID', 'effectsData', 'flying', 'isPlayerVehicle',
             'isArtillery'),
+        'ProjectileMover.hide': ('fireMissedTrigger', 'showExplosion'),
+        'ProjectileMover.__deleteProjectile': ('fireMissedTrigger',),
+        'ProjectileMover.__onCameraChanged': ('sniper',),
         'ProjectileMover.explode': (
             'artilleryID', 'effectsDescr', 'effectMaterial', 'attackerID',
             'fireMissedTrigger', 'showExplosion'),
@@ -1364,12 +1371,35 @@ EXPECTED_CODE_NAMES = {
             'dist', 'hitAngleCos', 'matInfo', 'compName'),
     },
     'scripts/client/ProjectileMover.pyc': {
+        'ProjectileMover.__init__': (
+            '_ProjectileMover__projectiles', 'PyBallisticsSimulator',
+            '_ProjectileMover__killProjectile',
+            '_ProjectileMover__deleteProjectile', 'setFixedBallisticsParams',
+            '_ProjectileMover__PROJECTILE_HIDING_TIME',
+            '_ProjectileMover__PROJECTILE_TIME_AFTER_DEATH',
+            '_ProjectileMover__AUTO_SCALE_DISTANCE', 'SERVER_TICK_LENGTH',
+            'inputHandler', 'onCameraChanged'),
         'ProjectileMover.add': (
             'distTo', '_ProjectileMover__START_POINT_MAX_DIFF',
             'salvo', 'addProjectile', '_ProjectileMover__ballistics',
             'BigWorld', 'Model', 'player', 'addModel', 'addMotor',
             'visible', 'visibleAttachments', 'attachTo', 'FlockManager',
             'getManager', 'onProjectile'),
+        'ProjectileMover.hide': (
+            '_ProjectileMover__projectiles', 'pop',
+            '_ProjectileMover__delProjectile',
+            '_ProjectileMover__notifyProjectileHit',
+            '_ProjectileMover__ballistics', 'hideProjectile'),
+        'ProjectileMover.hold': (
+            '_ProjectileMover__ballistics', 'holdProjectile'),
+        'ProjectileMover.setSpaceID': (
+            '_ProjectileMover__ballistics', 'setVariableBallisticsParams'),
+        'ProjectileMover.__deleteProjectile': (
+            '_ProjectileMover__projectiles', 'get',
+            '_ProjectileMover__delProjectile', 'TriggersManager',
+            'fireTrigger', 'PLAYER_SHOT_MISSED'),
+        'ProjectileMover.__onCameraChanged': (
+            '_ProjectileMover__ballistics', 'setBallisticsAutoScale'),
         'ProjectileMover.explode': (
             'TriggersManager', 'g_manager', 'fireTrigger', 'TRIGGER_TYPE',
             'PLAYER_SHOT_MISSED',

--- a/tools/audit_client_lifecycle.py
+++ b/tools/audit_client_lifecycle.py
@@ -236,6 +236,23 @@ ORDERED_USES = (
     ),
     (
         'scripts/client/ProjectileMover.pyc',
+        'ProjectileMover.hide',
+        ('_ProjectileMover__projectiles', 'pop',
+         '_ProjectileMover__projectiles', 'fireMissedTrigger',
+         'showExplosion', '_ProjectileMover__notifyProjectileHit',
+         '_ProjectileMover__ballistics', 'hideProjectile'),
+        'hide transfers the stock row before retiring its native motor',
+    ),
+    (
+        'scripts/client/ProjectileMover.pyc',
+        'ProjectileMover.__deleteProjectile',
+        ('_ProjectileMover__projectiles', 'get',
+         '_ProjectileMover__delProjectile', 'fireMissedTrigger',
+         'TriggersManager', 'fireTrigger'),
+        'native expiry deletes the model before optional missed feedback',
+    ),
+    (
+        'scripts/client/ProjectileMover.pyc',
         'ProjectileMover.destroy',
         ('inputHandler', 'onCameraChanged',
          '_ProjectileMover__onCameraChanged',

--- a/tools/audit_native_resource_ownership.py
+++ b/tools/audit_native_resource_ownership.py
@@ -177,14 +177,21 @@ ORDERED_CONTRACTS = (
         'entities/remote_vehicle.py',
         '_RemoteShotPresenter._projectile_mover',
         'ProjectileMover ownership follows the stock space binding',
-        (('call', 'ProjectileMover'), ('call', 'set_space_id'),
+        (('call', 'CanonicalProjectileMover'), ('call', 'set_space_id'),
          ('assign', 'self._mover')),
     ),
     (
         'entities/remote_vehicle.py',
         '_RemoteShotPresenter.destroy',
         'ProjectileMover native teardown precedes owner release',
-        (('call', 'callback'), ('assign', 'self._mover'),
+        (('call', 'self._mover.destroy'), ('assign', 'self._mover'),
+         ('call', 'self.reset_canonical')),
+    ),
+    (
+        'entities/remote_vehicle.py',
+        '_RemoteShotPresenter.reset_canonical',
+        'round reset retires native flight before forgetting logical shots',
+        (('call', 'mover.destroy'), ('assign', 'self._mover'),
          ('assign', 'self._projectile_shots')),
     ),
     (
@@ -435,6 +442,14 @@ class _ModuleIndex(ast.NodeVisitor):
         return '.'.join(self._scope) if self._scope else '<module>'
 
     def visit_ClassDef(self, node):
+        # Constructing a Python subclass still acquires its native base.
+        # Record it in the enclosing scope, where the constructor is called.
+        for base in node.bases:
+            resource = self._resource_name(base)
+            if resource is not None:
+                self._assignment_aliases[(self._qualname(), node.name)] = \
+                    resource
+                break
         self._scope.append(node.name)
         self.generic_visit(node)
         self._scope.pop()
@@ -472,8 +487,12 @@ class _ModuleIndex(ast.NodeVisitor):
             if leaf in RESOURCE_CALLS:
                 return leaf
             if isinstance(callee, ast.Name):
-                alias = self._assignment_aliases.get(
-                    (self._qualname(), callee.id))
+                alias = None
+                for width in range(len(self._scope), -1, -1):
+                    scope = '.'.join(self._scope[:width]) or '<module>'
+                    alias = self._assignment_aliases.get((scope, callee.id))
+                    if alias is not None:
+                        break
                 if alias is None:
                     alias = self._import_aliases.get(callee.id)
                 if alias is not None:


### PR DESCRIPTION
After a shot was confirmed, its visible tracer could still pause at the last worker-confirmed trajectory cursor. Delayed worker updates therefore delayed the firing presentation even after launch admission.

Use the stock #1513 `ProjectileMover` and its native ballistics motor to advance cosmetic flight continuously for both human and Bot shots. The worker still owns collision, damage, ricochet, ammunition, reload, and terminal results. This preserves the stock predicted-muzzle timeout and does not eliminate the initial wait for launch confirmation.

- Remove snapshot-driven tracer positioning and the competing Python Servo. Launches use the admitted trajectory and stock guarded visual muzzle; a first active snapshot can seed a late tracer.
- Apply canonical terminal and ricochet events through stock hide/explode/hold behavior. Deduplicate shot identities across native expiry, retain native ownership on failures, account for particle tails, and clean up on round reset and teardown.
- Suppress cosmetic native hit/missed feedback for canonical shots so worker terminal feedback remains the single owner. Extend exact-client ABI and lifecycle audits and update compatibility evidence.

Two existing disconnect/leave tests now derive the winning team from the player's actual assignment. The base commit restored random team selection, so their hard-coded team-2 expectations were already intermittent failures in [main CI](https://github.com/pengw0048/wot-offline-battles/actions/runs/33965471669). Both tests pass with the player explicitly assigned to each team; no settlement behavior changes.

Validation on commit `863b9af733370f226694369246f7ebd0ed4015df`:

- Both [PR CI](https://github.com/pengw0048/wot-offline-battles/actions/runs/33968527100) and [push CI](https://github.com/pengw0048/wot-offline-battles/actions/runs/33968525382) passed: full client and launcher suites, Windows server build/smoke checks, Python 2.7 client packaging and validation, and Windows launcher build/artifact checks.
- 1,169 related tests passed, covering projectile modules, battle runtime, simulation worker, and ABI/lifecycle/ownership audit tests. The selected discovery patterns were `test_port_0922_*projectile*.py`, `test_port_0922_battle_runtime.py`, `test_port_0922_client_abi_audit.py`, `test_port_0922_client_lifecycle_audit.py`, `test_audit_native_resource_ownership.py`, and `test_port_0922_simulation_worker.py`, run with `PYTHONDONTWRITEBYTECODE=1 python3`.
- All 91 client Python sources compiled with CPython 2.7.18 without writing adjacent bytecode.
- `python2.7 tools/audit_client_abi.py "$WOT_0922_CLIENT"` and `python2.7 tools/audit_client_lifecycle.py "$WOT_0922_CLIENT"` passed against the reviewed #1513 resource data.
- `python2.7 tools/audit_native_resource_ownership.py src/res/scripts/client/gui/mods/offline_lan_0922` passed with 7 acquisition sites and 46 ownership contracts, including native subclass acquisition and round-reset teardown.
- `git diff origin/main...HEAD --check` passed.

Exact Windows client acceptance is still needed for rendered flight, late terminal correction, ricochet appearance, particle lifetime, teardown, and frame pacing. Local tests establish adapter behavior and authority boundaries; they do not establish native gameplay feel. Worker FPS optimization is outside this PR.
