### PR TITLE
Keep a worker abort after the lobby restore out of the clean-exit rule

### DIFF
--- a/launcher/error_reports.py
+++ b/launcher/error_reports.py
@@ -748,8 +748,16 @@ def _client_exit_tail(session, role):
         stream.close()
 
 
-def client_exit_evidence(session, role):
-    """Classify one current-session game client's shutdown evidence."""
+def client_exit_evidence(session, role, stop_requested=False):
+    """Classify one current-session game client's shutdown evidence.
+
+    ``stop_requested`` states that the launcher asked this role to stop. It is
+    the only signal that separates an orderly stop from a self-inflicted exit
+    once the process is gone: ProcDump ``-t`` writes the same exception-free
+    dump for both, and a #1513 client that has just restored the lobby prints
+    nothing more until the hangar space loads, so the log tail is identical
+    too. Never infer it from the dump or the tail alone.
+    """
     if (not isinstance(session, dict) or not _is_latest(session) or
             role not in DUMP_ROLES):
         return VISIBLE_CLIENT_EXIT_UNKNOWN
@@ -761,7 +769,7 @@ def client_exit_evidence(session, role):
     exit_tail = _client_exit_tail(session, role)
     if exit_tail == "clean-shutdown":
         return VISIBLE_CLIENT_EXIT_CLEAN
-    if (exit_tail == "lobby-restored" and
+    if (stop_requested and exit_tail == "lobby-restored" and
             dump_evidence == MINIDUMP_EVIDENCE_TERMINATION):
         return VISIBLE_CLIENT_EXIT_CLEAN
     if dump_evidence == MINIDUMP_EVIDENCE_TERMINATION:
@@ -769,19 +777,23 @@ def client_exit_evidence(session, role):
     return VISIBLE_CLIENT_EXIT_UNKNOWN
 
 
-def client_exited_cleanly(session, role):
+def client_exited_cleanly(session, role, stop_requested=False):
     """Return whether one current-session game client exited normally."""
-    return client_exit_evidence(session, role) == VISIBLE_CLIENT_EXIT_CLEAN
+    return client_exit_evidence(
+        session, role, stop_requested=stop_requested) == (
+            VISIBLE_CLIENT_EXIT_CLEAN)
 
 
-def visible_client_exit_evidence(session):
+def visible_client_exit_evidence(session, stop_requested=False):
     """Classify the visible client's current-session shutdown evidence."""
-    return client_exit_evidence(session, ROLE_VISIBLE_CLIENT)
+    return client_exit_evidence(
+        session, ROLE_VISIBLE_CLIENT, stop_requested=stop_requested)
 
 
-def visible_client_exited_cleanly(session):
+def visible_client_exited_cleanly(session, stop_requested=False):
     """Return whether current-session evidence proves a clean client exit."""
-    return client_exited_cleanly(session, ROLE_VISIBLE_CLIENT)
+    return client_exited_cleanly(
+        session, ROLE_VISIBLE_CLIENT, stop_requested=stop_requested)
 
 
 def _open_valid_dump(session, role):

--- a/launcher/tests/test_error_reports.py
+++ b/launcher/tests/test_error_reports.py
@@ -192,7 +192,7 @@ class ErrorReportTest(unittest.TestCase):
         self.assertTrue(
             error_reports.visible_client_exited_cleanly(session))
 
-    def test_termination_dump_after_lobby_restore_is_normal(self):
+    def test_termination_dump_after_lobby_restore_needs_a_requested_stop(self):
         session = error_reports.begin_session(
             self.game, session_id=self.SESSION_1, started_at="start")
         visible = self._game_log(error_reports.ROLE_VISIBLE_CLIENT)
@@ -203,23 +203,36 @@ class ErrorReportTest(unittest.TestCase):
 
         self.assertEqual(
             error_reports.VISIBLE_CLIENT_EXIT_UNKNOWN,
-            error_reports.visible_client_exit_evidence(session))
+            error_reports.visible_client_exit_evidence(
+                session, stop_requested=True))
 
         self._write(error_reports.session_dump_path(
             session, error_reports.ROLE_VISIBLE_CLIENT), self._minidump(7))
 
         self.assertEqual(
             error_reports.VISIBLE_CLIENT_EXIT_CLEAN,
-            error_reports.visible_client_exit_evidence(session))
+            error_reports.visible_client_exit_evidence(
+                session, stop_requested=True))
         self.assertTrue(
-            error_reports.visible_client_exited_cleanly(session))
+            error_reports.visible_client_exited_cleanly(
+                session, stop_requested=True))
 
