### PR TITLE
Browse LAN maps in the stock map window

### DIFF
--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -1058,11 +1058,17 @@ crosses the Account-to-Avatar boundary. There is no synchronous-close fallback.
 The LAN room is now presented with the port's own native components. The stock
 map window described above remains the fallback for a client that cannot build
 them. The room carries the waiting-room presentation design reviewed in the
-retired predecessor source history: the live room status, one map selector
-limited to the server map pool, one start button for the host and one close
-control. It also presents the players who wait for
+retired predecessor source history: the live room status, a map choice limited
+to the server map pool, one start button for the host and one close control.
+It also presents the players who wait for
 the host, which the stock window cannot do. The desktop launcher owns the
 server address before the client starts, so the room never edits an endpoint.
+
+The map choice itself is made in the stock window, because this native surface
+cannot draw the client's map images. The room offers `RANDOM MAP`, which
+selects the server's own random option, and `MAP`, which hands the browse to
+that window. The battle time the window publishes travels with the next start
+request and becomes the round length the server counts down.
 
 Every native call is proved in exact build #1513:
 
@@ -1108,6 +1114,36 @@ so the room sets it optionally and logs a skip.
 Static inspection cannot prove that a native component receives mouse events
 while the Scaleform lobby is displayed. The room logs the surface it built, and
 a client that raises during construction keeps the stock map window.
+
+### Handing the screen to the stock map window
+
+The lobby movie draws at z 0.5 and this room at z 0.1, so the room covers every
+Scaleform view inside that movie, and it owns the native cursor while it is
+open. The room therefore never opens the map window itself: it asks its owner,
+which closes the room first - releasing its roots and restoring exactly the
+cursor state the lobby had - and only then calls `loadView`. The window's own
+close hook runs before the Scaleform view finishes tearing itself down, so the
+room is reopened from a `BigWorld.callback(0.0, ...)` after that, fenced by the
+client generation and the waiting state. Cancelling that reopen is part of
+every teardown: a battle start, a leave and a stop each retire the window and
+drop the pending return to the room.
+
+The window is the exact `TrainingSettingsWindow` already described above, with
+`isCreateRequest` still true, so its stock `getInfo` never asks for a prebattle
+entity this client does not have. The adapter then reports `canChangeComment`,
+`canMakeOpenedClosed`, `privacy` and `create` as false, and opens the view on
+the room's current arena and battle time. Whether that stock view hides or only
+disables the three fixed controls is a property of `gui.pkg`, not of any client
+script, and remains unproved until it is seen on the exact Windows client.
+
+`updateTrainingRoom` is the single Scaleform-to-Python call of that view
+(`TrainingWindowMeta`). In this mode it records the map and the battle time and
+returns to the room instead of starting the battle. The battle time arrives in
+whole minutes inside the exact `getTrainingBattleRoundLimits` range: 300..1800
+seconds for a plain account and 60..14400 seconds for one carrying
+`ACCOUNT_ATTR.DAILY_BONUS_1`. The LAN server accepts that same range for one
+round, denies anything else as `invalid_round_length`, and keeps 900 seconds
+for a start request that carries no round length.
 
 ## Battle and entity lifecycle
 

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -39,9 +39,11 @@ Play
    The battle runs the tank the garage fitted, with its modules, health, armour
    and gun.
 3. Every player sees the waiting room, drawn over the stock battle queue
-   screen. The first player is the room host: the host selects a standard map
-   with < and >, then clicks START BATTLE. LEAVE closes the room and returns
-   you to the garage.
+   screen. The first player is the room host. RANDOM MAP lets the server pick;
+   MAP opens the client's own map window, where the host picks a standard map
+   and a battle time and confirms. The room comes back with that choice, and
+   START BATTLE starts it. LEAVE closes the room and returns you to the
+   garage.
 4. The server fills each team to WOT_0922_TEAM_SIZE total tanks, including
    human players (1 through 15, default 15). Set that environment variable in
    the batch file that starts the server. Movement and firing unlock when the

--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ and battle logic, a small LAN server and a launcher.
      `192.168.1.20`.
 4. Click **Start game**. In the garage, fit a tank and click **Battle!**.
    Everyone lands in the LAN waiting room over the stock queue screen. The
-   host picks the map and clicks **START BATTLE**. **LEAVE** returns you to
-   the garage.
+   host picks the map - **RANDOM MAP**, or **MAP** to browse the client's own
+   map window and choose a battle time - and clicks **START BATTLE**.
+   **LEAVE** returns you to the garage.
 
 When you host, approve the UAC prompt that opens TCP 28782 for the launcher.
 Run the server only on a network you trust.

--- a/server/lan_battle_server.py
+++ b/server/lan_battle_server.py
@@ -81,6 +81,12 @@ MAX_TICK_FAILURE_DIAGNOSTIC_CHARS = 512
 MAX_CONSECUTIVE_TICK_FAILURES = 2
 PREBATTLE_SECONDS = 10.0
 BATTLE_DURATION_SECONDS = 900.0
+# Exact #1513 ``getTrainingBattleRoundLimits`` offers 300..1800 s to a
+# plain account and 60..14400 s to one with the daily-bonus attribute.
+# The room accepts that whole stock range for one requested round and
+# keeps 900 s for a start request that carries no round length.
+MIN_BATTLE_DURATION_SECONDS = 60
+MAX_BATTLE_DURATION_SECONDS = 14400
 PLAYER_DROWNING_SECONDS = 10.0
 PLAYER_OVERTURN_IGNORE_SECONDS = 0.10
 PLAYER_OVERTURN_DEATH_SECONDS = 30.0
@@ -2016,6 +2022,8 @@ class BattleState:
         self.phase = "waiting"
         self.round_id = 1
         self.state_revision = 0
+        # One accepted start request owns the round length.
+        self.battle_duration_seconds = BATTLE_DURATION_SECONDS
         self.host_player_id = None
         self.bot_roster = self._new_bot_roster()
         self.bot_authority_id = None
@@ -3277,7 +3285,24 @@ class BattleState:
             message.update(self._authority_fields())
             return message
 
-    def request_start(self, player_id, requested_map=None):
+    @staticmethod
+    def _requested_battle_duration(requested_round_seconds):
+        """Return the round length one start request asks for, or None.
+
+        The stock map window publishes whole minutes, so a start request that
+        carries no round length keeps the default round.
+        """
+        if requested_round_seconds is None:
+            return BATTLE_DURATION_SECONDS
+        try:
+            return float(_exact_int(requested_round_seconds,
+                                    MIN_BATTLE_DURATION_SECONDS,
+                                    MAX_BATTLE_DURATION_SECONDS))
+        except ValueError:
+            return None
+
+    def request_start(self, player_id, requested_map=None,
+                      requested_round_seconds=None):
         with self.lock:
             player = self.players.get(player_id)
             if player is None or not player.connected:
@@ -3286,6 +3311,10 @@ class BattleState:
                 return None, "already_started"
             if player_id != self.host_player_id:
                 return None, "host_only"
+            battle_duration_seconds = self._requested_battle_duration(
+                requested_round_seconds)
+            if battle_duration_seconds is None:
+                return None, "invalid_round_length"
             if (self.simulation_worker is None or
                     not self.simulation_worker.connected):
                 return None, "simulation_worker_required"
@@ -3366,6 +3395,9 @@ class BattleState:
                     if requested_map not in active_map_pool:
                         return None, "invalid_map"
                     self.map_name = requested_map
+            # Every accepted start owns the round length, so a host that stops
+            # publishing one returns the room to the default round.
+            self.battle_duration_seconds = battle_duration_seconds
             connected = [p for p in self.players.values() if p.connected]
             for participant in connected:
                 if not self._install_player_equipments(participant):
@@ -3561,7 +3593,7 @@ class BattleState:
             "authority_epoch": self.authority_epoch,
             "server_time_ms": self._server_time_ms(),
             "countdown_seconds": PREBATTLE_SECONDS,
-            "battle_duration_seconds": BATTLE_DURATION_SECONDS,
+            "battle_duration_seconds": self.battle_duration_seconds,
             "timing": self._timing_payload(),
         }
         live_message.update(self._authority_fields())
@@ -3579,7 +3611,7 @@ class BattleState:
     def _timing_payload(self):
         """Return server-authoritative phase time as relative milliseconds."""
         prebattle_ticks = int(round(PREBATTLE_SECONDS * TICK_HZ))
