### PR TITLE
Let Bots hold team-chat conversations

### DIFF
--- a/launcher/server_imports.py
+++ b/launcher/server_imports.py
@@ -30,6 +30,7 @@ import time
 import traceback
 import types
 import typing
+import unicodedata
 import uuid
 import weakref
 import zlib
@@ -59,6 +60,7 @@ SERVER_STDLIB_MODULES = (
     traceback.__name__,
     types.__name__,
     typing.__name__,
+    unicodedata.__name__,
     uuid.__name__,
     weakref.__name__,
     zlib.__name__,

--- a/launcher/stage_payload.py
+++ b/launcher/stage_payload.py
@@ -15,6 +15,7 @@ CLIENT_DIR = "client"
 
 PAYLOAD_FILES = {
     "0.9.22": (
+        "server/bot_chat.py",
         "server/lan_battle_server.py",
         "server/offline_rewards.py",
         "server/server_bot_ai.py",

--- a/launcher/tests/test_launcher_core.py
+++ b/launcher/tests/test_launcher_core.py
@@ -1606,6 +1606,21 @@ class ServerImportTest(unittest.TestCase):
                         name != '__future__'}
             self.assertLessEqual(required, declared, port_version)
 
+    def test_no_server_import_resolves_to_nothing(self):
+        """A payload import that resolves nowhere is an unstaged file.
+
+        The bundled servers import only the standard library and their own
+        modules.  Without this, a server module left out of ``PAYLOAD_FILES``
+        looks exactly like a third-party package, is filtered out as
+        non-standard, and only fails when the packaged server exits on
+        startup with no log.
+        """
+        for port_version in core.SUPPORTED_PORTS:
+            unresolved = {name for name in self._closure(port_version)
+                          if name not in sys.stdlib_module_names and
+                          name != '__future__'}
+            self.assertEqual(set(), unresolved, port_version)
+
     def test_the_declared_modules_all_import(self):
         for name in server_imports.SERVER_STDLIB_MODULES:
             self.assertIn(name, sys.modules, name)

--- a/server/bot_chat.py
+++ b/server/bot_chat.py
@@ -1,0 +1,714 @@
+"""Decide which Bot answers a team-chat line, when, and with what text.
+
+The stock #1513 client owns text entry, formatting, rendering, and sounds.
+This module owns only the conversation: who is being addressed, whether anyone
+answers at all, how many answer, whether one Bot answers another, and how fast
+the team may talk.  It hands plain text back to the LAN server, which publishes
+it through the same team-chat path a human line already uses.
+
+The director is pure.  It never reads a clock, opens a socket, or touches
+server state: the caller passes the current tick and one plain snapshot, and
+the director returns the lines to publish.  One round therefore replays
+identically in tests, which is what keeps the conversation rules provable
+while the line text itself stays replaceable.
+
+``compose`` on the line backend is the seam a local language model plugs into
+later.  ``TemplateLineBackend`` is the shipped default and the only backend
+that works with no optional download installed.
+"""
+
+import re
+import unicodedata
+
+
+# Conversation pacing, in seconds.  The director converts these with the
+# caller's tick rate so the server stays the single owner of TICK_HZ.
+REPLY_DELAY_MIN_SECONDS = 0.8
+REPLY_DELAY_MAX_SECONDS = 2.6
+HOP_DELAY_MIN_SECONDS = 1.2
+HOP_DELAY_MAX_SECONDS = 3.4
+THREAD_SILENCE_SECONDS = 20.0
+BOT_COOLDOWN_SECONDS = 9.0
+
+# A team may publish this many Bot lines inside one rolling window.  The
+# budget, not a per-event speaker cap, is what keeps the channel readable:
+# a squad call legitimately answers with more than one voice.
+TEAM_BUDGET_LINES = 6
+TEAM_BUDGET_SECONDS = 20.0
+
+# A Bot answering another Bot is the most alive-feeling part of the feature
+# and also the only way the conversation can fail to terminate.  Depth is
+# capped and each further hop is less likely than the last.
+MAX_CONVERSATION_HOPS = 2
+HOP_PROBABILITY = (0.55, 0.3)
+
+# Peng's product choice: most lines get an answer, and an interesting line may
+# get more than one.  Silence stays legal, it is simply not the default.
+ADDRESSED_REPLY_PROBABILITY = 0.97
+OPEN_REPLY_PROBABILITY = 0.72
+SECOND_SPEAKER_PROBABILITY = 0.35
+SQUAD_MAX_SPEAKERS = 2
+EVENT_REPLY_PROBABILITY = 0.4
+
+RECENT_LINE_MEMORY = 12
+MAX_CHAT_UTF16_UNITS = 140
+
+PERSONA_TACTICAL = "tactical"
+PERSONA_SLACKER = "slacker"
+PERSONA_MECHANIC = "mechanic"
+PERSONA_SCOUT = "scout"
+PERSONA_POETIC = "poetic"
+PERSONA_PLAIN = "plain"
+
+PERSONAS = (PERSONA_TACTICAL, PERSONA_SLACKER, PERSONA_MECHANIC,
+            PERSONA_SCOUT, PERSONA_POETIC, PERSONA_PLAIN)
+
+# The shipped callsigns already carry personality.  Reading it out of the name
+# costs nothing and keeps one Bot sounding like itself for the whole round.
+# Order matters: the poetic keys are single characters that also appear inside
+# tactical and scout names, so they are matched last.
+_PERSONA_KEYWORDS = (
+    (PERSONA_MECHANIC, (
+        "履带", "修理", "维修", "保养", "螺丝", "弹药架", "炮塔", "装填",
+        "充值", "车库", "备用", "刚修好")),
+    (PERSONA_SCOUT, (
+        "观察", "侦察", "探", "小地图", "亮", "眼睛", "草丛", "巡逻",
+        "守门", "看一眼", "前方", "侦查", "麻雀", "海鸥", "信号")),
+    (PERSONA_SLACKER, (
+        "不加班", "喝茶", "别催", "别急", "随缘", "缩圈", "手感", "一般",
+        "汽水", "半糖", "热茶", "常驻", "再来一局", "慢慢", "慢速", "慢行",
+        "汤圆", "苏打", "气泡", "柠檬", "橘子")),
+    (PERSONA_TACTICAL, (
+        "猎手", "穿杨", "孤狼", "之刃", "彗星", "残云", "洪流", "闪电",
+        "全开", "单骑", "纵横", "入魂", "幽灵", "亮剑", "破浪", "压路机",
+        "头铁", "卖头", "赤色", "钢铁", "铁骑", "打两炮", "这炮能中")),
+    (PERSONA_POETIC, (
+        "风", "雨", "月", "星", "雪", "云", "雾", "山", "江", "海", "夜",
+        "晨", "夏", "冬", "春", "秋", "长安", "南枝", "未央", "归舟",
+        "远岚", "拾光", "知夏", "青禾", "白榆", "岭南", "塞北", "江南")),
+)
+
+# Chinese class words a player actually types, mapped to the #1513 class tags
+# the server already stores on every catalogued vehicle.
+CLASS_KEYWORDS = (
+    ("lightTank", ("轻坦", "轻型", "快车", "小车", "light")),
+    ("mediumTank", ("中坦", "中型", "medium")),
+    ("heavyTank", ("重坦", "重型", "heavy")),
+    ("SPG", ("火炮", "自行火炮", "自走炮", "spg", "arty")),
+    ("AT-SPG", ("反坦克", "坦歼", "歼击", "td", "atspg")),
+)
+
+# ``fold_text`` has already removed the separators, and a word
+# boundary does not hold between a digit and a CJK character, so the
+# reference is bounded against Latin runs instead.
+_CELL_PATTERN = re.compile(r"(?<![a-z0-9])([a-j])(10|[1-9])(?![0-9])")
+_VEHICLE_PREFIX = re.compile(r"^[A-Za-z]{1,3}\d{1,3}_")
+_FOLD_STRIP = re.compile(r"[\s\-_.·、,，。!！?？~～]+")
+
+ADDRESS_NONE = "none"
+ADDRESS_THREAD = "thread"
+ADDRESS_CALLSIGN = "callsign"
+ADDRESS_VEHICLE = "vehicle"
+ADDRESS_CLASS = "class"
+ADDRESS_CELL = "cell"
+
+TRIGGER_REPLY = "reply"
+TRIGGER_HOP = "hop"
+TRIGGER_KILL = "kill"
+TRIGGER_DOWN = "down"
+TRIGGER_ALLY_DOWN = "ally_down"
+TRIGGER_LOW_HEALTH = "low_health"
+
+
+def fold_text(value):
+    """Return one comparable form of player text or a vehicle token."""
+    text = unicodedata.normalize("NFKC", str(value or ""))
+    return _FOLD_STRIP.sub("", text).lower()
+
+
+def vehicle_token(vehicle):
+    """Return the model designation players actually say for one vehicle.
+
+    ``ussr:R04_T-34`` becomes ``t34``: the nation prefix and the internal
+    ``R04_`` index are not part of any name a player types.
+    """
+    text = str(vehicle or "")
+    if ":" in text:
+        text = text.split(":", 1)[1]
+    return fold_text(_VEHICLE_PREFIX.sub("", text))
+
+
+def _is_latin_alnum(character):
+    """Return whether one character would extend a Latin model designation.
+
+    CJK characters answer ``True`` to ``str.isalnum``, so a naive boundary
+    test rejects the most common real phrasing: ``那个T-34``.  Only Latin
+    letters and digits can actually continue a designation like ``T-34``.
+    """
+    return character.isascii() and character.isalnum()
+
+
+def _token_present(token, folded):
+    """Return whether a folded model token stands alone inside folded text."""
+    if not token or len(token) < 2:
+        return False
+    start = 0
+    while True:
+        index = folded.find(token, start)
+        if index < 0:
+            return False
+        after = index + len(token)
+        before_ok = index == 0 or not _is_latin_alnum(folded[index - 1])
+        after_ok = after >= len(folded) or not _is_latin_alnum(folded[after])
+        if before_ok and after_ok:
+            return True
+        start = index + 1
+
+
+def _callsign_aliases(name):
+    """Return the short forms a player types instead of a full callsign."""
+    text = str(name or "")
+    aliases = set()
+    if len(text) >= 2:
+        aliases.add(text)
+    if len(text) >= 4:
+        aliases.add(text[-2:])
+        aliases.add(text[:2])
+        aliases.add(text[-3:])
+    return aliases
+
+
+def persona_for_callsign(name):
+    """Return one stable persona for a shipped callsign."""
+    text = str(name or "")
+    for persona, keywords in _PERSONA_KEYWORDS:
+        for keyword in keywords:
+            if keyword in text:
+                return persona
+    if not text:
+        return PERSONA_PLAIN
+    # A name that matches nothing still needs a stable voice for the round.
+    return PERSONAS[sum(ord(character) for character in text) % len(PERSONAS)]
+
+
+def clamp_chat_text(value):
+    """Return publishable stock text, or None when nothing survives.
+
+    The server validates again before publication.  This keeps a backend from
+    handing the transport a line that was only ever going to be rejected.
+    """
+    if not isinstance(value, str):
+        return None
+    text = unicodedata.normalize("NFKC", value)
+    text = " ".join(text.split())
+    if not text:
+        return None
+    try:
+        utf16 = text.encode("utf-16-le")
+        text.encode("utf-8")
+    except UnicodeError:
+        return None
+    if len(utf16) // 2 > MAX_CHAT_UTF16_UNITS:
+        text = utf16[:MAX_CHAT_UTF16_UNITS * 2].decode("utf-16-le", "ignore")
+        text = text.strip()
+    return text or None
+
+
+class TemplateLineBackend(object):
+    """Compose one line from shipped persona templates.
+
+    This backend is what a player gets with no optional model installed, so
+    it is a product surface rather than a placeholder.  It stays deliberately
+    small: variety comes from persona and trigger, and the director's own
+    repeat filter keeps a pool from sounding like a loop.
+    """
+
+    _COMMON = {
+        TRIGGER_REPLY: ("收到", "明白", "好", "在的", "听到了"),
+        TRIGGER_HOP: ("同上", "我也这么想", "+1", "有道理"),
+        TRIGGER_KILL: ("打掉一个", "拿下了", "少一个"),
+        TRIGGER_DOWN: ("我没了", "被打死了", "下课了"),
+        TRIGGER_ALLY_DOWN: ("队友没了", "少一个人了", "那边塌了"),
+        TRIGGER_LOW_HEALTH: ("我血不多了", "残血了", "血皮，别指望我"),
+    }
+
+    _PERSONA = {
+        PERSONA_TACTICAL: {
+            TRIGGER_REPLY: ("收到，这就去", "明白，交给我", "好，我压上去"),
+            TRIGGER_HOP: ("那我走前面", "我掩护", "跟上就行"),
+            TRIGGER_KILL: ("一炮带走", "干净利落", "下一个"),
+            TRIGGER_DOWN: ("失误了", "算我一个", "这波我亏了"),
+            TRIGGER_ALLY_DOWN: ("补上去", "别让他白死", "顶住"),
+            TRIGGER_LOW_HEALTH: ("血不多，但还能打", "残血，我卖头"),
+        },
+        PERSONA_SLACKER: {
+            TRIGGER_REPLY: ("哦，好吧", "行行行，来了", "别催，在路上"),
+            TRIGGER_HOP: ("他说得对", "听他的", "我随便"),
+            TRIGGER_KILL: ("哎，蒙中了", "运气好"),
+            TRIGGER_DOWN: ("下班了", "行吧，先歇会", "早知道不冲了"),
+            TRIGGER_ALLY_DOWN: ("哎呀", "有点惨"),
+            TRIGGER_LOW_HEALTH: ("我这血够呛", "别撞我，一下就没"),
+        },
+        PERSONA_MECHANIC: {
+            TRIGGER_REPLY: ("等我装填完", "好，装填还有几秒", "收到，修完就来"),
+            TRIGGER_HOP: ("同意", "他说的对"),
+            TRIGGER_KILL: ("这发打进去了", "弹药没白带"),
+            TRIGGER_DOWN: ("弹药架爆了", "履带先没的"),
+            TRIGGER_ALLY_DOWN: ("那边压力大", "得有人补位"),
+            TRIGGER_LOW_HEALTH: ("履带又掉了", "车不行了"),
+        },
+        PERSONA_SCOUT: {
+            TRIGGER_REPLY: ("收到，我去看一眼", "明白，先探路", "好，我亮一下"),
+            TRIGGER_HOP: ("我确认一下", "看到了"),
+            TRIGGER_KILL: ("点掉一个", "打中了"),
+            TRIGGER_DOWN: ("被抓到了", "亮太久了"),
+            TRIGGER_ALLY_DOWN: ("那边有埋伏", "小心侧面"),
+            TRIGGER_LOW_HEALTH: ("我血皮，退了", "先撤，别暴露"),
+        },
+        PERSONA_POETIC: {
+            TRIGGER_REPLY: ("好", "这就来", "听见了"),
+            TRIGGER_HOP: ("是这个道理", "我也这么觉得"),
+            TRIGGER_KILL: ("走一个", "落幕了"),
+            TRIGGER_DOWN: ("我先走一步", "到此为止"),
+            TRIGGER_ALLY_DOWN: ("可惜了", "又少一个"),
+            TRIGGER_LOW_HEALTH: ("撑不了多久", "血快见底了"),
+        },
+    }
+
+    def compose(self, request):
+        """Return one line for this request, or None to stay silent."""
+        trigger = request.get("trigger")
+        persona = request.get("persona") or PERSONA_PLAIN
+        rng = request["rng"]
+        pools = []
+        persona_pool = self._PERSONA.get(persona, {}).get(trigger)
+        if persona_pool:
+            pools.append(persona_pool)
+        common_pool = self._COMMON.get(trigger)
+        if common_pool:
+            pools.append(common_pool)
+        if not pools:
+            return None
+        # Persona lines are the point of the feature, so they are drawn first
+        # and the neutral pool only widens the choice.
+        candidates = list(pools[0])
+        if len(pools) > 1 and rng.random() < 0.3:
+            candidates = list(pools[1])
+        recent = set(request.get("recent_texts") or ())
+        fresh = [line for line in candidates if line not in recent]
+        chosen = rng.choice(fresh or candidates)
+        prefix = request.get("address_prefix")
+        if prefix and rng.random() < 0.5:
+            chosen = "%s %s" % (prefix, chosen)
+        return chosen
+
+
+class BotChatDirector(object):
+    """Own the team-chat conversation for every Bot in one round."""
+
+    def __init__(self, rng, tick_hz=30.0, backend=None):
+        self._rng = rng
+        self._tick_hz = float(tick_hz)
+        self._backend = backend or TemplateLineBackend()
+        self._round_id = None
+        self._personas = {}
+        self._pending = []
+        self._threads = {}
+        self._recent = {}
+        self._budget = {}
+        self._bot_last_line = {}
+        self._team_last_line = {}
+
+    # -- lifecycle ------------------------------------------------------
+
+    def reset_round(self, round_id):
+        """Fence every conversation at a round boundary."""
+        self._round_id = round_id
+        self._personas = {}
+        self._pending = []
+        self._threads = {}
+        self._recent = {}
+        self._budget = {}
+        self._bot_last_line = {}
+        self._team_last_line = {}
+
+    def set_backend(self, backend):
+        """Swap the line source without disturbing an active conversation."""
+        self._backend = backend or TemplateLineBackend()
+
+    def _ticks(self, seconds):
+        return max(1, int(round(float(seconds) * self._tick_hz)))
+
+    def persona(self, bot_id, name):
+        """Return this Bot's stable persona for the round."""
+        bot_id = int(bot_id)
+        persona = self._personas.get(bot_id)
+        if persona is None:
+            persona = persona_for_callsign(name)
+            self._personas[bot_id] = persona
+        return persona
+
+    # -- addressing -----------------------------------------------------
+
+    def resolve_address(self, text, team, snapshot):
+        """Return the addressed Bots and how they were addressed.
+
+        Every branch here is deterministic string and geometry work over the
+        roster that is actually in this battle.  A model is not required to
+        read a name, and in this release none is consulted: an unresolvable
+        reference stays unaddressed rather than becoming a guess.
+        """
+        folded = fold_text(text)
+        raw = unicodedata.normalize("NFKC", str(text or ""))
+        bots = self._team_bots(team, snapshot)
+        if not bots:
+            return {"kind": ADDRESS_NONE, "bot_ids": []}
+
+        named = [bot for bot in bots
+                 if any(alias and alias in raw
+                        for alias in _callsign_aliases(bot.get("name")))]
+        if named:
+            return {"kind": ADDRESS_CALLSIGN,
+                    "bot_ids": [bot["id"] for bot in named[:SQUAD_MAX_SPEAKERS]]}
+
+        matched = [bot for bot in bots
+                   if _token_present(vehicle_token(bot.get("vehicle")), folded)]
+        if matched:
+            chosen = self._disambiguate(matched, snapshot)
+            return {"kind": ADDRESS_VEHICLE, "bot_ids": chosen}
+
+        for class_tag, keywords in CLASS_KEYWORDS:
+            if not any(keyword in folded for keyword in keywords):
+                continue
+            squad = [bot for bot in bots
+                     if str(bot.get("vehicle_class") or "") == class_tag]
+            if squad:
+                squad = self._by_relevance(squad, snapshot)
+                return {"kind": ADDRESS_CLASS,
+                        "bot_ids": [bot["id"]
+                                    for bot in squad[:SQUAD_MAX_SPEAKERS]]}
+
+        cell = _CELL_PATTERN.search(folded)
+        if cell is not None:
+            index = self._cell_index(cell.group(1), cell.group(2), snapshot)
+            if index is not None:
+                near = [bot for bot in bots
+                        if self._bot_cell_index(bot, snapshot) == index]
+                if near:
+                    near = self._by_relevance(near, snapshot)
+                    return {"kind": ADDRESS_CELL, "bot_ids": [near[0]["id"]]}
+
+        thread = self._threads.get(team)
+        if thread:
+            # The player is still talking to whoever they addressed, even
+            # after other Bots have chimed in on top of that answer.
+            for candidate in ([thread.get("anchor")] +
+                              list(reversed(thread.get("participants") or ()))):
+                if candidate is None:
+                    continue
+                if any(bot["id"] == candidate for bot in bots):
+                    return {"kind": ADDRESS_THREAD, "bot_ids": [candidate]}
+        return {"kind": ADDRESS_NONE, "bot_ids": []}
+
+    def _disambiguate(self, matched, snapshot):
+        """Pick who ``那个 T-34`` meant when the team fields more than one."""
+        if len(matched) == 1:
+            return [matched[0]["id"]]
+        speaker = snapshot.get("speaker") or {}
+        spotted = set(speaker.get("spotted") or ())
+        # "那个" implies the player can see it, and the server already knows
+        # what this player has spotted.
+        visible = [bot for bot in matched if bot["id"] in spotted]
+        pool = visible or matched
+        pool = self._by_relevance(pool, snapshot)
+        return [pool[0]["id"]]
+
+    def _by_relevance(self, bots, snapshot):
+        speaker = snapshot.get("speaker") or {}
+        spotted = set(speaker.get("spotted") or ())
+        origin = (speaker.get("x"), speaker.get("z"))
+
+        def key(bot):
+            seen = 0 if bot["id"] in spotted else 1
+            if origin[0] is None or bot.get("x") is None:
+                distance = float("inf")
+            else:
+                distance = ((float(bot["x"]) - float(origin[0])) ** 2 +
+                            (float(bot["z"]) - float(origin[1])) ** 2)
+            return (seen, distance, bot["id"])
+
+        return sorted(bots, key=key)
+
+    @staticmethod
+    def _cell_index(letter, number, snapshot):
+        bounds = snapshot.get("arena_bounds")
+        if not bounds:
+            return None
+        column = ord(letter) - ord("a")
+        row = int(number) - 1
+        if not 0 <= column <= 9 or not 0 <= row <= 9:
+            return None
+        return row * 10 + column
+
+    @staticmethod
+    def _bot_cell_index(bot, snapshot):
+        bounds = snapshot.get("arena_bounds")
+        if not bounds or bot.get("x") is None:
+            return None
+        min_x, min_z, max_x, max_z = bounds
+        width = float(max_x) - float(min_x)
+        height = float(max_z) - float(min_z)
+        if width <= 0.0 or height <= 0.0:
+            return None
+        column = int((float(bot["x"]) - float(min_x)) / width * 10.0)
+        row = int((float(max_z) - float(bot["z"])) / height * 10.0)
+        if not 0 <= column <= 9 or not 0 <= row <= 9:
+            return None
+        return row * 10 + column
+
+    @staticmethod
+    def _team_bots(team, snapshot):
+        result = []
+        for bot in (snapshot.get("bots") or ()):
+            if int(bot.get("team", 0)) == int(team) and bot.get("alive"):
+                result.append(bot)
+        return result
+
+    # -- admission ------------------------------------------------------
+
+    def observe_player_line(self, tick, team, text, snapshot):
+        """Schedule the answers one human line earns."""
+        team = int(team)
+        address = self.resolve_address(text, team, snapshot)
+        self._remember(team, snapshot.get("speaker", {}).get("name"), text)
+        if address["kind"] in (ADDRESS_CALLSIGN, ADDRESS_VEHICLE,
+                               ADDRESS_CLASS, ADDRESS_CELL):
+            self._anchor_thread(team, address["bot_ids"][0], tick)
+        elif address["kind"] == ADDRESS_THREAD:
+            self._thread(team, tick)["last_tick"] = tick
+        bots = self._team_bots(team, snapshot)
+        if not bots:
+            return address
+        addressed = [bot_id for bot_id in address["bot_ids"]
+                     if self._can_speak(tick, bot_id)]
+        if addressed:
+            for index, bot_id in enumerate(addressed):
+                probability = (ADDRESSED_REPLY_PROBABILITY if index == 0
+                               else SECOND_SPEAKER_PROBABILITY)
+                if self._rng.random() <= probability:
+                    self._schedule(tick, bot_id, team, TRIGGER_REPLY,
+                                   address["kind"])
+            return address
+        # Nobody was named.  Peng's choice is that an open remark usually
+        # still gets an answer, and an interesting one may get two.
+        if self._rng.random() > self._open_probability(text):
+            return address
+        pool = [bot for bot in self._by_relevance(bots, snapshot)
+                if self._can_speak(tick, bot["id"])]
+        if not pool:
+            return address
+        self._schedule(tick, pool[0]["id"], team, TRIGGER_REPLY,
+                       ADDRESS_NONE)
+        if len(pool) > 1 and self._rng.random() < SECOND_SPEAKER_PROBABILITY:
+            self._schedule(tick, pool[1]["id"], team, TRIGGER_REPLY,
+                           ADDRESS_NONE)
+        return address
+
+    @staticmethod
+    def _open_probability(text):
+        """Answer an interesting remark more often than a grunt."""
+        raw = str(text or "")
+        probability = OPEN_REPLY_PROBABILITY
+        if any(mark in raw for mark in ("?", "？")):
+            probability = min(0.95, probability + 0.2)
+        if len(raw) >= 8:
+            probability = min(0.95, probability + 0.1)
+        elif len(raw) <= 2:
+            probability = max(0.2, probability - 0.35)
+        return probability
+
+    def observe_event(self, tick, team, trigger, bot_id, snapshot):
+        """Let a battle event start a line without any human speaking."""
+        if trigger not in (TRIGGER_KILL, TRIGGER_DOWN, TRIGGER_ALLY_DOWN,
+                           TRIGGER_LOW_HEALTH):
+            return False
+        team = int(team)
+        if bot_id is None:
+            return False
+        bot_id = int(bot_id)
+        # A destroyed Bot may still speak its own last line: ``_emit`` is what
+        # decides whether the snapshot must still show it alive.
+        if not self._can_speak(tick, bot_id):
+            return False
+        if self._rng.random() > EVENT_REPLY_PROBABILITY:
+            return False
+        self._schedule(tick, bot_id, team, trigger, ADDRESS_NONE)
+        return True
+
+    def _schedule(self, tick, bot_id, team, trigger, address_kind, hop=0):
+        delay_min, delay_max = ((HOP_DELAY_MIN_SECONDS, HOP_DELAY_MAX_SECONDS)
+                                if hop else
+                                (REPLY_DELAY_MIN_SECONDS,
+                                 REPLY_DELAY_MAX_SECONDS))
+        delay = self._rng.uniform(delay_min, delay_max)
+        self._pending.append({
+            "due_tick": int(tick) + self._ticks(delay),
+            "bot_id": int(bot_id),
+            "team": int(team),
+            "trigger": trigger,
+            "address_kind": address_kind,
+            "hop": int(hop),
+        })
+        # Reserve the slot now.  Without this, one burst of admissions would
+        # schedule every Bot before any of them has spoken.
+        self._bot_last_line[int(bot_id)] = int(tick)
+
+    # -- publication ----------------------------------------------------
+
+    def tick(self, tick, snapshot):
+        """Return the Bot lines due at this tick."""
+        tick = int(tick)
+        if not self._pending:
+            self._expire_threads(tick)
+            return []
+        due = [entry for entry in self._pending if entry["due_tick"] <= tick]
+        if not due:
+            self._expire_threads(tick)
+            return []
+        self._pending = [entry for entry in self._pending
+                         if entry["due_tick"] > tick]
+        published = []
+        for entry in due:
+            line = self._emit(tick, entry, snapshot)
+            if line is not None:
+                published.append(line)
+        self._expire_threads(tick)
+        return published
+
+    def _emit(self, tick, entry, snapshot):
+        team = entry["team"]
+        bot = self._find_bot(entry["bot_id"], snapshot)
+        if bot is None:
+            return None
+        if entry["trigger"] != TRIGGER_DOWN and not bot.get("alive"):
+            return None
+        if not self._spend_budget(tick, team):
+            return None
+        request = {
+            "trigger": entry["trigger"],
+            "persona": self.persona(bot["id"], bot.get("name")),
+            "address_kind": entry["address_kind"],
+            "address_prefix": self._address_prefix(entry, snapshot),
+            "bot": bot,
+            "recent_texts": [record["text"]
+                             for record in self._recent.get(team, ())],
+            "recent": list(self._recent.get(team, ())),
+            "rng": self._rng,
+        }
+        try:
+            text = self._backend.compose(request)
+        except Exception:
+            # A backend failure is contained to this one line.  It must never
+            # silence the team for the rest of the round or fault the tick.
+            return None
+        text = clamp_chat_text(text)
+        if text is None:
+            return None
+        if any(text == record["text"]
+               for record in list(self._recent.get(team, ()))[-3:]):
+            return None
+        self._remember(team, bot.get("name"), text)
+        self._bot_last_line[bot["id"]] = tick
+        self._team_last_line[team] = tick
+        self._advance_thread(team, bot["id"], tick)
+        self._maybe_hop(tick, entry, snapshot)
+        return {"bot_id": bot["id"], "team": team, "text": text}
+
+    def _address_prefix(self, entry, snapshot):
+        """Name the human back only when they named a Bot first."""
+        if entry["address_kind"] not in (ADDRESS_CALLSIGN, ADDRESS_VEHICLE):
+            return None
+        speaker = snapshot.get("speaker") or {}
+        name = speaker.get("name")
+        return str(name) if name else None
+
+    def _maybe_hop(self, tick, entry, snapshot):
+        """Let one Bot answer another, with a hard depth cap."""
+        hop = entry["hop"]
+        if hop >= MAX_CONVERSATION_HOPS:
+            return
+        if self._rng.random() >= HOP_PROBABILITY[hop]:
+            return
+        team = entry["team"]
+        candidates = [bot for bot in self._team_bots(team, snapshot)
+                      if bot["id"] != entry["bot_id"] and
+                      self._can_speak(tick, bot["id"])]
+        if not candidates:
+            return
+        speaker = self._rng.choice(candidates)
+        self._schedule(tick, speaker["id"], team, TRIGGER_HOP,
+                       ADDRESS_NONE, hop=hop + 1)
+
+    # -- budgets and threads --------------------------------------------
+
+    def _can_speak(self, tick, bot_id):
+        """Return whether one Bot is off its personal cooldown."""
+        last = self._bot_last_line.get(int(bot_id))
+        return (last is None or
+                tick - last >= self._ticks(BOT_COOLDOWN_SECONDS))
+
+    def _spend_budget(self, tick, team):
+        window = self._ticks(TEAM_BUDGET_SECONDS)
+        spent = [stamp for stamp in self._budget.get(team, ())
+                 if tick - stamp < window]
+        if len(spent) >= TEAM_BUDGET_LINES:
+            self._budget[team] = spent
+            return False
+        spent.append(tick)
+        self._budget[team] = spent
+        return True
+
+    def _thread(self, team, tick):
+        thread = self._threads.get(team)
+        if thread is None:
+            thread = {"anchor": None, "participants": [], "last_tick": tick}
+            self._threads[team] = thread
+        return thread
+
+    def _anchor_thread(self, team, bot_id, tick):
+        """Remember which teammate the player is actually talking to."""
+        thread = self._thread(team, tick)
+        thread["anchor"] = None if bot_id is None else int(bot_id)
+        thread["last_tick"] = tick
+
+    def _advance_thread(self, team, bot_id, tick):
+        thread = self._thread(team, tick)
+        participants = thread["participants"]
+        if bot_id in participants:
+            participants.remove(bot_id)
+        participants.append(bot_id)
+        del participants[:-SQUAD_MAX_SPEAKERS]
+        thread["last_tick"] = tick
+
+    def _expire_threads(self, tick):
+        window = self._ticks(THREAD_SILENCE_SECONDS)
+        for team in list(self._threads):
+            if tick - self._threads[team]["last_tick"] >= window:
+                del self._threads[team]
+
+    def _remember(self, team, name, text):
+        record = {"name": str(name or ""), "text": str(text or "")}
+        history = self._recent.setdefault(int(team), [])
+        history.append(record)
+        del history[:-RECENT_LINE_MEMORY]
+
+    def recent_lines(self, team):
+        """Return the rolling transcript one team has heard."""
+        return list(self._recent.get(int(team), ()))
+
+    @staticmethod
+    def _find_bot(bot_id, snapshot):
+        for bot in (snapshot.get("bots") or ()):
+            if int(bot.get("id", 0)) == int(bot_id):
+                return bot
+        return None

--- a/server/lan_battle_server.py
+++ b/server/lan_battle_server.py
@@ -39,6 +39,7 @@ _CLIENT_SCRIPT_ROOT = os.path.join(
 if _CLIENT_SCRIPT_ROOT not in sys.path:
     sys.path.insert(0, _CLIENT_SCRIPT_ROOT)
 
+import bot_chat
 from server_bot_ai import BotPlanner
 from offline_rewards import compute_offline_rewards
 from vehicle_overlay_store import (
@@ -73,6 +74,12 @@ TICK_HZ = 30.0
 # #1513 ingests observations and damage immediately, but only needs one
 # full-team tactical order synthesis per second.
 BOT_PLANNER_INTERVAL_TICKS = max(1, int(round(TICK_HZ)))
+# Bot conversation is paced in seconds, not frames.  Half a second is
+# fine grained enough for a scheduled reply and costs one dictionary
+# walk when nothing is due.
+BOT_CHAT_INTERVAL_TICKS = max(1, int(round(TICK_HZ / 2.0)))
+# A Bot reports its own damage once per round, below this fraction.
+BOT_CHAT_LOW_HEALTH_FRACTION = 0.3
 REPLICA_SNAPSHOT_HZ = 15.0
 REPLICA_SNAPSHOT_TICKS = max(
     1, int(round(TICK_HZ / REPLICA_SNAPSHOT_HZ)))
@@ -2062,6 +2069,12 @@ class BattleState:
         self.bot_orders = {"revision": 0, "orders": []}
         self.team_commands = OrderedDict()
         self._next_bot_planner_tick = 0
+        self.bot_chat = bot_chat.BotChatDirector(
+            random.Random(), tick_hz=TICK_HZ)
+        self._next_bot_chat_tick = 0
+        self.bot_chat_seq = {}
+        self.bot_chat_low_health = set()
+        self._bot_chat_class_cache = {}
         self.bot_reported_hits = set()
         self.bot_reported_rams = set()
         self.bot_reported_ram_fingerprints = {}
@@ -3184,6 +3197,7 @@ class BattleState:
         self.bot_orders = {"revision": 0, "orders": []}
         self.team_commands = OrderedDict()
         self._next_bot_planner_tick = 0
+        self._reset_bot_chat()
         self.bot_reported_hits = set()
         self.bot_reported_rams = set()
         self.bot_reported_ram_fingerprints = {}
@@ -3582,6 +3596,7 @@ class BattleState:
         self.phase = "battle"
         self.tick = 0
         self._next_bot_planner_tick = 0
+        self._reset_bot_chat()
         self.state_revision += 1
         live_message = {
             "type": "battle_live",
@@ -5348,6 +5363,7 @@ class BattleState:
                 "round_id": self.round_id,
                 "chat_seq": sequence,
                 "issuer_id": issuer_id,
+                "issuer_kind": "human",
                 "team": team,
                 "text": text,
             }
@@ -5358,10 +5374,216 @@ class BattleState:
             issuer.team_chat_publications[sequence] = fingerprint
             while len(issuer.team_chat_publications) > TEAM_CHAT_HISTORY:
                 issuer.team_chat_publications.popitem(last=False)
+            self._observe_bot_chat_line_locked(issuer, text)
         for recipient in recipients:
             if not recipient.offer_reliable(message):
                 self.remove_player(recipient.player_id, expected=recipient)
         return True
+
+    def _reset_bot_chat(self):
+        """Fence every Bot conversation at a round boundary."""
+        self.bot_chat.reset_round(self.round_id)
+        self._next_bot_chat_tick = 0
+        self.bot_chat_seq = {}
+        self.bot_chat_low_health = set()
+        self._bot_chat_class_cache = {}
+
+    def _bot_chat_vehicle_class_locked(self, vehicle):
+        """Return one catalogued class tag, remembering what was resolved.
+
+        The catalogue walk is linear in every vehicle the clients listed, and
+        the conversation asks about every Bot twice a second.  A vehicle's
+        class never changes, so a resolved answer is cached; an unresolved one
+        is not, because the catalogue may still arrive.
+        """
+        cached = self._bot_chat_class_cache.get(vehicle)
+        if cached is not None:
+            return cached
+        resolved = self._result_vehicle_class(vehicle)
+        if resolved:
+            self._bot_chat_class_cache[vehicle] = resolved
+        return resolved
+
+    def _bot_chat_snapshot_locked(self, speaker=None, with_bounds=False):
+        """Freeze the plain facts one conversation decision reads."""
+        bots = []
+        for identity in self.bot_manifest:
+            try:
+                bot_id = int(identity.get("id", 0))
+            except (TypeError, ValueError):
+                continue
+            state = self.bot_states.get(bot_id)
+            if state is None:
+                continue
+            vehicle = str(identity.get("vehicle") or "")
+            bots.append({
+                "id": bot_id,
+                "team": int(identity.get("team", 0)),
+                "name": str(identity.get("name") or ""),
+                "vehicle": vehicle,
+                "vehicle_class": self._bot_chat_vehicle_class_locked(vehicle),
+                "alive": bool(state.get("alive")),
+                "x": state.get("x"),
+                "z": state.get("z"),
+                "hp": state.get("health"),
+                "max_hp": state.get("max_health"),
+                "combat_mode": str(state.get("combat_mode") or ""),
+            })
+        return {
+            "bots": bots,
+            "speaker": speaker or {},
+            # Only address resolution reads the grid, and it is the one
+            # conversation step a human line drives.
+            "arena_bounds": (self._bot_defense_context()["arena_bounds"]
+                             if with_bounds else None),
+        }
+
+    def _bot_chat_speaker_locked(self, player):
+        """Describe the human who just spoke, including what they can see."""
+        spotted = self.player_spotted.get(int(player.player_id), frozenset())
+        return {
+            "name": str(player.name),
+            "x": float(player.x),
+            "z": float(player.z),
+            "spotted": set(
+                vehicle_id for kind, vehicle_id in spotted if kind == "bot"),
+        }
+
+    def _observe_bot_chat_line_locked(self, issuer, text):
+        """Let the Bot conversation react to one relayed human line."""
+        if self.battle_result is not None:
+            return
+        try:
+            self.bot_chat.observe_player_line(
+                self.tick, int(issuer.team), text,
+                self._bot_chat_snapshot_locked(
+                    self._bot_chat_speaker_locked(issuer), with_bounds=True))
+        except Exception as error:
+            # A conversation fault is contained to this line.  It must never
+            # cost the team its chat relay or fault the round.
+            _server_log("BOT CHAT line observation failed: %s" % (error,))
+
+    def _observe_bot_chat_kill_locked(self, attacker, victim):
+        """Let a kill start a line with nobody having spoken."""
+        if self.battle_result is not None:
+            return
+        try:
+            snapshot = self._bot_chat_snapshot_locked()
+            if attacker[0] == "bot":
+                self.bot_chat.observe_event(
+                    self.tick, self._vehicle_team(*attacker),
+                    bot_chat.TRIGGER_KILL, attacker[1], snapshot)
+            if victim[0] == "bot":
+                victim_team = self._vehicle_team(*victim)
+                self.bot_chat.observe_event(
+                    self.tick, victim_team, bot_chat.TRIGGER_DOWN,
+                    victim[1], snapshot)
+                mourner = self._bot_chat_nearest_ally(
+                    victim[1], victim_team, snapshot)
+                if mourner is not None:
+                    self.bot_chat.observe_event(
+                        self.tick, victim_team, bot_chat.TRIGGER_ALLY_DOWN,
+                        mourner, snapshot)
+        except Exception as error:
+            _server_log("BOT CHAT kill observation failed: %s" % (error,))
+
+    @staticmethod
+    def _bot_chat_nearest_ally(victim_id, team, snapshot):
+        """Return the living teammate standing closest to one loss."""
+        fallen = None
+        for bot in snapshot["bots"]:
+            if bot["id"] == int(victim_id):
+                fallen = bot
+                break
+        if fallen is None or fallen.get("x") is None:
+            return None
+        best = None
+        best_distance = None
+        for bot in snapshot["bots"]:
+            if (bot["id"] == int(victim_id) or not bot["alive"] or
+                    bot["team"] != int(team) or bot.get("x") is None):
+                continue
+            distance = ((float(bot["x"]) - float(fallen["x"])) ** 2 +
+                        (float(bot["z"]) - float(fallen["z"])) ** 2)
+            if best_distance is None or distance < best_distance:
+                best = bot["id"]
+                best_distance = distance
+        return best
+
+    def _observe_bot_chat_damage_locked(self, snapshot):
+        """Let a Bot mention its own damage once per round."""
+        for bot in snapshot["bots"]:
+            if bot["id"] in self.bot_chat_low_health or not bot["alive"]:
+                continue
+            try:
+                health = float(bot.get("hp") or 0.0)
+                maximum = float(bot.get("max_hp") or 0.0)
+            except (TypeError, ValueError):
+                continue
+            if (maximum <= 0.0 or
+                    health > maximum * BOT_CHAT_LOW_HEALTH_FRACTION):
+                continue
+            self.bot_chat_low_health.add(bot["id"])
+            self.bot_chat.observe_event(
+                self.tick, bot["team"], bot_chat.TRIGGER_LOW_HEALTH,
+                bot["id"], snapshot)
+
+    def _bot_team_chat_message_locked(self, line):
+        """Turn one composed line into a stock-shaped team chat message."""
+        try:
+            team = int(line.get("team", 0))
+        except (TypeError, ValueError):
+            return None
+        text = line.get("text")
+        if team not in (1, 2) or not self._valid_team_chat_text(text):
+            return None
+        identity = self._team_command_bot_identity_locked(line.get("bot_id"))
+        if identity is None or int(identity.get("team", 0)) != team:
+            return None
+        sequence = self.bot_chat_seq.get(team, 0) + 1
+        if sequence > PROJECTILE_MAX_ID:
+            return None
+        self.bot_chat_seq[team] = sequence
+        return {
+            "type": "team_chat",
+            "protocol": PROTOCOL_VERSION,
+            "round_id": self.round_id,
+            "chat_seq": sequence,
+            "issuer_id": int(identity["id"]),
+            "issuer_kind": "bot",
+            "team": team,
+            "text": text,
+        }
+
+    def publish_bot_team_chat(self):
+        """Publish the Bot lines this tick has due, at a bounded cadence."""
+        with self.lock:
+            if (self.phase != "battle" or self.battle_result is not None or
+                    self.tick < self._next_bot_chat_tick):
+                return False
+            self._next_bot_chat_tick = self.tick + BOT_CHAT_INTERVAL_TICKS
+            try:
+                snapshot = self._bot_chat_snapshot_locked()
+                self._observe_bot_chat_damage_locked(snapshot)
+                lines = self.bot_chat.tick(self.tick, snapshot)
+            except Exception as error:
+                _server_log("BOT CHAT tick failed: %s" % (error,))
+                return False
+            deliveries = []
+            for line in lines:
+                message = self._bot_team_chat_message_locked(line)
+                if message is None:
+                    continue
+                deliveries.append((message, tuple(
+                    player for player in self.players.values()
+                    if player.connected and player.participating and
+                    player.team == message["team"])))
+        for message, recipients in deliveries:
+            for recipient in recipients:
+                if not recipient.offer_reliable(message):
+                    self.remove_player(recipient.player_id,
+                                       expected=recipient)
+        return bool(deliveries)
 
     @staticmethod
     def _ordinary_bot_burst(fire_seq, shell_index):
@@ -11507,6 +11729,7 @@ class BattleState:
             "actor_speed": round(self._vehicle_speed(attacker), 4),
             "victim_speed": round(self._vehicle_speed(victim), 4),
         })
+        self._observe_bot_chat_kill_locked(attacker, victim)
         # Fadin wants the final enemy destroyed either directly by the last
         # round or by the fire that round started. Both facts are only true
         # at this instant.
@@ -12559,6 +12782,7 @@ class BattleState:
         }
 
     def tick_once(self, dt):
+        self.publish_bot_team_chat()
         reset_message = None
         had_pending_live = False
         failed_live_recipients = []

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -3432,11 +3432,17 @@ class BattleRuntime(object):
         if (not self._radio_message_current(message) or
                 message.get('team') != self.client.team):
             return False
-        issuer = self._radio_identity('human', message.get('issuer_id'))
+        # Bots speak on the same stock channel as their teammates.  The
+        # issuer kind selects the roster the identity is resolved against and
+        # keeps the two id spaces from colliding in the duplicate filter.
+        issuer_kind = message.get('issuer_kind', 'human')
+        if issuer_kind not in ('human', 'bot'):
+            return False
+        issuer = self._radio_identity(issuer_kind, message.get('issuer_id'))
         if issuer is None:
             return False
         seen = getattr(self, '_team_chat_seen', {})
-        key = (message['round_id'], message['issuer_id'])
+        key = (message['round_id'], issuer_kind, message['issuer_id'])
         if message['chat_seq'] <= seen.get(key, 0):
             return False
         result = self._server.receive_team_chat(message.get('text'), issuer[1])

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
@@ -5015,7 +5015,11 @@ class LANClient(object):
                      _projectile_int_range(message.get('chat_seq'),
                                            1, MAX_PROJECTILE_ID) is not None)
             if kind == 'team_chat':
