### PR TITLE
Keep the sold-vehicle restore tag out of battle eligibility

### DIFF
--- a/launcher/bot_lineup_profiles.py
+++ b/launcher/bot_lineup_profiles.py
@@ -20,15 +20,20 @@ UNUSABLE_BOT_VEHICLES_0922 = frozenset((
 # The exact set vehicle_configuration.NON_STANDARD_BATTLE_TAGS applies in the
 # mod, bound by a parity test.  ``secret`` is deliberately absent: a hidden
 # entry with an honest level and name stays selectable, and only the Bootcamp
-# clones below and the ``fallout`` copies are withheld.
+# clones below and the ``fallout`` copies are withheld.  ``unrecoverable`` is
+# absent for the same reason the mod drops it: #1513 reads that tag only in
+# its sold-vehicle and sold-crew restore rules.
 NON_STANDARD_BOT_TAGS_0922 = frozenset((
-    "event_battles", "premiumIGR", "observer", "unrecoverable", "fallout",
+    "event_battles", "premiumIGR", "observer", "fallout",
 ))
-NON_STANDARD_BOT_VEHICLES_0922 = frozenset(("usa:T23",))
 # #1513 publishes every ``_bootcamp`` tutorial copy at level 2 while it keeps
 # the original hull, so offering one as a Bot puts a tier 6 tank in a tier 2
 # slot.  Stock hides them with ``secret`` and this name suffix alone.
 CLONE_BOT_VEHICLE_SUFFIXES_0922 = ("_bootcamp",)
+# The tutorial and Bot placeholders, and the artillery strike emitter, are
+# the entries no roster may field.  Stock hides them the same way.
+NON_BATTLE_ENTITY_BOT_SUFFIXES_0922 = ("_bot", "_training")
+NON_BATTLE_ENTITY_BOT_VEHICLES_0922 = frozenset(("germany:Env_Artillery",))
 CATALOGUE_VISIBILITY_TAG_0922 = "secret"
 
 _NATION = re.compile(r"^[a-z][a-z0-9_]*$")
@@ -90,11 +95,12 @@ def vehicle_choice_is_eligible(choice):
     if not isinstance(tags, (list, tuple, set, frozenset)):
         raise BotLineupProfileError("The vehicle tags are invalid.")
     tags = set(str(tag) for tag in tags)
-    if (CATALOGUE_VISIBILITY_TAG_0922 in tags and
-            type_name.endswith(CLONE_BOT_VEHICLE_SUFFIXES_0922)):
+    if CATALOGUE_VISIBILITY_TAG_0922 in tags and (
+            type_name.endswith(CLONE_BOT_VEHICLE_SUFFIXES_0922) or
+            type_name.endswith(NON_BATTLE_ENTITY_BOT_SUFFIXES_0922) or
+            type_name in NON_BATTLE_ENTITY_BOT_VEHICLES_0922):
         return False
     return (not NON_STANDARD_BOT_TAGS_0922.intersection(tags) and
-            type_name not in NON_STANDARD_BOT_VEHICLES_0922 and
             type_name not in UNUSABLE_BOT_VEHICLES_0922)
 
 

--- a/launcher/tests/test_bot_lineup_profiles.py
+++ b/launcher/tests/test_bot_lineup_profiles.py
@@ -32,7 +32,11 @@ class BotLineupProfilesTests(unittest.TestCase):
     def test_eligible_choices_match_the_authority_exclusions(self):
         choices = [
             {"nation": "ussr", "vehicle": "R11_MS-1", "tags": ()},
-            {"nation": "usa", "vehicle": "T23", "tags": ()},
+            {"nation": "ussr", "vehicle": "R09_T-26_bot",
+             "tags": ("lightTank", "secret", "unrecoverable")},
+            {"nation": "japan", "vehicle": "J30_Edelweiss",
+             "tags": ("mediumTank", "lockOutfit", "lockCrew",
+                      "unrecoverable")},
             {"nation": "germany",
              "vehicle": "G138_VK168_02_Mauerbrecher", "tags": ()},
             {"nation": "ussr", "vehicle": "R98_T44_85",
@@ -54,7 +58,7 @@ class BotLineupProfilesTests(unittest.TestCase):
         # A hidden entry with an honest level and name stays selectable; the
         # Bootcamp and Fallout copies of a real tank do not.
         self.assertEqual(
-            ["ussr:R11_MS-1", "ussr:R98_T44_85"],
+            ["ussr:R11_MS-1", "japan:J30_Edelweiss", "ussr:R98_T44_85"],
             [choice["type_name"] for choice in
              bot_lineup_profiles.eligible_vehicle_choices(choices)])
 

--- a/launcher/vehicle_overlays.py
+++ b/launcher/vehicle_overlays.py
@@ -818,6 +818,23 @@ def _vehicle_display_id(vehicle):
     return display or value
 
 
+def _vehicle_is_selectable(type_name, tags):
+    """Return whether the editor offers this catalogue entry for editing.
+
+    ``secret`` hides vehicles from the retail tech tree, but it is not a
+    data-safety boundary for this local editor. Keep only the entries no
+    battle can field out of the player catalogue, so the editor still
+    reaches the Bootcamp and Fallout copies of a real tank;
+    bot_lineup_profiles applies the stricter roster rule on top of this list
+    before offering a vehicle as a Bot.
+    """
+    return bool(
+        not _NON_EDITABLE_VEHICLE_TAGS.intersection(tags) and
+        not ("secret" in tags and (
+            type_name in _NON_EDITABLE_VEHICLES or
+            type_name.endswith(_NON_EDITABLE_VEHICLE_SUFFIXES))))
+
+
 def _vehicle_roster_from_archive(archive, counts, nation=None):
     """Resolve vehicle definitions from each nation's stock list.xml."""
     list_members = []
@@ -886,18 +903,8 @@ def _vehicle_roster_from_archive(archive, counts, nation=None):
                 "userString": user_strings.get("userString", ""),
                 "shortUserString": user_strings.get("shortUserString", ""),
             }
-            # ``secret`` hides vehicles from the retail tech tree, but it is
-            # not a data-safety boundary for this local editor. Keep only
-            # native construction hazards out of the player catalogue, so the
-            # editor still reaches the Bootcamp and Fallout copies of a real
-            # tank; bot_lineup_profiles applies the stricter roster rule on
-            # top of this list before offering a vehicle as a Bot.
-            type_name = "%s:%s" % (roster_nation, vehicle)
-            record["selectable"] = bool(
-                not _NON_EDITABLE_VEHICLE_TAGS.intersection(record["tags"]) and
-                not ("secret" in record["tags"] and (
-                    type_name in _NON_EDITABLE_VEHICLES or
-                    type_name.endswith(_NON_EDITABLE_VEHICLE_SUFFIXES))))
+            record["selectable"] = _vehicle_is_selectable(
+                "%s:%s" % (roster_nation, vehicle), record["tags"])
             records.append(record)
     return sorted(records, key=lambda record: (
         record["nation"], record["vehicle"], record["member"]))

--- a/launcher/vehicle_overlays.py
+++ b/launcher/vehicle_overlays.py
@@ -69,8 +69,9 @@ _VEHICLE_CATALOG_PREFIX = re.compile(r"^[A-Za-z]{1,2}[0-9]{2,3}_")
 _SAFE_SEGMENT = re.compile(r"^[A-Za-z0-9_.-]+$")
 _DIGEST = re.compile(r"^[0-9a-f]{64}$")
 _NON_EDITABLE_VEHICLE_TAGS = frozenset((
-    "event_battles", "premiumIGR", "observer", "unrecoverable"))
-_NON_EDITABLE_VEHICLES = frozenset(("usa:T23",))
+    "event_battles", "premiumIGR", "observer"))
+_NON_EDITABLE_VEHICLE_SUFFIXES = ("_bot", "_training")
+_NON_EDITABLE_VEHICLES = frozenset(("germany:Env_Artillery",))
 
 _TYPE_NAMES = {
     packed_xml.TYPE_STRING: "string",
@@ -894,7 +895,9 @@ def _vehicle_roster_from_archive(archive, counts, nation=None):
             type_name = "%s:%s" % (roster_nation, vehicle)
             record["selectable"] = bool(
                 not _NON_EDITABLE_VEHICLE_TAGS.intersection(record["tags"]) and
-                type_name not in _NON_EDITABLE_VEHICLES)
+                not ("secret" in record["tags"] and (
+                    type_name in _NON_EDITABLE_VEHICLES or
+                    type_name.endswith(_NON_EDITABLE_VEHICLE_SUFFIXES))))
             records.append(record)
     return sorted(records, key=lambda record: (
         record["nation"], record["vehicle"], record["member"]))

--- a/server/lan_battle_server.py
+++ b/server/lan_battle_server.py
@@ -883,19 +883,23 @@ def _projectile_bounded_vector(value, lows, highs):
 def _bot_lineup_allowed_names(catalog):
     """Return catalog identities accepted by every Bot roster owner."""
     excluded_tags = {
-        "event_battles", "premiumIGR", "observer", "unrecoverable",
-        "fallout",
+        "event_battles", "premiumIGR", "observer", "fallout",
     }
     excluded_names = {
-        "usa:T23", "germany:G138_VK168_02_Mauerbrecher",
+        "germany:G138_VK168_02_Mauerbrecher",
     }
+    # ``secret`` also hides honest tanks, so it withholds an entry only when
+    # stock marks it a tutorial copy or a helper by its item_defs name.
+    hidden_names = {"germany:Env_Artillery"}
+    hidden_suffixes = ("_bootcamp", "_bot", "_training")
     return set(
         row.get("name") for row in (catalog or ())
         if isinstance(row, dict) and row.get("name") and
         not excluded_tags.intersection(row.get("tags") or ()) and
         row.get("name") not in excluded_names and
         not ("secret" in (row.get("tags") or ()) and
-             row.get("name").endswith("_bootcamp")))
+             (row.get("name") in hidden_names or
+              row.get("name").endswith(hidden_suffixes))))
 
 
 def _bounded_vector(value, lows, highs):

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/vehicle_configuration.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/vehicle_configuration.py
@@ -3,12 +3,22 @@
 
 # ``fallout`` is the stock #1513 tag name; gui/shared/gui_items/Vehicle.py
 # declares it in VEHICLE_TAGS next to the other exclusions listed here.
