### PR TITLE
Reduce worker Bot navigation, contact and projectile scanning work

### DIFF
--- a/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
@@ -10,6 +10,7 @@ probes so it can be tested outside the legacy client.
 
 import heapq
 import math
+from collections import deque
 
 from gui.mods.offline_lan_0922.ai.driver import (
 	FIRST_CANDIDATE_OFFSET, WAYPOINT_ARRIVAL_RADIUS)
@@ -20,6 +21,8 @@ BAKED_FATAL_HAZARDS = 1 | 2
 # Shallow water remains passable when no dry route exists, but the baked graph
 # assigns it a large traction/risk cost so ordinary shortcuts stay on land.
 BAKED_SHALLOW_WATER = 4
+# Cache compact answers, not crossed-cell lists, in the 32-bit worker.
+MAX_BAKED_CORRIDOR_CACHE = 2048
 BAKED_SHALLOW_WATER_PENALTY = 4.0
 BAKED_EDGE_CLEARANCE_WEIGHT = 0.20
 BAKED_FORMAT_NAME = 'offline-lan-0922-navgraph'
@@ -131,6 +134,8 @@ class TerrainGrid(object):
 		self._baked_max_grade = max(0.05, float(bake.get('max_grade', 0.30)))
 		self.bounds = tuple(graph.get('bounds') or self.bounds or ()) or None
 		self.prebaked = True
+		self._baked_corridor_cache = {}
+		self._baked_corridor_order = deque()
 
 	def cell_for(self, point):
 		origin_x, origin_z = self._baked_origin if self.prebaked else (0.0, 0.0)
@@ -333,20 +338,43 @@ class TerrainGrid(object):
 			cells.append((x, z))
 		return tuple(cells)
 
+	def _baked_corridor(self, start, end):
+		"""Share immutable directed link/hazard answers for one grid corridor.
+
+		Baked traversal depends on the endpoint cells, not each observer's
+		sub-cell position. Keep world bounds and short-distance checks in their
+		callers, and never cache live failed-edge penalties or native probes.
+		"""
+		key = (self.cell_for(start), self.cell_for(end))
+		cached = self._baked_corridor_cache.get(key)
+		if cached is not None:
+			return cached
+		cells = self._baked_segment_cells(start, end)
+		clear = bool(cells)
+		hazards = 0 if cells else None
+		for offset in range(1, len(cells)):
+			cell = cells[offset]
+			index = self._baked_index(cell)
+			if index is None:
+				clear, hazards = False, None
+				break
+			hazards |= int(self._baked_hazards[index])
+			if clear and self._baked_edge_height(cells[offset - 1], cell) is None:
+				clear = False
+		result = (clear, hazards)
+		if len(self._baked_corridor_cache) >= MAX_BAKED_CORRIDOR_CACHE:
+			self._baked_corridor_cache.pop(self._baked_corridor_order.popleft())
+		self._baked_corridor_cache[key] = result
+		self._baked_corridor_order.append(key)
+		return result
+
 	def segment_has_baked_hazard(self, start, end, hazard_mask):
 		"""Check cells entered by a shortcut without trapping a tank at its start."""
 		if not self.prebaked:
 			return False
-		cells = self._baked_segment_cells(start, end)
-		if not cells:
-			return True
-		# Exclude the start cell so a tank already on a shallow ford may leave it.
-		for cell in cells[1:]:
-			index = self._baked_index(cell)
-			if (index is None or
-					int(self._baked_hazards[index]) & int(hazard_mask)):
-				return True
-		return False
+		unused_clear, hazards = self._baked_corridor(start, end)
+		# The summary excludes the occupied start cell so a tank can leave a ford.
+		return hazards is None or bool(hazards & int(hazard_mask))
 
 	def baked_hazard_cells(self, start, end, hazard_mask):
 		"""Return entered hazard cells, or ``None`` for an invalid corridor."""
@@ -434,15 +462,7 @@ class TerrainGrid(object):
 		if distance < 0.25:
 			return True
 		if self.prebaked:
-			cells = self._baked_segment_cells(start, end)
-			if not cells:
-				return False
-			if len(cells) == 1:
-				return True
-			for old_cell, cell in zip(cells, cells[1:]):
-				if self._baked_edge_height(old_cell, cell) is None:
-					return False
-			return True
+			return self._baked_corridor(start, end)[0]
 		start_key = self._point_key(start)
 		end_key = self._point_key(end)
 		key = (start_key, end_key)

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -12405,10 +12405,7 @@ class BattleRuntime(object):
                     max(0, int(maximum_chords)), estimated_chords)
             except (KeyError, TypeError, ValueError, OverflowError):
                 return False