+                # A server without Bot chat omits the issuer kind, and every
+                # line it relays came from a human.
+                issuer_kind = message.get('issuer_kind', 'human')
                 valid = (valid and _exact_int(message.get('team')) == self.team and
+                         issuer_kind in ('human', 'bot') and
                          _projectile_int_range(message.get('issuer_id'),
                                                1, MAX_PROJECTILE_ID) is not None and
                          is_valid_team_chat_text(message.get('text')))

--- a/tests/test_port_0922_bot_chat.py
+++ b/tests/test_port_0922_bot_chat.py
@@ -1,0 +1,436 @@
+from pathlib import Path
+import random
+import sys
+import unittest
+
+
+TEST_ROOT = Path(__file__).resolve().parent
+SERVER_ROOT = TEST_ROOT.parent / 'server'
+sys.path.insert(0, str(TEST_ROOT))
+sys.path.insert(0, str(SERVER_ROOT))
+
+import bot_chat  # noqa: E402
+from bot_chat import (  # noqa: E402
+    ADDRESS_CALLSIGN, ADDRESS_CELL, ADDRESS_CLASS, ADDRESS_NONE,
+    ADDRESS_THREAD, ADDRESS_VEHICLE, BotChatDirector, MAX_CONVERSATION_HOPS,
+    PERSONA_MECHANIC, PERSONA_SCOUT, PERSONA_SLACKER, PERSONA_TACTICAL,
+    TEAM_BUDGET_LINES, TRIGGER_DOWN, TRIGGER_HOP, TRIGGER_KILL,
+    TRIGGER_REPLY, clamp_chat_text, persona_for_callsign, vehicle_token,
+)
+
+
+class _ScriptedRandom(object):
+    """A random source with no randomness, so a rule is provable."""
+
+    def __init__(self, value=0.0, choice_index=0):
+        self.value = value
+        self.choice_index = choice_index
+
+    def random(self):
+        return self.value
+
+    def uniform(self, low, high):
+        return low
+
+    def choice(self, sequence):
+        sequence = list(sequence)
+        return sequence[self.choice_index % len(sequence)]
+
+
+class _CountingBackend(object):
+    """Emit a distinct line every time so the repeat filter is not the subject."""
+
+    def __init__(self):
+        self.calls = []
+        self.count = 0
+
+    def compose(self, request):
+        self.count += 1
+        self.calls.append(request)
+        return 'line-%d' % self.count
+
+
+class _FailingBackend(object):
+    def compose(self, request):
+        raise RuntimeError('backend is unavailable')
+
+
+def _bot(bot_id, name, vehicle, vehicle_class, x=0.0, z=0.0, team=1,
+         alive=True):
+    return {'id': bot_id, 'team': team, 'name': name, 'vehicle': vehicle,
+            'vehicle_class': vehicle_class, 'alive': alive, 'x': x, 'z': z,
+            'hp': 400, 'max_hp': 400, 'combat_mode': 'route'}
+
+
+def _snapshot(bots, spotted=(), speaker_x=0.0, speaker_z=0.0,
+              arena_bounds=None):
+    return {
+        'bots': list(bots),
+        'speaker': {'name': 'Peng', 'x': speaker_x, 'z': speaker_z,
+                    'spotted': set(spotted)},
+        'arena_bounds': arena_bounds,
+    }
+
+
+def _roster():
+    return [
+        _bot(1, '今天不加班', 'ussr:R04_T-34', 'mediumTank', 10.0, 10.0),
+        _bot(2, '北方孤狼', 'germany:G54_E-50', 'heavyTank', 50.0, 50.0),
+        _bot(3, '草丛观察员', 'ussr:R11_MS-1', 'lightTank', 5.0, 5.0),
+        _bot(4, '履带又掉了', 'ussr:R04_T-34', 'mediumTank', 90.0, 90.0),
+    ]
+
+
+def _director(value=0.0, choice_index=0, backend=None):
+    director = BotChatDirector(_ScriptedRandom(value, choice_index),
+                               tick_hz=30.0,
+                               backend=backend or _CountingBackend())
+    director.reset_round(7)
+    return director
+
+
+def _drain(director, snapshot, start=0, stop=600):
+    published = []
+    for tick in range(start, stop):
+        published.extend(director.tick(tick, snapshot))
+    return published
+
+
+class VehicleTokenTest(unittest.TestCase):
+    def test_strips_nation_and_internal_index(self):
+        self.assertEqual(vehicle_token('ussr:R04_T-34'), 't34')
+        self.assertEqual(vehicle_token('germany:G54_E-50'), 'e50')
+        self.assertEqual(vehicle_token('ussr:R11_MS-1'), 'ms1')
+
+    def test_tolerates_missing_nation_and_index(self):
+        self.assertEqual(vehicle_token('T-34'), 't34')
+        self.assertEqual(vehicle_token(''), '')
+        self.assertEqual(vehicle_token(None), '')
+
+
+class AddressResolutionTest(unittest.TestCase):
+    def setUp(self):
+        self.director = _director()
+        self.snapshot = _snapshot(_roster())
+
+    def _resolve(self, text, snapshot=None):
+        return self.director.resolve_address(
+            text, 1, snapshot or self.snapshot)
+
+    def test_players_name_the_vehicle_not_the_callsign(self):
+        for text in ('那个t34 过来', '那个T-34过来', 't34 别走', 'T 34 顶住'):
+            address = self._resolve(text)
+            self.assertEqual(address['kind'], ADDRESS_VEHICLE, text)
+            self.assertEqual(address['bot_ids'], [1], text)
+
+    def test_a_longer_designation_does_not_match_a_shorter_one(self):
+        # ``T-34`` must not answer for ``T-34-85``: the folded token would be
+        # a prefix of it, which is exactly the ambiguity players complain of.
+        snapshot = _snapshot([_bot(1, '今天不加班', 'ussr:R04_T-34',
+                                   'mediumTank')])
+        self.assertEqual(self._resolve('t3485 上', snapshot)['kind'],
+                         ADDRESS_NONE)
+
+    def test_callsign_shorthand_resolves(self):
+        for text in ('孤狼 顶一下', '北方孤狼 顶一下', '北方 顶一下'):
+            address = self._resolve(text)
+            self.assertEqual(address['kind'], ADDRESS_CALLSIGN, text)
+            self.assertEqual(address['bot_ids'], [2], text)
+
+    def test_class_words_address_a_squad(self):
+        address = self._resolve('轻坦回家')
+        self.assertEqual(address['kind'], ADDRESS_CLASS)
+        self.assertEqual(address['bot_ids'], [3])
+
+    def test_class_word_without_that_class_present_addresses_nobody(self):
+        self.assertEqual(self._resolve('火炮打一下')['kind'], ADDRESS_NONE)
+
+    def test_two_of_one_model_prefer_the_vehicle_the_player_can_see(self):
+        spotted = _snapshot(_roster(), spotted=(4,))
+        self.assertEqual(self._resolve('那个t34 别冲', spotted)['bot_ids'], [4])
+
+    def test_two_of_one_model_otherwise_prefer_the_nearest(self):
+        self.assertEqual(self._resolve('那个t34 别冲')['bot_ids'], [1])
+
+    def test_grid_cell_addresses_the_bot_standing_in_it(self):
+        # The stock minimap puts A1 at the top left, so row 1 is the highest
+        # z and the Bot parked near the origin is in A10, not A1.
+        bounds = (0.0, 0.0, 100.0, 100.0)
+        roster = _roster() + [_bot(5, '山口守门员', 'usa:A20_M4_Sherman',
+                                   'mediumTank', 5.0, 95.0)]
+        snapshot = _snapshot(roster, arena_bounds=bounds)
+        top_left = self._resolve('a1 有人吗', snapshot)
+        self.assertEqual(top_left['kind'], ADDRESS_CELL)
+        self.assertEqual(top_left['bot_ids'], [5])
+        bottom_left = self._resolve('a10 有人吗', snapshot)
+        self.assertEqual(bottom_left['kind'], ADDRESS_CELL)
+        self.assertEqual(bottom_left['bot_ids'], [3])
+
+    def test_an_empty_grid_cell_addresses_nobody(self):
+        bounds = (0.0, 0.0, 100.0, 100.0)
+        snapshot = _snapshot(_roster(), arena_bounds=bounds)
+        self.assertEqual(self._resolve('j5 有人吗', snapshot)['kind'],
+                         ADDRESS_NONE)
+
+    def test_grid_cell_without_arena_bounds_addresses_nobody(self):
+        self.assertEqual(self._resolve('a1 有人吗')['kind'], ADDRESS_NONE)
+
+    def test_open_remark_addresses_nobody(self):
+        self.assertEqual(self._resolve('这局有点难打')['kind'], ADDRESS_NONE)
+
+    def test_no_living_teammate_addresses_nobody(self):
+        dead = [dict(bot, alive=False) for bot in _roster()]
+        self.assertEqual(self._resolve('那个t34 过来', _snapshot(dead)),
+                         {'kind': ADDRESS_NONE, 'bot_ids': []})
+
+    def test_the_other_team_is_never_addressed(self):
+        snapshot = _snapshot([_bot(9, '北方孤狼', 'ussr:R04_T-34',
+                                   'mediumTank', team=2)])
+        self.assertEqual(self._resolve('那个t34 过来', snapshot)['kind'],
+                         ADDRESS_NONE)
+
+
+class PersonaTest(unittest.TestCase):
+    def test_shipped_callsigns_carry_their_own_voice(self):
+        self.assertEqual(persona_for_callsign('今天不加班'), PERSONA_SLACKER)
+        self.assertEqual(persona_for_callsign('履带又掉了'), PERSONA_MECHANIC)
+        self.assertEqual(persona_for_callsign('草丛观察员'), PERSONA_SCOUT)
+        self.assertEqual(persona_for_callsign('北方孤狼'), PERSONA_TACTICAL)
+
+    def test_an_unclassified_callsign_still_gets_a_stable_voice(self):
+        first = persona_for_callsign('七号车组')
+        self.assertIn(first, bot_chat.PERSONAS)
+        self.assertEqual(first, persona_for_callsign('七号车组'))
+
+    def test_a_bot_keeps_one_persona_for_the_round(self):
+        director = _director()
+        first = director.persona(1, '今天不加班')
+        self.assertEqual(first, director.persona(1, '完全换了一个名字'))
+
+
+class ReplyAdmissionTest(unittest.TestCase):
+    def setUp(self):
+        self.snapshot = _snapshot(_roster())
+
+    def test_an_addressed_bot_answers(self):
+        director = _director()
+        director.observe_player_line(0, 1, '那个t34 过来', self.snapshot)
+        published = _drain(director, self.snapshot)
+        self.assertEqual(published[0]['bot_id'], 1)
+        self.assertLessEqual(len(published), 1 + MAX_CONVERSATION_HOPS)
+
+    def test_a_squad_call_may_answer_with_two_voices(self):
+        roster = _roster() + [_bot(5, '我先探个路', 'ussr:R11_MS-1',
+                                   'lightTank', 8.0, 8.0)]
+        snapshot = _snapshot(roster)
+        director = _director()
+        director.observe_player_line(0, 1, '轻坦回家', snapshot)
+        published = _drain(director, snapshot)
+        self.assertEqual(sorted(line['bot_id'] for line in published
+                                if line['bot_id'] in (3, 5)), [3, 5])
+
+    def test_an_open_remark_usually_still_gets_an_answer(self):
+        director = _director()
+        director.observe_player_line(0, 1, '这局打得有点难受', self.snapshot)
+        self.assertTrue(_drain(director, self.snapshot))
+
+    def test_silence_stays_legal(self):
+        director = _director(value=1.0)
+        director.observe_player_line(0, 1, '这局打得有点难受', self.snapshot)
+        self.assertEqual(_drain(director, self.snapshot), [])
+
+    def test_a_reply_is_delayed_rather_than_instant(self):
+        director = _director()
+        director.observe_player_line(0, 1, '那个t34 过来', self.snapshot)
+        self.assertEqual(director.tick(0, self.snapshot), [])
+
+    def test_a_dead_bot_does_not_answer(self):
+        roster = _roster()
+        roster[0]['alive'] = False
+        snapshot = _snapshot(roster)
+        director = _director()
+        director.observe_player_line(0, 1, '孤狼 顶一下', snapshot)
+        roster[1]['alive'] = False
+        self.assertEqual(_drain(director, snapshot), [])
+
+
+class ConversationContinuityTest(unittest.TestCase):
+    def setUp(self):
+        self.snapshot = _snapshot(_roster())
+
+    def test_an_unaddressed_follow_up_stays_with_who_was_addressed(self):
+        # Other Bots chime in on top of the answer.  The player is still
+        # talking to the teammate they named.
+        director = _director()
+        director.observe_player_line(0, 1, '孤狼 顶一下', self.snapshot)
+        published = _drain(director, self.snapshot, 0, 400)
+        self.assertGreater(len(published), 1)
+        address = director.resolve_address('你到了吗', 1, self.snapshot)
+        self.assertEqual(address['kind'], ADDRESS_THREAD)
+        self.assertEqual(address['bot_ids'], [2])
+
+    def test_a_thread_falls_back_when_the_addressed_bot_dies(self):
+        director = _director()
+        director.observe_player_line(0, 1, '孤狼 顶一下', self.snapshot)
+        _drain(director, self.snapshot, 0, 400)
+        roster = [dict(bot, alive=bot['id'] != 2) for bot in _roster()]
+        address = director.resolve_address('你到了吗', 1, _snapshot(roster))
+        self.assertEqual(address['kind'], ADDRESS_THREAD)
+        self.assertNotEqual(address['bot_ids'], [2])
+
+    def test_a_thread_expires_after_silence(self):
+        director = _director()
+        director.observe_player_line(0, 1, '孤狼 顶一下', self.snapshot)
+        _drain(director, self.snapshot, 0, 200)
+        silence = int(bot_chat.THREAD_SILENCE_SECONDS * 30.0) + 400
+        _drain(director, self.snapshot, 200, silence)
+        self.assertEqual(
+            director.resolve_address('你到了吗', 1, self.snapshot)['kind'],
+            ADDRESS_NONE)
+
+    def test_bots_answer_each_other_but_the_chain_terminates(self):
+        director = _director()
+        director.observe_player_line(0, 1, '那个t34 过来', self.snapshot)
+        published = _drain(director, self.snapshot, 0, 1200)
+        hops = [line for line in published
+                if line['bot_id'] != 1]
+        self.assertTrue(hops, 'expected at least one Bot to answer another')
+        self.assertLessEqual(len(hops), MAX_CONVERSATION_HOPS)
+
+    def test_a_named_reply_addresses_the_player_back(self):
+        backend = _CountingBackend()
+        director = _director(backend=backend)
+        director.observe_player_line(0, 1, '那个t34 过来', self.snapshot)
+        _drain(director, self.snapshot)
+        reply = backend.calls[0]
+        self.assertEqual(reply['trigger'], TRIGGER_REPLY)
+        self.assertEqual(reply['address_kind'], ADDRESS_VEHICLE)
+        self.assertEqual(reply['address_prefix'], 'Peng')
+
+    def test_a_hop_reply_does_not_address_the_player(self):
+        backend = _CountingBackend()
+        director = _director(backend=backend)
+        director.observe_player_line(0, 1, '那个t34 过来', self.snapshot)
+        _drain(director, self.snapshot, 0, 1200)
+        hop_calls = [call for call in backend.calls
+                     if call['trigger'] == TRIGGER_HOP]
+        self.assertTrue(hop_calls)
+        self.assertIsNone(hop_calls[0]['address_prefix'])
+
+    def test_the_backend_sees_the_rolling_transcript(self):
+        backend = _CountingBackend()
+        director = _director(backend=backend)
+        director.observe_player_line(0, 1, '那个t34 过来', self.snapshot)
+        _drain(director, self.snapshot)
+        recent = backend.calls[0]['recent']
+        self.assertEqual(recent[-1], {'name': 'Peng', 'text': '那个t34 过来'})
+
+
+class BudgetTest(unittest.TestCase):
+    def setUp(self):
+        self.snapshot = _snapshot(
+            [_bot(index, '车组%d' % index, 'ussr:R04_T-34', 'mediumTank',
+                  float(index), float(index))
+             for index in range(1, 12)])
+
+    def test_a_team_cannot_flood_the_channel(self):
+        director = _director()
+        for index in range(1, 12):
+            director.observe_player_line(index, 1, '有人吗？', self.snapshot)
+        published = _drain(director, self.snapshot, 0, 300)
+        self.assertLessEqual(len(published), TEAM_BUDGET_LINES)
+
+    def test_one_bot_does_not_answer_twice_in_a_row(self):
+        director = _director()
+        director.observe_player_line(0, 1, '车组1 在吗', self.snapshot)
+        director.observe_player_line(5, 1, '车组1 还在吗', self.snapshot)
+        published = _drain(director, self.snapshot, 0, 200)
+        speakers = [line['bot_id'] for line in published]
+        self.assertEqual(len(speakers), len(set(speakers)))
+
+
+class PublicationTest(unittest.TestCase):
+    def setUp(self):
+        self.snapshot = _snapshot(_roster())
+
+    def test_a_backend_failure_is_contained_to_one_line(self):
+        director = _director(backend=_FailingBackend())
+        director.observe_player_line(0, 1, '那个t34 过来', self.snapshot)
+        self.assertEqual(_drain(director, self.snapshot), [])
+        director.set_backend(_CountingBackend())
+        director.observe_player_line(600, 1, '孤狼 顶一下', self.snapshot)
+        self.assertTrue(_drain(director, self.snapshot, 600, 800))
+
+    def test_an_identical_line_is_not_repeated(self):
+        class _Stuck(object):
+            def compose(self, request):
+                return '收到'
+
+        director = _director(backend=_Stuck())
+        director.observe_player_line(0, 1, '那个t34 过来', self.snapshot)
+        published = _drain(director, self.snapshot, 0, 1200)
+        self.assertEqual(len(published), 1)
+
+    def test_an_event_can_start_a_line_with_nobody_speaking(self):
+        director = _director()
+        self.assertTrue(
+            director.observe_event(0, 1, TRIGGER_KILL, 2, self.snapshot))
+        published = _drain(director, self.snapshot)
+        self.assertEqual(published[0]['bot_id'], 2)
+
+    def test_an_unknown_event_is_refused(self):
+        director = _director()
+        self.assertFalse(
+            director.observe_event(0, 1, 'celebrate', 2, self.snapshot))
+
+    def test_a_destroyed_bot_may_still_report_its_own_death(self):
+        roster = _roster()
+        director = _director()
+        self.assertTrue(
+            director.observe_event(0, 1, TRIGGER_DOWN, 2, _snapshot(roster)))
+        roster[1]['alive'] = False
+        published = _drain(director, _snapshot(roster))
+        self.assertEqual(published[0]['bot_id'], 2)
+
+    def test_reset_round_clears_every_conversation(self):
+        director = _director()
+        director.observe_player_line(0, 1, '孤狼 顶一下', self.snapshot)
+        director.reset_round(8)
+        self.assertEqual(_drain(director, self.snapshot), [])
+        self.assertEqual(director.recent_lines(1), [])
+
+
+class ClampTest(unittest.TestCase):
+    def test_whitespace_is_collapsed(self):
+        self.assertEqual(clamp_chat_text('  收到   ,  这就去 '), '收到 , 这就去')
+
+    def test_an_over_long_line_is_truncated_to_the_stock_limit(self):
+        text = clamp_chat_text('好' * 400)
+        self.assertEqual(len(text.encode('utf-16-le')) // 2,
+                         bot_chat.MAX_CHAT_UTF16_UNITS)
+
+    def test_empty_and_non_text_are_refused(self):
+        self.assertIsNone(clamp_chat_text('   '))
+        self.assertIsNone(clamp_chat_text(None))
+        self.assertIsNone(clamp_chat_text(b'\xe5\xa5\xbd'))
+
+
+class DeterminismTest(unittest.TestCase):
+    def test_one_seed_replays_one_transcript(self):
+        def transcript():
+            director = BotChatDirector(random.Random(2024), tick_hz=30.0)
+            director.reset_round(7)
+            snapshot = _snapshot(_roster())
+            director.observe_player_line(0, 1, '那个t34 过来', snapshot)
+            director.observe_player_line(200, 1, '这局有点难打', snapshot)
+            return [(tick, line['bot_id'], line['text'])
+                    for tick in range(0, 900)
+                    for line in director.tick(tick, snapshot)]
+
+        first = transcript()
+        self.assertTrue(first)
+        self.assertEqual(first, transcript())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_port_0922_team_chat_transport.py
+++ b/tests/test_port_0922_team_chat_transport.py
@@ -11,6 +11,7 @@ SERVER_ROOT = TEST_ROOT.parent / 'server'
 sys.path.insert(0, str(TEST_ROOT))
 sys.path.insert(0, str(SERVER_ROOT))
 