-        self._write(visible, b"late failure after lobby restore\r\n", "ab")
+        # The same tail and the same exception-free dump describe a client
+        # that died on its own inside the post-battle lobby window.
         self.assertEqual(
             error_reports.VISIBLE_CLIENT_EXIT_TERMINATED,
             error_reports.visible_client_exit_evidence(session))
         self.assertFalse(
             error_reports.visible_client_exited_cleanly(session))
+
+        self._write(visible, b"late failure after lobby restore\r\n", "ab")
+        self.assertEqual(
+            error_reports.VISIBLE_CLIENT_EXIT_TERMINATED,
+            error_reports.visible_client_exit_evidence(
+                session, stop_requested=True))
+        self.assertFalse(
+            error_reports.visible_client_exited_cleanly(
+                session, stop_requested=True))
 
     def test_worker_termination_dump_after_lobby_restore_is_normal(self):
         session = error_reports.begin_session(
@@ -236,9 +249,51 @@ class ErrorReportTest(unittest.TestCase):
         self.assertEqual(
             error_reports.VISIBLE_CLIENT_EXIT_CLEAN,
             error_reports.client_exit_evidence(
-                session, error_reports.ROLE_HIDDEN_WORKER))
+                session, error_reports.ROLE_HIDDEN_WORKER,
+                stop_requested=True))
         self.assertTrue(error_reports.client_exited_cleanly(
+            session, error_reports.ROLE_HIDDEN_WORKER,
+            stop_requested=True))
+
+    def test_worker_abort_after_lobby_restore_is_not_normal(self):
+        """A worker nobody asked to stop keeps no excuse from its log tail.
+
+        #1513 prints nothing between the restored lobby and the hangar space
+        load, and ProcDump ``-t`` writes an exception-free dump for an
+        ``abort()`` exactly as it does for an orderly stop.
+        """
+        session = error_reports.begin_session(
+            self.game, needs_worker=True,
+            session_id=self.SESSION_1, started_at="start")
+        self._write(
+            self._game_log(error_reports.ROLE_HIDDEN_WORKER),
+            b"2026-09-06 13:16:37.949: INFO: [Offline LAN 0.9.22] "
+            b"deferred lobby Account restored\r\n")
+        self._write(error_reports.session_dump_path(
+            session, error_reports.ROLE_HIDDEN_WORKER), self._minidump(7))
+
+        self.assertEqual(
+            error_reports.VISIBLE_CLIENT_EXIT_TERMINATED,
+            error_reports.client_exit_evidence(
+                session, error_reports.ROLE_HIDDEN_WORKER))
+        self.assertFalse(error_reports.client_exited_cleanly(
             session, error_reports.ROLE_HIDDEN_WORKER))
