### PR TITLE
Give Bots gunnery skill tiers and a waiting-room difficulty mix

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -43,7 +43,9 @@ Play
    MAP opens the client's own map window, where the host picks a standard map
    and a battle time and confirms. The room comes back with that choice, and
    START BATTLE starts it. LEAVE closes the room and returns you to the
-   garage.
+   garage. BOT TIER picks which vehicle tiers the Bots bring, and BOT SKILL
+   picks how good their gunners are: Easy, Relaxed, Pub mix, Hard or Brutal.
+   Only the host sees those two rows.
 4. The server fills each team to WOT_0922_TEAM_SIZE total tanks, including
    human players (1 through 15, default 15). Set that environment variable in
    the batch file that starts the server. Movement and firing unlock when the

--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ whose profile changed after it started must be restarted first.
 - Automatically generated Bot lineups contain no self-propelled artillery.
   Player vehicles and manually assigned Bot lineups remain unrestricted;
   tank destroyers are not artillery and remain in the automatic pool.
+- Bot gunnery skill: every Bot is a rookie, regular, veteran or elite gunner.
+  The tier picks the crew level its vehicle is trained to, and how long that
+  gunner takes to react, how patiently it waits for the aiming circle, how
+  far off centre it lays the gun and how badly it leads a moving target. The
+  waiting room chooses the whole roster's mix - easy, relaxed, pub mix, hard
+  or brutal - and the launcher's exact Bot lineup can pin one slot's tier,
+  with or without also pinning its vehicle.
 - Live combat statistics, a damage log with assists, hit and critical-damage
   messages, target outlines, vehicle fires, wrecks, and a consumables panel
   that counts down each cooldown.

--- a/launcher/bot_lineup_profiles.py
+++ b/launcher/bot_lineup_profiles.py
@@ -35,6 +35,10 @@ CLONE_BOT_VEHICLE_SUFFIXES_0922 = ("_bootcamp",)
 NON_BATTLE_ENTITY_BOT_SUFFIXES_0922 = ("_bot", "_training")
 NON_BATTLE_ENTITY_BOT_VEHICLES_0922 = frozenset(("germany:Env_Artillery",))
 CATALOGUE_VISIBILITY_TAG_0922 = "secret"
+# The Bot gunnery tiers bot_gunnery.SKILL_TIERS defines, weakest first, bound
+# by a parity test so a new tier cannot appear on only one side.  ``None``
+# leaves a pinned slot on the room's own skill preset.
+BOT_SKILL_TIERS_0922 = ("rookie", "regular", "veteran", "elite")
 
 _NATION = re.compile(r"^[a-z][a-z0-9_]*$")
 _VEHICLE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
@@ -74,6 +78,15 @@ def vehicle_type_name(choice):
             _VEHICLE.fullmatch(vehicle) is None):
         raise BotLineupProfileError("The vehicle choice is invalid.")
     return "%s:%s" % (nation, vehicle)
+
+
+def _skill(value):
+    """Return one supported gunnery tier, or None to follow the room preset."""
+    if value is None:
+        return None
+    if value not in BOT_SKILL_TIERS_0922:
+        raise BotLineupProfileError("The Bot skill level is invalid.")
+    return value
 
 
 def _vehicle_type_name(value):
@@ -127,12 +140,23 @@ def _assignments(value):
             team, slot = int(raw.get("team")), int(raw.get("slot"))
         except (TypeError, ValueError, OverflowError):
             raise BotLineupProfileError("The Bot slot is invalid.")
-        vehicle = _vehicle_type_name(raw.get("vehicle"))
+        raw_vehicle = raw.get("vehicle")
+        vehicle = (None if raw_vehicle is None else
+                   _vehicle_type_name(raw_vehicle))
+        skill = _skill(raw.get("skill"))
         if (team not in (1, 2) or not 0 <= slot < 15 or
                 (team, slot) in seen):
             raise BotLineupProfileError("The Bot lineup is invalid.")
+        if vehicle is None and skill is None:
+            # An entry that pins nothing is not a saved slot at all.
+            continue
         seen.add((team, slot))
-        result.append({"team": team, "slot": slot, "vehicle": vehicle})
+        entry = {"team": team, "slot": slot}
+        if vehicle is not None:
+            entry["vehicle"] = vehicle
+        if skill is not None:
+            entry["skill"] = skill
+        result.append(entry)
     return sorted(result, key=lambda item: (item["team"], item["slot"]))
 
 
@@ -205,12 +229,15 @@ def assignments_for(store, raw_name):
         "That Bot lineup profile does not exist.")
 
 
-def set_assignment(store, raw_name, team, slot, vehicle):
+def set_assignment(store, raw_name, team, slot, vehicle=None, skill=None):
     store = normalize_store(store)
     name = _name(raw_name)
-    assignment = _assignments([{
-        "team": team, "slot": slot, "vehicle": vehicle,
-    }])[0]
+    pinned = _assignments([{
+        "team": team, "slot": slot, "vehicle": vehicle, "skill": skill,
+    }])
+    if not pinned:
+        return clear_assignment(store, raw_name, team, slot)
+    assignment = pinned[0]
     for profile in store["profiles"]:
         if profile["name"].casefold() != name.casefold():
             continue

--- a/launcher/bot_lineup_ui.py
+++ b/launcher/bot_lineup_ui.py
@@ -9,6 +9,24 @@ except ImportError:
     import vehicle_overlays
 
 
+# The editor labels every gunnery tier plus the "leave it to the room"
+# choice.  ``None`` keeps the waiting-room skill preset for that slot.
+SKILL_CHOICES = (
+    (None, "Room preset"),
+    ("rookie", "Rookie"),
+    ("regular", "Regular"),
+    ("veteran", "Veteran"),
+    ("elite", "Elite"),
+)
+
+
+def _skill_label(skill):
+    for value, label in SKILL_CHOICES:
+        if value == skill:
+            return label
+    return SKILL_CHOICES[0][1]
+
+
 class BotLineupEditorWindow(object):
     def __init__(self, parent, game_root, profile_name, store, on_save,
                  tk_module, ttk_module, messagebox_module, log=None):
@@ -34,29 +52,31 @@ class BotLineupEditorWindow(object):
         frame.pack(fill="both", expand=True)
         tk.Label(
             frame,
-            text=("Choose a nation and vehicle for any Bot slot. Empty slots "
-                  "continue to use the waiting-room tier preset. A human in a "
-                  "slot simply leaves that saved Bot choice unused."),
-            justify="left", anchor="w", wraplength=820).grid(
-                row=0, column=0, columnspan=6, sticky="we", pady=(0, 8))
+            text=("Choose a nation, vehicle and skill level for any Bot "
+                  "slot. Anything left empty continues to use the "
+                  "waiting-room presets, and a human in a slot simply leaves "
+                  "that saved Bot choice unused."),
+            justify="left", anchor="w", wraplength=1040).grid(
+                row=0, column=0, columnspan=8, sticky="we", pady=(0, 8))
         for column, title in ((0, "Team 1 Bot"), (1, "Nation"),
-                              (2, "Vehicle"), (3, "Team 2 Bot"),
-                              (4, "Nation"), (5, "Vehicle")):
+                              (2, "Vehicle"), (3, "Skill"),
+                              (4, "Team 2 Bot"), (5, "Nation"),
+                              (6, "Vehicle"), (7, "Skill")):
             tk.Label(frame, text=title, anchor="w").grid(
                 row=1, column=column, sticky="we", padx=(0, 5))
         for slot in range(15):
             self._make_slot(frame, 2 + slot, 1, slot, 0)
-            self._make_slot(frame, 2 + slot, 2, slot, 3)
+            self._make_slot(frame, 2 + slot, 2, slot, 4)
         self.status = tk.StringVar(value="Loading original vehicle list…")
         tk.Label(frame, textvariable=self.status, anchor="w").grid(
-            row=17, column=0, columnspan=6, sticky="we", pady=(8, 0))
+            row=17, column=0, columnspan=8, sticky="we", pady=(8, 0))
         tk.Button(
             frame, text="Clear all saved slots", command=self._clear_all).grid(
-                row=18, column=0, columnspan=3, sticky="we", pady=(8, 0))
+                row=18, column=0, columnspan=4, sticky="we", pady=(8, 0))
         tk.Button(frame, text="Close", command=self.root.destroy).grid(
-            row=18, column=3, columnspan=3, sticky="we", padx=(6, 0),
+            row=18, column=4, columnspan=4, sticky="we", padx=(6, 0),
             pady=(8, 0))
-        for column in (2, 5):
+        for column in (2, 6):
             frame.grid_columnconfigure(column, weight=1)
 
     def _make_slot(self, frame, row, team, slot, column):
@@ -77,11 +97,21 @@ class BotLineupEditorWindow(object):
         vehicle_box.bind(
             "<<ComboboxSelected>>",
             lambda unused, key=(team, slot): self._vehicle_changed(key))
+        skill = tk.StringVar(value=SKILL_CHOICES[0][1])
+        skill_box = self._ttk.Combobox(
+            frame, textvariable=skill, state="readonly", width=12,
+            values=tuple(label for unused_value, label in SKILL_CHOICES))
+        skill_box.grid(row=row, column=column + 3, sticky="we", padx=(0, 5))
+        skill_box.bind(
+            "<<ComboboxSelected>>",
+            lambda unused, key=(team, slot): self._skill_changed(key))
         self._rows[(team, slot)] = {
             "nation": nation,
             "vehicle": vehicle,
+            "skill": skill,
             "nation_box": nation_box,
             "vehicle_box": vehicle_box,
+            "skill_box": skill_box,
         }
 
     def _load_choices(self):
@@ -103,7 +133,7 @@ class BotLineupEditorWindow(object):
                 value["label"].casefold(), value["type_name"])))
             for nation, values in by_nation.items())
         assignments = dict(
-            ((value["team"], value["slot"]), value["vehicle"])
+            ((value["team"], value["slot"]), value)
             for value in bot_lineup_profiles.assignments_for(
                 self._store, self._profile_name))
         nations = tuple(sorted(self._choices_by_nation))
@@ -111,7 +141,9 @@ class BotLineupEditorWindow(object):
             (choice["type_name"], choice) for choice in self._choices)
         for key, row in self._rows.items():
             row["nation_box"].config(values=nations)
-            choice = choice_by_vehicle.get(assignments.get(key))
+            saved = assignments.get(key) or {}
+            row["skill"].set(_skill_label(saved.get("skill")))
+            choice = choice_by_vehicle.get(saved.get("vehicle"))
             if choice is not None:
                 row["nation"].set(choice["nation"])
                 self._set_vehicle_values(key, choice["nation"])
@@ -133,7 +165,34 @@ class BotLineupEditorWindow(object):
         row = self._rows[key]
         self._set_vehicle_values(key, row["nation"].get())
         row["vehicle"].set("")
-        self._clear_slot(key)
+        self._save_slot(key, None)
+
+    def _selected_skill(self, key):
+        label = self._rows[key]["skill"].get()
+        for value, choice_label in SKILL_CHOICES:
+            if choice_label == label:
+                return value
+        return None
+
+    def _skill_changed(self, key):
+        self._save_slot(key, self._selected_choice(key))
+
+    def _save_slot(self, key, choice):
+        """Persist whatever this slot still pins, or clear it when nothing."""
+        skill = self._selected_skill(key)
+        if choice is None and skill is None:
+            return self._clear_slot(key)
+        try:
+            self._store = bot_lineup_profiles.set_assignment(
+                self._store, self._profile_name, key[0], key[1],
+                None if choice is None else choice["type_name"], skill)
+            self._on_save(self._store)
+            self.status.set("Saved Team %d Bot %d: %s, %s" % (
+                key[0], key[1] + 1,
+                "generated vehicle" if choice is None else choice["label"],
+                _skill_label(skill)))
+        except bot_lineup_profiles.BotLineupProfileError as error:
+            self.status.set(str(error))
 
     def _selected_choice(self, key):
         row = self._rows[key]
@@ -151,18 +210,7 @@ class BotLineupEditorWindow(object):
         return matches[0] if len(matches) == 1 else None
 
     def _vehicle_changed(self, key):
-        selected = self._selected_choice(key)
-        if selected is None:
-            return self._clear_slot(key)
-        try:
-            self._store = bot_lineup_profiles.set_assignment(
-                self._store, self._profile_name, key[0], key[1],
-                selected["type_name"])
-            self._on_save(self._store)
-            self.status.set("Saved Team %d Bot %d: %s" % (
-                key[0], key[1] + 1, selected["label"]))
-        except bot_lineup_profiles.BotLineupProfileError as error:
-            self.status.set(str(error))
+        self._save_slot(key, self._selected_choice(key))
 
     def _clear_slot(self, key):
         try:
@@ -180,6 +228,7 @@ class BotLineupEditorWindow(object):
             self._on_save(self._store)
             for row in self._rows.values():
                 row["vehicle"].set("")
+                row["skill"].set(SKILL_CHOICES[0][1])
             self.status.set("All saved Bot slots were cleared.")
         except bot_lineup_profiles.BotLineupProfileError as error:
             self.status.set(str(error))

--- a/launcher/tests/test_bot_lineup_profiles.py
+++ b/launcher/tests/test_bot_lineup_profiles.py
@@ -15,6 +15,59 @@ class BotLineupProfilesTests(unittest.TestCase):
               "vehicle": "germany:G81_Pz_IV_AusfH"}],
             bot_lineup_profiles.assignments_for(store, name))
 
