### PR TITLE
Follow launcher language in the in-game LAN interface

### DIFF
--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -1950,3 +1950,32 @@ lobby features outside that matrix and all BigWorld-side behavior still remain
 empirical. If a real-client check fails, preserve `python.log`; the package
 intentionally avoids noisy per-frame tracing so the first actionable traceback
 remains visible.
+
+## Mod display language
+
+The launcher passes its resolved `en`/`zh` selection as
+`WOT_OFFLINE_UI_LANGUAGE` to the visible game starter, whose child inherits the
+process environment. It is presentation state only: map geometry keys, team
+requests, endpoint syntax, persisted choices and LAN messages do not change.
+Mod-owned waiting-room labels and lobby notifications use a Python 2 Unicode
+catalog; UTF-8 client map names and player names are decoded before formatting.
+In particular, the waiting-room refresh no longer calls Python 2 `str()` on
+Unicode roster text. Stock Scaleform UI retains the client's language.
+
+The waiting room uses the packaged `system/fonts/offline_lan_cjk.font` in both
+languages so Chinese player names also work with English labels. It requests
+Windows Microsoft YaHei at size 16 without a pre-generated Latin-only atlas.
+The [BigWorld Client Programming Guide, Fonts](https://howarduong.github.io/github.io/doc/html/client_programming_guide/ch18.html)
+documents dynamic glyph caching, installed TrueType fonts and CJK font support.
+This is engine documentation, not proof of #1513 native rendering. No font
+binary is redistributed. The font is assigned before text; load errors reach
+the existing session fallback to the stock training window.
+
+Local regression coverage checks launcher environment propagation, translated
+host/guest labels, Unicode names, map wire identity, denial notifications and
+catalog formatting. The available loose client files did not pass
+`tools/inspect_client.py` (missing version.xml, paths.xml and the client package
+layout); they are not a newly verified complete #1513 resource set. Exact
+Windows #1513 acceptance must still check font availability, Chinese glyphs,
+notification rendering and panel clipping at supported resolutions, in both
+launcher languages. A Chinese stock garage alone does not validate GUI.Text.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ and battle logic, a small LAN server and a launcher.
    host picks the map and clicks **START BATTLE**. **LEAVE** returns you to
    the garage.
 
+The mod's waiting room and LAN notifications follow the launcher's selected
+English or Simplified Chinese language when you start the game. **Automatic**
+uses the same resolved system language as the launcher. Restart the game after
+changing this selection. Stock garage and battle UI keep the client's language;
+Chinese map labels come from the client's own arena catalog. Direct batch-file
+launches retain English unless `WOT_OFFLINE_UI_LANGUAGE=zh` is set.
+
 When you host, approve the UAC prompt that opens TCP 28782 for the launcher.
 Run the server only on a network you trust.
 

--- a/launcher/core.py
+++ b/launcher/core.py
@@ -204,7 +204,7 @@ def visible_client_command(game_root, port_version, paired_worker=False):
 def visible_client_environment(port_version, host=LOCAL_HOST,
                                port=DEFAULT_SERVER_PORT,
                                paired_worker=False, environment=None,
-                               preferred_team=DEFAULT_PREFERRED_TEAM):
+                               preferred_team=DEFAULT_PREFERRED_TEAM, language="en"):
     """Keep worker-only state out of the visible game process."""
     environment = dict(os.environ if environment is None else environment)
     if port_version != PORT_0_9_22:
@@ -213,6 +213,7 @@ def visible_client_environment(port_version, host=LOCAL_HOST,
         environment, bundled_payload_identity(port_version))
     for name in (HIDDEN_DESKTOP_ENV_0922, WORKER_READY_MARKER_ENV_0922):
         environment.pop(name, None)
+    environment["WOT_OFFLINE_UI_LANGUAGE"] = ("zh" if language == "zh" else "en")
     environment[CLIENT_MODE_ENV_0922] = PLAYER_MODE_0922
     environment[CLIENT_SERVER_HOST_ENV_0922] = str(host)
     environment[CLIENT_SERVER_PORT_ENV_0922] = str(int(port))

--- a/launcher/tests/test_launcher_core.py
+++ b/launcher/tests/test_launcher_core.py
@@ -683,6 +683,15 @@ class ServerPayloadTest(unittest.TestCase):
                      core.WORKER_READY_MARKER_ENV_0922):
             self.assertNotIn(name, environment)
 
+    def test_visible_client_language_overrides_inherited_selection(self):
+        for language, expected in (("zh", "zh"), ("en", "en"),
+                                   ("invalid", "en")):
+            inherited = {"WOT_OFFLINE_UI_LANGUAGE": "zh"}
+            environment = core.visible_client_environment(
+                core.PORT_0_9_22, environment=inherited, language=language)
+            self.assertEqual(expected, environment["WOT_OFFLINE_UI_LANGUAGE"])
+            self.assertEqual({"WOT_OFFLINE_UI_LANGUAGE": "zh"}, inherited)
+
     def test_visible_client_carries_the_preferred_team(self):
         environment = core.visible_client_environment(
             core.PORT_0_9_22, environment={}, preferred_team=2)

--- a/launcher/tests/test_launcher_window.py
+++ b/launcher/tests/test_launcher_window.py
@@ -2108,6 +2108,18 @@ class WindowTest(unittest.TestCase):
                 boundary, wot_launcher.error_reports.ROLE_VISIBLE_CLIENT),
             environment[wot_launcher.CRASH_DUMP_PATH_ENV])
 
+    def test_game_receives_resolved_launcher_language(self):
+        for language in ("zh", "en"):
+            self.window.language = language
+            with mock.patch("wot_launcher.subprocess.Popen",
+                            return_value=_Process(exit_code=0)) as popen, \
+                    mock.patch("core.wait_for_game_exit"):
+                self.window._run_game(
+                    self.settings_dir, core.PORT_0_9_22, core.LOCAL_HOST,
+                    core.DEFAULT_SERVER_PORT)
+            self.assertEqual(language, popen.call_args.kwargs[
+                "env"]["WOT_OFFLINE_UI_LANGUAGE"])
+
     def test_online_0_9_22_starter_receives_dump_destination(self):
         boundary = wot_launcher.error_reports.begin_session(
             self.settings_dir,

--- a/launcher/wot_launcher.py
+++ b/launcher/wot_launcher.py
@@ -2345,7 +2345,7 @@ class LauncherWindow(object):
             game_root, port_version, paired_worker=paired_worker)
         environment = core.visible_client_environment(
             port_version, host, port, paired_worker=paired_worker,
-            preferred_team=preferred_team)
+            preferred_team=preferred_team, language=self.language)
         if port_version == core.PORT_0_9_22:
             environment = self._crash_capture_environment(
                 environment, error_reports.ROLE_VISIBLE_CLIENT)

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/lan_session.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/lan_session.py
@@ -7,6 +7,8 @@ import math
 import sys
 import time
 
