### PR TITLE
Keep a narrow passage from locking two Bots nose to nose

### DIFF
--- a/src/res/scripts/client/gui/mods/offline_lan_0922/ai/driver.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/ai/driver.py
@@ -577,10 +577,24 @@ class LocalDriver(object):
 			# Reverse recovery is an explicit reverse command. The traverse law flips
 			# steering from that command immediately, not from signed velocity.
 			recovery_turn = -direction
+			recovery_target = recovery_yaw
+			# Steering while reversing rotates the hull through the recovery offset,
+			# so the rear sweeps every heading between the straight reverse and its
+			# mirrored offset. In a gateway or alley narrower than that arc the
+			# manoeuvre parks the hull across the passage and blocks the whole
+			# column behind it. Keep the escape and drop the turn.
+			for fraction in RECOVERY_SWEEP_FRACTIONS:
+				if not self._clear(
+						direction_clear,
+						float(yaw) + math.pi +
+						direction * RECOVERY_YAW_OFFSET * fraction):
+					recovery_turn = 0.0
+					recovery_target = float(yaw)
+					break
 			return {
 				'throttle': -0.72,
 				'turn': recovery_turn,
-				'target_yaw': recovery_yaw,
+				'target_yaw': recovery_target,
 				'recovery_mode': 'reverse_turn',
 			}
 

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/ai/traffic.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/ai/traffic.py
@@ -91,13 +91,23 @@ def _intersection(first, second, first_axis, second_axis):
             first_pos[1] + first_axis[1] * distance)
 
 
-def _arrival(body, axis, speed, gate):
+def _arrival(body, axis, speed, gate, reference=0.0):
+    """Rank one body's arrival at the shared crossing point.
+
+    ``reference`` is the pair's pace, supplied only for a hull this coordinator
+    is itself holding. Such a hull has no measured speed while its route intent
+    is unchanged, and ranking it as never arriving made it lose every following
+    lease it entered, so the hull that already waited kept waiting. Every other
+    stationary hull - parked, in cover, or deployed - still ranks as not
+    arriving, because nothing says it intends to enter the junction.
+    """
     position = _position(body)
     distance = _dot((gate[0] - position[0], gate[1] - position[1]), axis)
     front_distance = distance - _radius(body, axis)
     if front_distance <= 0.0:
         return (0, front_distance, body['id'])