+    def test_profile_persists_a_vehicle_and_a_skill_tier_together(self):
+        store, name = bot_lineup_profiles.create(
+            bot_lineup_profiles.empty_store(), "City duel")
+        store = bot_lineup_profiles.set_assignment(
+            store, name, 2, 3, "germany:G81_Pz_IV_AusfH", "veteran")
+
+        self.assertEqual(
+            [{"team": 2, "slot": 3,
+              "vehicle": "germany:G81_Pz_IV_AusfH", "skill": "veteran"}],
+            bot_lineup_profiles.assignments_for(store, name))
+
+    def test_a_slot_may_pin_only_its_skill_tier(self):
+        store, name = bot_lineup_profiles.create(
+            bot_lineup_profiles.empty_store(), "City duel")
+        store = bot_lineup_profiles.set_assignment(
+            store, name, 1, 0, None, "rookie")
+
+        self.assertEqual(
+            [{"team": 1, "slot": 0, "skill": "rookie"}],
+            bot_lineup_profiles.assignments_for(store, name))
+
+    def test_a_profile_saved_before_skill_tiers_still_loads(self):
+        store = bot_lineup_profiles.normalize_store({
+            "schema": 1,
+            "profiles": [{
+                "name": "Old profile",
+                "assignments": [{
+                    "team": 1, "slot": 0,
+                    "vehicle": "germany:G81_Pz_IV_AusfH",
+                }],
+            }],
+        })
+
+        self.assertEqual(
+            [{"team": 1, "slot": 0,
+              "vehicle": "germany:G81_Pz_IV_AusfH"}],
+            bot_lineup_profiles.assignments_for(store, "Old profile"))
+
+    def test_an_unsupported_skill_tier_is_rejected_instead_of_degrading(self):
+        self.assertEqual(
+            bot_lineup_profiles.empty_store(),
+            bot_lineup_profiles.normalize_store({
+                "schema": 1,
+                "profiles": [{
+                    "name": "Old profile",
+                    "assignments": [{
+                        "team": 1, "slot": 0,
+                        "vehicle": "germany:G81_Pz_IV_AusfH",
+                        "skill": "perfect",
+                    }],
+                }],
+            }))
+
     def test_unqualified_saved_vehicle_is_rejected_instead_of_degrading(self):
         self.assertEqual(
             bot_lineup_profiles.empty_store(),

--- a/launcher/tests/test_bot_lineup_ui.py
+++ b/launcher/tests/test_bot_lineup_ui.py
@@ -28,6 +28,14 @@ class _Combo(object):
         return self.index
 
 
+def _row():
+    return {
+        "nation": _Variable(), "vehicle": _Variable(), "skill": _Variable(),
+        "nation_box": _Combo(), "vehicle_box": _Combo(),
+        "skill_box": _Combo(),
+    }
+
+
 class BotLineupUITests(unittest.TestCase):
     def test_restore_resolves_the_complete_nation_vehicle_identity(self):
         store, profile_name = bot_lineup_profiles.create(
@@ -40,10 +48,7 @@ class BotLineupUITests(unittest.TestCase):
         editor._store = store
         editor._profile_name = profile_name
         editor.status = _Variable()
-        editor._rows = {(2, 0): {
-            "nation": _Variable(), "vehicle": _Variable(),
-            "nation_box": _Combo(), "vehicle_box": _Combo(),
-        }}
+        editor._rows = {(2, 0): _row()}
         choices = [
             {"nation": "ussr", "vehicle": "G12_Ltraktor",
              "member": "ussr.xml", "label": "Other",
@@ -63,6 +68,68 @@ class BotLineupUITests(unittest.TestCase):
         self.assertEqual("Leichttraktor", row["vehicle"].get())
         self.assertEqual(
             ("Leichttraktor",), row["vehicle_box"].options["values"])
+        self.assertEqual("Room preset", row["skill"].get())
+
+    def test_a_saved_skill_tier_comes_back_into_the_editor(self):
+        store, profile_name = bot_lineup_profiles.create(
+            bot_lineup_profiles.empty_store(), "Saved")
+        store = bot_lineup_profiles.set_assignment(
+            store, profile_name, 2, 0, None, "elite")
+        editor = bot_lineup_ui.BotLineupEditorWindow.__new__(
+            bot_lineup_ui.BotLineupEditorWindow)
+        editor._game_root = "/game"
+        editor._store = store
+        editor._profile_name = profile_name
+        editor.status = _Variable()
+        editor._rows = {(2, 0): _row()}
+
+        with mock.patch.object(
+                bot_lineup_ui.vehicle_overlays, "list_vehicle_choices",
+                return_value=[]):
+            editor._load_choices()
+
+        self.assertEqual("Elite", editor._rows[(2, 0)]["skill"].get())
+
+    def test_choosing_a_skill_alone_pins_the_slot_without_a_vehicle(self):
+        store, profile_name = bot_lineup_profiles.create(
+            bot_lineup_profiles.empty_store(), "Saved")
+        editor = bot_lineup_ui.BotLineupEditorWindow.__new__(
+            bot_lineup_ui.BotLineupEditorWindow)
+        editor._store = store
+        editor._profile_name = profile_name
+        editor._choices_by_nation = {}
+        editor.status = _Variable()
+        saved = []
+        editor._on_save = saved.append
+        row = _row()
+        row["skill"].set("Rookie")
+        editor._rows = {(1, 3): row}
+
+        editor._skill_changed((1, 3))
+
+        self.assertEqual(
+            [{"team": 1, "slot": 3, "skill": "rookie"}],
+            bot_lineup_profiles.assignments_for(saved[-1], profile_name))
+
+    def test_returning_a_slot_to_the_room_preset_clears_it(self):
+        store, profile_name = bot_lineup_profiles.create(
+            bot_lineup_profiles.empty_store(), "Saved")
+        store = bot_lineup_profiles.set_assignment(
+            store, profile_name, 1, 3, None, "rookie")
+        editor = bot_lineup_ui.BotLineupEditorWindow.__new__(
+            bot_lineup_ui.BotLineupEditorWindow)
+        editor._store = store
+        editor._profile_name = profile_name
+        editor._choices_by_nation = {}
+        editor.status = _Variable()
+        saved = []
+        editor._on_save = saved.append
+        editor._rows = {(1, 3): _row()}
+
+        editor._skill_changed((1, 3))
+
+        self.assertEqual(
+            [], bot_lineup_profiles.assignments_for(saved[-1], profile_name))
 
 
 if __name__ == "__main__":

--- a/server/lan_battle_server.py
+++ b/server/lan_battle_server.py
@@ -50,6 +50,7 @@ from gui.mods.offline_lan_0922 import tank_collision
 from gui.mods.offline_lan_0922.battle_achievements import (
     ACHIEVEMENT_CONDITIONS, AWARDABLE_ACHIEVEMENTS, RECEIPT_STAT_NAMES,
     award_battle_achievements)
+from gui.mods.offline_lan_0922 import bot_gunnery
 from gui.mods.offline_lan_0922 import burst_mechanics
 from gui.mods.offline_lan_0922 import effective_params as effective_params_wire
 from gui.mods.offline_lan_0922 import equipment_mechanics
@@ -206,6 +207,7 @@ MODERN_VISIBLE_MESSAGE_TYPES = frozenset((
     "battle_ready", "leave_battle",
     "battle_receipt_ack", "descriptor_catalog", "select_vehicle",
     "select_team", "set_team_size", "set_bot_tier_mode",
+    "set_bot_skill_mode",
     "ping", "leave",
     "track_repair",
     "equipment_intent",
@@ -2004,7 +2006,8 @@ class BattleState:
     def __init__(self, map_name=DEFAULT_MAP, max_players=30, clock=None,
                  team_size=15,
                  receipt_state_path=None, team1_size=None, team2_size=None,
-                 bot_tier_mode='random', bot_lineup=None):
+                 bot_tier_mode='random', bot_lineup=None,
+                 bot_skill_mode=None):
         self.map_option = map_name
         self.map_name = self._choose_map()
         self.client_build = None
@@ -2017,6 +2020,8 @@ class BattleState:
         self.team_sizes = {1: team1_size, 2: team2_size}
         self.bot_tier_mode = bot_planner.normalize_bot_tier_mode(
             bot_tier_mode)
+        self.bot_skill_mode = bot_gunnery.normalize_skill_mode(
+            bot_skill_mode)
         self.bot_lineup = self._normalize_bot_lineup(bot_lineup)
         # Keep the old scalar on the wire for older protocol-v5 consumers.
         # New consumers use team_sizes; max remains a safe roster upper bound.
@@ -2158,21 +2163,32 @@ class BattleState:
             team = _exact_int(raw.get("team"), 1, 2)
             slot = _exact_int(raw.get("slot"), 0, 14)
             vehicle = raw.get("vehicle")
-            if (not isinstance(vehicle, str) or len(vehicle) > 96 or
-                    vehicle.count(":") != 1):
-                raise ValueError("invalid Bot lineup vehicle")
-            nation, vehicle_name = vehicle.split(":", 1)
-            if (re.fullmatch(r"[a-z][a-z0-9_]*", nation) is None or
-                    re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]*",
-                                 vehicle_name) is None):
-                raise ValueError("invalid Bot lineup vehicle")
+            skill = raw.get("skill")
+            if vehicle is None and skill is None:
+                raise ValueError("empty Bot lineup entry")
+            if vehicle is not None:
+                if (not isinstance(vehicle, str) or len(vehicle) > 96 or
+                        vehicle.count(":") != 1):
+                    raise ValueError("invalid Bot lineup vehicle")
+                nation, vehicle_name = vehicle.split(":", 1)
+                if (re.fullmatch(r"[a-z][a-z0-9_]*", nation) is None or
+                        re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]*",
+                                     vehicle_name) is None):
+                    raise ValueError("invalid Bot lineup vehicle")
             key = (team, slot)
             if key in seen:
                 raise ValueError("duplicate Bot lineup slot")
             seen.add(key)
-            result.append({
-                "team": team, "slot": slot, "vehicle": vehicle,
-            })
+            # A slot may pin its vehicle, its gunnery tier, or both.  What
+            # it leaves out stays with the room's own presets.
+            entry = {"team": team, "slot": slot}
+            if vehicle is not None:
+                entry["vehicle"] = vehicle
+            if skill is not None:
+                if skill not in bot_gunnery.SKILL_TIERS:
+                    raise ValueError("invalid Bot lineup skill")
+                entry["skill"] = skill
+            result.append(entry)
         return sorted(result, key=lambda item: (item["team"], item["slot"]))
 
     def _load_result_receipts(self):
@@ -2816,6 +2832,24 @@ class BattleState:
             self.state_revision += 1
             return True, None
 
+    def set_bot_skill_mode(self, player_id, requested_mode):
+        """Let only the room host choose the next round's Bot skill preset."""
+        with self.lock:
+            player = self.players.get(player_id)
+            if (player is None or not player.connected or
+                    self.phase != "waiting"):
+                return False, "not_waiting"
+            if player_id != self.host_player_id:
+                return False, "host_only"
+            mode = bot_gunnery.normalize_skill_mode(requested_mode)
+            if mode != requested_mode:
+                return False, "invalid_mode"
+            if mode == self.bot_skill_mode:
+                return True, None
+            self.bot_skill_mode = mode
+            self.state_revision += 1
+            return True, None
+
     def set_bot_tier_mode(self, player_id, requested_mode):
         """Let only the room host choose the next round's Bot tier preset."""
         with self.lock:
@@ -3289,6 +3323,7 @@ class BattleState:
                 "team_size": self.team_size,
                 "team_sizes": self._team_sizes_wire(),
                 "bot_tier_mode": self.bot_tier_mode,
+                "bot_skill_mode": self.bot_skill_mode,
                 "players": [self._public_player(p)
                             for p in self.players.values() if p.connected],
             }
@@ -3393,7 +3428,7 @@ class BattleState:
                     self.vehicle_catalogs.get(self.host_player_id))
                 if any(
                         raw["vehicle"] not in allowed_names
-                        for raw in self.bot_lineup):
+                        for raw in self.bot_lineup if "vehicle" in raw):
                     return None, "invalid_bot_lineup"
             if requested_map not in (None, ""):
                 requested_map = str(requested_map)
@@ -3443,6 +3478,7 @@ class BattleState:
                 "team_size": self.team_size,
                 "team_sizes": self._team_sizes_wire(),
                 "bot_tier_mode": self.bot_tier_mode,
+                "bot_skill_mode": self.bot_skill_mode,
                 "bot_lineup": list(self.bot_lineup),
                 "bot_authority_id": self.bot_authority_id,
                 "bot_manifest": list(self.bot_manifest),
@@ -4122,6 +4158,7 @@ class BattleState:
                 "team_size": self.team_size,
                 "team_sizes": self._team_sizes_wire(),
                 "bot_tier_mode": self.bot_tier_mode,
+                "bot_skill_mode": self.bot_skill_mode,
                 "bot_lineup": list(self.bot_lineup),
                 "bot_authority_id": self.bot_authority_id,
                 "bot_manifest": takeover_manifest,
@@ -13138,6 +13175,7 @@ class BattleState:
                     "team_size": self.team_size,
                     "team_sizes": self._team_sizes_wire(),
                     "bot_tier_mode": self.bot_tier_mode,
+                    "bot_skill_mode": self.bot_skill_mode,
                     "bot_lineup": list(self.bot_lineup),
                     "bot_authority_id": self.bot_authority_id,
                     "authority_epoch": self.authority_epoch,
@@ -13200,6 +13238,7 @@ class ClientHandler(socketserver.BaseRequestHandler):
             "team_size": state.team_size,
             "team_sizes": state._team_sizes_wire(),
             "bot_tier_mode": state.bot_tier_mode,
+            "bot_skill_mode": state.bot_skill_mode,
         }
         message.update(state._authority_fields())
         return message
@@ -13633,6 +13672,7 @@ class ClientHandler(socketserver.BaseRequestHandler):
                         "team_size": server.state.team_size,
                         "team_sizes": server.state._team_sizes_wire(),
                         "bot_tier_mode": server.state.bot_tier_mode,
+                        "bot_skill_mode": server.state.bot_skill_mode,
                     }
                     welcome_message.update({
                         "authority_epoch": server.state.authority_epoch,
@@ -13901,6 +13941,28 @@ class ClientHandler(socketserver.BaseRequestHandler):
                                     "size": message.get("size"),
                                     "team_sizes": server.state._team_sizes_wire(),
                                 })
+                        elif message_type == "set_bot_skill_mode":
+                            accepted, mode_error = \
+                                server.state.set_bot_skill_mode(
+                                    player.player_id, message.get("mode"))
+                            if accepted:
+                                _server_log(
+                                    "BOT SKILL MODE id=%d mode=%s" % (
+                                        player.player_id,
+                                        server.state.bot_skill_mode))
+                                server.state.broadcast_current_roster()
+                            else:
+                                player.send({
+                                    "type": "bot_skill_mode_denied",
+                                    "protocol": PROTOCOL_VERSION,
+                                    "round_id": server.state.round_id,
+                                    "state_revision":
+                                        server.state.state_revision,
+                                    "code": mode_error,
+                                    "mode": message.get("mode"),
+                                    "bot_skill_mode":
+                                        server.state.bot_skill_mode,
+                                })
                         elif message_type == "set_bot_tier_mode":
                             accepted, mode_error = server.state.set_bot_tier_mode(
                                 player.player_id, message.get("mode"))
@@ -14107,6 +14169,7 @@ def run_server(host, port, map_name, max_players,
                team_size=15, receipt_state_path=None,
                team1_size=None, team2_size=None,
                bot_tier_mode="random", bot_lineup=None,
+               bot_skill_mode=None,
                vehicle_overlay_root=None):
     if receipt_state_path is None:
         receipt_state_path = _default_result_receipt_state_path(port)
@@ -14115,7 +14178,8 @@ def run_server(host, port, map_name, max_players,
                         receipt_state_path=receipt_state_path,
                         team1_size=team1_size, team2_size=team2_size,
                         bot_tier_mode=bot_tier_mode,
-                        bot_lineup=bot_lineup)
+                        bot_lineup=bot_lineup,
+                        bot_skill_mode=bot_skill_mode)
     if vehicle_overlay_root:
         try:
             overlay = VehicleOverlayStore(vehicle_overlay_root)

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -4629,8 +4629,14 @@ class BattleRuntime(object):
                     self._bot_vehicle_assignments = {}
                     return False
                 vehicle = raw.get('vehicle')