+
+    def test_full_shutdown_tail_stays_clean_without_a_requested_stop(self):
+        session = error_reports.begin_session(
+            self.game, session_id=self.SESSION_1, started_at="start")
+        self._write(
+            self._game_log(error_reports.ROLE_VISIBLE_CLIENT),
+            b"2026-09-06 13:16:40.048: INFO: "
+            b"PostProcessing.Phases.fini()\r\n")
+        self._write(error_reports.session_dump_path(
+            session, error_reports.ROLE_VISIBLE_CLIENT), self._minidump(7))
+
+        self.assertEqual(
+            error_reports.VISIBLE_CLIENT_EXIT_CLEAN,
+            error_reports.visible_client_exit_evidence(session))
+        self.assertTrue(
+            error_reports.visible_client_exited_cleanly(session))
 
     def test_worker_termination_without_teardown_is_unexpected(self):
         session = error_reports.begin_session(

--- a/launcher/tests/test_launcher_window.py
+++ b/launcher/tests/test_launcher_window.py
@@ -174,6 +174,18 @@ class _Process(object):
         return self.exit_code
 
 
+class _StoppableProcess(_Process):
+    """A child that stays live until the launcher requests its stop."""
+
+    def __init__(self, exit_code=0, pid=1234):
+        _Process.__init__(self, exit_code=None, pid=pid)
+        self._stop_exit_code = exit_code
+
+    def request_stop(self, unused_process, unused_root):
+        self.exit_code = self._stop_exit_code
+        return True
+
+
 class WindowTest(unittest.TestCase):
     def setUp(self):
         self.settings_dir = tempfile.mkdtemp()
@@ -1963,7 +1975,40 @@ class WindowTest(unittest.TestCase):
             wot_launcher.error_reports.ROLE_HIDDEN_WORKER,
             self.window._observed_crash_roles)
 
-    def test_clean_worker_termination_is_not_a_crash(self):
+    def test_requested_worker_stop_with_nonzero_exit_is_not_a_crash(self):
+        worker = _StoppableProcess(exit_code=3, pid=42)
+        self.window._worker = worker
+        self.window._worker_starter_root = self.settings_dir
+
+        with mock.patch.object(
+                self.window, "_request_starter_stop",
+                side_effect=worker.request_stop), \
+                mock.patch.object(
+                    wot_launcher.error_reports, "minidump_evidence",
+                    return_value=(wot_launcher.error_reports.
+                                  MINIDUMP_EVIDENCE_TERMINATION)), \
+                mock.patch.object(
+                    wot_launcher.error_reports, "client_exited_cleanly",
+                    return_value=True) as clean_exit:
+            self.assertEqual(3, self.window._stop_worker())
+
+        self.assertIn("Stopping the hidden simulation worker", self._log_text())
+        clean_exit.assert_called_once_with(
+            self.window._active_report_session,
+            wot_launcher.error_reports.ROLE_HIDDEN_WORKER,
+            stop_requested=True)
+        self.assertNotIn(
+            wot_launcher.error_reports.ROLE_HIDDEN_WORKER,
+            self.window._observed_crash_roles)
+
+    def test_worker_already_gone_with_nonzero_exit_is_a_crash(self):
+        """The reported #1513 case: the worker aborts on its own.
+
+        Its last line is the restored lobby, ProcDump's ``-t`` dump carries no
+        exception stream, and nobody asked it to stop. Only the missing stop
+        request separates this from an orderly shutdown, so the launcher must
+        keep the dump and report the crash.
+        """
         worker = _Process(exit_code=3, pid=42)
         self.window._worker = worker
         self.window._worker_starter_root = self.settings_dir
@@ -1974,13 +2019,16 @@ class WindowTest(unittest.TestCase):
                     wot_launcher.error_reports.MINIDUMP_EVIDENCE_TERMINATION)), \
                 mock.patch.object(
                     wot_launcher.error_reports, "client_exited_cleanly",
-                    return_value=True) as clean_exit:
+                    return_value=False) as clean_exit:
             self.assertEqual(3, self.window._stop_worker())
 
+        self.assertNotIn(
+            "Stopping the hidden simulation worker", self._log_text())
         clean_exit.assert_called_once_with(
             self.window._active_report_session,
-            wot_launcher.error_reports.ROLE_HIDDEN_WORKER)
-        self.assertNotIn(
+            wot_launcher.error_reports.ROLE_HIDDEN_WORKER,
+            stop_requested=False)
+        self.assertIn(
             wot_launcher.error_reports.ROLE_HIDDEN_WORKER,
             self.window._observed_crash_roles)
 
@@ -2286,11 +2334,47 @@ class WindowTest(unittest.TestCase):
                 self.settings_dir, core.PORT_0_9_22, core.LOCAL_HOST,
                 core.DEFAULT_SERVER_PORT, paired_worker=True))
 