+# ``unrecoverable`` is not one of them.  #1513 reads that tag only in
+# items/vehicles.py ``isRestorable``, items/tankmen.py
+# ``TankmanDescr.isRestorable`` and gui/shared/gui_items/Vehicle.py
+# ``isUnrecoverable``: it decides whether a sold vehicle or crew can be
+# bought back, never whether the vehicle may enter a battle.  Reading it as
+# an eligibility rule withheld 17 shipped tanks, among them
+# ``japan:J29_Nameless`` and ``japan:J30_Edelweiss``.
 NON_STANDARD_BATTLE_TAGS = frozenset((
-    'event_battles', 'premiumIGR', 'observer', 'unrecoverable', 'fallout'))
-NON_STANDARD_BATTLE_NAMES = frozenset(('usa:T23',))
+    'event_battles', 'premiumIGR', 'observer', 'fallout'))
 # The Bootcamp tutorial copies are the one clone family stock gives no tag of
 # its own: it hides them with ``secret`` plus this item_defs name suffix.
 CLONE_NAME_SUFFIXES = ('_bootcamp',)
+# The tutorial and Bot placeholders stock drives itself, and the artillery
+# strike emitter, are hidden the same way: ``secret`` and an item_defs name.
+NON_BATTLE_ENTITY_SUFFIXES = ('_bot', '_training')
+NON_BATTLE_ENTITY_NAMES = frozenset(('germany:Env_Artillery',))
 CATALOGUE_VISIBILITY_TAG = 'secret'
 
 