-        battle_ticks = int(round(BATTLE_DURATION_SECONDS * TICK_HZ))
+        battle_ticks = int(round(self.battle_duration_seconds * TICK_HZ))
         total_ticks = prebattle_ticks + battle_ticks
         tick = max(0, int(self.tick))
         if self.phase == "loading":
@@ -3600,7 +3632,7 @@ class BattleState:
                              (total_ticks - max(tick, prebattle_ticks)) /
                              TICK_HZ))),
             "duration_ms": int(round(
-                BATTLE_DURATION_SECONDS * 1000.0)),
+                self.battle_duration_seconds * 1000.0)),
         }
 
     def mark_battle_ready(self, player_id, message):
@@ -7929,8 +7961,8 @@ class BattleState:
             stun_end_server_time_ms = _exact_int(
                 raw.get("stun_end_server_time_ms"),
                 int(stun_now_ms) + 1,
-                int(round((PREBATTLE_SECONDS + BATTLE_DURATION_SECONDS) *
-                          1000.0)))
+                int(round((PREBATTLE_SECONDS +
+                           self.battle_duration_seconds) * 1000.0)))
         return {
             "target_kind": target_kind, "target_id": target_id,
             "target": target, "target_team": target_team,
@@ -11189,8 +11221,8 @@ class BattleState:
         """
         end_server_time_ms = _exact_int(
             end_server_time_ms, 1,
-            int(round((PREBATTLE_SECONDS + BATTLE_DURATION_SECONDS) *
-                      1000.0)))
+            int(round((PREBATTLE_SECONDS +
+                       self.battle_duration_seconds) * 1000.0)))
         state = self._vehicle_stun_state(target)
         if state is None or not state["alive"]:
             return False
@@ -12581,7 +12613,8 @@ class BattleState:
             self._prune_orphaned_bot_launch_edges()
             if (self.battle_result is None and
                     self.tick >= int(round(
-                        (PREBATTLE_SECONDS + BATTLE_DURATION_SECONDS) *
+                        (PREBATTLE_SECONDS +
+                         self.battle_duration_seconds) *
                         TICK_HZ))):
                 self._finish_battle(0, "battle_timeout", 0)
             self._update_capture()
@@ -13767,7 +13800,8 @@ class ClientHandler(socketserver.BaseRequestHandler):
                                         len(server.state.players)))
                         elif message_type == "start_battle":
                             start_message, start_error = server.state.request_start(
-                                player.player_id, message.get("map"))
+                                player.player_id, message.get("map"),
+                                message.get("round_seconds"))
                             if start_message is None:
                                 player.send({
                                     "type": "start_denied",

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/config.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/config.py
@@ -469,12 +469,19 @@ def save_endpoint(host, port, path=ENDPOINT_PATH):
     return True
 
 
+# The stock map window publishes whole minutes inside the exact #1513
+# ``getTrainingBattleRoundLimits`` range.
+MIN_ROUND_SECONDS = 60
+MAX_ROUND_SECONDS = 14400
+
+
 def _empty_waiting_room_state():
     return {
         'schema': 1,
         'map': None,
         'team': 0,
         'team_sizes': {},
+        'round_seconds': None,
     }
 
 
@@ -497,6 +504,18 @@ def _normalise_waiting_room_state(value):
     if team not in (0, 1, 2):
         raise ValueError('LAN waiting room team is invalid')
     state['team'] = team
+    round_seconds = value.get('round_seconds')
+    if round_seconds is not None:
+        if isinstance(round_seconds, bool):
+            raise ValueError('LAN waiting room round length is invalid')
+        try:
+            round_seconds = int(round_seconds)
+        except (TypeError, ValueError, OverflowError):
+            raise ValueError('LAN waiting room round length is invalid')
+        if (round_seconds < MIN_ROUND_SECONDS or
+                round_seconds > MAX_ROUND_SECONDS):
+            raise ValueError('LAN waiting room round length is invalid')
+        state['round_seconds'] = round_seconds
     sizes = value.get('team_sizes') or {}
     if not isinstance(sizes, dict):
         raise ValueError('LAN waiting room team sizes are invalid')
@@ -535,6 +554,7 @@ def save_waiting_room_state(value, path=WAITING_ROOM_STATE_PATH):
             'schema': 1,
             'map': state['map'],
             'team': state['team'],
+            'round_seconds': state['round_seconds'],
             'team_sizes': dict((str(team), size) for team, size in
                                state['team_sizes'].items()),
         }

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
@@ -20,6 +20,12 @@ from gui.mods.offline_lan_0922 import spotting
 PROTOCOL_VERSION = 5
 CLIENT_BUILD = 'wot-0.9.22.0.1-cn-1513'
 RANDOM_MAP_OPTION = 'server_random'
+# The stock map window publishes whole minutes inside the exact #1513
+# ``getTrainingBattleRoundLimits`` range: 300..1800 s for a plain
+# account, 60..14400 s with the daily-bonus attribute.  The LAN server
+# accepts that same range for one round.
+MIN_ROUND_SECONDS = 60
+MAX_ROUND_SECONDS = 14400
 PROJECTILE_LEDGER_CAPABILITY = 'projectile_ledger_v2'
 RICOCHET_CONTINUATION_CAPABILITY = 'ricochet_continuation_v1'
 PROJECTILE_HIT_VEHICLE_CAPABILITY = 'projectile_hit_vehicle_v1'
@@ -1892,11 +1898,18 @@ class LANClient(object):
                     if not is_alive():
                         self._sender_thread = None
 
-    def request_start(self, map_name=None):
+    def request_start(self, map_name=None, round_seconds=None):
         if (not self.ready or self.phase != 'waiting' or
                 self.player_id != self.host_player_id):
             return False
         message = {'type': 'start_battle', 'round_id': self.round_id}
+        if round_seconds is not None:
+            round_seconds = _exact_int(round_seconds)
+            if (round_seconds is None or
+                    round_seconds < MIN_ROUND_SECONDS or
+                    round_seconds > MAX_ROUND_SECONDS):
+                return False
+            message['round_seconds'] = round_seconds
         if map_name:
             map_name = _safe_text(map_name, '', 80)
             if (map_name == RANDOM_MAP_OPTION and

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/lan_session.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/lan_session.py
@@ -464,6 +464,18 @@ class LANSession(object):
         self._picker_callback_id = None
         self._picker_close_callback_id = None
         self._picker_cleanup_pending = False
+        # The stock map window is the room's map browser.  It is a Scaleform
+        # view inside the lobby movie, so it can only be seen and clicked
+        # while the self-drawn room has released the screen and the cursor.
+        self._map_window = None
+        self._map_window_open = False
+        self._map_window_unavailable = False
+        self._map_window_close_callback_id = None
+        self._map_window_reopen_callback_id = None
+        self._room_hidden_for_map_window = False
+        self._round_seconds = int(
+            self._room_preferences.get('round_seconds') or
+            queue_ui.DEFAULT_ROUND_SECONDS)
         self._battle_start_callback_id = None
         self._retry_callback_id = None
         self._retry_token = None
@@ -873,6 +885,7 @@ class LANSession(object):
         self._cancel_retry_callback()
         self._cancel_postbattle_callback()
         self._cancel_picker_close_callback()
+        self._retire_map_window()
         self._cancel_round_end_watchdog()
         self._clear_pending_battle_start()
         client = self.client
@@ -1026,6 +1039,7 @@ class LANSession(object):
 
     def leave_room(self):
         """Leave the LAN room and return to the garage."""
+        self._retire_map_window()
         self._picker_open = False
         self._picker_dismissed = True
         self._cancel_retry_callback()
@@ -1285,6 +1299,26 @@ class LANSession(object):
         self._room_preferences['map'] = map_name
         return self._save_room_preferences()
 
+    def _remember_round_seconds(self, seconds):
+        """Persist the battle time the stock map window published."""
+        if isinstance(seconds, bool):
+            return False
+        try:
+            seconds = int(seconds)
+        except (TypeError, ValueError, OverflowError):
+            return False
+        if (seconds < queue_ui.MIN_ROUND_SECONDS or
+                seconds > queue_ui.MAX_ROUND_SECONDS):
+            return False
+        self._round_seconds = seconds
+        if self._room_preferences.get('round_seconds') == seconds:
+            return True
+        self._room_preferences['round_seconds'] = seconds
+        return self._save_room_preferences()
+
+    def _round_seconds_value(self):
+        return self._round_seconds
+
     def _remember_team(self, team):
         try:
             team = int(team)
@@ -1352,6 +1386,161 @@ class LANSession(object):
             self._queue = surface
         return self._queue
 
+    def _ensure_map_window(self):
+        """Install the stock map window the self-drawn room browses with."""
+        if self._map_window is not None:
+            return self._map_window
+        if self._map_window_unavailable or self._queue_factory is None:
+            return None
+        if not callable(getattr(self._queue, 'select_map', None)):
+            # The fallback surface already is the stock map window.
+            return None
+        try:
+            window = self._queue_factory(
+                self.request_start, self._map_pool_value,
+                endpoint=self._picker_description,
+                on_close=self._on_map_window_closed,
+                on_select=self._on_map_window_selected,
+                selection=self._map_window_selection)
+            window.install()
+        except Exception as error:
+            self._map_window_unavailable = True
+            sys.stdout.write(
+                '[Offline LAN 0.9.22] the stock map window is unavailable, '
+                'keeping the room selection: %s\n' % error)
+            return None
+        self._map_window = window
+        return window
+
+    def _map_window_selection(self):
+        """Report the choice the stock map window should open on."""
+        return self._room_preferences.get('map'), self._round_seconds
+
+    def _open_map_window(self):
+        """Hide the room and raise the stock map window over the lobby."""
+        if (self._stopped or self._map_window_open or
+                self.state != 'waiting' or not self._is_local_host()):
+            return False
+        room = self._queue
+        if room is None or not self._picker_open:
+            return False
+        window = self._ensure_map_window()
+        if window is None:
+            return False
+        # The room draws at z 0.1, in front of the whole lobby movie, and it
+        # owns the native cursor while it is open.  A Scaleform view is only
+        # visible and clickable once the room has released both.
+        if room.close() is False:
+            self._picker_cleanup_pending = True
+            return False
+        self._room_hidden_for_map_window = True
+        if not self._picker_opener():
+            self._reopen_room_after_map_window(immediate=True)
+            return False
+        self._map_window_open = True
+        return True
+
+    def _on_map_window_selected(self, map_name, round_seconds=None):
+        """Adopt one stock-window choice instead of starting the battle."""
+        if self._stopped:
+            return False
+        self._remember_map(map_name)
+        if round_seconds is not None:
+            self._remember_round_seconds(round_seconds)
+        select = getattr(self._queue, 'select_map', None)
+        if callable(select):
+            select(map_name)
+        # This runs inside the Scaleform event dispatcher, so the view may
+        # only be destroyed after it regains control.
+        self._close_map_window_after_event()
+        return True
+
+    def _on_map_window_closed(self):
+        """Follow the stock window back to the room, however it closed."""
+        self._map_window_open = False
+        self._cancel_map_window_close_callback()
+        self._reopen_room_after_map_window()
+
+    def _cancel_map_window_close_callback(self):
+        callback_id = self._map_window_close_callback_id
+        self._map_window_close_callback_id = None
+        if callback_id is not None and callable(self._cancel_callback):
+            self._cancel_callback(callback_id)
+
+    def _cancel_map_window_reopen_callback(self):
+        callback_id = self._map_window_reopen_callback_id
+        self._map_window_reopen_callback_id = None
+        if callback_id is not None and callable(self._cancel_callback):
+            self._cancel_callback(callback_id)
+
+    def _close_map_window_after_event(self):
+        """Close the stock window after its current event stack returns."""
+        if self._map_window_close_callback_id is not None:
+            return True
+        if not callable(self._callback):
+            return False
+
+        def close_map_window():
+            self._map_window_close_callback_id = None
+            if not self._stopped:
+                self._close_map_window()
+
+        self._map_window_close_callback_id = self._callback(
+            0.0, close_map_window)
+        return True
+
+    def _close_map_window(self):
+        window = self._map_window
+        if window is None or not self._map_window_open:
+            return False
+        # The stock close hook re-enters ``_on_map_window_closed``, which is
+        # what clears the open flag and asks for the room again.
+        return bool(window.close())
+
+    def _retire_map_window(self):
+        """Close the stock window and drop any pending return to the room.
+
+        Returns whether the room was still hidden behind that window, which
+        means its native roots and cursor were already released.
+        """
+        self._cancel_map_window_close_callback()
+        hidden = self._room_hidden_for_map_window
+        try:
+            self._close_map_window()
+        finally:
+            self._cancel_map_window_reopen_callback()
+            self._room_hidden_for_map_window = False
+        return hidden
+
+    def _reopen_room_after_map_window(self, immediate=False):
+        if not self._room_hidden_for_map_window:
+            return False
+        if immediate or not callable(self._callback):
+            return self._reopen_room()
+        if self._map_window_reopen_callback_id is not None:
+            return True
+        generation = self._client_generation
+
+        def reopen():
+            self._map_window_reopen_callback_id = None
+            if self._stopped or generation != self._client_generation:
+                return
+            self._reopen_room()
+
+        self._map_window_reopen_callback_id = self._callback(0.0, reopen)
+        return True
+
+    def _reopen_room(self):
+        """Take the screen and the native cursor back from the window."""
+        self._room_hidden_for_map_window = False
+        room = self._queue
+        if (room is None or self._stopped or self.state != 'waiting' or
+                self._picker_dismissed):
+            self._picker_open = False
+            return False
+        self._picker_open = bool(room.open())
+        return self._picker_open
+
     def _ensure_queue_screen(self):
         if self._queue_screen is None and self._queue_screen_factory is not None:
             try:
@@ -1401,6 +1590,8 @@ class LANSession(object):
                     'request_bot_tier_mode': self.set_bot_tier_mode,
                     'initial_map': self._room_preferences.get('map'),
                     'on_map_selected': self._remember_map,
+                    'open_map_picker': self._open_map_window,
+                    'round_seconds': self._round_seconds_value,
                 })
             room = self._room_factory(
                 self.request_start, self._map_pool_value, **options)
@@ -1443,6 +1634,12 @@ class LANSession(object):
         return bool(getattr(self._queue, 'guest_view', False))
 
     def _refresh_surface(self):
+        if self._map_window_open:
+            # The room is hidden behind the stock window, so the window is the
+            # surface that has to follow a changed server map pool.
+            refresh = getattr(self._map_window, 'refresh', None)
+            if callable(refresh):
+                return refresh()
         refresh = getattr(self._queue, 'refresh', None)
         if callable(refresh):
             return refresh()
@@ -1636,8 +1833,15 @@ class LANSession(object):
 
     def _close_picker(self):
         self._cancel_picker_callback()
+        room_was_hidden = self._retire_map_window()
         queue = self._queue
         if queue is None:
+            self._picker_open = False
+            self._picker_cleanup_pending = False
+            return True
+        if room_was_hidden:
+            # The room released its native roots and the cursor when the stock
+            # map window took the screen; there is nothing left to close.
             self._picker_open = False
             self._picker_cleanup_pending = False
             return True
@@ -1731,7 +1935,8 @@ class LANSession(object):
                 self._endpoint_value())
             self._close_picker_after_event()
             return True
-        accepted = bool(self.client.request_start(map_name))
+        accepted = bool(self.client.request_start(
+            map_name, self._round_seconds))
         if accepted:
             self._start_requested = True
             self._pending_map = None
@@ -1829,7 +2034,8 @@ class LANSession(object):
                         'The LAN server does not offer the selected map.')
                     self._sync_waiting_surface(previous_host_player_id)
                     return
-                if self.client.request_start(pending_map):
+                if self.client.request_start(pending_map,
+                                             self._round_seconds):
                     self._start_requested = True
                     self.state = 'awaiting_battle_start'
                     self._close_picker()
@@ -2419,6 +2625,15 @@ class LANSession(object):
                         'waiting-room uninstall remains pending')
             except Exception as error:
                 errors.append(error)
+        # The map window adapter patches the stock view class, so it has to be
+        # retired even when this session never opened it.
+        if picker_closed and self._map_window is not None:
+            try:
+                self._map_window.uninstall()
+            except Exception as error:
+                errors.append(error)
+            else:
+                self._map_window = None
         if picker_closed and self._queue_screen is not None:
             try:
                 if self._queue_screen.uninstall() is False:

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/map_catalog.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/map_catalog.py
@@ -57,6 +57,25 @@ def build(arena_cache, map_pool):
     return MapCatalog(rows)
 
 
+def arena_type_id(arena_cache, map_name, map_pool):
+    """Return the UI arena id that presents one selectable geometry."""
+    if not map_name:
+        return None
+    name = _text(map_name)
+    allowed = _allowed_names(map_pool)
+    if allowed is not None and name not in allowed:
+        return None
+    items = getattr(arena_cache, 'iteritems', arena_cache.items)
+    keys = [key for key, arena_type in items()
+            if getattr(arena_type, 'gameplayName', None) == 'ctf' and
+            _text(getattr(arena_type, 'geometryName', '')) == name]
+    if not keys:
+        return None
+    # One geometry can carry several arena types.  Present the same one the
+    # sorted window rows would, so a reopened window keeps its selection.
+    return sorted(keys)[0]
+
+
 def geometry_name(arena_cache, arena_type_id, map_pool):
     """Resolve one UI arena id only when it remains selectable by policy."""
     try:

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/queue_ui.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/queue_ui.py
@@ -17,6 +17,31 @@ UPSTREAM_TUXEDO_URL = (
     '/sources/scripts/client/gui/mods/mod_observer.py')
 
 
+# The stock window publishes its battle time in whole minutes inside the exact
+# #1513 ``getTrainingBattleRoundLimits`` range: 300..1800 s for a plain
+# account, 60..14400 s with the daily-bonus account attribute.
+DEFAULT_ROUND_SECONDS = 900
+MIN_ROUND_SECONDS = 60
+MAX_ROUND_SECONDS = 14400
+
+
+def round_seconds(round_length):
+    """Return one stock battle time in seconds, or None when it is not one.
+
+    An unusable battle time must not reject the map the player just chose, so
+    the caller keeps its current round length instead.
+    """
+    if isinstance(round_length, bool):
+        return None
+    try:
+        seconds = int(round_length) * 60
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if seconds < MIN_ROUND_SECONDS or seconds > MAX_ROUND_SECONDS:
+        return None
+    return seconds
+
+
 def _load_runtime():
     import ArenaType
     from gui.Scaleform.daapi.view.lobby.trainings.TrainingSettingsWindow import \
@@ -146,11 +171,15 @@ class QueueUI(object):
     """A reversible, chain-safe adapter for the stock map picker."""
 
     def __init__(self, request_start, map_pool, endpoint=None, runtime=None,
-                 on_close=None):
+                 on_close=None, on_select=None, selection=None):
         self._request_start = request_start
         self._map_pool = map_pool
         self._endpoint = endpoint or (lambda: '')
         self._on_close = on_close
+        # ``on_select`` turns this window into the waiting room's map picker:
+        # the choice returns to the room instead of starting the battle.
+        self._on_select = on_select
+        self._selection = selection or (lambda: (None, None))
         self._runtime = runtime
         self._installed = False
         self._window_type = None
@@ -209,6 +238,22 @@ class QueueUI(object):
                 return info
             result = dict(info or {})
             result['description'] = adapter._endpoint()
+            # A LAN room has no privacy, no room comment and no training room
+            # to create.  Report all three as fixed so the stock view offers
+            # the map and the battle time only.  ``__isCreateRequest`` stays
+            # true, so the stock ``getInfo`` above never asks a prebattle
+            # entity this client does not have.
+            result['canChangeComment'] = False
+            result['canMakeOpenedClosed'] = False
+            result['privacy'] = False
+            result['create'] = False
+            selected_map, selected_round_seconds = adapter._selection()
+            arena = map_catalog.arena_type_id(
+                arena_type.g_cache, selected_map, adapter._map_pool())
+            if arena is not None:
+                result['arena'] = arena
+            if selected_round_seconds:
+                result['timeout'] = int(selected_round_seconds) // 60
             return result
 
         def wrapped_update(window, arena, round_length, is_private, comment):
@@ -219,7 +264,11 @@ class QueueUI(object):
                                                  adapter._map_pool())
             if map_name is None:
                 return False
-            accepted = adapter._request_start(map_name, comment)
+            if adapter._on_select is not None:
+                accepted = adapter._on_select(
+                    map_name, round_seconds(round_length))
+            else:
+                accepted = adapter._request_start(map_name, comment)
             if accepted is False:
                 return False
             # This method is entered from Scaleform's native event dispatcher.

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/waiting_room_ui.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/waiting_room_ui.py
@@ -64,7 +64,6 @@ PANEL_RAISE_PIXELS = 24
 POINTER_TICK_SECONDS = 0.03
 RANDOM_MAP_OPTION = 'server_random'
 
-_HOST_CONTROLS = ('previous', 'map', 'next', 'start')
 _TEAM_SELECT_CONTROLS = ('team1', 'team2', 'team_random')
 _TEAM_SELECT_ACTIONS = {
     'team1': 1, 'team_random': 0, 'team2': 2,
@@ -108,6 +107,23 @@ def friendly_map_name(map_name):
         parts = parts[1:]
     return prefix + (' '.join([part.capitalize() for part in parts]) or
                      'Unknown')
+
+
+def friendly_round_length(seconds):
+    """Return the battle time suffix for the start button, or ''.
+
+    The stock map window owns this value.  A room whose owner never published
+    one keeps the plain button rather than showing an invented round length.
+    """
+    if isinstance(seconds, bool) or seconds is None:
+        return ''
+    try:
+        minutes = int(seconds) // 60
+    except (TypeError, ValueError, OverflowError):
+        return ''
+    if minutes <= 0:
+        return ''
+    return '  -  %d MIN' % minutes
 
 
 def friendly_bot_tier_mode(mode):
@@ -308,7 +324,8 @@ class WaitingRoomUI(object):
                  request_team=None, team_status=None,
                  request_team_size=None, initial_map=None,
                  on_map_selected=None, bot_tier_status=None,
-                 request_bot_tier_mode=None):
+                 request_bot_tier_mode=None, open_map_picker=None,
+                 round_seconds=None):
         self._request_start = request_start
         self._map_pool = map_pool
         self._status = status or (lambda: '')
@@ -321,6 +338,13 @@ class WaitingRoomUI(object):
         self._bot_tier_status = bot_tier_status or (lambda: {})
         self._request_bot_tier_mode = request_bot_tier_mode
         self._on_map_selected = on_map_selected
+        # The stock map window is the room's map browser: it presents the
+        # #1513 map images this native surface cannot draw.  Its owner opens
+        # it, because the room must release the screen and the native cursor
+        # first - the lobby movie and every Scaleform view inside it draw at
+        # z 0.5, behind this room at z 0.1.
+        self._open_map_picker = open_map_picker
+        self._round_seconds = round_seconds or (lambda: None)
         self._surface = surface
         self._panel = None
         self._controls = {}
@@ -383,9 +407,8 @@ class WaitingRoomUI(object):
         make_control('tier_previous', (-0.72, 0.28, CONTROL_Z), 0.20, 0.16)
         make_control('tier', (0.0, 0.28, CONTROL_Z), 1.15, 0.16)
         make_control('tier_next', (0.72, 0.28, CONTROL_Z), 0.20, 0.16)
-        make_control('previous', (-0.72, 0.04, CONTROL_Z), 0.20, 0.16)
-        make_control('map', (0.0, 0.04, CONTROL_Z), 1.15, 0.16)
-        make_control('next', (0.72, 0.04, CONTROL_Z), 0.20, 0.16)
+        make_control('map', (-0.30, 0.04, CONTROL_Z), 1.00, 0.16)
+        make_control('random', (0.62, 0.04, CONTROL_Z), 0.56, 0.16)
         make_control('team1_down', (-0.82, -0.18, CONTROL_Z), 0.12, 0.14)
         make_control('team1_up', (-0.22, -0.18, CONTROL_Z), 0.12, 0.14)
         make_control('team2_down', (0.22, -0.18, CONTROL_Z), 0.12, 0.14)
@@ -407,11 +430,9 @@ class WaitingRoomUI(object):
                    anchor='CENTER', colour=CONTROL_TEXT_COLOUR)
         make_label('tier_next', '>', (0.72, 0.28, 0.0), 0.18, 0.10,
                    anchor='CENTER', colour=CONTROL_TEXT_COLOUR)
-        make_label('previous', '<', (-0.72, 0.04, 0.0), 0.18, 0.10,
+        make_label('map', '', (-0.30, 0.04, 0.0), 0.96, 0.10,
                    anchor='CENTER', colour=CONTROL_TEXT_COLOUR)
-        make_label('map', '', (0.0, 0.04, 0.0), 1.10, 0.10,
-                   anchor='CENTER', colour=CONTROL_TEXT_COLOUR)
-        make_label('next', '>', (0.72, 0.04, 0.0), 0.18, 0.10,
+        make_label('random', 'RANDOM MAP', (0.62, 0.04, 0.0), 0.52, 0.10,
                    anchor='CENTER', colour=CONTROL_TEXT_COLOUR)
         make_label('team1_down', '-', (-0.82, -0.18, 0.0), 0.10, 0.09,
                    anchor='CENTER', colour=CONTROL_TEXT_COLOUR)
@@ -540,6 +561,15 @@ class WaitingRoomUI(object):
             except Exception as error:
                 _log('LAN waiting room could not save the selected map: %s' %
                      error)
+        return True
+
+    def select_map(self, map_name):
+        """Adopt one map chosen outside the room, such as in that window."""
+        if not map_name:
+            return False
+        self._set_selected_map(map_name)
+        self._message = ''
+        self.refresh()
         return True
 
     def open(self):
@@ -936,11 +966,15 @@ class WaitingRoomUI(object):
         else:
             self._set_text('map', lines[2] if len(lines) > 2 else
                            'The room host starts the battle.')
+        self._set_text('start', 'START BATTLE%s' % friendly_round_length(
+            self._round_seconds()))
         self._set_text('message', self._message)
+        random_supported = bool(is_host and self._random_supported())
         for role, component in self._controls.items():
             visible = (team_supported if role in _TEAM_SELECT_CONTROLS else
                        team_size_supported if role in _TEAM_SIZE_CONTROLS else
                        tier_supported if role in _BOT_TIER_CONTROLS else
+                       random_supported if role == 'random' else
                        role == 'close' or is_host)
             self._set(component, 'visible', visible)
             label = self._labels.get(role)
@@ -993,10 +1027,10 @@ class WaitingRoomUI(object):
                 -1 if role == 'tier_previous' else 1)
         if not self._host():
             return False
-        if role == 'previous':
-            return self._cycle(-1)
-        if role in ('next', 'map'):
-            return self._cycle(1)
+        if role == 'map':
+            return self._open_map_window()
+        if role == 'random':
+            return self._select_random_map()
         if role == 'start':
             return self._start()
         return False
@@ -1094,17 +1128,28 @@ class WaitingRoomUI(object):
         self.refresh()
         return True
 
-    def _cycle(self, step):
-        options = self._options()
-        if not options:
+    def _open_map_window(self):
+        """Ask this room's owner to raise the stock map window."""
+        if not self._options():
             self._message = 'The server has not published its map list yet.'
             self.refresh()
             return False
-        try:
-            index = options.index(self._selected_map)
-        except ValueError:
-            index = 0
-        self._set_selected_map(options[(index + int(step)) % len(options)])
+        if not callable(self._open_map_picker):
+            self._message = 'The stock map window is unavailable.'
+            self.refresh()
+            return False
+        if self._open_map_picker() is False:
+            self._message = 'The stock map window could not open.'
+            self.refresh()
+            return False
+        return True
+
+    def _select_random_map(self):
+        if not self._random_supported():
+            self._message = 'This LAN server does not offer a random map.'
+            self.refresh()
+            return False
+        self._set_selected_map(RANDOM_MAP_OPTION)
         self._message = ''
         self.refresh()
         return True

--- a/tests/test_port_0922.py
+++ b/tests/test_port_0922.py
@@ -688,6 +688,7 @@ class PortConfigTests(unittest.TestCase):
                 'map': '05_prohorovka',
                 'team': 2,
                 'team_sizes': {1: 4, 2: 9},
+                'round_seconds': 1200,
             }
 
             self.assertTrue(config_module.save_waiting_room_state(
@@ -697,8 +698,35 @@ class PortConfigTests(unittest.TestCase):
                 choices, config_module.load_waiting_room_state(path))
             self.assertEqual(
                 {'schema': 1, 'map': '05_prohorovka', 'team': 2,
+                 'round_seconds': 1200,
                  'team_sizes': {'1': 4, '2': 9}},
                 json.loads(Path(path).read_text(encoding='utf-8')))
+
+    def test_a_state_without_a_round_length_keeps_the_default_round(self):
+        config_module = _load_port_source('config')
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / 'waiting_room_state.json'
+            path.write_text(
+                '{"schema": 1, "map": "01_karelia", "team": 0, '
+                '"team_sizes": {}}', encoding='utf-8')
+
+            state = config_module.load_waiting_room_state(str(path))
+
+            self.assertIsNone(state['round_seconds'])
+
+    def test_an_out_of_range_round_length_falls_back_to_the_defaults(self):
+        config_module = _load_port_source('config')
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / 'waiting_room_state.json'
+            path.write_text(
+                '{"schema": 1, "map": "01_karelia", "team": 0, '
+                '"team_sizes": {}, "round_seconds": 14401}',
+                encoding='utf-8')
+
+            self.assertEqual(
+                {'schema': 1, 'map': None, 'team': 0, 'team_sizes': {},
+                 'round_seconds': None},
+                config_module.load_waiting_room_state(str(path)))
 
     def test_invalid_waiting_room_state_falls_back_without_blocking_login(self):
         config_module = _load_port_source('config')
@@ -709,7 +737,8 @@ class PortConfigTests(unittest.TestCase):
                 '"team_sizes": {"1": 99}}', encoding='utf-8')
 
             self.assertEqual(
-                {'schema': 1, 'map': None, 'team': 0, 'team_sizes': {}},
+                {'schema': 1, 'map': None, 'team': 0, 'team_sizes': {},
+                 'round_seconds': None},
                 config_module.load_waiting_room_state(str(path)))
 
     def test_legacy_user_state_is_copied_without_deleting_the_old_file(self):