-        clean_exit.assert_called_once_with(boundary)
+        clean_exit.assert_called_once_with(boundary, stop_requested=False)
         self.assertNotIn(
             wot_launcher.error_reports.ROLE_VISIBLE_CLIENT,
             self.window._observed_crash_roles)
         self.assertNotIn("exit code 1", self._log_text())
+
+    def test_worker_authority_exit_is_judged_without_a_stop_request(self):
+        """The launcher never asked, so the tail cannot excuse the exit."""
+        boundary = wot_launcher.error_reports.begin_session(
+            self.settings_dir, needs_worker=True,
+            session_id="20260823T120000Z-555555555555")
+        self.window._active_report_session = boundary
+        game = _Process(exit_code=None)
+        worker = _Process(exit_code=3)
+        self.window._worker = worker
+        with mock.patch(
+                "wot_launcher.subprocess.Popen", return_value=game), \
+                mock.patch(
+                    "core.wait_for_paired_player_exit",
+                    return_value=(1, True)), \
+                mock.patch.object(
+                    wot_launcher.error_reports, "minidump_evidence",
+                    return_value=(wot_launcher.error_reports.
+                                  MINIDUMP_EVIDENCE_TERMINATION)), \
+                mock.patch.object(
+                    wot_launcher.error_reports, "client_exited_cleanly",
+                    return_value=False) as clean_exit, \
+                mock.patch.object(self.window, "_log_worker_failure"):
+            self.window._run_game(
+                self.settings_dir, core.PORT_0_9_22, core.LOCAL_HOST,
+                core.DEFAULT_SERVER_PORT, paired_worker=True)
+
+        clean_exit.assert_called_once_with(
+            boundary, wot_launcher.error_reports.ROLE_HIDDEN_WORKER,
+            stop_requested=False)
+        self.assertTrue(self.window._worker_exited_unexpectedly)
+        self.assertIn(
+            wot_launcher.error_reports.ROLE_HIDDEN_WORKER,
+            self.window._observed_crash_roles)
+        self.assertIn("worker stopped with exit code 3", self._log_text())
+        self.assertNotIn("exited normally with code 3", self._log_text())
 
     def test_paired_player_logs_worker_failure(self):
         game = _Process(exit_code=None)

--- a/launcher/wot_launcher.py
+++ b/launcher/wot_launcher.py
@@ -367,6 +367,7 @@ class LauncherWindow(object):
         self._worker_exited_unexpectedly = False
         self._observed_crash_roles = set()
         self._forced_stop_roles = set()
+        self._stop_requested_roles = set()
         self._stop_requested = False
         self._close_pending = False
         self._selected_client = None
@@ -1266,13 +1267,20 @@ class LauncherWindow(object):
             return exit_code
         if role in self._forced_stop_roles or exit_code == 0:
             return exit_code
+        # A role the launcher never asked to stop cannot be excused by the
+        # post-battle log tail: an aborting worker and a politely stopped one
+        # leave the same last line and the same exception-free dump.
+        stop_requested = (self._stop_requested or
+                          role in self._stop_requested_roles)
         try:
             if role == error_reports.ROLE_VISIBLE_CLIENT:
                 clean_exit = error_reports.visible_client_exited_cleanly(
-                    self._active_report_session)
+                    self._active_report_session,
+                    stop_requested=stop_requested)
             else:
                 clean_exit = error_reports.client_exited_cleanly(
-                    self._active_report_session, role)
+                    self._active_report_session, role,
+                    stop_requested=stop_requested)
         except Exception:
             clean_exit = False
         if not clean_exit:
@@ -1750,6 +1758,7 @@ class LauncherWindow(object):
         self._save_settings()
         self._observed_crash_roles = set()
         self._forced_stop_roles = set()