+from gui.mods.offline_lan_0922.ui_i18n import as_text, tr
+
 from gui.mods.offline_lan_0922 import config as port_config
 from gui.mods.offline_lan_0922 import queue_screen
 from gui.mods.offline_lan_0922 import queue_ui
@@ -832,7 +834,7 @@ class LANSession(object):
         self._connection_error_notified = False
         if self._picker_open:
             self._close_picker_after_event()
-        self._status_notifier(VEHICLE_SELECTION_WARNING)
+        self._status_notifier(tr(VEHICLE_SELECTION_WARNING))
         return False
 
     def start(self):
@@ -967,11 +969,11 @@ class LANSession(object):
             (self._endpoint_value(), bool(user_requested)))
         if not self.start():
             if self.state not in ('ready_to_join', 'retrying'):
-                self._status_notifier('The LAN room could not be rejoined.')
+                self._status_notifier(tr('The LAN room could not be rejoined.'))
             return False
         if user_requested:
             self._status_notifier(
-                'Joining LAN room at %s...' % self._endpoint_value())
+                tr('Joining LAN room at %s...') % self._endpoint_value())
         return True
 
     def join(self, unused_map_id=None, unused_action_name=None):
@@ -989,7 +991,7 @@ class LANSession(object):
             return bool(self._rejoin_room())
         if self.state == 'awaiting_battle_start':
             self._status_notifier(
-                'The LAN round is starting. Wait for the battle to load.')
+                tr('The LAN round is starting. Wait for the battle to load.'))
             return True
         if self.client is None:
             self._picker_dismissed = False
@@ -1000,15 +1002,15 @@ class LANSession(object):
             if not self.start():
                 if self.state not in ('ready_to_join', 'retrying'):
                     self._status_notifier(
-                        'The LAN room could not be joined.')
+                        tr('The LAN room could not be joined.'))
             else:
                 self._status_notifier(
-                    'Joining LAN room at %s...' % self._endpoint_value())
+                    tr('Joining LAN room at %s...') % self._endpoint_value())
             return True
         if self.state in ('connecting', 'retrying'):
             self._status_notifier(
-                'Still connecting to LAN room at %s. '
-                'Opening server settings.' %
+                tr('Still connecting to LAN room at %s. '
+                'Opening server settings.') %
                 self._endpoint_value())
             self._open_connection_picker()
         elif self.state == 'waiting':
@@ -1045,7 +1047,7 @@ class LANSession(object):
         self._start_requested = False
         self._connection_error_notified = False
         self._status_notifier(
-            'You left the LAN room. Click Battle! to join again.')
+            tr('You left the LAN room. Click Battle! to join again.'))
         return True
 
     def _endpoint_value(self):
@@ -1063,7 +1065,7 @@ class LANSession(object):
         if value is None:
             return None
         try:
-            label = text_type(value)
+            label = as_text(value)
         except Exception:
             return None
         label = u' '.join(label.split())
@@ -1079,30 +1081,30 @@ class LANSession(object):
                 labels.append(label)
         shown = labels[:3]
         if len(labels) > len(shown):
-            shown.append(u'+%d more' % (len(labels) - len(shown)))
+            shown.append(tr(u'+%d more') % (len(labels) - len(shown)))
         if shown:
             roster = u', '.join(shown)
         else:
-            roster = u'waiting for roster'
+            roster = tr(u'waiting for roster')
         lines = [
             text_type(self._endpoint_value()),
-            u'PLAYERS (%d): %s' % (len(players), roster),
+            tr(u'PLAYERS (%d): %s') % (len(players), roster),
         ]
         if self._is_local_host():
             lines.extend((
-                u'SELECT A MAP, THEN CLICK CREATE TO START',
-                u'OTHER PLAYERS JOIN WITH THE BATTLE BUTTON',
+                tr(u'SELECT A MAP, THEN CLICK CREATE TO START'),
+                tr(u'OTHER PLAYERS JOIN WITH THE BATTLE BUTTON'),
             ))
         elif self.state == 'waiting':
             lines.extend((
-                u'WAITING FOR %s TO START THE BATTLE' %
+                tr(u'WAITING FOR %s TO START THE BATTLE') %
                 text_type(self._host_name()),
-                u'NO ACTION NEEDED; THE BATTLE OPENS AUTOMATICALLY',
+                tr(u'NO ACTION NEEDED; THE BATTLE OPENS AUTOMATICALLY'),
             ))
         else:
             lines.extend((
-                u'EDIT THE FIRST LINE TO CHANGE THE SERVER',
-                u'THEN CLICK CREATE TO CONNECT',
+                tr(u'EDIT THE FIRST LINE TO CHANGE THE SERVER'),
+                tr(u'THEN CLICK CREATE TO CONNECT'),
             ))
         return u'\n'.join(lines)
 
@@ -1157,8 +1159,8 @@ class LANSession(object):
             host = self._config.get('host', '127.0.0.1')
             port = self._config.get('port', 28782)
             self._status_notifier(
-                'LAN server %s:%s is unavailable (%s). Retrying and opening '
-                'server settings.' %
+                tr('LAN server %s:%s is unavailable (%s). Retrying and opening '
+                'server settings.') %
                 (host, port, error))
             sys.stdout.write(
                 '[Offline LAN 0.9.22] LAN connection failed: %s:%s (%s)\n' %
@@ -1233,12 +1235,12 @@ class LANSession(object):
         selector = getattr(self.client, 'select_team', None)
         if not callable(selector) or not selector(team):
             self._status_notifier(
-                'The LAN server did not accept that team selection.')
+                tr('The LAN server did not accept that team selection.'))
             return False
         self._remember_team(team)
         self._status_notifier(
-            'Requesting a random team...'
-            if team == 0 else 'Requesting Team %d...' % team)
+            tr('Requesting a random team...')
+            if team == 0 else tr('Requesting Team %d...') % team)
         return True
 
     def set_team_size(self, team, size):
@@ -1249,11 +1251,11 @@ class LANSession(object):
         setter = getattr(self.client, 'set_team_size', None)
         if not callable(setter) or not setter(team, size):
             self._status_notifier(
-                'The LAN server did not accept that team size.')
+                tr('The LAN server did not accept that team size.'))
             return False
         self._remember_team_size(team, size)
         self._status_notifier(
-            'Requesting Team %d size %d...' % (int(team), int(size)))
+            tr('Requesting Team %d size %d...') % (int(team), int(size)))
         return True
 
     def set_bot_tier_mode(self, mode):