@@ -5694,6 +5723,14 @@ class LANClientTests(unittest.TestCase):
         queued = client._outbound_queue[-1][1]
         self.assertEqual('start_battle', queued['type'])
         self.assertEqual('04_himmelsdorf', queued['map'])
+        self.assertNotIn('round_seconds', queued)
+        # The stock map window's battle time travels with the start request.
+        self.assertTrue(client.request_start('04_himmelsdorf', 1200))
+        self.assertEqual(1200, client._outbound_queue[-1][1]['round_seconds'])
+        for value in (59, 14401, 'ten', True):
+            self.assertFalse(
+                client.request_start('04_himmelsdorf', value), value)
+        self.assertEqual(1200, client._outbound_queue[-1][1]['round_seconds'])
         self.assertEqual(['welcome', 'roster'],
                          [item[0] for item in events])
 

--- a/tests/test_port_0922_lan_session.py
+++ b/tests/test_port_0922_lan_session.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 import importlib.util
 from pathlib import Path
 import sys
@@ -74,6 +75,7 @@ class _Client(object):
         self.stop_calls = 0
         self.leave_calls = 0
         self.requests = []
+        self.round_requests = []
         self.selections = []
         self.team_selections = []
         self.team_size_selections = []
@@ -86,8 +88,9 @@ class _Client(object):
     def stop(self):
         self.stop_calls += 1
 