+import bot_chat  # noqa: E402
 import lan_battle_server as server_module  # noqa: E402
 from lan_battle_server import (  # noqa: E402
     BattleState, CLIENT_BUILD_0922, ClientHandler, ThreadedTCPServer,
@@ -183,6 +184,7 @@ class TeamChatTransportTests(unittest.TestCase):
             'round_id': self.state.round_id,
             'chat_seq': 1,
             'issuer_id': sender_id,
+            'issuer_kind': 'human',
             'team': 1,
             'text': text,
         }, broadcast)
@@ -359,6 +361,142 @@ class TeamChatTransportTests(unittest.TestCase):
             (message.get('round_id') == old_round or
              message.get('text') == 'Stale in the new round.')
             for message in observed))
+
+
+class _ScriptedRandom(object):
+    """Remove the randomness so one conversation rule is provable."""
+
+    def random(self):
+        return 0.0
+
+    def uniform(self, low, high):
+        return low
+
+    def choice(self, sequence):
+        return list(sequence)[0]
+
+
+class _FixedBackend(object):
+    def __init__(self, text='收到, 这就回来'):
+        self.text = text
+
+    def compose(self, request):
+        return self.text
+
+
+class BotTeamChatTransportTests(unittest.TestCase):
+    """Cover the one wire change: a Bot as the issuer of a stock chat line."""
+
+    def setUp(self):
+        self.state = BattleState(
+            map_name='01_karelia', max_players=3,
+            team1_size=2, team2_size=1)
+        self.server = ThreadedTCPServer(('127.0.0.1', 0), ClientHandler)
+        self.server.game_server = type(
+            'GameServer', (), {'state': self.state})()
+        self.thread = threading.Thread(target=self.server.serve_forever)
+        self.thread.daemon = True
+        self.thread.start()
+        self.peers = []
+
+    def tearDown(self):
+        for peer in self.peers:
+            peer.close()
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(2.0)
+
+    def _connect(self, name, account_key, team):
+        peer = _Peer(self.server.server_address)
+        self.peers.append(peer)
+        peer.send(_player_hello(name, account_key, team))
+        messages = peer.receive_until(_type('welcome'))
+        welcome = next(message for message in messages
+                       if message.get('type') == 'welcome')
+        return peer, welcome['player_id']
+
+    def _prepare(self, backend=None):
+        sender, sender_id = self._connect('Sender', 'bot_chat_sender', 1)
+        opponent, unused_id = self._connect('Opponent', 'bot_chat_enemy', 2)
+        for sequence, peer in enumerate((sender, opponent), 1):
+            peer.send({'type': 'ping', 'seq': sequence})
+            peer.receive_until(
+                lambda message, expected=sequence:
+                message.get('type') == 'pong' and
+                message.get('seq') == expected)
+        with self.state.lock:
+            self.state.phase = 'battle'
+            self.state.bot_manifest = [{
+                'id': 5, 'team': 1, 'slot': 1, 'name': '今天不加班',
+                'vehicle': 'ussr:R04_T-34',
+            }]
+            self.state.bot_states = {5: {
+                'id': 5, 'team': 1, 'alive': True, 'x': 12.0, 'z': 12.0,
+                'health': 400, 'max_health': 400,
+            }}
+            self.state.bot_chat = bot_chat.BotChatDirector(
+                _ScriptedRandom(), tick_hz=server_module.TICK_HZ,
+                backend=backend or _FixedBackend())
+            self.state.bot_chat.reset_round(self.state.round_id)
+            self.state._next_bot_chat_tick = 0
+        return sender, sender_id, opponent
+
+    def _run_chat_ticks(self, limit=400):
+        published = False
+        for tick in range(limit):
+            with self.state.lock:
+                self.state.tick = tick
+            published = self.state.publish_bot_team_chat() or published
+        return published
+
+    def test_an_addressed_bot_answers_on_the_stock_channel(self):
+        sender, unused_sender_id, opponent = self._prepare()
+        sender.send({'type': 'team_chat', 'round_id': self.state.round_id,
+                     'chat_seq': 1, 'text': '那个t34 回来一下'})
+        sender.receive_until(_chat_ack(1))
+        self.assertTrue(self._run_chat_ticks())
+        line = next(
+            message for message in sender.receive_until(
+                lambda message: message.get('type') == 'team_chat' and
+                message.get('issuer_kind') == 'bot')
+            if message.get('issuer_kind') == 'bot')
+        self.assertEqual(line['issuer_id'], 5)
+        self.assertEqual(line['team'], 1)
+        self.assertEqual(line['round_id'], self.state.round_id)
+        self.assertEqual(line['text'], '收到, 这就回来')
+        self.assertGreaterEqual(line['chat_seq'], 1)
+
+    def test_a_bot_line_never_reaches_the_other_team(self):
+        sender, unused_sender_id, opponent = self._prepare()
+        sender.send({'type': 'team_chat', 'round_id': self.state.round_id,
+                     'chat_seq': 1, 'text': '那个t34 回来一下'})
+        sender.receive_until(_chat_ack(1))
+        self._run_chat_ticks()
+        opponent.send({'type': 'ping', 'seq': 99})
+        seen = opponent.receive_until(
+            lambda message: message.get('type') == 'pong' and
+            message.get('seq') == 99)
+        self.assertFalse([message for message in seen
+                          if message.get('type') == 'team_chat'])
+
+    def test_an_unpublishable_line_is_dropped_without_a_sequence(self):
+        sender, unused_sender_id, unused_opponent = self._prepare(
+            backend=_FixedBackend('   '))
+        sender.send({'type': 'team_chat', 'round_id': self.state.round_id,
+                     'chat_seq': 1, 'text': '那个t34 回来一下'})
+        sender.receive_until(_chat_ack(1))
+        self.assertFalse(self._run_chat_ticks())
+        with self.state.lock:
+            self.assertEqual({}, self.state.bot_chat_seq)
+
+    def test_a_finished_battle_stops_the_conversation(self):
+        sender, unused_sender_id, unused_opponent = self._prepare()
+        sender.send({'type': 'team_chat', 'round_id': self.state.round_id,
+                     'chat_seq': 1, 'text': '那个t34 回来一下'})
+        sender.receive_until(_chat_ack(1))
+        with self.state.lock:
+            self.state.battle_result = {'winner': 1}
+        self.assertFalse(self._run_chat_ticks())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Bots already answer stock radio commands on the team channel, but nothing
could make one say a sentence. This adds the conversation itself.