@@ -28,23 +38,40 @@ def is_clone_of_a_standard_vehicle(name, tags):
         str(name or '').endswith(CLONE_NAME_SUFFIXES))
 
 
+def is_non_battle_entity(name, tags):
+    """Return whether this entry is a helper the player never drives.
+
+    #1513 ``list.xml`` carries 19 of them: 11 ``_bot`` and 6 ``_training``
+    placeholders stock drives in the tutorial, ``germany:Env_Artillery``,
+    whose shell has no renderable projectile, and ``ussr:Observer``, which
+    the ``observer`` tag already excludes.  Every one of them also carries
+    ``secret``, so requiring the tag keeps the rule from hiding a shipped
+    vehicle whose item_defs name happens to end the same way.
+    """
+    name = str(name or '')
+    return bool(
+        CATALOGUE_VISIBILITY_TAG in tags and (
+            name in NON_BATTLE_ENTITY_NAMES or
+            name.endswith(NON_BATTLE_ENTITY_SUFFIXES)))
+
+
 def is_standard_battle_vehicle(vehicle_type):
     """Return whether #1513 exposes this type to ordinary tank battles.
 
-    The stock catalogue also contains observer, event, IGR and unrecoverable
-    environment helper entities.  Some of them can be constructed in the
-    garage but omit resources required by ``Vehicle.prerequisites``;
-    ``Env_Artillery`` is one example whose shell has no renderable projectile.
-    ``secret`` alone is only a catalogue-visibility tag: a hidden entry whose
-    own level and name are honest stays playable, and only the clones above
-    and the ``fallout`` event copies are withheld.
+    The stock catalogue also contains observer, event and IGR entries, and
+    the helper entities above, which can be constructed in the garage but
+    omit resources required by ``Vehicle.prerequisites``.  ``secret`` alone
+    is only a catalogue-visibility tag: a hidden entry whose own level and
+    name are honest stays playable, and only the clones, the ``fallout``
+    event copies and those helpers are withheld.
     """
     name = str(getattr(vehicle_type, 'name', '') or '')
     tags = set(getattr(vehicle_type, 'tags', ()) or ())
     return bool(
-        name and name not in NON_STANDARD_BATTLE_NAMES and
+        name and
         not NON_STANDARD_BATTLE_TAGS.intersection(tags) and
-        not is_clone_of_a_standard_vehicle(name, tags))
+        not is_clone_of_a_standard_vehicle(name, tags) and
+        not is_non_battle_entity(name, tags))
 
 
 def _sort_text(value):