-    def request_start(self, map_name):
+    def request_start(self, map_name, round_seconds=None):
         self.requests.append(map_name)
+        self.round_requests.append(round_seconds)
         return True
 
     def leave_battle(self):
@@ -129,11 +132,14 @@ class _Client(object):
 
 
 class _Queue(object):
-    def __init__(self, request_start, map_pool, endpoint=None, on_close=None):
+    def __init__(self, request_start, map_pool, endpoint=None, on_close=None,
+                 on_select=None, selection=None):
         self.request_start = request_start
         self.map_pool = map_pool
         self.endpoint = endpoint
         self.on_close = on_close
+        self.on_select = on_select
+        self.selection = selection
         self.install_calls = 0
         self.uninstall_calls = 0
         self.close_calls = 0
@@ -146,7 +152,12 @@ class _Queue(object):
         self.uninstall_calls += 1
 
     def close(self):
+        # The stock window notifies its owner from inside its own close hook,
+        # before the Scaleform view finishes tearing itself down.
         self.close_calls += 1
+        if callable(self.on_close):
+            self.on_close()
+        return True
 
     def refresh(self):
         self.refresh_calls += 1
@@ -2579,13 +2590,17 @@ class _Room(object):
     guest_view = True
 
     def __init__(self, request_start, map_pool, status=None, on_close=None,
-                 host=None, random_supported=None):
+                 host=None, random_supported=None, open_map_picker=None,
+                 round_seconds=None, **unused_options):
         self.request_start = request_start
         self.map_pool = map_pool
         self.status = status
         self.on_close = on_close
         self.host = host
         self.random_supported = random_supported
