### PR TITLE
Let a wedged hull back out of a passage instead of turning in place

### DIFF
--- a/src/res/scripts/client/gui/mods/offline_lan_0922/ai/adapter.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/ai/adapter.py
@@ -143,7 +143,8 @@ class BotAdapter(object):
                 movement_intent=movement_intent,
                 stopping_distance=state.get('stopping_distance'),
                 stop_at_target=stop_at_target,
-                decision_horizon=float(state.get('decision_horizon', 0.0)))
+                decision_horizon=float(state.get('decision_horizon', 0.0)),
+                pose_clear=state.get('pose_clear'))
         # Preserve the mature face-position intent which is separate from the
         # gun target.  At a route/cover stop it gives armoured turreted tanks
         # their stable 12-30 degree hull angle while the turret keeps tracking

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/ai/driver.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/ai/driver.py
@@ -147,6 +147,7 @@ class LocalDriver(object):
 
 	def __init__(self, stuck_seconds=1.8, recovery_seconds=0.85,
 			failure_ttl=2.0):
+		self._probe_takes_distance = True
 		self.stuck_seconds = max(0.4, float(stuck_seconds))
 		self.recovery_seconds = max(0.25, float(recovery_seconds))
 		self.failure_ttl = max(0.25, float(failure_ttl))
@@ -288,9 +289,31 @@ class LocalDriver(object):
 			return neighbour.get('position') or neighbour.get('pos')
 		return neighbour
 
-	def _clear(self, direction_clear, yaw):
+	def _clear(self, direction_clear, yaw, maximum_distance=None):
+		"""Ask one probe about a heading, optionally over a bounded distance.
+
+		A recovery manoeuvre travels a hull length, not the fifteen to twenty
+		metre travel horizon the ordinary drive candidates are ranked over.
+		Probes that predate the bounded form keep the unbounded answer.
+		"""
+		if maximum_distance is not None and self._probe_takes_distance:
+			try:
+				return bool(direction_clear(yaw, maximum_distance))
+			except TypeError:
+				self._probe_takes_distance = False
+			except Exception:
+				return False
 		try:
 			return bool(direction_clear(yaw))
+		except Exception:
+			return False
+
+	@staticmethod
+	def _pose_fits(pose_clear, yaw):
+		if pose_clear is None:
+			return True
+		try:
+			return bool(pose_clear(yaw))
 		except Exception:
 			return False
 
@@ -357,10 +380,15 @@ class LocalDriver(object):
 				if self._obb_overlap(
 						sweep, float(yaw), sweep_length, half_width,
 						other, other_yaw, other_length, other_width):
+					# Name the hull that owns the blockage. A wedged tank whose
+					# only escape is occupied by a team mate is a queue the
+					# caller can resolve; an anonymous veto is not.
+					if isinstance(neighbour, dict) and neighbour.get('id') is not None:
+						return neighbour['id']
 					return True
 			except Exception:
 				continue
-		return False
+		return None
 
 	def _recovery_occupancy(self, position, yaw, direction, neighbours,
 			half_length, half_width):
@@ -414,6 +442,25 @@ class LocalDriver(object):
 			return 1.0
 		return self._fallback_recovery_side(state)
 
+	def _pivot_side_fits(self, pose_clear, yaw, direction):
+		"""Report whether the hull can sweep one in-place turn.
+
+		``direction_clear`` answers about a heading; it cannot answer about a
+		rotation, because the corners a turn sweeps are metres away from every
+		ray it casts. Inside a gateway, an alley or a bridge underpass those
+		corners are already at the walls, so an unchecked turn only grinds
+		them and the column behind never moves.
+		"""
+		if pose_clear is None:
+			return True
+		for fraction in RECOVERY_SWEEP_FRACTIONS:
+			if not self._pose_fits(
+					pose_clear,
+					float(yaw) + float(direction) *
+					RECOVERY_YAW_OFFSET * float(fraction)):
+				return False
+		return True
+
 	def _choose_yaw(self, state, desired_yaw, direction_clear):
 		# Teammate proximity never replaces the route with a repulsion heading.
 		# Crossing priority is coordinated separately; real contact owns overlap.