-            upper_build_pose_reads = len(keys) * (len(history) + 2)
-            full_record_scans = estimated_chords * len(items)
-            if (estimated_chords <= 0 or
-                    upper_build_pose_reads >= full_record_scans):
+            if estimated_chords <= 0:
                 return False
         previous_time = None
         middle_samples = []
@@ -12434,6 +12431,10 @@ class BattleRuntime(object):
                 ceiling > float(history[-1][0]) + 1.0e-9):
             return False
         if maximum_chords is not None:
+            # Retaining 21 seconds for delayed launches does not make this
+            # advance's index read every old pose. Charge only the cursor
+            # interval (including presentation lag) and its two endpoints;
+            # using len(history) here disabled the index as battles warmed up.
             build_pose_reads = len(keys) * (len(middle_samples) + 2)
             full_record_scans = estimated_chords * len(items)
             if (estimated_chords <= 0 or

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -4626,10 +4626,12 @@ class BotRuntime(object):
         targets = []
         for state in live_bots:
             targets.append(('bot', int(state['id']),
-                            int(state.get('team', 0)), state))
+                            int(state.get('team', 0)),
+                            self._visibility_fire_sequence(state)))
         for raw in live_humans:
             targets.append(('human', int(raw['id']),
-                            int(raw.get('team', 0)), raw))
+                            int(raw.get('team', 0)),
+                            self._visibility_fire_sequence(raw)))
         sources = []
         for state in live_bots:
             sources.append((
@@ -4647,12 +4649,11 @@ class BotRuntime(object):
              source_eligible) in sources:
             if source_team not in (1, 2):
                 continue
-            for target_kind, target_id, target_team, target in targets:
+            for target_kind, target_id, target_team, fire_seq in targets:
                 if target_team == source_team or target_team not in (1, 2):
                     continue
                 key = (source_kind, source_id, target_kind, target_id)
                 cached = self._visibility_cache.get(key)
-                fire_seq = self._visibility_fire_sequence(target)
                 new_pair = cached is None
                 fire_edge = bool(
                     cached is not None and cached[2] != fire_seq)
@@ -4992,14 +4993,24 @@ class BotRuntime(object):
 
     @staticmethod
     def _copy_target_fields(raw, names):
-        return dict((name, raw[name]) for name in names if name in raw)
+        return {name: raw[name] for name in names if name in raw}
 
     @staticmethod
-    def _target_pose_snapshot(target):
+    def _target_pose_snapshot(target, cache=None):
+        # Only slice-scoped observation templates and refreshed probe targets
+        # may share this cache. Their pose is stable until the target's next
+        # motion phase, which owns a different record. Keep the record alive
+        # alongside its projection so identity cannot be recycled in a slice.
+        if cache is not None:
+            cached = cache.get(id(target))
+            if cached is not None:
+                return cached[1]
         remembered = BotRuntime._copy_target_fields(target, _TARGET_POSE_FIELDS)
         remembered['position'] = _position(target)
         for name in ('x', 'y', 'z', 'yaw', 'speed'):
             remembered.setdefault(name, 0.0)
+        if cache is not None:
+            cache[id(target)] = (target, remembered)
         return remembered
 
     def _human_observation_target(
@@ -5050,6 +5061,9 @@ class BotRuntime(object):
             self, players, now, aggregate, team_visibility,
             visibility_tick=None):
         """Merge trusted human direct observers into the contact batch."""
+        pose_cache = (
+            visibility_tick.setdefault('target_pose_snapshots', {})
+            if isinstance(visibility_tick, dict) else None)
         human_targets = [
             self._human_observation_target(raw, visibility_tick)
             for raw in players or ()
@@ -5118,7 +5132,7 @@ class BotRuntime(object):
                     continue
                 entry[3].add(source['id'])
                 team_visibility[key] = True
-                remembered = self._target_pose_snapshot(target)
+                remembered = self._target_pose_snapshot(target, pose_cache)
                 self._visible_target_poses[key] = remembered
                 entry[2].update(remembered)
                 duration = spotting.SPOT_MEMORY_SECONDS
@@ -5140,6 +5154,9 @@ class BotRuntime(object):
         remembered_team = (
             visibility_tick.setdefault('remembered_team', {})
             if isinstance(visibility_tick, dict) else {})
+        pose_cache = (
+            visibility_tick.setdefault('target_pose_snapshots', {})
+            if isinstance(visibility_tick, dict) else None)
 
         def resolve_source_view_range():
             if source_view_range[0] is None:
@@ -5147,11 +5164,11 @@ class BotRuntime(object):
                     source, now, visibility_tick)
             return source_view_range[0]
 
-        def retain_team_known_pose(target):
+        def retain_team_known_pose(target, template):
             key = (source_team, target.get('kind'),
                    int(target.get('network_id', 0)))
             if target['fresh_visible']:
-                remembered = self._target_pose_snapshot(target)
+                remembered = self._target_pose_snapshot(template, pose_cache)
                 self._visible_target_poses[key] = remembered
                 target.update(remembered)
                 return True
@@ -5200,23 +5217,25 @@ class BotRuntime(object):
                     not raw.get('alive', True) or
                     int(raw.get('team', 0)) == source_team):
                 continue
