### PR TITLE
Adjudicate the random human team in worker result tests

### DIFF
--- a/tests/test_port_0922_simulation_worker.py
+++ b/tests/test_port_0922_simulation_worker.py
@@ -856,7 +856,9 @@ class SimulationWorkerStateTests(unittest.TestCase):
         self.assertFalse(player.participating)
         self.assertIs(worker, state.simulation_worker)
         self.assertEqual('battle', state.phase)
-        self.assertEqual(2, state.battle_result['winner'])
+        # The room assigns the human a random team, so the surviving side is
+        # whichever team the only human is not on.
+        self.assertEqual(3 - int(player.team), state.battle_result['winner'])
         self.assertEqual('team_eliminated', state.battle_result['reason'])
         receipts = [
             receipt for receipt in state.result_receipts.values()
@@ -918,7 +920,7 @@ class SimulationWorkerStateTests(unittest.TestCase):
         self.assertFalse(reset)
         self.assertIs(worker, state.simulation_worker)
         self.assertIsNotNone(state.battle_result)
-        self.assertEqual(2, state.battle_result['winner'])
+        self.assertEqual(3 - int(player.team), state.battle_result['winner'])
         self.assertEqual('team_eliminated',
                          state.battle_result['reason'])
         receipt = next(


### PR DESCRIPTION
## Problem

`main` has been red since bf13124 "Restore random team selection", and the
failure also reddens unrelated pull requests - it hit PR #58 on its first run:

```
FAIL: test_live_human_disconnect_adjudicates_remaining_bots
AssertionError: 2 != 1
```

## Cause

`BattleState.add_player` now picks `random.choice` among the balanced teams
when the client requests team 0, which is the intended behaviour of that
commit. Two `SimulationWorkerStateTests` cases still assert that team 2 wins
after the only human dies or disconnects, so they pass or fail on a coin flip.

Locally on bf13124, `test_dead_human_leave_adjudicates_and_notifies_worker_once`
failed 5 of 12 runs and `test_live_human_disconnect_adjudicates_remaining_bots`
failed 5 of 8 runs of the module.

## Change

Test-only. Both cases now read the surviving side from the human's own team
(`3 - player.team`) instead of hard-coding 2. No runtime behaviour changes.

`test_dead_and_live_humans...` (the two-human case) is left alone on purpose:
the second player always lands on the opposite team of the first, so its
adjudication was already deterministic and it did not flake in repeated runs.

## Tests

- `python -m unittest test_port_0922_simulation_worker`: OK in 10 consecutive
  runs (it failed in 5 of 8 before the change).