@@ -1264,17 +1266,17 @@ class LANSession(object):
         setter = getattr(self.client, 'set_bot_tier_mode', None)
         if not callable(setter) or not setter(mode):
             self._status_notifier(
-                'The LAN server did not accept that Bot tier preset.')
+                tr('The LAN server did not accept that Bot tier preset.'))
             return False
-        self._status_notifier('Requesting Bot tier preset...')
+        self._status_notifier(tr('Requesting Bot tier preset...'))
         return True
 
     def _save_room_preferences(self):
         if port_config.save_waiting_room_state(self._room_preferences):
             return True
         self._status_notifier(
-            'Could not save the LAN waiting room choices. Check that the '
-            'user data directory is writable.')
+            tr('Could not save the LAN waiting room choices. Check that the '
+            'user data directory is writable.'))
         return False
 
     def _remember_map(self, map_name):
@@ -1422,14 +1424,14 @@ class LANSession(object):
                 labels.append(label)
         shown = labels[:6]
         if len(labels) > len(shown):
-            shown.append(u'+%d more' % (len(labels) - len(shown)))
+            shown.append(tr(u'+%d more') % (len(labels) - len(shown)))
         lines = [
             text_type(self._endpoint_value()),
-            u'PLAYERS (%d): %s' % (len(players),
-                                   u', '.join(shown) or u'waiting for roster'),
+            tr(u'PLAYERS (%d): %s') % (len(players),
+                                   u', '.join(shown) or tr(u'waiting for roster')),
         ]
         if not self._is_local_host():
-            lines.append(u'WAITING FOR %s TO START THE BATTLE' %
+            lines.append(tr(u'WAITING FOR %s TO START THE BATTLE') %
                          text_type(self._host_name()))
         return u'\n'.join(lines)
 
@@ -1610,7 +1612,7 @@ class LANSession(object):
             return
         self._waiting_notice_host_id = self._host_player_id
         self._status_notifier(
-            'Joined LAN room. Waiting for host %s to choose the map.' %
+            tr('Joined LAN room. Waiting for host %s to choose the map.') %
             self._host_name())
 
     def _sync_waiting_surface(self, previous_host_player_id=None):
@@ -1619,7 +1621,7 @@ class LANSession(object):
             if (previous_host_player_id is not None and
                     previous_host_player_id != self._host_player_id):
                 self._status_notifier(
-                    'You are now the LAN room host. Choose a map to start.')
+                    tr('You are now the LAN room host. Choose a map to start.'))
             self._open_waiting_picker('host election')
             return
         self._show_waiting_notice(
@@ -1684,8 +1686,8 @@ class LANSession(object):
             return True
         if not port_config.save_endpoint(host, port):
             self._status_notifier(
-                'Could not save the LAN server address. Check that the user '
-                'data directory is writable.')
+                tr('Could not save the LAN server address. Check that the user '
+                'data directory is writable.'))
             return False
         self._config['host'] = host
         self._config['port'] = port
@@ -1727,7 +1729,7 @@ class LANSession(object):
         if not bool(getattr(self.client, 'ready', False)):
             self._pending_map = map_name
             self._status_notifier(
-                'Connecting to %s. The selected map will start automatically.' %
+                tr('Connecting to %s. The selected map will start automatically.') %
                 self._endpoint_value())
             self._close_picker_after_event()
             return True
@@ -1763,7 +1765,7 @@ class LANSession(object):
             getattr(self.client, 'host_player_id', None))
         self._connection_error_notified = False
         if recovered_connection:
-            self._status_notifier('LAN server connected.')
+            self._status_notifier(tr('LAN server connected.'))
         self._map_pool = list(_message_value(
             message, 'map_pool', getattr(self.client, 'map_pool', [])) or [])
         phase = _message_value(message, 'phase', getattr(self.client, 'phase', None))
@@ -1826,7 +1828,7 @@ class LANSession(object):
                         pending_map == waiting_room_ui.RANDOM_MAP_OPTION and
                         self._server_supports_random_map())):
                     self._status_notifier(
-                        'The LAN server does not offer the selected map.')
+                        tr('The LAN server does not offer the selected map.'))
                     self._sync_waiting_surface(previous_host_player_id)
                     return
                 if self.client.request_start(pending_map):
@@ -1835,7 +1837,7 @@ class LANSession(object):
                     self._close_picker()
                     return
                 self._status_notifier(
-                    'The LAN server did not accept the start request.')
+                    tr('The LAN server did not accept the start request.'))
             self._sync_waiting_surface(previous_host_player_id)
         elif phase == 'battle':
             # Disconnect/failover roster updates are broadcast during a live
@@ -2018,7 +2020,7 @@ class LANSession(object):
             except Exception:
                 self.state = 'error'
                 self._status_notifier(
-                    'Battle could not start (%s). LAN session stopped.' %
+                    tr('Battle could not start (%s). LAN session stopped.') %
                     reason)
                 try:
                     # BattleRuntime already owns cleanup and Account restore.
@@ -2030,13 +2032,13 @@ class LANSession(object):
                 return False
             self._enter_awaiting_round_end()
             self._status_notifier(
-                'Battle could not start (%s). Returning to the map picker.' %
+                tr('Battle could not start (%s). Returning to the map picker.') %
                 reason)
             return True
 
         self.state = 'error'
         self._status_notifier(
-            'Battle could not start and the lobby was not restored (%s).' %
+            tr('Battle could not start and the lobby was not restored (%s).') %
             reason)
         try:
             # Runtime recovery already failed.  Do not recurse through its
@@ -2102,7 +2104,7 @@ class LANSession(object):
                 pass
 
         self._status_notifier(
-            'LAN room connection lost (%s). Click Battle! to rejoin.' %
+            tr('LAN room connection lost (%s). Click Battle! to rejoin.') %
             reason)
         return True
 
@@ -2163,10 +2165,10 @@ class LANSession(object):
                         self._host_player_id))
             if _message_value(message, 'code') == 'host_only':
                 self._status_notifier(
-                    'Only the LAN room host can choose the map and start.')
+                    tr('Only the LAN room host can choose the map and start.'))
             else:
                 self._status_notifier(
-                    'The LAN server refused the battle start (%s).' %
+                    tr('The LAN server refused the battle start (%s).') %
                     (_message_value(message, 'code') or 'unknown'))
             self._sync_waiting_surface()
         elif kind == 'team_denied':
@@ -2180,10 +2182,10 @@ class LANSession(object):
                 self._remember_team(0)
             if code == 'team_full':
                 self._status_notifier(
-                    'Team %s is full. Choose the other team or Random.' % team)
+                    tr('Team %s is full. Choose the other team or Random.') % team)
             else:
                 self._status_notifier(
-                    'The LAN server refused the team selection (%s).' %
+                    tr('The LAN server refused the team selection (%s).') %
                     (code or 'unknown'))
             self._refresh_surface()
         elif kind == 'team_size_denied':