-            target = dict(self._human_observation_target(
-                raw, visibility_tick, raw['id']))
+            template = self._human_observation_target(
+                raw, visibility_tick, raw['id'])
+            target = dict(template)
             planner_id = target['id']
             (target['visible'], target['direct_visible'],
              target['fresh_visible']) = visible_to_team(target)
-            if retain_team_known_pose(target):
+            if retain_team_known_pose(target, template):
                 lookup[planner_id] = target
             contacts.append(target)
         for bot_id, raw in self.states.items():
             if (bot_id == source.get('id') or not raw.get('alive', True) or
                     int(raw.get('team', 0)) == source_team):
                 continue
-            target = dict(self._bot_observation_target(
-                bot_id, raw, visibility_tick, processed_bot_ids))
+            template = self._bot_observation_target(
+                bot_id, raw, visibility_tick, processed_bot_ids)
+            target = dict(template)
             (target['visible'], target['direct_visible'],
              target['fresh_visible']) = visible_to_team(target)
-            if retain_team_known_pose(target):
+            if retain_team_known_pose(target, template):
                 lookup[int(bot_id)] = target
             contacts.append(target)
         return contacts, lookup
@@ -10093,7 +10112,8 @@ class BotRuntime(object):
         players = list(players or [])
         # Canonical player mechanics are immutable within this bounded slice.
         # Keep their source objects alive so every observer shares one result.
-        visibility_tick = {}
+        pose_cache = {}
+        visibility_tick = {'target_pose_snapshots': pose_cache}
         self._track_human_observer_lifecycle(
             players, now, visibility_tick)
         live_players = None
@@ -10410,7 +10430,8 @@ class BotRuntime(object):
                 team_visibility[key] = bool(
                     fresh_visible or team_visibility.get(key, False))
                 if fresh_visible:
-                    remembered = self._target_pose_snapshot(observed_target)
+                    remembered = self._target_pose_snapshot(
+                        observed_target, pose_cache)
                     self._visible_target_poses[key] = remembered
                     observed_target.update(remembered)
                 if collect_observation:

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -8000,12 +8000,14 @@ class BotRuntime(object):
 
         by_id = dict((tank['id'], tank) for tank in tanks)
         collision_bodies = {}
+        collision_radii = {}
         maximum_radius = 4.0
         for tank in tanks:
-            shape = tank.get('shape') or tank_collision.DEFAULT_SHAPE
+            shape = tank_collision._tank_shape(tank)
             radius = math.sqrt(
                 shape[0] * shape[0] + shape[1] * shape[1])
             maximum_radius = max(maximum_radius, radius)