-                if (team not in (1, 2) or not 0 <= slot < 15 or
-                        vehicle not in allowed_names):
+                if team not in (1, 2) or not 0 <= slot < 15:
+                    self._bot_vehicle_assignments = {}
+                    return False
+                if vehicle is None:
+                    # A slot that pins only its Bot skill tier keeps the
+                    # generated vehicle; the worker reads that tier directly.
+                    continue
+                if vehicle not in allowed_names:
                     self._bot_vehicle_assignments = {}
                     return False
                 if (team, slot) in assignments:

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bot_gunnery.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bot_gunnery.py
@@ -60,8 +60,11 @@ MAX_AIM_OFFSET_METRES = 8.0
 
 _PARAMETERS = {
     SKILL_ROOKIE: {
-        # #1513 crew level, fed to generateDefaultCrew.
-        'crew_level': 50,
+        # #1513 crew level, fed to generateDefaultCrew.  The crew level also
+        # shortens view range and slows reload, so only the two weaker tiers
+        # spend it at all and the top two share a full crew: this is a
+        # gunnery setting, not a spotting setting.
+        'crew_level': 75,
         # Seconds of holding a firing solution on one target before the
         # trigger is available at all.
         'reaction_seconds': 1.20,
@@ -79,7 +82,7 @@ _PARAMETERS = {
         'lead_error': 0.45,
     },
     SKILL_REGULAR: {
-        'crew_level': 75,
+        'crew_level': 90,
         'reaction_seconds': 0.75,
         'patience_seconds': 1.10,
         'converged_factor': 1.80,
@@ -87,7 +90,7 @@ _PARAMETERS = {
         'lead_error': 0.22,
     },
     SKILL_VETERAN: {
-        'crew_level': 90,
+        'crew_level': 100,
         'reaction_seconds': 0.45,
         'patience_seconds': 1.70,
         'converged_factor': 1.35,

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bot_gunnery.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bot_gunnery.py
@@ -1,0 +1,273 @@
+from __future__ import print_function
+
+"""Bot gunnery skill tiers for the hidden simulation worker.
+
+Retail #1513 ships no Bot skill rating, so every Bot in this project used to
+fire the same way: a 100 percent crew, an exact analytic intercept solution
+aimed at the target centre, and no delay between holding a target and pulling
+the trigger.  Shot dispersion was modelled correctly, but a perfectly centred
+circle on a perfectly predicted point is strictly better than a good human
+gunner, which is why Bots read as unnaturally accurate.
+
+This module owns the replacement, in two clearly separated halves.
+
+``crew_level`` is a real shipped mechanic.  It selects the level passed to
+``items.utils.generateDefaultCrew`` so a weaker tier inherits #1513's own
+longer aiming time, wider fully-aimed dispersion, slower reload, slower
+turret and shorter view range.  No coefficient here is invented.
+
+Everything else models the human gunner #1513 never simulated: a reaction
+delay, a bounded willingness to wait for the aiming circle, a slowly drifting
+aim-point bias and an imperfect lead on a moving target.  Those numbers are an
+explicit product choice for this project.  They are not retail data, they are
+not derived from client files, and they must not be presented as either.
+
+Every draw is seeded from stable round, Bot and target identity, so authority
+takeover reproduces the same gunner rather than re-rolling one mid-engagement.
+The radius law matches ``bot_runtime._dispersed_barrel_angles`` so the project
+keeps one truncated-half-normal idiom instead of two.
+"""
+
+import hashlib
+import math
+import random
+
+
+SKILL_ROOKIE = 'rookie'
+SKILL_REGULAR = 'regular'
+SKILL_VETERAN = 'veteran'
+SKILL_ELITE = 'elite'
+
+# Ordered weakest to strongest.  Wire values and saved launcher profiles use
+# these names, so they are protocol: extend the tuple, never renumber it.
+SKILL_TIERS = (SKILL_ROOKIE, SKILL_REGULAR, SKILL_VETERAN, SKILL_ELITE)
+DEFAULT_SKILL = SKILL_REGULAR
+
+# One aim-point bias is held for this long before the gunner re-lays the gun.
+# A single frozen bias would make a whole engagement uniformly lucky or
+# unlucky; re-drawing every frame would read as jitter rather than as aim.
+AIM_BIAS_SECONDS = 1.5
+
+# The vertical half of an aim-point error is deliberately smaller than the
+# lateral half.  A large vertical bias walks the solution into the terrain or
+# outside the gun's pitch limits, and the Bot then holds fire instead of
+# missing, which is not the behaviour being modelled.
+VERTICAL_BIAS_SHARE = 0.45
+
+# A long shot must not aim at the sky.  Beyond this the angular model stops
+# growing; the shot is already a clean miss.
+MAX_AIM_OFFSET_METRES = 8.0
+
+_PARAMETERS = {
+    SKILL_ROOKIE: {
+        # #1513 crew level, fed to generateDefaultCrew.
+        'crew_level': 50,
+        # Seconds of holding a firing solution on one target before the
+        # trigger is available at all.
+        'reaction_seconds': 1.20,
+        # Seconds this tier is willing to spend laying the gun before it
+        # opens fire anyway.  Bounded: a Bot that keeps moving never
+        # converges, but this wait always expires, so it still shoots.
+        'patience_seconds': 0.60,
+        # Multiple of the fully-aimed circle this tier accepts as "aimed".
+        'converged_factor': 2.60,
+        # Aim-point bias, as a multiple of the gun's own fully-aimed
+        # dispersion angle, so an accurate gun stays accurate and a derp gun
+        # stays a derp gun.
+        'aim_bias_factor': 1.80,
+        # Fraction of the computed lead this tier can be wrong by.
+        'lead_error': 0.45,
+    },
+    SKILL_REGULAR: {
+        'crew_level': 75,
+        'reaction_seconds': 0.75,
+        'patience_seconds': 1.10,
+        'converged_factor': 1.80,
+        'aim_bias_factor': 0.85,
+        'lead_error': 0.22,
+    },
+    SKILL_VETERAN: {
+        'crew_level': 90,
+        'reaction_seconds': 0.45,
+        'patience_seconds': 1.70,
+        'converged_factor': 1.35,
+        'aim_bias_factor': 0.35,
+        'lead_error': 0.09,
+    },
+    SKILL_ELITE: {
+        'crew_level': 100,
+        'reaction_seconds': 0.25,
+        'patience_seconds': 2.40,
+        'converged_factor': 1.12,
+        'aim_bias_factor': 0.10,
+        'lead_error': 0.02,
+    },
+}
+
+SKILL_MODE_EASY = 'easy'
+SKILL_MODE_RELAXED = 'relaxed'
+SKILL_MODE_MIXED = 'mixed'
+SKILL_MODE_HARD = 'hard'
+SKILL_MODE_BRUTAL = 'brutal'
+
+# Waiting-room presets.  Each is the tier distribution of the whole roster,
+# in SKILL_TIERS order.  ``mixed`` is the pub-team shape the project defaults
+# to: mostly ordinary Bots, a few clearly weak ones, a few clearly good ones.
+SKILL_MODES = (
+    SKILL_MODE_EASY, SKILL_MODE_RELAXED, SKILL_MODE_MIXED,
+    SKILL_MODE_HARD, SKILL_MODE_BRUTAL)
+DEFAULT_SKILL_MODE = SKILL_MODE_MIXED
+
+_MODE_WEIGHTS = {
+    SKILL_MODE_EASY: (0.85, 0.15, 0.00, 0.00),
+    SKILL_MODE_RELAXED: (0.45, 0.40, 0.15, 0.00),
+    SKILL_MODE_MIXED: (0.20, 0.45, 0.25, 0.10),
+    SKILL_MODE_HARD: (0.00, 0.25, 0.45, 0.30),
+    SKILL_MODE_BRUTAL: (0.00, 0.00, 0.00, 1.00),
+}
+
+
+def _stable_seed(*parts):
+    """Return the same positive integer on Python 2 and Python 3."""
+    text_parts = []
+    for part in parts:
+        try:
+            text_parts.append(str(part))
+        except Exception:
+            text_parts.append('?')
+    payload = '|'.join(text_parts).encode('utf-8')
+    return int(hashlib.sha1(payload).hexdigest()[:8], 16) & 0x7fffffff
+
+
+def normalize_skill(value):
+    """Return one supported gunnery tier name."""
+    return value if value in SKILL_TIERS else DEFAULT_SKILL
+
+
+def normalize_skill_mode(value):
+    """Return one supported waiting-room Bot skill preset."""
+    return value if value in SKILL_MODES else DEFAULT_SKILL_MODE
+
+
+def skill_parameters(skill):
+    """Return the shared parameter bundle for one tier.  Do not mutate it."""
+    return _PARAMETERS[normalize_skill(skill)]
+
+
+def crew_level(skill):
+    """Return the #1513 crew level this tier trains its Bots to."""
+    return int(skill_parameters(skill)['crew_level'])
+
+
+def resolve_skill(mode, round_id, team, slot):
+    """Pick one roster slot's tier from a preset, without shared state.
+
+    The draw depends only on the round and the slot, so the worker, the
+    server and any UI reach the same answer for the same Bot without the
+    tier having to travel between them first.
+    """
+    mode = normalize_skill_mode(mode)
+    weights = _MODE_WEIGHTS[mode]
+    roll = random.Random(
+        _stable_seed('bot-skill-v1', round_id, mode, team, slot)).random()
+    total = 0.0
+    for index, weight in enumerate(weights):
+        total += weight
+        if roll < total:
+            return SKILL_TIERS[index]
+    return SKILL_TIERS[-1]
+
+
+def bias_epoch(hold_seconds):
+    """Return the aiming epoch index for one continuous target hold."""
+    try:
+        held = float(hold_seconds)
+    except (TypeError, ValueError, OverflowError):
+        return 0
+    if math.isnan(held) or math.isinf(held) or held <= 0.0:
+        return 0
+    return int(held / AIM_BIAS_SECONDS)
+
+
+def engagement_error(skill, round_id, bot_id, target_key, epoch):
+    """Return one gunner's frozen error for one aiming epoch.
+
+    ``radius`` is a truncated half-normal in [0, 1]; the caller scales it by
+    the tier's bias factor and the gun's own dispersion.  ``lead_scale``
+    multiplies the target velocity fed to the intercept solve, so a weak
+    gunner under- or over-leads a moving target for the whole epoch instead
+    of correcting between shots.
+    """
+    params = skill_parameters(skill)
+    generator = random.Random(_stable_seed(
+        'bot-gunner-v1', round_id, bot_id, target_key, epoch))
+    radius = abs(generator.gauss(0.0, 0.5))
+    if radius > 1.0:
+        radius = generator.random()
+    return {
+        'radius': radius,
+        'azimuth': generator.uniform(0.0, 2.0 * math.pi),
+        'lead_scale': (1.0 + generator.uniform(-1.0, 1.0) *
+                       float(params['lead_error'])),
+    }
+
+
+def aim_offset_metres(skill, error, dispersion_angle, distance):
+    """Return the (lateral, vertical) aim-point error for one shot, in metres.
+
+    The caller maps these onto the line of sight.  The error is angular so it
+    grows with range exactly like the aiming circle it is measured against.
+    """
+    params = skill_parameters(skill)
+    try:
+        angle = float(dispersion_angle)
+        reach = float(distance)
+        radius = float(error['radius'])
+        azimuth = float(error['azimuth'])
+    except (KeyError, TypeError, ValueError, OverflowError):
+        return 0.0, 0.0
+    if (math.isnan(angle) or math.isinf(angle) or angle <= 0.0 or
+            math.isnan(reach) or math.isinf(reach) or reach <= 0.0):
+        return 0.0, 0.0
+    magnitude = min(
+        MAX_AIM_OFFSET_METRES,
+        float(params['aim_bias_factor']) * angle * reach * radius)
+    return (magnitude * math.cos(azimuth),
+            magnitude * math.sin(azimuth) * VERTICAL_BIAS_SHARE)
+
+
+def may_fire(skill, hold_seconds, laying_seconds, dispersion_factor,
+             opening_shot=True):
+    """Return whether this gunner has reacted and finished laying.
+
+    ``hold_seconds`` is the continuous hold on the current target and drives
+    the reaction delay.  ``laying_seconds`` runs from that acquisition and
+    drives the aiming patience.  ``dispersion_factor`` is the live circle as
+    a multiple of the fully-aimed circle, so 1.0 is fully aimed.
+
+    Only the opening shot of an engagement waits for the circle.  Every gun
+    blooms after firing, so a better tier - which accepts a tighter circle
+    and waits longer for it - would otherwise fire a fast or clip gun less
+    often than a worse tier holding the same gun, and the whole ladder would
+    invert.  After the opening shot the gun's own reload owns the cadence;
+    the aim-point bias and the lead error still separate the tiers on every
+    round.
+    """
+    params = skill_parameters(skill)
+    try:
+        held = float(hold_seconds)
+        laying = float(laying_seconds)
+        factor = float(dispersion_factor)
+    except (TypeError, ValueError, OverflowError):
+        return False
+    if (math.isnan(held) or math.isinf(held) or math.isnan(laying) or
+            math.isnan(factor)):
+        return False
+    if held < float(params['reaction_seconds']):
+        return False
+    if not opening_shot:
+        return True
+    if not math.isinf(factor) and factor <= float(
+            params['converged_factor']):
+        return True
+    return laying >= float(params['patience_seconds'])

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -16,6 +16,7 @@ from gui.mods.offline_lan_0922.ai.navigation import (
     BAKED_FATAL_HAZARDS, BAKED_SHALLOW_WATER, TerrainNavigator)
 from gui.mods.offline_lan_0922 import critical_damage
 from gui.mods.offline_lan_0922 import ballistics
+from gui.mods.offline_lan_0922 import bot_gunnery
 from gui.mods.offline_lan_0922 import burst_mechanics
 from gui.mods.offline_lan_0922 import device_damage
 from gui.mods.offline_lan_0922 import effective_params
@@ -499,32 +500,57 @@ def _forward_speed(descriptor):
     return max(4.0, min(value, 35.0))
 
 
-def _bot_default_crew_factors(descriptor):
-    """Return #1513's native factors for the target's plain 100% crew."""
-    factors = loadout.attribute_factors(descriptor, crew=None)
+# Crew levels this client refused, so the fallback below is reported once
+# per level per process rather than once per Bot per round.
+_LOGGED_CREW_LEVEL_REJECTIONS = set()
+
+
+def _bot_default_crew_factors(descriptor, crew_level=None):
+    """Return #1513's native factors for the target's generated default crew.
+
+    ``crew_level`` is the Bot skill tier's trained level.  ``None`` keeps the
+    pinned maximum, which is what every Bot used before skill tiers existed.
+
+    A sub-maximum level has not been accepted on the exact Windows client
+    yet.  If that client's ``generateDefaultCrew`` rejects one, fall back to
+    the maximum-level crew every Bot already used and say so once: a Bot
+    whose gunner tier is a little stronger than intended is recoverable, and
+    a round that refuses to start is not.
+    """
+    factors = loadout.attribute_factors(
+        descriptor, crew=None, crew_level=crew_level)
+    if factors is None and crew_level is not None:
+        if crew_level not in _LOGGED_CREW_LEVEL_REJECTIONS:
+            _LOGGED_CREW_LEVEL_REJECTIONS.add(crew_level)
+            sys.stdout.write(
+                '[Offline LAN 0.9.22] bot crew level %s was rejected by this '
+                'client; using the default crew\n' % (crew_level,))
+        factors = loadout.attribute_factors(descriptor, crew=None)
     if factors is None:
         raise RuntimeError(
             'bot default crew attribute factors are unavailable')
     return factors
 
 
-def _bot_profile(descriptor):
+def _bot_profile(descriptor, crew_level=None):
     """Spotting inputs for a vehicle whose crew is the #1513 default crew."""
     return loadout.spotting_profile(
-        descriptor, None, factors=_bot_default_crew_factors(descriptor))
+        descriptor, None,
+        factors=_bot_default_crew_factors(descriptor, crew_level))
 
 
-def _bot_physics_params(descriptor):
-    """Physics for the target vehicle with its plain 100% default crew."""
+def _bot_physics_params(descriptor, crew_level=None):
+    """Physics for the target vehicle with its generated default crew."""
     return vehicle_physics.derive_params(
-        descriptor, factors=_bot_default_crew_factors(descriptor))
+        descriptor,
+        factors=_bot_default_crew_factors(descriptor, crew_level))
 
 
-def _view_range(descriptor, still_seconds=0.0):
+def _view_range(descriptor, still_seconds=0.0, crew_level=None):
     """Bot view range, using the same device and crew law as the player."""
     turret = _value(descriptor, 'turret', {}) or {}
     misc = _value(descriptor, 'miscAttrs', {}) or {}
-    profile = _bot_profile(descriptor)
+    profile = _bot_profile(descriptor, crew_level)
     return spotting.effective_view_range(
         _value(turret, 'circularVisionRadius', 330.0),
         misc_factor=_value(misc, 'circularVisionRadiusFactor', 1.0),
@@ -536,14 +562,14 @@ def _view_range(descriptor, still_seconds=0.0):
                 still_seconds, profile['binocular_delay'])))
 
 
-def _vision_range_pair(descriptor):
+def _vision_range_pair(descriptor, crew_level=None):
     """Bot view range while moving, once its stereoscope arms, and the delay.
 
     The delay is ``None`` when the bot carries no stationary vision device, so
     the caller never pays for a stillness lookup it cannot use.
     """
-    profile = _bot_profile(descriptor)
-    moving = _view_range(descriptor)
+    profile = _bot_profile(descriptor, crew_level)
+    moving = _view_range(descriptor, crew_level=crew_level)
     if not profile['has_binoculars']:
         return moving, moving, None
     turret = _value(descriptor, 'turret', {}) or {}
@@ -1035,10 +1061,13 @@ class _BotGunState(object):
     empty until the full reload boundary completes.
     """
 
-    def __init__(self, descriptor, fire_seq=0, dispersion_factor=1.0):
+    def __init__(self, descriptor, fire_seq=0, dispersion_factor=1.0,
+                 crew_level=None):
         gun = _value(descriptor, 'gun', {}) or {}
+        self.crew_level = crew_level
         gun_modifiers = loadout.modifiers(
-            descriptor, factors=_bot_default_crew_factors(descriptor))
+            descriptor,
+            factors=_bot_default_crew_factors(descriptor, crew_level))
         self.loadout = dict(gun_modifiers)
         raw_dispersion = _value(gun, 'shotDispersionAngle')
         try:
@@ -1112,7 +1141,7 @@ class _BotGunState(object):
         old_dispersion = self.dispersion
         active_reload_duration = self.reload_duration
         aiming_elapsed = self.aiming_elapsed
-        candidate = _BotGunState(descriptor)
+        candidate = _BotGunState(descriptor, crew_level=self.crew_level)
         if (candidate.shell_count != self.shell_count or
                 candidate.clip_size != self.clip_size):
             raise RuntimeError(
@@ -2090,6 +2119,10 @@ class BotRuntime(object):
         self._reset_shot_lane_work()
         self._reset_shot_lane_diagnostics()
         self._physics_params = {}
+        self._bot_skills = {}
+        self._bot_skill_mode = bot_gunnery.DEFAULT_SKILL_MODE
+        self._bot_skill_pins = {}
+        self._gunnery_holds = {}
         self._suspension_params = {}
         self._suspension_param_failures = 0
         self._suspension_trial_reports = set()
@@ -2594,7 +2627,8 @@ class BotRuntime(object):
                                   not descriptor):
             params = vehicle_physics.derive_params({})
         else:
-            params = _bot_physics_params(descriptor)
+            params = _bot_physics_params(
+                descriptor, self.bot_crew_level(bot_id))
         self._physics_params[bot_id] = params
         return params
 
@@ -2706,7 +2740,8 @@ class BotRuntime(object):
             return False
         if state is not None:
             state.pop(_GUN_PITCH_LIMIT_CACHE, None)
-        self._physics_params[bot_id] = _bot_physics_params(descriptor)
+        self._physics_params[bot_id] = _bot_physics_params(
+            descriptor, self.bot_crew_level(bot_id))
         self._suspension_params.pop(bot_id, None)
         self._gun_yaw_limits[bot_id] = ai_driver.gun_yaw_limits(descriptor)
         gun_state = self._gun_states.get(bot_id)
@@ -3010,9 +3045,58 @@ class BotRuntime(object):
         state['_siege_intent_elapsed'] = 0.0
         return changed or switching
 
+    @staticmethod
+    def _lineup_skill_pins(message):
+        """Return the host's exact per-slot Bot gunnery tiers, if any."""
+        pins = {}
+        for raw in message.get('bot_lineup') or ():
+            if not isinstance(raw, dict):
+                continue
+            skill = raw.get('skill')
+            if skill not in bot_gunnery.SKILL_TIERS:
+                continue
+            try:
+                pins[(int(raw['team']), int(raw['slot']))] = skill
+            except (KeyError, TypeError, ValueError, OverflowError):
+                continue
+        return pins
+
+    def _resolve_bot_skill(self, raw):
+        """Return one Bot's gunnery tier for this round.
+
+        A takeover manifest already carries the tier the previous authority
+        installed, so it wins.  Then the host's explicit lineup pin.  Then the
+        room preset, which resolves from round and slot identity alone, so
+        every process reaches the same tier without it travelling first.
+        """
+        published = raw.get('skill')
+        if published in bot_gunnery.SKILL_TIERS:
+            return published
+        try:
+            team = int(raw.get('team', 1))
+            slot = int(raw.get('slot', 0))
+        except (TypeError, ValueError, OverflowError):
+            raise ValueError('authority manifest Bot slot identity is invalid')
+        pinned = self._bot_skill_pins.get((team, slot))
+        if pinned in bot_gunnery.SKILL_TIERS:
+            return pinned
+        return bot_gunnery.resolve_skill(
+            self._bot_skill_mode, self.round_id, team, slot)
+
+    def bot_skill(self, bot_id):
+        """Return the gunnery tier installed for one Bot this round."""
+        return self._bot_skills.get(int(bot_id), bot_gunnery.DEFAULT_SKILL)
+
+    def bot_crew_level(self, bot_id):
+        """Return the #1513 crew level this Bot's tier trains it to."""
+        return bot_gunnery.crew_level(self.bot_skill(bot_id))
+
     def battle_start(self, message):
         """Build a local authority manifest from the server roster once per round."""
         message = message if isinstance(message, dict) else {}
+        self._bot_skill_mode = bot_gunnery.normalize_skill_mode(
+            message.get('bot_skill_mode'))
+        self._bot_skill_pins = self._lineup_skill_pins(message)
         round_id = message.get('round_id')
         if round_id != self.round_id:
             self.round_id = round_id
@@ -3048,6 +3132,8 @@ class BotRuntime(object):
             self._reset_shot_lane_work()
             self._reset_shot_lane_diagnostics()
             self._physics_params = {}
+            self._bot_skills = {}
+            self._gunnery_holds = {}
             self._suspension_params = {}
             self._suspension_param_failures = 0
             self._suspension_trial_reports = set()
@@ -3161,6 +3247,7 @@ class BotRuntime(object):
             self._ram_cooldowns = {}
             self._human_ram_cooldowns = {}
             self._ram_contacts = frozenset()
+            self._gunnery_holds = {}
             self._cover_queue = []
             self._cover_results = []
             self._next_observation = 0.0
@@ -3226,6 +3313,8 @@ class BotRuntime(object):
             wire_total = int(raw_wire_total)
             siege_time_left = wire_time / 1000.0
             siege_transition_total = wire_total / 1000.0
+            self._bot_skills[bot_id] = self._resolve_bot_skill(raw)
+            crew_level = bot_gunnery.crew_level(self._bot_skills[bot_id])
             self._descriptor_pairs[bot_id] = descriptor_pair
             descriptor = siege_mechanics.active_descriptor(
                 descriptor_pair, siege_state)
@@ -3237,7 +3326,8 @@ class BotRuntime(object):
             if bot_id not in self._gun_states:
                 self._gun_states[bot_id] = _BotGunState(
                     descriptor, raw.get('fire_seq', 0),
-                    _critical_factor(raw, descriptor, 'dispersion'))
+                    _critical_factor(raw, descriptor, 'dispersion'),
+                    crew_level)
                 if restoring_authority:
                     if ('reload_time' not in raw or
                             'reload_duration' not in raw):
@@ -3254,7 +3344,8 @@ class BotRuntime(object):
                         raw.get('clip'), raw.get('clip_size'))
             else:
                 self._gun_states[bot_id].adopt_descriptor(descriptor)
-            self._physics_params[bot_id] = _bot_physics_params(descriptor)
+            self._physics_params[bot_id] = _bot_physics_params(
+                descriptor, crew_level)
             self._turn_speeds[bot_id] = 0.0
             if isinstance(raw.get('profile'), dict):
                 self.adapter.director.register_profile(bot_id, raw.get('team', 1),
@@ -4192,6 +4283,9 @@ class BotRuntime(object):
                 'siege_time_left_ms', 'siege_transition_total_ms',
                 'equipment_states', 'stun_end_server_time_ms')
         result = dict((key, state[key]) for key in keys)
+        # The tier rides the manifest so a takeover installs the same gunner
+        # rather than re-rolling one from a preset mid-round.
+        result['skill'] = self.bot_skill(state['id'])
         descriptor = self._descriptors.get(state['id'], {})
         terminal = _terminal_critical(state, descriptor, 'shot')
         # Retail descriptors always expose the physical crew. Keep synthetic
@@ -4301,7 +4395,8 @@ class BotRuntime(object):
             return cached
         if kind == 'bot':
             descriptor = self._descriptors.get(int(target_id), {})