+        self.open_map_picker = open_map_picker
+        self.round_seconds = round_seconds
+        self.selected_maps = []
         self.install_calls = 0
         self.open_calls = 0
         self.close_calls = 0
@@ -2605,6 +2620,10 @@ class _Room(object):
 
     def refresh(self):
         self.refresh_calls += 1
+        return True
+
+    def select_map(self, map_name):
+        self.selected_maps.append(map_name)
         return True
 
     def uninstall(self):
@@ -2761,3 +2780,199 @@ class LANSessionRoomTests(unittest.TestCase):
         self.assertEqual([], self.rooms)
         self.assertEqual(1, len(self.queues))
         self.assertEqual([True], self.opens)
+
+
+class LANSessionMapWindowTests(unittest.TestCase):
+    """The room browses maps in the stock window, then takes the screen back."""
+
+    def setUp(self):
+        self.module = _load()
+        self.preferences = {
+            'schema': 1, 'map': None, 'team': 0, 'team_sizes': {}}
+        self.module.port_config.load_waiting_room_state = mock.Mock(
+            return_value=self.preferences)
+        self.saved = []
+        self.module.port_config.save_waiting_room_state = mock.Mock(
+            side_effect=lambda value: self.saved.append(dict(value)) or True)
+        self.clients = []
+        self.queues = []
+        self.rooms = []
+        self.opens = []
+        self.scheduled = OrderedDict()
+        self.next_handle = 0
+        self.open_result = True
+
+        def client_factory(*args, **kwargs):
+            client = _Client(*args, **kwargs)
+            self.clients.append(client)
+            return client
+
+        def queue_factory(*args, **kwargs):
+            queue = _Queue(*args, **kwargs)
+            self.queues.append(queue)
+            return queue
+
+        def room_factory(*args, **kwargs):
+            room = _Room(*args, **kwargs)
+            self.rooms.append(room)
+            return room
+
+        def schedule(unused_delay, function):
+            self.next_handle += 1
+            self.scheduled[self.next_handle] = function
+            return self.next_handle
+
+        self.session = self.module.LANSession(
+            {'host': '10.0.0.5', 'port': 28782, 'name': 'P',
+             'vehicle': 'ussr:MS-1'},
+            client_factory=client_factory, queue_factory=queue_factory,
+            room_factory=room_factory,
+            picker_opener=lambda: self.opens.append(True) or self.open_result,
+            callback=schedule,
+            cancel_callback=lambda handle: self.scheduled.pop(handle, None),
+            battle_runtime=_BattleRuntime(),
+            vehicle_provider=lambda: ('ussr:R11_MS-1', 90),
+            status_notifier=lambda unused_message: None)
+        self.assertTrue(self.session.start())
+        self.session._picker_requested = True
+        self.client = self.clients[0]
+        self.client.ready = True
+        self.client.phase = 'waiting'
+        self.client.host_player_id = self.client.player_id
+        self.client.on_event('welcome', {
+            'phase': 'waiting',
+            'map_pool': ['01_karelia', '05_prohorovka']})
+        self.room = self.rooms[0]
+
+    def _run_callbacks(self):
+        """Run exactly the callbacks still scheduled, in order."""
+        pending = list(self.scheduled.values())
+        self.scheduled.clear()
+        for callback in pending:
+            callback()
+        return len(pending)
+
+    def _open_window(self):
+        self.assertTrue(self.session._open_map_window())
+        return self.queues[0]
+
+    def test_the_map_button_releases_the_room_before_the_stock_window(self):
+        window = self._open_window()
+
+        # The room draws in front of the whole lobby movie and owns the native
+        # cursor, so it has to close before the Scaleform view is raised.
+        self.assertEqual(1, self.room.close_calls)
+        self.assertEqual([True], self.opens)
+        self.assertEqual(1, window.install_calls)
+        self.assertTrue(self.session._map_window_open)
+        self.assertTrue(self.session._room_hidden_for_map_window)
+        self.assertEqual((None, 900), window.selection())
+
+    def test_a_chosen_map_returns_to_the_room_without_starting(self):
+        window = self._open_window()
+
+        self.assertTrue(window.on_select('05_prohorovka', 1200))
+
+        self.assertEqual(['05_prohorovka'], self.room.selected_maps)
+        self.assertEqual([], self.client.requests)
+        self.assertEqual(1200, self.session._round_seconds)
+        self.assertEqual('05_prohorovka', self.saved[-1]['map'])
+        self.assertEqual(1200, self.saved[-1]['round_seconds'])
+
+        # The view is destroyed after its own event stack returns, and the
+        # room only takes the cursor back on the tick after that.
+        self.assertEqual(0, window.close_calls)
+        self.assertEqual(1, self._run_callbacks())
+        self.assertEqual(1, window.close_calls)
+        self.assertEqual(1, self.room.open_calls)
+        self.assertEqual(1, self._run_callbacks())
+        self.assertEqual(2, self.room.open_calls)
+        self.assertTrue(self.session._picker_open)
+        self.assertFalse(self.session._map_window_open)
+        self.assertFalse(self.session._room_hidden_for_map_window)
+
+    def test_the_chosen_battle_time_reaches_the_server(self):
+        window = self._open_window()
+        window.on_select('05_prohorovka', 1200)
+        self._run_callbacks()
+        self._run_callbacks()
+
+        self.assertTrue(self.session.request_start('05_prohorovka'))
+
+        self.assertEqual(['05_prohorovka'], self.client.requests)
+        self.assertEqual([1200], self.client.round_requests)
+
+    def test_closing_the_window_without_a_choice_restores_the_room(self):
+        window = self._open_window()
+
+        window.on_close()
+
+        self.assertEqual(1, self._run_callbacks())
+        self.assertEqual(2, self.room.open_calls)
+        self.assertEqual([], self.room.selected_maps)
+        self.assertTrue(self.session._picker_open)
+
+    def test_a_refused_stock_window_returns_to_the_room_at_once(self):
+        self.open_result = False
+
+        self.assertFalse(self.session._open_map_window())
+
+        self.assertEqual(2, self.room.open_calls)
+        self.assertTrue(self.session._picker_open)
+        self.assertFalse(self.session._map_window_open)
+
+    def test_battle_start_retires_the_window_and_never_reopens_the_room(self):
+        window = self._open_window()
+
+        self.assertTrue(self.session._close_picker())
+
+        self.assertEqual(1, window.close_calls)
+        self.assertFalse(self.session._picker_open)
+        self.assertFalse(self.session._picker_cleanup_pending)
+        self.assertFalse(self.session._room_hidden_for_map_window)
+        # The room was already closed for the window; closing it again would
+        # report a failed native cleanup that never happened.
+        self.assertEqual(1, self.room.close_calls)
+        self.assertEqual(0, self._run_callbacks())
+        self.assertEqual(1, self.room.open_calls)
+
+    def test_leaving_the_room_from_the_window_stops_the_reopen(self):
+        window = self._open_window()
+
+        self.assertTrue(self.session.leave_room())
+
+        self.assertEqual(1, window.close_calls)
+        self.assertEqual(0, self._run_callbacks())
+        self.assertEqual(1, self.room.open_calls)
+        self.assertEqual('ready_to_join', self.session.state)
+
+    def test_an_incomplete_room_close_keeps_the_room_and_the_screen(self):
+        self.room.close = mock.Mock(return_value=False)
+
+        self.assertFalse(self.session._open_map_window())
+
+        # The room still owns native roots or the cursor, so the Scaleform
+        # view must not be raised behind it.
+        self.assertEqual([], self.opens)
+        self.assertFalse(self.session._map_window_open)
+        self.assertFalse(self.session._room_hidden_for_map_window)
+        self.assertTrue(self.session._picker_cleanup_pending)
+        self.assertTrue(self.session._picker_open)
+
+    def test_a_guest_never_opens_the_stock_map_window(self):
+        self.session._host_player_id = 'other'
+
+        self.assertFalse(self.session._open_map_window())
+
+        self.assertEqual([], self.queues)
+        self.assertEqual(0, self.room.close_calls)
+
+    def test_the_window_adapter_is_uninstalled_with_the_session(self):
+        window = self._open_window()
+        window.on_close()
+        self._run_callbacks()
+
+        self.session.stop(show_login=False, restore_account=False)
+
+        self.assertEqual(1, window.uninstall_calls)
+        self.assertIsNone(self.session._map_window)