+            collision_radii[tank['id']] = radius
             collision_bodies[tank['id']] = {
                 'position': (tank['x'], tank['y'], tank['z'])}
         collision_index = tank_collision.build_spatial_index(
@@ -8047,6 +8049,7 @@ class BotRuntime(object):
                 continue
             candidate_ids = tank_collision.nearby_ids(
                 collision_index, own['x'], own['z'])
+            own_radius = collision_radii[own['id']]
             others = []
             for tank_id in candidate_ids:
                 if tank_id == own['id'] or tank_id not in by_id:
@@ -8055,7 +8058,26 @@ class BotRuntime(object):
                 if pair in receipt_pairs:
                     continue
                 other = by_id[tank_id]
+                # The spatial bucket is deliberately conservative. Apply the
+                # resolver's existing circle exclusion using radii computed
+                # once for these frozen bodies, before parsing each distant
+                # peer again for every observing hull.
+                dx = own['x'] - other['x']
+                dz = own['z'] - other['z']
+                reach = (own_radius + collision_radii[tank_id] +
+                         tank_collision.CONTACT_BROADPHASE_PADDING)
+                if dx * dx + dz * dz > reach * reach:
+                    continue
                 others.append(other)
+            if not others:
+                # A separated tank still owns residual contact momentum and
+                # must advance/decay it through the same world collision gate.
+                if state.get('push_x', 0.0) or state.get('push_z', 0.0):
+                    self._apply_tank_contact_response(state, {
+                        'correction': (0.0, 0.0),
+                        'delta_velocity': (0.0, 0.0),
+                    }, step)
+                continue
             resolve_kwargs = {
                 'now': now,
                 'ram_cooldowns': self._ram_cooldowns,

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/tank_collision.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/tank_collision.py
@@ -33,6 +33,7 @@ POSITION_SLOP = 0.01
 # the centimetre.
 RAM_CONTACT_POINT_SLOP = 0.75
 POSITION_PERCENT = 0.95
+CONTACT_BROADPHASE_PADDING = 0.25
 _SHAPE_CACHE = {}
 SPATIAL_CELL_SIZE = 24.0
 
@@ -687,7 +688,7 @@ def resolve_tank(tank, others, now=None, ram_cooldowns=None,
         other_radius = math.sqrt(
             other_shape[0] * other_shape[0] +
             other_shape[1] * other_shape[1])
-        maximum_distance = own_radius + other_radius + 0.25
+        maximum_distance = own_radius + other_radius + CONTACT_BROADPHASE_PADDING
         if (center_dx * center_dx + center_dz * center_dz >
                 maximum_distance * maximum_distance):
             continue

--- a/tests/test_port_0922_battle_projectiles.py
+++ b/tests/test_port_0922_battle_projectiles.py
@@ -2507,6 +2507,63 @@ class BattleProjectileTests(unittest.TestCase):
             ({'cursor_time': 0.0},), 1.0, maximum_chords=1))
         self.assertIsNone(battle._projectile_spatial_bins)
 
+    def test_spatial_index_cost_ignores_history_before_active_cursors(self):
+        for target_kind in ('bot', 'player'):
+            with self.subTest(target_kind=target_kind):
+                battle, unused_bigworld = _battle()
+                target_key = '%s:8' % target_kind
+                battle._records[target_key] = {
+                    'engine_id': 42, 'network_id': 8, 'kind': target_kind,
+                    'local': False, 'ready': True,
+                    'state': {'health': 100, 'alive': True}}
+                source = battle._projectile_plain_pose((0.0, 0.0, 0.0))
+                for index in range(211):
+                    sample_time = (index - 200) / 10.0
+                    # Old retained poses must neither disable the index nor
+                    # expand this cursor's envelope to an obsolete position.
+                    target_x = 5.0 if sample_time < 0.0 else 1000.0
+                    battle._sample_projectile_positions(sample_time, {
+                        'player:7': source,
+                        target_key: battle._projectile_plain_pose(
+                            (target_x, 0.0, 0.0)),
+                    })
+                history = list(battle._projectile_position_history)
+
+                self.assertTrue(battle._build_projectile_spatial_bins(
+                    ({'cursor_time': 0.8},), 1.0, maximum_chords=32))
+                candidates = dict(battle._projectile_chord_records(
+                    (0.0, 0.0, 0.0), (10.0, 0.0, 0.0), 0.8, 0.85))
+
+                self.assertNotIn(target_key, candidates)
+                self.assertEqual(history, battle._projectile_position_history)
+
+    def test_warm_spatial_index_keeps_presented_target_history(self):
+        battle, unused_bigworld = _battle()
+        battle._records['bot:8'] = {
+            'engine_id': 42, 'network_id': 8, 'kind': 'bot',
+            'local': False, 'ready': True,
+            'state': {'health': 100, 'alive': True}}
+        source = battle._projectile_plain_pose((0.0, 0.0, 0.0))
+        for index in range(211):
+            sample_time = (index - 200) / 10.0
+            target_x = 5.0 if sample_time == 0.5 else 1000.0
+            battle._sample_projectile_positions(sample_time, {
+                'player:7': source,
+                'bot:8': battle._projectile_plain_pose((target_x, 0.0, 0.0)),
+            })
+        battle._projectile_meta['player:7:1'] = {
+            'presentation_offsets': {'bot:8': 0.4}}
+        states = tuple({'key': 'player:7:1', 'cursor_time': 0.8}
+                       for unused in range(4))
+
+        self.assertTrue(battle._build_projectile_spatial_bins(
+            states, 1.0, maximum_chords=32))
+        candidates = dict(battle._projectile_chord_records(
+            (0.0, 0.0, 0.0), (10.0, 0.0, 0.0), 0.8, 0.85))
+
+        self.assertIn('bot:8', candidates)
+        self.assertAlmostEqual(0.4, battle._projectile_spatial_floor)
+
     def test_spatial_index_cell_budgets_fall_back_to_all_records(self):
         battle, unused_bigworld = _battle()
         source = battle._projectile_plain_pose((0.0, 0.0, 0.0))
@@ -3001,6 +3058,11 @@ class BattleProjectileTests(unittest.TestCase):
             'stage=effects reason=missing_live_direct', output.getvalue())
 
     def test_stock_max_29_projectile_debt_bounds_frame_and_reduces_scans(self):