-            profile = _bot_profile(descriptor)
+            profile = _bot_profile(
+                descriptor, self.bot_crew_level(target_id))
             cached = (_base_invisibility(descriptor, profile),
                       _shot_invisibility_factor(descriptor), profile)
         else:
@@ -4328,8 +4423,9 @@ class BotRuntime(object):
         if cached is None:
             cached = loadout.modifiers(
                 descriptor,
-                factors=_bot_default_crew_factors(descriptor))[
-                    'repair_factor']
+                factors=_bot_default_crew_factors(
+                    descriptor, self.bot_crew_level(bot_id)))[
+                        'repair_factor']
             passive = self._equipment_passives.get(int(bot_id), {})
             cached *= 1.0 + max(
                 0.0, passive.get('repairkitBonusValue', 0.0))
@@ -4338,7 +4434,8 @@ class BotRuntime(object):
 
     def _cache_vision_range(self, bot_id, descriptor):
         """Record this bot's moving and armed view ranges, return the moving one."""
-        moving, still, delay = _vision_range_pair(descriptor)
+        moving, still, delay = _vision_range_pair(
+            descriptor, self.bot_crew_level(bot_id))
         self._vision_ranges[int(bot_id)] = (moving, still, delay)
         return moving
 
@@ -8664,8 +8761,102 @@ class BotRuntime(object):
             'pitch': pitch, 'flight_time': flight_time, 'arc': arc,
         }
 
+    def _track_gunnery_hold(self, state, target, now):
+        """Advance one Bot's continuous hold on its current target.
+
+        Returns ``(hold_seconds, laying_seconds, opening_shot)``, or ``None``
+        when the Bot holds no target.  ``laying_seconds`` restarts at the
+        Bot's own shot and ``opening_shot`` says whether this engagement has
+        produced one yet.  A momentary gap keeps the record: a gunner does
+        not react to the same tank twice.
+        """
+        bot_id = int(state['id'])
+        record = self._gunnery_holds.get(bot_id)
+        if not isinstance(target, dict):
+            return None
+        key = self._observer_target_key(target)
+        now = float(now)
+        if record is None or record['key'] != key:
+            record = {'key': key, 'since': now, 'laid_since': now,
+                      'fire_seq': int(_number(state.get('fire_seq'), 0)),
+                      'fired': False, 'epoch': None, 'error': None}
+            self._gunnery_holds[bot_id] = record
+        fire_seq = int(_number(state.get('fire_seq'), 0))
+        if record['fire_seq'] != fire_seq:
+            record['fire_seq'] = fire_seq
+            record['laid_since'] = now
+            record['fired'] = True
+        return (max(0.0, now - record['since']),
+                max(0.0, now - record['laid_since']),
+                not record['fired'])
+
+    def _gunnery_error(self, state, target, now):
+        """Return this Bot's frozen gunner error for the current aim epoch."""
+        held = self._track_gunnery_hold(state, target, now)
+        if held is None:
+            return None
+        bot_id = int(state['id'])
+        record = self._gunnery_holds[bot_id]
+        epoch = bot_gunnery.bias_epoch(held[0])
+        if record['epoch'] != epoch or record['error'] is None:
+            record['epoch'] = epoch
+            record['error'] = bot_gunnery.engagement_error(
+                self.bot_skill(bot_id), self.round_id, bot_id,
+                record['key'], epoch)
+        return record['error']
+
+    def _aimed_target(self, state, target, now):
+        """Return the point this Bot's gunner actually lays the gun on.
+
+        Retail #1513 has no Bot gunner, so an unmodified Bot solved an exact
+        intercept on the target centre and only ever paid the shot dispersion
+        every gun pays.  The tier's persistent bias moves that aim point and
+        its lead error scales the velocity fed to the solve, so a weak gunner
+        misses the way a human does.  The original target row is never
+        mutated: identity, visibility and lease state stay canonical.
+        """
+        if not isinstance(target, dict):
+            return target
+        error = self._gunnery_error(state, target, now)
+        if error is None:
+            return target
+        bot_id = int(state['id'])
+        gun_state = self._gun_states.get(bot_id)
+        if gun_state is None:
+            return target
+        position = _point(target.get('position'), _position(target))
+        origin = _position(state)
+        dx = position[0] - origin[0]
+        dz = position[2] - origin[2]
+        horizontal = math.sqrt(dx * dx + dz * dz)
+        if horizontal <= 1.0:
+            return target
+        lateral, vertical = bot_gunnery.aim_offset_metres(
+            self.bot_skill(bot_id), error,
+            gun_state.fully_aimed_dispersion, _distance(origin, position))
+        velocity = self._target_velocity(target)
+        scale = float(error['lead_scale'])
+        aimed = dict(target)
+        aimed['position'] = (
+            position[0] + (dz / horizontal) * lateral,
+            position[1] + vertical,
+            position[2] - (dx / horizontal) * lateral)
+        aimed['velocity'] = (velocity[0] * scale, velocity[1] * scale,
+                             velocity[2] * scale)
+        return aimed
+
+    def _gunner_ready(self, state, gun_state, target, now):
+        """Return whether this Bot's gunner has reacted and finished laying."""
+        held = self._track_gunnery_hold(state, target, now)
+        if held is None:
+            return False
+        return bot_gunnery.may_fire(
+            self.bot_skill(int(state['id'])), held[0], held[1],
+            gun_state.current_dispersion_factor, held[2])
+
     def _ballistic_solution(self, state, target, descriptor, shell_index,
                             now):
+        target = self._aimed_target(state, target, now)
         profile = state.get('profile')
         profile = profile if isinstance(profile, dict) else {}
         if str(profile.get('class_tag') or '') == 'SPG':
@@ -11115,11 +11306,17 @@ class BotRuntime(object):
                     not burst_state.active and
                     gun_state.ready(reload_factor) and
                     ammo_state.can_fire() and
+                    # The gunner tier is the last term on purpose.  It only
+                    # decides whether an already admitted shot leaves, so the
+                    # lane probe above keeps refreshing its receipt while the
+                    # gunner reacts and lays, exactly as it did before Bots
+                    # had tiers.
                     (pending_intent is not None or
                      pending_reproof is not None or
                      self._shot_clear(
                         state, target, now,
-                        probe_budget=final_shot_lane_budget))):
+                        probe_budget=final_shot_lane_budget)) and
+                    self._gunner_ready(state, gun_state, target, now)):
                 launch_receipt = None
                 launch_preview = None
                 lane_clear = False

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
@@ -11,6 +11,7 @@ import uuid
 from gui.mods.offline_lan_0922 import effective_params as effective_params_wire
 from gui.mods.offline_lan_0922.battle_achievements import (
     AWARDABLE_ACHIEVEMENTS, RECEIPT_STAT_NAMES)
+from gui.mods.offline_lan_0922 import bot_gunnery
 from gui.mods.offline_lan_0922 import burst_mechanics
 from gui.mods.offline_lan_0922 import equipment_mechanics
 from gui.mods.offline_lan_0922 import siege_mechanics
@@ -143,6 +144,7 @@ RESULT_INTERACTION_LIMITS = {
 }
 BOT_TIER_MODES = frozenset((
     'random', 'same', 'minus1_0', '0_plus1', 'minus1_plus2'))
+BOT_SKILL_MODES = frozenset(bot_gunnery.SKILL_MODES)
 SENDER_JOIN_TIMEOUT = 0.1
 SEND_STALL_TIMEOUT = 5.0
 LEAVE_SEND_TIMEOUT = 0.05
@@ -164,7 +166,7 @@ _BOT_STATE_WIRE_FIELDS = (
 STATE_BARRIER_TYPES = frozenset((
     'welcome', 'roster', 'battle_start', 'battle_live',
     'start_denied', 'team_denied', 'team_size_denied',
-    'bot_tier_mode_denied', 'events', 'error'))
+    'bot_tier_mode_denied', 'bot_skill_mode_denied', 'events', 'error'))
 ORDERED_RECEIVE_TYPES = STATE_BARRIER_TYPES | frozenset((
     'battle_receipt', 'fire_intent', 'fire_intent_result',
     'landing_observation_result',
@@ -173,7 +175,8 @@ ORDERED_RECEIVE_TYPES = STATE_BARRIER_TYPES | frozenset((
     'team_command_ack', 'team_command_terminal', 'team_chat', 'team_chat_ack'))
 SERVER_STATE_TYPES = frozenset((
     'welcome', 'roster', 'battle_start', 'battle_live', 'start_denied',
-    'team_denied', 'team_size_denied', 'bot_tier_mode_denied', 'snapshot',
+    'team_denied', 'team_size_denied', 'bot_tier_mode_denied',
+    'bot_skill_mode_denied', 'snapshot',
     'events', 'bot_observation',
     'battle_receipt', 'player_destructible_contact'))
 RECOVERABLE_RUNTIME_TYPES = frozenset((
@@ -1692,6 +1695,7 @@ class LANClient(object):
         self.team = None
         self.team_sizes = {1: 15, 2: 15}
         self.bot_tier_mode = 'random'
+        self.bot_skill_mode = bot_gunnery.DEFAULT_SKILL_MODE
         self.slot = 0
         self.map_name = None
         self.map_pool = []
@@ -1987,6 +1991,14 @@ class LANClient(object):
                 mode not in BOT_TIER_MODES):
             return False
         return self._send({'type': 'set_bot_tier_mode', 'mode': mode})
+
+    def set_bot_skill_mode(self, mode):
+        """Ask the waiting-room server to change the next Bot skill mix."""
+        if (not self.ready or self.phase != 'waiting' or
+                self.player_id != self.host_player_id or
+                mode not in BOT_SKILL_MODES):
+            return False
+        return self._send({'type': 'set_bot_skill_mode', 'mode': mode})
 
     def _adopt_published_vehicle(self, players):
         """Track the vehicle and HP the server holds for this client."""
@@ -4227,6 +4239,8 @@ class LANClient(object):
                 self.team_sizes)
             bot_tier_mode = _safe_text(
                 message.get('bot_tier_mode'), self.bot_tier_mode, 32)
+            bot_skill_mode = _safe_text(
+                message.get('bot_skill_mode'), self.bot_skill_mode, 32)
             if (player_id is None or state_revision is None or
                     state_revision < 0 or host_player_id is None or
                     host_player_id <= 0 or
@@ -4242,6 +4256,7 @@ class LANClient(object):
                     effective_params is None or
                     team_sizes is None or
                     bot_tier_mode not in BOT_TIER_MODES or
+                    bot_skill_mode not in BOT_SKILL_MODES or
                     not isinstance(spawn, dict) or
                     not all(axis in spawn for axis in ('x', 'y', 'z'))):
                 self.last_error = 'invalid welcome message'
@@ -4259,6 +4274,7 @@ class LANClient(object):
             self.team = team
             self.team_sizes = team_sizes
             self.bot_tier_mode = bot_tier_mode
+            self.bot_skill_mode = bot_skill_mode
             self.slot = slot
             self.max_health = max_health
             self.outfits = outfits
@@ -4320,6 +4336,8 @@ class LANClient(object):
                 self.team_sizes)
             bot_tier_mode = _safe_text(
                 message.get('bot_tier_mode'), self.bot_tier_mode, 32)
+            bot_skill_mode = _safe_text(
+                message.get('bot_skill_mode'), self.bot_skill_mode, 32)
             roster_server_time = None
             if 'server_time_ms' in message:
                 roster_server_time = _projectile_int_range(
@@ -4354,6 +4372,7 @@ class LANClient(object):
                     not player_assignments_valid or
                     team_sizes is None or
                     bot_tier_mode not in BOT_TIER_MODES or
+                    bot_skill_mode not in BOT_SKILL_MODES or
                     host_player_id not in player_ids or
                     not _valid_visible_authority_message(message) or
                     (ledger_required and authority_epoch is None) or
@@ -4397,6 +4416,7 @@ class LANClient(object):
             self.roster = players
             self.team_sizes = team_sizes
             self.bot_tier_mode = bot_tier_mode
+            self.bot_skill_mode = bot_skill_mode
             self._adopt_published_vehicle(players)
             self.host_player_id = host_player_id
             self.bot_authority_id = message.get(
@@ -4618,6 +4638,18 @@ class LANClient(object):
                 self.stop()
                 return
             self.bot_tier_mode = mode
+        elif kind == 'bot_skill_mode_denied':
+            round_id = _exact_int(message.get('round_id'))
+            mode = _safe_text(message.get('bot_skill_mode'), '', 32)
+            code = _safe_text(message.get('code'), '', 32)
+            if (round_id is None or round_id != self.round_id or
+                    mode not in BOT_SKILL_MODES or
+                    code not in ('host_only', 'invalid_mode',
+                                 'not_waiting')):
+                self.last_error = 'invalid bot_skill_mode_denied message'
+                self.stop()
+                return
+            self.bot_skill_mode = mode
         elif kind == 'snapshot':
             round_id = self._runtime_round_disposition(
                 kind, message, 'invalid snapshot message')

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/lan_session.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/lan_session.py
@@ -1236,6 +1236,13 @@ class LANSession(object):
                 self.client, 'set_bot_tier_mode', None)),
         }
 
+    def _bot_skill_status(self):
+        return {
+            'mode': getattr(self.client, 'bot_skill_mode', 'mixed'),
+            'supported': callable(getattr(
+                self.client, 'set_bot_skill_mode', None)),
+        }
+
     def select_team(self, team):
         """Ask the server to move this waiting-room player."""
         if self._stopped or self.client is None or self.state != 'waiting':
@@ -1283,6 +1290,19 @@ class LANSession(object):
                 tr('The LAN server did not accept that Bot tier preset.'))
             return False
         self._status_notifier(tr('Requesting Bot tier preset...'))
+        return True
+
+    def set_bot_skill_mode(self, mode):
+        """Ask the elected host server to use one Bot-skill preset."""
+        if (self._stopped or self.client is None or self.state != 'waiting' or
+                not self._is_local_host()):
+            return False
+        setter = getattr(self.client, 'set_bot_skill_mode', None)
+        if not callable(setter) or not setter(mode):
+            self._status_notifier(
+                tr('The LAN server did not accept that Bot skill preset.'))
+            return False
+        self._status_notifier(tr('Requesting Bot skill preset...'))
         return True
 
     def _save_room_preferences(self):
@@ -1598,6 +1618,8 @@ class LANSession(object):
                     'request_team_size': self.set_team_size,
                     'bot_tier_status': self._bot_tier_status,
                     'request_bot_tier_mode': self.set_bot_tier_mode,
+                    'bot_skill_status': self._bot_skill_status,
+                    'request_bot_skill_mode': self.set_bot_skill_mode,
                     'initial_map': self._room_preferences.get('map'),
                     'on_map_selected': self._remember_map,
                     'open_map_picker': self._open_map_window,
@@ -2440,6 +2462,20 @@ class LANSession(object):
             reject = getattr(self._queue, 'reject_bot_tier_mode', None)
             if callable(reject):
                 reject(_message_value(message, 'bot_tier_mode'), notice)
+            else:
+                self._refresh_surface()
+        elif kind == 'bot_skill_mode_denied':
+            code = _message_value(message, 'code')
+            if code == 'host_only':
+                notice = tr('Only the LAN room host can change the Bot skill '
+                            'preset.')
+            else:
+                notice = (tr('The LAN server refused the Bot skill preset '
+                             '(%s).') % (code or 'unknown'))
+            self._status_notifier(notice)
+            reject = getattr(self._queue, 'reject_bot_skill_mode', None)
+            if callable(reject):
+                reject(_message_value(message, 'bot_skill_mode'), notice)
             else:
                 self._refresh_surface()
         elif kind == 'battle_start':

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/loadout.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/loadout.py
@@ -39,6 +39,9 @@ _MISSING = object()
 CREW_FACTOR_BASE = 0.57
 CREW_FACTOR_SLOPE = 0.0043
 BASE_CREW_LEVEL = 100.0
+# #1513 trains a tankman between 50 and MAX_SKILL_LEVEL; a generated default
+# crew below that range is not a level the client can express.
+MIN_DEFAULT_CREW_LEVEL = 50
 COMMANDER_SHARE = 0.1
 VENTILATION_CREW_BONUS = 5.0
 BROTHERHOOD_CREW_BONUS = 5.0
@@ -205,9 +208,25 @@ def _native_attribute_factors(
     return factors
 
 
+def default_crew_level(tankmen_module, crew_level=None):
+    """Clamp a requested default-crew level into the #1513 trained range.
+
+    ``None`` keeps the pinned maximum, which is the level every consumer used
+    before Bot skill tiers existed.
+    """
+    maximum = int(tankmen_module.MAX_SKILL_LEVEL)
+    if crew_level is None:
+        return maximum
+    try:
+        requested = int(crew_level)
+    except (TypeError, ValueError, OverflowError):
+        return maximum
+    return max(MIN_DEFAULT_CREW_LEVEL, min(maximum, requested))
+
+
 def attribute_factors(
         descriptor, crew=None, equipments=(), activity_flags=None,
-        is_fire=False):
+        is_fire=False, crew_level=None):
     """Return the exact #1513 ``factors`` dictionary for one loadout.
 
     This is the same chain ``VehicleParameters`` runs for the garage panel:
@@ -216,6 +235,10 @@ def attribute_factors(
     factors and crew-level increase. ``activity_flags`` and ``is_fire`` are
     passed to the pinned native ``VehicleDescrCrew`` implementation. ``None``
     means the client machinery is unavailable or rejected the supplied state.
+
+    ``crew_level`` trains the generated default crew to something other than
+    the pinned maximum.  It is ignored when ``crew`` is a complete real crew,
+    which owns its own trained levels.
     """
     modules = _client_modules()
     if modules is None or descriptor is None:
@@ -223,13 +246,14 @@ def attribute_factors(
     (utils, tankmen, vehicles_module, aspects, qualifier_type, crew_class,
      qualifiers_class) = modules
     compact_descrs = crew_compact_descrs(crew)
+    level = default_crew_level(tankmen, crew_level)
     try:
         roles = descriptor.type.crewRoles
         has_complete_crew = len(compact_descrs) == len(roles)
         uses_existing_crew = bool(compact_descrs) and has_complete_crew
         if not has_complete_crew:
             compact_descrs = utils.generateDefaultCrew(
-                descriptor.type, tankmen.MAX_SKILL_LEVEL)
+                descriptor.type, level)
         flags = ([True] * len(compact_descrs) if activity_flags is None else
                  list(activity_flags))
         if (len(flags) != len(compact_descrs) or
@@ -250,7 +274,7 @@ def attribute_factors(
                     not _is_wrong_tankman_nation(error)):
                 raise
             default_crew = utils.generateDefaultCrew(
-                descriptor.type, tankmen.MAX_SKILL_LEVEL)
+                descriptor.type, level)
             factors = _native_attribute_factors(
                 utils, descriptor, default_crew, mounted, flags, is_fire,
                 aspects, qualifier_type, crew_class, qualifiers_class)