--- a/tests/test_port_0922_bootstrap_lifecycle.py
+++ b/tests/test_port_0922_bootstrap_lifecycle.py
@@ -250,14 +250,16 @@ class BootstrapLifecycleTests(unittest.TestCase):
                 part.guns = guns
             return part
 
-        def make_descriptor(nation_id, vehicle_type_id, base, tags=()):
+        def make_descriptor(nation_id, vehicle_type_id, base, tags=(),
+                            name=None):
             # Two entries per slot, stock first, exactly as #1513 orders them.
             guns = [_part(base + 4, 3), _part(base + 14, 6)]
             turrets = [[_part(base + 3, 2, guns[:1]),
                         _part(base + 13, 5, guns)]]
             vehicle_type = types.SimpleNamespace(
                 id=(nation_id, vehicle_type_id),
-                name='nation-%d:vehicle-%d' % (nation_id, vehicle_type_id),
+                name=name or 'nation-%d:vehicle-%d' % (
+                    nation_id, vehicle_type_id),
                 crewRoles=(('commander',), ('driver',)),
                 tags=frozenset(tags),
                 chassis=[_part(base + 2, 2), _part(base + 12, 5)],
@@ -321,8 +323,11 @@ class BootstrapLifecycleTests(unittest.TestCase):
             (2, 1): make_descriptor(2, 1, 7000, ('event_battles',)),
             (2, 2): make_descriptor(2, 2, 8000, ('premiumIGR',)),
             (2, 3): make_descriptor(2, 3, 9000, ('observer',)),
-            (2, 4): make_descriptor(2, 4, 10000, ('SPG', 'secret',
-                                                   'unrecoverable')),
+            # #1513 hides the artillery strike emitter with ``secret`` and
+            # this item_defs name; its shell has no renderable projectile.
+            (2, 4): make_descriptor(
+                2, 4, 10000, ('SPG', 'secret', 'unrecoverable'),
+                name='germany:Env_Artillery'),
         }
         delattr(descriptors[(1, 9)], 'gun')
         descriptors[(1, 9)].type.turrets = [[]]