+        for warm_history in (False, True):
+            with self.subTest(warm_history=warm_history):
+                self._check_stock_max_29_projectile_debt(warm_history)
+
+    def _check_stock_max_29_projectile_debt(self, warm_history):
         battle, bigworld = _battle()
         source = battle._server_entity(41)
         entities = {41: source}
@@ -3016,6 +3078,11 @@ class BattleProjectileTests(unittest.TestCase):
                 'local': False, 'ready': True,
                 'state': {'health': 100, 'alive': True}}
         battle._server_entity = lambda entity_id: entities.get(entity_id)
+        if warm_history:
+            poses = battle._projectile_record_poses()
+            for index in range(201):
+                battle._sample_projectile_positions(
+                    (index - 200) / 10.0, poses)
         for shot_seq in range(1, 30):
             event = dict(_event())
             event.update({

--- a/tests/test_port_0922_bot_runtime.py
+++ b/tests/test_port_0922_bot_runtime.py
@@ -14597,6 +14597,11 @@ class BotRuntimeTests(unittest.TestCase):
                 z=float(index * 100))
             self.runtime.states[state['id']] = state
 
+        pose_fields = ('x', 'y', 'z', 'yaw', 'speed', 'push_x', 'push_z')
+        poses_before = dict(
+            (bot_id, tuple(state[name] for name in pose_fields))
+            for bot_id, state in self.runtime.states.items())
+
         candidate_counts = []
         original = self.module.tank_collision.resolve_tank
 
@@ -14617,8 +14622,10 @@ class BotRuntimeTests(unittest.TestCase):
         finally:
             self.module.tank_collision.resolve_tank = original
 
-        self.assertEqual(29, len(candidate_counts))
-        self.assertEqual({0}, set(candidate_counts))
+        self.assertEqual([], candidate_counts)
+        self.assertEqual(poses_before, dict(
+            (bot_id, tuple(state[name] for name in pose_fields))
+            for bot_id, state in self.runtime.states.items()))
 
     def test_authority_failover_resumes_server_fire_sequence(self):
         waiting = dict(self.start, bot_authority_id=2)

--- a/tests/test_port_0922_bot_runtime.py
+++ b/tests/test_port_0922_bot_runtime.py
@@ -17119,6 +17119,62 @@ class BotRuntimeTests(unittest.TestCase):
             set((('bot', 25, False), ('bot', 25, True))),
             set(tick['target_templates']))
 