## The client contract was already complete

A human line already reaches the server, and stock rendering already accepts
any same-team `accountDBID` — which is why Bot command acks render today. So
the only wire change is one field:

```
team_chat { ..., "issuer_kind": "human" | "bot" }
```

The client resolves the identity against the roster that field names, and
includes the kind in its duplicate key so the human and Bot id spaces cannot
collide. `PROTOCOL_VERSION` stays at 5, matching how the radio feature added
its message types: the launcher ships the server and client together.

## Addressing: players say the tank, not the callsign

`server/bot_chat.py` is pure — it reads a caller-supplied tick and one plain
snapshot, never a clock or server state, so a round replays identically under
test. Every addressing branch is deterministic string and geometry work over
the roster actually in this battle.

| The player types | Resolves as | Who answers |
| --- | --- | --- |
| `那个t34 过来` / `T-34` / `t34` | vehicle | the T-34 |
| `孤狼 顶一下` | callsign shorthand | 北方孤狼 |
| `轻坦回家` | class | up to two lights |
| `a1 有人吗` | stock grid cell | the Bot standing there |
| `你到了吗` | thread | whoever was addressed before |
| `这局有点难打` | nobody | usually someone still answers |

Two details worth review:

- `ussr:R04_T-34` folds to `t34`, and the match is bounded against **Latin**
  runs only. A CJK character answers `True` to `str.isalnum`, so a naive word
  boundary rejects `那个T-34` — the single most common real phrasing.