-    return (1, front_distance / speed if speed > _EPSILON else float('inf'),
+    pace = speed if speed > _EPSILON else reference
+    return (1, front_distance / pace if pace > _EPSILON else float('inf'),
             body['id'])
 
 
@@ -111,11 +121,18 @@ class TrafficCoordinator(object):
 
     def __init__(self):
         self._pairs = {}
+        self._held = {}
 
     def forget(self, bot_id):
+        self._held.pop(bot_id, None)
         for pair in list(self._pairs):
             if bot_id in pair:
                 del self._pairs[pair]
+
+    def _holding(self, body, now):
+        """Report whether this coordinator is the reason a hull is stopped."""
+        since = self._held.get(body['id'])
+        return since is not None and now - since <= YIELD_SECONDS
 
     def _begin(self, first, second, now):
         # A neighbour reversing out of a blockage is not an oncoming route
@@ -150,10 +167,14 @@ class TrafficCoordinator(object):
         gate = _intersection(first, second, first_axis, second_axis)
         if gate is None:
             return None
-        ranked = sorted(((_arrival(first, first_axis, first_speed, gate),
-                          first, first_axis, second),
-                         (_arrival(second, second_axis, second_speed, gate),
-                          second, second_axis, first)), key=lambda value: value[0])
+        pace = max(first_speed, second_speed)
+        ranked = sorted(
+            ((_arrival(first, first_axis, first_speed, gate,
+                       pace if self._holding(first, now) else 0.0),
+              first, first_axis, second),
+             (_arrival(second, second_axis, second_speed, gate,
+                       pace if self._holding(second, now) else 0.0),
+              second, second_axis, first)), key=lambda value: value[0])
         unused_rank, winner, axis, loser = ranked[0]
         return {'mode': 'yield', 'winner': winner['id'], 'axis': axis,
                 'clear_after': _dot(gate, axis) + _radius(winner, axis) +
@@ -205,6 +226,7 @@ class TrafficCoordinator(object):
             if lease['mode'] == 'yield':
                 if bot_id != lease['winner'] and now < lease['until']:
                     result.update(throttle=0.0, turn=0.0, traffic_mode='yield')
+                    self._held[bot_id] = now
                 continue
             if result.get('traffic_mode') == 'yield':
                 continue
@@ -214,9 +236,24 @@ class TrafficCoordinator(object):
             except Exception:
                 clear = False
             if not clear:
+                # A passage narrower than the offset blocks both hulls' swing.
+                # Holding both of them for as long as the lease exists is a
+                # deadlock: neither footprint can separate laterally and
+                # neither centre can pass the other, so nothing ever clears
+                # the lease. Hold the pair only long enough to keep it from
+                # steering into the wall, then keep exactly one hull waiting
+                # and return the other to its own command, so the blockage is
+                # resolved by physical contact and ordinary recovery.
+                if lease.get('blocked_until') is None:
+                    lease['blocked_until'] = now + YIELD_SECONDS
+                if (now >= lease['blocked_until'] and
+                        bot_id != max(lease['targets'])):
+                    continue
                 result.update(throttle=0.0, turn=0.0, target_yaw=body['yaw'],
                               traffic_mode='head_on_blocked')
+                self._held[bot_id] = now
                 continue
+            lease['blocked_until'] = None
             delta = (target - body['yaw'] + math.pi) % (2.0 * math.pi) - math.pi
             result.update(turn=max(-1.0, min(1.0, delta / 0.58)),
                           target_yaw=target, traffic_mode='head_on')

--- a/tests/test_port_0922_ai.py
+++ b/tests/test_port_0922_ai.py
@@ -18,7 +18,7 @@ from gui.mods.offline_lan_0922.ai import (
 )
 from gui.mods.offline_lan_0922.ai.adapter import BotAdapter
 from gui.mods.offline_lan_0922.ai.driver import (
-    LocalDriver, TRAFFIC_WAIT_LEASE_SECONDS,
+    LocalDriver, RECOVERY_YAW_OFFSET, TRAFFIC_WAIT_LEASE_SECONDS,
 )
 from gui.mods.offline_lan_0922.ai.planner import (
     BattleDirector, build_vehicle_profile,
@@ -2181,6 +2181,45 @@ class BotAiPortTests(unittest.TestCase):
         # when slot zero's parity fallback points the other way.
         unused_driver, mirrored = force(202, 0, left_front)
         self.assertGreater(mirrored['target_yaw'], 0.0)
+
+    def test_reverse_recovery_keeps_a_narrow_passage_hull_straight(self):
+        """A gateway narrower than the recovery arc must not be crossed.
+
+        Steering while reversing rotates the hull through the recovery offset,
+        so its rear sweeps every heading between the straight reverse and the
+        mirrored offset. Inside a gatehouse or alley that arc ends with the
+        hull parked across the passage and the whole column behind it stopped.
+        """
+        def passage(yaw):
+            delta = (float(yaw) + math.pi) % (2.0 * math.pi) - math.pi
+            return abs(delta) < 0.15 or abs(abs(delta) - math.pi) < 0.15
+
+        def held(direction_clear):
+            driver = LocalDriver()
+            order = None
+            for unused_step in range(40):
+                order = driver.drive(
+                    311, 3, (404.0, 0.0, -150.0), 0.0, 0.0, 0.1,
+                    (404.0, 0.0, -120.0), (), direction_clear,
+                    half_length=5.46, half_width=2.24)
+                if order['recovery_mode'] != 'drive':
+                    break
+            return order
+
+        passage_order = held(passage)
+        self.assertEqual('reverse_turn', passage_order['recovery_mode'])
+        self.assertLess(passage_order['throttle'], 0.0)
+        self.assertEqual(0.0, passage_order['turn'])
+        self.assertEqual(0.0, passage_order['target_yaw'])
+
+        # Open ground still earns the steered escape; only the swept arc
+        # decides, so this is a probe result and not a new global rule.
+        open_order = held(lambda unused_yaw: True)
+        self.assertEqual('reverse_turn', open_order['recovery_mode'])
+        self.assertLess(open_order['throttle'], 0.0)
+        self.assertEqual(1.0, abs(open_order['turn']))
+        self.assertAlmostEqual(
+            RECOVERY_YAW_OFFSET, abs(open_order['target_yaw']))
 
     def test_recovery_geometry_is_independent_of_neighbour_order(self):
         driver = LocalDriver()

--- a/tests/test_port_0922_great_wall_gate.py
+++ b/tests/test_port_0922_great_wall_gate.py
@@ -1,0 +1,159 @@
+"""Two friendly hulls meeting inside Great Wall's gatehouse must both leave.
+
+The map's only east crossing is a gatehouse whose baked corridor is one cell
+wide at its north mouth and two cells inside, and both teams' ``wall_pass``
+and ``valley`` routes cross it in opposite directions. Every head-on swing
+offset is blocked in there, so an unbounded crossing hold stopped both hulls
+and each driver then timed out into a steered reverse that parked its hull
+across the passage.
+"""
+import copy
+import json
+import math
+from pathlib import Path
+import sys
+import unittest
+
+import test_port_0922_bot_runtime as runtime_fixtures
+from effective_params_fixture import bot_default_crew_factors
+from test_port_0922_fjord_departure import _bots
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MAP_NAME = '59_asia_great_wall'
+# The gatehouse passage, from the bake's own grid-phase record.
+PASSAGE_X = 404.0
+SOUTH_POSE = (PASSAGE_X, -158.0, 0.0)
+NORTH_POSE = (PASSAGE_X, -142.0, math.pi)
+# The gatehouse interior, from the baked passage rows.
+PASSAGE_SOUTH = -158.0
+PASSAGE_NORTH = -140.0
+SECONDS = 30.0
+FPS = 15
+
+
+def _flat_graph():
+    path = ROOT / 'navgraphs' / ('%s.json' % MAP_NAME)
+    graph = copy.deepcopy(json.loads(path.read_text()))
+    # Keep the production topology, hazards, routes and formations and isolate
+    # traffic from four-metre height sampling, exactly as the departure
+    # fixtures do.
+    graph['heights_mm'] = [
+        0 if value is not None else None for value in graph['heights_mm']]
+    return graph
+
+
+class GreatWallGateTests(unittest.TestCase):
+    def setUp(self):
+        self._gui_modules = dict(
+            (key, value) for key, value in sys.modules.items()
+            if key == 'gui' or key.startswith('gui.'))
+
+    def tearDown(self):
+        for key in list(sys.modules):
+            if key == 'gui' or key.startswith('gui.'):
+                sys.modules.pop(key, None)
+        sys.modules.update(self._gui_modules)
+
+    def test_opposed_hulls_in_the_gatehouse_both_leave_the_passage(self):
+        module = runtime_fixtures._load()
+        original_factors = module.loadout.attribute_factors
+        module.loadout.attribute_factors = bot_default_crew_factors
+        self.addCleanup(
+            setattr, module.loadout, 'attribute_factors', original_factors)
+        graph = _flat_graph()
+        runtime_box = {}
+
+        def spawn(team, slot):
+            if team == 2 and slot in (0, 1):
+                x, z, yaw = SOUTH_POSE if slot == 0 else NORTH_POSE
+                return ((x, 0.0, z), yaw)
+            point = graph['spawn_formations'][str(team)][slot]
+            return ((point[0], 0.0, point[2]), point[3])
+
+        def ground(unused_x, unused_z, unused_hint=0.0):
+            return 0.0
+
+        def baked_direction(position, yaw, speed, unused_descriptor,
+                            maximum_distance):
+            grid = runtime_box['runtime'].navigator.grid
+            distance = 20.0 if abs(float(speed)) > 5.0 else 15.0
+            if maximum_distance is not None:
+                distance = min(distance, max(0.5, float(maximum_distance)))
+            end = (float(position[0]) + math.sin(float(yaw)) * distance,
+                   float(position[1]),
+                   float(position[2]) + math.cos(float(yaw)) * distance)
+            clear = grid.segment_clear(position, end)
+            return {'clear': clear, 'collision': not clear,
+                    'water': False, 'slope': 0.0}
+
+        def baked_receipt(position, yaw, speed, descriptor, maximum_distance):
+            if not baked_direction(position, yaw, speed, descriptor,
+                                   maximum_distance)['clear']:
+                return False
+            distance = 15.0 if maximum_distance is None else min(
+                15.0, max(0.5, float(maximum_distance)))
+            return {'distance': distance, 'half_width': 1.6, 'leading': 3.5,
+                    'origin': tuple(position), 'yaw': float(yaw),
+                    'direction': -1 if float(speed) < 0.0 else 1}
+
+        runtime = module.BotRuntime(
+            1,
+            descriptor_resolver=lambda unused: (
+                runtime_fixtures._combat_descriptor()),
+            direction_probe=baked_direction,
+            world_receipt_probe=baked_receipt,
+            spawn_resolver=spawn,
+            ground_probe=ground, physics_ground_probe=ground,
+            baked_graph=graph,
+            visibility_probe=lambda *unused: False,
+            firing_lane_probe=lambda *unused: False)
+        runtime_box['runtime'] = runtime
+        runtime.battle_start({'map': MAP_NAME, 'round_id': 7,
+                              'bot_authority_id': 1, 'bots': _bots()})
+        opposed = [bot_id for bot_id, state in runtime.states.items()
+                   if int(state.get('team', 0)) == 2 and
+                   abs(state['x'] - PASSAGE_X) < 1.0 and
+                   -160.0 < state['z'] < -140.0]
+        self.assertEqual(2, len(opposed))
+
+        held = dict((bot_id, 0.0) for bot_id in opposed)
+        broadside = dict((bot_id, 0.0) for bot_id in opposed)
+        original_adjust = runtime._traffic_coordinator.adjust
+        clock = [0.0]
+
+        def adjust(bot_id, source, command, neighbours, now, direction_clear):
+            result = original_adjust(bot_id, source, command, neighbours, now,
+                                     direction_clear)
+            if (int(bot_id) in held and
+                    result.get('traffic_mode') == 'head_on_blocked'):
+                held[int(bot_id)] += 1.0 / FPS
+            return result
+
+        runtime._traffic_coordinator.adjust = adjust
+
+        for frame in range(1, int(FPS * SECONDS) + 1):
+            clock[0] = frame / float(FPS)
+            runtime.update(1.0 / float(FPS), clock[0])
+            for bot_id in opposed:
+                state = runtime.states[bot_id]
+                if (-160.0 < state['z'] < -140.0 and
+                        abs(math.sin(state['yaw'])) > 0.5):
+                    broadside[bot_id] += 1.0 / FPS
+
+        # Both hulls have to leave the passage: the northbound one through the
+        # wall, the one facing the other way back out of its south mouth.
+        # The passage has to be clear again: one hull through the wall, the
+        # other back out of the mouth it came from.
+        self.assertEqual([], [
+            (bot_id, round(runtime.states[bot_id]['z'], 1))
+            for bot_id in opposed
+            if PASSAGE_SOUTH <= runtime.states[bot_id]['z'] <= PASSAGE_NORTH])
+        # Neither may spend the round stopped by the crossing hold, and
+        # neither may sit broadside in a passage no hull can turn in.
+        self.assertLessEqual(max(held.values()), 5.0)
+        self.assertLessEqual(max(broadside.values()), 5.0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_port_0922_traffic.py
+++ b/tests/test_port_0922_traffic.py
@@ -118,6 +118,73 @@ class TrafficTests(unittest.TestCase):
             self.assertEqual(own['yaw'], result['target_yaw'])
         self.assertEqual(before, (first, second))
 
+    def test_blocked_head_on_hold_releases_one_hull_instead_of_deadlocking(self):
+        """A passage narrower than the offset must not stop both hulls forever.
+
+        Neither footprint can separate laterally and neither centre can pass
+        the other while both are held, so the lease never clears. Exactly one
+        hull keeps waiting; the other returns to its own command and the
+        blockage is resolved by contact and ordinary recovery.
+        """
+        first, second = body(1, 0.0, 0.0, speed=0.0), body(2, 0.0, 7.5, math.pi, 0.0)
+        for own, other in ((first, second), (second, first)):
+            result = self.adjust(own, other, clear=False)
+            self.assertEqual((0.0, 0.0), (result['throttle'], result['turn']))
+        later = YIELD_SECONDS + 0.1
+        self.assertEqual(
+            command(first['yaw']),
+            self.adjust(first, second, later, clear=False))
+        held = self.adjust(second, first, later, clear=False)
+        self.assertEqual(0.0, held['throttle'])
+        self.assertEqual('head_on_blocked', held['traffic_mode'])
+
+    def test_reopened_head_on_swing_restores_the_full_hold(self):
+        """Room to swing is a new situation, not a spent hold."""
+        first, second = body(1, 0.0, 0.0, speed=0.0), body(2, 0.0, 7.5, math.pi, 0.0)
+        self.adjust(first, second, clear=False)
+        opened = self.adjust(first, second, YIELD_SECONDS + 0.1, clear=True)
+        self.assertEqual('head_on', opened['traffic_mode'])
+        blocked = self.adjust(first, second, YIELD_SECONDS + 0.2, clear=False)
+        self.assertEqual('head_on_blocked', blocked['traffic_mode'])
+
+    def _hold_then_meet(self, hold_first):
+        waiting = body(9, 0.0, -4.0)
+        if hold_first:
+            holder = body(1, -5.0, 0.0, math.pi / 2.0, speed=12.0)
+            self.assertEqual('yield',
+                             self.adjust(waiting, holder)['traffic_mode'])
+        waiting['velocity'] = (0.0, 0.0, 0.0)
+        later = body(2, -6.0, 0.0, math.pi / 2.0)
+        return (self.adjust(waiting, later, 0.2),
+                self.adjust(later, waiting, 0.2))
+
+    def test_hull_this_coordinator_holds_can_win_its_next_lease(self):
+        """The hull that already waited must not keep losing on zero speed.
+
+        Its measured speed is this coordinator's own doing, not a change of
+        route intent, so ranking it as never arriving made every following
+        lease it entered pick the other hull again.
+        """
+        waited, later = self._hold_then_meet(True)
+        self.assertEqual(command(), waited)
+        self.assertEqual(0.0, later['throttle'])
+        self.assertEqual('yield', later['traffic_mode'])
+
+    def test_a_hull_stopped_by_something_else_still_gives_way(self):
+        """Parked, in cover or deployed is not a claim on the junction."""
+        stationary, crossing = self._hold_then_meet(False)
+        self.assertEqual(0.0, stationary['throttle'])
+        self.assertEqual('yield', stationary['traffic_mode'])
+        self.assertEqual(command(math.pi / 2.0), crossing)
+
+    def test_two_moving_hulls_still_rank_on_their_own_speeds(self):
+        """The stopped-hull rule must not re-rank an ordinary crossing."""
+        near_slow = body(9, 0.0, -5.0, speed=2.0)
+        far_fast = body(1, -10.0, 0.0, math.pi / 2.0, 10.0)
+        self.assertEqual(command(far_fast['yaw']),
+                         self.adjust(far_fast, near_slow))
+        self.assertEqual(0.0, self.adjust(near_slow, far_fast)['throttle'])
+
     def test_real_shape_width_wins_over_generic_half_width(self):
         first, second = body(1, 0.0, 0.0, speed=0.0), body(2, 2.2, 7.5, math.pi, 0.0)
         first['shape'] = second['shape'] = (1.0, 3.5, -0.8, 2.0)


### PR DESCRIPTION
## What was wrong

Three defects turned any single-file passage into a plug.

1. **The head-on lease had no deadline.** `TrafficCoordinator` swings both
   hulls by `HEAD_ON_OFFSET` (0.42 rad). Where the passage is narrower than
   that swing, `direction_clear` rejects both targets and each hull is held at
   `throttle 0` with `traffic_mode='head_on_blocked'`. `_cleared` can never
   fire: neither footprint can separate laterally and neither centre can pass
   the other while both are stopped, so the hold is permanent.
2. **`_arrival()` ranked a stopped hull as never arriving.** A hull the
   coordinator itself stopped then lost every following lease it entered.
3. **Reverse recovery always steered.** `LocalDriver` returns
   `reverse_turn` with `turn = -direction`, rotating the hull through
   `RECOVERY_YAW_OFFSET` (0.85 rad). In a passage narrower than that swept arc
   the manoeuvre parks a 10.9 m hull broadside and stops the column behind it.

## Where it was reproduced

| layer | evidence |
| --- | --- |
| module | `TrafficCoordinator` holds an opposed pair at zero throttle indefinitely; 14.4 m apart, lease never released |
| baked data | inside Great Wall's gatehouse (`404, -146 … -158`) the route heading is clear but **both** `±0.42 rad` swings are blocked on the tracked navgraph |
| runtime | two friendly hulls staged in that gatehouse cycle `head_on` → `head_on_blocked` → `pivot_recovery`/`reverse_turn` and travel **7.7 m and 3.7 m in 15 s** |

Great Wall is the reported instance: its only east crossing is **one baked
cell (4 m) wide** at the north mouth and two cells inside, going around costs
309 m → 1264 m, and both teams' `wall_pass` and `valley` routes cross it in
opposite directions. But **38 of 39 maps** have a route corridor of two cells
or fewer somewhere, so the fix is written for the class, not the map.

## The fix

- Bound the blocked head-on hold to one `YIELD_SECONDS` window, then keep
  exactly one hull waiting (the module's existing ascending-id tie-break) and
  return the other to its own command, so physical contact and ordinary
  recovery own the blockage — which is what `traffic.py`'s contract already
  says.
- Rank a hull *this coordinator is holding* by the distance it still has to
  cover at the pair's pace. Every other stationary hull — parked, in cover,
  deployed — still ranks as not arriving and gives way.
- Pick the reverse steering from the swept arc: straight out of a gateway or
  alley, still steered in the open.

## Results

- Recovery steps inside the gate, 120 s fifteen-hull column: **78 → 14**.
- Northbound hull clears the wall at **28.0 s instead of 42.2 s**.
- 12-map / 29-Bot / 60 s replay sweep: **9 maps bit-identical**, Redshire
  +0.8 % travel with traffic holds 8.13 % → 5.66 % of steps, nobody stranded,
  mean travel 230.43 m → 230.60 m.
- `tests/test_port_0922_great_wall_gate.py` is new and **fails on `main`**
  (both hulls still inside the passage after 30 s) and passes here.
- Full suite `python -m unittest discover -s tests`: 3994 tests, OK.
  CPython 2.7.18 source compile: 94 files, passed.

## What this does not prove

The plain 29-Bot replay with baked spawns and no combat does **not** jam at
this gate — arrivals self-stagger and all eight hulls cross. The
reproduction needs a staged opposing pair, which the map's route data makes
certain but which I have not confirmed against a real battle. A Great Wall
error-report zip (`hidden-worker.log` carries per-Bot `recovery_mode`) would
say whether the reported jam came through the head-on path or the yield path.
No Windows evidence in this PR.

Moving `valley`'s crossing away from the gatehouse is a separate, data-side
option that needs a re-bake against the client packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