+    def test_contact_pose_reuse_preserves_observer_and_motion_boundaries(self):
+        runtime = self.module.BotRuntime(
+            1, descriptor_resolver=lambda unused: _combat_descriptor())
+        bot = {'id': 25, 'team': 2, 'alive': True,
+               'x': 10.0, 'y': 1.0, 'z': 20.0, 'yaw': 0.2,
+               'velocity': (1.0, 0.0, 2.0), 'gun_pitch': 0.3}
+        player = _admit_player(dict(bot, id=2))
+        runtime.states = {25: bot}
+        sight_calls = []
+
+        def visible(source, target, *unused):
+            sight_calls.append((source['id'], target['kind']))
+            return source['id'] != 13
+
+        runtime._visible = visible
+        tick = {}
+        first, unused = runtime._contacts_for(
+            {'id': 11, 'team': 1}, [player], 1.0,
+            visibility_tick=tick, processed_bot_ids=set())
+        remembered = dict(runtime._visible_target_poses)
+        # Observer-local edits must never contaminate the shared projection.
+        first[0].update(x=999.0, gun_pitch=2.0)
+        second, unused = runtime._contacts_for(
+            {'id': 12, 'team': 1}, [player], 1.0,
+            visibility_tick=tick, processed_bot_ids=set())
+        for target in second:
+            key = (1, target['kind'], target['network_id'])
+            self.assertIs(remembered[key], runtime._visible_target_poses[key])
+            self.assertEqual((10.0, 1.0, 20.0), target['position'])
+            self.assertEqual(0.3, target['gun_pitch'])
+
+        bot.update(x=40.0, gun_pitch=0.6)
+        player.update(x=70.0, gun_pitch=0.9)
+        hidden, unused = runtime._contacts_for(
+            {'id': 13, 'team': 1}, [player], 1.0,
+            visibility_tick=tick, processed_bot_ids=set((25,)))
+        for target in hidden:
+            self.assertFalse(target['direct_visible'])
+            self.assertFalse(target['fresh_visible'])
+            self.assertEqual((10.0, 1.0, 20.0), target['position'])
+            self.assertEqual(0.3, target['gun_pitch'])
+        post_motion, unused = runtime._contacts_for(
+            {'id': 14, 'team': 1}, [player], 1.0,
+            visibility_tick=tick, processed_bot_ids=set((25,)))
+        self.assertEqual([10.0, 40.0], [target['x'] for target in post_motion])
+        self.assertEqual([0.3, 0.6],
+                         [target['gun_pitch'] for target in post_motion])
+        next_tick, unused = runtime._contacts_for(
+            {'id': 15, 'team': 1}, [player], 1.1,
+            visibility_tick={}, processed_bot_ids=set())
+        self.assertEqual([70.0, 40.0], [target['x'] for target in next_tick])
+        self.assertEqual(10, len(sight_calls))
+        for pose in remembered.values():
+            self.assertEqual(10.0, pose['x'])
+            self.assertEqual(0.3, pose['gun_pitch'])
+
     def test_compact_human_target_keeps_dynamic_spotting_contract(self):
         runtime = self.module.BotRuntime(
             1, descriptor_resolver=lambda unused: _combat_descriptor())

--- a/tests/test_port_0922_bot_runtime.py
+++ b/tests/test_port_0922_bot_runtime.py
@@ -12531,6 +12531,43 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertGreater(
             abs(runtime.states[11]['x'] - runtime.states[12]['x']), 2.0)
 
+    def test_contact_broadphase_skips_distant_bodies_and_keeps_residual_push(self):
+        runtime = self.module.BotRuntime(1)
+        runtime._clear = lambda *unused: True
+        state = {
+            'id': 11, 'team': 1, 'slot': 0, 'alive': True,
+            'x': 0.0, 'y': 0.0, 'z': 0.0, 'yaw': 0.0,
+            'mass': 25000.0,
+            'collision_shape': self.module.tank_collision.DEFAULT_SHAPE,
+            'speed': 0.0, 'push_x': 2.0, 'push_z': -1.0,
+        }
+        peer = dict(state, id=12, team=2, x=20.0, push_x=0.0, push_z=0.0)
+        runtime.states = {11: state, 12: peer}
+        runtime._ram_contacts = frozenset(((11, 12),))
+        calls = []
+        original = self.module.tank_collision.resolve_tank
+
+        def resolve(own, others, **kwargs):
+            calls.append((own['id'], tuple(other['id'] for other in others)))
+            return original(own, others, **kwargs)
+
+        self.module.tank_collision.resolve_tank = resolve
+        try:
+            self.assertEqual([], runtime._resolve_tank_contacts([], 1.0, 0.1))
+            self.assertEqual([], calls)
+            self.assertAlmostEqual(0.2, state['x'])
+            self.assertAlmostEqual(-0.1, state['z'])
+            self.assertAlmostEqual(2.0 * 0.9 ** 6, state['push_x'])
+            self.assertAlmostEqual(-1.0 * 0.9 ** 6, state['push_z'])
+            self.assertFalse(runtime._ram_contacts)
+            # Broad phase uses each mounted hull's size, including a wreck;
+            # it must never assume that all tanks fit a default-size circle.
+            peer.update(alive=False, collision_shape=(20.0, 3.5, -0.8, 2.0))
+            runtime._resolve_tank_contacts([], 1.1, 0.1)
+            self.assertEqual([(11, (12,))], calls)
+        finally:
+            self.module.tank_collision.resolve_tank = original
+
     def test_bot_push_decay_is_equal_across_render_rates(self):
         def run_for_one_second(frame_rate):
             runtime = self.module.BotRuntime(1)