@@ -399,7 +423,8 @@ def modifiers(descriptor=None, equipments=(), crew_skills=None, factors=None):
     ``crew_skill_names``; ``None`` means the crew is unknown, which keeps the
     bare-crew baseline instead of claiming Brothers in Arms.  ``factors`` is
     the dictionary ``attribute_factors`` built; when it is present every crew
-    and artefact contribution below comes from it.
+    and artefact contribution below comes from it, including the level a Bot
+    skill tier trained the generated default crew to.
     """
     devices = device_names(descriptor) if descriptor is not None else ()
     consumables = equipment_names(equipments)

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/ui_i18n.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/ui_i18n.py
@@ -50,6 +50,12 @@ _ZH = {
     'Tier -1 / +2': u'低一级 / 高两级',
     'Unknown': u'未知',
     'BOT TIER: %s%s': u'电脑等级：%s%s',
+    'BOT SKILL: %s%s': u'电脑水平：%s%s',
+    'Easy': u'简单',
+    'Relaxed': u'轻松',
+    'Pub mix': u'野队水平',
+    'Hard': u'困难',
+    'Brutal': u'变态',
     'RANDOM%s': u'随机%s',
     ' (ON)': u'（已选）',
     '  (YOU)': u'（已选）',
@@ -70,6 +76,15 @@ _ZH = {
     'The server did not accept that team size.': u'服务器未接受该队伍人数。',
     'Setting Bot tier preset...': u'正在设置电脑等级...',
     'The server did not accept that Bot tier preset.': u'服务器未接受该电脑等级设置。',
+    'Setting Bot skill preset...': u'正在设置电脑水平...',
+    'The server did not accept that Bot skill preset.': u'服务器未接受该电脑水平设置。',
+    'Only the LAN room host can change the Bot skill preset.':
+        u'只有房主可以更改电脑水平。',
+    'The LAN server refused the Bot skill preset (%s).':
+        u'服务器拒绝了电脑水平设置（%s）。',
+    'Requesting Bot skill preset...': u'正在申请电脑水平设置...',
+    'The LAN server did not accept that Bot skill preset.':
+        u'服务器未接受该电脑水平设置。',
     'The server has not published its map list yet.': u'服务器尚未发送地图列表。',
     'Choose a map first.': u'请先选择地图。',
     'Starting %s...': u'正在开始 %s...',

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/waiting_room_ui.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/waiting_room_ui.py
@@ -85,6 +85,13 @@ BOT_TIER_OPTIONS = (
     ('minus1_0', 'Tier -1 / 0'), ('0_plus1', 'Tier 0 / +1'),
     ('minus1_plus2', 'Tier -1 / +2'),
 )
+_BOT_SKILL_CONTROLS = ('skill_previous', 'skill', 'skill_next')
+# The values and their order are bot_gunnery.SKILL_MODES, easiest first, bound
+# by a parity test.  The labels name the enemy a preset produces.
+BOT_SKILL_OPTIONS = (
+    ('easy', 'Easy'), ('relaxed', 'Relaxed'), ('mixed', 'Pub mix'),
+    ('hard', 'Hard'), ('brutal', 'Brutal'),
+)
 
 
 def _LEFT_MOUSE_KEY():
@@ -146,6 +153,13 @@ def friendly_bot_tier_mode(mode):
         if value == mode:
             return tr(label)
     return tr('Random')
+
+
+def friendly_bot_skill_mode(mode):
+    for value, label in BOT_SKILL_OPTIONS:
+        if value == mode:
+            return tr(label)
+    return tr('Pub mix')
 
 
 def panel_geometry(screen_size):
@@ -340,7 +354,8 @@ class WaitingRoomUI(object):
                  request_team_size=None, initial_map=None,
                  on_map_selected=None, bot_tier_status=None,
                  request_bot_tier_mode=None, open_map_picker=None,
-                 round_seconds=None):
+                 round_seconds=None, bot_skill_status=None,
+                 request_bot_skill_mode=None):
         self._request_start = request_start
         self._map_pool = map_pool
         self._status = status or (lambda: '')
@@ -352,6 +367,8 @@ class WaitingRoomUI(object):
         self._team_status = team_status or (lambda: {})
         self._bot_tier_status = bot_tier_status or (lambda: {})
         self._request_bot_tier_mode = request_bot_tier_mode
+        self._bot_skill_status = bot_skill_status or (lambda: {})
+        self._request_bot_skill_mode = request_bot_skill_mode
         self._on_map_selected = on_map_selected
         # The stock map window is the room's map browser: it presents the
         # #1513 map images this native surface cannot draw.  Its owner opens
@@ -377,6 +394,7 @@ class WaitingRoomUI(object):
         self._message = ''
         self._pending_team_sizes = {}
         self._pending_bot_tier_mode = None
+        self._pending_bot_skill_mode = None
 
     def install(self):
         """Build the native components without showing them."""
@@ -419,11 +437,14 @@ class WaitingRoomUI(object):
             self._make_label(
                 role, text, position, width, height, panel=panel, labels=labels,
                 surface=surface, **kwargs)
-        make_control('tier_previous', (-0.72, 0.28, CONTROL_Z), 0.20, 0.16)
-        make_control('tier', (0.0, 0.28, CONTROL_Z), 1.15, 0.16)
-        make_control('tier_next', (0.72, 0.28, CONTROL_Z), 0.20, 0.16)
-        make_control('map', (-0.30, 0.04, CONTROL_Z), 1.00, 0.16)
-        make_control('random', (0.62, 0.04, CONTROL_Z), 0.56, 0.16)
+        make_control('tier_previous', (-0.72, 0.30, CONTROL_Z), 0.20, 0.13)
+        make_control('tier', (0.0, 0.30, CONTROL_Z), 1.15, 0.13)
+        make_control('tier_next', (0.72, 0.30, CONTROL_Z), 0.20, 0.13)
+        make_control('skill_previous', (-0.72, 0.15, CONTROL_Z), 0.20, 0.13)
+        make_control('skill', (0.0, 0.15, CONTROL_Z), 1.15, 0.13)
+        make_control('skill_next', (0.72, 0.15, CONTROL_Z), 0.20, 0.13)
+        make_control('map', (-0.30, 0.0, CONTROL_Z), 1.00, 0.14)
+        make_control('random', (0.62, 0.0, CONTROL_Z), 0.56, 0.14)
         make_control('team1_down', (-0.82, -0.18, CONTROL_Z), 0.12, 0.14)
         make_control('team1_up', (-0.22, -0.18, CONTROL_Z), 0.12, 0.14)
         make_control('team2_down', (0.22, -0.18, CONTROL_Z), 0.12, 0.14)
@@ -439,15 +460,21 @@ class WaitingRoomUI(object):
         make_label('players', '', (-0.86, 0.44, 0.0), 1.72, 0.11)
         # These labels sit on textured buttons, which render white until a
         # tint is proved, so their text has to be dark to stay readable.
-        make_label('tier_previous', '<', (-0.72, 0.28, 0.0), 0.18, 0.10,
+        make_label('tier_previous', '<', (-0.72, 0.30, 0.0), 0.18, 0.09,
                    anchor='CENTER', colour=CONTROL_TEXT_COLOUR)
-        make_label('tier', '', (0.0, 0.28, 0.0), 1.10, 0.10,
+        make_label('tier', '', (0.0, 0.30, 0.0), 1.10, 0.09,
                    anchor='CENTER', colour=CONTROL_TEXT_COLOUR)
-        make_label('tier_next', '>', (0.72, 0.28, 0.0), 0.18, 0.10,
+        make_label('tier_next', '>', (0.72, 0.30, 0.0), 0.18, 0.09,
                    anchor='CENTER', colour=CONTROL_TEXT_COLOUR)
-        make_label('map', '', (-0.30, 0.04, 0.0), 0.96, 0.10,
+        make_label('skill_previous', '<', (-0.72, 0.15, 0.0), 0.18, 0.09,
                    anchor='CENTER', colour=CONTROL_TEXT_COLOUR)
-        make_label('random', tr('RANDOM MAP'), (0.62, 0.04, 0.0), 0.52, 0.10,
+        make_label('skill', '', (0.0, 0.15, 0.0), 1.10, 0.09,
+                   anchor='CENTER', colour=CONTROL_TEXT_COLOUR)
+        make_label('skill_next', '>', (0.72, 0.15, 0.0), 0.18, 0.09,
+                   anchor='CENTER', colour=CONTROL_TEXT_COLOUR)
+        make_label('map', '', (-0.30, 0.0, 0.0), 0.96, 0.10,
+                   anchor='CENTER', colour=CONTROL_TEXT_COLOUR)
+        make_label('random', tr('RANDOM MAP'), (0.62, 0.0, 0.0), 0.52, 0.10,
                    anchor='CENTER', colour=CONTROL_TEXT_COLOUR)
         make_label('team1_down', '-', (-0.82, -0.18, 0.0), 0.10, 0.09,
                    anchor='CENTER', colour=CONTROL_TEXT_COLOUR)
@@ -957,6 +984,17 @@ class WaitingRoomUI(object):
         self._set_text('tier', tr('BOT TIER: %s%s') % (
             friendly_bot_tier_mode(shown_tier_mode),
             '...' if self._pending_bot_tier_mode is not None else ''))
+        skill_status = self._bot_skill_status() or {}
+        skill_supported = bool(
+            is_host and callable(self._request_bot_skill_mode) and
+            skill_status.get('supported'))
+        skill_mode = skill_status.get('mode', 'mixed')
+        if self._pending_bot_skill_mode == skill_mode:
+            self._pending_bot_skill_mode = None
+        shown_skill_mode = self._pending_bot_skill_mode or skill_mode
+        self._set_text('skill', tr('BOT SKILL: %s%s') % (
+            friendly_bot_skill_mode(shown_skill_mode),
+            '...' if self._pending_bot_skill_mode is not None else ''))
         preferred_team = team_status.get('preferred', 0)
         self._set_text('team_random', tr('RANDOM%s') % (
             tr(' (ON)') if preferred_team == 0 else ''))
@@ -992,6 +1030,7 @@ class WaitingRoomUI(object):
             visible = (team_supported if role in _TEAM_SELECT_CONTROLS else
                        team_size_supported if role in _TEAM_SIZE_CONTROLS else
                        tier_supported if role in _BOT_TIER_CONTROLS else
+                       skill_supported if role in _BOT_SKILL_CONTROLS else
                        random_supported if role == 'random' else
                        role == 'close' or is_host)
             self._set(component, 'visible', visible)
@@ -1000,7 +1039,8 @@ class WaitingRoomUI(object):
                 self._set(label, 'visible', visible)
         for role in _TEAM_CAPACITY_LABELS:
             self._set(self._labels[role], 'visible', team_supported)
-        for role in ('title', 'room', 'players', 'tier', 'map', 'message'):
+        for role in ('title', 'room', 'players', 'tier', 'skill', 'map',
+                     'message'):
             self._set(self._labels[role], 'visible', True)
         self._paint()
         self._set(self._panel, 'visible', True)
@@ -1043,6 +1083,9 @@ class WaitingRoomUI(object):
         if role in _BOT_TIER_CONTROLS:
             return self._cycle_bot_tier_mode(
                 -1 if role == 'tier_previous' else 1)
+        if role in _BOT_SKILL_CONTROLS:
+            return self._cycle_bot_skill_mode(
+                -1 if role == 'skill_previous' else 1)
         if not self._host():
             return False
         if role == 'map':
@@ -1137,6 +1180,37 @@ class WaitingRoomUI(object):
             self._message = tr('The server did not accept that Bot tier preset.')
             self.refresh()
             return False
+        return True
+
+    def _cycle_bot_skill_mode(self, step):
+        status = self._bot_skill_status() or {}
+        if (not self._host() or not callable(self._request_bot_skill_mode) or
+                not status.get('supported')):
+            return False
+        current = self._pending_bot_skill_mode or status.get('mode', 'mixed')
+        modes = [value for value, unused_label in BOT_SKILL_OPTIONS]
+        try:
+            index = modes.index(current)
+        except ValueError:
+            index = 0
+        target = modes[(index + int(step)) % len(modes)]
+        self._pending_bot_skill_mode = target
+        self._message = tr('Setting Bot skill preset...')
+        self.refresh()
+        if self._request_bot_skill_mode(target) is False:
+            self._pending_bot_skill_mode = None
+            self._message = tr(
+                'The server did not accept that Bot skill preset.')
+            self.refresh()
+            return False
+        return True
+
+    def reject_bot_skill_mode(self, unused_mode=None, message=None):
+        self._pending_bot_skill_mode = None
+        self._message = (message or
+                         tr('The server did not accept that Bot skill '
+                            'preset.'))
+        self.refresh()
         return True
 
     def reject_bot_tier_mode(self, unused_mode=None, message=None):

--- a/tests/effective_params_fixture.py
+++ b/tests/effective_params_fixture.py
@@ -149,11 +149,25 @@ def effective_params():
     }
 
 
-def bot_default_crew_factors(unused_descriptor, crew=None):
-    """Exact factor shape supplied by #1513 to pure-Python Bot fixtures."""
+# #1513's own effective level for a generated default crew: the crew level
+# plus the commander's ten percent share of it.
+_COMMANDER_SHARE = 1.1
+_MAX_CREW_FACTOR = 0.57 + 0.0043 * 100.0 * _COMMANDER_SHARE
+
+
+def bot_default_crew_factors(unused_descriptor, crew=None, crew_level=None):
+    """Exact factor shape supplied by #1513 to pure-Python Bot fixtures.
+
+    ``crew_level`` reproduces the native chain's response to a generated
+    default crew trained below the maximum, so a Bot skill tier has to reach
+    the factor boundary for a fixture to see it.  ``None`` keeps the maximum
+    and therefore the exact values every existing fixture already asserts.
+    """
     if crew is not None:
         raise AssertionError('Bot fixtures require the plain default crew')
-    crew_factor = 0.57 + 0.0043 * 110.0
+    level = (100.0 if crew_level is None else
+             max(50.0, min(100.0, float(crew_level))))
+    crew_factor = 0.57 + 0.0043 * level * _COMMANDER_SHARE
     crew_multiplier = 1.0 / crew_factor
     return {
         'turret/rotationSpeed': crew_factor,
@@ -166,7 +180,7 @@ def bot_default_crew_factors(unused_descriptor, crew=None):
         'engine/power': 1.0,
         'chassis/terrainResistance': (1.0, 1.0, 1.0),
         'radio/distance': 1.0,
-        'circularVisionRadius': 1.0,
+        'circularVisionRadius': crew_factor / _MAX_CREW_FACTOR,
         'camouflage': 0.57,
     }
 

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -1973,9 +1973,15 @@ def _mounted_current_vehicle_module():
     return current_vehicle
 
 
-def _plain_bot_factors(unused_descriptor):
-    """Exact-client factor shape for unrelated pure-Python startup tests."""
-    crew_factor = 0.57 + 0.0043 * 110.0
+def _plain_bot_factors(unused_descriptor, crew_level=None):
+    """Exact-client factor shape for unrelated pure-Python startup tests.
+
+    ``crew_level`` follows the Bot skill tier's trained crew, exactly like
+    ``effective_params_fixture.bot_default_crew_factors``.
+    """
+    level = (100.0 if crew_level is None else
+             max(50.0, min(100.0, float(crew_level))))
+    crew_factor = 0.57 + 0.0043 * level * 1.1
     crew_multiplier = 1.0 / crew_factor
     return {
         'turret/rotationSpeed': crew_factor,
@@ -1988,7 +1994,7 @@ def _plain_bot_factors(unused_descriptor):
         'engine/power': 1.0,
         'chassis/terrainResistance': (1.0, 1.0, 1.0),
         'radio/distance': 1.0,
-        'circularVisionRadius': 1.0,
+        'circularVisionRadius': crew_factor / (0.57 + 0.0043 * 110.0),
         'camouflage': 0.57,
     }
 