@@ -443,7 +490,7 @@ class LocalDriver(object):
 			neighbours, direction_clear, velocity=None,
 			half_length=3.5, half_width=1.7,
 			movement_intent=True, stopping_distance=None,
-			stop_at_target=True, decision_horizon=0.0):
+			stop_at_target=True, decision_horizon=0.0, pose_clear=None):
 		"""Return ``throttle``, ``turn``, ``target_yaw`` and ``recovery_mode``.
 
 		``team_slot`` is the explicit stable 0..14 formation slot. It must not be
@@ -564,10 +611,38 @@ class LocalDriver(object):
 					own_half_length, own_half_width)
 				state['recovery_side'] = direction
 			recovery_yaw = float(yaw) + direction * RECOVERY_YAW_OFFSET
-			if (not self._clear(direction_clear, float(yaw) + math.pi) or
-					self._reverse_blocked_by_vehicle(
-						position, yaw, neighbours,
-						own_half_length, own_half_width)):
+			# The escape is one bounded backing manoeuvre, so rank it over the
+			# distance it travels. Ranking it over the fifteen to twenty metre
+			# travel horizon rejects the rear of every gateway and alley on the
+			# map and leaves an in-place turn as the only recovery in exactly
+			# the places where a hull cannot turn.
+			escape_distance = own_half_length * 1.6
+			reverse_clear = self._clear(
+				direction_clear, float(yaw) + math.pi, escape_distance)
+			reverse_blocker = None
+			if reverse_clear:
+				reverse_blocker = self._reverse_blocked_by_vehicle(
+					position, yaw, neighbours,
+					own_half_length, own_half_width)
+			if not reverse_clear or reverse_blocker is not None:
+				if not self._pivot_side_fits(pose_clear, yaw, direction):
+					mirrored = -direction
+					if self._pivot_side_fits(pose_clear, yaw, mirrored):
+						state['recovery_side'] = direction = mirrored
+						recovery_yaw = float(yaw) + direction * RECOVERY_YAW_OFFSET
+					else:
+						# Neither rotation fits and the rear is denied. Hold the
+						# pose instead of grinding the corners, and publish the
+						# hull that owns the escape so the queue can clear it.
+						blocked = {
+							'throttle': 0.0,
+							'turn': 0.0,
+							'target_yaw': float(yaw),
+							'recovery_mode': 'blocked',
+						}
+						if reverse_blocker is not None:
+							blocked['reverse_blocked_by'] = reverse_blocker
+						return blocked
 				return {
 					'throttle': 0.0,
 					'turn': direction,
@@ -587,7 +662,8 @@ class LocalDriver(object):
 				if not self._clear(
 						direction_clear,
 						float(yaw) + math.pi +
-						direction * RECOVERY_YAW_OFFSET * fraction):
+						direction * RECOVERY_YAW_OFFSET * fraction,
+						escape_distance):
 					recovery_turn = 0.0
 					recovery_target = float(yaw)
 					break

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
@@ -105,6 +105,7 @@ class TerrainGrid(object):
 		# only the amount of side exploration changes.
 		self.heuristic_weight = 1.70
 		self._ground_cache = {}
+		self._corridor_cache = {}
 		self._edge_cache = {}
 		self._segment_cache = {}
 		self._failed_edges = {}
@@ -143,6 +144,72 @@ class TerrainGrid(object):
 		                       self.cell_size + 0.5)),
 		        int(math.floor((float(point[2]) - origin_z) /
 		                       self.cell_size + 0.5)))
+
+	# Four grid orientations name the shape a hull actually has to drive:
+	# the direction the baked cells run furthest in is the passage, and the
+	# span across it is the room the hull has to turn in.
+	_CORRIDOR_AXES = ((1, 0), (1, 1), (0, 1), (-1, 1))
+	CORRIDOR_SPAN_CELLS = 5
+
+	def local_corridor(self, point):
+		"""Return ``(axis_yaw, width)`` for the baked space around ``point``.
+
+		``width`` is the free span in metres across the longest local axis.
+		Returns ``None`` outside baked support, where there is no measured
+		passage and the caller must not invent one.
+		"""
+		if not self.prebaked:
+			return None
+		cell = self.cell_for(point)
+		if self._baked_index(cell) is None:
+			return None
+		cached = self._corridor_cache.get(cell)
+		if cached is not None:
+			return cached
+		spans = []
+		for axis_x, axis_z in self._CORRIDOR_AXES:
+			step = math.hypot(axis_x, axis_z) * self.cell_size
+			cells = 1
+			for sign in (1, -1):
+				for reach in range(1, self.CORRIDOR_SPAN_CELLS + 1):
+					probe = (cell[0] + axis_x * reach * sign,
+					         cell[1] + axis_z * reach * sign)
+					if self._baked_index(probe) is None:
+						break
+					cells += 1
+			spans.append(cells * step)
+		longest = max(range(len(spans)), key=lambda index: spans[index])
+		axis_x, axis_z = self._CORRIDOR_AXES[longest]
+		result = (math.atan2(float(axis_x), float(axis_z)),
+		          spans[(longest + 2) % len(self._CORRIDOR_AXES)])
+		self._corridor_cache[cell] = result
+		return result
+
+	def hull_pose_clear(self, point, yaw, half_length, half_width):
+		"""Report whether one chassis rectangle stands on baked cells.
+
+		A ray answers whether a direction is drivable; it cannot answer
+		whether a hull already standing here may rotate, because the corners
+		that a turn sweeps are metres away from every ray it casts. Sample
+		the real rectangle instead, so an in-place turn inside a gateway is
+		refused for the geometry that actually stops it.
+		"""
+		if not self.prebaked:
+			return True
+		half_length = max(0.5, float(half_length))
+		half_width = max(0.3, float(half_width))
+		forward = (math.sin(float(yaw)), math.cos(float(yaw)))
+		side = (math.cos(float(yaw)), -math.sin(float(yaw)))
+		for along in (-half_length, 0.0, half_length):
+			for across in (-half_width, 0.0, half_width):
+				sample = (float(point[0]) + forward[0] * along +
+				          side[0] * across,
+				          0.0,
+				          float(point[2]) + forward[1] * along +
+				          side[1] * across)
+				if self._baked_index(self.cell_for(sample)) is None:
+					return False
+		return True
 
 	def point_for(self, cell, height):
 		origin_x, origin_z = self._baked_origin if self.prebaked else (0.0, 0.0)

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -10255,17 +10255,20 @@ class BotRuntime(object):
             raw_command = None
             planner_probe_samples = {}
 
-            def planner_sample_direction(sample_yaw):
+            def planner_sample_direction(sample_yaw, maximum_distance=None):
                 # Invalid or unavailable baked data retains the mature native
                 # planner path.  These advisory samples never enter the motion
                 # cache and never authorize the finally selected direction.
                 normalised = ((float(sample_yaw) + math.pi) %
                               (2.0 * math.pi) - math.pi)
-                key = round(normalised, 4)
+                key = (round(normalised, 4),
+                       None if maximum_distance is None
+                       else round(float(maximum_distance), 2))
                 if key not in planner_probe_samples:
                     planner_probe_samples[key] = self._probe_direction(
                         position, sample_yaw, state.get('speed', 0.0),
-                        self._descriptors.get(state['id']))
+                        self._descriptors.get(state['id']),
+                        maximum_distance)
                 return planner_probe_samples[key]
 
             grid = getattr(self.navigator, 'grid', None)
@@ -10278,7 +10281,28 @@ class BotRuntime(object):
             controlled_shallow_commit = getattr(
                 self.navigator, 'controlled_shallow_committed', None)
 
-            def sample_clear(sample_yaw):
+            def sample_pose_clear(sample_yaw):
+                # Whether this hull may rotate where it stands is a question
+                # about a rectangle, not about a heading. Answer it from the
+                # shipped graph the navigator already owns.
+                pose_grid = getattr(self.navigator, 'grid', None)
+                pose_probe = getattr(pose_grid, 'hull_pose_clear', None)
+                if not callable(pose_probe):
+                    return True
+                try:
+                    return bool(pose_probe(
+                        position, sample_yaw,
+                        state.get('half_length', 3.5),
+                        state.get('half_width', 1.7)))
+                except Exception:
+                    return True
+
+            def sample_clear(sample_yaw, maximum_distance=None):
+                # A short manoeuvre asks about the space it actually enters.
+                # Ranking a five-metre backing escape against the fifteen to
+                # twenty metre travel horizon rejects every gateway, alley and
+                # bridge underpass on the map, which leaves an in-place turn
+                # as the only recovery in exactly the places no hull can turn.
                 advisory = self._planner_corridor_clear(
                     position, sample_yaw, state.get('speed', 0.0),
                     wet_escape=(baked_shallow_escape or
@@ -10289,7 +10313,8 @@ class BotRuntime(object):
                                        state['id'], position, sample_yaw)))
                 if advisory is not None:
                     return bool(advisory)
-                sample = planner_sample_direction(sample_yaw)
+                sample = planner_sample_direction(
+                    sample_yaw, maximum_distance)
                 # Exhausting the soft-static recast budget is not a wall. Keep
                 # the previous drive intent; commit-side world collision still
                 # stops the hull if this corridor reaches real hard geometry.
@@ -10360,6 +10385,7 @@ class BotRuntime(object):
                     # is the physical quantity being consumed.
                     'speed': state['speed'],
                     'dt': decision_step, 'now': now,
+                    'pose_clear': sample_pose_clear,
                     'health': state['health'],
                     'max_health': state['max_health'],
                     'contacts': contacts,


### PR DESCRIPTION
Follow-up to #70, from the 2026-09-06 Windows report
(`wot-error-report-20260906-011822`, build `local-pr69-pr70`, Great Wall).

## What that report showed

#70 worked: crossing leases are 8 of 254 stall samples. They were not the
main cause. **123 of 254 stall samples (48%) are inside one 30x80 m box
around the gatehouse**, and they start at 01:16:24 — **54 seconds before the
first shot**.

The signature is not "decided to stop". It is `throttle=1.00 speed=0.00
grind=4 path_clear=True`: full throttle, no translation, hard contact every
tick.

| bot | at | immobile | full throttle | grinding |
| --- | --- | --- | --- | --- |
| 16 | (402.3, −152.7) | 64.3 s | 6/22 | 13/22 |
| 18 | (408.7, −148.6) | 62.5 s | 0/21 | 3/21 |
| 26 | (405.7, −155.6) | 59.7 s | 4/20 | 3/20 |
| 30 | (407.2, −206.0) | 27.6 s | 9/10 | 1/10 |
| 19 | (409.7, −200.8) | 18.4 s | 6/7 | 7/7 |

## Why they never got out

Two questions, both asked about the wrong thing.

1. **The backing escape was ranked over the travel horizon.** A reverse
   recovery travels `half_length * 1.6` ≈ 5.8 m, but `direction_clear` was
   asked about the 15–20 m drive horizon. In a passage that always reaches a
   wall. On bot 19's exact pose — (409.7, −200.7), hull skewed 22° — the
   tracked graph answers BLOCKED at 15 m, BLOCKED at 20 m and **clear at
   5.8 m**. So the reverse was refused and the driver fell back to
   `pivot_recovery`.
2. **The in-place turn is geometrically impossible there.** A ray answers
   about a heading, never about a rotation: the corners a turn sweeps are
   metres from every ray it casts. Measured against the shipped graph, a
   VK 65.01 (2.95 × 7.24 m) standing in that gatehouse **cannot rotate 15°**.
   Its in-place turn needs 7.82 m of diameter; the gate is 4 m at the north
   mouth and 8 m inside.

So the hull ground its corners into the wall, re-armed the stuck timer,
turned again, for 18–64 s each — and the queue behind it never moved. Combat
then froze several of them in place (`engage/arrived` with
`strategic_goal` equal to their own position), which is a separate problem.

## The change

* Rank the backing escape over its own manoeuvre distance
  (`sample_clear` and `LocalDriver._clear` gained an optional bounded
  distance; probes that predate it keep the unbounded answer).
* Prove an in-place turn against the chassis rectangle before committing to
  it. Try the mirrored side; if neither rotation fits and the rear is denied,
  hold the pose and publish `reverse_blocked_by` instead of grinding.
* `TerrainGrid.hull_pose_clear` answers "may this hull rotate here" from the
  shipped graph, and `TerrainGrid.local_corridor` measures the passage width
  and axis. Both are pure baked-data reads, cached per cell.

Reproduction: a five-hull column staged in the gatehouse approach with a
chassis-rectangle contact model (the point-sample model the older replay used
cannot express a corner hitting a wall, which is why the plain replay never
reproduced this). In-place recovery steps **204 → 1**, no hull grinds.

`test_port_0922_traffic`, `test_port_0922_ai`, `test_port_0922_navigation`,
`test_port_0922_navigation_clearance` and `test_port_0922_great_wall_gate`
pass; CPython 2.7.18 source compile passes (94 files).

## Handoff — what needs the real client

**This branch does not make the Great Wall gate passable if the world
geometry there is closed.** Peng reports that a *human* player cannot drive
through that gatehouse at all, and that another player got stuck in the
München bridge underpass. If that holds, the shipped Great Wall graph
contains a passage that does not exist, and no amount of driver work fixes
it.

The passage in the graph was **forced**. `tools/bake_navigation_0922.py`
shifts the entire X sampling phase by 2 m so that one node lands exactly on
x=404 (`grid_phase_override`, reason `#1513 gatehouse passage requires an
x=404m graph centre`), and `_record_target_grid_phase` then asserts that
(400, −146) and (408, −146) must stay impassable. The bake hard-codes a
single 4 m column through the wall.

Needed on the machine with the client:

1. **Confirm in game.** Drive to (404, −150) and (404, −146). Is there
   collision across the opening? Compare x=400 / 404 / 408.
2. **`res/packages/59_asia_great_wall.pkg`**, plus
   `res/packages/shared_content.pkg` if the gatehouse model is shared. With
   those the exact collision at the opening can be rastered here and the free
   width proved, instead of inferred from the bake's own pass/fail.
3. **If the gate is closed**, re-bake without the forced passage:
   ```
   export WOT_0922_CLIENT=/path/to/World_of_Tanks_0.09.22.00.01_CH_1513_HD
   python3 tools/bake_navigation_0922.py 59_asia_great_wall --output /tmp/gw.json
   ```
   Removing the nine passage nodes costs nothing structurally — the graph
   stays one component and only those nine nodes are lost — but `wall_pass`
   and `valley` then have to route the long way (309 m → 1264 m), so the
   routes need re-baking with them.
4. **The München underpass** wants the same check. Its
   `underpass_layer` adapter puts terrain nodes under a deck whose
   neighbouring cells are the deck itself, 8.4 m above, in the same
   single-layer plane.

Also still open, from the same report: two hulls climbed to **+4.05 m and
+4.55 m above the baked floor at (405–408, −156)** and were marooned there
for 49 s with every probed direction exceeding the 0.38 grade limit. Two
different hulls reaching the same height at the same point means static
geometry the bake does not model — most likely steps under
`VEHICLE_GROUND_CLEARANCE` (0.65 m), which the obstacle raster ignores and
which never become a surface. That is the same map-package question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