--- a/tests/test_port_0922_navigation.py
+++ b/tests/test_port_0922_navigation.py
@@ -256,6 +256,7 @@ class ClimbApproachNavigationTests(unittest.TestCase):
         next_point = path[pivot + 1]
         cell = navigator.grid.cell_for(next_point)
         graph['hazards'][cell[1] * graph['width'] + cell[0]] = 4
+        navigator.grid._install_baked_graph(graph)
         selected = navigator.next_target(7, path[pivot], path[-1], key, 1.0)
         self.assertEqual(next_point, selected)
         self.assertEqual(next_point,
@@ -292,6 +293,7 @@ class ClimbApproachNavigationTests(unittest.TestCase):
         next_point = path[pivot + 1]
         cell = navigator.grid.cell_for(next_point)
         graph['hazards'][cell[1] * graph['width'] + cell[0]] = 4
+        navigator.grid._install_baked_graph(graph)
         self.assertEqual(next_point, navigator.next_target(
             7, path[pivot], path[-1], key, 1.0))
 

--- a/tests/test_port_0922_navigation_clearance.py
+++ b/tests/test_port_0922_navigation_clearance.py
@@ -7,7 +7,10 @@ PORT_ROOT = Path(__file__).resolve().parents[1]
 CLIENT_SCRIPTS = PORT_ROOT / 'src' / 'res' / 'scripts' / 'client'
 sys.path.insert(0, str(CLIENT_SCRIPTS))
 
-from gui.mods.offline_lan_0922.ai.navigation import TerrainGrid, TerrainNavigator
+from gui.mods.offline_lan_0922.ai.navigation import (
+    BAKED_SHALLOW_WATER, MAX_BAKED_CORRIDOR_CACHE,
+    TerrainGrid, TerrainNavigator,
+)
 
 
 DIRECTIONS = (
@@ -53,6 +56,68 @@ def _graph(width, height, open_cells):
 
 
 class BakedClearanceNavigationTests(unittest.TestCase):
+    def test_baked_corridor_reuse_keeps_world_bounds_and_live_penalties(self):
+        graph = _graph(4, 1, ((x, 0) for x in range(4)))
+        grid = TerrainGrid(lambda *unused: 0.0, baked_graph=graph)
+        scans = []
+        original = grid._baked_segment_cells
+
+        def scan(start, end):
+            scans.append((start, end))
+            return original(start, end)
+
+        grid._baked_segment_cells = scan
+        start, end = (0.0, 0.0, 0.0), (12.0, 0.0, 0.0)
+        self.assertTrue(grid.dry_segment_clear(start, end, 1.0))
+        self.assertTrue(grid.dry_segment_clear(
+            (0.2, 4.0, 0.0), (11.9, 6.0, 0.0), 1.1))
+        self.assertEqual(1, len(scans))
+        # This point still rounds into the same end cell but is outside the
+        # authored world rectangle, so a cached clear corridor cannot admit it.
+        self.assertFalse(grid.segment_clear(start, (12.1, 0.0, 0.0)))
+        grid._failed_edges[((0, 0), (1, 0))] = (3.0, 100.0)
+        self.assertFalse(grid.dry_segment_clear(start, end, 2.0))
+        self.assertTrue(grid.dry_segment_clear(start, end, 3.0))
+        self.assertEqual(1, len(scans))
+
+    def test_baked_corridor_reuse_keeps_directional_links_and_ford_exit(self):
+        graph = _graph(4, 1, ((x, 0) for x in range(4)))
+        graph['hazards'] = (BAKED_SHALLOW_WATER, 0, 0, 0)
+        links = list(graph['links'])
+        links[3] = 0
+        graph['links'] = tuple(links)
+        grid = TerrainGrid(lambda *unused: 0.0, baked_graph=graph)
+        start, end = (0.0, 0.0, 0.0), (12.0, 0.0, 0.0)
+        for unused in range(2):
+            self.assertTrue(grid.dry_segment_clear(start, end, 1.0))
+            self.assertFalse(grid.segment_clear(end, start))
+            self.assertTrue(grid.segment_has_baked_hazard(
+                end, start, BAKED_SHALLOW_WATER))
+            self.assertFalse(grid.segment_has_baked_hazard(
+                start, end, BAKED_SHALLOW_WATER))
+        # Installing another map must not inherit the old map's clear result.
+        replacement = _graph(4, 1, ((0, 0), (3, 0)))
+        grid._install_baked_graph(replacement)
+        self.assertFalse(grid.segment_clear(start, end))
+        self.assertTrue(grid.segment_has_baked_hazard(start, end, 0))
+
+    def test_baked_corridor_cache_stays_bounded_as_routes_change(self):
+        graph = _graph(48, 48, (
+            (x, z) for z in range(48) for x in range(48)))
+        grid = TerrainGrid(lambda *unused: 0.0, baked_graph=graph)
+        start = (0.0, 0.0, 0.0)
+        for z in range(48):
+            for x in range(48):
+                end = (x * 4.0, 0.0, z * 4.0)
+                self.assertTrue(grid.dry_segment_clear(start, end, 1.0))
+        self.assertEqual(MAX_BAKED_CORRIDOR_CACHE,
+                         len(grid._baked_corridor_cache))
+        self.assertEqual(MAX_BAKED_CORRIDOR_CACHE,
+                         len(grid._baked_corridor_order))
+        self.assertTrue(grid.dry_segment_clear(start, (4.0, 0.0, 0.0), 2.0))
+        self.assertEqual(MAX_BAKED_CORRIDOR_CACHE,
+                         len(grid._baked_corridor_cache))
+
     def test_wide_corridor_path_moves_off_the_exposed_edge(self):
         graph = _graph(21, 5, (
             (x, z) for z in range(5) for x in range(21)))


### PR DESCRIPTION
Worker Bot updates repeatedly evaluate the same static navigation corridors and project the same target pose for different observers. Spatial contact buckets also send clearly distant bodies through the full resolver. Separately, retaining projectile history for delayed launches makes the old cost estimate reject the spatial index even when the active cursor interval is short.

This change:

- Shares compact, directed baked-corridor link/hazard answers in a bounded cache. World bounds, live blocked-edge penalties, ford exit direction and native motion checks retain their existing ownership.
- Reuses target pose projections within one physical slice and motion phase, while keeping observer visibility and hidden-target memory separate. Reads target fire sequences once per visibility scheduling pass.
- Applies the existing descriptor-sized contact circle exclusion before invoking the full resolver. Separated tanks still advance and decay residual push through the world collision gate.
- Estimates projectile index cost from the actual cursor/presentation interval instead of all retained history. History coverage, moving-target envelopes, fallback candidates and projectile terminal bookkeeping are preserved.

A deterministic 29-Bot Prokhorovka scenario using the actual driver/navigation code, baked map data and fake native probes ran for 60 simulated seconds at 30 callbacks/s and 10 control steps/s. Three alternating repetitions on Linux CPython 3.12.3 reduced median Bot update CPU time from 11.036 s to 9.378 s (15.0%). All 721 output messages, logical probe totals and navigation diagnostics matched. Static segment traversals fell from 97,646 to 17,654. This is a Python workload comparison, not Windows FPS acceptance.

The warm-history 29-projectile regression reproduces 19,140 record scans on the old implementation and 638 after the fix, while completing the same 638 chords.

Validation:

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -p test_port_0922_bot_runtime.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -p 'test_port_0922_battle*.py'`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -p 'test_port_0922_navigation*.py'`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -p test_port_0922_tank_collision.py`
- All-map comparison: 41 baked graphs, 6,560 directed corridors and 39,360 link/hazard checks matched the baseline under both CPython 3.12.3 and CPython 2.7.18.
- CPython 2.7.18 source compilation of all 93 client modules.
- Focused regressions cover pose phase changes, observer isolation, remembered hidden poses, cache capacity, graph replacement, directed water/link checks, live edge penalties, large wrecks and residual push.

All CI jobs passed for `0c0db95b01b71bb279f5f5bad5672467bc44a2e2`: [PR merge checks](https://github.com/pengw0048/wot-offline-battles/actions/runs/34004703924) and [branch checks](https://github.com/pengw0048/wot-offline-battles/actions/runs/34004701960), including the complete tests, Python 2.7 client package validation and Windows server/launcher smoke tests.

Exact CN HD #1513 Windows worker frame pacing and gameplay remain unmeasured for this change. No cadence, physical coefficient, projectile budget or safety rule was reduced.