--- a/tests/test_port_0922_bot_gunnery.py
+++ b/tests/test_port_0922_bot_gunnery.py
@@ -1,0 +1,266 @@
+"""Contract tests for the Bot gunnery skill tiers and their presets."""
+
+import importlib.util
+from pathlib import Path
+import sys
+import types
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_ROOT = (
+    ROOT / 'src' / 'res' / 'scripts' / 'client' / 'gui' / 'mods' /
+    'offline_lan_0922')
+sys.path.insert(0, str(ROOT / 'launcher'))
+
+
+def _load(module_name):
+    for name in ('gui', 'gui.mods', 'gui.mods.offline_lan_0922'):
+        if name not in sys.modules:
+            module = types.ModuleType(name)
+            module.__path__ = [str(PACKAGE_ROOT)]
+            sys.modules[name] = module
+    full_name = 'gui.mods.offline_lan_0922.%s' % module_name
+    sys.modules.pop(full_name, None)
+    spec = importlib.util.spec_from_file_location(
+        full_name, PACKAGE_ROOT / ('%s.py' % module_name))
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[full_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+gunnery = _load('bot_gunnery')
+
+
+class SkillTierTableTests(unittest.TestCase):
+    def test_the_tiers_are_ordered_from_the_weakest_to_the_best_gunner(self):
+        """Every knob has to move the same way, or a preset means nothing."""
+        rows = [gunnery.skill_parameters(skill)
+                for skill in gunnery.SKILL_TIERS]
+        for name in ('reaction_seconds', 'converged_factor',
+                     'aim_bias_factor', 'lead_error'):
+            values = [row[name] for row in rows]
+            self.assertEqual(sorted(values, reverse=True), values, name)
+            self.assertEqual(len(set(values)), len(values), name)
+        for name in ('crew_level', 'patience_seconds'):
+            values = [row[name] for row in rows]
+            self.assertEqual(sorted(values), values, name)
+            self.assertEqual(len(set(values)), len(values), name)
+
+    def test_every_crew_level_is_one_1513_can_train(self):
+        for skill in gunnery.SKILL_TIERS:
+            level = gunnery.crew_level(skill)
+            self.assertGreaterEqual(level, 50)
+            self.assertLessEqual(level, 100)
+        self.assertEqual(100, gunnery.crew_level(gunnery.SKILL_ELITE))
+
+    def test_unknown_names_fall_back_instead_of_raising(self):
+        for value in (None, '', 'perfect', 7, object()):
+            self.assertEqual(gunnery.DEFAULT_SKILL,
+                             gunnery.normalize_skill(value))
+            self.assertEqual(gunnery.DEFAULT_SKILL_MODE,
+                             gunnery.normalize_skill_mode(value))
+
+    def test_every_preset_is_a_complete_distribution(self):
+        for mode in gunnery.SKILL_MODES:
+            weights = gunnery._MODE_WEIGHTS[mode]
+            self.assertEqual(len(gunnery.SKILL_TIERS), len(weights), mode)
+            self.assertAlmostEqual(1.0, sum(weights), places=6, msg=mode)
+            self.assertTrue(all(weight >= 0.0 for weight in weights), mode)
+
+
+class SkillResolutionTests(unittest.TestCase):
+    def _roster(self, mode, round_id=5):
+        return [gunnery.resolve_skill(mode, round_id, team, slot)
+                for team in (1, 2) for slot in range(15)]
+
+    def test_one_slot_resolves_the_same_way_everywhere(self):
+        first = gunnery.resolve_skill('mixed', 9, 2, 4)
+        self.assertEqual(first, gunnery.resolve_skill('mixed', 9, 2, 4))
+        self.assertIn(first, gunnery.SKILL_TIERS)
+
+    def test_the_brutal_preset_is_every_bot_elite(self):
+        self.assertEqual(
+            set([gunnery.SKILL_ELITE]), set(self._roster('brutal')))
+
+    def test_the_easy_preset_never_produces_a_strong_gunner(self):
+        for round_id in range(1, 40):
+            roster = self._roster('easy', round_id)
+            self.assertEqual(
+                set(), set(roster) & set(
+                    (gunnery.SKILL_VETERAN, gunnery.SKILL_ELITE)))
+
+    def test_the_pub_mix_spreads_over_the_whole_ladder(self):
+        seen = set()
+        for round_id in range(1, 20):
+            seen.update(self._roster('mixed', round_id))
+        self.assertEqual(set(gunnery.SKILL_TIERS), seen)
+
+    def test_a_preset_roughly_matches_its_own_weights(self):
+        counts = dict((skill, 0) for skill in gunnery.SKILL_TIERS)
+        rounds = 400
+        for round_id in range(rounds):
+            for skill in self._roster('mixed', round_id):
+                counts[skill] += 1
+        total = float(sum(counts.values()))
+        for index, skill in enumerate(gunnery.SKILL_TIERS):
+            expected = gunnery._MODE_WEIGHTS['mixed'][index]
+            self.assertAlmostEqual(
+                expected, counts[skill] / total, delta=0.03, msg=skill)
+
+    def test_an_unknown_preset_still_resolves_a_supported_tier(self):
+        self.assertIn(
+            gunnery.resolve_skill('impossible', 3, 1, 0), gunnery.SKILL_TIERS)
+
+
+class EngagementErrorTests(unittest.TestCase):
+    def test_the_same_engagement_epoch_reproduces_the_same_gunner(self):
+        first = gunnery.engagement_error('regular', 5, 11, ('human', 2), 3)
+        second = gunnery.engagement_error('regular', 5, 11, ('human', 2), 3)
+        self.assertEqual(first, second)
+
+    def test_a_new_epoch_re_lays_the_gun(self):
+        errors = [gunnery.engagement_error('regular', 5, 11, ('human', 2), n)
+                  for n in range(6)]
+        self.assertGreater(len(set(error['radius'] for error in errors)), 1)
+
+    def test_the_radius_stays_inside_the_tier_envelope(self):
+        for epoch in range(500):
+            error = gunnery.engagement_error(
+                'rookie', 5, 11, ('bot', 12), epoch)
+            self.assertGreaterEqual(error['radius'], 0.0)
+            self.assertLessEqual(error['radius'], 1.0)
+            self.assertGreaterEqual(error['azimuth'], 0.0)
+
+    def test_the_lead_error_is_bounded_by_the_tier(self):
+        for skill in gunnery.SKILL_TIERS:
+            bound = gunnery.skill_parameters(skill)['lead_error']
+            for epoch in range(200):
+                scale = gunnery.engagement_error(
+                    skill, 5, 11, ('human', 2), epoch)['lead_scale']
+                self.assertGreaterEqual(scale, 1.0 - bound - 1e-9)
+                self.assertLessEqual(scale, 1.0 + bound + 1e-9)
+
+    def test_the_aim_offset_grows_with_range_and_with_the_gun_circle(self):
+        error = {'radius': 1.0, 'azimuth': 0.0}
+        near = gunnery.aim_offset_metres('rookie', error, 0.0035, 100.0)
+        far = gunnery.aim_offset_metres('rookie', error, 0.0035, 200.0)
+        wide = gunnery.aim_offset_metres('rookie', error, 0.0070, 100.0)
+        self.assertAlmostEqual(2.0 * near[0], far[0], places=6)
+        self.assertAlmostEqual(2.0 * near[0], wide[0], places=6)
+
+    def test_a_better_gunner_lays_the_gun_closer_to_the_centre(self):
+        error = {'radius': 1.0, 'azimuth': 0.0}
+        offsets = [abs(gunnery.aim_offset_metres(
+            skill, error, 0.0035, 300.0)[0]) for skill in gunnery.SKILL_TIERS]
+        self.assertEqual(sorted(offsets, reverse=True), offsets)
+
+    def test_a_long_shot_never_aims_at_the_sky(self):
+        error = {'radius': 1.0, 'azimuth': 0.5 * 3.14159265}
+        lateral, vertical = gunnery.aim_offset_metres(
+            'rookie', error, 0.0035, 100000.0)
+        self.assertLessEqual(abs(lateral), gunnery.MAX_AIM_OFFSET_METRES)
+        self.assertLessEqual(
+            abs(vertical),
+            gunnery.MAX_AIM_OFFSET_METRES * gunnery.VERTICAL_BIAS_SHARE)
+
+    def test_a_missing_gun_circle_removes_the_bias_instead_of_raising(self):
+        error = {'radius': 1.0, 'azimuth': 0.0}
+        self.assertEqual(
+            (0.0, 0.0), gunnery.aim_offset_metres('rookie', error, 0.0, 100.0))
+        self.assertEqual(
+            (0.0, 0.0),
+            gunnery.aim_offset_metres('rookie', error, 0.0035, 0.0))
+        self.assertEqual(
+            (0.0, 0.0), gunnery.aim_offset_metres('rookie', {}, 0.0035, 100.0))
+
+
+class FireGateTests(unittest.TestCase):
+    def test_no_tier_fires_before_it_has_reacted(self):
+        for skill in gunnery.SKILL_TIERS:
+            reaction = gunnery.skill_parameters(skill)['reaction_seconds']
+            self.assertFalse(gunnery.may_fire(skill, reaction - 0.01, 99.0,
+                                              1.0))
+            self.assertTrue(gunnery.may_fire(skill, reaction, 0.0, 1.0))
+
+    def test_a_converged_circle_fires_without_spending_the_patience(self):
+        params = gunnery.skill_parameters('veteran')
+        self.assertTrue(gunnery.may_fire(
+            'veteran', params['reaction_seconds'], 0.0,
+            params['converged_factor']))
+        self.assertFalse(gunnery.may_fire(
+            'veteran', params['reaction_seconds'], 0.0,
+            params['converged_factor'] + 0.01))
+
+    def test_a_better_tier_never_opens_fire_later_than_its_own_patience(self):
+        for skill in gunnery.SKILL_TIERS:
+            params = gunnery.skill_parameters(skill)
+            self.assertTrue(gunnery.may_fire(
+                skill,
+                params['reaction_seconds'] + params['patience_seconds'],
+                params['patience_seconds'], float('inf')))
+
+    def test_a_moving_bot_still_fires_once_its_patience_expires(self):
+        params = gunnery.skill_parameters('elite')
+        self.assertFalse(gunnery.may_fire(
+            'elite', 30.0, params['patience_seconds'] - 0.01, 6.0))
+        self.assertTrue(gunnery.may_fire(
+            'elite', 30.0, params['patience_seconds'], 6.0))
+
+    def test_only_the_opening_shot_waits_for_the_aiming_circle(self):
+        """After the first shot the gun's own reload owns the cadence."""
+        self.assertFalse(gunnery.may_fire('elite', 300.0, 0.0, 6.0))
+        self.assertTrue(
+            gunnery.may_fire('elite', 300.0, 0.0, 6.0, opening_shot=False))
+
+    def test_a_better_tier_never_fires_a_follow_up_later_than_a_worse_one(self):
+        """The ladder must not invert on a fast or clip gun."""
+        for bloom in (1.0, 2.0, 4.2, float('inf')):
+            for laying in (0.0, 0.3, 1.0, 3.0):
+                allowed = [gunnery.may_fire(skill, 300.0, laying, bloom,
+                                            opening_shot=False)
+                           for skill in gunnery.SKILL_TIERS]
+                self.assertEqual(
+                    sorted(allowed), allowed,
+                    'bloom=%r laying=%r' % (bloom, laying))
+
+    def test_an_unusable_clock_holds_fire_instead_of_guessing(self):
+        self.assertFalse(gunnery.may_fire('regular', float('nan'), 0.0, 1.0))
+        self.assertFalse(gunnery.may_fire('regular', 5.0, 0.0, float('nan')))
+        self.assertFalse(gunnery.may_fire('regular', None, 0.0, 1.0))
+
+    def test_an_infinite_circle_waits_for_the_patience_bound(self):
+        params = gunnery.skill_parameters('regular')
+        self.assertFalse(gunnery.may_fire(
+            'regular', 30.0, params['patience_seconds'] - 0.01, float('inf')))
+        self.assertTrue(gunnery.may_fire(
+            'regular', 30.0, params['patience_seconds'], float('inf')))
+
+
+class SkillVocabularyParityTests(unittest.TestCase):
+    """One vocabulary, four owners: worker, wire, room panel and launcher."""
+
+    def test_the_launcher_offers_the_same_tiers_as_the_worker(self):
+        import bot_lineup_profiles
+
+        self.assertEqual(
+            tuple(gunnery.SKILL_TIERS),
+            tuple(bot_lineup_profiles.BOT_SKILL_TIERS_0922))
+
+    def test_the_waiting_room_offers_every_preset_in_order(self):
+        waiting_room_ui = _load('waiting_room_ui')
+
+        self.assertEqual(
+            tuple(gunnery.SKILL_MODES),
+            tuple(value for value, unused_label
+                  in waiting_room_ui.BOT_SKILL_OPTIONS))
+
+    def test_the_wire_accepts_exactly_the_supported_presets(self):
+        lan_client = _load('lan_client')
+
+        self.assertEqual(
+            frozenset(gunnery.SKILL_MODES), lan_client.BOT_SKILL_MODES)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_port_0922_bot_gunnery.py
+++ b/tests/test_port_0922_bot_gunnery.py
@@ -42,10 +42,15 @@ class SkillTierTableTests(unittest.TestCase):
             values = [row[name] for row in rows]
             self.assertEqual(sorted(values, reverse=True), values, name)
             self.assertEqual(len(set(values)), len(values), name)
-        for name in ('crew_level', 'patience_seconds'):
+        for name in ('patience_seconds',):
             values = [row[name] for row in rows]
             self.assertEqual(sorted(values), values, name)
             self.assertEqual(len(set(values)), len(values), name)
+        # The crew level only has to never fall, because it is the one knob
+        # that also moves view range and reload; tiers are allowed to share
+        # a full crew and separate on gunnery alone.
+        levels = [row['crew_level'] for row in rows]
+        self.assertEqual(sorted(levels), levels)
 
     def test_every_crew_level_is_one_1513_can_train(self):
         for skill in gunnery.SKILL_TIERS:
@@ -53,6 +58,17 @@ class SkillTierTableTests(unittest.TestCase):
             self.assertGreaterEqual(level, 50)
             self.assertLessEqual(level, 100)
         self.assertEqual(100, gunnery.crew_level(gunnery.SKILL_ELITE))
+
+    def test_only_the_two_weaker_tiers_train_below_a_full_crew(self):
+        """The crew level is deliberately not the knob that ranks tiers.
+
+        It also shortens view range and slows reload, so spending it on every
+        tier would turn a gunnery preset into a spotting preset.  Veteran and
+        elite share #1513's full crew and separate on the gunner model alone.
+        """
+        self.assertEqual(
+            [75, 90, 100, 100],
+            [gunnery.crew_level(skill) for skill in gunnery.SKILL_TIERS])
 
     def test_unknown_names_fall_back_instead_of_raising(self):
         for value in (None, '', 'perfect', 7, object()):

--- a/tests/test_port_0922_bot_lineup_integration.py
+++ b/tests/test_port_0922_bot_lineup_integration.py
@@ -173,6 +173,7 @@ class BotLineupIntegrationTests(unittest.TestCase):
         editor._rows = {(2, 0): {
             "nation": _Variable("germany"),
             "vehicle": _Variable("Leichttraktor"),
+            "skill": _Variable("Veteran"),
             "vehicle_box": _Combo(0),
         }}
         editor._on_save = saved.append
@@ -187,6 +188,7 @@ class BotLineupIntegrationTests(unittest.TestCase):
         assignments = self._ui_saved_assignment()
         expected_name = "germany:G12_Ltraktor"
         self.assertEqual(expected_name, assignments[0]["vehicle"])
+        self.assertEqual("veteran", assignments[0]["skill"])
 
         environment = launcher_core.server_environment(
             launcher_core.PORT_0_9_22, "/game", {},

--- a/tests/test_port_0922_bot_runtime.py
+++ b/tests/test_port_0922_bot_runtime.py
@@ -8231,8 +8231,8 @@ class BotRuntimeTests(unittest.TestCase):
         self.runtime.battle_start(dict(self.start, bot_skill_mode='easy'))
 
         self.assertEqual('rookie', self.runtime.bot_skill(11))
-        self.assertEqual(50, self.runtime.bot_crew_level(11))
-        self.assertIn(50, self.crew_levels)
+        self.assertEqual(75, self.runtime.bot_crew_level(11))
+        self.assertIn(75, self.crew_levels)
         self.assertNotIn(None, self.crew_levels)
 
     def test_a_weaker_crew_aims_more_slowly_and_scatters_further(self):

--- a/tests/test_port_0922_bot_runtime.py
+++ b/tests/test_port_0922_bot_runtime.py
@@ -1297,21 +1297,31 @@ class BotRuntimeTests(unittest.TestCase):
         self._native_attribute_factors = self.module.loadout.attribute_factors
         crew_factor = 0.57 + 0.0043 * 110.0
         crew_multiplier = 1.0 / crew_factor
+        self.crew_levels = []
 
-        def test_attribute_factors(unused_descriptor, crew=None):
+        def test_attribute_factors(unused_descriptor, crew=None,
+                                   crew_level=None):
             self.assertIsNone(crew)
+            self.crew_levels.append(crew_level)
+            # A Bot skill tier trains its generated default crew below the
+            # maximum, so the fixture has to answer at that level too; a
+            # constant here would hide the tier before it reached the gun.
+            level = (100.0 if crew_level is None else
+                     max(50.0, min(100.0, float(crew_level))))
+            tier_factor = 0.57 + 0.0043 * level * 1.1
+            tier_multiplier = 1.0 / tier_factor
             return {
-                'turret/rotationSpeed': crew_factor,
-                'gun/rotationSpeed': crew_factor,
-                'gun/reloadTime': crew_multiplier,
-                'gun/aimingTime': crew_multiplier,
-                'shotDispersion': (crew_multiplier,),
+                'turret/rotationSpeed': tier_factor,
+                'gun/rotationSpeed': tier_factor,
+                'gun/reloadTime': tier_multiplier,
+                'gun/aimingTime': tier_multiplier,
+                'shotDispersion': (tier_multiplier,),
                 'repairSpeed': 0.57,
                 'vehicle/rotationSpeed': 1.0,
                 'engine/power': 1.0,
                 'chassis/terrainResistance': (1.0, 1.0, 1.0),
                 'radio/distance': 1.0,
-                'circularVisionRadius': 1.0,
+                'circularVisionRadius': tier_factor / crew_factor,
                 'camouflage': 0.57,
             }
 
@@ -1329,7 +1339,12 @@ class BotRuntimeTests(unittest.TestCase):
             physics_ground_probe=lambda unused_x, unused_z, unused_hint: 0.0,
             spawn_resolver=_spawn_resolver,
             baked_graph=_graph())
+        # Pin the room's Bot skill preset so every unrelated gun, reload and
+        # view-range assertion below keeps the exact 100 percent default crew
+        # it was written against.  The tiers themselves are covered by their
+        # own tests and by test_port_0922_bot_gunnery.
         self.start = {'round_id': 5, 'map': '01_karelia', 'bot_authority_id': 1,
+                      'bot_skill_mode': 'brutal',
                       'bots': [{'id': 11, 'team': 2, 'slot': 0, 'name': 'Bot'}]}
 
     def tearDown(self):
@@ -1403,8 +1418,8 @@ class BotRuntimeTests(unittest.TestCase):
         original_factors = self.module.loadout.attribute_factors
         original_derive = self.module.vehicle_physics.derive_params
 
-        def factors(actual, crew=missing):
-            factor_calls.append((actual, crew))
+        def factors(actual, crew=missing, crew_level=missing):
+            factor_calls.append((actual, crew, crew_level))
             return expected_factors
 
         def derive(actual, factors=missing):
@@ -1414,7 +1429,7 @@ class BotRuntimeTests(unittest.TestCase):
         self.module.loadout.attribute_factors = factors
         self.module.vehicle_physics.derive_params = derive
         try:
-            result = self.module._bot_physics_params(descriptor)
+            result = self.module._bot_physics_params(descriptor, 75)
         finally:
             self.module.loadout.attribute_factors = original_factors
             self.module.vehicle_physics.derive_params = original_derive
@@ -1423,6 +1438,9 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertEqual(1, len(factor_calls))
         self.assertIs(descriptor, factor_calls[0][0])
         self.assertIsNone(factor_calls[0][1])
+        # The Bot skill tier's trained crew has to reach the native chain,
+        # not stop at the runtime helper that resolved it.
+        self.assertEqual(75, factor_calls[0][2])
         self.assertEqual(1, len(physics_calls))
         self.assertIs(descriptor, physics_calls[0][0])
         self.assertIs(expected_factors, physics_calls[0][1])
@@ -1484,7 +1502,8 @@ class BotRuntimeTests(unittest.TestCase):
     def test_every_bot_consumer_rejects_missing_default_crew_factors(self):
         descriptor = _combat_descriptor()
         original_factors = self.module.loadout.attribute_factors
-        self.module.loadout.attribute_factors = lambda unused, crew=None: None
+        self.module.loadout.attribute_factors = (
+            lambda unused, crew=None, crew_level=None: None)
         self.runtime._repair_factors = {}
         try:
             consumers = (
@@ -1512,7 +1531,7 @@ class BotRuntimeTests(unittest.TestCase):
         original_bot = self.module._bot_physics_params
         original_derive = self.module.vehicle_physics.derive_params
 
-        def bot_physics(actual):
+        def bot_physics(actual, crew_level=None):
             bot_calls.append(actual)
             return expected
 
@@ -5254,7 +5273,7 @@ class BotRuntimeTests(unittest.TestCase):
         calls = []
         original = self.module._bot_physics_params
 
-        def bot_physics(actual):
+        def bot_physics(actual, crew_level=None):
             calls.append(actual)
             return dict(expected)
 
@@ -5550,8 +5569,15 @@ class BotRuntimeTests(unittest.TestCase):
         result = self.runtime.update(.04, 1.46, players=player)
         bot = result[0]['bots'][0]
         self.assertEqual('bot_state', result[0]['type'])
-        self.assertGreater(bot['z'], 0.0); self.assertEqual(1, bot['fire_seq'])
+        self.assertGreater(bot['z'], 0.0)
         self.assertEqual(0, bot['shell_index'])
+        # The opening shot also waits for this Bot's gunner tier, which the
+        # banked-pose contract above is not about.
+        now = 1.46
+        while now < 8.0 and not self.runtime.states[11]['fire_seq']:
+            now += .04
+            self.runtime.update(.04, now, players=player)
+        self.assertEqual(1, self.runtime.states[11]['fire_seq'])
 
     def test_publication_sample_clock_tracks_integrated_time_not_callback_time(self):
         self.runtime.battle_start(self.start)
@@ -8109,9 +8135,9 @@ class BotRuntimeTests(unittest.TestCase):
             'yaw': 0.0, 'pitch': 0.0, 'flight_time': 0.1,
             'arc': 'low', '_origin': (0.0, 1.0, 0.0),
         }
-        freshness = [False, True]
+        freshness = [False]
         runtime._cadenced_ballistic_solution = lambda *unused, **kwargs: (
-            solution, freshness.pop(0))
+            solution, freshness[0])
         player = _admit_player({
             'id': 2, 'team': 1, 'alive': True,
             'x': 0.0, 'y': 1.0, 'z': 100.0,
@@ -8119,8 +8145,300 @@ class BotRuntimeTests(unittest.TestCase):
 
         stale = runtime.update(0.2, 1.0, players=[player])[0]['bots'][0]
         self.assertEqual(0, stale['fire_seq'])
-        fresh = runtime.update(0.2, 1.2, players=[player])[0]['bots'][0]
-        self.assertEqual(1, fresh['fire_seq'])
+
+        # A fresh solution admits exactly one shot, once the gunner has also
+        # spent its own tier opening delay.
+        freshness[0] = True
+        now, fired = 1.0, 0
+        while now < 8.0 and not fired:
+            now += 0.2
+            runtime.update(0.2, now, players=[player])
+            fired = runtime.states[11]['fire_seq']
+        self.assertEqual(1, fired)
+
+        # Going stale again holds the next shot even with the gun reloaded
+        # and the gunner long past every delay it has.
+        freshness[0] = False
+        runtime._gun_states[11].elapsed = 100.0
+        runtime.update(0.2, now + 0.2, players=[player])
+        self.assertEqual(1, runtime.states[11]['fire_seq'])
+
+    def _spend_gunner_delay(self, runtime, players, now=1.0, step=0.04,
+                            bot_id=11, hold_fire=True):
+        """Run the clock through this Bot's opening-shot delay, trigger held.
+
+        The tier's reaction and aiming patience are deliberate behaviour with
+        their own tests.  These callers measure fire bookkeeping instead, so
+        spend both with ``fire_allowed`` off - the gunner still tracks its
+        target through the ordinary solve - and let the caller's own next
+        tick take the shot.
+        """
+        params = self.module.bot_gunnery.skill_parameters(
+            runtime.bot_skill(bot_id))
+        deadline = (now + params['reaction_seconds'] +
+                    params['patience_seconds'])
+        command = (getattr(runtime.adapter, 'command', None)
+                   if hold_fire else None)
+        allowed = None if command is None else command.get('fire_allowed')
+        if command is not None:
+            command['fire_allowed'] = False
+        try:
+            while now + step < deadline:
+                now += step
+                runtime.update(step, now, players=players)
+        finally:
+            if command is not None:
+                command['fire_allowed'] = allowed
+        return now
+
+    def _gunnery_command(self):
+        return {
+            'target_yaw': 0.0, 'throttle': 0.0, 'turn': 0.0,
+            'shell_index': 0, 'fire_allowed': True,
+            'target_id': self.module.HUMAN_TARGET_ID_BASE + 2,
+            'fire_range': 500.0, 'combat_mode': 'engage',
+            'aim_position': (0.0, 10.5, 100.0),
+            'face_position': (0.0, 10.5, 100.0),
+            'move_position': (0.0, 0.0, 0.0),
+            'recovery_mode': 'arrived', 'movement_intent': False,
+        }
+
+    def _gunnery_runtime(self, command, round_id=None, **start_overrides):
+        runtime = self.module.BotRuntime(
+            1, descriptor_resolver=lambda unused: _combat_descriptor(
+                gun_speed=2.5),
+            adapter_factory=lambda *unused, **kwargs: _FixedAdapter(command),
+            direction_probe=lambda *unused: {'clear': True, 'slope': 0.0},
+            visibility_probe=lambda *unused: True,
+            firing_lane_probe=lambda *unused: True,
+            ground_probe=lambda *unused: 0.0,
+            physics_ground_probe=lambda *unused: 0.0,
+            spawn_resolver=_spawn_resolver, baked_graph=_graph())
+        start = dict(self.start, **start_overrides)
+        if round_id is not None:
+            start['round_id'] = round_id
+        runtime.battle_start(start)
+        runtime._next_observation = 100.0
+        runtime._next_shot_lane_refresh = 100.0
+        runtime._next_cover_refresh = 100.0
+        state = runtime.states[11]
+        state['x'], state['y'], state['z'], state['yaw'] = 0.0, 0.0, 0.0, 0.0
+        return runtime
+
+    def test_a_skill_tier_trains_the_generated_default_crew(self):
+        """The crew level is the one real #1513 half of a skill tier."""
+        self.crew_levels = []
+        self.runtime.battle_start(dict(self.start, bot_skill_mode='easy'))
+
+        self.assertEqual('rookie', self.runtime.bot_skill(11))
+        self.assertEqual(50, self.runtime.bot_crew_level(11))
+        self.assertIn(50, self.crew_levels)
+        self.assertNotIn(None, self.crew_levels)
+
+    def test_a_weaker_crew_aims_more_slowly_and_scatters_further(self):
+        rookie = self.module._BotGunState(
+            _combat_descriptor(),
+            crew_level=self.module.bot_gunnery.crew_level('rookie'))
+        elite = self.module._BotGunState(
+            _combat_descriptor(),
+            crew_level=self.module.bot_gunnery.crew_level('elite'))
+
+        self.assertGreater(rookie.aiming_time, elite.aiming_time)
+        self.assertGreater(
+            rookie.fully_aimed_dispersion, elite.fully_aimed_dispersion)
+        self.assertGreater(rookie.reload_full, elite.reload_full)
+
+    def test_the_room_preset_resolves_every_slot_without_a_lineup(self):
+        self.runtime.battle_start(dict(self.start, bot_skill_mode='brutal'))
+
+        self.assertEqual('elite', self.runtime.bot_skill(11))
+        self.assertEqual(100, self.runtime.bot_crew_level(11))
+
+    def test_a_lineup_pin_overrides_the_room_preset_for_that_slot(self):
+        self.runtime.battle_start(dict(
+            self.start, bot_skill_mode='brutal',
+            bot_lineup=[{'team': 2, 'slot': 0, 'skill': 'rookie'}]))
+
+        self.assertEqual('rookie', self.runtime.bot_skill(11))
+
+    def test_an_unpinned_slot_keeps_the_room_preset(self):
+        self.runtime.battle_start(dict(
+            self.start, bot_skill_mode='brutal',
+            bot_lineup=[{'team': 1, 'slot': 4, 'skill': 'rookie'}]))
+
+        self.assertEqual('elite', self.runtime.bot_skill(11))
+
+    def test_the_manifest_publishes_each_bot_gunnery_tier(self):
+        messages = self.runtime.battle_start(
+            dict(self.start, bot_skill_mode='brutal'))
+
+        published = [state for message in messages
+                     for state in message.get('bots') or ()]
+        self.assertEqual(['elite'], [row['skill'] for row in published])
+
+    def test_a_takeover_installs_the_published_tier_not_a_new_roll(self):
+        """A second authority must not re-roll a Bot mid-round."""
+        manifest = self.runtime.battle_start(
+            dict(self.start, bot_skill_mode='brutal'))[0]
+        successor = self.module.BotRuntime(
+            2, descriptor_resolver=lambda unused: _combat_descriptor(),
+            adapter_factory=lambda *args: _Adapter(*args),
+            direction_probe=lambda *unused: {'clear': True, 'slope': 0.0},
+            ground_probe=lambda *unused: 0.0,
+            physics_ground_probe=lambda *unused: 0.0,
+            spawn_resolver=_spawn_resolver, baked_graph=_graph())
+
+        successor.battle_start(dict(
+            self.start, bot_authority_id=2, bot_skill_mode='easy',
+            bot_manifest=list(manifest['bots'])))
+
+        self.assertEqual('elite', successor.bot_skill(11))
+
+    def test_a_weak_gunner_lays_the_gun_off_the_target_centre(self):
+        command = self._gunnery_command()
+        player = _admit_player(
+            {'id': 2, 'team': 1, 'alive': True,
+             'x': 0.0, 'y': 10.5, 'z': 100.0})
+        offsets = {'rookie': [], 'elite': []}
+        # One seeded engagement is one draw from a half-normal, so average a
+        # spread of rounds instead of asserting on a single lucky gunner.
+        for round_id in range(1, 21):
+            for skill in offsets:
+                runtime = self._gunnery_runtime(
+                    command, round_id=round_id,
+                    bot_lineup=[{'team': 2, 'slot': 0, 'skill': skill}])
+                runtime.update(0.20, 1.0, players=[player])
+                aim = runtime._ballistic_solution_cache[11][2]['aim_position']
+                offsets[skill].append(math.sqrt(
+                    (aim[0] - 0.0) ** 2 + (aim[2] - 100.0) ** 2))
+
+        rookie = sum(offsets['rookie']) / len(offsets['rookie'])
+        elite = sum(offsets['elite']) / len(offsets['elite'])
+        self.assertGreater(rookie, 0.20)
+        self.assertGreater(rookie, elite * 5.0)
+
+    def test_a_better_tier_never_fires_a_clip_gun_less_often(self):
+        """The tier ladder must not invert on a gun that reloads fast."""
+        command = self._gunnery_command()
+        player = _admit_player(
+            {'id': 2, 'team': 1, 'alive': True,
+             'x': 0.0, 'y': 10.5, 'z': 100.0})
+        shots = {}
+        for skill in ('rookie', 'elite'):
+            runtime = self._gunnery_runtime(
+                command, bot_lineup=[{'team': 2, 'slot': 0, 'skill': skill}])
+            now = 1.0
+            for unused_step in range(200):
+                now += 0.05
+                published = runtime.update(0.05, now, players=[player])
+                shots[skill] = published[0]['bots'][0]['fire_seq']
+
+        self.assertGreater(shots['rookie'], 0)
+        self.assertGreaterEqual(shots['elite'], shots['rookie'])
+
+    def test_a_weak_gunner_mis_leads_a_moving_target(self):
+        command = self._gunnery_command()
+        player = _admit_player(
+            {'id': 2, 'team': 1, 'alive': True, 'yaw': 1.5707963,
+             'speed': 12.0, 'x': 0.0, 'y': 10.5, 'z': 100.0})
+        leads = {}
+        for skill in ('rookie', 'elite'):
+            runtime = self._gunnery_runtime(
+                command,
+                bot_lineup=[{'team': 2, 'slot': 0, 'skill': skill}])
+            state = runtime.states[11]
+            target = {
+                'kind': 'human', 'network_id': 2, 'id': 2,
+                'alive': True, 'visible': True,
+                'position': (0.0, 10.5, 100.0),
+                'yaw': 1.5707963, 'speed': 12.0}
+            aimed = runtime._aimed_target(state, target, 1.0)
+            lead = runtime._target_velocity(aimed)[0] / 12.0
+            leads[skill] = abs(1.0 - lead)
+
+        self.assertGreater(
+            self.module.bot_gunnery.skill_parameters('rookie')['lead_error'],
+            self.module.bot_gunnery.skill_parameters('elite')['lead_error'])
+        self.assertLessEqual(
+            leads['elite'],
+            self.module.bot_gunnery.skill_parameters('elite')['lead_error'])
+        self.assertLessEqual(
+            leads['rookie'],
+            self.module.bot_gunnery.skill_parameters('rookie')['lead_error'])
+
+    def test_a_bot_holds_fire_until_its_reaction_delay_expires(self):
+        command = self._gunnery_command()
+        player = _admit_player(
+            {'id': 2, 'team': 1, 'alive': True,
+             'x': 0.0, 'y': 10.5, 'z': 100.0})
+        runtime = self._gunnery_runtime(
+            command, bot_lineup=[{'team': 2, 'slot': 0, 'skill': 'rookie'}])
+        reaction = self.module.bot_gunnery.skill_parameters(
+            'rookie')['reaction_seconds']
+
+        now = 1.0
+        while now < 1.0 + reaction - 1.0e-6:
+            now += 0.05
+            published = runtime.update(0.05, now, players=[player])
+            self.assertEqual(
+                0, published[0]['bots'][0]['fire_seq'],
+                'a Bot fired %.2fs into a %.2fs reaction delay' % (
+                    now - 1.0, reaction))
+
+        fired = 0
+        while now < 1.0 + reaction + 4.0 and not fired:
+            now += 0.05
+            fired = runtime.update(
+                0.05, now, players=[player])[0]['bots'][0]['fire_seq']
+        self.assertEqual(1, fired)
+
+    def test_the_hold_survives_one_missing_target_frame(self):
+        """A gunner does not react to the same tank twice."""
+        command = self._gunnery_command()
+        state = self.runtime.states.get(11)
+        self.runtime.battle_start(self.start)
+        state = self.runtime.states[11]
+        target = {'kind': 'human', 'network_id': 2, 'id': 2, 'alive': True,
+                  'position': (0.0, 10.5, 100.0)}
+
+        self.assertEqual(
+            (0.0, 0.0, True),
+            self.runtime._track_gunnery_hold(state, target, 1.0))
+        self.assertIsNone(
+            self.runtime._track_gunnery_hold(state, None, 1.5))
+        self.assertEqual(
+            (2.0, 2.0, True),
+            self.runtime._track_gunnery_hold(state, target, 3.0))
+
+    def test_a_new_target_restarts_the_reaction_clock(self):
+        self.runtime.battle_start(self.start)
+        state = self.runtime.states[11]
+        first = {'kind': 'human', 'network_id': 2, 'id': 2, 'alive': True,
+                 'position': (0.0, 10.5, 100.0)}
+        second = dict(first, network_id=3, id=3)
+
+        self.runtime._track_gunnery_hold(state, first, 1.0)
+        self.assertEqual(
+            (2.0, 2.0, True),
+            self.runtime._track_gunnery_hold(state, first, 3.0))
+        self.assertEqual(
+            (0.0, 0.0, True),
+            self.runtime._track_gunnery_hold(state, second, 3.0))
+
+    def test_the_bots_own_shot_ends_the_opening_shot_of_an_engagement(self):
+        self.runtime.battle_start(self.start)
+        state = self.runtime.states[11]
+        target = {'kind': 'human', 'network_id': 2, 'id': 2, 'alive': True,
+                  'position': (0.0, 10.5, 100.0)}
+
+        self.runtime._track_gunnery_hold(state, target, 1.0)
+        state['fire_seq'] = 1
+        self.assertEqual(
+            (3.0, 0.0, False),
+            self.runtime._track_gunnery_hold(state, target, 4.0))
+        self.assertEqual(
+            (4.0, 1.0, False),
+            self.runtime._track_gunnery_hold(state, target, 5.0))
 
     def test_bot_fire_uses_turret_pitch_los_reload_clip_and_barrel_scatter(self):
         lane_probes = []
@@ -8193,7 +8511,13 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertEqual(1, fired['fire_seq'])
         self.assertIn('shot_yaw', fired)
         self.assertIn('shot_pitch', fired)
-        self.assertAlmostEqual(0.0, fired['aim_yaw'], places=6)
+        # The barrel points at this gunner's own aim point, which its tier
+        # lays a little off the target centre; the dispersed ray below is
+        # measured against that, not against a perfect solution.
+        self.assertLess(
+            abs(fired['aim_yaw']),
+            self.module.bot_gunnery.skill_parameters(
+                runtime.bot_skill(11))['aim_bias_factor'] * 0.1)
         self.assertGreater(fired['shot_pitch'], 0.0)
         self.assertEqual(1, runtime.states[11]['clip'])
         self.assertAlmostEqual(0.2, runtime.states[11]['reload_duration'])
@@ -8301,10 +8625,13 @@ class BotRuntimeTests(unittest.TestCase):
         player = _admit_player({'id': 2, 'team': 1, 'alive': True,
                                 'x': 0.0, 'y': 0.0, 'z': 100.0})
         runtime.states[11].update(x=0.0, y=0.0, z=0.0, yaw=0.0)
-        blocked = runtime.update(0.2, 1.0, players=[player])[0]['bots'][0]
+        now = self._spend_gunner_delay(runtime, [player])
+        blocked = runtime.update(
+            0.15, now + 0.15, players=[player])[0]['bots'][0]
         self.assertEqual(0, blocked['fire_seq'])
         self.assertNotIn(11, runtime._ballistic_solution_cache)
-        fired = runtime.update(0.2, 1.2, players=[player])[0]['bots'][0]
+        fired = runtime.update(
+            0.15, now + 0.30, players=[player])[0]['bots'][0]
         self.assertEqual(1, fired['fire_seq'])
         self.assertTrue(runtime.states[11]['gun_aligned'])
         self.assertLess(fired['gun_pitch'], 0.0)
@@ -8453,8 +8780,12 @@ class BotRuntimeTests(unittest.TestCase):
         }
         player = _admit_player(player)
 
+        # The first callback acquires the target; the second is long enough
+        # for the gunner to spend its tier reaction.  The SPG is stationary,
+        # so its aiming circle is already converged.
+        runtime.update(0.04, 1.0, players=[player])
         pending = runtime.update(
-            0.04, 1.0, players=[player])[0]['bots'][0]
+            0.40, 1.40, players=[player])[0]['bots'][0]
         self.assertEqual(0, pending['fire_seq'])
         self.assertEqual((0, 1), (
             pending['shell_index'], pending['next_shell_index']))