--- a/tests/test_port_0922_bot_lineup_integration.py
+++ b/tests/test_port_0922_bot_lineup_integration.py
@@ -326,12 +326,7 @@ class BotLineupIntegrationTests(unittest.TestCase):
     @staticmethod
     def _launcher_admits(name, tags):
         """Reproduce the composed launcher decision for one vehicle."""
-        if vehicle_overlays._NON_EDITABLE_VEHICLE_TAGS.intersection(tags):
-            return False
-        if 'secret' in tags and (
-                name in vehicle_overlays._NON_EDITABLE_VEHICLES or
-                name.endswith(
-                    vehicle_overlays._NON_EDITABLE_VEHICLE_SUFFIXES)):
+        if not vehicle_overlays._vehicle_is_selectable(name, tags):
             return False
         nation, vehicle = name.split(':', 1)
         return bool(bot_lineup_profiles.eligible_vehicle_choices([{
@@ -378,6 +373,38 @@ class BotLineupIntegrationTests(unittest.TestCase):
                 'name': name, 'level': 5, 'tags': list(tags),
             }])
             self.assertEqual(admitted, name in server_names, name)
+
+    def test_the_helper_rule_withholds_nothing_without_the_secret_tag(self):
+        # ``secret`` is what separates a stock placeholder from a shipped
+        # tank whose item_defs name happens to end the same way, so every
+        # authority must require the tag before it withholds an entry.
+        for name in ('ussr:R09_T-26_bot', 'ussr:R07_T-34-85_training',
+                     'germany:Env_Artillery'):
+            self.assertTrue(vehicle_configuration.is_non_battle_entity(
+                name, ('lightTank', 'secret')), name)
+            self.assertFalse(vehicle_configuration.is_non_battle_entity(
+                name, ('lightTank',)), name)
+            nation, vehicle = name.split(':', 1)
+            for tags, expected in ((('lightTank', 'secret'), False),
+                                   (('lightTank',), True)):
+                entry = types.SimpleNamespace(name=name, level=2, tags=tags)
+                self.assertEqual(
+                    expected,
+                    vehicle_configuration.is_standard_battle_vehicle(entry),
+                    name)
+                self.assertEqual(
+                    expected,
+                    bot_lineup_profiles.vehicle_choice_is_eligible({
+                        'nation': nation, 'vehicle': vehicle,
+                        'tags': list(tags)}),
+                    name)
+                self.assertEqual(
+                    expected,
+                    name in server_runtime._bot_lineup_allowed_names([{
+                        'name': name, 'level': 2, 'tags': list(tags)}]),
+                    name)
+                self.assertEqual(
+                    expected, self._launcher_admits(name, tags), name)
 
     def test_missing_exact_vehicle_is_rejected_by_hidden_worker(self):
         lineup = [{

--- a/tests/test_port_0922_bot_lineup_integration.py
+++ b/tests/test_port_0922_bot_lineup_integration.py
@@ -304,23 +304,34 @@ class BotLineupIntegrationTests(unittest.TestCase):
     _EXCLUSION_CASES = (
         ('ussr:R11_MS-1', ('lightTank',), True),
         ('ussr:R99_SecretTank', ('mediumTank', 'secret'), True),
+        # The two #1513 tanks stock sells but never lets a player buy back.
+        ('japan:J29_Nameless',
+         ('heavyTank', 'lockOutfit', 'lockCrew', 'unrecoverable'), True),
+        ('japan:J30_Edelweiss',
+         ('mediumTank', 'lockOutfit', 'lockCrew', 'unrecoverable'), True),
+        # A retired tank keeps an honest name and level while it is hidden.
+        ('usa:A08_T23', ('mediumTank', 'secret', 'unrecoverable'), True),
         ('ussr:R07_T-34-85_bootcamp', ('mediumTank', 'secret'), False),
         ('ussr:R45_IS-7_fallout', ('heavyTank', 'fallout', 'secret'), False),
         ('ussr:R07_T-34-85_training',
          ('mediumTank', 'secret', 'unrecoverable'), False),
+        ('ussr:R09_T-26_bot', ('lightTank', 'secret', 'unrecoverable'), False),
         ('germany:Env_Artillery', ('SPG', 'secret', 'unrecoverable'), False),
         ('germany:G01_Maus_IGR', ('heavyTank', 'premiumIGR', 'secret'), False),
         ('ussr:EventTank', ('mediumTank', 'event_battles'), False),
         ('ussr:Observer', ('lightTank', 'observer'), False),
-        ('usa:T23', ('mediumTank',), False),
         ('germany:G138_VK168_02_Mauerbrecher', ('heavyTank',), False),
     )
 
     @staticmethod
     def _launcher_admits(name, tags):
         """Reproduce the composed launcher decision for one vehicle."""
-        if (vehicle_overlays._NON_EDITABLE_VEHICLE_TAGS.intersection(tags) or
-                name in vehicle_overlays._NON_EDITABLE_VEHICLES):
+        if vehicle_overlays._NON_EDITABLE_VEHICLE_TAGS.intersection(tags):
+            return False
+        if 'secret' in tags and (
+                name in vehicle_overlays._NON_EDITABLE_VEHICLES or
+                name.endswith(
+                    vehicle_overlays._NON_EDITABLE_VEHICLE_SUFFIXES)):
             return False
         nation, vehicle = name.split(':', 1)
         return bool(bot_lineup_profiles.eligible_vehicle_choices([{
@@ -332,11 +343,14 @@ class BotLineupIntegrationTests(unittest.TestCase):
             frozenset(vehicle_configuration.NON_STANDARD_BATTLE_TAGS),
             frozenset(bot_lineup_profiles.NON_STANDARD_BOT_TAGS_0922))
         self.assertEqual(
-            frozenset(vehicle_configuration.NON_STANDARD_BATTLE_NAMES),
-            frozenset(bot_lineup_profiles.NON_STANDARD_BOT_VEHICLES_0922))
-        self.assertEqual(
             tuple(vehicle_configuration.CLONE_NAME_SUFFIXES),
             tuple(bot_lineup_profiles.CLONE_BOT_VEHICLE_SUFFIXES_0922))
+        self.assertEqual(
+            tuple(vehicle_configuration.NON_BATTLE_ENTITY_SUFFIXES),
+            tuple(bot_lineup_profiles.NON_BATTLE_ENTITY_BOT_SUFFIXES_0922))
+        self.assertEqual(
+            frozenset(vehicle_configuration.NON_BATTLE_ENTITY_NAMES),
+            frozenset(bot_lineup_profiles.NON_BATTLE_ENTITY_BOT_VEHICLES_0922))
         self.assertEqual(
             vehicle_configuration.CATALOGUE_VISIBILITY_TAG,
             bot_lineup_profiles.CATALOGUE_VISIBILITY_TAG_0922)
@@ -347,7 +361,10 @@ class BotLineupIntegrationTests(unittest.TestCase):
             frozenset(bot_lineup_profiles.NON_STANDARD_BOT_TAGS_0922))
         self.assertLessEqual(
             frozenset(vehicle_overlays._NON_EDITABLE_VEHICLES),
-            frozenset(bot_lineup_profiles.NON_STANDARD_BOT_VEHICLES_0922))
+            frozenset(bot_lineup_profiles.NON_BATTLE_ENTITY_BOT_VEHICLES_0922))
+        self.assertLessEqual(
+            frozenset(vehicle_overlays._NON_EDITABLE_VEHICLE_SUFFIXES),
+            frozenset(bot_lineup_profiles.NON_BATTLE_ENTITY_BOT_SUFFIXES_0922))
 
         for name, tags, expected in self._EXCLUSION_CASES:
             entry = types.SimpleNamespace(name=name, level=5, tags=tags)


### PR DESCRIPTION
## What Peng asked

Whether the CH client's 无名 and 雪绒花 — the two 9.22 Valkyria Chronicles
tanks — should be in the game. They are shipped client data, and this port
was hiding them.

## What the pinned client says

`scripts/item_defs/vehicles/japan/list.xml` in `res/packages/scripts.pkg`
carries both, with complete resources (the baked `vehicle_blacklist.py`,
generated over all 680 entries, lists only `germany:G138_VK168_02_Mauerbrecher`
as unloadable):

```
J29_Nameless   level 8  heavyTank  ... lockOutfit HD unrecoverable lockCrew
J30_Edelweiss  level 8  mediumTank ... lockOutfit HD unrecoverable lockCrew
```

## Why they never reached the player

`vehicle_configuration.NON_STANDARD_BATTLE_TAGS` listed `unrecoverable`, and
the launcher's editor pass, the launcher's Bot picker and the server's lineup
validator each carried a copy of that set. #1513 itself reads the tag in
exactly three places, all of them the sold-vehicle/sold-crew restore rule:

- `items/vehicles.py isRestorable`
- `items/tankmen.py TankmanDescr.isRestorable` (`'lockCrew' in vehicleTags and
  'unrecoverable' in vehicleTags`)
- `gui/shared/gui_items/Vehicle.py isUnrecoverable`

Nothing in stock uses it for battle eligibility. Using it as a proxy for
"tutorial or environment helper entity" withheld the whole class of tanks
that merely cannot be bought back.

## Scope, from the pinned client's 680 `list.xml` entries

36 entries carry `unrecoverable`:

| family | count | disposition |
| --- | --- | --- |
| `_bot` placeholders | 11 | still withheld |
| `_training` placeholders | 6 | still withheld |
| `germany:Env_Artillery`, `ussr:Observer` | 2 | still withheld |
| real tanks | 17 | admitted |

Every one of the 19 helpers also carries `secret`, so they are now withheld
the way the Bootcamp clones already are: the stock `secret` tag plus the
item_defs name (`_bot` / `_training` suffix, or `germany:Env_Artillery`;
`ussr:Observer` is already covered by the `observer` tag).

The 17 admitted tanks, none of which shares a `userString` with a live entry:

| tier | vehicle | `secret` |
| --- | --- | --- |
| 8 | `japan:J29_Nameless` | no |
| 8 | `japan:J30_Edelweiss` | no |
| 7 | `usa:A112_T71E2` | no |
| 2 | `usa:A15_T57`, `usa:A26_T18` | yes |
| 5 | `ussr:R05_KV`, `ussr:R70_T_50_2`, `germany:G79_Pz_IV_AusfGH` | yes |
| 7 | `germany:G04_PzVI_Tiger_IA`, `germany:G85_Auf_Panther` | yes |
| 8 | `usa:A08_T23` | yes |
| 9 | `ussr:R75_SU122_54` | yes |
| 10 | `ussr:R93_Object263B`, `ussr:R96_Object_430B`, `germany:G98_Waffentrager_E100`, `uk:GB70_FV4202_105`, `china:Ch22_113` | yes |

They are hidden entries with honest names and levels, which is exactly the
class PR #63 decided stays playable.

Also dropped: the `usa:T23` name rule. That key belongs to the retired 0.8.2
tree; #1513 publishes the tank as `usa:A08_T23`, so the rule never matched
anything on this client.

## Verification

- Replayed all four effective predicates over the pinned client's 680
  `list.xml` rows: the mod, the composed launcher pass and the server now
  admit the same 588 vehicles (589 for the mod before its separate resource
  blacklist), 17 more than before, and withhold nothing they admitted
  previously.
- `python3 -m unittest discover -s tests -p "test_*.py"` — 3987 tests, OK.
- `python3 -m unittest discover -s tests -p "test_*.py"` in `launcher` — 482
  tests, OK (2 skipped).
- CPython 2.7 source compile over `src/res/scripts/client`: 94 files, passed.
- `tests/test_port_0922_bot_lineup_integration.py` now replays the two tanks,
  a hidden-but-honest retired tank, and a `_bot` placeholder through the mod,
  the launcher and the server predicates.

## Not proved here

That the two tanks load and play on the exact Windows client. `lockOutfit` is
already exercised by 14 admitted vehicles, but `lockCrew` exists only on these
two; stock reads it only in the crew restore rule and the port's
`generateTankmen` path does not look at it, so an ordinary Japanese crew is
expected to be generated for them. Their localized names could not be checked
on this machine — `res/text/LC_MESSAGES` is not available here — so if any of
the 14 retired variants turns out to display a raw string key in the garage,
that is a separate, data-driven exclusion.