--- a/tests/test_port_0922_queue_ui.py
+++ b/tests/test_port_0922_queue_ui.py
@@ -321,6 +321,71 @@ class QueueUITests(unittest.TestCase):
         self.assertTrue(window.closed)
         self.assertFalse(getattr(window, self.queue_ui._PICKER_MARKER))
 
+    def test_select_only_mode_returns_the_choice_and_the_battle_time(self):
+        selected = []
+        adapter = self.queue_ui.QueueUI(
+            lambda *args: self.started.append(args),
+            lambda: ('01_karelia', '05_prohorovka'),
+            endpoint=lambda: 'LAN SERVER: 10.0.0.5:28782',
+            runtime=(self.arena_type, _Window),
+            on_close=lambda: self.closed.append(True),
+            on_select=lambda name, seconds: selected.append((name, seconds)),
+            selection=lambda: ('05_prohorovka', 1200))
+        self.addCleanup(adapter.uninstall)
+        adapter.install()
+        window = _Window({'isOfflineLanPicker': True})
+
+        info = window.getInfo()
+        # The LAN room has no privacy, no room comment and no training room
+        # to create, and the window opens on the room's current choice.
+        self.assertFalse(info['canChangeComment'])
+        self.assertFalse(info['canMakeOpenedClosed'])
+        self.assertFalse(info['privacy'])
+        self.assertFalse(info['create'])
+        self.assertEqual(3, info['arena'])
+        self.assertEqual(20, info['timeout'])
+
+        self.assertIsNone(window.updateTrainingRoom(1, 20, False, 'ignored'))
+        self.assertEqual([('01_karelia', 1200)], selected)
+        # A map choice never starts the battle in this mode.
+        self.assertEqual([], self.started)
+
+    def test_an_unusable_battle_time_keeps_the_owner_round_length(self):
+        selected = []
+        adapter = self.queue_ui.QueueUI(
+            lambda *args: self.started.append(args),
+            lambda: ('01_karelia',),
+            runtime=(self.arena_type, _Window),
+            on_select=lambda name, seconds: selected.append((name, seconds)))
+        self.addCleanup(adapter.uninstall)
+        adapter.install()
+        window = _Window({'isOfflineLanPicker': True})
+
+        self.assertIsNone(window.updateTrainingRoom(1, 0, False, ''))
+        self.assertEqual([('01_karelia', None)], selected)
+
+    def test_round_seconds_follows_the_exact_1513_training_limits(self):
+        self.assertEqual(900, self.queue_ui.DEFAULT_ROUND_SECONDS)
+        self.assertEqual(60, self.queue_ui.MIN_ROUND_SECONDS)
+        self.assertEqual(14400, self.queue_ui.MAX_ROUND_SECONDS)
+        self.assertEqual(300, self.queue_ui.round_seconds(5))
+        self.assertEqual(1800, self.queue_ui.round_seconds(30))
+        self.assertIsNone(self.queue_ui.round_seconds(0))
+        self.assertIsNone(self.queue_ui.round_seconds(241))
+        self.assertIsNone(self.queue_ui.round_seconds(None))
+        self.assertIsNone(self.queue_ui.round_seconds(True))
+
+    def test_arena_id_lookup_honours_gameplay_and_server_pool(self):
+        cache = self.arena_type.g_cache
+        self.assertEqual(
+            3, self.catalog.arena_type_id(cache, '05_prohorovka', None))
+        self.assertIsNone(
+            self.catalog.arena_type_id(cache, '04_himmelsdorf', None))
+        self.assertIsNone(
+            self.catalog.arena_type_id(cache, '01_karelia',
+                                       ('05_prohorovka',)))
+        self.assertIsNone(self.catalog.arena_type_id(cache, None, None))
+
     def test_close_clears_marker_before_stock_window_cleanup(self):
         self.adapter.install()
         window = _Window({'isOfflineLanPicker': True})