@@ -8462,7 +8793,7 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertEqual(1, calls[0][3])
         self.assertEqual(0, calls[0][2])
 
-        fired_message = runtime.update(0.04, 1.04, players=[player])[0]
+        fired_message = runtime.update(0.04, 1.44, players=[player])[0]
         fired = fired_message['bots'][0]
         launch = fired_message['launches'][0]
         self.assertEqual(1, fired['fire_seq'])
@@ -9673,7 +10004,7 @@ class BotRuntimeTests(unittest.TestCase):
         calls = []
         original = self.module._bot_physics_params
 
-        def bot_physics(descriptor):
+        def bot_physics(descriptor, crew_level=None):
             calls.append(descriptor)
             mass = 31000.0 if descriptor is travel else 32000.0
             return dict(base_params, mass=mass)
@@ -9951,7 +10282,7 @@ class BotRuntimeTests(unittest.TestCase):
         original_attribute_factors = self.module.loadout.attribute_factors
         original_modifiers = self.module.loadout.modifiers
 
-        def attribute_factors(value, crew=None):
+        def attribute_factors(value, crew=None, crew_level=None):
             self.assertIsNone(crew)
             factor_calls.append(value)
             return {'source': '1513-default-crew'}
@@ -10031,11 +10362,15 @@ class BotRuntimeTests(unittest.TestCase):
         }
         player = _admit_player(player)
 