@@ -2199,12 +2201,12 @@ class LANSession(object):
             if actual_size is not None:
                 self._remember_team_size(team, actual_size)
             if code == 'host_only':
-                notice = 'Only the LAN room host can change team sizes.'
+                notice = tr('Only the LAN room host can change team sizes.')
             elif code == 'team_occupied':
-                notice = ('Team %s already has too many players for that '
-                          'size.' % team)
+                notice = (tr('Team %s already has too many players for that '
+                          'size.') % team)
             else:
-                notice = ('The LAN server refused the team size (%s).' %
+                notice = (tr('The LAN server refused the team size (%s).') %
                           (code or 'unknown'))
             self._status_notifier(notice)
             reject = getattr(self._queue, 'reject_team_size', None)
@@ -2215,10 +2217,10 @@ class LANSession(object):
         elif kind == 'bot_tier_mode_denied':
             code = _message_value(message, 'code')
             if code == 'host_only':
-                notice = ('Only the LAN room host can change the Bot tier '
-                          'preset.')
+                notice = (tr('Only the LAN room host can change the Bot tier '
+                          'preset.'))
             else:
-                notice = ('The LAN server refused the Bot tier preset (%s).' %
+                notice = (tr('The LAN server refused the Bot tier preset (%s).') %
                           (code or 'unknown'))
             self._status_notifier(notice)
             reject = getattr(self._queue, 'reject_bot_tier_mode', None)
@@ -2340,11 +2342,11 @@ class LANSession(object):
                 code = _message_value(message, 'code')
                 if code == 'team_full':
                     self._status_notifier(
-                        'The selected LAN team is full. Choose the other '
-                        'team or Random in the waiting room.')
+                        tr('The selected LAN team is full. Choose the other '
+                        'team or Random in the waiting room.'))
                 else:
                     self._status_notifier(
-                        'The launcher team selection is invalid.')
+                        tr('The launcher team selection is invalid.'))
                 self.stop(show_login=True)
             elif (kind == 'error' and not self._battle_started and
                     not bool(getattr(self.client, 'ready', False)) and
@@ -2366,8 +2368,8 @@ class LANSession(object):
                         'kind=%s round=%r: %s\n' %
                         (kind, self._active_round_id, reason))
                     self._status_notifier(
-                        'LAN battle connection lost (%s). Returning to the '
-                        'garage.' % reason)
+                        tr('LAN battle connection lost (%s). Returning to the '
+                        'garage.') % reason)
                 self.stop(show_login=True)
         if self._on_event_callback is not None:
             self._on_event_callback(kind, message)

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/ui_i18n.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/ui_i18n.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+"""Mod-owned UI text; the launcher supplies its resolved display language."""
+
+import os
+
+LANGUAGE_ENV = 'WOT_OFFLINE_UI_LANGUAGE'
+CHINESE_FONT = 'offline_lan_cjk.font'
+
+try:
+    text_type = unicode
+except NameError:
+    text_type = str
+
+
+def as_text(value):
+    """Keep JSON Unicode and decode UTF-8 before Python 2 interpolation."""
+    if isinstance(value, bytes):
+        return value.decode('utf-8', 'replace')
+    return text_type(value)
+
+
+def language():
+    # Direct batch-file launches retain their existing English UI.
+    return 'zh' if os.environ.get(LANGUAGE_ENV) == 'zh' else 'en'
+
+
+def tr(source):
+    if language() == 'zh':
+        return _ZH.get(source, as_text(source))
+    return as_text(source)
+
+
+_ZH = {
+    'LAN WAITING ROOM': u'局域网等待房间',
+    'TEAM 1': u'队伍 1',
+    'TEAM 2': u'队伍 2',
+    'RANDOM': u'随机',
+    'LEAVE': u'离开',
+    'START BATTLE': u'开始战斗',
+    'Random': u'随机',
+    'Same tier': u'同级',
+    'Tier -1 / 0': u'低一级 / 同级',
+    'Tier 0 / +1': u'同级 / 高一级',
+    'Tier -1 / +2': u'低一级 / 高两级',
+    'Unknown': u'未知',
+    'BOT TIER: %s%s': u'电脑等级：%s%s',
+    'RANDOM%s': u'随机%s',
+    ' (ON)': u'（已选）',
+    '  (YOU)': u'（已选）',
+    'TEAM %d SIZE: %d%s': u'队伍 %d 人数：%d%s',
+    'TEAM %d%s': u'队伍 %d%s',
+    'MAP: %s': u'地图：%s',
+    'waiting for the server map list': u'等待服务器地图列表',
+    'The room host starts the battle.': u'由房主开始战斗。',
+    'Random team selection is already on.': u'已选择随机队伍。',
+    'Already on Team %d.': u'已在队伍 %d。',
+    'Requesting a random team...': u'正在申请随机队伍...',
+    'Requesting Team %d...': u'正在申请加入队伍 %d...',
+    'The server did not accept random selection.': u'服务器未接受随机队伍选择。',
+    'The server did not accept Team %d.': u'服务器未接受加入队伍 %d。',
+    'Team %d already has %d player(s).': u'队伍 %d 已有 %d 名玩家。',
+    'Team %d size is already %d.': u'队伍 %d 人数已为 %d。',
+    'Setting Team %d size to %d...': u'正在设置队伍 %d 人数为 %d...',
+    'The server did not accept that team size.': u'服务器未接受该队伍人数。',
+    'Setting Bot tier preset...': u'正在设置电脑等级...',
+    'The server did not accept that Bot tier preset.': u'服务器未接受该电脑等级设置。',
+    'The server has not published its map list yet.': u'服务器尚未发送地图列表。',
+    'Choose a map first.': u'请先选择地图。',
+    'Starting %s...': u'正在开始 %s...',
+    'The server did not accept that map.': u'服务器未接受该地图。',
+    'Select a valid vehicle in the garage, then click Battle! again.': u'请在车库选择有效车辆，然后再次点击战斗按钮。',
+    'You left the LAN room. Click Battle! to join again.': u'已离开局域网房间。点击战斗按钮可重新加入。',
+    'waiting for roster': u'等待玩家列表',
+    'Requesting Bot tier preset...': u'正在申请电脑等级设置...',
+    'Could not save the LAN waiting room choices. Check that the user data directory is writable.': u'无法保存房间设置，请检查用户数据目录是否可写。',
+    'The LAN round is starting. Wait for the battle to load.': u'本局正在开始，请等待战斗加载。',
+    'PLAYERS (%d): %s': u'玩家（%d）：%s',
+    'The LAN server did not accept that team selection.': u'服务器未接受该队伍选择。',
+    'The LAN server did not accept that team size.': u'服务器未接受该队伍人数。',
+    'Requesting Team %d size %d...': u'正在申请队伍 %d 人数为 %d...',
+    'The LAN server did not accept that Bot tier preset.': u'服务器未接受该电脑等级设置。',
+    'Joined LAN room. Waiting for host %s to choose the map.': u'已加入房间，等待房主 %s 选择地图。',
+    'Could not save the LAN server address. Check that the user data directory is writable.': u'无法保存服务器地址，请检查用户数据目录是否可写。',
+    'LAN server connected.': u'已连接局域网服务器。',
+    'Battle could not start and the lobby was not restored (%s).': u'无法开始战斗，且未能返回车库（%s）。',
+    'LAN room connection lost (%s). Click Battle! to rejoin.': u'房间连接已断开（%s），点击战斗按钮可重新加入。',
+    'The LAN room could not be rejoined.': u'无法重新加入房间。',
+    'Joining LAN room at %s...': u'正在加入房间 %s...',
+    'Still connecting to LAN room at %s. Opening server settings.': u'仍在连接房间 %s，正在打开服务器设置。',
+    '+%d more': u'另有 %d 人',
+    'SELECT A MAP, THEN CLICK CREATE TO START': u'选择地图，然后点击创建开始战斗',
+    'OTHER PLAYERS JOIN WITH THE BATTLE BUTTON': u'其他玩家可点击战斗按钮加入',
+    'LAN server %s:%s is unavailable (%s). Retrying and opening server settings.': u'服务器 %s:%s 不可用（%s），正在重试并打开服务器设置。',
+    'WAITING FOR %s TO START THE BATTLE': u'等待 %s 开始战斗',
+    'You are now the LAN room host. Choose a map to start.': u'你现在是房主，请选择地图开始战斗。',
+    'Connecting to %s. The selected map will start automatically.': u'正在连接 %s，所选地图将自动开始。',
+    'The LAN server did not accept the start request.': u'服务器未接受开始战斗请求。',
+    'Battle could not start (%s). Returning to the map picker.': u'无法开始战斗（%s），正在返回地图选择。',
+    'The LAN room could not be joined.': u'无法加入房间。',
+    'NO ACTION NEEDED; THE BATTLE OPENS AUTOMATICALLY': u'无需操作，战斗将自动开始',
+    'EDIT THE FIRST LINE TO CHANGE THE SERVER': u'编辑第一行可更改服务器',
+    'THEN CLICK CREATE TO CONNECT': u'然后点击创建进行连接',
+    'The LAN server does not offer the selected map.': u'服务器不支持所选地图。',
+    'Only the LAN room host can choose the map and start.': u'只有房主可以选择地图并开始战斗。',
+    'Battle could not start (%s). LAN session stopped.': u'无法开始战斗（%s），局域网会话已停止。',
+    'The LAN server refused the battle start (%s).': u'服务器拒绝开始战斗（%s）。',
+    'Only the LAN room host can change team sizes.': u'只有房主可以更改队伍人数。',
+    'Team %s is full. Choose the other team or Random.': u'队伍 %s 已满，请选择另一队或随机。',
+    'The LAN server refused the team selection (%s).': u'服务器拒绝队伍选择（%s）。',
+    'Only the LAN room host can change the Bot tier preset.': u'只有房主可以更改电脑等级。',
+    'Team %s already has too many players for that size.': u'队伍 %s 现有玩家数超过该人数设置。',
+    'The LAN server refused the team size (%s).': u'服务器拒绝队伍人数设置（%s）。',
+    'The LAN server refused the Bot tier preset (%s).': u'服务器拒绝电脑等级设置（%s）。',
+    'The selected LAN team is full. Choose the other team or Random in the waiting room.': u'所选队伍已满，请在等待房间选择另一队或随机。',
+    'The launcher team selection is invalid.': u'启动器中的队伍选择无效。',
+    'LAN battle connection lost (%s). Returning to the garage.': u'战斗连接已断开（%s），正在返回车库。',
+}

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/waiting_room_ui.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/waiting_room_ui.py
@@ -18,7 +18,8 @@ Exact #1513 evidence for the native surface used here:
   texture name all drew the same white, and the untextured quad drew nothing.
   So every visible rectangle here carries ``system/maps/col_white.dds`` and is
   white, and readable contrast comes from dark ``GUI.Text`` on top.