--- a/tests/test_port_0922_server_team_size.py
+++ b/tests/test_port_0922_server_team_size.py
@@ -8,7 +8,8 @@ SERVER_ROOT = Path(__file__).resolve().parents[1] / 'server'
 sys.path.insert(0, str(SERVER_ROOT))
 
 from lan_battle_server import (  # noqa: E402
-    BattleState, BOT_CALLSIGNS_0922, CLIENT_BUILD_0922,
+    BattleState, BATTLE_DURATION_SECONDS, BOT_CALLSIGNS_0922,
+    CLIENT_BUILD_0922,
     DESTRUCTIBLE_CATALOG_V5_CAPABILITY,
     HUMAN_RAM_TIMELINE_CAPABILITY, PROJECTILE_CAPABILITY,
     MODERN_VISIBLE_MESSAGE_TYPES, PLAYER_ENVIRONMENT_CAPABILITY,
@@ -499,6 +500,53 @@ class ServerTeamSizeTests(unittest.TestCase):
         self.assertEqual('05_prohorovka', state.map_name)
         self.assertEqual('05_prohorovka', start['map'])
         choose.assert_any_call(tuple(state._active_map_pool()))
+
+    def test_one_start_request_owns_the_round_length(self):
+        state = BattleState(map_name='01_karelia', team_size=1)
+        _attach_worker(state)
+        player, error = state.add_player(
+            _Connection(), ('10.0.0.1', 1001), _hello(1, 1))
+        self.assertIsNone(error)
+        self.assertEqual(BATTLE_DURATION_SECONDS,
+                         state.battle_duration_seconds)
+
+        start, error = state.request_start(player.player_id, '01_karelia',
+                                           1200)
+
+        self.assertIsNone(error)
+        self.assertEqual(1200.0, state.battle_duration_seconds)
+        timing = state._timing_payload()
+        self.assertEqual(1200000, timing['duration_ms'])
+
+    def test_a_start_without_a_round_length_keeps_the_default_round(self):
+        state = BattleState(map_name='01_karelia', team_size=1)
+        _attach_worker(state)
+        player, error = state.add_player(
+            _Connection(), ('10.0.0.1', 1001), _hello(1, 1))
+        self.assertIsNone(error)
+        state.battle_duration_seconds = 1800.0
+
+        start, error = state.request_start(player.player_id, '01_karelia')
+
+        self.assertIsNone(error)
+        self.assertEqual(BATTLE_DURATION_SECONDS,
+                         state.battle_duration_seconds)
+
+    def test_an_out_of_range_round_length_is_denied_before_the_round(self):
+        state = BattleState(map_name='01_karelia', team_size=1)
+        _attach_worker(state)
+        player, error = state.add_player(
+            _Connection(), ('10.0.0.1', 1001), _hello(1, 1))
+        self.assertIsNone(error)
+
+        for value in (59, 14401, 'ten', 900.0, True, False):
+            start, error = state.request_start(
+                player.player_id, '01_karelia', value)
+            self.assertIsNone(start, value)
+            self.assertEqual('invalid_round_length', error)
+        self.assertEqual('waiting', state.phase)
+        self.assertEqual(BATTLE_DURATION_SECONDS,
+                         state.battle_duration_seconds)
 
     def test_unknown_start_map_remains_fail_closed(self):
         state = BattleState(

--- a/tests/test_port_0922_waiting_room_ui.py
+++ b/tests/test_port_0922_waiting_room_ui.py
@@ -182,6 +182,10 @@ class WaitingRoomTests(unittest.TestCase):
     def _visible(self, role):
         return self.room._controls[role].properties['visible']
 
+    @staticmethod
+    def _label_of(room, role):
+        return room._labels[role].properties['text']
+
     def _root_count(self, room=None):
         """The room panel plus one root per arrow row."""
         return 1 + len((room or self.room)._pointer_parts)
@@ -198,9 +202,10 @@ class WaitingRoomTests(unittest.TestCase):
 
     def test_the_host_sees_the_map_selector_and_start_button(self):
         self.room.open()
-        for role in ('previous', 'map', 'next', 'start'):
+        for role in ('map', 'random', 'start'):
             self.assertTrue(self._visible(role), role)
         self.assertEqual('MAP: Random', self._label('map'))
+        self.assertEqual('START BATTLE', self._label('start'))
         self.assertEqual('LAN SERVER: 10.0.0.5:28782', self._label('room'))
         self.assertEqual('PLAYERS (2): Host, Guest', self._label('players'))
 
@@ -212,8 +217,74 @@ class WaitingRoomTests(unittest.TestCase):
         self.assertTrue(self.room.activate('start'))
         self.assertEqual([self.module.RANDOM_MAP_OPTION], self.started)
 
-        self.assertTrue(self.room.activate('next'))
-        self.assertEqual('MAP: 01 - Karelia', self._label('map'))
+    def test_the_map_button_asks_its_owner_for_the_stock_map_window(self):
+        opened = []
+        room = self.module.WaitingRoomUI(
+            self._request_start, lambda: list(self.pool),
+            status=lambda: self.status, host=lambda: True,
+            surface=self.surface,
+            open_map_picker=lambda: opened.append(1) or True)
+
+        self.assertTrue(room.open())
+        self.assertTrue(room.activate('map'))
+        self.assertEqual([1], opened)
+        # The window owns the choice; the room must not cycle one itself.
+        self.assertEqual(self.module.RANDOM_MAP_OPTION, room._selected_map)
+
+    def test_a_refused_map_window_reports_it_and_keeps_the_selection(self):
+        room = self.module.WaitingRoomUI(
+            self._request_start, lambda: list(self.pool),
+            status=lambda: self.status, host=lambda: True,
+            surface=self.surface, open_map_picker=lambda: False)
+
+        self.assertTrue(room.open())
+        self.assertFalse(room.activate('map'))
+        self.assertEqual('The stock map window could not open.',
+                         room._labels['message'].properties['text'])
+        self.assertEqual(self.module.RANDOM_MAP_OPTION, room._selected_map)
+
+    def test_the_map_window_choice_becomes_the_room_selection(self):
+        selected = []
+        room = self.module.WaitingRoomUI(
+            self._request_start, lambda: list(self.pool),
+            status=lambda: self.status, host=lambda: True,
+            surface=self.surface, on_map_selected=selected.append,
+            round_seconds=lambda: 1200)
+
+        self.assertTrue(room.open())
+        self.assertTrue(room.select_map('05_prohorovka'))
+        self.assertEqual('05_prohorovka', room._selected_map)
+        self.assertEqual([self.module.RANDOM_MAP_OPTION, '05_prohorovka'],
+                         selected)
+        self.assertEqual('MAP: 05 - Prohorovka', self._label_of(room, 'map'))
+        self.assertEqual('START BATTLE  -  20 MIN',
+                         self._label_of(room, 'start'))
+        self.assertTrue(room.activate('start'))
+        self.assertEqual(['05_prohorovka'], self.started)
+
+    def test_the_random_button_selects_the_wire_random_name(self):
+        room = self.module.WaitingRoomUI(
+            self._request_start, lambda: list(self.pool),
+            status=lambda: self.status, host=lambda: True,
+            surface=self.surface, initial_map='01_karelia')
+
+        self.assertTrue(room.open())
+        self.assertEqual('01_karelia', room._selected_map)
+        self.assertTrue(room.activate('random'))
+        self.assertEqual(self.module.RANDOM_MAP_OPTION, room._selected_map)
+        self.assertEqual('MAP: Random', self._label_of(room, 'map'))
+
+    def test_the_random_button_is_hidden_without_server_support(self):
+        room = self.module.WaitingRoomUI(
+            self._request_start, lambda: list(self.pool),
+            status=lambda: self.status, host=lambda: True,
+            surface=self.surface, random_supported=lambda: False)
+
+        self.assertTrue(room.open())
+        self.assertFalse(room._controls['random'].properties['visible'])
+        self.assertTrue(room._controls['map'].properties['visible'])
+        self.assertFalse(room.activate('random'))
+        self.assertEqual('01_karelia', room._selected_map)
 
     def test_random_is_hidden_when_the_server_does_not_advertise_it(self):
         room = self.module.WaitingRoomUI(
@@ -237,8 +308,8 @@ class WaitingRoomTests(unittest.TestCase):
         self.assertTrue(room.open())
         self.assertEqual('05_prohorovka', room._selected_map)
         self.assertEqual([], selected)
-        self.assertTrue(room.activate('next'))
-        self.assertEqual([self.module.RANDOM_MAP_OPTION], selected)
+        self.assertTrue(room.select_map('01_karelia'))
+        self.assertEqual(['01_karelia'], selected)
 
     def test_unavailable_saved_map_falls_back_and_updates_the_saved_choice(self):
         selected = []


### PR DESCRIPTION
## What changed

The self-drawn waiting room could only step through the server map pool with
`<` and `>`, because a native GUI surface cannot present this client's map
images. It now shows **RANDOM MAP** and one **MAP** button that hands the
browse to the exact #1513 `TrainingSettingsWindow`, which already draws them.

- `waiting_room_ui`: the two arrows become `MAP` (asks its owner for the stock
  window) and `RANDOM MAP` (selects the server's own random option, hidden when
  the server does not offer one). `select_map` adopts a choice made outside the
  room, and the start button shows the chosen battle time.
- `lan_session`: the room and the stock window now coexist. The room draws at
  z 0.1, in front of the whole lobby movie (the lobby's own Flash cursor is at
  z 0.5), and owns the native cursor while open, so the session closes the room
  before `loadView` and reopens it from a next-tick callback after the window
  closes - fenced by the client generation and the waiting state. A battle
  start, a leave, a stop and a revive each retire the window and drop that
  pending reopen.
- `queue_ui`: an `on_select` mode records the choice instead of starting the
  battle, and `getInfo` reports `canChangeComment`, `canMakeOpenedClosed`,
  `privacy` and `create` as false, opening the view on the room's current arena
  and battle time. `isCreateRequest` stays true, so the stock `getInfo` still
  never asks for a prebattle entity this client does not have.
- The battle time that window publishes now reaches the game: it travels with
  the start request and the server counts down that round length instead of a
  fixed 900 s. The accepted range is the exact `getTrainingBattleRoundLimits`
  range (60..14400 s); a start request without one keeps the 900 s default, and
  anything else is denied as `invalid_round_length`. The chosen length is
  persisted with the other waiting-room choices.

A host who never opens the window now sends `round_seconds` anyway (900 from
the default), so the `start_battle` message grew one field with no change in
effect. The `_Queue` test double now calls `on_close` from `close()`, which is
what the real adapter does; no existing expectation changed.

## Tests

- `python3 -m unittest discover -s tests -p "test_*.py"`: 3958 tests, OK
  (plus `test_port_0922_lan_session` rerun with the last added test: 116, OK).
- CPython 2.7 source compile over `src/res/scripts/client`: 93 files, passed.
- New coverage: the room's two buttons and the outside choice; the select-only
  window mode, the four fixed `getInfo` flags and the arena preselect; the
  session handoff (release, choose, next-tick close, next-tick reopen, cancel
  on teardown, refused open, incomplete room close, guest refusal); the server
  round length; the client wire field; the persisted round length.

## Not proved here - needs the exact Windows client

1. `MAP` click: the room disappears and the stock window appears with the lobby
   cursor only (no second pointer).
2. Whether that view **hides or only greys** the comment and privacy controls,
   and whether `create: False` relabels the button (`#menu:training/info/
   settings/okButton`) or keeps `创建`. This is a `gui.pkg` property, not
   derivable from any client script.
3. Confirm returns to the room on its own, showing `MAP: X` and
   `START BATTLE - N MIN`; closing with X returns without changing the choice.
4. The countdown and the round actually last N minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)