### PR TITLE
Enter the whole bot line-up without a wall-clock spawn delay

### DIFF
--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -184,7 +184,6 @@ ARTILLERY_ARC_RAYS_PER_FRAME = 4
 STANDARD_GAMEPLAY = 'ctf'
 PREBATTLE_SECONDS = 10.0
 BATTLE_SECONDS = 900.0
-BOT_SPAWN_SECONDS = 0.30
 BOT_MANIFEST_RETRY_SECONDS = 0.25
 PLAYER_ENVIRONMENT_SECONDS = 0.3
 MAX_PENDING_LANDING_IMPACTS = 32
@@ -1625,7 +1624,8 @@ class BattleRuntime(object):
         self._pending_bot_create_order = []
         self._last_bot_create_team = None
         self._bots_ready_reported = False
-        self._next_bot_create_time = 0.0
+        self._bot_create_started = None
+        self._bot_create_finished = None
         self._arena_type = None
         self._arena_bounds = None
         self._spawn_planner = None
@@ -1909,7 +1909,8 @@ class BattleRuntime(object):
         self._pending_bot_create_order = []
         self._last_bot_create_team = None
         self._bots_ready_reported = False
-        self._next_bot_create_time = 0.0
+        self._bot_create_started = None
+        self._bot_create_finished = None
         self._navigation_graph = None
         self._grounded_bot_ids = set()
         self._bot_vehicle_assignments = {}
@@ -15244,10 +15245,12 @@ class BattleRuntime(object):
     def _maybe_send_battle_ready(self):
         """Open the shared countdown after the complete line-up has entered.
 
-        Bot presentation remains staggered to keep one 32-bit render callback
-        from constructing 29 HD compounds.  It now finishes behind the stock
-        BattleLoading screen instead of spending the first countdown seconds
-        loading the line-up that will shortly begin moving.
+        The stock battle page appears as soon as the local Vehicle enters, so
+        every remaining create is visible to the player.  Bot creates stay one
+        per render callback to keep one 32-bit callback from constructing 29
+        HD compounds, but they are no longer spread over wall-clock time: the
+        countdown opens once the roster has entered, not one fixed delay per
+        bot later.
         """
         if self._ready_sent or self._battle_live:
             return False
@@ -15274,6 +15277,29 @@ class BattleRuntime(object):
         if not ready(bases):
             raise RuntimeError('LAN server did not accept battle readiness')
         self._ready_sent = True
+        self._report_lineup_windows(len(bot_records))
+        return True
+
+    def _report_lineup_windows(self, bot_count):
+        """Say how long this process held the shared countdown closed.
+
+        ``created`` is the wall time spent issuing native creates and ``ready``
+        the time until the last compound finished entering the world.  Both are
+        measured from the first create, so one report line from the visible
+        client and one from the hidden worker explain the whole gap between the
+        bot manifest and BATTLE LIVE in the server log.
+        """
+        started = self._bot_create_started
+        if started is None:
+            return False
+        finished = self._bot_create_finished
+        now = self._clock()
+        sys.stdout.write(
+            '[Offline LAN 0.9.22] LINEUP bots=%d created_s=%.3f '
+            'ready_s=%.3f\n' % (
+                bot_count,
+                0.0 if finished is None else max(0.0, finished - started),
+                max(0.0, now - started)))
         return True
 
     def _sample_ground_plane(self, position, yaw, descriptor=None):
@@ -19252,12 +19278,12 @@ class BattleRuntime(object):
             self._destroy_entity(event)
 
     def _queue_bot_create(self, event):
-        """Coalesce one bot until its staggered native createEntity call.
+        """Coalesce one bot until its own native createEntity callback.
 
-        The 0.8.2 implementation deliberately spreads the line-up over time.
         Creating 29 HD Vehicle entities and their model prerequisites in one
         BigWorld callback is both visibly janky and unsafe in this 32-bit