+        self._stop_requested_roles = set()
         self._stop_requested = False
         self._set_busy(True)
         thread = threading.Thread(
@@ -1962,6 +1971,7 @@ class LauncherWindow(object):
             self._worker_exited_unexpectedly = False
             self._observed_crash_roles = set()
             self._forced_stop_roles = set()
+            self._stop_requested_roles = set()
             self._set_busy(False)
             if automatic_report_path is not None:
                 self.root.after(
@@ -2286,6 +2296,7 @@ class LauncherWindow(object):
         if exit_code is not None:
             return exit_code
         self._log("Stopping the hidden simulation worker...")
+        self._stop_requested_roles.add(error_reports.ROLE_HIDDEN_WORKER)
         stopped = (starter_root is not None and
                    self._request_starter_stop(worker, starter_root))
         if not stopped:
@@ -2385,7 +2396,8 @@ class LauncherWindow(object):
             try:
                 visible_exit_evidence = (
                     error_reports.visible_client_exit_evidence(
-                        self._active_report_session))
+                        self._active_report_session,
+                        stop_requested=closed_for_required_process))
             except Exception:
                 visible_exit_evidence = (
                     error_reports.VISIBLE_CLIENT_EXIT_UNKNOWN)


### PR DESCRIPTION
## What the report showed

`~/user-error.zip` (0.6.9, `897f2388`) ends like this:

```
13:16:37.949 worker    deferred lobby Account restored      <- worker log ENDS
13:16:39.767 client    [SPACE] Loading space: spaces/hangar_v2
13:16:40.048 client    last line
13:16:41     launcher  The hidden simulation worker exited normally with code 3.
```

After rounds 1 and 2 the worker loaded `spaces/hangar_v2` 1.6-1.7 s after that
same line. After round 3 it never got there; `hidden-worker-starter.log` holds
`stage=worker_process_exit exit_code=3`. `core.wait_for_paired_player_exit`
then terminated the visible client for its lost simulation authority, which is
why the client log stops mid hangar load with no `PostProcessing.Phases.fini()`
and why the player saw the game vanish.

## The misclassification

`client_exit_evidence` returned CLEAN from two facts that do not prove a clean
exit:

* the log tail is `deferred lobby Account restored` - a #1513 client prints
  nothing between the restored lobby and the hangar space load, so an orderly
  stop in that window and an `abort()` in that window leave the same last line;
* the dump carries no exception stream - ProcDump runs as
  `-accepteula <mode> -n 1 -e -t`, and `-t` writes the same termination dump
  for both.

The nonzero exit code was then discarded, so `ROLE_HIDDEN_WORKER` never entered
`_observed_crash_roles`. Three consequences: the launcher logged "exited
normally with code 3", no crash report was offered, and
`cleanup_session_dumps(roles=normal_roles)` **deleted `hidden-worker.dmp`** -
the only evidence of the crash.

## The change

Whether the launcher asked a role to stop is the signal that separates the two
cases, and it is not in the session state, so it is passed in.
`client_exit_evidence` gains `stop_requested`, and only the weaker
lobby-restored pair requires it; a full `PostProcessing.Phases.fini()` tail
stays clean without it, so quitting from the game itself is unaffected.
`_remember_process_exit` supplies it from `_stop_requested` plus a new
`_stop_requested_roles`, which `_stop_worker_locked` sets when it actually
requests the worker's stop - after the early return that covers a worker
already found gone.

With this, the reported session records the worker crash, keeps the dump, and
offers the report.

## Tests

`launcher/tests/test_error_reports.py`
* `test_worker_abort_after_lobby_restore_is_not_normal` - the reported case;
  fails on `main` with `clean` instead of `unexpected-termination`.
* `test_full_shutdown_tail_stays_clean_without_a_requested_stop`.
* `test_termination_dump_after_lobby_restore_needs_a_requested_stop` now
  asserts both sides of the gate.

`launcher/tests/test_launcher_window.py`
* `test_worker_authority_exit_is_judged_without_a_stop_request` - end to end
  through `_run_game`.
* `test_requested_worker_stop_with_nonzero_exit_is_not_a_crash` and
  `test_worker_already_gone_with_nonzero_exit_is_a_crash` replace
  `test_clean_worker_termination_is_not_a_crash`, whose fake worker was
  already gone before the stop was requested.

`cd launcher && PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -p "test_*.py"`
-> 486 tests, OK (skipped=2).

## Not fixed here

Why the worker aborts is unknown. This change is what makes the next report
carry the dump needed to answer that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)