-        blocked = runtime.update(.04, 1.0, players=[player])[0]['bots'][0]
+        now = self._spend_gunner_delay(runtime, [player])
+        self.assertEqual([], probes)
+        blocked = runtime.update(
+            .15, now + .15, players=[player])[0]['bots'][0]
         self.assertEqual(0, blocked['fire_seq'])
         self.assertEqual(1, probes[0][2]['fire_seq'])
         self.assertNotIn(11, runtime._friendly_repositions)
-        fired = runtime.update(.15, 1.15, players=[player])[0]['bots'][0]
+        fired = runtime.update(
+            .15, now + .30, players=[player])[0]['bots'][0]
         self.assertEqual(1, fired['fire_seq'])
         self.assertEqual([1, 1], [item[2]['fire_seq'] for item in probes])
         self.assertEqual(
@@ -10092,14 +10427,15 @@ class BotRuntimeTests(unittest.TestCase):
         }
         player = _admit_player(player)
 
-        runtime.update(.04, 1.0, players=[player])
+        now = self._spend_gunner_delay(runtime, [player]) + .04
+        runtime.update(.04, now, players=[player])
         self.assertIn(11, runtime._friendly_repositions)
         self.assertEqual(1, state['fire_seq'])
         start_position = self.module._position(state)
         moved = False
         for index in range(1, 151):
             runtime.update(
-                .04, 1.0 + .04 * index, players=[player])
+                .04, now + .04 * index, players=[player])
             if self.module._distance(
                     start_position, self.module._position(state)) > 0.05:
                 moved = True
@@ -10161,13 +10497,14 @@ class BotRuntimeTests(unittest.TestCase):
         }
         player = _admit_player(player)
 
-        runtime.update(.04, 1.0, players=[player])
+        now = self._spend_gunner_delay(runtime, [player]) + .04
+        runtime.update(.04, now, players=[player])
         self.assertIn(11, runtime._friendly_repositions)
         initial_position = self.module._position(state)
         initial_ammo = list(state['ammo_remaining'])
         expired = False
         for index in range(1, 140):
-            runtime.update(.04, 1.0 + .04 * index, players=[player])
+            runtime.update(.04, now + .04 * index, players=[player])
             if 11 not in runtime._friendly_repositions:
                 expired = True
                 break
@@ -10368,13 +10705,17 @@ class BotRuntimeTests(unittest.TestCase):
         }
         player = _admit_player(player)
 
-        blocked = runtime.update(.04, 1.0, players=[player])[0]['bots'][0]
+        # The first callback acquires the target; the second is long enough
+        # for the gunner to spend its tier reaction.  The SPG is stationary,
+        # so its aiming circle is already converged.
+        runtime.update(.04, 1.0, players=[player])
+        blocked = runtime.update(.40, 1.40, players=[player])[0]['bots'][0]
         self.assertEqual(0, blocked['fire_seq'])
         self.assertNotIn(11, runtime._artillery_intents)
         self.assertNotIn(11, runtime._artillery_reproofs)
         destination = runtime._friendly_repositions[11]['destination']
         state['x'], state['y'], state['z'] = destination
-        fired = runtime.update(.15, 1.15, players=[player])[0]['bots'][0]
+        fired = runtime.update(.15, 1.55, players=[player])[0]['bots'][0]
         self.assertEqual(1, fired['fire_seq'])
         self.assertEqual(2, len(probes))
 
@@ -14701,6 +15042,9 @@ class BotRuntimeTests(unittest.TestCase):
             }), server.last_bot_state_reject)
         start = server.current_battle_message()
         start['bot_authority_id'] = 1
+        # The room preset travels with the round, so the successor installs
+        # the same gunner tier and therefore the same reload contract.
+        start['bot_skill_mode'] = self.start['bot_skill_mode']
         takeover = self.module.BotRuntime(
             1, descriptor_resolver=lambda unused: _combat_descriptor(),
             adapter_factory=lambda *args, **kwargs: _Adapter(*args),

--- a/tests/test_port_0922_server_team_size.py
+++ b/tests/test_port_0922_server_team_size.py
@@ -121,6 +121,69 @@ class ServerTeamSizeTests(unittest.TestCase):
             guest.player_id, 'same'))
         self.assertEqual('random', state.bot_tier_mode)
 
+    def test_host_can_select_a_bot_skill_preset(self):
+        self.assertIn('set_bot_skill_mode', MODERN_VISIBLE_MESSAGE_TYPES)
+        state = BattleState()
+        host, error = state.add_player(
+            _Connection(), ('10.0.0.1', 1000), _hello(1))
+        self.assertIsNone(error)
+
+        self.assertEqual('mixed', state.bot_skill_mode)
+        self.assertEqual((True, None), state.set_bot_skill_mode(
+            host.player_id, 'brutal'))
+        self.assertEqual('brutal', state.bot_skill_mode)
+        self.assertEqual(
+            'brutal', state.lobby_message()['bot_skill_mode'])
+
+    def test_guest_cannot_select_a_bot_skill_preset(self):
+        state = BattleState()
+        unused_host, error = state.add_player(
+            _Connection(), ('10.0.0.1', 1000), _hello(1))
+        self.assertIsNone(error)
+        guest, error = state.add_player(
+            _Connection(), ('10.0.0.2', 1001), _hello(2))
+        self.assertIsNone(error)
+
+        self.assertEqual((False, 'host_only'), state.set_bot_skill_mode(
+            guest.player_id, 'easy'))
+        self.assertEqual('mixed', state.bot_skill_mode)
+
+    def test_an_unsupported_bot_skill_preset_is_refused(self):
+        state = BattleState()
+        host, error = state.add_player(
+            _Connection(), ('10.0.0.1', 1000), _hello(1))
+        self.assertIsNone(error)
+
+        self.assertEqual((False, 'invalid_mode'), state.set_bot_skill_mode(
+            host.player_id, 'perfect'))
+        self.assertEqual('mixed', state.bot_skill_mode)
+
+    def test_exact_lineup_may_pin_a_slot_skill_with_or_without_a_vehicle(self):
+        state = BattleState(bot_lineup=[
+            {'team': 1, 'slot': 0, 'skill': 'elite'},
+            {'team': 2, 'slot': 3, 'vehicle': 'germany:G12_Ltraktor',
+             'skill': 'rookie'},
+            {'team': 2, 'slot': 4, 'vehicle': 'germany:G12_Ltraktor'},
+        ])
+
+        self.assertEqual([
+            {'team': 1, 'slot': 0, 'skill': 'elite'},
+            {'team': 2, 'slot': 3, 'vehicle': 'germany:G12_Ltraktor',
+             'skill': 'rookie'},
+            {'team': 2, 'slot': 4, 'vehicle': 'germany:G12_Ltraktor'},
+        ], state.bot_lineup)
+
+    def test_exact_lineup_rejects_an_unsupported_slot_skill(self):
+        with self.assertRaises(ValueError):
+            BattleState(bot_lineup=[{
+                'team': 2, 'slot': 3,
+                'vehicle': 'germany:G12_Ltraktor', 'skill': 'perfect',
+            }])
+
+    def test_exact_lineup_rejects_a_slot_that_pins_nothing(self):
+        with self.assertRaises(ValueError):
+            BattleState(bot_lineup=[{'team': 2, 'slot': 3}])
+
     def test_exact_lineup_requires_unique_fully_qualified_slots(self):
         state = BattleState(bot_lineup=[{
             'team': 2, 'slot': 3,

--- a/tests/test_port_0922_simulation_worker.py
+++ b/tests/test_port_0922_simulation_worker.py
@@ -1626,6 +1626,7 @@ class SimulationWorkerSocketTests(unittest.TestCase):
                 'state_revision', 'spawn', 'bot_authority_id', 'team_size',
                 'authority_epoch', 'capabilities', 'server_capabilities',
                 'team_sizes', 'requested_team', 'bot_tier_mode',
+                'bot_skill_mode',
                 'worker_status', 'vehicle_compact_descr',
                 'effective_params',
             }, set(welcome))

--- a/tests/test_port_0922_waiting_room_ui.py
+++ b/tests/test_port_0922_waiting_room_ui.py
@@ -546,6 +546,69 @@ class WaitingRoomTests(unittest.TestCase):
         self.assertEqual(['same'], requested)
         self.assertIn('Same tier', room._labels['tier'].properties['text'])
 
+    def test_host_can_cycle_the_bot_skill_preset(self):
+        requested = []
+        skill_state = {'mode': 'mixed', 'supported': True}
+        room = self.module.WaitingRoomUI(
+            self._request_start, lambda: list(self.pool),
+            status=lambda: self.status, host=lambda: True,
+            surface=self.surface,
+            bot_skill_status=lambda: dict(skill_state),
+            request_bot_skill_mode=lambda mode: requested.append(mode) or True)
+
+        self.assertTrue(room.open())
+        for role in self.module._BOT_SKILL_CONTROLS:
+            self.assertTrue(room._controls[role].properties['visible'])
+        self.assertIn('Pub mix', room._labels['skill'].properties['text'])
+        self.assertTrue(room.activate('skill_next'))
+        self.assertEqual(['hard'], requested)
+        self.assertIn('Hard', room._labels['skill'].properties['text'])
+        self.assertTrue(room.activate('skill_previous'))
+        self.assertEqual(['hard', 'mixed'], requested)
+
+    def test_a_guest_never_sees_the_bot_skill_controls(self):
+        room = self.module.WaitingRoomUI(
+            self._request_start, lambda: list(self.pool),
+            status=lambda: self.status, host=lambda: False,
+            surface=self.surface,
+            bot_skill_status=lambda: {'mode': 'mixed', 'supported': True},
+            request_bot_skill_mode=lambda mode: True)
+
+        self.assertTrue(room.open())
+        for role in self.module._BOT_SKILL_CONTROLS:
+            self.assertFalse(room._controls[role].properties['visible'])
+
+    def test_a_denied_bot_skill_preset_retires_the_optimistic_label(self):
+        room = self.module.WaitingRoomUI(
+            self._request_start, lambda: list(self.pool),
+            status=lambda: self.status, host=lambda: True,
+            surface=self.surface,
+            bot_skill_status=lambda: {'mode': 'mixed', 'supported': True},
+            request_bot_skill_mode=lambda mode: True)
+
+        self.assertTrue(room.open())
+        self.assertTrue(room.activate('skill_next'))
+        self.assertIn('Hard', room._labels['skill'].properties['text'])
+        self.assertTrue(room.reject_bot_skill_mode('hard'))
+        self.assertIn('Pub mix', room._labels['skill'].properties['text'])
+
+    def test_the_bot_skill_row_never_overlaps_its_neighbours(self):
+        """Both preset rows and the map row share one narrow native panel."""
+        room = self.module.WaitingRoomUI(
+            self._request_start, lambda: list(self.pool),
+            status=lambda: self.status, host=lambda: True,
+            surface=self.surface)
+
+        self.assertTrue(room.open())
+        spans = []
+        for role in ('tier', 'skill', 'map'):
+            component = room._controls[role]
+            centre = component.properties['position'][1]
+            half = component.properties['height'] / 2.0
+            spans.append((centre - half, centre + half))
+        for lower, upper in zip(spans, spans[1:]):
+            self.assertGreater(lower[0], upper[1])
+
     def test_non_host_sees_capacities_but_not_size_controls(self):
         team_state = {
             'team': 2, 'sizes': {1: 4, 2: 6},


### PR DESCRIPTION
## Why

Bots read as unnaturally accurate, and the reason is not the aiming circle.

Confirmed from source on `origin/main`:

- Bots already run real mechanics: movement, rotation and turret bloom, the
  exponential aiming convergence, after-shot bloom, reload and clip clocks,
  turret traverse and gun pitch limits.
- The shot-ray sampling law (`bot_runtime._dispersed_barrel_angles`) is the
  same truncated half-normal the player's gun uses (`gun_mechanics.scatter`),
  so there is no Bot-side accuracy buff.
- The asymmetry is everything around the circle:
  1. the aim point is the exact target centre plus one metre, reached through
     an exact analytic intercept solve, so a moving target is led perfectly
     and there is no aim error at all;
  2. every Bot ran a 100 percent crew, because `attribute_factors` always
     asked `generateDefaultCrew` for `MAX_SKILL_LEVEL`;
  3. the fire gate was geometric alignment plus reload plus a clear lane, and
     the live dispersion factor was never read, so there was no reaction time
     and no notion of waiting until aimed.

A stationary Bot tracking a target therefore fired a fully converged circle
centred on a perfectly predicted point, which is strictly better than a good
human.

## What this changes

`bot_gunnery.py` owns Bot gunnery skill in two clearly separated halves.

**A real shipped mechanic.** `crew_level` selects the level passed to
`items.utils.generateDefaultCrew`, so a weaker tier inherits #1513's own
longer aiming time, wider fully-aimed dispersion, slower reload, slower
turret and shorter view range. No coefficient there is invented.

**An explicit human-gunner model**, labelled as one in the module: a reaction
delay, a bounded wait for the aiming circle before the opening shot, a slowly
drifting aim-point bias measured as a multiple of the gun's own fully-aimed
dispersion, and an imperfect lead on a moving target. These are a product
choice for this project, not retail data.

| tier | crew | reaction | patience | aimed at | aim bias | lead error |
|---|---|---|---|---|---|---|
| rookie | 75 | 1.20 s | 0.60 s | 2.60x | 1.80x | ±45% |
| regular | 90 | 0.75 s | 1.10 s | 1.80x | 0.85x | ±22% |
| veteran | 100 | 0.45 s | 1.70 s | 1.35x | 0.35x | ±9% |
| elite | 100 | 0.25 s | 2.40 s | 1.12x | 0.10x | ±2% |

The crew level is deliberately not the knob that ranks the ladder. It also
shortens view range and slows reload, so only the two weaker tiers spend it
at all; veteran and elite share #1513's full crew and separate on the gunner
model alone. This keeps a gunnery preset from quietly becoming a spotting
preset.

Only the opening shot of an engagement waits for the circle. Every gun blooms
after firing, so a better tier - which accepts a tighter circle and waits
longer for it - would otherwise fire a fast or clip gun less often than a
worse tier holding the same gun, and the whole ladder would invert. After the
opening shot the gun's own reload owns the cadence, while the aim bias and
the lead error keep separating the tiers on every round.

The gunner check is the last term of the fire gate, after the shot-lane
probe, so it only decides whether an already admitted shot leaves. The lane
receipt keeps refreshing while the gunner reacts and lays, and team-spotting
projection, lane diagnostics and probe fairness behave as they did before.

Every draw is seeded from stable round, Bot and target identity, so an
authority takeover reproduces the same gunner instead of re-rolling one, and
the resolved tier also rides the authority manifest.

## Choosing the enemy

- The waiting room gains a `BOT SKILL` row next to `BOT TIER`, host only,
  with five presets: Easy, Relaxed, Pub mix (default), Hard, Brutal. Each is
  a distribution over the four tiers; Brutal is every Bot elite, and Easy is
  85 percent rookie.
- The launcher's exact Bot lineup editor gains a Skill column per slot. A
  slot may now pin its vehicle, its tier, or both, so a lineup can set one
  slot's gunner without also pinning what it drives.
- `set_bot_skill_mode` mirrors `set_bot_tier_mode` end to end: room option,
  host-only guard, denial message, client allowlist, waiting-room control.

## Tests

- `tests/test_port_0922_bot_gunnery.py`: tier ordering, preset
  distributions, deterministic per-slot resolution, bounded aim and lead
  error, the fire gate including the ladder-cannot-invert property, and
  vocabulary parity across worker, wire, room panel and launcher.
- `tests/test_port_0922_bot_runtime.py`: crew level reaching the native
  factor boundary, lineup pin over preset, takeover keeping the published
  tier, manifest publication, a weak gunner laying off centre, a mis-led
  moving target, the reaction delay holding fire, and elite never firing a
  clip gun less often than rookie.
- Server, waiting-room, launcher profile and launcher UI tests for the new
  option, the skill-only lineup pin and the editor column.

## Not proved here

- A generated default crew below `MAX_SKILL_LEVEL` has never been exercised
  against #1513's own `items/utils`. If that client rejects one,
  `_bot_default_crew_factors` falls back to the maximum-level crew and logs
  it once, rather than refusing to start the round.
- The waiting-room layout change is proved only as geometry by a
  non-overlap test; how the new row renders needs the Windows client.
- How the tiers feel needs play on the exact client.