-        client.  Keep the newest snapshot pose while preserving roster order.
+        client, so each queued bot is created in a callback of its own.  Keep
+        the newest snapshot pose while preserving roster order.
         """
         key = event.get('entity')
         if not key or key in self._records:
@@ -19286,9 +19312,20 @@ class BattleRuntime(object):
         return True
 
     def _flush_pending_bot_create(self, now):
-        if (not self._pending_bot_create_order or
-                now < self._next_bot_create_time):
+        """Create the next queued bot in this render callback.
+
+        One create per callback is the whole rule: a single BigWorld callback
+        must never construct the entire line-up, but nothing in #1513 requires
+        the line-up to be spread over wall-clock time.  The former fixed
+        0.30 s delay between creates delayed the shared countdown by roughly
+        nine seconds for a 29 bot roster, because both the visible client and
+        the hidden worker only report battle readiness once their whole roster
+        exists.
+        """
+        if not self._pending_bot_create_order:
             return False
+        if self._bot_create_started is None:
+            self._bot_create_started = now
         key = self._pending_bot_create_order[0]
         # Alternate teams so both bases materialize together instead of one
         # full lineup appearing before the other.
@@ -19302,7 +19339,6 @@ class BattleRuntime(object):
                     break
         self._pending_bot_create_order.remove(key)
         event = self._pending_bot_creates.pop(key, None)
-        self._next_bot_create_time = now + BOT_SPAWN_SECONDS
         if event is None or key in self._records:
             return False
         self._create_remote(event)
@@ -19316,6 +19352,7 @@ class BattleRuntime(object):
             # battle_start runs before the first bot is queued, so the native
             # counters only mean something once the whole roster exists.
             self._bots_ready_reported = True
+            self._bot_create_finished = now
             self._report_memory('bots_ready')
         return created
 

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -9849,15 +9849,14 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertFalse(battle._sync._entities['bot:11']['dead'])
         self.assertFalse(battle._sync._entities['bot:12']['dead'])
 
+        # One create per render callback, and no wall-clock delay between
+        # them: the second bot enters on the very next frame.
         battle._frame()
         self.assertIn('bot:11', battle._records)
         self.assertNotIn('bot:12', battle._records)
-        runtime.bigworld.now += 0.29
-        battle._frame()
-        self.assertNotIn('bot:12', battle._records)
-        runtime.bigworld.now += 0.02
         battle._frame()
         self.assertIn('bot:12', battle._records)
+        self.assertEqual(10.0, runtime.bigworld.now)
 
         # VehicleDescr returns unloaded #1513 testers in this full startup
         # fixture. The resolver must admit every bot descriptor before
@@ -9912,8 +9911,8 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertFalse(battle._ready_sent)
         self.assertEqual(1, len(battle._pending_bot_create_order))
         self.assertFalse(battle._battle_live)
-        # Enemy models finish behind BattleLoading, but their marker/minimap
-        # visual is still not registered before the first real spot.
+        # The enemy model is assembled, but its marker/minimap visual is
+        # still not registered before the first real spot.
         self.assertEqual(0, len(runtime.bigworld.avatar.visual_starts))
         enemy = battle._records['bot:11']
         self.assertFalse(enemy['spot_visible'])
@@ -9923,9 +9922,9 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertIsNone(runtime.bigworld.entities.get(enemy['engine_id']))
         self.assertNotIn(enemy['engine_id'], runtime.bigworld.entities)
 
-        runtime.bigworld.now += battle_runtime_module.BOT_SPAWN_SECONDS + 0.01
         battle._frame()
 
+        self.assertEqual(10.0, runtime.bigworld.now)
         client.send_battle_ready.assert_called_once()
         self.assertTrue(battle._ready_sent)
         self.assertFalse(battle._pending_bot_create_order)
@@ -9952,6 +9951,85 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertNotIn('bot:11', battle._records)
         self.assertIsNone(battle._remote_factory.get(enemy['engine_id']))
         self.assertIsNone(runtime.bigworld.entity(enemy['engine_id']))
+
+    def test_lineup_enters_without_a_wall_clock_spawn_delay(self):
+        """The countdown waits for the roster, not for one delay per bot.
+
+        The former fixed 0.30 s gap between creates held the server's shared
+        countdown closed for roughly nine seconds on a 29 bot roster, because
+        both the visible client and the hidden worker only report readiness
+        once their whole line-up exists.
+        """
+        runtime = _runtime()
+        runtime.bigworld.defer_vehicle_entry = True
+        original_load = runtime.bigworld.loadResourceListBG
+        compound_loads = []
+
+        def defer_compounds(resources, callback):
+            if isinstance(resources[0], str):
+                original_load(resources, callback)
+                return
+            compound_loads.append((resources, callback))
+
+        runtime.bigworld.loadResourceListBG = defer_compounds
+        battle = BattleRuntime(runtime)
+        client = _Client()
+        client.send_battle_ready = mock.Mock(return_value=True)
+        start = {
+            'round_id': 1, 'map': '01_karelia', 'bot_authority_id': 1,
+            'players': [{
+                'id': 1, 'team': 1, 'slot': 0, 'name': 'Player',
+                'vehicle': 'ussr:R11_MS-1', 'health': 500}],
+            'bots': [{
+                'id': 11, 'team': 2, 'slot': 0, 'name': 'Enemy 1'}, {
+                'id': 12, 'team': 2, 'slot': 1, 'name': 'Enemy 2'}, {
+                'id': 21, 'team': 1, 'slot': 1, 'name': 'Ally 1'}, {
+                'id': 22, 'team': 1, 'slot': 2, 'name': 'Ally 2'}]}
+
+        self.assertTrue(battle.start({
+            'map': '01_karelia', 'vehicle': 'ussr:R11_MS-1',
+            'name': 'Player', 'native_remote_vehicles': False},
+            start, client))
+        runtime.bigworld.callbacks.pop(0)()
+        runtime.bigworld.enter_pending_vehicle(battle._server.vehicle_id)
+        runtime.bigworld.callbacks.pop(0)()
+
+        self.assertEqual(4, len(battle._pending_bot_create_order))
+        started = runtime.bigworld.now
+
+        # One create per render callback, four callbacks, no engine time.
+        teams = []
+        for expected_pending in (3, 2, 1, 0):
+            self.assertTrue(battle._flush_pending_bot_create(
+                runtime.bigworld.now))
+            self.assertEqual(
+                expected_pending, len(battle._pending_bot_create_order))
+            teams.append(battle._last_bot_create_team)
+        self.assertEqual(started, runtime.bigworld.now)
+        self.assertFalse(battle._flush_pending_bot_create(
+            runtime.bigworld.now))
+
+        # Both bases still materialize together rather than one whole team
+        # before the other.
+        self.assertEqual([2, 1, 2, 1], teams)
+        self.assertEqual(4, len(
+            [key for key in battle._records if key.startswith('bot:')]))
+        self.assertEqual(4, len(compound_loads))
+
+        # Model assembly stays asynchronous, so the shared countdown remains
+        # closed until every bot compound is really in the world.
+        battle._frame()
+        client.send_battle_ready.assert_not_called()
+        self.assertFalse(battle._ready_sent)
+
+        for resources, callback in compound_loads:
+            original_load(resources, callback)
+        battle._frame()
+
+        client.send_battle_ready.assert_called_once()
+        self.assertTrue(battle._ready_sent)
+        self.assertEqual(started, runtime.bigworld.now)
+        battle.stop(show_login=False)
 
     def test_wreck_prewarm_is_batched_in_loading_before_runtime_starts(self):
         runtime = _runtime()
@@ -9986,7 +10064,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
             start, client))
 
         # All selected descriptors submit immediately from _create_entities;
-        # no bot-spawn timer has run and engine time has not advanced.
+        # no bot has been created yet and engine time has not advanced.
         self.assertTrue(wreck_requests)
         self.assertEqual(10.0, runtime.bigworld.now)
         self.assertEqual(


### PR DESCRIPTION
## Observed problem

Every round has a phase, after the battlefield is on screen and before the
countdown starts, in which bots pop in one at a time. On a 29 bot roster it
lasts about nine seconds.

## Evidence

From a Windows session report (server log):

```
[08:04:05] BATTLE LOADING round=1 map=02_malinovka players=1
[08:04:10] BOT MANIFEST authority=-1 bots=29
[08:04:19] BATTLE LIVE round=1 countdown=10.0s players=1
```

Nine seconds between the manifest and the countdown, which is `29 x 0.30`.
Both processes agree: the visible client's `PERF collections` at 08:04:14.964
reported `pending_bots=15 records=15`, the hidden worker's at 08:04:15.705
reported `pending_bots=12 records=19` - roughly 0.33 s per bot in each.

## Cause

`BOT_SPAWN_SECONDS = 0.30` (inherited from 0.8.2) forced a fixed wall-clock
gap between consecutive bot creates, and `_maybe_send_battle_ready` only
reports readiness once the whole roster exists. Both the visible client and
the hidden worker must report before the server opens the shared countdown,
so the roster drain time is the countdown delay.

## Change

`_flush_pending_bot_create` now creates one queued bot per render callback and
the timer is gone. The invariant the old comment actually cared about - one
BigWorld callback must never construct 29 HD compounds in this 32-bit client -
is preserved by the one-per-callback rule; wall-clock spacing was never part of
it. `FRAME_SECONDS` is 0.0, so 29 creates now cost 29 render frames.

Unchanged: team alternation, roster order, snapshot-pose coalescing, and the
readiness barrier. The countdown still opens only after every compound has
really entered the world, so the line-up appears complete instead of popping in
during the freeze.

Also in this change:

- Two docstrings claimed the staggering finished behind the stock
  `BattleLoading` screen. The stock battle page appears as soon as the local
  Vehicle enters, so those creates were visible to the player. Corrected.
- One `LINEUP bots=N created_s=X ready_s=Y` line per process at the readiness
  barrier, so the next Windows session can measure what is left of the gap
  without a profiler.

## Tests

- New `test_lineup_enters_without_a_wall_clock_spawn_delay`: four queued bots
  enter in four callbacks with no engine time advanced, teams still alternate
  `2,1,2,1`, and the barrier stays closed until the deferred compound loads
  complete.
- `test_countdown_waits_until_all_bot_presentations_are_ready` and
  `test_empty_loading_snapshot_cannot_tombstone_authority_bots` no longer
  advance the fake clock between creates.
- `python -m unittest discover -s tests -p "test_*.py"`: 3618 tests, OK.
- CPython 2.7.18 source compile of `src/res/scripts/client`: 91 files, passed.

## Not proved here

What actually changes at runtime is loader concurrency: today at most one or
two vehicle compounds load at a time, after this change up to 29 are in flight.
Only the exact Windows client can prove that #1513 absorbs that without a hitch
or a 32-bit transient-memory spike. The `LINEUP` line plus the existing
`bots_ready` memory report are the instruments for that comparison. If Windows
shows a problem, the correct escalation is a bound on created-but-not-ready
entities, not a reinstated timer.