- Two of one model disambiguate by what the speaker has already **spotted**,
  which is what `那个` means, then by distance. An unresolvable reference
  addresses nobody rather than guessing.

## Turn taking

- A thread stays anchored on the teammate the player **addressed**, not on
  whichever Bot spoke last, so a follow-up needs no second callsign.
- Bots answer each other — capped at two hops with decaying probability,
  which is the only way this could fail to terminate.
- A rolling per-team budget, not a one-speaker rule, keeps the channel
  readable. A squad call legitimately answers with more than one voice.
- Silence stays legal; it is simply not the default.

## Personas come from the shipped callsigns

`今天不加班` does not talk like `北方孤狼`. Reading the persona out of
`BOT_CALLSIGNS_0922` costs nothing and keeps one Bot sounding like itself for
the whole round.

## The seam for a local model

`compose` on the line backend is where an optional local language model plugs
in later. `TemplateLineBackend` ships as the default and is what a player gets
with no optional download installed, so it is a product surface rather than a
placeholder — and it keeps the model out of the pure-data Python 3 suite.

A backend failure, an unpublishable line, or a director fault is contained to
that one line. It never costs the team its chat relay and never faults the
round.

## Validation

- `tests/test_port_0922_bot_chat.py` — 43 new tests: addressing,
  disambiguation, thread anchoring, hop termination, budget, cooldown,
  persona stability, containment, determinism.
- `tests/test_port_0922_team_chat_transport.py` — 4 new tests for the Bot
  publication path, team isolation, and the finished-battle stop.
- CPython 2.7.18 source compile gate passes (94 client files).

## Not proved here

Whether a Bot-sourced action-22 **text** line renders with the Bot's name on
Windows. Peng has confirmed Bot command acks render, and text uses the
identical `int64 accountDBID -> messenger roster` lookup with a different
action id — so this is a strong inference, not evidence. First Windows run
settles it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)