### PR TITLE
Bot chat: a local model, and the launcher that installs it

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ downloaded until you ask, downloads resume where they stopped, everything is
 checked against its published checksum, and Remove deletes it all again. With
 no model installed the feature is simply off and every Bot is quiet.
 
+Installed files are not the same thing as a working feature, so the panel does
+not claim to be ready on their account: it says whether the switch is on, and
+**Test** proves this PC can actually load the model and write a line before you
+find out in a battle. In a LAN room the chat comes from the **host's** PC, so a
+joiner's own model does nothing.
+
 The launcher's Tools tab can also edit vehicle data directly. A vehicle data
 profile is a named set of Packed XML field changes (health, damage,
 penetration, armour, speeds, reload and more) made in the launcher's editor;

--- a/README.md
+++ b/README.md
@@ -53,6 +53,15 @@ The 0.9.22 client gets a working offline garage:
   range, concealment, reload, aim time, dispersion, traverse, engine power,
   terrain resistance and repair speed.
 
+The Tools tab also has an **AI chat** panel, off by default. Turning it on
+installs a small local language model and llama.cpp's inference program, and
+Bots then hold conversations in team chat: they answer when you address one by
+its tank ("那个 T-34"), by class, by grid square or by callsign, they answer
+each other, and each keeps a voice of its own for the round. Nothing is
+downloaded until you ask, downloads resume where they stopped, everything is
+checked against its published checksum, and Remove deletes it all again. With
+no model installed the feature is simply off and every Bot is quiet.
+
 The launcher's Tools tab can also edit vehicle data directly. A vehicle data
 profile is a named set of Packed XML field changes (health, damage,
 penetration, armour, speeds, reload and more) made in the launcher's editor;

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -83,10 +83,14 @@ repositories, file names, sizes and SHA-256 digests are pinned in
 Inference runs in a separate `llama-server` process from
 [`ggml-org/llama.cpp`](https://github.com/ggml-org/llama.cpp), distributed
 under the MIT License. The launcher downloads one pinned CPU-only Windows
-release archive, unmodified, either from that project's own release assets or
-from a ModelScope repository that mirrors the identical archives together
-with llama.cpp's license text. The pinned SHA-256 validates the download from
-either host.
+release archive, unmodified, from that project's own GitHub release assets or,
+for the x64 build, from a third-party ModelScope repository that republishes
+the identical archive together with llama.cpp's license text. The archive from
+that mirror was verified to have the same SHA-256 as the official asset, and
+the digest pinned in
+[`server/bot_chat_models.py`](server/bot_chat_models.py) is the official one,
+so a mirror that is stale, wrong or hostile fails verification rather than
+installing anything.
 
 ## Wargaming intellectual property
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -65,6 +65,26 @@ Official information is available from the
 [ProcDump documentation](https://learn.microsoft.com/en-us/sysinternals/downloads/procdump)
 and [Sysinternals licensing FAQ](https://learn.microsoft.com/en-us/sysinternals/license-faq).
 
+## Optional local chat model and inference runtime
+
+The optional Bot team-chat feature is off unless a player chooses to install
+it, and neither half is distributed with this project.
+
+When a player enables it, the launcher downloads a Qwen2.5-Instruct model in
+GGUF form, published by Alibaba Cloud's Qwen team under the Apache License
+2.0. The same file is offered from
+[ModelScope](https://www.modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF)
+and [Hugging Face](https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct-GGUF);
+ModelScope is listed first because it is reachable from mainland China. Both
+mirrors were verified to serve the identical file, and the exact repositories,
+file names, sizes and SHA-256 digests are pinned in
+[`server/bot_chat_models.py`](server/bot_chat_models.py).
+
+Inference runs in a separate `llama-server` process from
+[`ggml-org/llama.cpp`](https://github.com/ggml-org/llama.cpp), distributed
+under the MIT License. The launcher downloads the pinned CPU-only Windows
+build from that project's official release assets.
+
 ## Wargaming intellectual property
 
 This project is an unofficial compatibility modification. It does not include

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -70,20 +70,23 @@ and [Sysinternals licensing FAQ](https://learn.microsoft.com/en-us/sysinternals/
 The optional Bot team-chat feature is off unless a player chooses to install
 it, and neither half is distributed with this project.
 
-When a player enables it, the launcher downloads a Qwen2.5-Instruct model in
-GGUF form, published by Alibaba Cloud's Qwen team under the Apache License
-2.0. The same file is offered from
-[ModelScope](https://www.modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF)
-and [Hugging Face](https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct-GGUF);
-ModelScope is listed first because it is reachable from mainland China. Both
-mirrors were verified to serve the identical file, and the exact repositories,
-file names, sizes and SHA-256 digests are pinned in
+When a player enables it, the launcher downloads a Qwen model in GGUF form,
+published by Alibaba Cloud's Qwen team under the Apache License 2.0. Each
+offered model is available from both
+[ModelScope](https://www.modelscope.cn/models/Qwen/Qwen3-0.6B-GGUF) and
+[Hugging Face](https://huggingface.co/Qwen/Qwen3-0.6B-GGUF); ModelScope is
+listed first because it is reachable from mainland China. Every file was
+verified to be byte-identical across both mirrors, and the exact
+repositories, file names, sizes and SHA-256 digests are pinned in
 [`server/bot_chat_models.py`](server/bot_chat_models.py).
 
 Inference runs in a separate `llama-server` process from
 [`ggml-org/llama.cpp`](https://github.com/ggml-org/llama.cpp), distributed
-under the MIT License. The launcher downloads the pinned CPU-only Windows
-build from that project's official release assets.
+under the MIT License. The launcher downloads one pinned CPU-only Windows
+release archive, unmodified, either from that project's own release assets or
+from a ModelScope repository that mirrors the identical archives together
+with llama.cpp's license text. The pinned SHA-256 validates the download from
+either host.
 
 ## Wargaming intellectual property
 

--- a/launcher/LAUNCHER_README.txt
+++ b/launcher/LAUNCHER_README.txt
@@ -157,6 +157,56 @@ https://learn.microsoft.com/en-us/sysinternals/downloads/procdump
 https://learn.microsoft.com/en-us/sysinternals/license-faq
 https://learn.microsoft.com/en-us/sysinternals/license-terms
 
+Neither the AI teammate chat model nor its inference program is included in
+this launcher, and the feature stays off until you install them from the AI
+chat tab. Both go to %LOCALAPPDATA%\WoTOfflineBattles\bot-chat, and Remove on
+that tab deletes them again.
+
+The models are Qwen2.5-Instruct and Qwen3 in GGUF form, published by Alibaba
+Cloud's Qwen team under the Apache License 2.0. Each is offered from ModelScope
+and from Hugging Face; ModelScope is tried first because it is reachable from
+mainland China, and both were verified to serve the identical file. The
+smallest is about 610 MB and the largest about 1.7 GB.
+
+Inference runs in a separate llama-server process from ggml-org/llama.cpp,
+distributed under the MIT License, whose text is reproduced below. The launcher
+downloads one pinned CPU-only Windows release archive, unmodified, and unpacks
+only that program and the libraries it loads. For the x64 build it tries a
+ModelScope repository that republishes the identical archive before falling
+back to GitHub. Every download is checked against the SHA-256 of the official
+release asset, so a mirror that is stale, wrong or hostile fails verification
+and installs nothing.
+
+If you already have llama-server.exe, the AI chat tab accepts its path instead
+and downloads only the model.
+
+https://www.modelscope.cn/models/Qwen/Qwen3-0.6B-GGUF
+https://huggingface.co/Qwen/Qwen3-0.6B-GGUF
+https://github.com/ggml-org/llama.cpp
+
+MIT LICENSE FOR LLAMA.CPP
+----------------------------------------------------------------------
+
+Copyright (c) 2023-2024 The ggml authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
 World of Tanks and its assets are not included with this server. This project
 is unofficial and is not endorsed by Wargaming.
 

--- a/launcher/bot_chat_install.py
+++ b/launcher/bot_chat_install.py
@@ -1,0 +1,361 @@
+"""Install the optional Bot chat model and inference runtime.
+
+The model is the largest download this project has ever asked for, over a
+route that is slow for many of its players, so every part of this is built
+around being interrupted: progress is reported continuously, a cancel is
+honoured within one chunk, a partial file is resumed rather than restarted,
+and nothing is accepted without matching the digest pinned beside it.
+
+The catalogue itself lives with the server, in ``bot_chat_models``. This
+module never restates a URL, size or digest; it is handed the entry.
+
+Nothing here imports a GUI. The launcher window drives it from a worker
+thread, and the tests drive it with an injected opener.
+"""
+
+import hashlib
+import os
+import shutil
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+import zipfile
+
+
+CHAT_DIR = "bot-chat"
+MODEL_DIR = "models"
+RUNTIME_DIR = "runtime"
+PART_SUFFIX = ".part"
+
+CHUNK_BYTES = 1 << 20
+DOWNLOAD_TIMEOUT_SECONDS = 60.0
+# A pinned entry states its own size, so anything materially larger is a
+# wrong or hostile response rather than a big model.
+SIZE_SLACK_BYTES = 1 << 20
+
+RUNTIME_EXECUTABLE = "llama-server.exe"
+
+
+class InstallError(Exception):
+    """One download or extraction could not be completed."""
+
+
+class InstallCancelled(Exception):
+    """The player stopped the install; a partial file is kept for resume."""
+
+
+def _default_base_dir():
+    base = os.environ.get("LOCALAPPDATA")
+    if not base:
+        base = os.path.join(os.path.expanduser("~"), ".config")
+    return os.path.join(base, "WoTOfflineBattles")
+
+
+def install_root(base_dir=None):
+    """Return the directory holding everything this feature downloads."""
+    return os.path.join(base_dir or _default_base_dir(), CHAT_DIR)
+
+
+def model_path(entry, base_dir=None):
+    """Return where one catalogued model is stored once installed."""
+    return os.path.join(install_root(base_dir), MODEL_DIR, entry["file"])
+
+
+def runtime_root(base_dir=None):
+    """Return the directory the runtime archive is unpacked into."""
+    return os.path.join(install_root(base_dir), RUNTIME_DIR)
+
+
+def runtime_executable(base_dir=None):
+    """Return the generator executable this feature runs."""
+    return os.path.join(runtime_root(base_dir), RUNTIME_EXECUTABLE)
+
+
+def _check_cancel(cancel):
+    if cancel is not None and cancel():
+        raise InstallCancelled("the install was stopped")
+
+
+def file_digest(path, cancel=None, progress=None):
+    """Return one file's SHA-256, staying interruptible on a large file."""
+    digest = hashlib.sha256()
+    total = os.path.getsize(path)
+    done = 0
+    with open(path, "rb") as stream:
+        while True:
+            _check_cancel(cancel)
+            block = stream.read(CHUNK_BYTES)
+            if not block:
+                break
+            digest.update(block)
+            done += len(block)
+            if progress is not None:
+                progress(done, total)
+    return digest.hexdigest()
+
+
+def is_installed(path, entry, cancel=None, progress=None):
+    """Return whether a complete, verified copy is already on disk.
+
+    Size is checked first because it rejects almost every bad file without
+    reading a gigabyte.
+    """
+    try:
+        if not os.path.isfile(path) or os.path.getsize(path) != entry["size"]:
+            return False
+    except OSError:
+        return False
+    try:
+        return file_digest(path, cancel, progress) == entry["sha256"]
+    except OSError:
+        return False
+
+
+def _open(opener, url, offset):
+    request = urllib.request.Request(url)
+    if offset:
+        request.add_header("Range", "bytes=%d-" % offset)
+    return opener(request, timeout=DOWNLOAD_TIMEOUT_SECONDS)
+
+
+def _response_status(response):
+    status = getattr(response, "status", None)
+    if status is None:
+        getcode = getattr(response, "getcode", None)
+        status = getcode() if callable(getcode) else None
+    return status
+
+
+def download_file(url, destination, entry, progress=None, cancel=None,
+                  opener=None):
+    """Fetch one catalogued file, resuming a partial copy when possible."""
+    opener = opener or urllib.request.urlopen
+    directory = os.path.dirname(destination)
+    if directory:
+        os.makedirs(directory, exist_ok=True)
+    part = destination + PART_SUFFIX
+    total = int(entry["size"])
+    offset = 0
+    if os.path.isfile(part):
+        offset = os.path.getsize(part)
+        if offset > total:
+            # A partial file longer than the finished one is not this file.
+            os.remove(part)
+            offset = 0
+    if offset == total:
+        # The bytes are all there; only the digest is still unproven.
+        os.replace(part, destination)
+        return _finish(destination, entry, cancel)
+
+    _check_cancel(cancel)
+    try:
+        response = _open(opener, url, offset)
+    except (urllib.error.URLError, OSError, ValueError) as error:
+        raise InstallError("%s could not be reached: %s" % (url, error))
+    try:
+        status = _response_status(response)
+        if offset and status != 206:
+            # The host ignored the range request, so the partial copy is
+            # worthless and the whole file arrives from the start.
+            offset = 0
+        mode = "r+b" if offset else "wb"
+        with open(part, mode) as stream:
+            stream.seek(offset)
+            stream.truncate(offset)
+            done = offset
+            if progress is not None:
+                progress(done, total)
+            while True:
+                _check_cancel(cancel)
+                block = response.read(CHUNK_BYTES)
+                if not block:
+                    break
+                done += len(block)
+                if done > total + SIZE_SLACK_BYTES:
+                    raise InstallError(
+                        "%s returned more data than the catalogue expects"
+                        % url)
+                stream.write(block)
+                if progress is not None:
+                    progress(done, total)
+    except InstallCancelled:
+        raise
+    except (urllib.error.URLError, OSError, ValueError) as error:
+        raise InstallError("%s could not be downloaded: %s" % (url, error))
+    finally:
+        close = getattr(response, "close", None)
+        if callable(close):
+            close()
+
+    if os.path.getsize(part) != total:
+        raise InstallError(
+            "%s ended early; run the install again to resume" % url)
+    os.replace(part, destination)
+    return _finish(destination, entry, cancel)
+
+
+def _finish(destination, entry, cancel):
+    """Accept a complete file only when its digest matches the catalogue."""
+    digest = file_digest(destination, cancel)
+    if digest != entry["sha256"]:
+        os.remove(destination)
+        raise InstallError(
+            "the download did not match its published checksum; "
+            "nothing was installed")
+    return destination
+
+
+def _sources_for(catalogue, kind, arch=None):
+    if kind == "runtime":
+        return catalogue.runtime_sources(arch)
+    return catalogue.SOURCES
+
+
+def _download_from_sources(urls, destination, entry, progress, cancel,
+                           opener):
+    """Try every published host in turn, keeping the first real failure."""
+    first_error = None
+    for url in urls:
+        if url is None:
+            continue
+        try:
+            return download_file(url, destination, entry, progress, cancel,
+                                 opener)
+        except InstallCancelled:
+            raise
+        except InstallError as error:
+            if first_error is None:
+                first_error = error
+    raise first_error or InstallError("no download host is published")
+
+
+def install_model(catalogue, tier_key, base_dir=None, progress=None,
+                  cancel=None, opener=None, sources=None):
+    """Install one catalogued model, returning its path."""
+    entry = catalogue.tier(tier_key)
+    if entry is None:
+        raise InstallError("unknown model: %s" % tier_key)
+    destination = model_path(entry, base_dir)
+    if is_installed(destination, entry, cancel):
+        return destination
+    urls = [catalogue.model_url(tier_key, source)
+            for source in (sources or catalogue.SOURCES)]
+    return _download_from_sources(urls, destination, entry, progress, cancel,
+                                  opener)
+
+
+def install_runtime(catalogue, arch, base_dir=None, progress=None,
+                    cancel=None, opener=None, sources=None):
+    """Install the inference runtime, returning the generator executable."""
+    entry = catalogue.runtime_asset(arch)
+    if entry is None:
+        raise InstallError(
+            "no inference runtime is published for this machine")
+    executable = runtime_executable(base_dir)
+    if os.path.isfile(executable):
+        return executable
+    root = runtime_root(base_dir)
+    os.makedirs(root, exist_ok=True)
+    archive = os.path.join(root, entry["file"])
+    if not is_installed(archive, entry, cancel):
+        urls = [catalogue.runtime_url(arch, source)
+                for source in (sources or catalogue.runtime_sources(arch))]
+        _download_from_sources(urls, archive, entry, progress, cancel, opener)
+    try:
+        extract_runtime(archive, root, cancel)
+    finally:
+        # The unpacked files are the installation; the archive is 17 MB of
+        # nothing once they exist, and it can always be fetched again.
+        try:
+            os.remove(archive)
+        except OSError:
+            pass
+    if not os.path.isfile(executable):
+        raise InstallError(
+            "the runtime archive did not contain %s" % RUNTIME_EXECUTABLE)
+    return executable
+
+
+def extract_runtime(archive, root, cancel=None):
+    """Unpack the generator and its libraries, and nothing else.
+
+    The published archive also carries twenty other command line tools. Only
+    the server and the shared libraries it loads are installed, and any
+    member naming a directory is refused rather than written.
+    """
+    with zipfile.ZipFile(archive) as bundle:
+        for info in bundle.infolist():
+            _check_cancel(cancel)
+            name = info.filename
+            if info.is_dir() or not _is_wanted_member(name):
+                continue
+            if (os.path.basename(name) != name or
+                    os.path.isabs(name) or "\\" in name):
+                raise InstallError(
+                    "the runtime archive contains an unexpected path: %s"
+                    % name)
+            target = os.path.join(root, name)
+            with bundle.open(info) as source:
+                with open(target, "wb") as stream:
+                    shutil.copyfileobj(source, stream, CHUNK_BYTES)
+
+
+def _is_wanted_member(name):
+    lowered = name.lower()
+    return lowered.endswith(".dll") or lowered == RUNTIME_EXECUTABLE.lower()
+
+
+def installation_state(catalogue, tier_key, arch, base_dir=None):
+    """Describe what is installed, without hashing a gigabyte to find out."""
+    entry = catalogue.tier(tier_key)
+    model = model_path(entry, base_dir) if entry else None
+    executable = runtime_executable(base_dir)
+    model_present = bool(
+        entry and model and os.path.isfile(model) and
+        os.path.getsize(model) == entry["size"])
+    runtime_present = os.path.isfile(executable)
+    return {
+        "model": model,
+        "model_present": model_present,
+        "runtime": executable,
+        "runtime_present": runtime_present,
+        "runtime_available": catalogue.runtime_asset(arch) is not None,
+        "ready": bool(model_present and runtime_present),
+    }
+
+
+def remove_installation(base_dir=None):
+    """Delete everything this feature downloaded."""
+    root = install_root(base_dir)
+    if not os.path.isdir(root):
+        return False
+    # Rename first so a locked file cannot leave a half-deleted install
+    # looking installed.
+    holding = tempfile.mkdtemp(prefix=".bot-chat-removed-",
+                               dir=os.path.dirname(root))
+    target = os.path.join(holding, CHAT_DIR)
+    os.replace(root, target)
+    shutil.rmtree(holding, ignore_errors=True)
+    return True
+
+
+def machine_architecture(catalogue, machine=None):
+    """Return the catalogue's name for this machine, or None."""
+    if machine is None:
+        import platform
+
+        machine = platform.machine()
+    return catalogue.runtime_arch(machine)
+
+
+def format_bytes(count):
+    """Return a short human-readable size for a progress line."""
+    value = float(count)
+    for unit in ("B", "KB", "MB", "GB"):
+        if value < 1024.0 or unit == "GB":
+            if unit == "B":
+                return "%d B" % int(value)
+            return "%.1f %s" % (value, unit)
+        value /= 1024.0
+    return "%.1f GB" % value

--- a/launcher/bot_chat_ui.py
+++ b/launcher/bot_chat_ui.py
@@ -1,0 +1,345 @@
+"""Tk panel for installing and enabling the optional Bot chat model.
+
+The panel owns one long download and must stay honest about it: the work
+runs on a worker thread, progress is reported continuously, and Stop is
+answered within one chunk while keeping the partial file for a resume.
+
+Every Tk module is injected so the panel can be driven headlessly by the
+tests, and every catalogue fact comes from the server's pinned module rather
+than being restated here.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+
+try:
+    from . import bot_chat_install
+except ImportError:
+    import bot_chat_install
+
+
+ENABLED_SETTING = "bot_chat_enabled"
+TIER_SETTING = "bot_chat_model"
+RUNTIME_OVERRIDE_SETTING = "bot_chat_runtime_override"
+
+STATE_ABSENT = "absent"
+STATE_READY = "ready"
+STATE_WORKING = "working"
+STATE_UNSUPPORTED = "unsupported"
+
+
+def tier_labels(catalogue):
+    """Return one selectable label per catalogued model, and its key."""
+    labels = []
+    for entry in catalogue.MODEL_TIERS:
+        labels.append((entry["key"], "%s  %s  %s" % (
+            entry["key"], entry["parameters"],
+            bot_chat_install.format_bytes(entry["size"]))))
+    return labels
+
+
+def key_for_label(catalogue, label):
+    """Resolve one displayed label back to its catalogue key."""
+    for key, text in tier_labels(catalogue):
+        if text == label:
+            return key
+    return catalogue.DEFAULT_TIER_KEY
+
+
+def resolved_paths(catalogue, tier_key, base_dir=None, runtime_override=""):
+    """Return the runtime and model the server should be given, if any.
+
+    A player who already has ``llama-server.exe`` may point at it instead of
+    downloading a second copy, so the override wins whenever it names a real
+    file.
+    """
+    entry = catalogue.tier(tier_key) or catalogue.default_tier()
+    model = bot_chat_install.model_path(entry, base_dir)
+    runtime = str(runtime_override or "").strip()
+    if not runtime or not os.path.isfile(runtime):
+        runtime = bot_chat_install.runtime_executable(base_dir)
+    return {"runtime": runtime, "model": model}
+
+
+def install_plan(catalogue, tier_key, arch, base_dir=None,
+                 runtime_override=""):
+    """Describe what still has to be downloaded before a room can talk."""
+    state = bot_chat_install.installation_state(
+        catalogue, tier_key, arch, base_dir)
+    override = str(runtime_override or "").strip()
+    if override and os.path.isfile(override):
+        state["runtime"] = override
+        state["runtime_present"] = True
+        state["ready"] = state["model_present"]
+    if not state["runtime_available"] and not state["runtime_present"]:
+        state["status"] = STATE_UNSUPPORTED
+    elif state["ready"]:
+        state["status"] = STATE_READY
+    else:
+        state["status"] = STATE_ABSENT
+    entry = catalogue.tier(tier_key)
+    pending = 0
+    if entry is not None and not state["model_present"]:
+        pending += int(entry["size"])
+    if not state["runtime_present"]:
+        asset = catalogue.runtime_asset(arch)
+        pending += int(asset["size"]) if asset else 0
+    state["pending_bytes"] = pending
+    return state
+
+
+class BotChatPanel(object):
+    """Drive one install from the launcher window without blocking it."""
+
+    def __init__(self, parent, catalogue, tk_module, ttk_module, settings,
+                 on_change=None, log=None, base_dir=None, machine=None):
+        self._tk = tk_module
+        self._ttk = ttk_module
+        self._catalogue = catalogue
+        self._settings = settings
+        self._on_change = on_change or (lambda: None)
+        self._log = log or (lambda unused: None)
+        self._base_dir = base_dir
+        self._arch = bot_chat_install.machine_architecture(catalogue, machine)
+        self._thread = None
+        self._working = False
+        self._cancel = threading.Event()
+        self._build(parent)
+        self.refresh()
+
+    # -- construction ---------------------------------------------------
+
+    def _build(self, parent):
+        tk = self._tk
+        self.enabled = tk.BooleanVar(
+            value=bool(self._settings.get(ENABLED_SETTING)))
+        self.enable_check = tk.Checkbutton(
+            parent, text="", variable=self.enabled,
+            command=self._enabled_changed)
+        self.enable_check.grid(row=0, column=0, columnspan=3, sticky="w")
+
+        self.model_label = tk.Label(parent, text="")
+        self.model_label.grid(row=1, column=0, sticky="w")
+        labels = [text for unused, text in tier_labels(self._catalogue)]
+        current = self._settings.get(
+            TIER_SETTING, self._catalogue.DEFAULT_TIER_KEY)
+        selected = labels[0]
+        for key, text in tier_labels(self._catalogue):
+            if key == current:
+                selected = text
+        self.model_choice = tk.StringVar(value=selected)
+        self.model_box = self._ttk.Combobox(
+            parent, textvariable=self.model_choice, values=tuple(labels),
+            state="readonly", width=34)
+        self.model_box.grid(row=1, column=1, sticky="we", padx=(6, 0))
+        self.model_box.bind("<<ComboboxSelected>>",
+                            lambda unused: self._model_changed())
+
+        self.runtime_label = tk.Label(parent, text="")
+        self.runtime_label.grid(row=2, column=0, sticky="w")
+        self.runtime_override = tk.StringVar(
+            value=self._settings.get(RUNTIME_OVERRIDE_SETTING, ""))
+        self.runtime_entry = tk.Entry(
+            parent, textvariable=self.runtime_override, width=34)
+        self.runtime_entry.grid(row=2, column=1, sticky="we", padx=(6, 0))
+        self.runtime_browse = tk.Button(
+            parent, text="...", width=3, command=self._browse_runtime)
+        self.runtime_browse.grid(row=2, column=2, sticky="w", padx=(6, 0))
+
+        self.progress = self._ttk.Progressbar(
+            parent, orient="horizontal", mode="determinate", maximum=1000)
+        self.progress.grid(row=3, column=0, columnspan=3, sticky="we",
+                           pady=(8, 0))
+        self.status = tk.StringVar(value="")
+        self.status_label = tk.Label(parent, textvariable=self.status,
+                                     anchor="w", justify="left")
+        self.status_label.grid(row=4, column=0, columnspan=3, sticky="we")
+
+        self.install_button = tk.Button(parent, text="",
+                                        command=self.start_install)
+        self.install_button.grid(row=5, column=0, sticky="we", pady=(6, 0))
+        self.stop_button = tk.Button(parent, text="", command=self.stop,
+                                     state="disabled")
+        self.stop_button.grid(row=5, column=1, sticky="we", pady=(6, 0),
+                              padx=(6, 0))
+        self.remove_button = tk.Button(parent, text="", command=self.remove)
+        self.remove_button.grid(row=5, column=2, sticky="we", pady=(6, 0),
+                                padx=(6, 0))
+        parent.grid_columnconfigure(1, weight=1)
+
+    # -- settings -------------------------------------------------------
+
+    def _enabled_changed(self):
+        self._settings[ENABLED_SETTING] = bool(self.enabled.get())
+        self.refresh()
+        self._on_change()
+
+    def _model_changed(self):
+        self._settings[TIER_SETTING] = key_for_label(
+            self._catalogue, self.model_choice.get())
+        self.refresh()
+        self._on_change()
+
+    def _browse_runtime(self):
+        from tkinter import filedialog
+
+        chosen = filedialog.askopenfilename(
+            title=bot_chat_install.RUNTIME_EXECUTABLE,
+            filetypes=[("llama-server", bot_chat_install.RUNTIME_EXECUTABLE)])
+        if chosen:
+            self.runtime_override.set(chosen)
+            self._settings[RUNTIME_OVERRIDE_SETTING] = chosen
+            self.refresh()
+            self._on_change()
+
+    def tier_key(self):
+        return key_for_label(self._catalogue, self.model_choice.get())
+
+    def paths(self):
+        """Return what the server should be told, or None when it is off."""
+        if not self.enabled.get():
+            return None
+        plan = self.plan()
+        if plan["status"] != STATE_READY:
+            return None
+        return resolved_paths(self._catalogue, self.tier_key(),
+                              self._base_dir, self.runtime_override.get())
+
+    def plan(self):
+        return install_plan(self._catalogue, self.tier_key(), self._arch,
+                            self._base_dir, self.runtime_override.get())
+
+    # -- install --------------------------------------------------------
+
+    def busy(self):
+        """Return whether an install is in flight.
+
+        This is an explicit flag rather than ``Thread.is_alive`` because the
+        worker reports its own completion: at that moment its thread is
+        still running, and asking the thread would leave the panel stuck
+        reporting a download that has already finished.
+        """
+        return self._working
+
+    def start_install(self, opener=None):
+        """Download whatever is still missing, on a worker thread."""
+        if self.busy():
+            return False
+        plan = self.plan()
+        if plan["status"] == STATE_UNSUPPORTED:
+            self._set_status(STATE_UNSUPPORTED)
+            return False
+        if plan["status"] == STATE_READY:
+            self.refresh()
+            return False
+        self._cancel.clear()
+        self._working = True
+        self._set_working()
+        self._thread = threading.Thread(
+            target=self._install, args=(self.tier_key(), opener),
+            name="bot-chat-install", daemon=True)
+        self._thread.start()
+        return True
+
+    def stop(self):
+        """Ask the running install to stop at the next chunk."""
+        self._cancel.set()
+
+    def _install(self, tier_key, opener=None):
+        cancel = self._cancel.is_set
+        try:
+            if not self.plan()["runtime_present"]:
+                self._stage("runtime")
+                bot_chat_install.install_runtime(
+                    self._catalogue, self._arch, self._base_dir,
+                    progress=self._progress, cancel=cancel, opener=opener)
+            self._stage("model")
+            bot_chat_install.install_model(
+                self._catalogue, tier_key, self._base_dir,
+                progress=self._progress, cancel=cancel, opener=opener)
+        except bot_chat_install.InstallCancelled:
+            self._finish(None, cancelled=True)
+            return
+        except bot_chat_install.InstallError as error:
+            self._finish(str(error))
+            return
+        except Exception as error:  # noqa: BLE001 - a worker must not vanish
+            self._finish(str(error))
+            return
+        self._finish(None)
+
+    # -- reporting ------------------------------------------------------
+
+    def _stage(self, name):
+        self._stage_name = name
+        self._log("BOT CHAT downloading %s" % name)
+
+    def _progress(self, done, total):
+        self._last_progress = (done, total)
+
+    def progress_text(self):
+        done, total = getattr(self, "_last_progress", (0, 0))
+        if not total:
+            return ""
+        return "%s / %s" % (bot_chat_install.format_bytes(done),
+                            bot_chat_install.format_bytes(total))
+
+    def progress_fraction(self):
+        done, total = getattr(self, "_last_progress", (0, 0))
+        return (float(done) / float(total)) if total else 0.0
+
+    def _set_working(self):
+        self._state = STATE_WORKING
+        self._apply_button_state()
+
+    def _set_status(self, state):
+        self._state = state
+        self._apply_button_state()
+
+    def _apply_button_state(self):
+        working = self._state == STATE_WORKING
+        self.install_button.config(state="disabled" if working else "normal")
+        self.stop_button.config(state="normal" if working else "disabled")
+        self.remove_button.config(state="disabled" if working else "normal")
+
+    def _finish(self, error, cancelled=False):
+        self._working = False
+        self._error = error
+        self._cancelled = cancelled
+        if error:
+            self._log("BOT CHAT install failed: %s" % error)
+        elif cancelled:
+            self._log("BOT CHAT install stopped; progress was kept")
+        else:
+            self._log("BOT CHAT install finished")
+        self.refresh()
+        self._on_change()
+
+    def last_error(self):
+        return getattr(self, "_error", None)
+
+    def was_cancelled(self):
+        return bool(getattr(self, "_cancelled", False))
+
+    def refresh(self):
+        """Recompute the panel state from what is actually on disk."""
+        if self.busy():
+            self._set_working()
+            return
+        plan = self.plan()
+        self._set_status(plan["status"])
+
+    def state(self):
+        return getattr(self, "_state", STATE_ABSENT)
+
+    def remove(self):
+        """Delete the download so the disk space comes back."""
+        if self.busy():
+            return False
+        removed = bot_chat_install.remove_installation(self._base_dir)
+        self._last_progress = (0, 0)
+        self.refresh()
+        self._on_change()
+        return removed

--- a/launcher/bot_chat_ui.py
+++ b/launcher/bot_chat_ui.py
@@ -78,6 +78,18 @@ def resolved_paths(catalogue, tier_key, base_dir=None, runtime_override=""):
     return {"runtime": runtime, "model": model}
 
 
+def _with_reason(message, supervisor):
+    """Append the generator's own last words to a failure message."""
+    tail = ""
+    reader = getattr(supervisor, "output_tail", None)
+    if callable(reader):
+        try:
+            tail = reader()
+        except Exception:
+            tail = ""
+    return "%s (%s)" % (message, tail) if tail else message
+
+
 def install_plan(catalogue, tier_key, arch, base_dir=None,
                  runtime_override=""):
     """Describe what still has to be downloaded before a room can talk."""
@@ -307,7 +319,11 @@ class BotChatPanel(object):
             if not supervisor.start():
                 raise RuntimeError("the inference program did not start")
             if not supervisor.wait_ready(timeout=CHECK_TIMEOUT_SECONDS):
-                raise RuntimeError("the model did not finish loading")
+                # Whatever the generator printed before dying is the only
+                # thing that explains this, so it goes in front of the
+                # player rather than only into a log file.
+                raise RuntimeError(_with_reason(
+                    "the model did not finish loading", supervisor))
             backend = runtime.LlamaChatBackend(supervisor.endpoint,
                                                log=self._log)
             backend.start()

--- a/launcher/bot_chat_ui.py
+++ b/launcher/bot_chat_ui.py
@@ -29,6 +29,17 @@ STATE_READY = "ready"
 STATE_WORKING = "working"
 STATE_UNSUPPORTED = "unsupported"
 
+# What a self test found, if one has run. Installed files only prove that
+# bytes are on disk; a machine still has to be able to load the model and
+# produce a line.
+CHECK_UNKNOWN = "unknown"
+CHECK_RUNNING = "running"
+CHECK_PASSED = "passed"
+CHECK_FAILED = "failed"
+
+CHECK_PROMPT = "\u8bf4\u4e00\u53e5\u8bdd"
+CHECK_TIMEOUT_SECONDS = 180.0
+
 # The progress bar's own scale. A byte count would overflow a Tk integer on
 # a large model, and a fraction of a thousand is finer than the eye.
 PROGRESS_STEPS = 1000
@@ -114,6 +125,7 @@ class BotChatPanel(object):
         self._thread = None
         self._working = False
         self._cancel = threading.Event()
+        self.check_timeout = CHECK_TIMEOUT_SECONDS
         self._build(parent)
         self.refresh()
 
@@ -184,6 +196,10 @@ class BotChatPanel(object):
         self.remove_button = tk.Button(parent, text="", command=self.remove)
         self.remove_button.grid(row=6, column=2, sticky="we", pady=(6, 0),
                                 padx=(6, 0))
+        self.check_button = tk.Button(parent, text="",
+                                      command=self.start_check)
+        self.check_button.grid(row=7, column=0, columnspan=3, sticky="we",
+                               pady=(6, 0))
         parent.grid_columnconfigure(1, weight=1)
 
     # -- settings -------------------------------------------------------
@@ -229,6 +245,122 @@ class BotChatPanel(object):
                             self._base_dir, self.runtime_override.get())
 
     # -- install --------------------------------------------------------
+
+    def enabled_and_ready(self):
+        """Return whether a room started now would really have chat.
+
+        Installed files are not the same thing as a switched-on feature, and
+        saying otherwise is what makes a silent battle baffling.
+        """
+        return bool(self.enabled.get()) and self.state() == STATE_READY
+
+    def check_state(self):
+        return getattr(self, "_check_state", CHECK_UNKNOWN)
+
+    def check_line(self):
+        """Return the line the self test produced, if it produced one."""
+        return getattr(self, "_check_line", None)
+
+    def check_error(self):
+        return getattr(self, "_check_error", None)
+
+    def start_check(self, runtime=None):
+        """Prove this machine can load the model and write one line."""
+        if self.busy() or self.state() != STATE_READY:
+            return False
+        runtime = runtime or self._runtime_module()
+        if runtime is None:
+            return False
+        self._working = True
+        self._check_state = CHECK_RUNNING
+        self._check_error = None
+        self._check_line = None
+        self._set_working()
+        self._thread = threading.Thread(
+            target=self._check, args=(runtime,), name="bot-chat-check",
+            daemon=True)
+        self._thread.start()
+        self._on_start()
+        return True
+
+    def _runtime_module(self):
+        try:
+            from . import core
+        except ImportError:
+            try:
+                import core
+            except ImportError:
+                return None
+        try:
+            return core.bot_chat_runtime()
+        except Exception as error:
+            self._log("BOT CHAT self test is unavailable: %s" % error)
+            return None
+
+    def _check(self, runtime):
+        paths = resolved_paths(self._catalogue, self.tier_key(),
+                               self._base_dir, self.runtime_override.get())
+        supervisor = runtime.LlamaServerSupervisor(
+            paths["runtime"], paths["model"], log=self._log)
+        backend = None
+        try:
+            if not supervisor.start():
+                raise RuntimeError("the inference program did not start")
+            if not supervisor.wait_ready(timeout=CHECK_TIMEOUT_SECONDS):
+                raise RuntimeError("the model did not finish loading")
+            backend = runtime.LlamaChatBackend(supervisor.endpoint,
+                                               log=self._log)
+            backend.start()
+            request = self._check_request()
+            backend.prefetch(request)
+            line = self._await_line(backend, request,
+                                    timeout=self.check_timeout)
+            if not line:
+                raise RuntimeError("the model produced no usable line")
+            self._check_line = line
+            self._check_state = CHECK_PASSED
+            self._check_error = None
+        except Exception as error:
+            self._check_state = CHECK_FAILED
+            self._check_error = str(error)
+        finally:
+            if backend is not None:
+                backend.stop()
+            supervisor.stop()
+            self._working = False
+            self.refresh()
+            self._on_change()
+
+    def _check_request(self):
+        import random
+
+        return {
+            "request_id": 1,
+            "trigger": "reply",
+            "persona": "plain",
+            "address_kind": "none",
+            "address_prefix": None,
+            "ask": None,
+            "asked_by": None,
+            "speaker": {"name": "Peng"},
+            "bot": {"id": 1, "name": "\u4eca\u5929\u4e0d\u52a0\u73ed",
+                    "vehicle": "ussr:R04_T-34", "hp": 400, "max_hp": 400},
+            "recent": [{"name": "Peng", "text": CHECK_PROMPT}],
+            "recent_texts": [],
+            "rng": random.Random(1),
+        }
+
+    @staticmethod
+    def _await_line(backend, request, timeout=CHECK_TIMEOUT_SECONDS):
+        import time
+
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            line = backend.compose(request)
+            if line:
+                return line
+            time.sleep(0.1)
+        return None
 
     def busy(self):
         """Return whether an install is in flight.
@@ -337,6 +469,10 @@ class BotChatPanel(object):
         self.install_button.config(state="disabled" if working else "normal")
         self.stop_button.config(state="normal" if working else "disabled")
         self.remove_button.config(state="disabled" if working else "normal")
+        # Nothing to test until both halves are actually installed.
+        self.check_button.config(
+            state="normal" if (not working and self._state == STATE_READY)
+            else "disabled")
 
     def _finish(self, error, cancelled=False):
         self._working = False
@@ -377,6 +513,9 @@ class BotChatPanel(object):
         self._stage_name = None
         self._error = None
         self._cancelled = False
+        self._check_state = CHECK_UNKNOWN
+        self._check_line = None
+        self._check_error = None
         self.refresh()
         self._on_change()
         return removed

--- a/launcher/bot_chat_ui.py
+++ b/launcher/bot_chat_ui.py
@@ -29,6 +29,10 @@ STATE_READY = "ready"
 STATE_WORKING = "working"
 STATE_UNSUPPORTED = "unsupported"
 
+# The progress bar's own scale. A byte count would overflow a Tk integer on
+# a large model, and a fraction of a thousand is finer than the eye.
+PROGRESS_STEPS = 1000
+
 
 def tier_labels(catalogue):
     """Return one selectable label per catalogued model, and its key."""
@@ -94,12 +98,16 @@ class BotChatPanel(object):
     """Drive one install from the launcher window without blocking it."""
 
     def __init__(self, parent, catalogue, tk_module, ttk_module, settings,
-                 on_change=None, log=None, base_dir=None, machine=None):
+                 on_change=None, log=None, base_dir=None, machine=None,
+                 on_start=None):
         self._tk = tk_module
         self._ttk = ttk_module
         self._catalogue = catalogue
         self._settings = settings
         self._on_change = on_change or (lambda: None)
+        # The window starts reading progress when a download starts, and
+        # stops when it ends, rather than polling an idle panel forever.
+        self._on_start = on_start or (lambda: None)
         self._log = log or (lambda unused: None)
         self._base_dir = base_dir
         self._arch = bot_chat_install.machine_architecture(catalogue, machine)
@@ -149,23 +157,32 @@ class BotChatPanel(object):
         self.runtime_browse.grid(row=2, column=2, sticky="w", padx=(6, 0))
 
         self.progress = self._ttk.Progressbar(
-            parent, orient="horizontal", mode="determinate", maximum=1000)
+            parent, orient="horizontal", mode="determinate",
+            maximum=PROGRESS_STEPS)
         self.progress.grid(row=3, column=0, columnspan=3, sticky="we",
                            pady=(8, 0))
         self.status = tk.StringVar(value="")
         self.status_label = tk.Label(parent, textvariable=self.status,
                                      anchor="w", justify="left")
         self.status_label.grid(row=4, column=0, columnspan=3, sticky="we")
+        # A player about to spend hundreds of megabytes should be able to see
+        # where they are going before deciding, and what Remove will delete.
+        self.location = tk.StringVar(value=bot_chat_install.install_root(
+            self._base_dir))
+        self.location_entry = tk.Entry(
+            parent, textvariable=self.location, state="readonly",
+            relief="flat", borderwidth=0, highlightthickness=0)
+        self.location_entry.grid(row=5, column=0, columnspan=3, sticky="we")
 
         self.install_button = tk.Button(parent, text="",
                                         command=self.start_install)
-        self.install_button.grid(row=5, column=0, sticky="we", pady=(6, 0))
+        self.install_button.grid(row=6, column=0, sticky="we", pady=(6, 0))
         self.stop_button = tk.Button(parent, text="", command=self.stop,
                                      state="disabled")
-        self.stop_button.grid(row=5, column=1, sticky="we", pady=(6, 0),
+        self.stop_button.grid(row=6, column=1, sticky="we", pady=(6, 0),
                               padx=(6, 0))
         self.remove_button = tk.Button(parent, text="", command=self.remove)
-        self.remove_button.grid(row=5, column=2, sticky="we", pady=(6, 0),
+        self.remove_button.grid(row=6, column=2, sticky="we", pady=(6, 0),
                                 padx=(6, 0))
         parent.grid_columnconfigure(1, weight=1)
 
@@ -241,6 +258,7 @@ class BotChatPanel(object):
             target=self._install, args=(self.tier_key(), opener),
             name="bot-chat-install", daemon=True)
         self._thread.start()
+        self._on_start()
         return True
 
     def stop(self):
@@ -274,10 +292,26 @@ class BotChatPanel(object):
 
     def _stage(self, name):
         self._stage_name = name
+        self._last_progress = (0, 0)
         self._log("BOT CHAT downloading %s" % name)
+
+    def stage(self):
+        """Return which half is downloading, for the status line."""
+        return getattr(self, "_stage_name", None)
 
     def _progress(self, done, total):
         self._last_progress = (done, total)
+
+    def apply_progress(self):
+        """Push the worker's latest count onto the bar.
+
+        The download runs on a worker thread, which must not touch Tk. The
+        window polls this instead, which is also why the bar exists at all:
+        without it a six hundred megabyte download looked like a frozen
+        panel.
+        """
+        self.progress.config(
+            value=int(round(self.progress_fraction() * PROGRESS_STEPS)))
 
     def progress_text(self):
         done, total = getattr(self, "_last_progress", (0, 0))
@@ -340,6 +374,9 @@ class BotChatPanel(object):
             return False
         removed = bot_chat_install.remove_installation(self._base_dir)
         self._last_progress = (0, 0)
+        self._stage_name = None
+        self._error = None
+        self._cancelled = False
         self.refresh()
         self._on_change()
         return removed

--- a/launcher/core.py
+++ b/launcher/core.py
@@ -74,6 +74,9 @@ WORKER_READY_MARKER_ENV_0922 = "OFFLINE_LAN_0922_WORKER_READY_MARKER"
 WORKER_STARTER_FILENAME_0922 = "offline_worker_starter.exe"
 WORKER_READY_MARKER_FILENAME_0922 = "offline-worker.ready"
 WORKER_FAILURE_LOG_FILENAME_0922 = "offline-worker-starter.log"
+SERVER_BOT_CHAT_RUNTIME_ENV_0922 = "WOT_BOT_CHAT_RUNTIME"
+SERVER_BOT_CHAT_MODEL_ENV_0922 = "WOT_BOT_CHAT_MODEL"
+
 SERVER_LOG_FILENAME = "server.log"
 LAUNCHER_LOG_FILENAME = "launcher.log"
 BUILD_IDENTITY_FILENAME_0922 = "build_identity.json"
@@ -1531,7 +1534,8 @@ def server_argv(port_version, base_dir=None):
 
 def server_environment(port_version, game_root, environment=None,
                        team_size=DEFAULT_TEAM_SIZE, loopback_only=False,
-                       team1_size=None, team2_size=None, bot_lineup=None):
+                       team1_size=None, team2_size=None, bot_lineup=None,
+                       bot_chat=None):
     """Build the endpoint and roster environment for one LAN server."""
     environment = dict(os.environ if environment is None else environment)
     if port_version == PORT_0_9_22:
@@ -1553,7 +1557,44 @@ def server_environment(port_version, game_root, environment=None,
             environment[SERVER_LOOPBACK_ONLY_ENV_0922] = "1"
         else:
             environment.pop(SERVER_LOOPBACK_ONLY_ENV_0922, None)
+        _apply_bot_chat_environment(environment, bot_chat)
     return environment
+
+
+def _apply_bot_chat_environment(environment, bot_chat):
+    """Name the optional chat model, or make sure no stale one is named.
+
+    Both halves must be present. Naming one alone would start a room that
+    reports a disabled feature every time it looks for the other.
+    """
+    runtime = str((bot_chat or {}).get("runtime") or "")
+    model = str((bot_chat or {}).get("model") or "")
+    if (runtime and model and os.path.isfile(runtime) and
+            os.path.isfile(model)):
+        environment[SERVER_BOT_CHAT_RUNTIME_ENV_0922] = runtime
+        environment[SERVER_BOT_CHAT_MODEL_ENV_0922] = model
+        return
+    environment.pop(SERVER_BOT_CHAT_RUNTIME_ENV_0922, None)
+    environment.pop(SERVER_BOT_CHAT_MODEL_ENV_0922, None)
+
+
+def bot_chat_catalogue(port_version=PORT_0_9_22, base_dir=None):
+    """Import the pinned model catalogue the bundled server carries.
+
+    The launcher downloads what the server will load, so both must read one
+    catalogue. The server payload already reaches this process through
+    ``sys.path`` when a room runs in it; this makes the same directory
+    importable before any room exists.
+    """
+    script = server_script(port_version, base_dir)
+    if script is None:
+        raise LauncherError("Unknown client port: %s" % port_version)
+    directory = os.path.dirname(script)
+    if directory not in sys.path:
+        sys.path.insert(0, directory)
+    import bot_chat_models
+
+    return bot_chat_models
 
 
 def server_child_command(port_version, launcher_script=None, executable=None,

--- a/launcher/core.py
+++ b/launcher/core.py
@@ -1597,6 +1597,19 @@ def bot_chat_catalogue(port_version=PORT_0_9_22, base_dir=None):
     return bot_chat_models
 
 
+def bot_chat_runtime(port_version=PORT_0_9_22, base_dir=None):
+    """Import the server's generator module so the launcher can test it.
+
+    Proving that a machine can actually produce a line is the only honest
+    way to call an install ready. Reusing the server's own supervisor and
+    backend means the launcher tests the thing a room will really run.
+    """
+    bot_chat_catalogue(port_version, base_dir)
+    import bot_chat_llm
+
+    return bot_chat_llm
+
+
 def server_child_command(port_version, launcher_script=None, executable=None,
                          frozen=None):
     """Build the command that runs one server in a child of this launcher."""

--- a/launcher/server_imports.py
+++ b/launcher/server_imports.py
@@ -19,6 +19,7 @@ import json
 import math
 import os
 import pickle
+import platform
 import random
 import re
 import socket
@@ -31,6 +32,8 @@ import traceback
 import types
 import typing
 import unicodedata
+import urllib.error
+import urllib.request
 import uuid
 import weakref
 import zlib
@@ -49,6 +52,7 @@ SERVER_STDLIB_MODULES = (
     math.__name__,
     os.__name__,
     pickle.__name__,
+    platform.__name__,
     random.__name__,
     re.__name__,
     socket.__name__,
@@ -61,6 +65,7 @@ SERVER_STDLIB_MODULES = (
     types.__name__,
     typing.__name__,
     unicodedata.__name__,
+    urllib.__name__,
     uuid.__name__,
     weakref.__name__,
     zlib.__name__,

--- a/launcher/stage_payload.py
+++ b/launcher/stage_payload.py
@@ -16,6 +16,8 @@ CLIENT_DIR = "client"
 PAYLOAD_FILES = {
     "0.9.22": (
         "server/bot_chat.py",
+        "server/bot_chat_llm.py",
+        "server/bot_chat_models.py",
         "server/lan_battle_server.py",
         "server/offline_rewards.py",
         "server/server_bot_ai.py",

--- a/launcher/tests/test_bot_chat_install.py
+++ b/launcher/tests/test_bot_chat_install.py
@@ -1,0 +1,504 @@
+import hashlib
+import io
+import os
+from pathlib import Path
+import shutil
+import sys
+import tempfile
+import unittest
+import zipfile
+
+
+LAUNCHER_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(LAUNCHER_ROOT))
+
+import bot_chat_install as install  # noqa: E402
+import core  # noqa: E402
+
+
+PAYLOAD = b"".join(bytes([index % 251]) for index in range(4096))
+DIGEST = hashlib.sha256(PAYLOAD).hexdigest()
+ENTRY = {"file": "model.gguf", "size": len(PAYLOAD), "sha256": DIGEST}
+
+
+class _Response(object):
+    """The subset of a urlopen result the installer actually uses."""
+
+    def __init__(self, payload, status=200):
+        self._stream = io.BytesIO(payload)
+        self.status = status
+        self.closed = False
+
+    def read(self, size=-1):
+        return self._stream.read(size)
+
+    def close(self):
+        self.closed = True
+
+
+class _Host(object):
+    """Serve one payload, honouring or refusing range requests."""
+
+    def __init__(self, payload=PAYLOAD, honour_range=True, fail=None,
+                 truncate_at=None, extra=b""):
+        self.payload = payload
+        self.honour_range = honour_range
+        self.fail = fail
+        self.truncate_at = truncate_at
+        self.extra = extra
+        self.requests = []
+        self.responses = []
+
+    def __call__(self, request, timeout=None):
+        header = request.get_header("Range") or ""
+        self.requests.append(header)
+        if self.fail is not None:
+            raise self.fail
+        offset = 0
+        if header.startswith("bytes=") and self.honour_range:
+            offset = int(header[len("bytes="):].rstrip("-"))
+            body = self.payload[offset:] + self.extra
+            response = _Response(body, status=206)
+        else:
+            body = self.payload + self.extra
+            response = _Response(body, status=200)
+        if self.truncate_at is not None:
+            response = _Response(body[:self.truncate_at],
+                                 status=response.status)
+        self.responses.append(response)
+        return response
+
+
+class _Catalogue(object):
+    """A stand-in for the server's pinned catalogue."""
+
+    MODELSCOPE = "modelscope"
+    HUGGINGFACE = "huggingface"
+    GITHUB = "github"
+    SOURCES = (MODELSCOPE, HUGGINGFACE)
+    MODEL_TIERS = ({"key": "tiny", **ENTRY},)
+    RUNTIME_ASSETS = {"x64": {"file": "runtime.zip"}}
+
+    def __init__(self, runtime_entry=None):
+        self.runtime_entry = runtime_entry
+
+    def tier(self, key):
+        return dict(ENTRY, key="tiny") if key == "tiny" else None
+
+    def model_url(self, key, source):
+        return None if self.tier(key) is None else "https://%s/%s" % (
+            source, ENTRY["file"])
+
+    def runtime_asset(self, arch):
+        return dict(self.runtime_entry) if (
+            arch == "x64" and self.runtime_entry) else None
+
+    def runtime_sources(self, arch):
+        return (self.MODELSCOPE, self.GITHUB) if arch == "x64" else ()
+
+    def runtime_url(self, arch, source=None):
+        if self.runtime_asset(arch) is None:
+            return None
+        return "https://%s/%s" % (source or self.MODELSCOPE,
+                                  self.runtime_entry["file"])
+
+    @staticmethod
+    def runtime_arch(machine):
+        return "x64" if str(machine).lower() in ("amd64", "x86_64") else None
+
+
+def _read(path):
+    with open(path, 'rb') as stream:
+        return stream.read()
+
+
+def _runtime_zip(members):
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as bundle:
+        for name, payload in members:
+            bundle.writestr(name, payload)
+    return buffer.getvalue()
+
+
+class _Temp(unittest.TestCase):
+    def setUp(self):
+        self.base = tempfile.mkdtemp(prefix="bot-chat-test-")
+        self.addCleanup(shutil.rmtree, self.base, ignore_errors=True)
+
+    def _destination(self, name="model.gguf"):
+        return os.path.join(install.install_root(self.base), name)
+
+
+class PathTest(_Temp):
+    def test_everything_lives_under_one_removable_directory(self):
+        root = install.install_root(self.base)
+        self.assertTrue(install.model_path(ENTRY, self.base).startswith(root))
+        self.assertTrue(install.runtime_executable(
+            self.base).startswith(root))
+
+    def test_the_generator_is_named_by_the_installer(self):
+        self.assertTrue(install.runtime_executable(self.base).endswith(
+            'llama-server.exe'))
+
+
+class DigestTest(_Temp):
+    def _write(self, payload):
+        path = self._destination()
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, 'wb') as stream:
+            stream.write(payload)
+        return path
+
+    def test_a_matching_file_is_installed(self):
+        self.assertTrue(install.is_installed(self._write(PAYLOAD), ENTRY))
+
+    def test_a_short_file_is_rejected_without_hashing(self):
+        self.assertFalse(install.is_installed(self._write(PAYLOAD[:-1]),
+                                              ENTRY))
+
+    def test_a_same_length_different_file_is_rejected(self):
+        corrupt = bytearray(PAYLOAD)
+        corrupt[7] ^= 0xFF
+        self.assertFalse(install.is_installed(self._write(bytes(corrupt)),
+                                              ENTRY))
+
+    def test_a_missing_file_is_not_installed(self):
+        self.assertFalse(install.is_installed(
+            os.path.join(self.base, 'absent'), ENTRY))
+
+    def test_hashing_can_be_cancelled(self):
+        path = self._write(PAYLOAD)
+        self.assertRaises(install.InstallCancelled, install.file_digest,
+                          path, lambda: True)
+
+
+class DownloadTest(_Temp):
+    def test_a_fresh_download_is_verified_and_placed(self):
+        host = _Host()
+        path = install.download_file('https://host/f', self._destination(),
+                                     ENTRY, opener=host)
+        self.assertEqual(PAYLOAD, _read(path))
+        self.assertEqual([''], host.requests)
+        self.assertFalse(os.path.exists(path + install.PART_SUFFIX))
+
+    def test_progress_reaches_the_declared_total(self):
+        seen = []
+        install.download_file('https://host/f', self._destination(), ENTRY,
+                              progress=lambda done, total: seen.append(
+                                  (done, total)),
+                              opener=_Host())
+        self.assertEqual((0, ENTRY['size']), seen[0])
+        self.assertEqual((ENTRY['size'], ENTRY['size']), seen[-1])
+        self.assertEqual(sorted(done for done, unused in seen),
+                         [done for done, unused in seen])
+
+    def test_a_partial_file_is_resumed_rather_than_restarted(self):
+        destination = self._destination()
+        os.makedirs(os.path.dirname(destination), exist_ok=True)
+        with open(destination + install.PART_SUFFIX, 'wb') as stream:
+            stream.write(PAYLOAD[:1000])
+        host = _Host()
+        path = install.download_file('https://host/f', destination, ENTRY,
+                                     opener=host)
+        self.assertEqual(PAYLOAD, _read(path))
+        self.assertEqual(['bytes=1000-'], host.requests)
+
+    def test_a_host_that_ignores_range_restarts_cleanly(self):
+        destination = self._destination()
+        os.makedirs(os.path.dirname(destination), exist_ok=True)
+        with open(destination + install.PART_SUFFIX, 'wb') as stream:
+            stream.write(PAYLOAD[:1000])
+        host = _Host(honour_range=False)
+        path = install.download_file('https://host/f', destination, ENTRY,
+                                     opener=host)
+        self.assertEqual(PAYLOAD, _read(path))
+
+    def test_a_partial_file_longer_than_the_real_one_is_discarded(self):
+        destination = self._destination()
+        os.makedirs(os.path.dirname(destination), exist_ok=True)
+        with open(destination + install.PART_SUFFIX, 'wb') as stream:
+            stream.write(PAYLOAD + b'junk')
+        host = _Host()
+        install.download_file('https://host/f', destination, ENTRY,
+                              opener=host)
+        self.assertEqual([''], host.requests)
+
+    def test_a_complete_partial_file_is_only_verified(self):
+        destination = self._destination()
+        os.makedirs(os.path.dirname(destination), exist_ok=True)
+        with open(destination + install.PART_SUFFIX, 'wb') as stream:
+            stream.write(PAYLOAD)
+        host = _Host()
+        install.download_file('https://host/f', destination, ENTRY,
+                              opener=host)
+        self.assertEqual([], host.requests)
+
+    def test_a_wrong_checksum_installs_nothing(self):
+        host = _Host(payload=bytes(len(PAYLOAD)))
+        destination = self._destination()
+        self.assertRaises(install.InstallError, install.download_file,
+                          'https://host/f', destination, ENTRY,
+                          opener=host)
+        self.assertFalse(os.path.exists(destination))
+
+    def test_a_truncated_response_keeps_the_partial_file_for_resume(self):
+        destination = self._destination()
+        host = _Host(truncate_at=1000)
+        self.assertRaises(install.InstallError, install.download_file,
+                          'https://host/f', destination, ENTRY, opener=host)
+        part = destination + install.PART_SUFFIX
+        self.assertTrue(os.path.isfile(part))
+        self.assertEqual(1000, os.path.getsize(part))
+
+    def test_a_host_sending_far_too_much_is_refused(self):
+        host = _Host(extra=b'x' * (install.SIZE_SLACK_BYTES + 16))
+        self.assertRaises(install.InstallError, install.download_file,
+                          'https://host/f', self._destination(), ENTRY,
+                          opener=host)
+
+    def test_a_transport_failure_becomes_an_install_error(self):
+        host = _Host(fail=OSError('connection refused'))
+        self.assertRaises(install.InstallError, install.download_file,
+                          'https://host/f', self._destination(), ENTRY,
+                          opener=host)
+
+    def test_a_cancel_stops_within_a_chunk_and_keeps_progress(self):
+        destination = self._destination()
+        calls = []
+
+        def cancel():
+            calls.append(1)
+            return len(calls) > 2
+
+        big = _Host(payload=PAYLOAD)
+        self.assertRaises(install.InstallCancelled, install.download_file,
+                          'https://host/f', destination, ENTRY,
+                          cancel=cancel, opener=big)
+        self.assertFalse(os.path.exists(destination))
+
+    def test_the_response_is_always_closed(self):
+        host = _Host()
+        install.download_file('https://host/f', self._destination(), ENTRY,
+                              opener=host)
+        self.assertTrue(all(r.closed for r in host.responses))
+
+
+class SourceFallbackTest(_Temp):
+    def test_a_dead_first_host_falls_through_to_the_second(self):
+        catalogue = _Catalogue()
+        attempts = []
+
+        def opener(request, timeout=None):
+            attempts.append(request.full_url)
+            if 'modelscope' in request.full_url:
+                raise OSError('unreachable')
+            return _Host()(request, timeout)
+
+        path = install.install_model(catalogue, 'tiny', self.base,
+                                     opener=opener)
+        self.assertEqual(PAYLOAD, _read(path))
+        self.assertEqual(2, len(attempts))
+        self.assertIn('modelscope', attempts[0])
+
+    def test_every_host_failing_reports_the_first_failure(self):
+        catalogue = _Catalogue()
+
+        def opener(request, timeout=None):
+            raise OSError('unreachable')
+
+        with self.assertRaises(install.InstallError) as caught:
+            install.install_model(catalogue, 'tiny', self.base, opener=opener)
+        self.assertIn('modelscope', str(caught.exception))
+
+    def test_a_cancel_does_not_try_the_next_host(self):
+        catalogue = _Catalogue()
+        attempts = []
+
+        def opener(request, timeout=None):
+            attempts.append(request.full_url)
+            return _Host()(request, timeout)
+
+        self.assertRaises(install.InstallCancelled, install.install_model,
+                          catalogue, 'tiny', self.base, cancel=lambda: True,
+                          opener=opener)
+        self.assertEqual([], attempts)
+
+    def test_an_unknown_model_is_refused(self):
+        self.assertRaises(install.InstallError, install.install_model,
+                          _Catalogue(), 'enormous', self.base)
+
+    def test_an_installed_model_is_not_downloaded_again(self):
+        catalogue = _Catalogue()
+        attempts = []
+
+        def opener(request, timeout=None):
+            attempts.append(request.full_url)
+            return _Host()(request, timeout)
+
+        install.install_model(catalogue, 'tiny', self.base, opener=opener)
+        install.install_model(catalogue, 'tiny', self.base, opener=opener)
+        self.assertEqual(1, len(attempts))
+
+
+class RuntimeTest(_Temp):
+    def _catalogue(self, members=None):
+        members = members or (
+            ('llama-server.exe', b'MZ server'),
+            ('ggml-base.dll', b'MZ ggml'),
+            ('llama-cli.exe', b'MZ unwanted tool'),
+            ('rpc-server.exe', b'MZ unwanted tool'),
+        )
+        archive = _runtime_zip(members)
+        entry = {'file': 'runtime.zip', 'size': len(archive),
+                 'sha256': hashlib.sha256(archive).hexdigest()}
+        return _Catalogue(runtime_entry=entry), archive
+
+    def test_only_the_generator_and_its_libraries_are_installed(self):
+        catalogue, archive = self._catalogue()
+        path = install.install_runtime(catalogue, 'x64', self.base,
+                                       opener=_Host(payload=archive))
+        root = install.runtime_root(self.base)
+        self.assertTrue(os.path.isfile(path))
+        self.assertEqual({'llama-server.exe', 'ggml-base.dll'},
+                         set(os.listdir(root)))
+
+    def test_the_archive_is_removed_once_unpacked(self):
+        catalogue, archive = self._catalogue()
+        install.install_runtime(catalogue, 'x64', self.base,
+                                opener=_Host(payload=archive))
+        self.assertNotIn('runtime.zip',
+                         os.listdir(install.runtime_root(self.base)))
+
+    def test_an_archive_without_the_generator_is_refused(self):
+        catalogue, archive = self._catalogue(
+            members=(('ggml-base.dll', b'MZ ggml'),))
+        self.assertRaises(install.InstallError, install.install_runtime,
+                          catalogue, 'x64', self.base,
+                          opener=_Host(payload=archive))
+
+    def test_a_member_naming_a_path_is_refused(self):
+        catalogue, archive = self._catalogue(
+            members=(('llama-server.exe', b'MZ'),
+                     ('../escape.dll', b'MZ')))
+        self.assertRaises(install.InstallError, install.install_runtime,
+                          catalogue, 'x64', self.base,
+                          opener=_Host(payload=archive))
+
+    def test_an_installed_runtime_is_not_downloaded_again(self):
+        catalogue, archive = self._catalogue()
+        attempts = []
+
+        def opener(request, timeout=None):
+            attempts.append(request.full_url)
+            return _Host(payload=archive)(request, timeout)
+
+        install.install_runtime(catalogue, 'x64', self.base, opener=opener)
+        install.install_runtime(catalogue, 'x64', self.base, opener=opener)
+        self.assertEqual(1, len(attempts))
+
+    def test_a_machine_with_no_published_runtime_is_told_so(self):
+        catalogue, unused = self._catalogue()
+        self.assertRaises(install.InstallError, install.install_runtime,
+                          catalogue, 'arm64', self.base)
+
+
+class StateTest(_Temp):
+    def test_nothing_installed_is_not_ready(self):
+        state = install.installation_state(_Catalogue(), 'tiny', 'x64',
+                                           self.base)
+        self.assertFalse(state['ready'])
+        self.assertFalse(state['model_present'])
+        self.assertFalse(state['runtime_present'])
+
+    def test_both_halves_present_is_ready(self):
+        catalogue, archive = RuntimeTest()._catalogue()
+        install.install_model(catalogue, 'tiny', self.base, opener=_Host())
+        install.install_runtime(catalogue, 'x64', self.base,
+                                opener=_Host(payload=archive))
+        state = install.installation_state(catalogue, 'tiny', 'x64',
+                                           self.base)
+        self.assertTrue(state['ready'])
+
+    def test_one_half_alone_is_not_ready(self):
+        catalogue = _Catalogue()
+        install.install_model(catalogue, 'tiny', self.base, opener=_Host())
+        state = install.installation_state(catalogue, 'tiny', 'x64',
+                                           self.base)
+        self.assertTrue(state['model_present'])
+        self.assertFalse(state['ready'])
+
+    def test_removal_deletes_everything_downloaded(self):
+        install.install_model(_Catalogue(), 'tiny', self.base, opener=_Host())
+        self.assertTrue(install.remove_installation(self.base))
+        self.assertFalse(os.path.isdir(install.install_root(self.base)))
+        self.assertFalse(install.remove_installation(self.base))
+
+
+class MachineTest(unittest.TestCase):
+    def test_the_architecture_comes_from_the_catalogue(self):
+        self.assertEqual('x64', install.machine_architecture(
+            _Catalogue(), 'AMD64'))
+        self.assertIsNone(install.machine_architecture(_Catalogue(), 'x86'))
+
+    def test_sizes_read_as_sizes(self):
+        self.assertEqual('512 B', install.format_bytes(512))
+        self.assertEqual('1.0 KB', install.format_bytes(1024))
+        self.assertEqual('610.0 MB', install.format_bytes(610 * 1024 * 1024))
+
+
+class CatalogueBridgeTest(unittest.TestCase):
+    def test_the_launcher_reads_the_server_catalogue(self):
+        catalogue = core.bot_chat_catalogue()
+        self.assertTrue(catalogue.MODEL_TIERS)
+        self.assertIn(catalogue.DEFAULT_TIER_KEY,
+                      [entry['key'] for entry in catalogue.MODEL_TIERS])
+        self.assertTrue(catalogue.RUNTIME_BUILD)
+
+
+class ServerEnvironmentTest(unittest.TestCase):
+    def setUp(self):
+        self.root = tempfile.mkdtemp(prefix='bot-chat-env-')
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+        self.runtime = os.path.join(self.root, 'llama-server.exe')
+        self.model = os.path.join(self.root, 'model.gguf')
+        for path in (self.runtime, self.model):
+            with open(path, 'wb') as stream:
+                stream.write(b'x')
+
+    def _environment(self, bot_chat):
+        return core.server_environment(
+            core.PORT_0_9_22, self.root, environment={},
+            bot_chat=bot_chat)
+
+    def test_both_halves_present_names_the_model(self):
+        environment = self._environment(
+            {'runtime': self.runtime, 'model': self.model})
+        self.assertEqual(
+            self.runtime,
+            environment[core.SERVER_BOT_CHAT_RUNTIME_ENV_0922])
+        self.assertEqual(
+            self.model, environment[core.SERVER_BOT_CHAT_MODEL_ENV_0922])
+
+    def test_a_missing_half_names_nothing(self):
+        for bot_chat in (None, {}, {'runtime': self.runtime},
+                         {'model': self.model},
+                         {'runtime': self.runtime,
+                          'model': os.path.join(self.root, 'absent.gguf')}):
+            environment = self._environment(bot_chat)
+            self.assertNotIn(core.SERVER_BOT_CHAT_RUNTIME_ENV_0922,
+                             environment, bot_chat)
+            self.assertNotIn(core.SERVER_BOT_CHAT_MODEL_ENV_0922,
+                             environment, bot_chat)
+
+    def test_a_stale_name_is_cleared_rather_than_inherited(self):
+        environment = core.server_environment(
+            core.PORT_0_9_22, self.root,
+            environment={core.SERVER_BOT_CHAT_RUNTIME_ENV_0922: 'old',
+                         core.SERVER_BOT_CHAT_MODEL_ENV_0922: 'old'},
+            bot_chat=None)
+        self.assertNotIn(core.SERVER_BOT_CHAT_RUNTIME_ENV_0922, environment)
+        self.assertNotIn(core.SERVER_BOT_CHAT_MODEL_ENV_0922, environment)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/launcher/tests/test_bot_chat_ui.py
+++ b/launcher/tests/test_bot_chat_ui.py
@@ -408,6 +408,125 @@ class ProgressReportingTest(_Temp):
         self.assertIsNone(panel.stage())
 
 
+class _FakeSupervisor(object):
+    def __init__(self, started=True, ready=True):
+        self.started = started
+        self.ready = ready
+        self.stopped = False
+        self.endpoint = "http://127.0.0.1:1"
+
+    def start(self):
+        return self.started
+
+    def wait_ready(self, timeout=None):
+        return self.ready
+
+    def stop(self):
+        self.stopped = True
+
+
+class _FakeBackend(object):
+    def __init__(self, line="收到"):
+        self.line = line
+        self.stopped = False
+
+    def start(self):
+        pass
+
+    def prefetch(self, request):
+        pass
+
+    def compose(self, request):
+        return self.line
+
+    def stop(self):
+        self.stopped = True
+
+
+class _FakeRuntime(object):
+    def __init__(self, supervisor=None, backend=None):
+        self.supervisor = supervisor or _FakeSupervisor()
+        self.backend = backend if backend is not None else _FakeBackend()
+
+    def LlamaServerSupervisor(self, executable, model, log=None):
+        return self.supervisor
+
+    def LlamaChatBackend(self, endpoint, log=None):
+        return self.backend
+
+
+class SelfTestTest(_Temp):
+    """Installed files are not proof; a machine has to produce a line."""
+
+    def _installed(self):
+        panel = _panel(self.base)
+        panel.start_install(opener=_opener())
+        self.assertTrue(_await(lambda: not panel.busy()))
+        panel.enabled.set(True)
+        return panel
+
+    def test_nothing_installed_cannot_be_tested(self):
+        panel = _panel(self.base)
+        self.assertFalse(panel.start_check(runtime=_FakeRuntime()))
+        self.assertEqual(ui.CHECK_UNKNOWN, panel.check_state())
+
+    def test_a_working_machine_reports_the_line_it_produced(self):
+        panel = self._installed()
+        runtime = _FakeRuntime()
+        self.assertTrue(panel.start_check(runtime=runtime))
+        self.assertTrue(_await(lambda: not panel.busy()))
+        self.assertEqual(ui.CHECK_PASSED, panel.check_state())
+        self.assertEqual("收到", panel.check_line())
+        self.assertTrue(runtime.supervisor.stopped)
+        self.assertTrue(runtime.backend.stopped)
+
+    def test_a_runtime_that_will_not_start_is_reported(self):
+        panel = self._installed()
+        runtime = _FakeRuntime(supervisor=_FakeSupervisor(started=False))
+        panel.start_check(runtime=runtime)
+        self.assertTrue(_await(lambda: not panel.busy()))
+        self.assertEqual(ui.CHECK_FAILED, panel.check_state())
+        self.assertIn("did not start", panel.check_error())
+
+    def test_a_model_that_never_loads_is_reported(self):
+        panel = self._installed()
+        runtime = _FakeRuntime(supervisor=_FakeSupervisor(ready=False))
+        panel.start_check(runtime=runtime)
+        self.assertTrue(_await(lambda: not panel.busy()))
+        self.assertEqual(ui.CHECK_FAILED, panel.check_state())
+        self.assertIn("finish loading", panel.check_error())
+
+    def test_a_model_that_writes_nothing_is_reported(self):
+        panel = self._installed()
+        runtime = _FakeRuntime(backend=_FakeBackend(line=None))
+        panel.check_timeout = 0.5
+        panel.start_check(runtime=runtime)
+        self.assertTrue(_await(lambda: not panel.busy(), timeout=30.0))
+        self.assertEqual(ui.CHECK_FAILED, panel.check_state())
+
+    def test_the_generator_is_always_stopped_afterwards(self):
+        panel = self._installed()
+        runtime = _FakeRuntime(supervisor=_FakeSupervisor(started=False))
+        panel.start_check(runtime=runtime)
+        self.assertTrue(_await(lambda: not panel.busy()))
+        self.assertTrue(runtime.supervisor.stopped)
+
+    def test_removing_clears_a_test_result(self):
+        panel = self._installed()
+        panel.start_check(runtime=_FakeRuntime())
+        self.assertTrue(_await(lambda: not panel.busy()))
+        panel.remove()
+        self.assertEqual(ui.CHECK_UNKNOWN, panel.check_state())
+        self.assertIsNone(panel.check_line())
+
+    def test_a_switched_off_install_is_not_a_working_feature(self):
+        panel = self._installed()
+        panel.enabled.set(False)
+        self.assertFalse(panel.enabled_and_ready())
+        panel.enabled.set(True)
+        self.assertTrue(panel.enabled_and_ready())
+
+
 class ResolvedPathTest(_Temp):
     def test_the_catalogue_model_is_named_for_the_selected_tier(self):
         catalogue = _Catalogue()

--- a/launcher/tests/test_bot_chat_ui.py
+++ b/launcher/tests/test_bot_chat_ui.py
@@ -1,0 +1,367 @@
+import hashlib
+import io
+import os
+from pathlib import Path
+import shutil
+import sys
+import tempfile
+import time
+import unittest
+import zipfile
+
+
+LAUNCHER_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(LAUNCHER_ROOT))
+
+import bot_chat_install as install  # noqa: E402
+import bot_chat_ui as ui  # noqa: E402
+
+
+MODEL_PAYLOAD = b"model" * 400
+RUNTIME_MEMBERS = (("llama-server.exe", b"MZ server"),
+                   ("ggml-base.dll", b"MZ ggml"))
+
+
+def _zip(members):
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as bundle:
+        for name, payload in members:
+            bundle.writestr(name, payload)
+    return buffer.getvalue()
+
+
+RUNTIME_PAYLOAD = _zip(RUNTIME_MEMBERS)
+
+
+def _entry(name, payload):
+    return {"file": name, "size": len(payload),
+            "sha256": hashlib.sha256(payload).hexdigest()}
+
+
+class _Catalogue(object):
+    MODELSCOPE = "modelscope"
+    HUGGINGFACE = "huggingface"
+    GITHUB = "github"
+    SOURCES = (MODELSCOPE, HUGGINGFACE)
+    DEFAULT_TIER_KEY = "small"
+    MODEL_TIERS = (
+        dict(_entry("small.gguf", MODEL_PAYLOAD), key="small",
+             parameters="0.6B", quantization="Q8_0", license="Apache-2.0"),
+        dict(_entry("big.gguf", MODEL_PAYLOAD + b"!"), key="big",
+             parameters="1.7B", quantization="Q8_0", license="Apache-2.0"),
+    )
+
+    def __init__(self, arch_supported=True):
+        self.arch_supported = arch_supported
+
+    def tier(self, key):
+        for entry in self.MODEL_TIERS:
+            if entry["key"] == key:
+                return dict(entry)
+        return None
+
+    def default_tier(self):
+        return self.tier(self.DEFAULT_TIER_KEY)
+
+    def model_url(self, key, source):
+        entry = self.tier(key)
+        return None if entry is None else "https://%s/%s" % (
+            source, entry["file"])
+
+    def runtime_asset(self, arch):
+        if arch != "x64" or not self.arch_supported:
+            return None
+        return dict(_entry("runtime.zip", RUNTIME_PAYLOAD))
+
+    def runtime_sources(self, arch):
+        return (self.MODELSCOPE, self.GITHUB) if self.runtime_asset(
+            arch) else ()
+
+    def runtime_url(self, arch, source=None):
+        if self.runtime_asset(arch) is None:
+            return None
+        return "https://%s/runtime.zip" % (source or self.MODELSCOPE)
+
+    @staticmethod
+    def runtime_arch(machine):
+        return "x64" if str(machine).lower() == "amd64" else None
+
+
+class _Response(object):
+    def __init__(self, payload):
+        self._stream = io.BytesIO(payload)
+        self.status = 200
+
+    def read(self, size=-1):
+        return self._stream.read(size)
+
+    def close(self):
+        pass
+
+
+def _opener(model_payload=MODEL_PAYLOAD, fail_urls=()):
+    def opener(request, timeout=None):
+        url = request.full_url
+        if any(token in url for token in fail_urls):
+            raise OSError("unreachable")
+        if "runtime.zip" in url:
+            return _Response(RUNTIME_PAYLOAD)
+        if "big.gguf" in url:
+            return _Response(MODEL_PAYLOAD + b"!")
+        return _Response(model_payload)
+    return opener
+
+
+class _Var(object):
+    def __init__(self, value=None):
+        self.value = value
+
+    def get(self):
+        return self.value
+
+    def set(self, value):
+        self.value = value
+
+
+class _Widget(object):
+    def __init__(self, *unused_args, **options):
+        self.options = dict(options)
+        self.gridded = None
+
+    def grid(self, **options):
+        self.gridded = options
+
+    def config(self, **options):
+        self.options.update(options)
+
+    def bind(self, *unused):
+        pass
+
+
+class _Tk(object):
+    BooleanVar = staticmethod(lambda value=False: _Var(bool(value)))
+    StringVar = staticmethod(lambda value="": _Var(value))
+    Label = _Widget
+    Entry = _Widget
+    Button = _Widget
+    Checkbutton = _Widget
+    Frame = _Widget
+
+
+class _Ttk(object):
+    Combobox = _Widget
+    Progressbar = _Widget
+
+
+class _Parent(_Widget):
+    def grid_columnconfigure(self, *unused, **unused_options):
+        pass
+
+
+def _panel(base, catalogue=None, settings=None, machine="AMD64"):
+    return ui.BotChatPanel(
+        _Parent(), catalogue or _Catalogue(), _Tk, _Ttk,
+        settings if settings is not None else {},
+        base_dir=base, machine=machine)
+
+
+def _await(predicate, timeout=20.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+class _Temp(unittest.TestCase):
+    def setUp(self):
+        self.base = tempfile.mkdtemp(prefix="bot-chat-ui-")
+        self.addCleanup(shutil.rmtree, self.base, ignore_errors=True)
+
+
+class LabelTest(unittest.TestCase):
+    def test_every_model_is_offered_with_its_download_size(self):
+        labels = ui.tier_labels(_Catalogue())
+        self.assertEqual(["small", "big"], [key for key, unused in labels])
+        self.assertIn("0.6B", labels[0][1])
+        self.assertIn("KB", labels[0][1])
+
+    def test_a_label_resolves_back_to_its_key(self):
+        catalogue = _Catalogue()
+        for key, text in ui.tier_labels(catalogue):
+            self.assertEqual(key, ui.key_for_label(catalogue, text))
+
+    def test_an_unknown_label_falls_back_to_the_default(self):
+        self.assertEqual("small", ui.key_for_label(_Catalogue(), "nonsense"))
+
+
+class PlanTest(_Temp):
+    def test_nothing_installed_needs_both_downloads(self):
+        catalogue = _Catalogue()
+        plan = ui.install_plan(catalogue, "small", "x64", self.base)
+        self.assertEqual(ui.STATE_ABSENT, plan["status"])
+        self.assertEqual(len(MODEL_PAYLOAD) + len(RUNTIME_PAYLOAD),
+                         plan["pending_bytes"])
+
+    def test_a_machine_with_no_runtime_is_reported_unsupported(self):
+        plan = ui.install_plan(_Catalogue(arch_supported=False), "small",
+                               None, self.base)
+        self.assertEqual(ui.STATE_UNSUPPORTED, plan["status"])
+
+    def test_an_existing_generator_satisfies_the_runtime(self):
+        existing = os.path.join(self.base, "llama-server.exe")
+        with open(existing, "wb") as stream:
+            stream.write(b"MZ")
+        plan = ui.install_plan(_Catalogue(), "small", "x64", self.base,
+                               runtime_override=existing)
+        self.assertTrue(plan["runtime_present"])
+        self.assertEqual(existing, plan["runtime"])
+        self.assertEqual(len(MODEL_PAYLOAD), plan["pending_bytes"])
+
+    def test_an_override_naming_nothing_is_ignored(self):
+        plan = ui.install_plan(_Catalogue(), "small", "x64", self.base,
+                               runtime_override="/nowhere/llama-server.exe")
+        self.assertFalse(plan["runtime_present"])
+
+
+class PanelTest(_Temp):
+    def test_a_fresh_panel_reports_nothing_installed(self):
+        panel = _panel(self.base)
+        self.assertEqual(ui.STATE_ABSENT, panel.state())
+        self.assertIsNone(panel.paths())
+
+    def test_installing_both_halves_makes_the_panel_ready(self):
+        panel = _panel(self.base)
+        self.assertTrue(panel.start_install(opener=_opener()))
+        self.assertTrue(_await(lambda: not panel.busy()))
+        self.assertIsNone(panel.last_error())
+        self.assertEqual(ui.STATE_READY, panel.state())
+
+    def test_a_ready_panel_names_both_paths_only_when_enabled(self):
+        settings = {}
+        panel = _panel(self.base, settings=settings)
+        panel.start_install(opener=_opener())
+        self.assertTrue(_await(lambda: not panel.busy()))
+        self.assertIsNone(panel.paths())
+        panel.enabled.set(True)
+        paths = panel.paths()
+        self.assertTrue(os.path.isfile(paths["runtime"]))
+        self.assertTrue(os.path.isfile(paths["model"]))
+
+    def test_the_enable_choice_is_remembered(self):
+        settings = {}
+        panel = _panel(self.base, settings=settings)
+        panel.enabled.set(True)
+        panel._enabled_changed()
+        self.assertTrue(settings[ui.ENABLED_SETTING])
+
+    def test_the_model_choice_is_remembered(self):
+        settings = {}
+        panel = _panel(self.base, settings=settings)
+        panel.model_choice.set(ui.tier_labels(_Catalogue())[1][1])
+        panel._model_changed()
+        self.assertEqual("big", settings[ui.TIER_SETTING])
+        self.assertEqual("big", panel.tier_key())
+
+    def test_a_remembered_model_is_selected_on_the_next_launch(self):
+        panel = _panel(self.base, settings={ui.TIER_SETTING: "big"})
+        self.assertEqual("big", panel.tier_key())
+
+    def test_a_failed_download_is_reported_and_installs_nothing(self):
+        panel = _panel(self.base)
+        panel.start_install(opener=_opener(fail_urls=("modelscope",
+                                                      "github",
+                                                      "huggingface")))
+        self.assertTrue(_await(lambda: not panel.busy()))
+        self.assertIsNotNone(panel.last_error())
+        self.assertEqual(ui.STATE_ABSENT, panel.state())
+
+    def test_a_second_install_is_refused_while_one_runs(self):
+        panel = _panel(self.base)
+        started = threading_gate()
+        panel.start_install(opener=started.opener)
+        self.assertFalse(panel.start_install(opener=_opener()))
+        started.release()
+        self.assertTrue(_await(lambda: not panel.busy()))
+
+    def test_stopping_keeps_what_was_downloaded(self):
+        panel = _panel(self.base)
+        gate = threading_gate(cancel_panel=panel)
+        panel.start_install(opener=gate.opener)
+        self.assertTrue(_await(lambda: not panel.busy()))
+        self.assertTrue(panel.was_cancelled())
+        self.assertIsNone(panel.last_error())
+
+    def test_removing_deletes_the_download(self):
+        panel = _panel(self.base)
+        panel.start_install(opener=_opener())
+        self.assertTrue(_await(lambda: not panel.busy()))
+        self.assertTrue(panel.remove())
+        self.assertEqual(ui.STATE_ABSENT, panel.state())
+
+    def test_an_unsupported_machine_never_starts_a_download(self):
+        panel = _panel(self.base, catalogue=_Catalogue(arch_supported=False),
+                       machine="x86")
+        self.assertFalse(panel.start_install(opener=_opener()))
+        self.assertEqual(ui.STATE_UNSUPPORTED, panel.state())
+
+    def test_progress_is_reportable_while_working(self):
+        panel = _panel(self.base)
+        panel.start_install(opener=_opener())
+        self.assertTrue(_await(lambda: not panel.busy()))
+        self.assertEqual(1.0, panel.progress_fraction())
+        self.assertIn("/", panel.progress_text())
+
+    def test_buttons_follow_the_working_state(self):
+        panel = _panel(self.base)
+        panel._set_working()
+        self.assertEqual("disabled", panel.install_button.options["state"])
+        self.assertEqual("normal", panel.stop_button.options["state"])
+        panel._set_status(ui.STATE_ABSENT)
+        self.assertEqual("normal", panel.install_button.options["state"])
+        self.assertEqual("disabled", panel.stop_button.options["state"])
+
+
+class _Gate(object):
+    """Hold one download open so a concurrent state can be observed."""
+
+    def __init__(self, cancel_panel=None):
+        self._release = False
+        self._cancel_panel = cancel_panel
+
+    def opener(self, request, timeout=None):
+        if self._cancel_panel is not None:
+            self._cancel_panel.stop()
+        while not self._release and self._cancel_panel is None:
+            time.sleep(0.005)
+        return _opener()(request, timeout)
+
+    def release(self):
+        self._release = True
+
+
+def threading_gate(cancel_panel=None):
+    return _Gate(cancel_panel)
+
+
+class ResolvedPathTest(_Temp):
+    def test_the_catalogue_model_is_named_for_the_selected_tier(self):
+        catalogue = _Catalogue()
+        paths = ui.resolved_paths(catalogue, "big", self.base)
+        self.assertTrue(paths["model"].endswith("big.gguf"))
+
+    def test_an_unknown_tier_falls_back_to_the_default_model(self):
+        paths = ui.resolved_paths(_Catalogue(), "gone", self.base)
+        self.assertTrue(paths["model"].endswith("small.gguf"))
+
+    def test_an_existing_generator_is_preferred_over_a_download(self):
+        existing = os.path.join(self.base, "mine.exe")
+        with open(existing, "wb") as stream:
+            stream.write(b"MZ")
+        paths = ui.resolved_paths(_Catalogue(), "small", self.base, existing)
+        self.assertEqual(existing, paths["runtime"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/launcher/tests/test_bot_chat_ui.py
+++ b/launcher/tests/test_bot_chat_ui.py
@@ -409,11 +409,15 @@ class ProgressReportingTest(_Temp):
 
 
 class _FakeSupervisor(object):
-    def __init__(self, started=True, ready=True):
+    def __init__(self, started=True, ready=True, tail=""):
         self.started = started
         self.ready = ready
+        self.tail = tail
         self.stopped = False
         self.endpoint = "http://127.0.0.1:1"
+
+    def output_tail(self, lines=12):
+        return self.tail
 
     def start(self):
         return self.started
@@ -510,6 +514,21 @@ class SelfTestTest(_Temp):
         panel.start_check(runtime=runtime)
         self.assertTrue(_await(lambda: not panel.busy()))
         self.assertTrue(runtime.supervisor.stopped)
+
+    def test_a_failed_load_quotes_what_the_generator_said(self):
+        panel = self._installed()
+        runtime = _FakeRuntime(supervisor=_FakeSupervisor(
+            ready=False, tail='error: invalid argument: --reasoning-budget'))
+        panel.start_check(runtime=runtime)
+        self.assertTrue(_await(lambda: not panel.busy()))
+        self.assertIn('--reasoning-budget', panel.check_error())
+
+    def test_a_silent_generator_still_names_the_step_that_failed(self):
+        panel = self._installed()
+        runtime = _FakeRuntime(supervisor=_FakeSupervisor(ready=False))
+        panel.start_check(runtime=runtime)
+        self.assertTrue(_await(lambda: not panel.busy()))
+        self.assertIn('finish loading', panel.check_error())
 
     def test_removing_clears_a_test_result(self):
         panel = self._installed()

--- a/launcher/tests/test_bot_chat_ui.py
+++ b/launcher/tests/test_bot_chat_ui.py
@@ -345,6 +345,69 @@ def threading_gate(cancel_panel=None):
     return _Gate(cancel_panel)
 
 
+class ProgressReportingTest(_Temp):
+    """The bar and the stage exist so a long download does not look hung."""
+
+    def test_the_bar_starts_empty(self):
+        panel = _panel(self.base)
+        panel.apply_progress()
+        self.assertEqual(0, panel.progress.options["value"])
+
+    def test_the_bar_follows_the_byte_count(self):
+        panel = _panel(self.base)
+        panel._progress(50, 200)
+        panel.apply_progress()
+        self.assertEqual(ui.PROGRESS_STEPS // 4,
+                         panel.progress.options["value"])
+
+    def test_the_bar_fills_completely(self):
+        panel = _panel(self.base)
+        panel._progress(200, 200)
+        panel.apply_progress()
+        self.assertEqual(ui.PROGRESS_STEPS, panel.progress.options["value"])
+
+    def test_each_stage_reports_its_own_progress(self):
+        panel = _panel(self.base)
+        panel._progress(10, 200)
+        panel._stage("model")
+        # A new stage restarts the count rather than inheriting the last.
+        self.assertEqual("model", panel.stage())
+        self.assertEqual(0.0, panel.progress_fraction())
+
+    def test_the_window_is_told_when_a_download_starts(self):
+        started = []
+        panel = ui.BotChatPanel(
+            _Parent(), _Catalogue(), _Tk, _Ttk, {}, base_dir=self.base,
+            machine="AMD64", on_start=lambda: started.append(1))
+        self.assertTrue(panel.start_install(opener=_opener()))
+        self.assertTrue(_await(lambda: not panel.busy()))
+        self.assertEqual(1, len(started))
+
+    def test_a_refused_start_tells_the_window_nothing(self):
+        started = []
+        panel = ui.BotChatPanel(
+            _Parent(), _Catalogue(arch_supported=False), _Tk, _Ttk, {},
+            base_dir=self.base, machine="x86",
+            on_start=lambda: started.append(1))
+        self.assertFalse(panel.start_install(opener=_opener()))
+        self.assertEqual([], started)
+
+    def test_the_install_location_is_shown(self):
+        panel = _panel(self.base)
+        self.assertEqual(ui.bot_chat_install.install_root(self.base),
+                         panel.location.get())
+
+    def test_removing_clears_the_last_failure(self):
+        panel = _panel(self.base)
+        panel.start_install(opener=_opener(fail_urls=("modelscope", "github",
+                                                      "huggingface")))
+        self.assertTrue(_await(lambda: not panel.busy()))
+        self.assertIsNotNone(panel.last_error())
+        panel.remove()
+        self.assertIsNone(panel.last_error())
+        self.assertIsNone(panel.stage())
+
+
 class ResolvedPathTest(_Temp):
     def test_the_catalogue_model_is_named_for_the_selected_tier(self):
         catalogue = _Catalogue()

--- a/launcher/tests/test_launcher_window.py
+++ b/launcher/tests/test_launcher_window.py
@@ -12,6 +12,8 @@ import time
 import unittest
 from unittest import mock
 
+import bot_chat_ui
+import i18n
 import core
 import wot_launcher
 
@@ -141,6 +143,7 @@ class _FakeTk(object):
 class _FakeTtk(object):
     Combobox = _Widget
     Notebook = _Notebook
+    Progressbar = _Widget
 
 
 class _FakeFileDialog(object):
@@ -2433,6 +2436,49 @@ class WindowTest(unittest.TestCase):
         self.assertEqual(stopped, ["terminate"])
         self.assertIsNone(self.window._room_vehicle_overlay_root)
         self.assertTrue(self.window.root.destroyed)
+
+
+class BotChatTabTests(unittest.TestCase):
+    """The optional chat panel is really built, not silently unavailable."""
+
+    # Reuse the window fixture without re-running every window test.
+    setUp = WindowTest.setUp
+
+    def test_the_panel_is_constructed(self):
+        self.assertIsNotNone(self.window._bot_chat)
+
+    def test_a_disabled_panel_names_no_model_to_the_server(self):
+        self.assertIsNone(self.window._bot_chat_paths())
+
+    def test_enabling_without_an_install_still_names_nothing(self):
+        self.window._bot_chat.enabled.set(True)
+        self.assertIsNone(self.window._bot_chat_paths())
+
+    def test_the_panel_choices_are_saved(self):
+        panel = self.window._bot_chat
+        panel.enabled.set(True)
+        self.window._save_settings()
+        saved = core.load_settings(core.settings_path())
+        self.assertTrue(saved[bot_chat_ui.ENABLED_SETTING])
+        self.assertEqual(panel.tier_key(), saved[bot_chat_ui.TIER_SETTING])
+
+    def test_the_status_line_survives_every_state(self):
+        panel = self.window._bot_chat
+        for state in (bot_chat_ui.STATE_ABSENT, bot_chat_ui.STATE_READY,
+                      bot_chat_ui.STATE_WORKING,
+                      bot_chat_ui.STATE_UNSUPPORTED):
+            panel._state = state
+            self.assertTrue(self.window._bot_chat_status(panel), state)
+
+    def test_the_tab_is_titled_in_both_languages(self):
+        for language in (i18n.LANGUAGE_ENGLISH, i18n.LANGUAGE_CHINESE):
+            self.window.language = language
+            self.window._apply_language()
+            title = self.window.tools_tabs.tab_options[
+                self.window.bot_chat_panel]["text"]
+            self.assertTrue(title, language)
+            self.assertTrue(self.window._bot_chat.install_button.options[
+                "text"], language)
 
 
 if __name__ == "__main__":

--- a/launcher/tests/test_launcher_window.py
+++ b/launcher/tests/test_launcher_window.py
@@ -2470,6 +2470,42 @@ class BotChatTabTests(unittest.TestCase):
             panel._state = state
             self.assertTrue(self.window._bot_chat_status(panel), state)
 
+    def test_polling_puts_the_byte_count_on_the_panel(self):
+        panel = self.window._bot_chat
+        panel._state = bot_chat_ui.STATE_WORKING
+        panel._stage('model')
+        panel._progress(50, 200)
+        # The fake root runs an after() callback immediately, so this also
+        # proves the poll stops re-arming once the download is not running.
+        self.window._poll_bot_chat()
+        self.assertEqual(bot_chat_ui.PROGRESS_STEPS // 4,
+                         panel.progress.options['value'])
+        self.assertIn('/', panel.status.get())
+
+    def test_the_status_names_which_half_is_downloading(self):
+        panel = self.window._bot_chat
+        panel._state = bot_chat_ui.STATE_WORKING
+        panel._progress(1, 2)
+        panel._stage('runtime')
+        runtime_status = self.window._bot_chat_status(panel)
+        panel._stage('model')
+        model_status = self.window._bot_chat_status(panel)
+        self.assertNotEqual(runtime_status, model_status)
+        self.assertTrue(runtime_status and model_status)
+
+    def test_a_ready_panel_says_bots_will_talk(self):
+        panel = self.window._bot_chat
+        panel._state = bot_chat_ui.STATE_READY
+        self.assertIn('Bots', self.window._bot_chat_status(panel))
+
+    def test_the_panel_shows_where_the_download_goes(self):
+        self.assertIn('bot-chat', self.window._bot_chat.location.get())
+
+    def test_the_runtime_field_is_labelled_optional(self):
+        self.window._apply_language()
+        self.assertIn('optional',
+                      self.window._bot_chat.runtime_label.options['text'])
+
     def test_the_tab_is_titled_in_both_languages(self):
         for language in (i18n.LANGUAGE_ENGLISH, i18n.LANGUAGE_CHINESE):
             self.window.language = language

--- a/launcher/tests/test_launcher_window.py
+++ b/launcher/tests/test_launcher_window.py
@@ -2493,10 +2493,54 @@ class BotChatTabTests(unittest.TestCase):
         self.assertNotEqual(runtime_status, model_status)
         self.assertTrue(runtime_status and model_status)
 
-    def test_a_ready_panel_says_bots_will_talk(self):
+    def test_downloaded_but_switched_off_does_not_claim_to_be_ready(self):
+        # Installed files are not a working feature. Claiming otherwise is
+        # what makes a silent battle baffling.
         panel = self.window._bot_chat
         panel._state = bot_chat_ui.STATE_READY
-        self.assertIn('Bots', self.window._bot_chat_status(panel))
+        panel.enabled.set(False)
+        status = self.window._bot_chat_status(panel)
+        self.assertIn('switch', status)
+        self.assertFalse(panel.enabled_and_ready())
+
+    def test_downloaded_and_on_asks_to_be_tested(self):
+        panel = self.window._bot_chat
+        panel._state = bot_chat_ui.STATE_READY
+        panel.enabled.set(True)
+        self.assertIn('Test', self.window._bot_chat_status(panel))
+        self.assertTrue(panel.enabled_and_ready())
+
+    def test_a_passed_test_quotes_the_line_and_names_the_lan_owner(self):
+        panel = self.window._bot_chat
+        panel._state = bot_chat_ui.STATE_READY
+        panel.enabled.set(True)
+        panel._check_state = bot_chat_ui.CHECK_PASSED
+        panel._check_line = '收到'
+        status = self.window._bot_chat_status(panel)
+        self.assertIn('收到', status)
+        self.assertIn('host', status)
+
+    def test_a_failed_test_says_why(self):
+        panel = self.window._bot_chat
+        panel._state = bot_chat_ui.STATE_READY
+        panel.enabled.set(True)
+        panel._check_state = bot_chat_ui.CHECK_FAILED
+        panel._check_error = 'the model did not finish loading'
+        self.assertIn('did not finish loading',
+                      self.window._bot_chat_status(panel))
+
+    def test_a_running_test_says_it_may_take_a_minute(self):
+        panel = self.window._bot_chat
+        panel._state = bot_chat_ui.STATE_WORKING
+        panel._check_state = bot_chat_ui.CHECK_RUNNING
+        self.assertIn('minute', self.window._bot_chat_status(panel))
+
+    def test_the_test_button_needs_an_install(self):
+        panel = self.window._bot_chat
+        panel._set_status(bot_chat_ui.STATE_ABSENT)
+        self.assertEqual('disabled', panel.check_button.options['state'])
+        panel._set_status(bot_chat_ui.STATE_READY)
+        self.assertEqual('normal', panel.check_button.options['state'])
 
     def test_the_panel_shows_where_the_download_goes(self):
         self.assertIn('bot-chat', self.window._bot_chat.location.get())

--- a/launcher/wot_launcher.py
+++ b/launcher/wot_launcher.py
@@ -15,6 +15,7 @@ import time
 
 if __package__ in (None, ""):
     sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    import bot_chat_ui
     import bot_lineup_profiles
     import bot_lineup_ui
     import core
@@ -24,8 +25,8 @@ if __package__ in (None, ""):
     import vehicle_overlays
 else:
     from . import (
-        bot_lineup_profiles, bot_lineup_ui, core, error_reports, i18n,
-        vehicle_editor_ui, vehicle_overlays)
+        bot_chat_ui, bot_lineup_profiles, bot_lineup_ui, core, error_reports,
+        i18n, vehicle_editor_ui, vehicle_overlays)
 
 
 LAUNCHER_VERSION = "0.6.9"
@@ -167,6 +168,22 @@ _CHINESE = {
     "ProcDump was downloaded and crash dumps are enabled.":
         "ProcDump 下载完成，闪退转储已启用。",
     "ProcDump could not be enabled: %s": "无法启用 ProcDump：%s",
+    "AI chat": "AI 队友",
+    "Let Bots talk in team chat (downloads a local model)":
+        "让 Bot 在队伍频道说话（需要下载本地模型）",
+    "Model": "模型",
+    "llama-server": "推理程序",
+    "Not installed. %s to download.": "尚未安装，需要下载 %s。",
+    "Ready.": "已就绪。",
+    "This machine has no published inference runtime.":
+        "本机没有可用的推理程序版本。",
+    "Downloading... %s": "正在下载… %s",
+    "Stopped. Progress was kept; install again to resume.":
+        "已停止。进度已保留，再次安装可继续。",
+    "Install failed: %s": "安装失败：%s",
+    "Install": "安装",
+    "Stop": "停止",
+    "Remove": "删除",
     "Report game crash?": "是否汇报游戏闪退？",
     "The game closed unexpectedly and an error report is ready. Choose Yes "
     "to select the ZIP in Windows Explorer; choosing No deletes it.":
@@ -538,8 +555,10 @@ class LauncherWindow(object):
         self.vehicle_panel = tk.Frame(self.tools_tabs, padx=10, pady=10)
         self.bot_lineup_panel = tk.Frame(self.tools_tabs, padx=10, pady=10)
         self.repair_panel = tk.Frame(self.tools_tabs, padx=10, pady=10)
+        self.bot_chat_panel = tk.Frame(self.tools_tabs, padx=10, pady=10)
         self.tools_tabs.add(self.vehicle_panel, text="")
         self.tools_tabs.add(self.bot_lineup_panel, text="")
+        self.tools_tabs.add(self.bot_chat_panel, text="")
         self.tools_tabs.add(self.repair_panel, text="")
 
         self._bot_lineup_store = bot_lineup_profiles.normalize_store(
@@ -631,6 +650,9 @@ class LauncherWindow(object):
             self.log_panel, height=10, width=72, state="disabled",
                                 wrap="none")
         self.log_view.pack(fill="both", expand=True)
+        # The panel reports its own failures through the log, so it is the
+        # first thing built once the log exists.
+        self._bot_chat = self._build_bot_chat(settings)
         self.author_text = tk.StringVar(value=(
             "作者：伪红学家  Bilibili：@tiancaihb  GitHub: "
             "https://github.com/pengw0048/wot-offline-battles"))
@@ -675,6 +697,67 @@ class LauncherWindow(object):
         self._log("Launcher session: %s role=launcher." %
                   core.payload_identity_text(identity))
 
+    def _build_bot_chat(self, settings):
+        """Build the optional chat panel, or leave the tab empty on failure.
+
+        The catalogue lives with the server payload. A launcher that cannot
+        read it must still start: the tab reports that the feature is
+        unavailable rather than taking the window down with it.
+        """
+        try:
+            catalogue = core.bot_chat_catalogue()
+        except Exception as error:
+            self._log("BOT CHAT is unavailable: %s" % error)
+            return None
+        try:
+            return bot_chat_ui.BotChatPanel(
+                self.bot_chat_panel, catalogue, self._tk, self._ttk,
+                settings, on_change=self._bot_chat_changed, log=self._log)
+        except Exception as error:
+            self._log("BOT CHAT panel could not be built: %s" % error)
+            return None
+
+    def _bot_chat_changed(self):
+        self._save_settings()
+        self._apply_bot_chat_language()
+
+    def _apply_bot_chat_language(self):
+        """Retitle the chat panel and restate what it is currently doing."""
+        panel = getattr(self, "_bot_chat", None)
+        if panel is None:
+            return
+        panel.enable_check.config(text=self._t(
+            "Let Bots talk in team chat (downloads a local model)"))
+        panel.model_label.config(text=self._t("Model"))
+        panel.runtime_label.config(text=self._t("llama-server"))
+        panel.install_button.config(text=self._t("Install"))
+        panel.stop_button.config(text=self._t("Stop"))
+        panel.remove_button.config(text=self._t("Remove"))
+        panel.status.set(self._bot_chat_status(panel))
+
+    def _bot_chat_status(self, panel):
+        state = panel.state()
+        if state == bot_chat_ui.STATE_UNSUPPORTED:
+            return self._t(
+                "This machine has no published inference runtime.")
+        if state == bot_chat_ui.STATE_WORKING:
+            return self._t("Downloading... %s") % panel.progress_text()
+        if state == bot_chat_ui.STATE_READY:
+            return self._t("Ready.")
+        error = panel.last_error()
+        if error:
+            return self._t("Install failed: %s") % error
+        if panel.was_cancelled():
+            return self._t(
+                "Stopped. Progress was kept; install again to resume.")
+        pending = panel.plan()["pending_bytes"]
+        return self._t("Not installed. %s to download.") % (
+            bot_chat_ui.bot_chat_install.format_bytes(pending))
+
+    def _bot_chat_paths(self):
+        panel = getattr(self, "_bot_chat", None)
+        return panel.paths() if panel is not None else None
+
     def _t(self, text):
         if self.language == i18n.LANGUAGE_CHINESE:
             return _CHINESE.get(text, text)
@@ -706,7 +789,10 @@ class LauncherWindow(object):
             self.vehicle_panel, text=self._t("Vehicle modifier"))
         self.tools_tabs.tab(
             self.bot_lineup_panel, text=self._t("Exact lineup"))
+        self.tools_tabs.tab(
+            self.bot_chat_panel, text=self._t("AI chat"))
         self.tools_tabs.tab(self.repair_panel, text=self._t("Repair"))
+        self._apply_bot_chat_language()
         self.vehicle_profile_label.config(text=self._t("Vehicle data profile"))
         self.new_profile_button.config(text=self._t("New profile..."))
         self.vehicle_editor_button.config(
@@ -1364,7 +1450,20 @@ class LauncherWindow(object):
                 bool(self.full_crash_dumps.get()),
             PROCDUMP_CONSENT_SETTING:
                 bool(self._procdump_download_consent),
+            **self._bot_chat_settings(),
         })
+
+    def _bot_chat_settings(self):
+        """Return the chat panel's remembered choices, or nothing."""
+        panel = getattr(self, "_bot_chat", None)
+        if panel is None:
+            return {}
+        return {
+            bot_chat_ui.ENABLED_SETTING: bool(panel.enabled.get()),
+            bot_chat_ui.TIER_SETTING: panel.tier_key(),
+            bot_chat_ui.RUNTIME_OVERRIDE_SETTING:
+                panel.runtime_override.get().strip(),
+        }
 
     def _start_maintenance(self, action):
         if self._busy or self._maintenance_busy:
@@ -2118,7 +2217,7 @@ class LauncherWindow(object):
         command = core.server_child_command(port_version)
         environment = core.server_environment(
             port_version, game_root, loopback_only=loopback_only,
-            bot_lineup=bot_lineup)
+            bot_lineup=bot_lineup, bot_chat=self._bot_chat_paths())
         server_log_path = core.server_log_path()
         report_session = self._active_report_session
         if report_session is not None:

--- a/launcher/wot_launcher.py
+++ b/launcher/wot_launcher.py
@@ -175,8 +175,17 @@ _CHINESE = {
     "llama-server (optional, if you already have one)":
         "推理程序（可选，已经有就填路径）",
     "Not installed. %s to download.": "尚未安装，需要下载 %s。",
-    "Ready. Bots will talk in your next battle.":
-        "已就绪，下一局 Bot 就会说话了。",
+    "Downloaded, but the switch above is off.":
+        "已下载，但上面的开关没有打开。",
+    "Downloaded and on. Test it to prove this PC can run it.":
+        "已下载并启用。点下面的自检，确认这台机器跑得动。",
+    "Working. A Bot said: %s": "可以用。Bot 说：%s",
+    "The test failed: %s": "自检失败：%s",
+    "Testing... loading the model can take a minute.":
+        "正在自检…加载模型可能要一分钟。",
+    "Test": "自检",
+    "In a LAN room the host's PC provides this, not yours.":
+        "局域网房间里，这个由房主那台机器提供，不是你这台。",
     "Downloading the inference program... %s": "正在下载推理程序… %s",
     "Downloading the model... %s": "正在下载模型… %s",
     "This machine has no published inference runtime.":
@@ -741,6 +750,7 @@ class LauncherWindow(object):
         panel.install_button.config(text=self._t("Install"))
         panel.stop_button.config(text=self._t("Stop"))
         panel.remove_button.config(text=self._t("Remove"))
+        panel.check_button.config(text=self._t("Test"))
         panel.status.set(self._bot_chat_status(panel))
 
     def _bot_chat_status(self, panel):
@@ -749,12 +759,29 @@ class LauncherWindow(object):
             return self._t(
                 "This machine has no published inference runtime.")
         if state == bot_chat_ui.STATE_WORKING:
+            if panel.check_state() == bot_chat_ui.CHECK_RUNNING:
+                return self._t(
+                    "Testing... loading the model can take a minute.")
             key = ("Downloading the model... %s"
                    if panel.stage() == "model" else
                    "Downloading the inference program... %s")
             return self._t(key) % (panel.progress_text() or "...")
         if state == bot_chat_ui.STATE_READY:
-            return self._t("Ready. Bots will talk in your next battle.")
+            # Files on disk are not a working feature. Say which of the
+            # remaining conditions is not met, rather than "ready".
+            if not panel.enabled.get():
+                return self._t("Downloaded, but the switch above is off.")
+            check = panel.check_state()
+            if check == bot_chat_ui.CHECK_PASSED:
+                return "%s  %s" % (
+                    self._t("Working. A Bot said: %s") % panel.check_line(),
+                    self._t(
+                        "In a LAN room the host's PC provides this, not "
+                        "yours."))
+            if check == bot_chat_ui.CHECK_FAILED:
+                return self._t("The test failed: %s") % panel.check_error()
+            return self._t(
+                "Downloaded and on. Test it to prove this PC can run it.")
         error = panel.last_error()
         if error:
             return self._t("Install failed: %s") % error

--- a/launcher/wot_launcher.py
+++ b/launcher/wot_launcher.py
@@ -172,12 +172,16 @@ _CHINESE = {
     "Let Bots talk in team chat (downloads a local model)":
         "让 Bot 在队伍频道说话（需要下载本地模型）",
     "Model": "模型",
-    "llama-server": "推理程序",
+    "llama-server (optional, if you already have one)":
+        "推理程序（可选，已经有就填路径）",
     "Not installed. %s to download.": "尚未安装，需要下载 %s。",
-    "Ready.": "已就绪。",
+    "Ready. Bots will talk in your next battle.":
+        "已就绪，下一局 Bot 就会说话了。",
+    "Downloading the inference program... %s": "正在下载推理程序… %s",
+    "Downloading the model... %s": "正在下载模型… %s",
     "This machine has no published inference runtime.":
         "本机没有可用的推理程序版本。",
-    "Downloading... %s": "正在下载… %s",
+
     "Stopped. Progress was kept; install again to resume.":
         "已停止。进度已保留，再次安装可继续。",
     "Install failed: %s": "安装失败：%s",
@@ -194,6 +198,8 @@ _CHINESE = {
 
 COLLECT_CRASH_REPORTS_SETTING = "collect_crash_reports"
 FULL_CRASH_DUMPS_SETTING = "full_crash_dumps"
+# How often the window reads the install thread's byte counts.
+BOT_CHAT_POLL_MILLISECONDS = 250
 PROCDUMP_CONSENT_SETTING = "procdump_download_consent"
 PROCDUMP_PATH_ENV = "WOT_OFFLINE_PROCDUMP_PATH"
 CRASH_DUMP_PATH_ENV = "WOT_OFFLINE_CRASH_DUMP_PATH"
@@ -712,7 +718,8 @@ class LauncherWindow(object):
         try:
             return bot_chat_ui.BotChatPanel(
                 self.bot_chat_panel, catalogue, self._tk, self._ttk,
-                settings, on_change=self._bot_chat_changed, log=self._log)
+                settings, on_change=self._bot_chat_changed, log=self._log,
+                on_start=self._start_bot_chat_poll)
         except Exception as error:
             self._log("BOT CHAT panel could not be built: %s" % error)
             return None
@@ -729,7 +736,8 @@ class LauncherWindow(object):
         panel.enable_check.config(text=self._t(
             "Let Bots talk in team chat (downloads a local model)"))
         panel.model_label.config(text=self._t("Model"))
-        panel.runtime_label.config(text=self._t("llama-server"))
+        panel.runtime_label.config(text=self._t(
+            "llama-server (optional, if you already have one)"))
         panel.install_button.config(text=self._t("Install"))
         panel.stop_button.config(text=self._t("Stop"))
         panel.remove_button.config(text=self._t("Remove"))
@@ -741,9 +749,12 @@ class LauncherWindow(object):
             return self._t(
                 "This machine has no published inference runtime.")
         if state == bot_chat_ui.STATE_WORKING:
-            return self._t("Downloading... %s") % panel.progress_text()
+            key = ("Downloading the model... %s"
+                   if panel.stage() == "model" else
+                   "Downloading the inference program... %s")
+            return self._t(key) % (panel.progress_text() or "...")
         if state == bot_chat_ui.STATE_READY:
-            return self._t("Ready.")
+            return self._t("Ready. Bots will talk in your next battle.")
         error = panel.last_error()
         if error:
             return self._t("Install failed: %s") % error
@@ -753,6 +764,27 @@ class LauncherWindow(object):
         pending = panel.plan()["pending_bytes"]
         return self._t("Not installed. %s to download.") % (
             bot_chat_ui.bot_chat_install.format_bytes(pending))
+
+    def _poll_bot_chat(self):
+        """Move the download's progress onto the panel while it runs.
+
+        The install thread must not touch Tk, so the window reads its counts
+        here instead. Without this the bar never moved and a six hundred
+        megabyte download looked like the launcher had hung.
+        """
+        panel = getattr(self, "_bot_chat", None)
+        if panel is None:
+            return
+        try:
+            panel.apply_progress()
+            panel.status.set(self._bot_chat_status(panel))
+        except Exception:
+            return
+        if panel.busy():
+            self.root.after(BOT_CHAT_POLL_MILLISECONDS, self._poll_bot_chat)
+
+    def _start_bot_chat_poll(self):
+        self.root.after(BOT_CHAT_POLL_MILLISECONDS, self._poll_bot_chat)
 
     def _bot_chat_paths(self):
         panel = getattr(self, "_bot_chat", None)

--- a/server/bot_chat.py
+++ b/server/bot_chat.py
@@ -49,10 +49,12 @@ MAX_CONVERSATION_HOPS = 2
 HOP_PROBABILITY = (0.55, 0.3)
 
 # A generating backend is asked when the line is scheduled and states how
-# long it wants.  Ordinary reply pacing already covers a small local model,
-# so this only matters for a slow one, and the cap bounds how long a hung
-# generator can hold a scheduled line before it is abandoned.
-MAX_PREFETCH_WAIT_SECONDS = 15.0
+# long it wants.  Ordinary reply pacing already covers a fast machine, so
+# this only matters for a slow one, and the cap bounds how long a hung
+# generator can hold a scheduled line before it is abandoned.  A late answer
+# still reads as a teammate who took their time; an abandoned one reads as a
+# feature that does not work.
+MAX_PREFETCH_WAIT_SECONDS = 30.0
 
 # Peng's product choice: most lines get an answer, and an interesting line may
 # get more than one.  Silence stays legal, it is simply not the default.

--- a/server/bot_chat.py
+++ b/server/bot_chat.py
@@ -48,13 +48,16 @@ TEAM_BUDGET_SECONDS = 20.0
 MAX_CONVERSATION_HOPS = 2
 HOP_PROBABILITY = (0.55, 0.3)
 
-# A generating backend is asked when the line is scheduled and states how
-# long it wants.  Ordinary reply pacing already covers a fast machine, so
-# this only matters for a slow one, and the cap bounds how long a hung
-# generator can hold a scheduled line before it is abandoned.  A late answer
-# still reads as a teammate who took their time; an abandoned one reads as a
-# feature that does not work.
+# How long a backend may ask the director to hold a line before first
+# looking for its text.  This bounds the initial wait only: a line whose
+# text is not ready yet keeps waiting for as long as it is still being
+# written, because a late answer still reads as a teammate who took their
+# time and an abandoned one reads as a feature that does not work.
 MAX_PREFETCH_WAIT_SECONDS = 30.0
+# How often a line whose text has not arrived yet is looked at again. The
+# estimate that scheduled it is only an estimate, and abandoning a line the
+# moment it is late throws away work that is about to finish.
+PREFETCH_RETRY_SECONDS = 0.5
 
 # Peng's product choice: most lines get an answer, and an interesting line may
 # get more than one.  Silence stays legal, it is simply not the default.
@@ -534,6 +537,7 @@ class BotChatDirector(object):
                 float(getattr(self._backend, "latency_hint_seconds", 0.0))))
         self._pending.append({
             "due_tick": int(tick) + self._ticks(delay),
+            "scheduled_tick": int(tick),
             "bot_id": int(bot_id),
             "team": int(team),
             "trigger": trigger,
@@ -589,6 +593,8 @@ class BotChatDirector(object):
             # A backend failure is contained to this one line.  It must never
             # silence the team for the rest of the round or fault the tick.
             return None
+        if not text and self._still_writing(tick, entry, request):
+            return None
         text = clamp_chat_text(text)
         if text is None:
             return None
@@ -602,6 +608,27 @@ class BotChatDirector(object):
         self._advance_thread(team, bot["id"], tick)
         self._maybe_hop(tick, entry, snapshot)
         return {"bot_id": bot["id"], "team": team, "text": text}
+
+    def _still_writing(self, tick, entry, request):
+        """Put a late line back rather than throwing its answer away.
+
+        There is deliberately no deadline here. A guessed one has twice now
+        discarded an answer that was seconds from being finished, and the
+        honest boundary is whether the backend is still writing at all: it
+        stops saying so when the generation completes or its own request
+        times out, and the line is dropped on the next look.
+        """
+        pending = getattr(self._backend, "pending", None)
+        if pending is None:
+            return False
+        try:
+            if not pending(request):
+                return False
+        except Exception:
+            return False
+        entry["due_tick"] = tick + self._ticks(PREFETCH_RETRY_SECONDS)
+        self._pending.append(entry)
+        return True
 
     def _address_prefix(self, address_kind, snapshot):
         """Name the human back only when they named a Bot first."""

--- a/server/bot_chat.py
+++ b/server/bot_chat.py
@@ -12,9 +12,10 @@ the director returns the lines to publish.  One round therefore replays
 identically in tests, which is what keeps the conversation rules provable
 while the line text itself stays replaceable.
 
-``compose`` on the line backend is the seam a local language model plugs into
-later.  ``TemplateLineBackend`` is the shipped default and the only backend
-that works with no optional download installed.
+A line backend writes the text.  Without one -- which is what an install
+with no optional model downloaded looks like -- the director schedules
+nothing and every Bot stays quiet.  There is deliberately no second line
+source: a canned stand-in would only make a broken model look healthy.
 """
 
 import re
@@ -23,10 +24,15 @@ import unicodedata
 
 # Conversation pacing, in seconds.  The director converts these with the
 # caller's tick rate so the server stays the single owner of TICK_HZ.
-REPLY_DELAY_MIN_SECONDS = 0.8
-REPLY_DELAY_MAX_SECONDS = 2.6
-HOP_DELAY_MIN_SECONDS = 1.2
-HOP_DELAY_MAX_SECONDS = 3.4
+#
+# A teammate reads the channel, decides to answer, and types a line of
+# Chinese while driving.  Ten seconds is ordinary, and an instant answer is
+# the thing that reads as a machine.  The generous window is also what gives
+# a small local model room to finish without anybody waiting on it.
+REPLY_DELAY_MIN_SECONDS = 1.5
+REPLY_DELAY_MAX_SECONDS = 9.0
+HOP_DELAY_MIN_SECONDS = 2.0
+HOP_DELAY_MAX_SECONDS = 11.0
 THREAD_SILENCE_SECONDS = 20.0
 BOT_COOLDOWN_SECONDS = 9.0
 
@@ -41,6 +47,12 @@ TEAM_BUDGET_SECONDS = 20.0
 # capped and each further hop is less likely than the last.
 MAX_CONVERSATION_HOPS = 2
 HOP_PROBABILITY = (0.55, 0.3)
+
+# A generating backend is asked when the line is scheduled and states how
+# long it wants.  Ordinary reply pacing already covers a small local model,
+# so this only matters for a slow one, and the cap bounds how long a hung
+# generator can hold a scheduled line before it is abandoned.
+MAX_PREFETCH_WAIT_SECONDS = 15.0
 
 # Peng's product choice: most lines get an answer, and an interesting line may
 # get more than one.  Silence stays legal, it is simply not the default.
@@ -214,102 +226,13 @@ def clamp_chat_text(value):
     return text or None
 
 
-class TemplateLineBackend(object):
-    """Compose one line from shipped persona templates.
-
-    This backend is what a player gets with no optional model installed, so
-    it is a product surface rather than a placeholder.  It stays deliberately
-    small: variety comes from persona and trigger, and the director's own
-    repeat filter keeps a pool from sounding like a loop.
-    """
-
-    _COMMON = {
-        TRIGGER_REPLY: ("收到", "明白", "好", "在的", "听到了"),
-        TRIGGER_HOP: ("同上", "我也这么想", "+1", "有道理"),
-        TRIGGER_KILL: ("打掉一个", "拿下了", "少一个"),
-        TRIGGER_DOWN: ("我没了", "被打死了", "下课了"),
-        TRIGGER_ALLY_DOWN: ("队友没了", "少一个人了", "那边塌了"),
-        TRIGGER_LOW_HEALTH: ("我血不多了", "残血了", "血皮，别指望我"),
-    }
-
-    _PERSONA = {
-        PERSONA_TACTICAL: {
-            TRIGGER_REPLY: ("收到，这就去", "明白，交给我", "好，我压上去"),
-            TRIGGER_HOP: ("那我走前面", "我掩护", "跟上就行"),
-            TRIGGER_KILL: ("一炮带走", "干净利落", "下一个"),
-            TRIGGER_DOWN: ("失误了", "算我一个", "这波我亏了"),
-            TRIGGER_ALLY_DOWN: ("补上去", "别让他白死", "顶住"),
-            TRIGGER_LOW_HEALTH: ("血不多，但还能打", "残血，我卖头"),
-        },
-        PERSONA_SLACKER: {
-            TRIGGER_REPLY: ("哦，好吧", "行行行，来了", "别催，在路上"),
-            TRIGGER_HOP: ("他说得对", "听他的", "我随便"),
-            TRIGGER_KILL: ("哎，蒙中了", "运气好"),
-            TRIGGER_DOWN: ("下班了", "行吧，先歇会", "早知道不冲了"),
-            TRIGGER_ALLY_DOWN: ("哎呀", "有点惨"),
-            TRIGGER_LOW_HEALTH: ("我这血够呛", "别撞我，一下就没"),
-        },
-        PERSONA_MECHANIC: {
-            TRIGGER_REPLY: ("等我装填完", "好，装填还有几秒", "收到，修完就来"),
-            TRIGGER_HOP: ("同意", "他说的对"),
-            TRIGGER_KILL: ("这发打进去了", "弹药没白带"),
-            TRIGGER_DOWN: ("弹药架爆了", "履带先没的"),
-            TRIGGER_ALLY_DOWN: ("那边压力大", "得有人补位"),
-            TRIGGER_LOW_HEALTH: ("履带又掉了", "车不行了"),
-        },
-        PERSONA_SCOUT: {
-            TRIGGER_REPLY: ("收到，我去看一眼", "明白，先探路", "好，我亮一下"),
-            TRIGGER_HOP: ("我确认一下", "看到了"),
-            TRIGGER_KILL: ("点掉一个", "打中了"),
-            TRIGGER_DOWN: ("被抓到了", "亮太久了"),
-            TRIGGER_ALLY_DOWN: ("那边有埋伏", "小心侧面"),
-            TRIGGER_LOW_HEALTH: ("我血皮，退了", "先撤，别暴露"),
-        },
-        PERSONA_POETIC: {
-            TRIGGER_REPLY: ("好", "这就来", "听见了"),
-            TRIGGER_HOP: ("是这个道理", "我也这么觉得"),
-            TRIGGER_KILL: ("走一个", "落幕了"),
-            TRIGGER_DOWN: ("我先走一步", "到此为止"),
-            TRIGGER_ALLY_DOWN: ("可惜了", "又少一个"),
-            TRIGGER_LOW_HEALTH: ("撑不了多久", "血快见底了"),
-        },
-    }
-
-    def compose(self, request):
-        """Return one line for this request, or None to stay silent."""
-        trigger = request.get("trigger")
-        persona = request.get("persona") or PERSONA_PLAIN
-        rng = request["rng"]
-        pools = []
-        persona_pool = self._PERSONA.get(persona, {}).get(trigger)
-        if persona_pool:
-            pools.append(persona_pool)
-        common_pool = self._COMMON.get(trigger)
-        if common_pool:
-            pools.append(common_pool)
-        if not pools:
-            return None
-        # Persona lines are the point of the feature, so they are drawn first
-        # and the neutral pool only widens the choice.
-        candidates = list(pools[0])
-        if len(pools) > 1 and rng.random() < 0.3:
-            candidates = list(pools[1])
-        recent = set(request.get("recent_texts") or ())
-        fresh = [line for line in candidates if line not in recent]
-        chosen = rng.choice(fresh or candidates)
-        prefix = request.get("address_prefix")
-        if prefix and rng.random() < 0.5:
-            chosen = "%s %s" % (prefix, chosen)
-        return chosen
-
-
 class BotChatDirector(object):
     """Own the team-chat conversation for every Bot in one round."""
 
     def __init__(self, rng, tick_hz=30.0, backend=None):
         self._rng = rng
         self._tick_hz = float(tick_hz)
-        self._backend = backend or TemplateLineBackend()
+        self._backend = backend
         self._round_id = None
         self._personas = {}
         self._pending = []
@@ -318,6 +241,7 @@ class BotChatDirector(object):
         self._budget = {}
         self._bot_last_line = {}
         self._team_last_line = {}
+        self._request_seq = 0
 
     # -- lifecycle ------------------------------------------------------
 
@@ -331,10 +255,15 @@ class BotChatDirector(object):
         self._budget = {}
         self._bot_last_line = {}
         self._team_last_line = {}
+        self._request_seq = 0
 
     def set_backend(self, backend):
         """Swap the line source without disturbing an active conversation."""
-        self._backend = backend or TemplateLineBackend()
+        self._backend = backend
+
+    def enabled(self):
+        """Return whether any backend can write a line at all."""
+        return self._backend is not None
 
     def _ticks(self, seconds):
         return max(1, int(round(float(seconds) * self._tick_hz)))
@@ -479,6 +408,8 @@ class BotChatDirector(object):
     def observe_player_line(self, tick, team, text, snapshot):
         """Schedule the answers one human line earns."""
         team = int(team)
+        if self._backend is None:
+            return {"kind": ADDRESS_NONE, "bot_ids": []}
         address = self.resolve_address(text, team, snapshot)
         self._remember(team, snapshot.get("speaker", {}).get("name"), text)
         if address["kind"] in (ADDRESS_CALLSIGN, ADDRESS_VEHICLE,
@@ -497,7 +428,7 @@ class BotChatDirector(object):
                                else SECOND_SPEAKER_PROBABILITY)
                 if self._rng.random() <= probability:
                     self._schedule(tick, bot_id, team, TRIGGER_REPLY,
-                                   address["kind"])
+                                   address["kind"], snapshot)
             return address
         # Nobody was named.  Peng's choice is that an open remark usually
         # still gets an answer, and an interesting one may get two.
@@ -508,10 +439,10 @@ class BotChatDirector(object):
         if not pool:
             return address
         self._schedule(tick, pool[0]["id"], team, TRIGGER_REPLY,
-                       ADDRESS_NONE)
+                       ADDRESS_NONE, snapshot)
         if len(pool) > 1 and self._rng.random() < SECOND_SPEAKER_PROBABILITY:
             self._schedule(tick, pool[1]["id"], team, TRIGGER_REPLY,
-                           ADDRESS_NONE)
+                           ADDRESS_NONE, snapshot)
         return address
 
     @staticmethod
@@ -529,8 +460,9 @@ class BotChatDirector(object):
 
     def observe_event(self, tick, team, trigger, bot_id, snapshot):
         """Let a battle event start a line without any human speaking."""
-        if trigger not in (TRIGGER_KILL, TRIGGER_DOWN, TRIGGER_ALLY_DOWN,
-                           TRIGGER_LOW_HEALTH):
+        if self._backend is None or trigger not in (
+                TRIGGER_KILL, TRIGGER_DOWN, TRIGGER_ALLY_DOWN,
+                TRIGGER_LOW_HEALTH):
             return False
         team = int(team)
         if bot_id is None:
@@ -542,15 +474,50 @@ class BotChatDirector(object):
             return False
         if self._rng.random() > EVENT_REPLY_PROBABILITY:
             return False
-        self._schedule(tick, bot_id, team, trigger, ADDRESS_NONE)
+        self._schedule(tick, bot_id, team, trigger, ADDRESS_NONE, snapshot)
         return True
 
-    def _schedule(self, tick, bot_id, team, trigger, address_kind, hop=0):
+    def _build_request(self, bot, team, trigger, address_kind, snapshot):
+        """Describe one line completely enough for any backend to write it."""
+        self._request_seq += 1
+        return {
+            "request_id": self._request_seq,
+            "trigger": trigger,
+            "persona": self.persona(bot["id"], bot.get("name")),
+            "address_kind": address_kind,
+            "address_prefix": self._address_prefix(address_kind, snapshot),
+            "speaker": dict(snapshot.get("speaker") or {}),
+            "bot": bot,
+            "recent_texts": [record["text"]
+                             for record in self._recent.get(team, ())],
+            "recent": list(self._recent.get(team, ())),
+            "rng": self._rng,
+        }
+
+    def _schedule(self, tick, bot_id, team, trigger, address_kind, snapshot,
+                  hop=0):
+        bot = self._find_bot(bot_id, snapshot)
+        if bot is None:
+            return
         delay_min, delay_max = ((HOP_DELAY_MIN_SECONDS, HOP_DELAY_MAX_SECONDS)
                                 if hop else
                                 (REPLY_DELAY_MIN_SECONDS,
                                  REPLY_DELAY_MAX_SECONDS))
         delay = self._rng.uniform(delay_min, delay_max)
+        request = self._build_request(bot, team, trigger, address_kind,
+                                      snapshot)
+        # Hand a generating backend the work now, and hold the line back long
+        # enough for it to finish.  ``rng`` is deliberately not shared across
+        # a thread boundary: a backend copies what it needs.
+        prefetch = getattr(self._backend, "prefetch", None)
+        if prefetch is not None:
+            try:
+                prefetch(request)
+            except Exception:
+                pass
+            delay = max(delay, min(
+                MAX_PREFETCH_WAIT_SECONDS,
+                float(getattr(self._backend, "latency_hint_seconds", 0.0))))
         self._pending.append({
             "due_tick": int(tick) + self._ticks(delay),
             "bot_id": int(bot_id),
@@ -558,6 +525,7 @@ class BotChatDirector(object):
             "trigger": trigger,
             "address_kind": address_kind,
             "hop": int(hop),
+            "request": request,
         })
         # Reserve the slot now.  Without this, one burst of admissions would
         # schedule every Bot before any of them has spoken.
@@ -592,19 +560,15 @@ class BotChatDirector(object):
             return None
         if entry["trigger"] != TRIGGER_DOWN and not bot.get("alive"):
             return None
-        if not self._spend_budget(tick, team):
+        if self._backend is None or not self._budget_available(tick, team):
             return None
-        request = {
-            "trigger": entry["trigger"],
-            "persona": self.persona(bot["id"], bot.get("name")),
-            "address_kind": entry["address_kind"],
-            "address_prefix": self._address_prefix(entry, snapshot),
-            "bot": bot,
-            "recent_texts": [record["text"]
-                             for record in self._recent.get(team, ())],
-            "recent": list(self._recent.get(team, ())),
-            "rng": self._rng,
-        }
+        # The request was frozen when the line was scheduled so a generating
+        # backend could start early.  Only the facts that move are refreshed.
+        request = entry["request"]
+        request["bot"] = bot
+        request["recent_texts"] = [record["text"]
+                                   for record in self._recent.get(team, ())]
+        request["recent"] = list(self._recent.get(team, ()))
         try:
             text = self._backend.compose(request)
         except Exception:
@@ -617,6 +581,7 @@ class BotChatDirector(object):
         if any(text == record["text"]
                for record in list(self._recent.get(team, ()))[-3:]):
             return None
+        self._spend_budget(tick, team)
         self._remember(team, bot.get("name"), text)
         self._bot_last_line[bot["id"]] = tick
         self._team_last_line[team] = tick
@@ -624,9 +589,9 @@ class BotChatDirector(object):
         self._maybe_hop(tick, entry, snapshot)
         return {"bot_id": bot["id"], "team": team, "text": text}
 
-    def _address_prefix(self, entry, snapshot):
+    def _address_prefix(self, address_kind, snapshot):
         """Name the human back only when they named a Bot first."""
-        if entry["address_kind"] not in (ADDRESS_CALLSIGN, ADDRESS_VEHICLE):
+        if address_kind not in (ADDRESS_CALLSIGN, ADDRESS_VEHICLE):
             return None
         speaker = snapshot.get("speaker") or {}
         name = speaker.get("name")
@@ -647,7 +612,7 @@ class BotChatDirector(object):
             return
         speaker = self._rng.choice(candidates)
         self._schedule(tick, speaker["id"], team, TRIGGER_HOP,
-                       ADDRESS_NONE, hop=hop + 1)
+                       ADDRESS_NONE, snapshot, hop=hop + 1)
 
     # -- budgets and threads --------------------------------------------
 
@@ -657,16 +622,17 @@ class BotChatDirector(object):
         return (last is None or
                 tick - last >= self._ticks(BOT_COOLDOWN_SECONDS))
 
-    def _spend_budget(self, tick, team):
+    def _budget_available(self, tick, team):
+        """Return whether this team may still publish inside the window."""
         window = self._ticks(TEAM_BUDGET_SECONDS)
         spent = [stamp for stamp in self._budget.get(team, ())
                  if tick - stamp < window]
-        if len(spent) >= TEAM_BUDGET_LINES:
-            self._budget[team] = spent
-            return False
-        spent.append(tick)
         self._budget[team] = spent
-        return True
+        return len(spent) < TEAM_BUDGET_LINES
+
+    def _spend_budget(self, tick, team):
+        """Charge one published line against the team's window."""
+        self._budget.setdefault(team, []).append(tick)
 
     def _thread(self, team, tick):
         thread = self._threads.get(team)

--- a/server/bot_chat.py
+++ b/server/bot_chat.py
@@ -411,7 +411,8 @@ class BotChatDirector(object):
         """Schedule the answers one human line earns."""
         team = int(team)
         if self._backend is None:
-            return {"kind": ADDRESS_NONE, "bot_ids": []}
+            return {"kind": ADDRESS_NONE, "bot_ids": [], "scheduled": 0}
+        scheduled_before = len(self._pending)
         address = self.resolve_address(text, team, snapshot)
         self._remember(team, snapshot.get("speaker", {}).get("name"), text)
         if address["kind"] in (ADDRESS_CALLSIGN, ADDRESS_VEHICLE,
@@ -421,7 +422,7 @@ class BotChatDirector(object):
             self._thread(team, tick)["last_tick"] = tick
         bots = self._team_bots(team, snapshot)
         if not bots:
-            return address
+            return self._admitted(address, scheduled_before)
         addressed = [bot_id for bot_id in address["bot_ids"]
                      if self._can_speak(tick, bot_id)]
         if addressed:
@@ -431,21 +432,32 @@ class BotChatDirector(object):
                 if self._rng.random() <= probability:
                     self._schedule(tick, bot_id, team, TRIGGER_REPLY,
                                    address["kind"], snapshot)
-            return address
+            return self._admitted(address, scheduled_before)
         # Nobody was named.  Peng's choice is that an open remark usually
         # still gets an answer, and an interesting one may get two.
         if self._rng.random() > self._open_probability(text):
-            return address
+            return self._admitted(address, scheduled_before)
         pool = [bot for bot in self._by_relevance(bots, snapshot)
                 if self._can_speak(tick, bot["id"])]
         if not pool:
-            return address
+            return self._admitted(address, scheduled_before)
         self._schedule(tick, pool[0]["id"], team, TRIGGER_REPLY,
                        ADDRESS_NONE, snapshot)
         if len(pool) > 1 and self._rng.random() < SECOND_SPEAKER_PROBABILITY:
             self._schedule(tick, pool[1]["id"], team, TRIGGER_REPLY,
                            ADDRESS_NONE, snapshot)
-        return address
+        return self._admitted(address, scheduled_before)
+
+    def _admitted(self, address, scheduled_before):
+        """Describe what one human line produced, for the room's log.
+
+        A battle where nobody answers has no evidence in it otherwise: the
+        line either never arrived, addressed nobody, or was addressed and
+        declined, and those need telling apart.
+        """
+        result = dict(address)
+        result["scheduled"] = len(self._pending) - scheduled_before
+        return result
 
     @staticmethod
     def _open_probability(text):

--- a/server/bot_chat.py
+++ b/server/bot_chat.py
@@ -68,6 +68,10 @@ SQUAD_MAX_SPEAKERS = 2
 EVENT_REPLY_PROBABILITY = 0.4
 
 RECENT_LINE_MEMORY = 12
+# One line continuing another word for word reads as the same line to a
+# player, which is how a small model repeats itself when it does not repeat
+# itself exactly.
+REPEAT_PREFIX_CHARACTERS = 3
 MAX_CHAT_UTF16_UNITS = 140
 
 PERSONA_TACTICAL = "tactical"
@@ -333,15 +337,13 @@ class BotChatDirector(object):
                     return {"kind": ADDRESS_CELL, "bot_ids": [near[0]["id"]]}
 
         thread = self._threads.get(team)
-        if thread:
-            # The player is still talking to whoever they addressed, even
-            # after other Bots have chimed in on top of that answer.
-            for candidate in ([thread.get("anchor")] +
-                              list(reversed(thread.get("participants") or ()))):
-                if candidate is None:
-                    continue
-                if any(bot["id"] == candidate for bot in bots):
-                    return {"kind": ADDRESS_THREAD, "bot_ids": [candidate]}
+        anchor = (thread or {}).get("anchor")
+        # Only a teammate the player actually named keeps the follow-up. A
+        # Bot that merely answered an open remark must not become the
+        # addressee of everything said for the rest of the round, which is
+        # what made one tank do all the talking.
+        if anchor is not None and any(bot["id"] == anchor for bot in bots):
+            return {"kind": ADDRESS_THREAD, "bot_ids": [anchor]}
         return {"kind": ADDRESS_NONE, "bot_ids": []}
 
     def _disambiguate(self, matched, snapshot):
@@ -356,6 +358,20 @@ class BotChatDirector(object):
         pool = visible or matched
         pool = self._by_relevance(pool, snapshot)
         return [pool[0]["id"]]
+
+    def _by_turn(self, bots, snapshot):
+        """Order an unaddressed answer by who has been quiet longest.
+
+        Relevance alone is a fixed ordering, so the same Bot answered every
+        open remark for a whole battle while fourteen others never spoke.
+        """
+        relevance = dict(
+            (bot["id"], index)
+            for index, bot in enumerate(self._by_relevance(bots, snapshot)))
+        return sorted(
+            bots,
+            key=lambda bot: (self._bot_last_line.get(bot["id"], -1),
+                             relevance.get(bot["id"], 0), bot["id"]))
 
     def _by_relevance(self, bots, snapshot):
         speaker = snapshot.get("speaker") or {}
@@ -440,7 +456,7 @@ class BotChatDirector(object):
         # still gets an answer, and an interesting one may get two.
         if self._rng.random() > self._open_probability(text):
             return self._admitted(address, scheduled_before)
-        pool = [bot for bot in self._by_relevance(bots, snapshot)
+        pool = [bot for bot in self._by_turn(bots, snapshot)
                 if self._can_speak(tick, bot["id"])]
         if not pool:
             return self._admitted(address, scheduled_before)
@@ -598,8 +614,7 @@ class BotChatDirector(object):
         text = clamp_chat_text(text)
         if text is None:
             return None
-        if any(text == record["text"]
-               for record in list(self._recent.get(team, ()))[-3:]):
+        if self._is_repetition(team, text):
             return None
         self._spend_budget(tick, team)
         self._remember(team, bot.get("name"), text)
@@ -702,6 +717,23 @@ class BotChatDirector(object):
         for team in list(self._threads):
             if tick - self._threads[team]["last_tick"] >= window:
                 del self._threads[team]
+
+    def _is_repetition(self, team, text):
+        """Refuse a line the channel has effectively just heard.
+
+        Comparing only the last few lines for exact equality let a small
+        model say the same thing over and over with a character changed, so
+        the whole remembered window is checked and a shared opening counts.
+        """
+        for record in self._recent.get(team, ()):
+            said = record["text"]
+            if said == text:
+                return True
+            shorter, longer = sorted((said, text), key=len)
+            if (len(shorter) >= REPEAT_PREFIX_CHARACTERS and
+                    longer.startswith(shorter)):
+                return True
+        return False
 
     def _remember(self, team, name, text):
         record = {"name": str(name or ""), "text": str(text or "")}

--- a/server/bot_chat_llm.py
+++ b/server/bot_chat_llm.py
@@ -1,0 +1,430 @@
+"""Write Bot chat lines with an optional local language model.
+
+The model is a download a player chooses, never a requirement.  With no
+model installed the whole feature is off and every Bot stays quiet.  With one
+installed, the hard rule is that nothing here may block the caller: a slow,
+unhealthy or absent generator costs one unsaid line, never a stalled battle.
+
+The generator runs as a separate ``llama-server`` child process on loopback.
+That keeps a native inference crash out of the LAN server, keeps the model's
+memory out of the game process, and lets one worker thread bound how much CPU
+the feature can take from a 32-bit game client and the hidden worker.
+
+``BotChatDirector`` freezes a line's request the moment the line is scheduled
+and hands it here immediately, so generation runs during the seconds a human
+teammate would spend reading and typing.  A line whose generation has not
+finished, failed, or produced nothing publishable is simply not said: there
+is no canned stand-in, because one would only make a broken model look
+healthy.
+"""
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+
+from bot_chat import (
+    PERSONA_MECHANIC, PERSONA_PLAIN, PERSONA_POETIC, PERSONA_SCOUT,
+    PERSONA_SLACKER, PERSONA_TACTICAL, TRIGGER_ALLY_DOWN, TRIGGER_DOWN,
+    TRIGGER_HOP, TRIGGER_KILL, TRIGGER_LOW_HEALTH, TRIGGER_REPLY,
+    clamp_chat_text,
+)
+
+
+READY_TIMEOUT_SECONDS = 90.0
+REQUEST_TIMEOUT_SECONDS = 12.0
+HEALTH_INTERVAL_SECONDS = 0.5
+# One line is at most 140 UTF-16 units and the prompt asks for far less, so a
+# short cap is a latency control rather than a quality limit.
+MAX_TOKENS = 48
+CONTEXT_TOKENS = 2048
+TEMPERATURE = 0.9
+TOP_P = 0.9
+# Qwen closes a turn with ``<|im_end|>``.  A newline ends the line whatever
+# the model intended: this channel carries exactly one sentence.
+STOP_SEQUENCES = ("<|im_end|>", "<|endoftext|>", "\n")
+PENDING_LIMIT = 24
+RESULT_LIMIT = 48
+
+PERSONA_STYLE = {
+    PERSONA_TACTICAL: "干脆、果断，像个老车长，说话短促",
+    PERSONA_SLACKER: "懒散、爱抱怨、有点摸鱼，语气松散",
+    PERSONA_MECHANIC: "满脑子车况：装填、履带、弹药架",
+    PERSONA_SCOUT: "谨慎、爱报点、先看再动",
+    PERSONA_POETIC: "话少，偶尔带一点文气，但不掉书袋",
+    PERSONA_PLAIN: "普通队友，平实直接",
+}
+
+TRIGGER_TASK = {
+    TRIGGER_REPLY: "回应队伍频道里最后那句话",
+    TRIGGER_HOP: "接住队友刚才那句话，不要重复他说过的内容",
+    TRIGGER_KILL: "你刚刚打掉了一个敌人",
+    TRIGGER_DOWN: "你刚刚被打死了",
+    TRIGGER_ALLY_DOWN: "你的一个队友刚刚阵亡",
+    TRIGGER_LOW_HEALTH: "你的血量已经很低了",
+}
+
+
+def free_loopback_port():
+    """Reserve and release one loopback port for a child process to bind."""
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        probe.bind(("127.0.0.1", 0))
+        return int(probe.getsockname()[1])
+    finally:
+        probe.close()
+
+
+def inference_threads(cpu_count=None):
+    """Return how many threads inference may take.
+
+    The game client, the hidden worker and this server all want the same
+    cores.  Leaving two behind keeps a reply from costing frames.
+    """
+    total = cpu_count if cpu_count is not None else (os.cpu_count() or 2)
+    return max(1, int(total) - 2)
+
+
+def _no_window_flags():
+    """Return creation flags that keep a console off the player's screen."""
+    if sys.platform != "win32":
+        return 0
+    return getattr(subprocess, "CREATE_NO_WINDOW", 0)
+
+
+class LlamaServerSupervisor(object):
+    """Own one hidden ``llama-server`` child process."""
+
+    def __init__(self, executable, model_path, port=None, threads=None,
+                 context_tokens=CONTEXT_TOKENS, log=None):
+        self.executable = str(executable)
+        self.model_path = str(model_path)
+        self.port = int(port) if port else None
+        self.threads = (int(threads) if threads else inference_threads())
+        self.context_tokens = int(context_tokens)
+        self._log = log or (lambda message: None)
+        self._process = None
+        self._ready = False
+
+    @property
+    def endpoint(self):
+        if not self.port:
+            return None
+        return "http://127.0.0.1:%d" % self.port
+
+    def available(self):
+        """Return whether both halves of the optional download are present."""
+        return (os.path.isfile(self.executable) and
+                os.path.isfile(self.model_path))
+
+    def start(self):
+        """Launch the generator, or report why it cannot run."""
+        if self._process is not None:
+            return True
+        if not self.available():
+            self._log("BOT CHAT model or runtime is not installed")
+            return False
+        if not self.port:
+            self.port = free_loopback_port()
+        command = [
+            self.executable,
+            "-m", self.model_path,
+            "--host", "127.0.0.1",
+            "--port", str(self.port),
+            "-c", str(self.context_tokens),
+            "-t", str(self.threads),
+        ]
+        try:
+            self._process = subprocess.Popen(
+                command,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                creationflags=_no_window_flags())
+        except OSError as error:
+            self._log("BOT CHAT runtime failed to start: %s" % (error,))
+            self._process = None
+            return False
+        self._log("BOT CHAT runtime started on port %d with %d threads"
+                  % (self.port, self.threads))
+        return True
+
+    def poll(self):
+        """Return the child's exit code, or None while it is running."""
+        return None if self._process is None else self._process.poll()
+
+    def wait_ready(self, timeout=READY_TIMEOUT_SECONDS, clock=time.monotonic,
+                   sleep=time.sleep):
+        """Block until the generator answers, or give up.
+
+        Only the caller that owns startup waits here.  A model load takes
+        seconds, and the battle must never be one of the things waiting.
+        """
+        if self._ready:
+            return True
+        deadline = clock() + float(timeout)
+        while clock() < deadline:
+            if self._process is not None and self._process.poll() is not None:
+                self._log("BOT CHAT runtime exited during startup")
+                return False
+            if self._health():
+                self._ready = True
+                return True
+            sleep(HEALTH_INTERVAL_SECONDS)
+        self._log("BOT CHAT runtime did not become ready")
+        return False
+
+    def is_ready(self):
+        return self._ready
+
+    def _health(self):
+        endpoint = self.endpoint
+        if endpoint is None:
+            return False
+        try:
+            with urllib.request.urlopen(
+                    endpoint + "/health", timeout=2.0) as response:
+                return response.status == 200
+        except (urllib.error.URLError, OSError, ValueError):
+            # An unready port refuses the connection rather than hanging.
+            return False
+
+    def stop(self):
+        """Terminate the child so no orphan holds the model in memory."""
+        process = self._process
+        self._process = None
+        self._ready = False
+        if process is None or process.poll() is not None:
+            return
+        try:
+            process.terminate()
+            try:
+                process.wait(timeout=5.0)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=5.0)
+        except OSError as error:
+            self._log("BOT CHAT runtime failed to stop: %s" % (error,))
+
+
+def build_messages(request):
+    """Turn one frozen line request into a Qwen chat exchange."""
+    bot = request.get("bot") or {}
+    persona = request.get("persona") or PERSONA_PLAIN
+    name = str(bot.get("name") or "队友")
+    vehicle = str(bot.get("vehicle") or "")
+    if ":" in vehicle:
+        vehicle = vehicle.split(":", 1)[1]
+    system = "\n".join((
+        "你在玩《坦克世界》，是玩家的AI队友，正在队伍聊天频道里说话。",
+        "你的ID是“%s”，开的车是 %s。" % (name, vehicle),
+        "你的说话风格：%s。" % PERSONA_STYLE.get(persona, PERSONA_STYLE[
+            PERSONA_PLAIN]),
+        "规则：",
+        "1. 只输出一句话，不超过25个字。",
+        "2. 不要加引号，不要写自己的ID，不要解释，不要换行。",
+        "3. 玩家说中文你就说中文，玩家说英文你就说英文。",
+        "4. 像队友在打字，可以口语、可以不完整。",
+    ))
+
+    lines = []
+    health = bot.get("hp")
+    maximum = bot.get("max_hp")
+    if health is not None and maximum:
+        lines.append("你的血量：%s/%s。" % (health, maximum))
+    transcript = [record for record in (request.get("recent") or ())
+                  if record.get("text")]
+    if transcript:
+        lines.append("队伍频道最近的话：")
+        for record in transcript[-6:]:
+            speaker = record.get("name") or "队友"
+            lines.append("%s：%s" % (speaker, record["text"]))
+    task = TRIGGER_TASK.get(request.get("trigger"))
+    if task:
+        lines.append("现在轮到你说话：%s。" % task)
+    prefix = request.get("address_prefix")
+    if prefix:
+        lines.append("刚才是 %s 在叫你。" % prefix)
+    lines.append("只回一句话：")
+    return [
+        {"role": "system", "content": system},
+        {"role": "user", "content": "\n".join(lines)},
+    ]
+
+
+class LlamaChatBackend(object):
+    """Compose Bot lines against a local ``llama-server``, never blocking.
+
+    ``prefetch`` starts one generation; ``compose`` collects whichever result
+    is already finished.  A line whose generation is still running, failed, or
+    produced nothing publishable simply has no result, and the caller falls
+    back to the shipped templates.
+    """
+
+    def __init__(self, endpoint, latency_hint_seconds=3.0,
+                 timeout=REQUEST_TIMEOUT_SECONDS, opener=None, log=None):
+        self.endpoint = str(endpoint).rstrip("/")
+        self.latency_hint_seconds = float(latency_hint_seconds)
+        self._timeout = float(timeout)
+        self._opener = opener or self._post
+        self._log = log or (lambda message: None)
+        self._lock = threading.Lock()
+        self._results = {}
+        self._order = []
+        self._pending = set()
+        self._thread = None
+        self._queue = []
+        self._wake = threading.Condition(self._lock)
+        self._stopped = False
+
+    # -- lifecycle ------------------------------------------------------
+
+    def start(self):
+        """Start the single generation worker."""
+        with self._lock:
+            if self._thread is not None:
+                return
+            self._stopped = False
+            self._thread = threading.Thread(
+                target=self._run, name="bot-chat-llm")
+            self._thread.daemon = True
+            self._thread.start()
+
+    def stop(self):
+        """Stop the worker without waiting on an in-flight request."""
+        with self._lock:
+            self._stopped = True
+            self._queue = []
+            self._wake.notify_all()
+            thread = self._thread
+            self._thread = None
+        if thread is not None:
+            thread.join(timeout=1.0)
+
+    # -- backend contract -----------------------------------------------
+
+    def prefetch(self, request):
+        """Queue one line for generation."""
+        request_id = request.get("request_id")
+        if request_id is None:
+            return
+        try:
+            messages = build_messages(request)
+        except Exception as error:
+            self._log("BOT CHAT prompt failed: %s" % (error,))
+            return
+        with self._lock:
+            if self._stopped or request_id in self._pending:
+                return
+            if len(self._queue) >= PENDING_LIMIT:
+                # The battle outran the generator.  Dropping the oldest keeps
+                # the queue answering the current conversation rather than one
+                # that has already moved on.
+                dropped = self._queue.pop(0)
+                self._pending.discard(dropped[0])
+            self._queue.append((request_id, messages))
+            self._pending.add(request_id)
+            self._wake.notify()
+
+    def compose(self, request):
+        """Return this line's finished text, or None to fall back."""
+        request_id = request.get("request_id")
+        if request_id is None:
+            return None
+        with self._lock:
+            return self._results.pop(request_id, None)
+
+    # -- worker ---------------------------------------------------------
+
+    def _run(self):
+        while True:
+            with self._lock:
+                while not self._queue and not self._stopped:
+                    self._wake.wait(0.5)
+                if self._stopped:
+                    return
+                request_id, messages = self._queue.pop(0)
+            text = None
+            try:
+                text = self._generate(messages)
+            except Exception as error:
+                self._log("BOT CHAT generation failed: %s" % (error,))
+            with self._lock:
+                self._pending.discard(request_id)
+                if self._stopped:
+                    return
+                if text:
+                    self._results[request_id] = text
+                    self._order.append(request_id)
+                    while len(self._order) > RESULT_LIMIT:
+                        self._results.pop(self._order.pop(0), None)
+
+    def _generate(self, messages):
+        payload = {
+            "messages": messages,
+            "max_tokens": MAX_TOKENS,
+            "temperature": TEMPERATURE,
+            "top_p": TOP_P,
+            "stop": list(STOP_SEQUENCES),
+            "stream": False,
+        }
+        body = self._opener(self.endpoint + "/v1/chat/completions", payload)
+        return sanitize_line(extract_content(body))
+
+    def _post(self, url, payload):
+        data = json.dumps(payload).encode("utf-8")
+        appeal = urllib.request.Request(
+            url, data=data, headers={"Content-Type": "application/json"})
+        with urllib.request.urlopen(appeal, timeout=self._timeout) as response:
+            return json.loads(response.read().decode("utf-8"))
+
+
+def extract_content(body):
+    """Return the assistant text from one chat completion, or None."""
+    if not isinstance(body, dict):
+        return None
+    choices = body.get("choices")
+    if not isinstance(choices, list) or not choices:
+        return None
+    message = choices[0].get("message") if isinstance(choices[0], dict) else None
+    if not isinstance(message, dict):
+        return None
+    content = message.get("content")
+    return content if isinstance(content, str) else None
+
+
+def sanitize_line(text):
+    """Reduce model output to one publishable stock chat line, or None.
+
+    The model is untrusted input like any other.  This strips the shapes a
+    small instruct model actually produces -- a leading callsign, wrapping
+    quotes, a reasoning block, several lines at once -- before the stock
+    length and encoding rules get the final say.
+    """
+    if not isinstance(text, str):
+        return None
+    cleaned = text
+    # Qwen2.5 has no thinking mode, but a mis-picked model would leak one.
+    while "<think>" in cleaned and "</think>" in cleaned:
+        head, rest = cleaned.split("<think>", 1)
+        cleaned = head + rest.split("</think>", 1)[1]
+    for marker in ("<|im_end|>", "<|endoftext|>", "<|im_start|>"):
+        cleaned = cleaned.replace(marker, " ")
+    # Only the first line is a chat message; the rest is the model continuing
+    # a conversation with itself.
+    cleaned = cleaned.replace("\r", "\n").split("\n")[0].strip()
+    for quote in ('"', "'", "“", "”", "「", "」", "『", "』"):
+        cleaned = cleaned.strip(quote)
+    cleaned = cleaned.strip()
+    # ``名字：内容`` is the single most common instruct-model slip here.
+    for separator in ("：", ":"):
+        head, sep, tail = cleaned.partition(separator)
+        if sep and tail.strip() and len(head) <= 12 and "，" not in head:
+            cleaned = tail.strip()
+            break
+    return clamp_chat_text(cleaned)

--- a/server/bot_chat_llm.py
+++ b/server/bot_chat_llm.py
@@ -44,7 +44,9 @@ READY_TIMEOUT_SECONDS = 90.0
 # never a frame of the battle.
 REQUEST_TIMEOUT_SECONDS = 90.0
 # What one line is assumed to cost before this machine has shown otherwise.
-INITIAL_LATENCY_SECONDS = 4.0
+# A measured session took 9.6 s for its first line, so a smaller guess only
+# means the first line waits an extra look before it is published.
+INITIAL_LATENCY_SECONDS = 10.0
 # How much longer than the average observed line to hold a scheduled one.
 LATENCY_MARGIN = 1.4
 LATENCY_SMOOTHING = 0.4
@@ -425,12 +427,24 @@ class LlamaChatBackend(object):
             self._wake.notify()
 
     def compose(self, request):
-        """Return this line's finished text, or None to fall back."""
+        """Return this line's finished text, if it has finished."""
         request_id = request.get("request_id")
         if request_id is None:
             return None
         with self._lock:
             return self._results.pop(request_id, None)
+
+    def pending(self, request):
+        """Return whether this line is still being written.
+
+        A line that is merely late is not a line that failed, and the
+        difference decides whether the caller should wait or give up.
+        """
+        request_id = request.get("request_id")
+        if request_id is None:
+            return False
+        with self._lock:
+            return request_id in self._pending
 
     # -- worker ---------------------------------------------------------
 

--- a/server/bot_chat_llm.py
+++ b/server/bot_chat_llm.py
@@ -77,7 +77,8 @@ SHARED_RULES = (
     "你在玩《坦克世界》，是玩家的AI队友，正在队伍聊天频道里说话。",
     "规则：",
     "1. 只输出一句话，不超过25个字。",
-    "2. 不要加引号，不要写自己的ID，不要解释，不要换行。",
+    "2. 不要加引号，不要写名字，不要解释，不要换行。",
+    "5. 不要重复上面已经说过的话，换个说法。",
     "3. 玩家说中文你就说中文，玩家说英文你就说英文。",
     "4. 像队友在打字，可以口语、可以不完整。",
 )
@@ -294,15 +295,18 @@ def build_messages(request):
     """Turn one frozen line request into a Qwen chat exchange."""
     bot = request.get("bot") or {}
     persona = request.get("persona") or PERSONA_PLAIN
-    name = str(bot.get("name") or "队友")
     vehicle = str(bot.get("vehicle") or "")
     if ":" in vehicle:
         vehicle = vehicle.split(":", 1)[1]
     # The shared rules come first and the per-Bot identity last, so every
     # Bot's prompt starts with the same tokens. llama.cpp reuses the cached
     # prefix, and on a slow machine prompt processing is most of the wait.
+    # The callsign is deliberately absent. A small model given its own name
+    # simply says it: a Bot called 慢慢开别急 answered every line with a
+    # variation on its own callsign. The persona is already derived from that
+    # name, so nothing is lost by not repeating it here.
     system = "\n".join(SHARED_RULES + (
-        "你的ID是“%s”，开的车是 %s。" % (name, vehicle),
+        "你开的车是 %s。" % vehicle,
         "你的说话风格：%s。" % PERSONA_STYLE.get(persona, PERSONA_STYLE[
             PERSONA_PLAIN]),
     ))

--- a/server/bot_chat_llm.py
+++ b/server/bot_chat_llm.py
@@ -48,6 +48,11 @@ TOP_P = 0.9
 # Qwen closes a turn with ``<|im_end|>``.  A newline ends the line whatever
 # the model intended: this channel carries exactly one sentence.
 STOP_SEQUENCES = ("<|im_end|>", "<|endoftext|>", "\n")
+# A reasoning model would spend the whole reply budget inside a ``<think>``
+# block nobody sees, so thinking is switched off at both levels the pinned
+# runtime offers.  Each is a no-op for a template that has no thinking mode.
+REASONING_BUDGET = "0"
+CHAT_TEMPLATE_KWARGS = {"enable_thinking": False}
 PENDING_LIMIT = 24
 RESULT_LIMIT = 48
 
@@ -138,6 +143,7 @@ class LlamaServerSupervisor(object):
             "--port", str(self.port),
             "-c", str(self.context_tokens),
             "-t", str(self.threads),
+            "--reasoning-budget", REASONING_BUDGET,
         ]
         try:
             self._process = subprocess.Popen(
@@ -372,6 +378,7 @@ class LlamaChatBackend(object):
             "top_p": TOP_P,
             "stop": list(STOP_SEQUENCES),
             "stream": False,
+            "chat_template_kwargs": dict(CHAT_TEMPLATE_KWARGS),
         }
         body = self._opener(self.endpoint + "/v1/chat/completions", payload)
         return sanitize_line(extract_content(body))
@@ -409,7 +416,8 @@ def sanitize_line(text):
     if not isinstance(text, str):
         return None
     cleaned = text
-    # Qwen2.5 has no thinking mode, but a mis-picked model would leak one.
+    # Thinking is switched off at the runtime and in the template, so this
+    # only fires when one of those switches did not take.
     while "<think>" in cleaned and "</think>" in cleaned:
         head, rest = cleaned.split("<think>", 1)
         cleaned = head + rest.split("</think>", 1)[1]

--- a/server/bot_chat_llm.py
+++ b/server/bot_chat_llm.py
@@ -53,6 +53,9 @@ STOP_SEQUENCES = ("<|im_end|>", "<|endoftext|>", "\n")
 # runtime offers.  Each is a no-op for a template that has no thinking mode.
 REASONING_BUDGET = "0"
 CHAT_TEMPLATE_KWARGS = {"enable_thinking": False}
+# Where the generator's own output is kept, beside its executable.
+RUNTIME_LOG_NAME = "llama-server.log"
+OUTPUT_TAIL_BYTES = 8192
 PENDING_LIMIT = 24
 RESULT_LIMIT = 48
 
@@ -106,14 +109,20 @@ class LlamaServerSupervisor(object):
     """Own one hidden ``llama-server`` child process."""
 
     def __init__(self, executable, model_path, port=None, threads=None,
-                 context_tokens=CONTEXT_TOKENS, log=None):
+                 context_tokens=CONTEXT_TOKENS, log=None, output_path=None):
         self.executable = str(executable)
         self.model_path = str(model_path)
         self.port = int(port) if port else None
         self.threads = (int(threads) if threads else inference_threads())
         self.context_tokens = int(context_tokens)
         self._log = log or (lambda message: None)
+        # A generator that dies during startup says why on its own output.
+        # Discarding that leaves "it exited" as the entire diagnosis, which
+        # is not a diagnosis.
+        self.output_path = output_path or os.path.join(
+            os.path.dirname(self.executable) or ".", RUNTIME_LOG_NAME)
         self._process = None
+        self._output = None
         self._ready = False
 
     @property
@@ -146,19 +155,52 @@ class LlamaServerSupervisor(object):
             "--reasoning-budget", REASONING_BUDGET,
         ]
         try:
+            self._output = open(self.output_path, "wb")
+        except OSError:
+            self._output = None
+        try:
             self._process = subprocess.Popen(
                 command,
                 stdin=subprocess.DEVNULL,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
+                stdout=self._output or subprocess.DEVNULL,
+                stderr=subprocess.STDOUT if self._output
+                else subprocess.DEVNULL,
                 creationflags=_no_window_flags())
         except OSError as error:
             self._log("BOT CHAT runtime failed to start: %s" % (error,))
+            self._close_output()
             self._process = None
             return False
-        self._log("BOT CHAT runtime started on port %d with %d threads"
-                  % (self.port, self.threads))
+        self._log("BOT CHAT runtime started on port %d with %d threads: %s"
+                  % (self.port, self.threads, " ".join(command)))
         return True
+
+    def _close_output(self):
+        output, self._output = self._output, None
+        if output is not None:
+            try:
+                output.close()
+            except OSError:
+                pass
+
+    def output_tail(self, lines=12):
+        """Return the generator's last words, for a failure report."""
+        try:
+            with open(self.output_path, "rb") as stream:
+                text = stream.read()[-OUTPUT_TAIL_BYTES:]
+        except OSError:
+            return ""
+        decoded = text.decode("utf-8", "replace").replace("\r", "")
+        kept = [line for line in decoded.split("\n") if line.strip()]
+        return " | ".join(kept[-lines:])
+
+    def _report_exit(self, reason):
+        """Log why the generator stopped, with whatever it said about it."""
+        code = self.poll()
+        tail = self.output_tail()
+        self._log("BOT CHAT runtime %s (exit=%s): %s" % (
+            reason, "?" if code is None else code,
+            tail or "it wrote nothing; see %s" % self.output_path))
 
     def poll(self):
         """Return the child's exit code, or None while it is running."""
@@ -176,13 +218,14 @@ class LlamaServerSupervisor(object):
         deadline = clock() + float(timeout)
         while clock() < deadline:
             if self._process is not None and self._process.poll() is not None:
-                self._log("BOT CHAT runtime exited during startup")
+                self._close_output()
+                self._report_exit("exited during startup")
                 return False
             if self._health():
                 self._ready = True
                 return True
             sleep(HEALTH_INTERVAL_SECONDS)
-        self._log("BOT CHAT runtime did not become ready")
+        self._report_exit("did not become ready")
         return False
 
     def is_ready(self):
@@ -206,6 +249,7 @@ class LlamaServerSupervisor(object):
         self._process = None
         self._ready = False
         if process is None or process.poll() is not None:
+            self._close_output()
             return
         try:
             process.terminate()
@@ -216,6 +260,8 @@ class LlamaServerSupervisor(object):
                 process.wait(timeout=5.0)
         except OSError as error:
             self._log("BOT CHAT runtime failed to stop: %s" % (error,))
+        finally:
+            self._close_output()
 
 
 def build_messages(request):

--- a/server/bot_chat_llm.py
+++ b/server/bot_chat_llm.py
@@ -37,7 +37,17 @@ from bot_chat import (
 
 
 READY_TIMEOUT_SECONDS = 90.0
-REQUEST_TIMEOUT_SECONDS = 12.0
+# Generous rather than tuned. A slow machine -- an emulated CPU, two threads,
+# a cold prompt -- takes far longer for one short line than a desktop does,
+# and cutting it off produces silence rather than a fast answer. Nothing
+# waits on this: a stuck request costs unsaid lines on one worker thread and
+# never a frame of the battle.
+REQUEST_TIMEOUT_SECONDS = 90.0
+# What one line is assumed to cost before this machine has shown otherwise.
+INITIAL_LATENCY_SECONDS = 4.0
+# How much longer than the average observed line to hold a scheduled one.
+LATENCY_MARGIN = 1.4
+LATENCY_SMOOTHING = 0.4
 HEALTH_INTERVAL_SECONDS = 0.5
 # One line is at most 140 UTF-16 units and the prompt asks for far less, so a
 # short cap is a latency control rather than a quality limit.
@@ -58,6 +68,20 @@ RUNTIME_LOG_NAME = "llama-server.log"
 OUTPUT_TAIL_BYTES = 8192
 PENDING_LIMIT = 24
 RESULT_LIMIT = 48
+
+# Identical for every Bot in every round, and therefore the part worth
+# putting in front of the cache.
+SHARED_RULES = (
+    "你在玩《坦克世界》，是玩家的AI队友，正在队伍聊天频道里说话。",
+    "规则：",
+    "1. 只输出一句话，不超过25个字。",
+    "2. 不要加引号，不要写自己的ID，不要解释，不要换行。",
+    "3. 玩家说中文你就说中文，玩家说英文你就说英文。",
+    "4. 像队友在打字，可以口语、可以不完整。",
+)
+# How much of the channel one line is given as context. Every extra line is
+# prompt this machine has to process again before it can answer.
+TRANSCRIPT_LINES = 4
 
 PERSONA_STYLE = {
     PERSONA_TACTICAL: "干脆、果断，像个老车长，说话短促",
@@ -272,16 +296,13 @@ def build_messages(request):
     vehicle = str(bot.get("vehicle") or "")
     if ":" in vehicle:
         vehicle = vehicle.split(":", 1)[1]
-    system = "\n".join((
-        "你在玩《坦克世界》，是玩家的AI队友，正在队伍聊天频道里说话。",
+    # The shared rules come first and the per-Bot identity last, so every
+    # Bot's prompt starts with the same tokens. llama.cpp reuses the cached
+    # prefix, and on a slow machine prompt processing is most of the wait.
+    system = "\n".join(SHARED_RULES + (
         "你的ID是“%s”，开的车是 %s。" % (name, vehicle),
         "你的说话风格：%s。" % PERSONA_STYLE.get(persona, PERSONA_STYLE[
             PERSONA_PLAIN]),
-        "规则：",
-        "1. 只输出一句话，不超过25个字。",
-        "2. 不要加引号，不要写自己的ID，不要解释，不要换行。",
-        "3. 玩家说中文你就说中文，玩家说英文你就说英文。",
-        "4. 像队友在打字，可以口语、可以不完整。",
     ))
 
     lines = []
@@ -293,7 +314,7 @@ def build_messages(request):
                   if record.get("text")]
     if transcript:
         lines.append("队伍频道最近的话：")
-        for record in transcript[-6:]:
+        for record in transcript[-TRANSCRIPT_LINES:]:
             speaker = record.get("name") or "队友"
             lines.append("%s：%s" % (speaker, record["text"]))
     task = TRIGGER_TASK.get(request.get("trigger"))
@@ -318,10 +339,11 @@ class LlamaChatBackend(object):
     back to the shipped templates.
     """
 
-    def __init__(self, endpoint, latency_hint_seconds=3.0,
+    def __init__(self, endpoint, latency_hint_seconds=INITIAL_LATENCY_SECONDS,
                  timeout=REQUEST_TIMEOUT_SECONDS, opener=None, log=None):
         self.endpoint = str(endpoint).rstrip("/")
-        self.latency_hint_seconds = float(latency_hint_seconds)
+        self._initial_latency = float(latency_hint_seconds)
+        self._observed_latency = None
         self._timeout = float(timeout)
         self._opener = opener or self._post
         self._log = log or (lambda message: None)
@@ -333,6 +355,25 @@ class LlamaChatBackend(object):
         self._queue = []
         self._wake = threading.Condition(self._lock)
         self._stopped = False
+
+    @property
+    def latency_hint_seconds(self):
+        """Return how long this machine actually needs for one line.
+
+        A constant cannot serve both a desktop and an emulated VM, so the
+        estimate follows what this machine has really done. Until it has done
+        anything, the initial guess stands.
+        """
+        if self._observed_latency is None:
+            return self._initial_latency
+        return max(self._initial_latency,
+                   self._observed_latency * LATENCY_MARGIN)
+
+    def _record_latency(self, seconds):
+        previous = self._observed_latency
+        self._observed_latency = (
+            seconds if previous is None else
+            previous + (seconds - previous) * LATENCY_SMOOTHING)
 
     # -- lifecycle ------------------------------------------------------
 
@@ -402,10 +443,18 @@ class LlamaChatBackend(object):
                     return
                 request_id, messages = self._queue.pop(0)
             text = None
+            started = time.monotonic()
             try:
                 text = self._generate(messages)
+                elapsed = time.monotonic() - started
+                self._record_latency(elapsed)
+                self._log("BOT CHAT generated one line in %.1fs" % elapsed)
             except Exception as error:
-                self._log("BOT CHAT generation failed: %s" % (error,))
+                elapsed = time.monotonic() - started
+                # Naming the wait is what separates "the model is slow" from
+                # "the model is broken".
+                self._log("BOT CHAT generation failed after %.1fs: %s"
+                          % (elapsed, error))
             with self._lock:
                 self._pending.discard(request_id)
                 if self._stopped:

--- a/server/bot_chat_models.py
+++ b/server/bot_chat_models.py
@@ -16,7 +16,14 @@ resolved from "latest" so a working install cannot change under a player.
 
 MODELSCOPE = "modelscope"
 HUGGINGFACE = "huggingface"
+GITHUB = "github"
 SOURCES = (MODELSCOPE, HUGGINGFACE)
+# The runtime's upstream home is GitHub, which is the least reliable host in
+# this catalogue from mainland China.  A ModelScope repository mirrors the
+# pinned release assets byte for byte, so the same digest validates either
+# and a stale or wrong mirror fails integrity rather than installing
+# something else.
+RUNTIME_SOURCES = (MODELSCOPE, GITHUB)
 
 # ``FilePath`` serves the LFS object directly, which is what makes ModelScope
 # usable without its SDK.
@@ -89,7 +96,10 @@ DEFAULT_TIER_KEY = "qwen3-0.6b"
 
 RUNTIME_BUILD = "b10819"
 RUNTIME_LICENSE = "MIT"
-_RUNTIME_URL = (
+# Redistributing the MIT-licensed binaries only requires the licence to
+# travel with them, so the mirror carries llama.cpp's LICENSE file too.
+RUNTIME_MODELSCOPE_REPO = "pengw0048/wot-offline-battles-llama-runtime"
+_RUNTIME_GITHUB_URL = (
     "https://github.com/ggml-org/llama.cpp/releases/download/%s/%s")
 RUNTIME_ASSETS = {
     "x64": {
@@ -154,9 +164,16 @@ def runtime_asset(arch):
     return dict(entry) if entry else None
 
 
-def runtime_url(arch):
-    """Return the pinned runtime download URL, or None."""
+def runtime_url(arch, source=MODELSCOPE):
+    """Return one pinned runtime download URL, or None.
+
+    ModelScope is the default for the same reason it leads the model list.
+    Both mirrors serve the identical archive, so a caller may try either and
+    validate the result against one ``sha256``.
+    """
     entry = runtime_asset(arch)
-    if entry is None:
+    if entry is None or source not in RUNTIME_SOURCES:
         return None
-    return _RUNTIME_URL % (RUNTIME_BUILD, entry["file"])
+    if source == MODELSCOPE:
+        return _MODELSCOPE_URL % (RUNTIME_MODELSCOPE_REPO, entry["file"])
+    return _RUNTIME_GITHUB_URL % (RUNTIME_BUILD, entry["file"])

--- a/server/bot_chat_models.py
+++ b/server/bot_chat_models.py
@@ -1,0 +1,130 @@
+"""Name the optional local chat model and runtime, and where to fetch them.
+
+This module is pure data and URL construction.  It downloads nothing and
+imports nothing beyond the standard library, so the launcher, the server and
+the tests can all agree on exactly one catalogue.
+
+Two mirrors serve every model entry.  ModelScope is reachable from mainland
+China, where Hugging Face generally is not; both were verified to serve the
+byte-identical file, so one ``sha256`` validates a download from either.
+
+Every listed model is Apache-2.0.  The runtime is the upstream llama.cpp
+CPU-only Windows build: the game already owns the GPU, and a CPU build is a
+fraction of the size of the CUDA one.  The build is pinned rather than
+resolved from "latest" so a working install cannot change under a player.
+"""
+
+MODELSCOPE = "modelscope"
+HUGGINGFACE = "huggingface"
+SOURCES = (MODELSCOPE, HUGGINGFACE)
+
+# ``FilePath`` serves the LFS object directly, which is what makes ModelScope
+# usable without its SDK.
+_MODELSCOPE_URL = (
+    "https://www.modelscope.cn/api/v1/models/%s/repo"
+    "?Revision=master&FilePath=%s")
+_HUGGINGFACE_URL = "https://huggingface.co/%s/resolve/main/%s"
+
+# Qwen2.5-Instruct rather than Qwen3: Qwen3 emits ``<think>`` reasoning
+# blocks, which would both blow a 140 unit chat line and spend the whole
+# reply budget on text nobody sees.  Do not "upgrade" this without solving
+# that first.
+MODEL_TIERS = (
+    {
+        "key": "small",
+        "parameters": "0.5B",
+        "quantization": "Q4_K_M",
+        "repo": "Qwen/Qwen2.5-0.5B-Instruct-GGUF",
+        "file": "qwen2.5-0.5b-instruct-q4_k_m.gguf",
+        "size": 491400032,
+        "sha256":
+            "74a4da8c9fdbcd15bd1f6d01d621410d31c6fc00986f5eb687824e7b93d7a9db",
+        "license": "Apache-2.0",
+    },
+    {
+        "key": "large",
+        "parameters": "1.5B",
+        "quantization": "Q4_K_M",
+        "repo": "Qwen/Qwen2.5-1.5B-Instruct-GGUF",
+        "file": "qwen2.5-1.5b-instruct-q4_k_m.gguf",
+        "size": 1117320736,
+        "sha256":
+            "6a1a2eb6d15622bf3c96857206351ba97e1af16c30d7a74ee38970e434e9407e",
+        "license": "Apache-2.0",
+    },
+)
+DEFAULT_TIER_KEY = "small"
+
+RUNTIME_BUILD = "b10819"
+RUNTIME_LICENSE = "MIT"
+_RUNTIME_URL = (
+    "https://github.com/ggml-org/llama.cpp/releases/download/%s/%s")
+RUNTIME_ASSETS = {
+    "x64": {
+        "file": "llama-b10819-bin-win-cpu-x64.zip",
+        "size": 18413010,
+        "sha256":
+            "4599e502b374196d24600ea9b03c842a448c853116a15b55e8ba502bdc727b3f",
+    },
+    "arm64": {
+        "file": "llama-b10819-bin-win-cpu-arm64.zip",
+        "size": 11980559,
+        "sha256":
+            "5802d55f633b68bf6dbe574d75f9f47387761fe3b6ddef4193ea9ea423642afb",
+    },
+}
+RUNTIME_EXECUTABLE = "llama-server.exe"
+
+
+def tier(key):
+    """Return one catalogued model tier, or None."""
+    for entry in MODEL_TIERS:
+        if entry["key"] == str(key):
+            return dict(entry)
+    return None
+
+
+def default_tier():
+    """Return the tier a player gets without choosing one."""
+    return tier(DEFAULT_TIER_KEY)
+
+
+def model_url(tier_key, source):
+    """Return the direct download URL for one tier from one mirror."""
+    entry = tier(tier_key)
+    if entry is None or source not in SOURCES:
+        return None
+    if source == MODELSCOPE:
+        return _MODELSCOPE_URL % (entry["repo"], entry["file"])
+    return _HUGGINGFACE_URL % (entry["repo"], entry["file"])
+
+
+def runtime_arch(machine):
+    """Map a ``platform.machine()`` string onto a published runtime build.
+
+    A Windows-on-ARM host runs the x64 build under emulation, which is
+    markedly slower than its native ARM64 build.  Naming the architecture
+    honestly is the difference between a usable reply and a timeout.
+    """
+    name = str(machine or "").strip().lower()
+    if name in ("arm64", "aarch64"):
+        return "arm64"
+    if name in ("amd64", "x86_64", "x64"):
+        return "x64"
+    # A 32-bit host has no published CPU build; the caller must report that
+    # rather than download an executable that cannot run.
+    return None
+
+
+def runtime_asset(arch):
+    """Return the pinned runtime archive for one architecture, or None."""
+    entry = RUNTIME_ASSETS.get(str(arch))
+    return dict(entry) if entry else None
+
+
+def runtime_url(arch):
+    """Return the pinned runtime download URL, or None."""
+    entry = runtime_asset(arch)
+    if entry is None:
+        return None
+    return _RUNTIME_URL % (RUNTIME_BUILD, entry["file"])

--- a/server/bot_chat_models.py
+++ b/server/bot_chat_models.py
@@ -25,13 +25,41 @@ _MODELSCOPE_URL = (
     "?Revision=master&FilePath=%s")
 _HUGGINGFACE_URL = "https://huggingface.co/%s/resolve/main/%s"
 
-# Qwen2.5-Instruct rather than Qwen3: Qwen3 emits ``<think>`` reasoning
-# blocks, which would both blow a 140 unit chat line and spend the whole
-# reply budget on text nobody sees.  Do not "upgrade" this without solving
-# that first.
+# Qwen3 thinking is switched off explicitly rather than avoided: the pinned
+# runtime accepts ``--reasoning-budget 0`` and the request carries
+# ``chat_template_kwargs {"enable_thinking": false}``.  Both are no-ops for a
+# model whose template has no thinking mode, so the same call serves either
+# generation.  Without them a reasoning model would spend the whole reply
+# budget on a ``<think>`` block nobody sees.
+#
+# The Qwen organisation publishes only Q8_0 for the Qwen3 GGUF repositories,
+# so those entries are larger than the Q4_K_M Qwen2.5 ones at similar
+# parameter counts.  Third-party requantisations are deliberately not listed.
 MODEL_TIERS = (
     {
-        "key": "small",
+        "key": "qwen3-0.6b",
+        "parameters": "0.6B",
+        "quantization": "Q8_0",
+        "repo": "Qwen/Qwen3-0.6B-GGUF",
+        "file": "Qwen3-0.6B-Q8_0.gguf",
+        "size": 639446688,
+        "sha256":
+            "9465e63a22add5354d9bb4b99e90117043c7124007664907259bd16d043bb031",
+        "license": "Apache-2.0",
+    },
+    {
+        "key": "qwen3-1.7b",
+        "parameters": "1.7B",
+        "quantization": "Q8_0",
+        "repo": "Qwen/Qwen3-1.7B-GGUF",
+        "file": "Qwen3-1.7B-Q8_0.gguf",
+        "size": 1834426016,
+        "sha256":
+            "061b54daade076b5d3362dac252678d17da8c68f07560be70818cace6590cb1a",
+        "license": "Apache-2.0",
+    },
+    {
+        "key": "qwen2.5-0.5b",
         "parameters": "0.5B",
         "quantization": "Q4_K_M",
         "repo": "Qwen/Qwen2.5-0.5B-Instruct-GGUF",
@@ -42,7 +70,7 @@ MODEL_TIERS = (
         "license": "Apache-2.0",
     },
     {
-        "key": "large",
+        "key": "qwen2.5-1.5b",
         "parameters": "1.5B",
         "quantization": "Q4_K_M",
         "repo": "Qwen/Qwen2.5-1.5B-Instruct-GGUF",
@@ -53,7 +81,11 @@ MODEL_TIERS = (
         "license": "Apache-2.0",
     },
 )
-DEFAULT_TIER_KEY = "small"
+# The smallest current-generation entry: newer than the Qwen2.5 pair at a
+# comparable size, and small enough to be the one tier every machine tries
+# first.  Which of these actually writes a better Chinese one-liner in time
+# has not been measured on Windows.
+DEFAULT_TIER_KEY = "qwen3-0.6b"
 
 RUNTIME_BUILD = "b10819"
 RUNTIME_LICENSE = "MIT"

--- a/server/bot_chat_models.py
+++ b/server/bot_chat_models.py
@@ -18,12 +18,6 @@ MODELSCOPE = "modelscope"
 HUGGINGFACE = "huggingface"
 GITHUB = "github"
 SOURCES = (MODELSCOPE, HUGGINGFACE)
-# The runtime's upstream home is GitHub, which is the least reliable host in
-# this catalogue from mainland China.  A ModelScope repository mirrors the
-# pinned release assets byte for byte, so the same digest validates either
-# and a stale or wrong mirror fails integrity rather than installing
-# something else.
-RUNTIME_SOURCES = (MODELSCOPE, GITHUB)
 
 # ``FilePath`` serves the LFS object directly, which is what makes ModelScope
 # usable without its SDK.
@@ -94,25 +88,39 @@ MODEL_TIERS = (
 # has not been measured on Windows.
 DEFAULT_TIER_KEY = "qwen3-0.6b"
 
-RUNTIME_BUILD = "b10819"
+# llama.cpp publishes Windows builds only as GitHub release assets, which is
+# the least reliable host in this catalogue from mainland China.  The pin is
+# therefore chosen to be a build that a third-party ModelScope repository
+# already mirrors, rather than the newest one.  b9637 documents every switch
+# this code uses, including ``--reasoning-budget`` and ``chat_template_kwargs``.
+#
+# Trusting that mirror costs nothing: the digest below is the official GitHub
+# artifact's, verified byte-identical to what the mirror serves, so a mirror
+# that is stale, wrong or hostile fails integrity instead of installing
+# something else.  Its repository name embeds the build, so moving the pin
+# retires the mirror cleanly into a 404 and GitHub takes over.
+RUNTIME_BUILD = "b9637"
 RUNTIME_LICENSE = "MIT"
-# Redistributing the MIT-licensed binaries only requires the licence to
-# travel with them, so the mirror carries llama.cpp's LICENSE file too.
-RUNTIME_MODELSCOPE_REPO = "pengw0048/wot-offline-battles-llama-runtime"
+RUNTIME_MODELSCOPE_REPO = "ytr56269/llama.cpp-b9637-Windows-Runtime"
 _RUNTIME_GITHUB_URL = (
     "https://github.com/ggml-org/llama.cpp/releases/download/%s/%s")
 RUNTIME_ASSETS = {
     "x64": {
-        "file": "llama-b10819-bin-win-cpu-x64.zip",
-        "size": 18413010,
+        "file": "llama-b9637-bin-win-cpu-x64.zip",
+        "size": 16906751,
         "sha256":
-            "4599e502b374196d24600ea9b03c842a448c853116a15b55e8ba502bdc727b3f",
+            "f7783c2b8c007f95e710ac40f26a24861a80b603b0b739fc54d7c926a4716c1e",
+        # Ordered by reachability from mainland China, not by authority.
+        "sources": (MODELSCOPE, GITHUB),
     },
     "arm64": {
-        "file": "llama-b10819-bin-win-cpu-arm64.zip",
-        "size": 11980559,
+        "file": "llama-b9637-bin-win-cpu-arm64.zip",
+        "size": 10846442,
         "sha256":
-            "5802d55f633b68bf6dbe574d75f9f47387761fe3b6ddef4193ea9ea423642afb",
+            "db1d3f4c13c08b693f539e100bf6d3a435148b0ffc186b044fdd65d490cc6df7",
+        # No mirror publishes the ARM64 build.  A Windows-on-ARM host can
+        # still run the x64 archive under emulation if GitHub is unreachable.
+        "sources": (GITHUB,),
     },
 }
 RUNTIME_EXECUTABLE = "llama-server.exe"
@@ -164,15 +172,25 @@ def runtime_asset(arch):
     return dict(entry) if entry else None
 
 
-def runtime_url(arch, source=MODELSCOPE):
+def runtime_sources(arch):
+    """Return the hosts that serve one architecture, best route first."""
+    entry = RUNTIME_ASSETS.get(str(arch))
+    return tuple(entry["sources"]) if entry else ()
+
+
+def runtime_url(arch, source=None):
     """Return one pinned runtime download URL, or None.
 
-    ModelScope is the default for the same reason it leads the model list.
-    Both mirrors serve the identical archive, so a caller may try either and
-    validate the result against one ``sha256``.
+    With no source named, the best route for that architecture is used.
+    Every host serves the identical archive, so a caller may try them in
+    order and validate whichever answers against one ``sha256``.
     """
     entry = runtime_asset(arch)
-    if entry is None or source not in RUNTIME_SOURCES:
+    if entry is None:
+        return None
+    if source is None:
+        source = entry["sources"][0]
+    if source not in entry["sources"]:
         return None
     if source == MODELSCOPE:
         return _MODELSCOPE_URL % (RUNTIME_MODELSCOPE_REPO, entry["file"])

--- a/server/lan_battle_server.py
+++ b/server/lan_battle_server.py
@@ -14461,7 +14461,7 @@ def print_bot_chat_catalogue(stream=None):
     stream = stream or sys.stdout
     arch = bot_chat_models.runtime_arch(platform.machine())
     for entry in bot_chat_models.MODEL_TIERS:
-        print("%-6s %-5s %-8s %6.0f MB  %s" % (
+        print("%-13s %-5s %-7s %6.0f MB  %s" % (
             entry["key"], entry["parameters"], entry["quantization"],
             entry["size"] / 1048576.0, entry["license"]), file=stream)
         for source in bot_chat_models.SOURCES:

--- a/server/lan_battle_server.py
+++ b/server/lan_battle_server.py
@@ -14476,7 +14476,7 @@ def print_bot_chat_catalogue(stream=None):
     print("runtime       %-5s %-7s %6.0f MB  %s" % (
         arch, bot_chat_models.RUNTIME_BUILD, asset["size"] / 1048576.0,
         bot_chat_models.RUNTIME_LICENSE), file=stream)
-    for source in bot_chat_models.RUNTIME_SOURCES:
+    for source in bot_chat_models.runtime_sources(arch):
         print("       %-12s %s" % (
             source, bot_chat_models.runtime_url(arch, source)), file=stream)
 

--- a/server/lan_battle_server.py
+++ b/server/lan_battle_server.py
@@ -23,6 +23,7 @@ import math
 import random
 import re
 import os
+import platform
 import sys
 import socket
 import socketserver
@@ -40,6 +41,8 @@ if _CLIENT_SCRIPT_ROOT not in sys.path:
     sys.path.insert(0, _CLIENT_SCRIPT_ROOT)
 
 import bot_chat
+import bot_chat_llm
+import bot_chat_models
 from server_bot_ai import BotPlanner
 from offline_rewards import compute_offline_rewards
 from vehicle_overlay_store import (
@@ -80,6 +83,10 @@ BOT_PLANNER_INTERVAL_TICKS = max(1, int(round(TICK_HZ)))
 BOT_CHAT_INTERVAL_TICKS = max(1, int(round(TICK_HZ / 2.0)))
 # A Bot reports its own damage once per round, below this fraction.
 BOT_CHAT_LOW_HEALTH_FRACTION = 0.3
+# The optional local chat model.  The launcher installs both halves and names
+# them here; with either missing the feature is simply off and Bots are quiet.
+BOT_CHAT_RUNTIME_ENV = "WOT_BOT_CHAT_RUNTIME"
+BOT_CHAT_MODEL_ENV = "WOT_BOT_CHAT_MODEL"
 REPLICA_SNAPSHOT_HZ = 15.0
 REPLICA_SNAPSHOT_TICKS = max(
     1, int(round(TICK_HZ / REPLICA_SNAPSHOT_HZ)))
@@ -14321,7 +14328,8 @@ def run_server(host, port, map_name, max_players,
                team_size=15, receipt_state_path=None,
                team1_size=None, team2_size=None,
                bot_tier_mode="random", bot_lineup=None,
-               vehicle_overlay_root=None):
+               vehicle_overlay_root=None,
+               bot_chat_runtime=None, bot_chat_model=None):
     if receipt_state_path is None:
         receipt_state_path = _default_result_receipt_state_path(port)
     state = BattleState(map_name=map_name, max_players=max_players,
@@ -14344,6 +14352,10 @@ def run_server(host, port, map_name, max_players,
             _server_log("VEHICLE OVERLAY none; the room runs stock data")
     else:
         overlay = VehicleOverlayStore()
+    bot_chat_generator = configured_bot_chat(
+        state, bot_chat_runtime, bot_chat_model)
+    if bot_chat_generator is not None:
+        bot_chat_generator.start()
     tcp_server = ThreadedTCPServer((host, port), ClientHandler)
     tcp_server.game_server = type("GameServer", (), {
         "state": state,
@@ -14369,10 +14381,103 @@ def run_server(host, port, map_name, max_players,
         print("\nStopping server", flush=True)
     finally:
         state.running = False
+        # The generator is a child process holding the model in memory. It
+        # must not outlive the room that started it.
+        if bot_chat_generator is not None:
+            bot_chat_generator.stop()
         shutdown_controller.request()
         tcp_server.server_close()
         thread.join(2.0)
         shutdown_controller.wait(2.0)
+
+
+class BotChatGenerator(object):
+    """Attach the optional local model to one room, off every hot path.
+
+    Loading a model takes seconds and a first reply takes more.  Nothing in
+    the battle waits for either: until the generator answers its health
+    check, the director has no backend and every Bot stays quiet.
+    """
+
+    def __init__(self, state, executable, model_path):
+        self._state = state
+        self._supervisor = bot_chat_llm.LlamaServerSupervisor(
+            executable, model_path, log=_server_log)
+        self._backend = None
+        self._thread = None
+
+    @property
+    def supervisor(self):
+        return self._supervisor
+
+    def start(self):
+        """Launch the generator and attach it once it is ready."""
+        if not self._supervisor.available():
+            _server_log(
+                "BOT CHAT disabled: runtime or model is not installed")
+            return False
+        if not self._supervisor.start():
+            return False
+        self._thread = threading.Thread(
+            target=self._attach, name="bot-chat-start", daemon=True)
+        self._thread.start()
+        return True
+
+    def _attach(self):
+        if not self._supervisor.wait_ready():
+            self._supervisor.stop()
+            return
+        backend = bot_chat_llm.LlamaChatBackend(
+            self._supervisor.endpoint, log=_server_log)
+        backend.start()
+        self._backend = backend
+        with self._state.lock:
+            self._state.bot_chat.set_backend(backend)
+        _server_log("BOT CHAT ready at %s" % self._supervisor.endpoint)
+
+    def stop(self):
+        """Detach and terminate, leaving no process holding the model."""
+        with self._state.lock:
+            self._state.bot_chat.set_backend(None)
+        backend, self._backend = self._backend, None
+        if backend is not None:
+            backend.stop()
+        self._supervisor.stop()
+
+
+def configured_bot_chat(state, executable=None, model_path=None):
+    """Return the configured generator for one room, or None when it is off."""
+    executable = str(
+        executable or os.environ.get(BOT_CHAT_RUNTIME_ENV, "")).strip()
+    model_path = str(
+        model_path or os.environ.get(BOT_CHAT_MODEL_ENV, "")).strip()
+    if not executable or not model_path:
+        return None
+    return BotChatGenerator(state, executable, model_path)
+
+
+def print_bot_chat_catalogue(stream=None):
+    """Print what the optional chat model download offers, and from where."""
+    stream = stream or sys.stdout
+    arch = bot_chat_models.runtime_arch(platform.machine())
+    for entry in bot_chat_models.MODEL_TIERS:
+        print("%-6s %-5s %-8s %6.0f MB  %s" % (
+            entry["key"], entry["parameters"], entry["quantization"],
+            entry["size"] / 1048576.0, entry["license"]), file=stream)
+        for source in bot_chat_models.SOURCES:
+            print("       %-12s %s" % (
+                source, bot_chat_models.model_url(entry["key"], source)),
+                file=stream)
+    if arch is None:
+        print("runtime: no CPU build is published for this machine (%s)"
+              % platform.machine(), file=stream)
+        return
+    asset = bot_chat_models.runtime_asset(arch)
+    print("runtime %-5s %6.0f MB  %s" % (
+        arch, asset["size"] / 1048576.0, bot_chat_models.RUNTIME_LICENSE),
+        file=stream)
+    print("       %-12s %s" % ("github", bot_chat_models.runtime_url(arch)),
+          file=stream)
 
 
 def main():
@@ -14393,11 +14498,27 @@ def main():
     parser.add_argument(
         "--team-2-size", type=int, choices=range(1, 16), default=None,
         help="total Team 2 tanks, including players")
+    parser.add_argument(
+        "--bot-chat-runtime", default=None,
+        help="path to llama-server for optional Bot chat (default: $%s)"
+             % BOT_CHAT_RUNTIME_ENV)
+    parser.add_argument(
+        "--bot-chat-model", default=None,
+        help="path to the GGUF model for optional Bot chat (default: $%s)"
+             % BOT_CHAT_MODEL_ENV)
+    parser.add_argument(
+        "--list-chat-models", action="store_true",
+        help="print the optional Bot chat downloads and their mirrors")
     args = parser.parse_args()
+    if args.list_chat_models:
+        print_bot_chat_catalogue()
+        return
     run_server(
         args.host, args.port, args.map_name, args.max_players,
         team_size=args.team_size,
-        team1_size=args.team_1_size, team2_size=args.team_2_size)
+        team1_size=args.team_1_size, team2_size=args.team_2_size,
+        bot_chat_runtime=args.bot_chat_runtime,
+        bot_chat_model=args.bot_chat_model)
 
 
 if __name__ == "__main__":

--- a/server/lan_battle_server.py
+++ b/server/lan_battle_server.py
@@ -14473,11 +14473,12 @@ def print_bot_chat_catalogue(stream=None):
               % platform.machine(), file=stream)
         return
     asset = bot_chat_models.runtime_asset(arch)
-    print("runtime %-5s %6.0f MB  %s" % (
-        arch, asset["size"] / 1048576.0, bot_chat_models.RUNTIME_LICENSE),
-        file=stream)
-    print("       %-12s %s" % ("github", bot_chat_models.runtime_url(arch)),
-          file=stream)
+    print("runtime       %-5s %-7s %6.0f MB  %s" % (
+        arch, bot_chat_models.RUNTIME_BUILD, asset["size"] / 1048576.0,
+        bot_chat_models.RUNTIME_LICENSE), file=stream)
+    for source in bot_chat_models.RUNTIME_SOURCES:
+        print("       %-12s %s" % (
+            source, bot_chat_models.runtime_url(arch, source)), file=stream)
 
 
 def main():

--- a/server/lan_battle_server.py
+++ b/server/lan_battle_server.py
@@ -5460,11 +5460,22 @@ class BattleState:
         """Let the Bot conversation react to one relayed human line."""
         if self.battle_result is not None:
             return
+        if not self.bot_chat.enabled():
+            _server_log("TEAM CHAT id=%d team=%d relayed; Bot chat is off"
+                        % (issuer.player_id, issuer.team))
+            return
         try:
-            self.bot_chat.observe_player_line(
+            outcome = self.bot_chat.observe_player_line(
                 self.tick, int(issuer.team), text,
                 self._bot_chat_snapshot_locked(
                     self._bot_chat_speaker_locked(issuer), with_bounds=True))
+            # Whether a line reached the room, who it was taken to address,
+            # and how many Bots were given one to answer. Without this a
+            # battle where nobody replies has no evidence in it at all.
+            _server_log(
+                "TEAM CHAT id=%d team=%d address=%s bots=%s replies=%d"
+                % (issuer.player_id, issuer.team, outcome.get("kind"),
+                   outcome.get("bot_ids"), outcome.get("scheduled", 0)))
         except Exception as error:
             # A conversation fault is contained to this line.  It must never
             # cost the team its chat relay or fault the round.

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -1489,6 +1489,7 @@ class BattleRuntime(object):
         self._optional_failures_reported = set()
         self._disabled_optional_features = set()
         self._team_chat_initialized = False
+        self._team_chat_waiting_reasons = set()
         self._avatar = None
         self._binding = None
         self._server = None
@@ -1842,6 +1843,7 @@ class BattleRuntime(object):
         self._optional_failures_reported = set()
         self._disabled_optional_features = set()
         self._team_chat_initialized = False
+        self._team_chat_waiting_reasons = set()
         self._sixth_sense = None
         self._has_sixth_sense = False
         self._has_expert = False
@@ -2718,29 +2720,50 @@ class BattleRuntime(object):
             return False
 
     def _start_team_chat_when_roster_ready(self):
-        """Start stock Chat2 only after its ArenaDP teammate guard passes."""
+        """Start stock Chat2 only after its ArenaDP teammate guard passes.
+
+        This runs every frame until it succeeds, and every way it can decline
+        is silent from inside a battle: the player simply types and nothing
+        happens. Each distinct reason is therefore reported once per round.
+        """
         if (self._worker_mode or self._team_chat_initialized or
                 self.state != 'running'):
             return False
         provider = getattr(self._avatar, 'guiSessionProvider', None)
         arena_getter = getattr(provider, 'getArenaDP', None)
         if not callable(arena_getter):
-            return False
+            return self._team_chat_waiting('no session provider')
         arena_dp = arena_getter()
         allies_getter = getattr(arena_dp, 'getAlliesVehiclesNumber', None)
         if not callable(allies_getter):
-            return False
+            return self._team_chat_waiting('no arena roster reader')
         try:
-            has_teammate = int(allies_getter()) > 1
-        except (TypeError, ValueError, OverflowError, ReferenceError):
-            return False
-        if not has_teammate:
-            return False
+            allies = int(allies_getter())
+        except (TypeError, ValueError, OverflowError, ReferenceError) as error:
+            return self._team_chat_waiting('roster unreadable: %s' % error)
+        if allies <= 1:
+            return self._team_chat_waiting('only %d ally in the roster'
+                                           % allies)
         started = self._run_optional_feature(
             'team chat initialization', self._server.start_team_chat)
         if started:
             self._team_chat_initialized = True
-        return bool(started)
+            sys.stdout.write(
+                '[Offline LAN 0.9.22] team chat armed with %d allies\n'
+                % allies)
+            return True
+        return self._team_chat_waiting('stock channels refused to start')
+
+    def _team_chat_waiting(self, reason):
+        """Report one distinct reason chat is not armed yet, once."""
+        seen = getattr(self, '_team_chat_waiting_reasons', None)
+        if seen is None:
+            seen = self._team_chat_waiting_reasons = set()
+        if reason not in seen:
+            seen.add(reason)
+            sys.stdout.write(
+                '[Offline LAN 0.9.22] team chat not armed yet: %s\n' % reason)
+        return False
 
     def _disable_standard_space_visibility(self):
         self._standard_space_visibility = None

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -3449,6 +3449,12 @@ class BattleRuntime(object):
         if result:
             seen[key] = message['chat_seq']
             self._team_chat_seen = seen
+        else:
+            # The stock channel refused it. That is invisible in the battle,
+            # so it has to be visible in the log.
+            sys.stdout.write(
+                '[Offline LAN 0.9.22] team chat from %s %s was not shown\n'
+                % (issuer_kind, message.get('issuer_id')))
         return result
 
     def on_team_command(self, message):

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
@@ -3356,10 +3356,17 @@ class LANClient(object):
     def send_team_chat(self, text):
         from gui.mods.offline_lan_0922.tactical_radio import (
             is_valid_team_chat_text)
+        # A battle where nobody answers needs to distinguish a line that was
+        # never sent from one the room ignored, and only this end can say
+        # which.
         if (not self.ready or self.phase != 'battle' or
                 self.is_bot_authority()):
+            print('[Offline LAN 0.9.22] team chat not sent: '
+                  'ready=%s phase=%s worker=%s' % (
+                      self.ready, self.phase, self.is_bot_authority()))
             return False
         if not is_valid_team_chat_text(text):
+            print('[Offline LAN 0.9.22] team chat refused: unusable text')
             return False
         if self._team_chat_round != self.round_id:
             self._team_chat_round = self.round_id
@@ -3371,6 +3378,8 @@ class LANClient(object):
                            'chat_seq': sequence, 'text': text}):
             return False
         self._team_chat_seq = sequence
+        print('[Offline LAN 0.9.22] team chat sent seq=%d round=%s' % (
+            sequence, self.round_id))
         return sequence
 
     def send_bot_observation(self, contacts, affordances=None):

--- a/tests/test_port_0922_bot_chat.py
+++ b/tests/test_port_0922_bot_chat.py
@@ -89,7 +89,7 @@ def _director(value=0.0, choice_index=0, backend=None):
     return director
 
 
-def _drain(director, snapshot, start=0, stop=600):
+def _drain(director, snapshot, start=0, stop=1200):
     published = []
     for tick in range(start, stop):
         published.extend(director.tick(tick, snapshot))
@@ -400,6 +400,31 @@ class PublicationTest(unittest.TestCase):
         self.assertEqual(director.recent_lines(1), [])
 
 
+class NoBackendTest(unittest.TestCase):
+    """With no optional model installed the feature is simply off."""
+
+    def setUp(self):
+        self.snapshot = _snapshot(_roster())
+
+    def _director(self):
+        director = BotChatDirector(_ScriptedRandom(), tick_hz=30.0)
+        director.reset_round(7)
+        return director
+
+    def test_no_backend_reports_disabled(self):
+        self.assertFalse(self._director().enabled())
+
+    def test_no_backend_schedules_nothing_for_a_human_line(self):
+        director = self._director()
+        director.observe_player_line(0, 1, '那个t34 过来', self.snapshot)
+        self.assertEqual([], _drain(director, self.snapshot))
+
+    def test_no_backend_refuses_an_event(self):
+        director = self._director()
+        self.assertFalse(
+            director.observe_event(0, 1, TRIGGER_KILL, 2, self.snapshot))
+
+
 class ClampTest(unittest.TestCase):
     def test_whitespace_is_collapsed(self):
         self.assertEqual(clamp_chat_text('  收到   ,  这就去 '), '收到 , 这就去')
@@ -418,13 +443,14 @@ class ClampTest(unittest.TestCase):
 class DeterminismTest(unittest.TestCase):
     def test_one_seed_replays_one_transcript(self):
         def transcript():
-            director = BotChatDirector(random.Random(2024), tick_hz=30.0)
+            director = BotChatDirector(random.Random(2024), tick_hz=30.0,
+                                       backend=_CountingBackend())
             director.reset_round(7)
             snapshot = _snapshot(_roster())
             director.observe_player_line(0, 1, '那个t34 过来', snapshot)
             director.observe_player_line(200, 1, '这局有点难打', snapshot)
             return [(tick, line['bot_id'], line['text'])
-                    for tick in range(0, 900)
+                    for tick in range(0, 1600)
                     for line in director.tick(tick, snapshot)]
 
         first = transcript()

--- a/tests/test_port_0922_bot_chat.py
+++ b/tests/test_port_0922_bot_chat.py
@@ -8,6 +8,8 @@ TEST_ROOT = Path(__file__).resolve().parent
 SERVER_ROOT = TEST_ROOT.parent / 'server'
 sys.path.insert(0, str(TEST_ROOT))
 sys.path.insert(0, str(SERVER_ROOT))
+CLIENT_ROOT = TEST_ROOT.parent / 'src' / 'res' / 'scripts' / 'client'
+sys.path.insert(0, str(CLIENT_ROOT))
 
 import bot_chat  # noqa: E402
 from bot_chat import (  # noqa: E402
@@ -398,6 +400,95 @@ class PublicationTest(unittest.TestCase):
         director.reset_round(8)
         self.assertEqual(_drain(director, self.snapshot), [])
         self.assertEqual(director.recent_lines(1), [])
+
+
+class ArmingReportTest(unittest.TestCase):
+    """Every way chat can fail to arm is silent inside a battle."""
+
+    class _Runtime(object):
+        _worker_mode = False
+        _team_chat_initialized = False
+        state = 'running'
+
+        def __init__(self, provider=None):
+            self._avatar = type('Avatar', (), {
+                'guiSessionProvider': provider})()
+            self.written = []
+
+        def _run_optional_feature(self, unused_name, callback):
+            return callback()
+
+    def _runtime(self, allies=None, provider_missing=False,
+                 reader_missing=False, start=True):
+        import io
+        import sys as system
+
+        from gui.mods.offline_lan_0922 import battle_runtime as module
+
+        provider = None
+        if not provider_missing:
+            arena_dp = type('ArenaDP', (), {})()
+            if not reader_missing:
+                arena_dp.getAlliesVehiclesNumber = lambda: allies
+            provider = type('Provider', (), {
+                'getArenaDP': staticmethod(lambda: arena_dp)})()
+        runtime = self._Runtime(provider)
+        runtime._server = type('Server', (), {
+            'start_team_chat': staticmethod(lambda: start)})()
+        runtime._team_chat_waiting = (
+            module.BattleRuntime._team_chat_waiting.__get__(runtime))
+        stream = io.StringIO()
+        original, system.stdout = system.stdout, stream
+        try:
+            armed = module.BattleRuntime._start_team_chat_when_roster_ready(
+                runtime)
+        finally:
+            system.stdout = original
+        return armed, stream.getvalue()
+
+    def test_a_missing_session_provider_is_reported(self):
+        armed, said = self._runtime(provider_missing=True)
+        self.assertFalse(armed)
+        self.assertIn('no session provider', said)
+
+    def test_a_missing_roster_reader_is_reported(self):
+        armed, said = self._runtime(reader_missing=True)
+        self.assertFalse(armed)
+        self.assertIn('no arena roster reader', said)
+
+    def test_a_roster_with_nobody_in_it_is_reported(self):
+        armed, said = self._runtime(allies=1)
+        self.assertFalse(armed)
+        self.assertIn('only 1 ally', said)
+
+    def test_stock_channels_refusing_is_reported(self):
+        armed, said = self._runtime(allies=15, start=False)
+        self.assertFalse(armed)
+        self.assertIn('refused to start', said)
+
+    def test_arming_says_so_with_the_roster_it_saw(self):
+        armed, said = self._runtime(allies=15)
+        self.assertTrue(armed)
+        self.assertIn('armed with 15 allies', said)
+
+    def test_one_reason_is_not_repeated_every_frame(self):
+        import io
+        import sys as system
+
+        from gui.mods.offline_lan_0922 import battle_runtime as module
+
+        runtime = self._Runtime(None)
+        runtime._team_chat_waiting = (
+            module.BattleRuntime._team_chat_waiting.__get__(runtime))
+        stream = io.StringIO()
+        original, system.stdout = system.stdout, stream
+        try:
+            for unused in range(5):
+                module.BattleRuntime._start_team_chat_when_roster_ready(
+                    runtime)
+        finally:
+            system.stdout = original
+        self.assertEqual(1, stream.getvalue().count('no session provider'))
 
 
 class AdmissionReportTest(unittest.TestCase):

--- a/tests/test_port_0922_bot_chat.py
+++ b/tests/test_port_0922_bot_chat.py
@@ -271,14 +271,34 @@ class ConversationContinuityTest(unittest.TestCase):
         self.assertEqual(address['kind'], ADDRESS_THREAD)
         self.assertEqual(address['bot_ids'], [2])
 
-    def test_a_thread_falls_back_when_the_addressed_bot_dies(self):
+    def test_a_dead_addressee_returns_the_line_to_the_room(self):
+        # Handing the follow-up to whoever spoke last is what made one tank
+        # answer everything; an open remark is open again instead.
         director = _director()
         director.observe_player_line(0, 1, '孤狼 顶一下', self.snapshot)
         _drain(director, self.snapshot, 0, 400)
         roster = [dict(bot, alive=bot['id'] != 2) for bot in _roster()]
         address = director.resolve_address('你到了吗', 1, _snapshot(roster))
-        self.assertEqual(address['kind'], ADDRESS_THREAD)
-        self.assertNotEqual(address['bot_ids'], [2])
+        self.assertEqual(ADDRESS_NONE, address['kind'])
+
+    def test_an_open_remark_never_anchors_the_thread(self):
+        director = _director()
+        director.observe_player_line(0, 1, '这局有点难打', self.snapshot)
+        _drain(director, self.snapshot, 0, 400)
+        address = director.resolve_address('还行吧', 1, self.snapshot)
+        self.assertEqual(ADDRESS_NONE, address['kind'])
+
+    def test_the_voice_moves_around_the_team(self):
+        # Fifteen Bots and one of them doing all the talking is the bug.
+        director = _director()
+        snapshot = _snapshot(_roster())
+        speakers = []
+        for index in range(4):
+            tick = index * 900
+            director.observe_player_line(tick, 1, '这局有点难打', snapshot)
+            for line in _drain(director, snapshot, tick, tick + 900):
+                speakers.append(line['bot_id'])
+        self.assertGreater(len(set(speakers)), 1, speakers)
 
     def test_a_thread_expires_after_silence(self):
         director = _director()
@@ -525,6 +545,49 @@ class AdmissionReportTest(unittest.TestCase):
         outcome = director.observe_player_line(
             0, 1, '那个t34 过来', _snapshot(dead))
         self.assertEqual(0, outcome['scheduled'])
+
+
+class RepetitionTest(unittest.TestCase):
+    """A small model repeats itself by continuing, not by copying."""
+
+    def setUp(self):
+        self.snapshot = _snapshot(_roster())
+
+    def _published(self, lines):
+        class _Scripted(object):
+            def __init__(self):
+                self.index = 0
+
+            def compose(self, request):
+                text = lines[min(self.index, len(lines) - 1)]
+                self.index += 1
+                return text
+
+        director = _director(backend=_Scripted())
+        published = []
+        for index in range(len(lines)):
+            tick = index * 900
+            director.observe_player_line(tick, 1, '这局有点难打',
+                                         self.snapshot)
+            published.extend(_drain(director, self.snapshot, tick,
+                                    tick + 900))
+        return [line['text'] for line in published]
+
+    def test_the_same_line_twice_is_said_once(self):
+        self.assertEqual(['慢慢开车'], self._published(['慢慢开车',
+                                                       '慢慢开车']))
+
+    def test_one_line_continuing_another_is_refused(self):
+        self.assertEqual(['慢慢开车'],
+                         self._published(['慢慢开车', '慢慢开车，别急']))
+
+    def test_genuinely_different_lines_are_all_said(self):
+        said = self._published(['我在B3', '右边有人', '装填好了'])
+        self.assertEqual(3, len(said))
+
+    def test_a_short_answer_is_not_treated_as_a_repeat(self):
+        said = self._published(['好', '好的这就去'])
+        self.assertEqual(2, len(said))
 
 
 class NoBackendTest(unittest.TestCase):

--- a/tests/test_port_0922_bot_chat.py
+++ b/tests/test_port_0922_bot_chat.py
@@ -400,6 +400,42 @@ class PublicationTest(unittest.TestCase):
         self.assertEqual(director.recent_lines(1), [])
 
 
+class AdmissionReportTest(unittest.TestCase):
+    """A battle where nobody answers must leave evidence of which case it was."""
+
+    def setUp(self):
+        self.snapshot = _snapshot(_roster())
+
+    def test_an_addressed_line_reports_who_and_how_many(self):
+        director = _director()
+        outcome = director.observe_player_line(
+            0, 1, '那个t34 过来', self.snapshot)
+        self.assertEqual(ADDRESS_VEHICLE, outcome['kind'])
+        self.assertEqual([1], outcome['bot_ids'])
+        self.assertGreaterEqual(outcome['scheduled'], 1)
+
+    def test_a_line_nobody_answers_reports_zero(self):
+        director = _director(value=1.0)
+        outcome = director.observe_player_line(
+            0, 1, '这局有点难打', self.snapshot)
+        self.assertEqual(ADDRESS_NONE, outcome['kind'])
+        self.assertEqual(0, outcome['scheduled'])
+
+    def test_a_line_with_the_feature_off_reports_zero(self):
+        director = BotChatDirector(_ScriptedRandom(), tick_hz=30.0)
+        director.reset_round(7)
+        outcome = director.observe_player_line(
+            0, 1, '那个t34 过来', self.snapshot)
+        self.assertEqual(0, outcome['scheduled'])
+
+    def test_a_team_with_no_living_bots_reports_zero(self):
+        dead = [dict(bot, alive=False) for bot in _roster()]
+        director = _director()
+        outcome = director.observe_player_line(
+            0, 1, '那个t34 过来', _snapshot(dead))
+        self.assertEqual(0, outcome['scheduled'])
+
+
 class NoBackendTest(unittest.TestCase):
     """With no optional model installed the feature is simply off."""
 

--- a/tests/test_port_0922_bot_chat_llm.py
+++ b/tests/test_port_0922_bot_chat_llm.py
@@ -130,8 +130,20 @@ class CatalogTest(unittest.TestCase):
         self.assertIsNone(catalog.model_url('gigantic', catalog.MODELSCOPE))
         self.assertIsNone(catalog.model_url('small', 'some-other-mirror'))
 
-    def test_the_default_tier_is_the_small_one(self):
-        self.assertEqual('small', catalog.default_tier()['key'])
+    def test_the_default_tier_is_one_of_the_smallest(self):
+        default = catalog.default_tier()
+        self.assertEqual(catalog.DEFAULT_TIER_KEY, default['key'])
+        smallest = min(entry['size'] for entry in catalog.MODEL_TIERS)
+        # The default must stay a tier every machine can reasonably try, not
+        # simply the best one available.
+        self.assertLess(default['size'], smallest * 2)
+
+    def test_every_tier_key_is_unique_and_names_its_model(self):
+        keys = [entry['key'] for entry in catalog.MODEL_TIERS]
+        self.assertEqual(len(keys), len(set(keys)))
+        for entry in catalog.MODEL_TIERS:
+            self.assertIn(entry['key'].split('-')[0].replace('.', ''),
+                          entry['repo'].lower().replace('.', ''))
 
     def test_runtime_architecture_is_named_honestly(self):
         self.assertEqual('x64', catalog.runtime_arch('AMD64'))
@@ -328,6 +340,9 @@ class BackendTest(unittest.TestCase):
         self.assertFalse(payload['stream'])
         self.assertIn('<|im_end|>', payload['stop'])
         self.assertIn('\n', payload['stop'])
+        # A reasoning model must not spend the reply budget thinking.
+        self.assertEqual({'enable_thinking': False},
+                         payload['chat_template_kwargs'])
 
 
 class _StubBackend(object):
@@ -492,6 +507,28 @@ class SupervisorTest(unittest.TestCase):
 
     def test_a_reserved_port_is_usable(self):
         self.assertTrue(1 <= free_loopback_port() <= 65535)
+
+    def test_thinking_is_switched_off_on_the_command_line(self):
+        supervisor = LlamaServerSupervisor('/bin/true', '/bin/true', port=1)
+        started = []
+        supervisor._log = started.append
+        import subprocess as _subprocess
+        recorded = {}
+
+        def fake_popen(command, **unused):
+            recorded['command'] = command
+            raise OSError('not launched')
+
+        original, _subprocess.Popen = _subprocess.Popen, fake_popen
+        try:
+            supervisor.start()
+        finally:
+            _subprocess.Popen = original
+        command = recorded['command']
+        self.assertIn('--reasoning-budget', command)
+        self.assertEqual(
+            bot_chat_llm.REASONING_BUDGET,
+            command[command.index('--reasoning-budget') + 1])
 
     def test_a_missing_download_reports_rather_than_launching(self):
         messages = []

--- a/tests/test_port_0922_bot_chat_llm.py
+++ b/tests/test_port_0922_bot_chat_llm.py
@@ -1,0 +1,535 @@
+import json
+import os
+from pathlib import Path
+import random
+import stat
+import sys
+import tempfile
+import threading
+import time
+import unittest
+
+
+TEST_ROOT = Path(__file__).resolve().parent
+SERVER_ROOT = TEST_ROOT.parent / 'server'
+sys.path.insert(0, str(TEST_ROOT))
+sys.path.insert(0, str(SERVER_ROOT))
+
+import bot_chat  # noqa: E402
+import bot_chat_llm  # noqa: E402
+import bot_chat_models as catalog  # noqa: E402
+from bot_chat import BotChatDirector  # noqa: E402
+from bot_chat_llm import (  # noqa: E402
+    LlamaChatBackend, LlamaServerSupervisor, build_messages, extract_content,
+    free_loopback_port, inference_threads, sanitize_line,
+)
+
+
+_FAKE_RUNTIME = '''#!/usr/bin/env python3
+"""Answer the two endpoints the backend actually calls."""
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+PORT = int(sys.argv[sys.argv.index('--port') + 1])
+REPLY = '收到, 这就回来'
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *unused):
+        pass
+
+    def do_GET(self):
+        if self.path == '/health':
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            self.wfile.write(b'{"status":"ok"}')
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def do_POST(self):
+        length = int(self.headers.get('Content-Length', 0))
+        self.rfile.read(length)
+        body = json.dumps({
+            'choices': [{'message': {'role': 'assistant', 'content': REPLY}}],
+        }).encode('utf-8')
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+HTTPServer(('127.0.0.1', PORT), Handler).serve_forever()
+'''
+
+
+def _write_fake_runtime(directory):
+    """Write an executable stand-in that speaks the real wire protocol."""
+    script = Path(directory) / 'fake_llama_server.py'
+    script.write_text(_FAKE_RUNTIME, encoding='utf-8')
+    launcher = Path(directory) / 'llama-server'
+    launcher.write_text(
+        '#!/bin/sh\nexec "%s" "%s" "$@"\n' % (sys.executable, script),
+        encoding='utf-8')
+    launcher.chmod(launcher.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP)
+    model = Path(directory) / 'model.gguf'
+    model.write_bytes(b'GGUF stand-in')
+    return str(launcher), str(model)
+
+
+def _await(predicate, timeout=20.0):
+    """Wait for a real state transition rather than assuming a duration."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        value = predicate()
+        if value:
+            return value
+        time.sleep(0.02)
+    return None
+
+
+def _request(request_id=1, trigger=bot_chat.TRIGGER_REPLY,
+             persona=bot_chat.PERSONA_SLACKER, recent=(), prefix=None):
+    return {
+        'request_id': request_id,
+        'trigger': trigger,
+        'persona': persona,
+        'address_kind': bot_chat.ADDRESS_VEHICLE,
+        'address_prefix': prefix,
+        'speaker': {'name': 'Peng'},
+        'bot': {'id': 1, 'name': '今天不加班', 'vehicle': 'ussr:R04_T-34',
+                'hp': 120, 'max_hp': 400},
+        'recent_texts': [record['text'] for record in recent],
+        'recent': list(recent),
+        'rng': random.Random(1),
+    }
+
+
+class CatalogTest(unittest.TestCase):
+    def test_both_mirrors_serve_the_same_file_name(self):
+        for entry in catalog.MODEL_TIERS:
+            modelscope = catalog.model_url(entry['key'], catalog.MODELSCOPE)
+            huggingface = catalog.model_url(entry['key'], catalog.HUGGINGFACE)
+            self.assertIn(entry['repo'], modelscope)
+            self.assertIn(entry['file'], modelscope)
+            self.assertIn(entry['repo'], huggingface)
+            self.assertIn(entry['file'], huggingface)
+            self.assertTrue(modelscope.startswith('https://www.modelscope.cn/'))
+            self.assertTrue(huggingface.startswith('https://huggingface.co/'))
+
+    def test_every_tier_declares_an_integrity_digest_and_licence(self):
+        for entry in catalog.MODEL_TIERS:
+            self.assertEqual(64, len(entry['sha256']))
+            self.assertGreater(entry['size'], 0)
+            self.assertEqual('Apache-2.0', entry['license'])
+
+    def test_an_unknown_tier_or_source_has_no_url(self):
+        self.assertIsNone(catalog.model_url('gigantic', catalog.MODELSCOPE))
+        self.assertIsNone(catalog.model_url('small', 'some-other-mirror'))
+
+    def test_the_default_tier_is_the_small_one(self):
+        self.assertEqual('small', catalog.default_tier()['key'])
+
+    def test_runtime_architecture_is_named_honestly(self):
+        self.assertEqual('x64', catalog.runtime_arch('AMD64'))
+        self.assertEqual('arm64', catalog.runtime_arch('ARM64'))
+        self.assertEqual('arm64', catalog.runtime_arch('aarch64'))
+        # A 32-bit host has no published CPU build, and saying so beats
+        # downloading an executable that cannot run.
+        self.assertIsNone(catalog.runtime_arch('x86'))
+        self.assertIsNone(catalog.runtime_url(None))
+
+    def test_the_runtime_build_is_pinned(self):
+        url = catalog.runtime_url('x64')
+        self.assertIn(catalog.RUNTIME_BUILD, url)
+        self.assertNotIn('latest', url)
+
+
+class SanitizeTest(unittest.TestCase):
+    def test_a_plain_line_survives(self):
+        self.assertEqual('收到, 这就回来', sanitize_line('收到, 这就回来'))
+
+    def test_only_the_first_line_is_a_chat_message(self):
+        self.assertEqual('收到', sanitize_line('收到\n然后我去B3\n再说'))
+
+    def test_a_leading_callsign_is_removed(self):
+        self.assertEqual('这就来', sanitize_line('今天不加班：这就来'))
+        self.assertEqual('这就来', sanitize_line('Bot: 这就来'))
+
+    def test_a_sentence_containing_a_colon_is_not_truncated(self):
+        # Only a short leading run reads as a callsign.  NFKC folds the
+        # full width colon, exactly as the stock outgoing filter does.
+        self.assertEqual(
+            '我在B3, 情况是这样的, 你听我说:他们从右边来了',
+            sanitize_line('我在B3, 情况是这样的, 你听我说：他们从右边来了'))
+
+    def test_wrapping_quotes_are_removed(self):
+        self.assertEqual('好的', sanitize_line('“好的”'))
+        self.assertEqual('好的', sanitize_line('"好的"'))
+
+    def test_a_reasoning_block_is_stripped(self):
+        self.assertEqual(
+            '好', sanitize_line('<think>玩家在叫我回防</think>好'))
+
+    def test_chat_markers_are_removed(self):
+        self.assertEqual('收到', sanitize_line('收到<|im_end|>'))
+
+    def test_an_over_long_line_is_cut_to_the_stock_limit(self):
+        text = sanitize_line('好' * 400)
+        self.assertEqual(bot_chat.MAX_CHAT_UTF16_UNITS,
+                         len(text.encode('utf-16-le')) // 2)
+
+    def test_nothing_publishable_is_refused(self):
+        self.assertIsNone(sanitize_line(''))
+        self.assertIsNone(sanitize_line('   '))
+        self.assertIsNone(sanitize_line(None))
+        self.assertIsNone(sanitize_line('<think>只有思考</think>'))
+
+
+class ExtractTest(unittest.TestCase):
+    def test_a_well_formed_completion_yields_its_content(self):
+        self.assertEqual('好', extract_content(
+            {'choices': [{'message': {'content': '好'}}]}))
+
+    def test_every_malformed_shape_yields_nothing(self):
+        for body in (None, {}, {'choices': []}, {'choices': [{}]},
+                     {'choices': [{'message': {}}]},
+                     {'choices': [{'message': {'content': 5}}]},
+                     {'choices': 'text'}):
+            self.assertIsNone(extract_content(body), body)
+
+
+class PromptTest(unittest.TestCase):
+    def test_the_persona_and_identity_reach_the_system_turn(self):
+        messages = build_messages(_request())
+        system = messages[0]['content']
+        self.assertEqual('system', messages[0]['role'])
+        self.assertIn('今天不加班', system)
+        self.assertIn('T-34', system)
+        self.assertIn(bot_chat_llm.PERSONA_STYLE[bot_chat.PERSONA_SLACKER],
+                      system)
+
+    def test_the_transcript_and_task_reach_the_user_turn(self):
+        recent = ({'name': 'Peng', 'text': '那个t34 回来一下'},)
+        messages = build_messages(_request(recent=recent, prefix='Peng'))
+        user = messages[1]['content']
+        self.assertIn('那个t34 回来一下', user)
+        self.assertIn('Peng', user)
+        self.assertIn('120/400', user)
+        self.assertIn(bot_chat_llm.TRIGGER_TASK[bot_chat.TRIGGER_REPLY], user)
+
+    def test_a_hop_is_told_not_to_repeat_its_teammate(self):
+        messages = build_messages(_request(trigger=bot_chat.TRIGGER_HOP))
+        self.assertIn('不要重复', messages[1]['content'])
+
+
+class BackendTest(unittest.TestCase):
+    def setUp(self):
+        self.calls = []
+
+    def _opener(self, text='收到, 这就回来'):
+        def opener(url, payload):
+            self.calls.append((url, payload))
+            return {'choices': [{'message': {'content': text}}]}
+        return opener
+
+    def test_a_prefetched_line_becomes_available(self):
+        backend = LlamaChatBackend('http://127.0.0.1:1', opener=self._opener())
+        backend.start()
+        self.addCleanup(backend.stop)
+        request = _request()
+        backend.prefetch(request)
+        self.assertTrue(_await(lambda: backend.compose(request)))
+
+    def test_a_line_is_delivered_once(self):
+        backend = LlamaChatBackend('http://127.0.0.1:1', opener=self._opener())
+        backend.start()
+        self.addCleanup(backend.stop)
+        request = _request()
+        backend.prefetch(request)
+        self.assertTrue(_await(lambda: backend.compose(request)))
+        self.assertIsNone(backend.compose(request))
+
+    def test_an_unfetched_line_composes_to_nothing(self):
+        backend = LlamaChatBackend('http://127.0.0.1:1', opener=self._opener())
+        self.assertIsNone(backend.compose(_request(request_id=99)))
+
+    def test_compose_never_waits_for_the_generator(self):
+        release = threading.Event()
+
+        def slow(url, payload):
+            release.wait(10.0)
+            return {'choices': [{'message': {'content': '慢'}}]}
+
+        backend = LlamaChatBackend('http://127.0.0.1:1', opener=slow)
+        backend.start()
+        self.addCleanup(backend.stop)
+        self.addCleanup(release.set)
+        request = _request()
+        backend.prefetch(request)
+        started = time.monotonic()
+        self.assertIsNone(backend.compose(request))
+        self.assertLess(time.monotonic() - started, 1.0)
+
+    def test_a_transport_failure_is_contained(self):
+        def broken(url, payload):
+            raise OSError('connection refused')
+
+        backend = LlamaChatBackend('http://127.0.0.1:1', opener=broken)
+        backend.start()
+        self.addCleanup(backend.stop)
+        request = _request()
+        backend.prefetch(request)
+        self.assertIsNone(_await(lambda: backend.compose(request),
+                                 timeout=1.5))
+        # The worker survives to answer the next line.
+        backend._opener = self._opener()
+        follow_up = _request(request_id=2)
+        backend.prefetch(follow_up)
+        self.assertTrue(_await(lambda: backend.compose(follow_up)))
+
+    def test_unpublishable_output_produces_no_result(self):
+        backend = LlamaChatBackend('http://127.0.0.1:1',
+                                   opener=self._opener('   '))
+        backend.start()
+        self.addCleanup(backend.stop)
+        request = _request()
+        backend.prefetch(request)
+        self.assertIsNone(_await(lambda: backend.compose(request),
+                                 timeout=1.5))
+
+    def test_the_same_line_is_not_queued_twice(self):
+        backend = LlamaChatBackend('http://127.0.0.1:1', opener=self._opener())
+        request = _request()
+        backend.prefetch(request)
+        backend.prefetch(request)
+        self.assertEqual(1, len(backend._queue))
+
+    def test_an_overrun_queue_drops_its_oldest_line(self):
+        backend = LlamaChatBackend('http://127.0.0.1:1', opener=self._opener())
+        for index in range(bot_chat_llm.PENDING_LIMIT + 5):
+            backend.prefetch(_request(request_id=index + 1))
+        self.assertEqual(bot_chat_llm.PENDING_LIMIT, len(backend._queue))
+        self.assertEqual(6, backend._queue[0][0])
+
+    def test_the_request_carries_the_stock_shaped_sampling_bounds(self):
+        backend = LlamaChatBackend('http://127.0.0.1:1', opener=self._opener())
+        backend.start()
+        self.addCleanup(backend.stop)
+        request = _request()
+        backend.prefetch(request)
+        self.assertTrue(_await(lambda: backend.compose(request)))
+        url, payload = self.calls[0]
+        self.assertTrue(url.endswith('/v1/chat/completions'))
+        self.assertEqual(bot_chat_llm.MAX_TOKENS, payload['max_tokens'])
+        self.assertFalse(payload['stream'])
+        self.assertIn('<|im_end|>', payload['stop'])
+        self.assertIn('\n', payload['stop'])
+
+
+class _StubBackend(object):
+    """A generating backend with the timing behaviour but no model."""
+
+    def __init__(self, text=None, latency_hint_seconds=4.0):
+        self.text = text
+        self.latency_hint_seconds = float(latency_hint_seconds)
+        self.prefetched = []
+
+    def prefetch(self, request):
+        self.prefetched.append(request['request_id'])
+
+    def compose(self, request):
+        return self.text
+
+
+class _InstantBackend(object):
+    """A backend with no prefetch, so ordinary reply pacing applies."""
+
+    def compose(self, request):
+        return '好'
+
+
+class DirectorIntegrationTest(unittest.TestCase):
+    def setUp(self):
+        self.snapshot = {
+            'bots': [{'id': 1, 'team': 1, 'name': '今天不加班',
+                      'vehicle': 'ussr:R04_T-34', 'vehicle_class': 'mediumTank',
+                      'alive': True, 'x': 0.0, 'z': 0.0, 'hp': 400,
+                      'max_hp': 400}],
+            'speaker': {'name': 'Peng', 'x': 0.0, 'z': 0.0, 'spotted': set()},
+            'arena_bounds': None,
+        }
+
+    def _director(self, backend):
+        director = BotChatDirector(random.Random(5), tick_hz=30.0,
+                                   backend=backend)
+        director.reset_round(1)
+        return director
+
+    def test_a_generating_backend_is_asked_when_the_line_is_scheduled(self):
+        backend = _StubBackend('模型写的')
+        director = self._director(backend)
+        director.observe_player_line(0, 1, '那个t34 回来一下', self.snapshot)
+        self.assertEqual(1, len(backend.prefetched))
+
+    def test_a_slow_backend_may_hold_its_line_past_human_pacing(self):
+        # Ordinary pacing already reaches nine seconds, so the hint only
+        # matters for a generator slower than a teammate typing.
+        backend = _StubBackend('模型写的', latency_hint_seconds=12.0)
+        director = self._director(backend)
+        director.observe_player_line(0, 1, '那个t34 回来一下', self.snapshot)
+        early = [line for tick in range(0, 359)
+                 for line in director.tick(tick, self.snapshot)]
+        self.assertEqual([], early)
+        late = [line for tick in range(359, 600)
+                for line in director.tick(tick, self.snapshot)]
+        self.assertEqual(['模型写的'], [line['text'] for line in late])
+
+    def test_a_hung_generator_cannot_hold_a_line_forever(self):
+        backend = _StubBackend('模型写的', latency_hint_seconds=600.0)
+        director = self._director(backend)
+        director.observe_player_line(0, 1, '那个t34 回来一下', self.snapshot)
+        cap = int(bot_chat.MAX_PREFETCH_WAIT_SECONDS * 30.0) + 2
+        published = [(tick, line) for tick in range(0, cap)
+                     for line in director.tick(tick, self.snapshot)]
+        self.assertTrue(published)
+
+    def test_a_model_that_writes_nothing_says_nothing(self):
+        director = self._director(_StubBackend(None))
+        director.observe_player_line(0, 1, '那个t34 回来一下', self.snapshot)
+        published = [line for tick in range(0, 900)
+                     for line in director.tick(tick, self.snapshot)]
+        self.assertEqual([], published)
+
+    def test_a_backend_without_prefetch_keeps_ordinary_reply_pacing(self):
+        director = self._director(_InstantBackend())
+        director.observe_player_line(0, 1, '那个t34 回来一下', self.snapshot)
+        published = [(tick, line) for tick in range(0, 900)
+                     for line in director.tick(tick, self.snapshot)]
+        self.assertTrue(published)
+        self.assertLessEqual(published[0][0],
+                             int(bot_chat.REPLY_DELAY_MAX_SECONDS * 30.0) + 1)
+
+
+class ServerWiringTest(unittest.TestCase):
+    """The room only speaks when both halves of the download are configured."""
+
+    def setUp(self):
+        sys.path.insert(0, str(SERVER_ROOT))
+        import lan_battle_server
+        self.module = lan_battle_server
+
+    def _clear_env(self):
+        for name in (self.module.BOT_CHAT_RUNTIME_ENV,
+                     self.module.BOT_CHAT_MODEL_ENV):
+            previous = os.environ.pop(name, None)
+            if previous is not None:
+                self.addCleanup(os.environ.__setitem__, name, previous)
+
+    def test_no_configuration_leaves_the_feature_off(self):
+        self._clear_env()
+        self.assertIsNone(self.module.configured_bot_chat(object()))
+
+    def test_half_a_configuration_leaves_the_feature_off(self):
+        self._clear_env()
+        self.assertIsNone(self.module.configured_bot_chat(
+            object(), executable='/tmp/llama-server'))
+        self.assertIsNone(self.module.configured_bot_chat(
+            object(), model_path='/tmp/model.gguf'))
+
+    def test_the_environment_configures_the_generator(self):
+        self._clear_env()
+        os.environ[self.module.BOT_CHAT_RUNTIME_ENV] = '/tmp/llama-server'
+        os.environ[self.module.BOT_CHAT_MODEL_ENV] = '/tmp/model.gguf'
+        generator = self.module.configured_bot_chat(object())
+        self.assertIsNotNone(generator)
+        self.assertEqual('/tmp/llama-server', generator.supervisor.executable)
+
+    def test_the_catalogue_prints_both_mirrors_for_every_tier(self):
+        import io
+        stream = io.StringIO()
+        self.module.print_bot_chat_catalogue(stream)
+        printed = stream.getvalue()
+        for entry in catalog.MODEL_TIERS:
+            self.assertIn(entry['key'], printed)
+            self.assertIn(entry['license'], printed)
+            for source in catalog.SOURCES:
+                self.assertIn(catalog.model_url(entry['key'], source),
+                              printed)
+        self.assertIn('runtime', printed)
+
+    def test_an_uninstalled_generator_refuses_to_start(self):
+        generator = self.module.configured_bot_chat(
+            object(), executable='/nonexistent/llama-server',
+            model_path='/nonexistent/model.gguf')
+        self.assertFalse(generator.start())
+
+    @unittest.skipIf(sys.platform == 'win32',
+                     'the stand-in runtime is a POSIX shell script')
+    def test_a_started_generator_attaches_and_detaches_the_director(self):
+        directory = tempfile.mkdtemp()
+        executable, model = _write_fake_runtime(directory)
+        state = self.module.BattleState(
+            map_name='01_karelia', max_players=2, team1_size=1, team2_size=1)
+        generator = self.module.configured_bot_chat(
+            state, executable=executable, model_path=model)
+        self.addCleanup(generator.stop)
+        self.assertFalse(state.bot_chat.enabled())
+        self.assertTrue(generator.start())
+        self.assertTrue(_await(lambda: state.bot_chat.enabled(), timeout=30.0))
+        generator.stop()
+        self.assertFalse(state.bot_chat.enabled())
+
+
+class SupervisorTest(unittest.TestCase):
+    def test_threads_leave_the_game_some_cores(self):
+        self.assertEqual(6, inference_threads(8))
+        self.assertEqual(1, inference_threads(2))
+        self.assertEqual(1, inference_threads(1))
+
+    def test_a_reserved_port_is_usable(self):
+        self.assertTrue(1 <= free_loopback_port() <= 65535)
+
+    def test_a_missing_download_reports_rather_than_launching(self):
+        messages = []
+        supervisor = LlamaServerSupervisor(
+            '/nonexistent/llama-server', '/nonexistent/model.gguf',
+            log=messages.append)
+        self.assertFalse(supervisor.available())
+        self.assertFalse(supervisor.start())
+        self.assertTrue(any('not installed' in message
+                            for message in messages))
+
+    @unittest.skipIf(sys.platform == 'win32',
+                     'the stand-in runtime is a POSIX shell script')
+    def test_a_real_child_starts_answers_and_stops(self):
+        directory = tempfile.mkdtemp()
+        self.addCleanup(
+            lambda: [os.remove(os.path.join(directory, name))
+                     for name in os.listdir(directory)] and None)
+        executable, model = _write_fake_runtime(directory)
+        supervisor = LlamaServerSupervisor(executable, model, threads=1)
+        self.addCleanup(supervisor.stop)
+        self.assertTrue(supervisor.available())
+        self.assertTrue(supervisor.start())
+        self.assertTrue(supervisor.wait_ready(timeout=30.0))
+        self.assertTrue(supervisor.is_ready())
+
+        backend = LlamaChatBackend(supervisor.endpoint)
+        backend.start()
+        self.addCleanup(backend.stop)
+        request = _request()
+        backend.prefetch(request)
+        self.assertEqual('收到, 这就回来',
+                         _await(lambda: backend.compose(request)))
+
+        supervisor.stop()
+        self.assertFalse(supervisor.is_ready())
+        self.assertIsNone(supervisor.poll())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_port_0922_bot_chat_llm.py
+++ b/tests/test_port_0922_bot_chat_llm.py
@@ -257,6 +257,28 @@ class PromptTest(unittest.TestCase):
         self.assertIn('120/400', user)
         self.assertIn(bot_chat_llm.TRIGGER_TASK[bot_chat.TRIGGER_REPLY], user)
 
+    def test_every_bot_shares_the_same_prompt_prefix(self):
+        # Prompt processing dominates on a slow machine, and llama.cpp can
+        # only reuse a cached prefix that actually matches.
+        first = build_messages(_request())
+        other = dict(_request())
+        other['persona'] = bot_chat.PERSONA_TACTICAL
+        other['bot'] = {'id': 2, 'name': '北方孤狼',
+                        'vehicle': 'germany:G54_E-50', 'hp': 300,
+                        'max_hp': 300}
+        second = build_messages(other)
+        shared = "\n".join(bot_chat_llm.SHARED_RULES)
+        self.assertTrue(first[0]['content'].startswith(shared))
+        self.assertTrue(second[0]['content'].startswith(shared))
+        self.assertNotEqual(first[0]['content'], second[0]['content'])
+
+    def test_the_transcript_is_bounded(self):
+        recent = tuple({'name': 'Peng', 'text': '第%d句' % index}
+                       for index in range(12))
+        user = build_messages(_request(recent=recent))[1]['content']
+        included = [line for line in recent if line['text'] in user]
+        self.assertEqual(bot_chat_llm.TRANSCRIPT_LINES, len(included))
+
     def test_a_hop_is_told_not_to_repeat_its_teammate(self):
         messages = build_messages(_request(trigger=bot_chat.TRIGGER_HOP))
         self.assertIn('不要重复', messages[1]['content'])
@@ -389,6 +411,42 @@ class _InstantBackend(object):
 
     def compose(self, request):
         return '好'
+
+
+class LatencyTest(unittest.TestCase):
+    """One constant cannot serve both a desktop and an emulated VM."""
+
+    def _backend(self):
+        return LlamaChatBackend('http://127.0.0.1:1',
+                                opener=lambda url, payload: {
+                                    'choices': [{'message': {
+                                        'content': '好'}}]})
+
+    def test_an_untried_machine_uses_the_initial_guess(self):
+        self.assertEqual(bot_chat_llm.INITIAL_LATENCY_SECONDS,
+                         self._backend().latency_hint_seconds)
+
+    def test_a_slow_machine_asks_for_longer(self):
+        backend = self._backend()
+        backend._record_latency(20.0)
+        self.assertGreater(backend.latency_hint_seconds, 20.0)
+
+    def test_a_fast_machine_never_asks_for_less_than_the_guess(self):
+        backend = self._backend()
+        backend._record_latency(0.2)
+        self.assertEqual(bot_chat_llm.INITIAL_LATENCY_SECONDS,
+                         backend.latency_hint_seconds)
+
+    def test_the_estimate_follows_repeated_observations(self):
+        backend = self._backend()
+        for unused in range(20):
+            backend._record_latency(30.0)
+        self.assertAlmostEqual(30.0, backend._observed_latency, places=1)
+
+    def test_the_request_timeout_outlasts_a_slow_machine(self):
+        # A twelve second cap turned a working slow generator into silence.
+        self.assertGreaterEqual(bot_chat_llm.REQUEST_TIMEOUT_SECONDS, 60.0)
+        self.assertGreaterEqual(bot_chat.MAX_PREFETCH_WAIT_SECONDS, 30.0)
 
 
 class DirectorIntegrationTest(unittest.TestCase):

--- a/tests/test_port_0922_bot_chat_llm.py
+++ b/tests/test_port_0922_bot_chat_llm.py
@@ -152,28 +152,33 @@ class CatalogTest(unittest.TestCase):
         # A 32-bit host has no published CPU build, and saying so beats
         # downloading an executable that cannot run.
         self.assertIsNone(catalog.runtime_arch('x86'))
-        for source in catalog.RUNTIME_SOURCES:
-            self.assertIsNone(catalog.runtime_url(None, source))
+        self.assertEqual((), catalog.runtime_sources(None))
+        self.assertIsNone(catalog.runtime_url(None))
 
     def test_the_runtime_build_is_pinned(self):
-        for source in catalog.RUNTIME_SOURCES:
-            url = catalog.runtime_url('x64', source)
-            self.assertIn(catalog.RUNTIME_BUILD, url, source)
-            self.assertNotIn('latest', url, source)
-
-    def test_the_runtime_has_a_mirror_that_is_not_github(self):
-        # GitHub is the least reliable host in this catalogue from mainland
-        # China, and it is the only home the runtime has upstream.
-        mirrored = catalog.runtime_url('x64', catalog.MODELSCOPE)
-        self.assertTrue(mirrored.startswith('https://www.modelscope.cn/'))
-        self.assertIn(catalog.runtime_asset('x64')['file'], mirrored)
-        self.assertEqual(catalog.MODELSCOPE, catalog.RUNTIME_SOURCES[0])
-
-    def test_both_runtime_mirrors_name_the_same_archive(self):
         for arch in ('x64', 'arm64'):
-            name = catalog.runtime_asset(arch)['file']
-            for source in catalog.RUNTIME_SOURCES:
-                self.assertIn(name, catalog.runtime_url(arch, source))
+            for source in catalog.runtime_sources(arch):
+                url = catalog.runtime_url(arch, source)
+                self.assertIn(catalog.RUNTIME_BUILD, url, (arch, source))
+                self.assertNotIn('latest', url, (arch, source))
+                self.assertIn(catalog.runtime_asset(arch)['file'], url)
+
+    def test_the_x64_runtime_is_reachable_without_github(self):
+        # GitHub is the least reliable host in this catalogue from mainland
+        # China, and it is the runtime's only upstream home.  The pin is
+        # chosen to be a build a mirror already carries.
+        self.assertEqual(catalog.MODELSCOPE,
+                         catalog.runtime_sources('x64')[0])
+        mirrored = catalog.runtime_url('x64')
+        self.assertTrue(mirrored.startswith('https://www.modelscope.cn/'))
+        self.assertIn(catalog.RUNTIME_BUILD, catalog.RUNTIME_MODELSCOPE_REPO)
+
+    def test_an_architecture_with_no_mirror_says_so(self):
+        # Nothing mirrors the ARM64 build; claiming otherwise would send the
+        # launcher to a URL that cannot exist.
+        self.assertEqual((catalog.GITHUB,), catalog.runtime_sources('arm64'))
+        self.assertIsNone(
+            catalog.runtime_url('arm64', catalog.MODELSCOPE))
 
     def test_an_unknown_runtime_source_has_no_url(self):
         self.assertIsNone(catalog.runtime_url('x64', 'some-other-mirror'))
@@ -496,7 +501,7 @@ class ServerWiringTest(unittest.TestCase):
         self.assertIn('runtime', printed)
         arch = catalog.runtime_arch(__import__('platform').machine())
         if arch is not None:
-            for source in catalog.RUNTIME_SOURCES:
+            for source in catalog.runtime_sources(arch):
                 self.assertIn(catalog.runtime_url(arch, source), printed)
 
     def test_an_uninstalled_generator_refuses_to_start(self):

--- a/tests/test_port_0922_bot_chat_llm.py
+++ b/tests/test_port_0922_bot_chat_llm.py
@@ -239,14 +239,19 @@ class ExtractTest(unittest.TestCase):
 
 
 class PromptTest(unittest.TestCase):
-    def test_the_persona_and_identity_reach_the_system_turn(self):
+    def test_the_persona_reaches_the_system_turn(self):
         messages = build_messages(_request())
         system = messages[0]['content']
         self.assertEqual('system', messages[0]['role'])
-        self.assertIn('今天不加班', system)
         self.assertIn('T-34', system)
         self.assertIn(bot_chat_llm.PERSONA_STYLE[bot_chat.PERSONA_SLACKER],
                       system)
+
+    def test_the_callsign_is_kept_out_of_the_prompt(self):
+        # A small model handed its own name simply says it: one Bot answered
+        # every line with a variation on its own callsign.
+        for message in build_messages(_request()):
+            self.assertNotIn('今天不加班', message['content'])
 
     def test_the_transcript_and_task_reach_the_user_turn(self):
         recent = ({'name': 'Peng', 'text': '那个t34 回来一下'},)

--- a/tests/test_port_0922_bot_chat_llm.py
+++ b/tests/test_port_0922_bot_chat_llm.py
@@ -485,7 +485,8 @@ class DirectorIntegrationTest(unittest.TestCase):
                 for line in director.tick(tick, self.snapshot)]
         self.assertEqual(['模型写的'], [line['text'] for line in late])
 
-    def test_a_hung_generator_cannot_hold_a_line_forever(self):
+    def test_a_backend_asking_for_too_long_is_still_bounded(self):
+        # The initial hold is capped even when a backend asks for minutes.
         backend = _StubBackend('模型写的', latency_hint_seconds=600.0)
         director = self._director(backend)
         director.observe_player_line(0, 1, '那个t34 回来一下', self.snapshot)
@@ -493,6 +494,56 @@ class DirectorIntegrationTest(unittest.TestCase):
         published = [(tick, line) for tick in range(0, cap)
                      for line in director.tick(tick, self.snapshot)]
         self.assertTrue(published)
+
+    def test_a_line_still_being_written_is_waited_for(self):
+        # A first line on a slow machine was always discarded: the estimate
+        # that scheduled it was shorter than the generation it was waiting on.
+        class _Slow(object):
+            latency_hint_seconds = 2.0
+
+            def __init__(self):
+                self.ready_at = 400
+                self.tick = 0
+                self.asked = 0
+
+            def prefetch(self, request):
+                pass
+
+            def pending(self, request):
+                return self.tick < self.ready_at
+
+            def compose(self, request):
+                self.asked += 1
+                return '慢慢写完的' if self.tick >= self.ready_at else None
+
+        backend = _Slow()
+        director = self._director(backend)
+        director.observe_player_line(0, 1, '那个t34 回来一下', self.snapshot)
+        published = []
+        for tick in range(0, 600):
+            backend.tick = tick
+            published.extend(director.tick(tick, self.snapshot))
+        self.assertEqual(['慢慢写完的'], [line['text'] for line in published])
+        self.assertGreater(backend.asked, 1)
+
+    def test_a_line_the_backend_gave_up_on_is_dropped(self):
+        class _GaveUp(object):
+            latency_hint_seconds = 2.0
+
+            def prefetch(self, request):
+                pass
+
+            def pending(self, request):
+                return False
+
+            def compose(self, request):
+                return None
+
+        director = self._director(_GaveUp())
+        director.observe_player_line(0, 1, '那个t34 回来一下', self.snapshot)
+        published = [line for tick in range(0, 900)
+                     for line in director.tick(tick, self.snapshot)]
+        self.assertEqual([], published)
 
     def test_a_model_that_writes_nothing_says_nothing(self):
         director = self._director(_StubBackend(None))

--- a/tests/test_port_0922_bot_chat_llm.py
+++ b/tests/test_port_0922_bot_chat_llm.py
@@ -558,6 +558,64 @@ class SupervisorTest(unittest.TestCase):
             bot_chat_llm.REASONING_BUDGET,
             command[command.index('--reasoning-budget') + 1])
 
+    def test_a_generator_that_dies_reports_its_own_last_words(self):
+        # Discarding the child's output left "it exited" as the entire
+        # diagnosis of a failed install, which is not a diagnosis.
+        directory = tempfile.mkdtemp()
+        model = os.path.join(directory, 'model.gguf')
+        launcher = os.path.join(directory, 'llama-server')
+        with open(model, 'wb') as stream:
+            stream.write(b'GGUF')
+        with open(launcher, 'w', encoding='utf-8') as stream:
+            stream.write('#!/bin/sh\n'
+                         'echo "error: invalid argument: --nonsense" >&2\n'
+                         'exit 1\n')
+        os.chmod(launcher, 0o755)
+        messages = []
+        supervisor = LlamaServerSupervisor(
+            launcher, model, port=1, threads=1, log=messages.append)
+        self.addCleanup(supervisor.stop)
+        self.assertTrue(supervisor.start())
+        self.assertFalse(supervisor.wait_ready(timeout=10.0))
+        reported = ' '.join(messages)
+        self.assertIn('invalid argument: --nonsense', reported)
+        self.assertIn('exit=1', reported)
+
+    def test_the_command_line_is_logged_when_it_starts(self):
+        directory = tempfile.mkdtemp()
+        model = os.path.join(directory, 'model.gguf')
+        launcher = os.path.join(directory, 'llama-server')
+        for path, payload in ((model, b'GGUF'), (launcher, b'#!/bin/sh\nexit 0\n')):
+            with open(path, 'wb') as stream:
+                stream.write(payload)
+        os.chmod(launcher, 0o755)
+        messages = []
+        supervisor = LlamaServerSupervisor(
+            launcher, model, port=1, threads=3, log=messages.append)
+        self.addCleanup(supervisor.stop)
+        supervisor.start()
+        started = ' '.join(messages)
+        self.assertIn('--reasoning-budget', started)
+        self.assertIn(model, started)
+
+    def test_a_silent_death_still_names_the_log_to_read(self):
+        directory = tempfile.mkdtemp()
+        model = os.path.join(directory, 'model.gguf')
+        launcher = os.path.join(directory, 'llama-server')
+        for path, payload in ((model, b'GGUF'), (launcher, b'#!/bin/sh\nexit 3\n')):
+            with open(path, 'wb') as stream:
+                stream.write(payload)
+        os.chmod(launcher, 0o755)
+        messages = []
+        supervisor = LlamaServerSupervisor(
+            launcher, model, port=1, threads=1, log=messages.append)
+        self.addCleanup(supervisor.stop)
+        supervisor.start()
+        supervisor.wait_ready(timeout=10.0)
+        reported = ' '.join(messages)
+        self.assertIn('exit=3', reported)
+        self.assertIn(supervisor.output_path, reported)
+
     def test_a_missing_download_reports_rather_than_launching(self):
         messages = []
         supervisor = LlamaServerSupervisor(

--- a/tests/test_port_0922_bot_chat_llm.py
+++ b/tests/test_port_0922_bot_chat_llm.py
@@ -152,12 +152,31 @@ class CatalogTest(unittest.TestCase):
         # A 32-bit host has no published CPU build, and saying so beats
         # downloading an executable that cannot run.
         self.assertIsNone(catalog.runtime_arch('x86'))
-        self.assertIsNone(catalog.runtime_url(None))
+        for source in catalog.RUNTIME_SOURCES:
+            self.assertIsNone(catalog.runtime_url(None, source))
 
     def test_the_runtime_build_is_pinned(self):
-        url = catalog.runtime_url('x64')
-        self.assertIn(catalog.RUNTIME_BUILD, url)
-        self.assertNotIn('latest', url)
+        for source in catalog.RUNTIME_SOURCES:
+            url = catalog.runtime_url('x64', source)
+            self.assertIn(catalog.RUNTIME_BUILD, url, source)
+            self.assertNotIn('latest', url, source)
+
+    def test_the_runtime_has_a_mirror_that_is_not_github(self):
+        # GitHub is the least reliable host in this catalogue from mainland
+        # China, and it is the only home the runtime has upstream.
+        mirrored = catalog.runtime_url('x64', catalog.MODELSCOPE)
+        self.assertTrue(mirrored.startswith('https://www.modelscope.cn/'))
+        self.assertIn(catalog.runtime_asset('x64')['file'], mirrored)
+        self.assertEqual(catalog.MODELSCOPE, catalog.RUNTIME_SOURCES[0])
+
+    def test_both_runtime_mirrors_name_the_same_archive(self):
+        for arch in ('x64', 'arm64'):
+            name = catalog.runtime_asset(arch)['file']
+            for source in catalog.RUNTIME_SOURCES:
+                self.assertIn(name, catalog.runtime_url(arch, source))
+
+    def test_an_unknown_runtime_source_has_no_url(self):
+        self.assertIsNone(catalog.runtime_url('x64', 'some-other-mirror'))
 
 
 class SanitizeTest(unittest.TestCase):
@@ -475,6 +494,10 @@ class ServerWiringTest(unittest.TestCase):
                 self.assertIn(catalog.model_url(entry['key'], source),
                               printed)
         self.assertIn('runtime', printed)
+        arch = catalog.runtime_arch(__import__('platform').machine())
+        if arch is not None:
+            for source in catalog.RUNTIME_SOURCES:
+                self.assertIn(catalog.runtime_url(arch, source), printed)
 
     def test_an_uninstalled_generator_refuses_to_start(self):
         generator = self.module.configured_bot_chat(


### PR DESCRIPTION
Stacked on #64. That PR built the conversation — who answers, when, how many,
and how fast. This one replaces its shipped template backend with the thing it
was a seam for: a local Qwen2.5-Instruct model served by llama.cpp, downloaded
only when a player asks for it.

## No template fallback

With no model installed the feature is off and every Bot is quiet. With one
installed, a line that fails to generate is simply not said. `TemplateLineBackend`
is deleted rather than demoted — a canned stand-in would only make a broken
model look healthy.

## Nothing in a battle waits on the generator

- It runs as a separate `llama-server` child on loopback, so a native inference
  crash stays out of the LAN server and the model's memory stays out of the game
  process.
- One worker thread bounds the CPU this can take from a 32-bit game client and
  the hidden worker; inference gets two cores fewer than the machine has.
- The director freezes a line's request when the line is **scheduled** and hands
  it over immediately, so generation runs during the seconds a teammate would
  spend reading and typing.
- Model load happens on a startup thread. Until the health check answers, the
  director has no backend.
- `CREATE_NO_WINDOW`, an ephemeral loopback port, and termination in the
  server's shutdown path so no orphan holds the model in RAM.

## Reply pacing is human now

Replies land between **1.5 and 9 seconds** — a teammate reads the channel and
types a line of Chinese while driving; an instant answer is what reads as a
machine. That window is also what gives a small local model room to finish,
which is why the prefetch latency hint only matters for a generator slower than
a person. A hung one is abandoned rather than holding a line forever.

## Thinking is switched off, not designed around

An earlier revision justified the model choice by claiming a reasoning model
could not be used. That was wrong. The pinned runtime documents
`--reasoning-budget 0` ("0 for immediate end") and `chat_template_kwargs`, and
both are present in **b10819**, not only on master. Thinking is now switched off
at both levels; each is a no-op for a template that has no thinking mode, so one
call path serves either generation. The `<think>` strip in `sanitize_line` stays
as defence for a switch that did not take, not as the only guard.

## Catalogue

| tier | params | quant | size | licence |
| --- | --- | --- | --- | --- |
| `qwen3-0.6b` **(default)** | 0.6B | Q8_0 | 610 MB | Apache-2.0 |
| `qwen3-1.7b` | 1.7B | Q8_0 | 1749 MB | Apache-2.0 |
| `qwen2.5-0.5b` | 0.5B | Q4_K_M | 469 MB | Apache-2.0 |
| `qwen2.5-1.5b` | 1.5B | Q4_K_M | 1066 MB | Apache-2.0 |

The Qwen organisation publishes only Q8_0 for its Qwen3 GGUF repositories, which
is why those are larger at a comparable parameter count. Third-party
requantisations are deliberately not listed.

**Every file was verified byte-identical across ModelScope and Hugging Face**
(HF's `x-linked-etag` equals ModelScope's `Sha256`), so one pinned digest
validates a download from either. ModelScope leads because it is reachable from
mainland China.

## The runtime is pinned to a build a mirror already carries

llama.cpp publishes Windows builds only as GitHub release assets -- the host
least likely to answer in China -- so the pin is chosen to be a build that an
existing third-party ModelScope repository already republishes, rather than the
newest one. **b9637**, CPU-only, x64 (16.9 MB) and ARM64 (10.8 MB). The game
already owns the GPU.

Verified, not assumed: the x64 archive was downloaded from that mirror and
hashes to `f7783c2b8c00...`, exactly the digest GitHub reports for its own
asset at the same 16906751 bytes, and it contains `llama-server.exe` with the
full set of per-microarchitecture ggml CPU libraries.

Trusting a stranger's mirror therefore costs nothing. **The pinned digest is
the official artifact's**, so a mirror that is stale, wrong or hostile fails
verification instead of installing something else; the worst it can do is be
unavailable, with GitHub listed behind it. The mirror's repository name embeds
the build, so a future pin retires it cleanly into a 404.

b9637 documents every switch this code uses, including `--reasoning-budget` and
`chat_template_kwargs`; only `reasoning_effort`, unused here, is newer.

Sources are per architecture, because nothing mirrors the ARM64 build and
claiming otherwise would send the launcher to a URL that cannot exist.

Two routes that looked promising were rejected on evidence: npm's
`@node-llama-cpp` on npmmirror ships a Node addon and no `llama-server.exe`,
and conda-forge's `llama.cpp` on the Tsinghua mirror has one but only as
`.conda` archives, whose zstd payload CPython 3.11 cannot read, and it depends
on mkl, shaderc, libvulkan-loader and libcurl rather than standing alone.

`--list-chat-models` prints all four models and both runtime hosts, so what a
player is about to fetch is inspectable before any download exists to inspect.

## Installing it from the launcher

The **AI chat** Tools tab downloads what this catalogue names and hands the
resolved paths to every room the launcher starts.

### Built around being interrupted


610 MB over a route that is slow for many of these players is not a download
you can treat as an atomic operation.

- **Progress** is reported continuously, in bytes and as a fraction.
- **Stop** is answered within one chunk, and keeps the partial file.
- **Resume** sends a range request for what is missing. A host that ignores
  the range restarts cleanly instead of appending to nothing, and a partial
  file longer than the finished one is discarded rather than trusted.
- **Every published host is tried in turn** — an unreachable ModelScope falls
  through to Hugging Face, an unreachable mirror falls through to GitHub.
- **Nothing is accepted without matching the pinned SHA-256.** A mismatch
  deletes the file rather than installing it.
- A **cancel does not fall through to the next host**; it stops.

## Only what is needed is unpacked

The runtime archive carries twenty other command line tools. Only
`llama-server.exe` and the libraries it loads are extracted, a member naming a
path is refused rather than written, and the archive is deleted once unpacked.

## One catalogue, not two

`core.bot_chat_catalogue` imports the server's own pinned module the same way a
room reaches it, so **the launcher downloads exactly what the server will
load**. No URL, size or digest is restated on this side.

`server_environment` names both halves only when both are really on disk, and
clears a stale name it inherited — naming one alone would start a room that
reports a disabled feature every time it looks for the other.

## Escape hatches

A player who already has `llama-server.exe` points at it and downloads only the
model. A machine with no published build is told so rather than being offered a
download that cannot run. **Remove** deletes everything and gives the disk
space back.

## A bug worth naming

`BotChatPanel.busy` is an explicit flag rather than `Thread.is_alive`. The
worker reports its own completion, and at that moment its thread is still
running — asking the thread left the panel reporting a download that had
already finished, permanently. The tests caught it.

## Model output is untrusted input

`sanitize_line` strips what a small instruct model actually produces — a leading
callsign, wrapping quotes, a reasoning block, several lines at once — before the
stock length and encoding rules get the final say. The server then validates
again before publication.

## Also fixed

A team's chat budget is charged when a line is **published**, not when one is
attempted. With silence now a normal outcome, that difference is no longer
academic.

## Validation

- 118 new tests. Server side: catalogue and every mirror, sanitisation, prompt assembly,
  async prefetch/compose, non-blocking compose, transport failure containment,
  queue bounds, director timing, reasoning shutoff, server wiring, and a **real
  child process** started, health-checked, queried and terminated end to end.
  Launcher side: resume, range refusal, over-long partials, truncated and
  oversized responses, digest mismatch, transport failure, cancel timing,
  source fallback, extraction filtering, path-traversal refusal,
  install/remove state, panel threading, settings round-trip, and the
  environment handed to a room.
- Launcher suite: 552 tests pass.
- Full suite: 4084 tests pass.
- CPython 2.7.18 client compile gate passes (94 files).

## Not proved here

Real generation latency and quality on Windows. Everything above is measured
against a stand-in that speaks the same wire protocol — it proves the plumbing,
not that a 0.5B writes a good Chinese one-liner in time. Peng's VM is ARM64
emulating x86, so its numbers read as a floor, not a target.

The launcher download UI is deliberately not here — a 469 MB fetch needs
progress, cancellation, resume and integrity checking, which is its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