-- Font ``system/fonts/default_small.font``: package member.
+- Mod-owned font ``system/fonts/offline_lan_cjk.font`` uses Windows
+  Microsoft YaHei with dynamic glyph caching; Windows rendering is pending.
 - ``GUI.addRoot`` / ``GUI.delRoot`` / ``GUI.reSort`` and an overlay at
   ``position.z = 0.1`` with ``focus``, ``moveFocus`` and ``wg_inputKeyMode``:
   ``scripts/client/new_year/fade_window.pyc``.
@@ -40,6 +41,9 @@ Exact #1513 evidence for the native surface used here:
 import sys
 import time
 
+from gui.mods.offline_lan_0922 import ui_i18n
+from gui.mods.offline_lan_0922.ui_i18n import as_text, tr
+
 # An untextured GUI.Simple/GUI.Window draws nothing on this client, and vertex
 # colour is never applied to a textured one, so every visible rectangle is a
 # white col_white quad and contrast comes from GUI.Text.  The panel stays
@@ -51,7 +55,7 @@ CONTROL_TEXTURE = 'system/maps/col_white.dds'
 OUTLINE_TEXTURE = 'system/maps/col_black.dds'
 CONTROL_TEXT_COLOUR = (16, 26, 36, 255)
 CONTROL_HOVER_COLOUR = (14, 82, 140, 255)
-PANEL_FONT = 'default_small.font'
+PANEL_FONT = ui_i18n.CHINESE_FONT
 OVERLAY_Z = 0.1
 # Smaller z draws in front. The buttons render at CONTROL_Z and the pointer at
 # z=0 did not, so the pointer keeps the same 0.01 step inside that band.
@@ -100,21 +104,32 @@ def _log(message):
 def friendly_map_name(map_name):
     """Turn a server geometry name into a readable room label."""
     if map_name == RANDOM_MAP_OPTION:
-        return 'Random'
-    parts = str(map_name or '').split('_')
+        return tr('Random')
+    if ui_i18n.language() == 'zh':
+        try:
+            import ArenaType
+            for arena in ArenaType.g_cache.values():
+                if (getattr(arena, 'geometryName', None) == map_name and
+                        getattr(arena, 'gameplayName', None) == 'ctf'):
+                    name = getattr(arena, 'name', None)
+                    if name:
+                        return as_text(name)
+        except (ImportError, AttributeError):
+            pass
+    parts = as_text(map_name or '').split('_')
     prefix = ''
     if parts and parts[0].isdigit():
         prefix = parts[0] + ' - '
         parts = parts[1:]
     return prefix + (' '.join([part.capitalize() for part in parts]) or
-                     'Unknown')
+                     tr('Unknown'))
 
 
 def friendly_bot_tier_mode(mode):
     for value, label in BOT_TIER_OPTIONS:
         if value == mode:
-            return label
-    return 'Random'
+            return tr(label)
+    return tr('Random')
 
 
 def panel_geometry(screen_size):
@@ -395,7 +410,7 @@ class WaitingRoomUI(object):
         make_control('team_random', (0.52, -0.38, CONTROL_Z), 0.42, 0.14)
         make_control('start', (0.0, -0.58, CONTROL_Z), 1.20, 0.20)
         make_control('close', (0.0, -0.90, CONTROL_Z), 0.50, 0.16)
-        make_label('title', 'LAN WAITING ROOM', (-0.86, 0.82, 0.0), 1.72,
+        make_label('title', tr('LAN WAITING ROOM'), (-0.86, 0.82, 0.0), 1.72,
                    0.12, colour=(232, 244, 255, 255))
         make_label('room', '', (-0.86, 0.62, 0.0), 1.72, 0.11)
         make_label('players', '', (-0.86, 0.44, 0.0), 1.72, 0.11)
@@ -425,15 +440,15 @@ class WaitingRoomUI(object):
                    anchor='CENTER', colour=(232, 244, 255, 255))
         make_label('team2_up', '+', (0.82, -0.18, 0.0), 0.10, 0.09,
                    anchor='CENTER', colour=CONTROL_TEXT_COLOUR)
-        make_label('team1', 'TEAM 1', (-0.52, -0.38, 0.0), 0.40, 0.09,
+        make_label('team1', tr('TEAM 1'), (-0.52, -0.38, 0.0), 0.40, 0.09,
                    anchor='CENTER', colour=CONTROL_TEXT_COLOUR)
-        make_label('team2', 'TEAM 2', (0.0, -0.38, 0.0), 0.40, 0.09,
+        make_label('team2', tr('TEAM 2'), (0.0, -0.38, 0.0), 0.40, 0.09,
                    anchor='CENTER', colour=CONTROL_TEXT_COLOUR)
-        make_label('team_random', 'RANDOM', (0.52, -0.38, 0.0), 0.40, 0.09,
+        make_label('team_random', tr('RANDOM'), (0.52, -0.38, 0.0), 0.40, 0.09,
                    anchor='CENTER', colour=CONTROL_TEXT_COLOUR)
-        make_label('start', 'START BATTLE', (0.0, -0.58, 0.0), 1.16, 0.11,
+        make_label('start', tr('START BATTLE'), (0.0, -0.58, 0.0), 1.16, 0.11,
                    anchor='CENTER', colour=CONTROL_TEXT_COLOUR)
-        make_label('close', 'LEAVE', (0.0, -0.90, 0.0), 0.46, 0.10,
+        make_label('close', tr('LEAVE'), (0.0, -0.90, 0.0), 0.46, 0.10,
                    anchor='CENTER', colour=CONTROL_TEXT_COLOUR)
         make_label('message', '', (-0.86, -0.75, 0.0), 1.72, 0.10,
                    colour=(184, 205, 222, 255))
@@ -501,14 +516,17 @@ class WaitingRoomUI(object):
         labels = self._labels if labels is None else labels
         surface = self._surface if surface is None else surface
         component = surface.text()
+        # A missing font must reach the session's stock-window fallback,
+        # not silently leave translated text in an unreviewed default font.
+        component.font = PANEL_FONT
         for name, value in (
-                ('text', text),
+                ('text', as_text(text)),
                 ('horizontalPositionMode', 'CLIP'),
                 ('verticalPositionMode', 'CLIP'),
                 ('widthMode', 'CLIP'), ('heightMode', 'CLIP'),
                 ('horizontalAnchor', anchor), ('verticalAnchor', 'CENTER'),
                 ('position', position), ('width', width), ('height', height),
-                ('font', PANEL_FONT), ('colour', colour), ('multiline', False),
+                ('colour', colour), ('multiline', False),
                 ('focus', False), ('mouseButtonFocus', False),
                 ('crossFocus', False), ('moveFocus', False),
                 ('visible', False)):
@@ -906,12 +924,12 @@ class WaitingRoomUI(object):
         if self._pending_bot_tier_mode == tier_mode:
             self._pending_bot_tier_mode = None
         shown_tier_mode = self._pending_bot_tier_mode or tier_mode
-        self._set_text('tier', 'BOT TIER: %s%s' % (
+        self._set_text('tier', tr('BOT TIER: %s%s') % (
             friendly_bot_tier_mode(shown_tier_mode),
             '...' if self._pending_bot_tier_mode is not None else ''))
         preferred_team = team_status.get('preferred', 0)
-        self._set_text('team_random', 'RANDOM%s' % (
-            ' (ON)' if preferred_team == 0 else ''))
+        self._set_text('team_random', tr('RANDOM%s') % (
+            tr(' (ON)') if preferred_team == 0 else ''))
         sizes = team_status.get('sizes') or {}
         for team in (1, 2):
             size = int(sizes.get(team, sizes.get(str(team), 15)))
@@ -921,21 +939,21 @@ class WaitingRoomUI(object):
                 pending = None
             shown_size = pending if pending is not None else size
             self._set_text('team%d_capacity' % team,
-                           'TEAM %d SIZE: %d%s' % (
+                           tr('TEAM %d SIZE: %d%s') % (
                                team, shown_size,
                                '...' if pending is not None else ''))
-            self._set_text('team%d' % team, 'TEAM %d%s' % (
-                team, '  (YOU)' if preferred_team == team else ''))
-        lines = str(self._status() or '').splitlines()
+            self._set_text('team%d' % team, tr('TEAM %d%s') % (
+                team, tr('  (YOU)') if preferred_team == team else ''))
+        lines = as_text(self._status() or '').splitlines()
         self._set_text('room', lines[0] if lines else '')
         self._set_text('players', lines[1] if len(lines) > 1 else '')
         if is_host:
-            self._set_text('map', 'MAP: %s' % (
+            self._set_text('map', tr('MAP: %s') % (
                 friendly_map_name(self._selected_map) if options else
-                'waiting for the server map list'))
+                tr('waiting for the server map list')))
         else:
             self._set_text('map', lines[2] if len(lines) > 2 else
-                           'The room host starts the battle.')
+                           tr('The room host starts the battle.'))
         self._set_text('message', self._message)
         for role, component in self._controls.items():
             visible = (team_supported if role in _TEAM_SELECT_CONTROLS else
@@ -957,7 +975,7 @@ class WaitingRoomUI(object):
     def _set_text(self, role, value):
         label = self._labels.get(role)
         if label is not None:
-            self._set(label, 'text', value)
+            self._set(label, 'text', as_text(value))
 
     def _paint(self):
         """Show hover through the label, the only colour this client applies."""
@@ -1007,19 +1025,19 @@ class WaitingRoomUI(object):
             return False
         current_choice = status.get('preferred', status.get('team'))
         if current_choice == team:
-            self._message = ('Random team selection is already on.'
+            self._message = (tr('Random team selection is already on.')
                              if team == 0 else
-                             'Already on Team %d.' % team)
+                             tr('Already on Team %d.') % team)
             self.refresh()
             return True
-        self._message = ('Requesting a random team...'
+        self._message = (tr('Requesting a random team...')
                          if team == 0 else
-                         'Requesting Team %d...' % team)
+                         tr('Requesting Team %d...') % team)
         self.refresh()
         if self._request_team(team) is False:
-            self._message = ('The server did not accept random selection.'
+            self._message = (tr('The server did not accept random selection.')
                              if team == 0 else
-                             'The server did not accept Team %d.' % team)
+                             tr('The server did not accept Team %d.') % team)
             self.refresh()
             return False
         self.refresh()
@@ -1036,20 +1054,20 @@ class WaitingRoomUI(object):
             team, int(sizes.get(team, sizes.get(str(team), 15))))
         target = max(1, min(15, int(current) + int(step)))
         if target < int(counts.get(team, 0)):
-            self._message = 'Team %d already has %d player(s).' % (
+            self._message = tr('Team %d already has %d player(s).') % (
                 team, int(counts.get(team, 0)))
             self.refresh()
             return False
         if target == current:
-            self._message = 'Team %d size is already %d.' % (team, target)
+            self._message = tr('Team %d size is already %d.') % (team, target)
             self.refresh()
             return True
         self._pending_team_sizes[team] = target
-        self._message = 'Setting Team %d size to %d...' % (team, target)
+        self._message = tr('Setting Team %d size to %d...') % (team, target)
         self.refresh()
         if self._request_team_size(team, target) is False:
             self._pending_team_sizes.pop(team, None)
-            self._message = 'The server did not accept that team size.'
+            self._message = tr('The server did not accept that team size.')
             self.refresh()
             return False
         return True
@@ -1061,7 +1079,7 @@ class WaitingRoomUI(object):
         except (TypeError, ValueError):
             return False
         self._pending_team_sizes.pop(team, None)
-        self._message = message or 'The server did not accept that team size.'
+        self._message = message or tr('The server did not accept that team size.')
         self.refresh()
         return True
 
@@ -1078,11 +1096,11 @@ class WaitingRoomUI(object):
             index = 0
         target = modes[(index + int(step)) % len(modes)]
         self._pending_bot_tier_mode = target
-        self._message = 'Setting Bot tier preset...'
+        self._message = tr('Setting Bot tier preset...')
         self.refresh()
         if self._request_bot_tier_mode(target) is False:
             self._pending_bot_tier_mode = None
-            self._message = 'The server did not accept that Bot tier preset.'
+            self._message = tr('The server did not accept that Bot tier preset.')
             self.refresh()
             return False
         return True
@@ -1090,14 +1108,14 @@ class WaitingRoomUI(object):
     def reject_bot_tier_mode(self, unused_mode=None, message=None):
         self._pending_bot_tier_mode = None
         self._message = (message or
-                         'The server did not accept that Bot tier preset.')
+                         tr('The server did not accept that Bot tier preset.'))
         self.refresh()
         return True
 
     def _cycle(self, step):
         options = self._options()
         if not options:
-            self._message = 'The server has not published its map list yet.'
+            self._message = tr('The server has not published its map list yet.')
             self.refresh()
             return False
         try:
@@ -1111,15 +1129,15 @@ class WaitingRoomUI(object):
 
     def _start(self):
         if not self._selected_map:
-            self._message = 'Choose a map first.'
+            self._message = tr('Choose a map first.')
             self.refresh()
             return False
-        self._message = 'Starting %s...' % friendly_map_name(
+        self._message = tr('Starting %s...') % friendly_map_name(
             self._selected_map)
         self.refresh()
         accepted = self._request_start(self._selected_map)
         if accepted is False:
-            self._message = 'The server did not accept that map.'
+            self._message = tr('The server did not accept that map.')
             self.refresh()
             return False
         return True

--- a/src/res/system/fonts/offline_lan_cjk.font
+++ b/src/res/system/fonts/offline_lan_cjk.font
@@ -1,0 +1,10 @@
+<offline_lan_cjk.font>
+    <creation>
+        <sourceFont>Microsoft YaHei</sourceFont>
+        <sourceFontSize>16</sourceFontSize>
+        <effectsMargin>1</effectsMargin>
+        <textureMargin>1</textureMargin>
+        <dropShadow>false</dropShadow>
+        <bold>false</bold>
+    </creation>
+</offline_lan_cjk.font>

--- a/tests/test_port_0922_lan_session.py
+++ b/tests/test_port_0922_lan_session.py
@@ -1,4 +1,5 @@
 import importlib.util
+import os
 from pathlib import Path
 import sys
 import types
@@ -2669,6 +2670,20 @@ class LANSessionRoomTests(unittest.TestCase):
         if 'players' in message:
             self.client.roster = list(message['players'])
         self.client.on_event(kind, message)
+
+    def test_chinese_guest_roster_and_denial_keep_player_names(self):
+        with mock.patch.dict(os.environ, {'WOT_OFFLINE_UI_LANGUAGE': 'zh'}):
+            self.emit('welcome', {
+                'phase': 'waiting', 'map_pool': ['01_karelia'],
+                'host_player_id': 'p2',
+                'players': [{'id': 'p1', 'name': '小鹏'},
+                            {'id': 'p2', 'name': '房主'}]})
+            status = self.session._room_status()
+            self.assertIn('玩家（2）：小鹏, 房主', status)
+            self.assertIn('等待 房主 开始战斗', status)
+            self.emit('team_denied', {'code': 'team_full', 'team': 2})
+            self.assertEqual('队伍 2 已满，请选择另一队或随机。',
+                             self.statuses[-1])
 
     def test_incomplete_native_close_keeps_room_owned_for_retry(self):
         self.emit('welcome', {

--- a/tests/test_port_0922_ui_i18n.py
+++ b/tests/test_port_0922_ui_i18n.py
@@ -1,0 +1,53 @@
+import importlib.util
+import os
+from pathlib import Path
+import re
+import unittest
+from unittest import mock
+import xml.etree.ElementTree as ET
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = (ROOT / 'src/res/scripts/client/gui/mods/offline_lan_0922/'
+               'ui_i18n.py')
+spec = importlib.util.spec_from_file_location('mod_ui_i18n', MODULE_PATH)
+i18n = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(i18n)
+
+
+class ModLanguageTests(unittest.TestCase):
+    def test_missing_or_unknown_language_retains_english(self):
+        for value in ('', 'invalid', 'auto', 'en'):
+            with mock.patch.dict(os.environ, {i18n.LANGUAGE_ENV: value}):
+                self.assertEqual('START BATTLE', i18n.tr('START BATTLE'))
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertEqual('START BATTLE', i18n.tr('START BATTLE'))
+
+    def test_chinese_catalog_preserves_all_interpolation_arguments(self):
+        pattern = re.compile(r'%(?:\([^)]+\))?[#0 +\-]*\d*(?:\.\d+)?[sdrf]')
+        with mock.patch.dict(os.environ, {i18n.LANGUAGE_ENV: 'zh'}):
+            for source, translated in i18n._ZH.items():
+                self.assertEqual(pattern.findall(source),
+                                 pattern.findall(translated), source)
+                self.assertEqual(translated, i18n.tr(source))
+                args = tuple(2 if token[-1] in 'drf' else '小鹏'
+                             for token in pattern.findall(source))
+                if args:
+                    self.assertIsInstance(i18n.tr(source) % args, str)
+            self.assertEqual('untranslated detail',
+                             i18n.tr('untranslated detail'))
+
+    def test_utf8_names_are_decoded_before_formatting(self):
+        name = '小鹏'
+        self.assertEqual(name, i18n.as_text(name.encode('utf-8')))
+        self.assertEqual(name, i18n.as_text(name))
+        self.assertEqual('bad\ufffd', i18n.as_text(b'bad\xff'))
+
+    def test_mod_font_uses_dynamic_glyphs_and_a_cjk_family(self):
+        path = ROOT / 'src/res/system/fonts' / i18n.CHINESE_FONT
+        font = ET.parse(path).getroot()
+        self.assertEqual('Microsoft YaHei',
+                         font.findtext('creation/sourceFont'))
+        self.assertIsNone(font.find('generated'))
+        self.assertIsNone(font.find('creation/startChar'))
+        self.assertIsNone(font.find('creation/endChar'))

--- a/tests/test_port_0922_waiting_room_ui.py
+++ b/tests/test_port_0922_waiting_room_ui.py
@@ -1,4 +1,5 @@
 import importlib.util
+import os
 from pathlib import Path
 import sys
 import types
@@ -185,6 +186,44 @@ class WaitingRoomTests(unittest.TestCase):
     def _root_count(self, room=None):
         """The room panel plus one root per arrow row."""
         return 1 + len((room or self.room)._pointer_parts)
+
+    def test_chinese_room_preserves_names_and_wire_map_id(self):
+        self.status = 'LAN SERVER: 10.0.0.5:28782\n玩家（2）：房主, 小鹏'
+        with mock.patch.dict(os.environ, {'WOT_OFFLINE_UI_LANGUAGE': 'zh'}):
+            self.assertTrue(self.room.open())
+            self.assertEqual('局域网等待房间', self._label('title'))
+            self.assertEqual('开始战斗', self._label('start'))
+            self.assertEqual('地图：随机', self._label('map'))
+            self.assertEqual('玩家（2）：房主, 小鹏', self._label('players'))
+            self.assertEqual('电脑等级：随机', self._label('tier'))
+            self.assertTrue(self.room.activate('start'))
+            self.assertEqual(['server_random'], self.started)
+            self.assertEqual('正在开始 随机...', self._label('message'))
+        self.assertTrue(self.room.close())
+
+    def test_chinese_map_label_uses_client_name_without_changing_geometry(self):
+        arena = types.SimpleNamespace(
+            geometryName='01_karelia', gameplayName='ctf',
+            name='卡累利阿'.encode('utf-8'))
+        with mock.patch.dict(os.environ, {'WOT_OFFLINE_UI_LANGUAGE': 'zh'}), \
+                mock.patch.dict(sys.modules, {
+                    'ArenaType': types.SimpleNamespace(g_cache={1: arena})}):
+            self.assertEqual('卡累利阿',
+                             self.module.friendly_map_name('01_karelia'))
+            self.assertEqual('99 - Missing',
+                             self.module.friendly_map_name('99_missing'))
+
+    def test_missing_mod_font_reaches_stock_window_fallback_boundary(self):
+        class MissingFont(_Component):
+            def __setattr__(self, name, value):
+                if name == 'font':
+                    raise ValueError('font unavailable')
+                super().__setattr__(name, value)
+
+        self.surface.text = lambda: MissingFont('text')
+        with self.assertRaisesRegex(ValueError, 'font unavailable'):
+            self.room.install()
+        self.assertEqual([], self.surface.roots)
 
     def test_the_room_only_uses_properties_this_client_has(self):
         self.room.install()


### PR DESCRIPTION
The launcher already offers English and Simplified Chinese, but the in-game LAN room and connection notices always remained English. Pass the launcher's resolved language to the visible game process and translate mod-owned labels and notifications, including team controls and host/guest status. Chinese map labels use the client's arena catalog while requests retain the original geometry IDs.

Keep text as Unicode through Python 2 room refresh and decode UTF-8 names before formatting; the old `str(unicode_roster)` raises UnicodeEncodeError for Chinese names. Package a dedicated dynamic Microsoft YaHei font for the native room, assign it before text, and let font-load failures reach the existing stock-window fallback. Stock garage/battle UI retains the client language; launcher changes apply on the next game start.

Validation:
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -p 'test_*.py'`: all 3933 client tests passed.
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -p 'test_port_0922_waiting_room_ui.py'`: 47 passed.
- Same discovery command for `test_port_0922_lan_session.py`: 107 passed; for `test_port_0922_ui_i18n.py`: 4 passed.
- `cd launcher` then `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -p 'test_*.py'`: 482 tests, 2 skipped, passed.
- CPython 2.7.18 compiled all 94 client sources; executed Unicode formatting/label assignment and reproduced the original ASCII conversion failure.
- Built a temporary mod with the production staging/archive helpers; `python3 tools/validate_wotmod.py /tmp/wot-language-validation.wotmod` passed. Independent ZIP inspection confirmed the CJK font and Python 2.7 language module.

Windows acceptance remains pending: the available loose client files do not pass the full #1513 client inspection. The engine font documentation supports the approach, but native font availability, Chinese glyphs, notification rendering and clipping still need the exact Chinese HD #1513 Windows client. This PR does not claim native rendering acceptance or publish a release.
