### PR TITLE
Reduce worker combat work and preserve complete timing traces

### DIFF
--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -585,12 +585,18 @@ slow loading or travel alone cannot exhaust the captures before combat.
 Owned Python stages report call
 count, inclusive total, self time excluding measured children, and maximum
 single-call duration. `bot.probe.*` measures logical probe boundaries;
-`native.projectile.armour/world/material` counts the actual calls at the
+`native.projectile.armour/world/material/sticker` counts the actual calls at the
 instrumented `localHitTest`, `wg_collideSegment`, and material-query seams,
 including calls that raise. These are not a census of all BigWorld calls.
 The existing `PERF` records remain; `PERF combat_trace` adds JSON detail for
 the three slowest intervals and up to three neighbouring frames on either
-side of the worst interval. Neighbours at a reporting or round boundary may
+side of the worst interval. Schema 2 emits each frame separately, identifying
+its `relation` (focus/previous/following) and `index` within that relation.
+Each line stays below 7168 ASCII bytes: an oversized trace or summary becomes
+ordered `combat_trace_part` or `combat_summary_part` records. Concatenate their
+`data` strings in `part` order (checking `parts`) before parsing the complete
+JSON record. This preserves evidence across the observed #1513 8 KiB native
+log-line limit. Neighbours at a reporting or round boundary may
 be incomplete. `PERF combat_summary` reports each closed capture's stage
 totals, frame/time span, queue maxima, and counters. Detailed clocks are
 inactive between captures; the small frame ring remains available.
@@ -614,6 +620,38 @@ outputs, player/Bot volleys, progress acknowledgements, and local query or
 clock failure without changing simulation outcomes. Timings include diagnostic
 overhead; exact #1513 Windows logs are still required to attribute a real
 combat stall or measure that overhead in the embedded runtime.
+
+Supplemental lane service rejects due, currently out-of-range pairs before
+copying full source/target jobs or spending the bounded service cohort. It
+uses the same ordinary/SPG distance rule as the final shot gate and records
+the negative receipt at service time. The independent incoming enemy-to-own
+probe retains its one-job budget even when the outgoing source cannot reach
+the enemy. Selected-first service and round-robin completion remain bounded
+by the existing native query budget. A pending cover job reserves a lane
+window only when its phase is due and its source/remembered target are still
+current; a future or stale cover job no longer pauses the entire queue.
+
+Countdown frames may prepare one ready, non-local worker vehicle's internal
+hit layout. All component hit-tester bounds must exist before the ordinary
+layout builder may populate its configuration cache; incomplete descriptors
+stay eligible and do not poison that cache. The normal hit path retains the
+same builder, configuration key, damage rules, and failure handling. Combat
+timings separately report armour resolution, sticker validation, equipment
+projection, and direct/explosion critical proposals. Cold preparation can be
+moved out of a first hit, but this does not establish the cause of a captured
+Windows terminal spike.
+
+`tools/benchmark_bot_workload.py` exercises the copied 29-Bot control loop
+with real local drivers and a selected shipped navgraph. It can record complete
+outputs for cross-checkout parity and optional cProfile data. Native queries
+use deterministic test seams, so its CPU results do not measure Windows FPS
+or native collision cost. Baked A* reads each expanded cell's link mask once,
+preserving neighbour order, costs, hazards and expansion budgets; empty
+failed-edge tables no longer require per-edge key construction.
+Hidden contact projections reuse the removal of live pose fields only within
+one authority slice and template/remembered-pose identity. Each observer keeps
+its own contact object and visibility flags; new poses and slices invalidate
+that reuse.
 
 The previous 0.3.65 schema-v2 catalog supplied transformed OBBs but joined
 runtime slots by native filename taken from the chunk list. A slot may be

--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -577,6 +577,44 @@ return values, freshness windows, deadlines and 110-pair safety budget are
 unchanged. Straight-line Windows driving remains the frame-pacing acceptance
 test; this source review cannot claim that the visible hitch is eliminated.
 
+The current hidden worker also supports bounded combat timing beyond its
+five-second startup probe sample. `worker_diagnostics.py` captures up to three
+30-second windows per round, with a 30-second cooldown. A live battle frame
+with active projectiles or pending supplemental shot lanes can arm a window;
+slow loading or travel alone cannot exhaust the captures before combat.
+Owned Python stages report call
+count, inclusive total, self time excluding measured children, and maximum
+single-call duration. `bot.probe.*` measures logical probe boundaries;
+`native.projectile.armour/world/material` counts the actual calls at the
+instrumented `localHitTest`, `wg_collideSegment`, and material-query seams,
+including calls that raise. These are not a census of all BigWorld calls.
+The existing `PERF` records remain; `PERF combat_trace` adds JSON detail for
+the three slowest intervals and up to three neighbouring frames on either
+side of the worst interval. Neighbours at a reporting or round boundary may
+be incomplete. `PERF combat_summary` reports each closed capture's stage
+totals, frame/time span, queue maxima, and counters. Detailed clocks are
+inactive between captures; the small frame ring remains available.
+
+The supplemental-lane shadow ledger retains at most 1024 identities and
+records actual enqueue-to-completion wait separately from phase-deadline
+overdue time and the existing whole-refresh-cycle overdue metric. It counts
+admission, deduplication, cache/probe/distance completion, invalid retirement,
+materialization, budget deferral, and cover-work pauses. Selected-target waits
+and oldest pending identities are separate. With cover work blocking service,
+`eligibility_checked=false` means the pending gauge includes identities whose
+current eligibility was not checked. Capture wait percentiles cover the last
+512 completions; `count` and `kept` expose that sampling boundary. Positive
+receipt publications distinguish repeated exports, distinct captured results,
+selected targets, replacement, and expiry before export. Publication means
+inclusion in worker observations, not acknowledgement or proof of a server
+planner decision; `shootable_by_bot_ids` feeds server target/position choices.
+The diagnostic cannot label every unselected result wasted, since alternative
+lanes also inform movement. Identical-input tests cover queue order, Bot
+outputs, player/Bot volleys, progress acknowledgements, and local query or
+clock failure without changing simulation outcomes. Timings include diagnostic
+overhead; exact #1513 Windows logs are still required to attribute a real
+combat stall or measure that overhead in the embedded runtime.
+
 The previous 0.3.65 schema-v2 catalog supplied transformed OBBs but joined
 runtime slots by native filename taken from the chunk list. A slot may be
 present as `''`, while an unresolved, handlerless or NULL-name slot is absent;

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
@@ -80,6 +80,9 @@ class TerrainGrid(object):
 		(-1, 0, 1.0),                         (1, 0, 1.0),
 		(-1, 1, SQRT_TWO),  (0, 1, 1.0),  (1, 1, SQRT_TWO),
 	)
+	_NEIGHBOUR_BITS = dict(((dx, dz), 1 << index)
+		for index, (dx, dz, unused_length) in enumerate(_NEIGHBOURS))
+	_LINK_COUNTS = tuple(bin(mask).count('1') for mask in range(256))
 
 	def __init__(self, ground_probe, obstacle_probe=None, bounds=None,
 			cell_size=18.0, max_grade_up=0.48, max_grade_down=0.38,
@@ -583,15 +586,25 @@ class TerrainGrid(object):
 			return None
 		dx = next_cell[0] - cell[0]
 		dz = next_cell[1] - cell[1]
-		direction_index = None
-		for candidate, neighbour in enumerate(self._NEIGHBOURS):
-			if neighbour[0] == dx and neighbour[1] == dz:
-				direction_index = candidate
-				break
-		if (direction_index is None or
-				not (int(self._baked_links[index]) & (1 << direction_index))):
+		bit = self._NEIGHBOUR_BITS.get((dx, dz), 0)
+		if not (int(self._baked_links[index]) & bit):
 			return None
 		return float(self._baked_heights[next_index]) / 1000.0
+
+	def _baked_neighbours(self, cell):
+		"""Read one cell's immutable link mask once per A* expansion."""
+		index = self._baked_index(cell)
+		if index is None:
+			return
+		mask = int(self._baked_links[index])
+		for direction, (dx, dz, length) in enumerate(self._NEIGHBOURS):
+			if not (mask & (1 << direction)):
+				continue
+			next_cell = (cell[0] + dx, cell[1] + dz)
+			next_index = self._baked_index(next_cell)
+			if next_index is not None:
+				yield (dx, dz, length, next_cell,
+				       float(self._baked_heights[next_index]) / 1000.0)
 
 	def _baked_link_count(self, cell):
 		"""Return the number of independently baked exits from one safe cell."""
@@ -599,11 +612,7 @@ class TerrainGrid(object):
 		if index is None:
 			return 0
 		mask = int(self._baked_links[index]) & 0xff
-		count = 0
-		while mask:
-			count += mask & 1
-			mask >>= 1
-		return count
+		return self._LINK_COUNTS[mask]
 
 	def _baked_clearance_penalty(self, cell):
 		"""Prefer the middle of a proved corridor without inventing new links.
@@ -794,12 +803,22 @@ class TerrainGrid(object):
 				reached = current
 				break
 			current_y = heights[current]
-			for offset_x, offset_z, length_scale in self._NEIGHBOURS:
-				next_cell = (current[0] + offset_x, current[1] + offset_z)
-				next_y = self._edge(current, current_y, next_cell)
+			grade_limit = (self._baked_max_grade if self.prebaked else
+			               min(self.max_grade_up, self.max_grade_down))
+			grade_divisor = max(0.05, grade_limit)
+			if self.prebaked:
+				neighbours = self._baked_neighbours(current)
+			else:
+				neighbours = ((dx, dz, length,
+					(current[0] + dx, current[1] + dz),
+					self._edge(current, current_y,
+					           (current[0] + dx, current[1] + dz)))
+					for dx, dz, length in self._NEIGHBOURS)
+			for offset_x, offset_z, length_scale, next_cell, next_y in neighbours:
 				if next_y is None:
 					continue
-				edge_key = tuple(sorted((current, next_cell)))
+				edge_key = (tuple(sorted((current, next_cell)))
+				            if hard_edge_penalties or edge_penalties else None)
 				if (hard_edge_penalties and
 						edge_key in hard_edge_penalties):
 					continue
@@ -813,9 +832,7 @@ class TerrainGrid(object):
 				run = self.cell_size * length_scale
 				delta_y = next_y - current_y
 				slope = abs(delta_y) / max(run, 0.1)
-				grade_limit = (self._baked_max_grade if self.prebaked else
-				               min(self.max_grade_up, self.max_grade_down))
-				slope_ratio = slope / max(0.05, grade_limit)
+				slope_ratio = slope / grade_divisor
 				# Risk rises non-linearly near the controllable-grade limit.  A
 				# downhill edge costs a little more because braking and lateral
 				# slide leave less recovery room than climbing the same surface.
@@ -828,7 +845,8 @@ class TerrainGrid(object):
 				new_cost = (cost_so_far[current] + run + slope_cost +
 				            self._penalty(
 				                next_cell, avoid_points, prefer_clearance) +
-				            self._failed_edge_penalty(current, next_cell, now) +
+				            (self._failed_edge_penalty(current, next_cell, now)
+				             if self._failed_edges else 0.0) +
 				            local_penalty)
 				if next_cell not in cost_so_far or new_cost < cost_so_far[next_cell]:
 					cost_so_far[next_cell] = new_cost

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -6,6 +6,7 @@ import base64
 import bisect
 import collections
 import copy
+import json
 import math
 import os
 import random
@@ -46,6 +47,8 @@ from gui.mods.offline_lan_0922.projectile_runtime import (
     projectile_range_distance, trajectory_position)
 from gui.mods.offline_lan_0922.snapshot_sync import SnapshotSync
 from gui.mods.offline_lan_0922.spawn_planner import SpawnPlanner
+from gui.mods.offline_lan_0922.worker_diagnostics import (
+    WorkerCombatDiagnostics, timed, call as timed_call)
 from gui.mods.offline_lan_0922 import (
     ballistics, combat_rules, critical_damage, descriptor_donation,
     destructibles_compat, device_damage, effective_params,
@@ -439,6 +442,7 @@ class _FrameDiagnostics(object):
 
     def reset(self):
         self._pending = None
+        self._recent_frames = collections.deque(maxlen=3)
         self._frame_id = 0
         self._window_id = 0
         self._window_seconds = self._initial_window_seconds
@@ -483,6 +487,7 @@ class _FrameDiagnostics(object):
         self._projectile_maxima = dict(
             (name, 0.0) for name in _PROJECTILE_METRIC_NAMES)
         self._slow = []
+        self._combat_completed = []
         self._over_50 = 0
         self._over_67 = 0
         self._over_100 = 0
@@ -534,6 +539,15 @@ class _FrameDiagnostics(object):
             return frame_id
 
     def _add(self, row):
+        if row.get('context', {}).get('role') == 'worker':
+            compact = self._compact_frame(row)
+            for previous in self._slow:
+                following = previous.get('following')
+                if following is not None and len(following) < 3:
+                    following.append(compact)
+            row['previous'] = tuple(self._recent_frames)
+            row['following'] = []
+            self._recent_frames.append(compact)
         self._samples += 1
         gap = row['wall_gap']
         raw_dt = row['raw_dt']
@@ -626,6 +640,26 @@ class _FrameDiagnostics(object):
             return False
         self._worker_runtime = dict(report)
         return True
+
+    def note_combat_captures(self, captures):
+        if self.enabled:
+            self._combat_completed.extend(captures)
+
+    @staticmethod
+    def _compact_frame(row):
+        """Retain only plain bounded data, without recursive neighbour rows."""
+        return {
+            'cause': row['cause'], 'next': row['next'],
+            'authority_time': row.get('context', {}).get('authority_time'),
+            'gap_ms': round(row['wall_gap'] * 1000.0, 3),
+            'exec_ms': round(row['exec'] * 1000.0, 3),
+            'outside_ms': round(row['outside'] * 1000.0, 3),
+            'offframe_ms': round(row.get('offframe', 0.0) * 1000.0, 3),
+            'stages_ms': dict((name, round(value * 1000.0, 3))
+                              for name, value in row['stages'].items()),
+            'projectile': dict(row.get('projectile') or {}),
+            'detail': row.get('combat'),
+        }
 
     @staticmethod
     def _milliseconds(value):
@@ -934,10 +968,27 @@ class _FrameDiagnostics(object):
                          name, self._milliseconds(
                              probe_durations.get(name, 0.0)))
                               for name in PROBE_KINDS)))
+            if context.get('role') == 'worker':
+                trace = {
+                    'schema': 1, 'window': self._window_id, 'rank': rank,
+                    'round': context.get('round'), 'map': context.get('map'),
+                    'focus': self._compact_frame(row),
+                }
+                if rank == 1:
+                    trace['previous'] = row.get('previous', ())
+                    trace['following'] = row.get('following', ())
+                lines.append(prefix + 'combat_trace ' + json.dumps(
+                    trace, sort_keys=True, separators=(',', ':')) + '\n')
+        for capture in self._combat_completed:
+            lines.append(prefix + 'combat_summary ' + json.dumps({
+                'schema': 1, 'round': self._last_context.get('round'),
+                'map': self._last_context.get('map'), 'capture': capture,
+            }, sort_keys=True, separators=(',', ':')) + '\n')
         return ''.join(lines)
 
     def finish(self, frame_id, entry_wall, tick_dt, motion_dt, stages,
-               probes, context, probe_durations=None, projectile=None):
+               probes, context, probe_durations=None, projectile=None,
+               combat=None):
         if not self.enabled:
             return
         try:
@@ -963,8 +1014,19 @@ class _FrameDiagnostics(object):
                 'stages': stages, 'probes': probes,
                 'probe_durations': dict(probe_durations or {}),
                 'projectile': dict(projectile or {}),
+                'combat': combat,
                 'context': dict(context or {}), 'emitted': emitted,
             }
+        except Exception:
+            self._disable()
+
+    def flush(self):
+        """Publish the last sealed intervals when a round ends early."""
+        if not self.enabled or not self._samples:
+            return
+        try:
+            self._writer(self._format())
+            self._reset_window()
         except Exception:
             self._disable()
 
@@ -1527,6 +1589,7 @@ class BattleRuntime(object):
             _FrameDiagnostics(
                 initial_window_seconds=DIAGNOSTIC_INITIAL_WINDOW_SECONDS)
             if PERFORMANCE_DIAGNOSTICS else None)
+        self._combat_diagnostics = None
         self._sixth_sense = None
         self._has_sixth_sense = False
         self._has_expert = False
@@ -1790,6 +1853,9 @@ class BattleRuntime(object):
         self._runtime = self._runtime or _load_runtime()
         self._config = dict(config or {})
         self._worker_mode = bool(self._config.get('worker_mode', False))
+        self._combat_diagnostics = (
+            WorkerCombatDiagnostics(_PROFILE_CLOCK)
+            if self._worker_mode and PERFORMANCE_DIAGNOSTICS else None)
         if self._worker_mode:
             self._config['native_remote_vehicles'] = False
             self._config['bot_track_animation'] = False
@@ -3227,7 +3293,8 @@ class BattleRuntime(object):
                 probe_timing_seconds=(
                     WORKER_NATIVE_PROBE_SECONDS if self._worker_mode else 0.0),
                 control_seconds=(
-                    WORKER_CONTROL_SECONDS if self._worker_mode else None))
+                    WORKER_CONTROL_SECONDS if self._worker_mode else None),
+                combat_diagnostics=self._combat_diagnostics)
             self._bots.debug_logging = bool(
                 self._config.get('debug_logging', False))
             # Sampled here, not before BotRuntime exists: the bot, navigator
@@ -12258,6 +12325,7 @@ class BattleRuntime(object):
             cache[cache_key] = dict(result) if result is not None else None
         return result
 
+    @timed('projectile.pose')
     def _projectile_historic_pose_uncached(self, key, wanted):
         """Compute one detached historic pose from the current history."""
         history = self._projectile_position_history
@@ -12363,6 +12431,7 @@ class BattleRuntime(object):
                 maximum = max(maximum, max(offsets.values()))
         return maximum
 
+    @timed('projectile.index')
     def _build_projectile_spatial_bins(self, states, now,
                                        maximum_chords=None):
         """Index a conservative target envelope for one synchronous advance.
@@ -12566,6 +12635,7 @@ class BattleRuntime(object):
             key=lambda key: order[key])
         return tuple((key, records[key]) for key in ordered)
 
+    @timed('projectile.update')
     def _advance_projectiles(self, now, force_progress=False):
         """Advance collision cursors and optionally publish an extra barrier."""
         self._projectile_perf = {}
@@ -12674,6 +12744,7 @@ class BattleRuntime(object):
             second.get('gun_pitch', 0.0)))
         return max(hull, turret, gun)
 
+    @timed('projectile.sweep')
     def _projectile_pose_sweep_fractions(self, key, absolute_start,
                                          absolute_end):
         """Split at recorded samples, then enforce the component angle cap."""
@@ -12759,6 +12830,7 @@ class BattleRuntime(object):
                          [1.0])
         return tuple(fractions)
 
+    @timed('projectile.components')
     def _projectile_frozen_target(self, target, pose):
         """Build one target view whose outer and inner geometry agree."""
         descriptor = self._projectile_descriptor_at_pose(target, pose)
@@ -12779,6 +12851,7 @@ class BattleRuntime(object):
             target, descriptor, matrix, position, appearance,
             self._runtime.math)
 
+    @timed('projectile.vehicle')
     def _projectile_vehicle_collisions(self, record, target, start, end,
                                        pose=None):
         """Return retail ABI collisions plus private world-normal evidence."""
@@ -12805,7 +12878,8 @@ class BattleRuntime(object):
                 if frozen_target is not None:
                     evidence = tuple(_collide_vehicle_evidence_at_matrix(
                         frozen_target, frozen_target.matrix, start, end,
-                        self._runtime.math) or ())
+                        self._runtime.math,
+                        diagnostic=self._combat_diagnostics) or ())
                     return (tuple(item.collision for item in evidence), evidence)
             # A historical query may never borrow a live render matrix or live
             # aim as a fallback: that would combine two different instants in
@@ -12826,10 +12900,12 @@ class BattleRuntime(object):
         if body_matrix is not None:
             evidence = tuple(_collide_vehicle_evidence_at_matrix(
                 target, body_matrix, start, end, self._runtime.math,
-                chassis_matrix=chassis_matrix) or ())
+                chassis_matrix=chassis_matrix,
+                diagnostic=self._combat_diagnostics) or ())
             return (tuple(item.collision for item in evidence), evidence)
         return (tuple(target.collideSegmentExt(start, end) or ()), ())
 
+    @timed('projectile.chord')
     def _projectile_chord(self, state, start, end,
                           absolute_start, absolute_end):
         try:
@@ -13527,6 +13603,7 @@ class BattleRuntime(object):
                     str(record.get('network_id')), error)
         return None
 
+    @timed('projectile.direct')
     def _projectile_direct_effect(self, meta, state, terminal_data):
         target_key = terminal_data.get('target_key')
         record = self._records.get(target_key)
@@ -13740,6 +13817,7 @@ class BattleRuntime(object):
         })
         return result
 
+    @timed('projectile.splash')
     def _projectile_splash_effects(self, meta, impact, direct_key, state=None,
                                    visual_impact=None):
 
@@ -13938,6 +14016,7 @@ class BattleRuntime(object):
                 meta, state, 'resolution_build', reason, submit_error)
             return False
 
+    @timed('projectile.terminal')
     def _projectile_terminal(self, state, terminal):
         try:
             return self._projectile_terminal_impl(state, terminal)
@@ -15013,6 +15092,17 @@ class BattleRuntime(object):
         self._spotted_signature = None
         frame_id = (diagnostics.begin(entry_wall, raw_dt, offframe)
                     if profiling else 0)
+        combat_diagnostic = self._combat_diagnostics
+        if combat_diagnostic is not None and self._battle_live and profiling:
+            trigger = None
+            if self._projectiles is not None and len(self._projectiles):
+                trigger = 'projectiles'
+            elif self._bots is not None and getattr(
+                    self._bots, '_shot_lane_pending_pairs', 0):
+                trigger = 'lane_queue'
+            combat_diagnostic.begin_frame(frame_id, now, trigger)
+            diagnostics.note_combat_captures(
+                combat_diagnostic.drain_completed())
         stages = {}
         probes = dict((name, 0) for name in PROBE_KINDS)
         probe_durations = dict((name, 0.0) for name in PROBE_KINDS)
@@ -15403,6 +15493,7 @@ class BattleRuntime(object):
             diagnostics.finish(
                 frame_id, entry_wall, tick_dt, dt, stages, probes, {
                     'round': (self._start_message or {}).get('round_id', '-'),
+                    'authority_time': now,
                     'map': (self._config or {}).get('map', '-'),
                     'phase': 'live' if self._battle_live else 'prebattle',
                     'role': ('worker' if self._worker_mode else
@@ -15417,7 +15508,9 @@ class BattleRuntime(object):
                     'grind': int(self._local_grind),
                     'transitioned': transitioned,
                 }, probe_durations=probe_durations,
-                projectile=projectile_perf)
+                projectile=projectile_perf,
+                combat=(combat_diagnostic.finish_frame()
+                        if combat_diagnostic is not None else None))
 
     def _mutable_shot_ray(self):
         """Copy #1513's native gun ray before normalising or scattering it."""
@@ -22969,6 +23062,7 @@ class BattleRuntime(object):
         index = max(0, min(int(shell_index), max(0, len(shots) - 1)))
         return shots[index] if shots else {}
 
+    @timed('projectile.scene')
     def _resolve_shot_scene(self, start, end, direction, shot,
                             penetration_factor=None,
                             initial_piercing_loss=0.0,
@@ -22985,7 +23079,9 @@ class BattleRuntime(object):
                 (projectile_state.get('payload') or {}).get(
                     'base_penetration_multiplier'), 1.0)
         if self._destructibles is None:
-            hit = self._runtime.bigworld.wg_collideSegment(
+            hit = timed_call(
+                self._combat_diagnostics, 'native.projectile.world',
+                self._runtime.bigworld.wg_collideSegment,
                 self._avatar.spaceID, start, end, 128)
             return {
                 'world_distance': ((hit[0] - start).length
@@ -23000,7 +23096,8 @@ class BattleRuntime(object):
             cursor = start + direction.scale(travelled)
             result = self._destructibles.shot_world_distance(
                 self._runtime.bigworld, self._avatar.spaceID,
-                cursor, end, direction, shot)
+                cursor, end, direction, shot,
+                diagnostic=self._combat_diagnostics)
             if not isinstance(result, dict):
                 raise RuntimeError(
                     '#1513 destructible shot result must be a dictionary')
@@ -23370,6 +23467,14 @@ class BattleRuntime(object):
             raise cleanup_error
 
     def _cleanup(self):
+        combat_diagnostic = self._combat_diagnostics
+        if combat_diagnostic is not None:
+            combat_diagnostic.close()
+            if self._frame_diagnostics is not None:
+                self._frame_diagnostics.note_combat_captures(
+                    combat_diagnostic.drain_completed())
+                self._frame_diagnostics.flush()
+        self._combat_diagnostics = None
         cleanup_error = None
         try:
             self._restore_native_ram_contact_hook()

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -425,6 +425,23 @@ _PROJECTILE_METRIC_NAMES = (
     'candidates')
 
 
+def _combat_log_lines(prefix, kind, record):
+    """Keep each native log line below #1513's observed 8 KiB limit."""
+    payload = json.dumps(record, sort_keys=True, separators=(',', ':'))
+    line = prefix + kind + ' ' + payload + '\n'
+    if len(line) <= 7168:
+        return line
+    # JSON is ASCII here. Even escaping every byte of one chunk again stays
+    # below the native limit, with room for the engine's own log prefix.
+    chunks = [payload[index:index + 2500]
+              for index in range(0, len(payload), 2500)]
+    return ''.join(prefix + kind + '_part ' + json.dumps({
+        'schema': 2, 'part': index + 1, 'parts': len(chunks),
+        'data': chunk,
+    }, sort_keys=True, separators=(',', ':')) + '\n'
+        for index, chunk in enumerate(chunks))
+
+
 class _FrameDiagnostics(object):
     """Correlate one callback's work with the following render interval."""
 
@@ -969,21 +986,24 @@ class _FrameDiagnostics(object):
                              probe_durations.get(name, 0.0)))
                               for name in PROBE_KINDS)))
             if context.get('role') == 'worker':
-                trace = {
-                    'schema': 1, 'window': self._window_id, 'rank': rank,
-                    'round': context.get('round'), 'map': context.get('map'),
-                    'focus': self._compact_frame(row),
-                }
+                frames = [('focus', 0, self._compact_frame(row))]
                 if rank == 1:
-                    trace['previous'] = row.get('previous', ())
-                    trace['following'] = row.get('following', ())
-                lines.append(prefix + 'combat_trace ' + json.dumps(
-                    trace, sort_keys=True, separators=(',', ':')) + '\n')
+                    for relation in ('previous', 'following'):
+                        frames.extend((relation, index, frame)
+                                      for index, frame in enumerate(
+                                          row.get(relation, ())))
+                for relation, index, frame in frames:
+                    lines.append(_combat_log_lines(prefix, 'combat_trace', {
+                        'schema': 2, 'window': self._window_id, 'rank': rank,
+                        'round': context.get('round'),
+                        'map': context.get('map'), 'relation': relation,
+                        'index': index, 'frame': frame,
+                    }))
         for capture in self._combat_completed:
-            lines.append(prefix + 'combat_summary ' + json.dumps({
-                'schema': 1, 'round': self._last_context.get('round'),
+            lines.append(_combat_log_lines(prefix, 'combat_summary', {
+                'schema': 2, 'round': self._last_context.get('round'),
                 'map': self._last_context.get('map'), 'capture': capture,
-            }, sort_keys=True, separators=(',', ':')) + '\n')
+            }))
         return ''.join(lines)
 
     def finish(self, frame_id, entry_wall, tick_dt, motion_dt, stages,
@@ -13381,6 +13401,7 @@ class BattleRuntime(object):
             return None
         return self._server_entity(record.get('engine_id'))
 
+    @timed('projectile.sticker')
     def _projectile_damage_sticker(self, record, target, shot, start, end,
                                    collisions, result, historic=False):
         """Encode one direct hit against the exact sampled component pose."""
@@ -13429,7 +13450,10 @@ class BattleRuntime(object):
                     decoded_start is None or decoded_end is None or
                     decoded_start == decoded_end or
                     not callable(local_hit_test) or
-                    not local_hit_test(decoded_start, decoded_end)):
+                    not timed_call(
+                        getattr(self, '_combat_diagnostics', None),
+                        'native.projectile.sticker', local_hit_test,
+                        decoded_start, decoded_end)):
                 return None
             return encoded
         except Exception:
@@ -13615,6 +13639,7 @@ class BattleRuntime(object):
 
     @timed('projectile.direct')
     def _projectile_direct_effect(self, meta, state, terminal_data):
+        diagnostic = getattr(self, '_combat_diagnostics', None)
         target_key = terminal_data.get('target_key')
         record = self._records.get(target_key)
         source = self._projectile_source_entity(meta)
@@ -13653,7 +13678,9 @@ class BattleRuntime(object):
         factor = terminal_data.get('penetration_factor')
         range_distance = projectile_range_distance(
             state, terminal_data['impact'])
-        contact = combat_rules.resolve_armor_contact(
+        contact = timed_call(
+            diagnostic, 'projectile.armour_resolve',
+            combat_rules.resolve_armor_contact,
             shot, range_distance, collisions,
             pierce_loss=terminal_data.get('piercing_loss', 0.0),
             penetration_factor=factor,
@@ -13733,17 +13760,22 @@ class BattleRuntime(object):
         if int(result) == 0:
             damage = 0
             hull_damage = 0
-        self._install_critical_equipment_effects(record, critical_target)
+        timed_call(diagnostic, 'projectile.critical_equipment',
+                   self._install_critical_equipment_effects,
+                   record, critical_target)
         if int(result) != 0 and is_he:
             damage, critical, critical_delta = (
-                critical_damage.propose_explosion(
+                timed_call(diagnostic, 'projectile.critical_explosion',
+                    critical_damage.propose_explosion,
                     critical_target, layers, critical_impact,
                     explosion_direction, damage, legacy_shell,
                     attacker_id, deadeye=deadeye, with_delta=True,
                     allow_interior=(int(result) == 2 or
                                     blast_contact is not None)))
         elif int(result) != 0:
-            damage, critical, critical_delta = critical_damage.propose_direct(
+            damage, critical, critical_delta = timed_call(
+                diagnostic, 'projectile.critical_direct',
+                critical_damage.propose_direct,
                 critical_target, layers, trace_start, trace_end, damage,
                 legacy_shell, attacker_id, penetrated=int(result) == 2,
                 deadeye=deadeye, with_delta=True,
@@ -15069,6 +15101,36 @@ class BattleRuntime(object):
             return False
         return probe.stop(reason)
 
+    def _prewarm_critical_layout(self):
+        """Build at most one ready vehicle's hit layout per countdown frame."""
+        if (not self._worker_mode or self._battle_live or
+                self._prebattle_deadline is None):
+            return False
+        for key in sorted(self._records):
+            record = self._records[key]
+            if (not record.get('ready') or record.get('tombstone') or
+                    record.get('local')):
+                continue
+            entity = self._server_entity(record.get('engine_id'))
+            if entity is None or not getattr(entity, 'isStarted', False):
+                continue
+            descriptor = getattr(entity, 'typeDescriptor', None)
+            if (descriptor is None or
+                    record.get('critical_layout_prewarmed') is descriptor):
+                continue
+            try:
+                completed = critical_damage.prewarm_layout(descriptor)
+            except Exception as error:
+                # Prewarming must not block the match or repeatedly retry a
+                # broken layout. The shot path retains its own normal guards.
+                completed = True
+                self._warn_optional_failure(
+                    'critical layout prewarm for %s' % key, error)
+            if completed:
+                record['critical_layout_prewarmed'] = descriptor
+                return True
+        return False
+
     def _frame(self):
         if self.state != 'running':
             return
@@ -15220,6 +15282,10 @@ class BattleRuntime(object):
                     # Tree registration is likewise a countdown optimisation.
                     # A broken native registry must not prevent battle start.
                     pass
+            try:
+                self._prewarm_critical_layout()
+            except Exception as error:
+                self._warn_optional_failure('critical layout prewarm', error)
             if profiling:
                 next_boundary = _PROFILE_CLOCK()
                 stages['prewarm'] = max(0.0, next_boundary - boundary)

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -30,6 +30,7 @@ from gui.mods.offline_lan_0922 import loadout
 from gui.mods.offline_lan_0922 import lan_client
 from gui.mods.offline_lan_0922 import tank_collision
 from gui.mods.offline_lan_0922 import vehicle_physics
+from gui.mods.offline_lan_0922.worker_diagnostics import timed, call as timed_call
 
 
 try:
@@ -1927,8 +1928,9 @@ class BotRuntime(object):
                  water_depth_probe=None, ram_contact_probe=None,
                  bot_equipment_resolver=None,
                  destructible_body_scan=None, control_seconds=None,
-                 incoming_lane_probe=None):
+                 incoming_lane_probe=None, combat_diagnostics=None):
         self.local_player_id = local_player_id
+        self._combat_diagnostics = combat_diagnostics
         self.descriptor_resolver = descriptor_resolver or (lambda unused: {})
         self.player_descriptor_resolver = player_descriptor_resolver
         # Production resolves the same descriptor-local part selected by the
@@ -2233,19 +2235,31 @@ class BotRuntime(object):
         }
 
     def _probe_started(self):
-        if self._probe_clock is None:
-            return None
+        diagnostic = self._combat_diagnostics
+        detail = (diagnostic.start()
+                  if diagnostic is not None and diagnostic.active else None)
+        started = None
         try:
-            return float(self._probe_clock())
+            if self._probe_clock is not None:
+                started = float(self._probe_clock())
         except Exception:
             # Diagnostics must never change or terminate gameplay.
             self._probe_clock = None
             self._probe_clock_pending = None
             self._probe_timing_deadline = None
             self._probe_timing_state = 'failed'
-            return None
+        return (started, detail) if detail is not None else started
+
+    def _probe_timing_enabled(self):
+        return bool(self._probe_clock is not None or
+                    (self._combat_diagnostics is not None and
+                     self._combat_diagnostics.active))
 
     def _probe_finished(self, index, started):
+        if isinstance(started, tuple):
+            started, detail = started
+            self._combat_diagnostics.stop(
+                'bot.probe.' + PROBE_KINDS[index], detail)
         if started is None or self._probe_clock is None:
             return
         try:
@@ -2445,6 +2459,7 @@ class BotRuntime(object):
         self._world_receipt_waiting = next_waiting
         self._world_receipt_frame = None
 
+    @timed('bot.motion_proof')
     def _probe_world_receipt(self, bot_id, position, yaw, speed, descriptor,
                              uncached, maximum_distance=None):
         """Run one read-only exact-hull proof for the selected travel ray."""
@@ -4484,6 +4499,8 @@ class BotRuntime(object):
 
     def _reset_shot_lane_work(self):
         """Discard supplemental identities at one authority boundary."""
+        if self._combat_diagnostics is not None:
+            self._combat_diagnostics.queue_reset()
         self._shot_lane_work_cycle = None
         self._shot_lane_work = []
         self._shot_lane_work_set = set()
@@ -4610,6 +4627,7 @@ class BotRuntime(object):
             cached is not None and cached[0] == cache_key and
             now < cached[1])
 
+    @timed('bot.visibility_schedule')
     def _prepare_visibility_frame(self, players, now, include_humans):
         """Select a bounded, fair stale-pair cohort before native calls."""
         frame = self._visibility_frame
@@ -5057,6 +5075,7 @@ class BotRuntime(object):
             cache[key] = target
         return target
 
+    @timed('bot.human_observations')
     def _append_human_observations(
             self, players, now, aggregate, team_visibility,
             visibility_tick=None):
@@ -5144,6 +5163,7 @@ class BotRuntime(object):
                 self._human_direct_targets[source['id']] = direct_targets
         return True
 
+    @timed('bot.targets')
     def _contacts_for(self, source, players, now, team_spotted=None,
                       visibility_tick=None, processed_bot_ids=None):
         contacts = []
@@ -5985,6 +6005,7 @@ class BotRuntime(object):
             # the old native candidate probe; it never becomes a clear path.
             return None
 
+    @timed('bot.slope')
     def _update_slope_pose(self, state, allow_ungrounded=False):
         """Refresh the four-point hull pose after this tick's ground settle."""
         # The ten-spring solver already owns authoritative pitch and roll.
@@ -6043,15 +6064,19 @@ class BotRuntime(object):
         try:
             hull_yaw = _number(state.get('yaw'))
             motion_yaw = yaw if _number(speed) >= 0.0 else yaw + math.pi
-            if self._probe_clock is None:
-                status = self.motion_resolver(
+            if not self._probe_timing_enabled():
+                status = timed_call(
+                    self._combat_diagnostics, 'bot.physics',
+                    self.motion_resolver,
                     state['id'], position, hull_yaw, speed,
                     descriptor, step, now, commit_enabled,
                     motion_yaw=motion_yaw)
             else:
                 probe_started = self._probe_started()
                 try:
-                    status = self.motion_resolver(
+                    status = timed_call(
+                        self._combat_diagnostics, 'bot.physics',
+                        self.motion_resolver,
                         state['id'], position, hull_yaw, speed,
                         descriptor, step, now, commit_enabled,
                         motion_yaw=motion_yaw)
@@ -6439,6 +6464,7 @@ class BotRuntime(object):
             state['rotation_dir'] = 0
         return False
 
+    @timed('bot.vertical')
     def _update_vertical_motion(self, state, step, tick_pose=None,
                                 attempted_yaw=None,
                                 suspension_motion_pose=None):
@@ -6584,6 +6610,7 @@ class BotRuntime(object):
             state['airborne'] = False
         return False
 
+    @timed('bot.pose_guard')
     def _guard_realised_pose(self, state, tick_pose, tick_was_safe,
                              attempted_yaw, suspension_snapshot=None):
         """Reject a new hazard or outward map-edge drift after all motion."""
@@ -7941,6 +7968,7 @@ class BotRuntime(object):
             except Exception:
                 continue
 
+    @timed('bot.vehicle_contacts')
     def _resolve_tank_contacts(self, players, now, step):
         """Apply current 0.8.2 chassis OBB response and report rams."""
         if self.native_motion:
@@ -8671,7 +8699,7 @@ class BotRuntime(object):
                     state, target, descriptor, shell_index, reproof)
             if not callable(self.ballistic_solution_probe):
                 return None
-            if self._probe_clock is None:
+            if not self._probe_timing_enabled():
                 value = self.ballistic_solution_probe(
                     _copy_runtime_state(state), (dict(target)
                                   if target is not None else None),
@@ -8721,6 +8749,7 @@ class BotRuntime(object):
             int(state.get('fire_seq', 0)),
         )
 
+    @timed('bot.ballistic_aim')
     def _cadenced_ballistic_solution(
             self, state, target, descriptor, shell_index, now, force=False):
         """Refresh target geometry at 10 Hz while presentation stays 30 Hz."""
@@ -8744,6 +8773,7 @@ class BotRuntime(object):
             return solution, True
         return cached[2], False
 
+    @timed('bot.gun_aim')
     def _update_gun_aim(self, state, command, target, step):
         """Slew the rendered turret and barrel through the 0.8.2 limits."""
         descriptor = self._descriptors.get(state['id'], {})
@@ -8863,15 +8893,21 @@ class BotRuntime(object):
         return (float(bucket) / SHOT_LANE_PHASES) * \
             SHOT_LANE_REFRESH_SECONDS
 
-    def _queue_shot_lane_identity(self, key, cycle_time):
+    def _queue_shot_lane_identity(self, key, cycle_time, now):
         if (self._shot_los_deadlines.get(key) == cycle_time or
                 key in self._shot_lane_work_set):
+            if self._combat_diagnostics is not None:
+                self._combat_diagnostics.count('lane_deduplicated')
             return False
         self._shot_lane_work.append(key)
         self._shot_lane_work_set.add(key)
+        if self._combat_diagnostics is not None:
+            self._combat_diagnostics.queue_added(
+                key, now, cycle_time - SHOT_LANE_REFRESH_SECONDS +
+                self._shot_los_phase(key))
         return True
 
-    def _prepare_shot_lane_work(self, cycle_time, team_visibility):
+    def _prepare_shot_lane_work(self, cycle_time, team_visibility, now):
         """Add identities once per target/cycle, never full target records."""
         cycle_time = _number(cycle_time)
         if self._shot_lane_work_cycle != cycle_time:
@@ -8891,7 +8927,7 @@ class BotRuntime(object):
                 team, kind, target_id = target_key
                 for source_id in live_sources.get(team, ()):
                     self._queue_shot_lane_identity(
-                        (source_id, kind, target_id), cycle_time)
+                        (source_id, kind, target_id), cycle_time, now)
 
         for target_key in sorted(
                 key for key, visible in team_visibility.items() if visible):
@@ -8903,7 +8939,7 @@ class BotRuntime(object):
             self._shot_lane_enqueued_targets.add(target_key)
             for source_id in live_sources[team]:
                 self._queue_shot_lane_identity(
-                    (source_id, kind, int(target_id)), cycle_time)
+                    (source_id, kind, int(target_id)), cycle_time, now)
         return True
 
     def _shot_lane_live_records(
@@ -8947,13 +8983,19 @@ class BotRuntime(object):
         return (source_cache[source_id], target_cache[cache_key],
                 target_key)
 
+    @timed('bot.lane_service')
     def _service_shot_lane_work(
             self, now, cycle_time, team_visibility, players,
             visibility_tick, processed_bot_ids, selected_priorities,
             probe_budget):
         """Service bounded current-pose jobs from one persistent identity set."""
-        self._prepare_shot_lane_work(cycle_time, team_visibility)
+        self._prepare_shot_lane_work(cycle_time, team_visibility, now)
+        diagnostic = self._combat_diagnostics
+        if diagnostic is not None:
+            diagnostic.count('lane_service_callbacks')
         if not self._shot_lane_work_set:
+            if diagnostic is not None:
+                diagnostic.queue_state(now, (), selected_priorities)
             return 0
         now = _number(now)
         cycle_time = _number(cycle_time)
@@ -8968,17 +9010,23 @@ class BotRuntime(object):
         materialized = [0]
         maximum_jobs = max(0, int(probe_budget[0]))
 
+        def retire(key, reason):
+            self._shot_lane_work_set.discard(key)
+            if diagnostic is not None:
+                diagnostic.queue_retired(
+                    key, now, reason, key in selected_priorities)
+
         def attempt(key):
             if key in attempted or key not in self._shot_lane_work_set:
                 return False
             attempted.add(key)
             if self._shot_los_deadlines.get(key) == cycle_time:
-                self._shot_lane_work_set.discard(key)
+                retire(key, 'already_complete')
                 return False
             source = self.states.get(int(key[0]))
             if (not isinstance(source, dict) or
                     not source.get('alive', True)):
-                self._shot_lane_work_set.discard(key)
+                retire(key, 'invalid')
                 return False
             source_team = int(source.get('team', 0))
             if key[1] == 'bot':
@@ -8990,19 +9038,23 @@ class BotRuntime(object):
             if (not isinstance(raw_target, dict) or
                     not raw_target.get('alive', True) or
                     int(raw_target.get('team', 0)) == source_team):
-                self._shot_lane_work_set.discard(key)
+                retire(key, 'invalid')
                 return False
             target_key = (source_team, key[1], int(key[2]))
             if not team_visibility.get(target_key, False):
+                if diagnostic is not None:
+                    diagnostic.count('lane_attempt_hidden')
                 return False
             cached = self._shot_los_cache.get(key)
             if cached is not None and cached[0] > window_start + 1e-9:
                 self._shot_los_deadlines[key] = cycle_time
                 self._shot_lane_completed_pairs += 1
-                self._shot_lane_work_set.discard(key)
+                retire(key, 'cache')
                 return False
             deadline = window_start + self._shot_los_phase(key)
             if now + 1e-9 < deadline:
+                if diagnostic is not None:
+                    diagnostic.count('lane_attempt_not_due')
                 return False
             if materialized[0] >= maximum_jobs:
                 return False
@@ -9010,12 +9062,12 @@ class BotRuntime(object):
                 key, live_players, visibility_tick, processed_bot_ids,
                 source_cache, target_cache)
             if source is None or target is None:
-                self._shot_lane_work_set.discard(key)
+                retire(key, 'invalid')
                 return False
             if not team_visibility.get(target_key, False):
                 return False
             if self._shot_los_key(source, target) != key:
-                self._shot_lane_work_set.discard(key)
+                retire(key, 'invalid')
                 return False
             # Only this direct-spot-gated queue may inspect incoming geometry.
             # One extra pair per control callback keeps advisory threat work
@@ -9037,11 +9089,15 @@ class BotRuntime(object):
             # native budget. A distant pure-data rejection is still one
             # bounded job even though it consumes no collision ray.
             materialized[0] += 1
+            probes_before = self._probe_totals[1]
+            distance_cache = [None]
             self._refresh_shot_clear(
                 source, target, now, cycle_time, probe_budget,
-                lane_key=key, distance_cache=[None])
+                lane_key=key, distance_cache=distance_cache)
             if self._shot_los_deadlines.get(key) == cycle_time:
-                self._shot_lane_work_set.discard(key)
+                retire(key, ('probe' if self._probe_totals[1] > probes_before
+                             else 'distance' if distance_cache[0] is not None
+                             else 'cache'))
             return True
 
         selected = sorted(
@@ -9074,6 +9130,8 @@ class BotRuntime(object):
         service_budget_exhausted = materialized[0] >= maximum_jobs
         pending = 0
         budget_deferred = 0
+        eligible_keys = ([] if diagnostic is not None and diagnostic.active
+                         else None)
         for key in self._shot_lane_work_set:
             source = self.states.get(int(key[0]))
             if (not isinstance(source, dict) or
@@ -9094,6 +9152,8 @@ class BotRuntime(object):
             if not team_visibility.get(target_key, False):
                 continue
             pending += 1
+            if eligible_keys is not None:
+                eligible_keys.append(key)
             if (not service_budget_exhausted or key in attempted or
                     now + 1e-9 <
                     window_start + self._shot_los_phase(key)):
@@ -9111,6 +9171,10 @@ class BotRuntime(object):
                     query_distance:
                 budget_deferred += 1
         self._shot_lane_budget_deferred_attempts += budget_deferred
+        if diagnostic is not None:
+            diagnostic.count('lane_materialized', materialized[0])
+            diagnostic.count('lane_budget_deferred_attempts', budget_deferred)
+            diagnostic.queue_state(now, eligible_keys, selected_priorities)
         return pending
 
     def _merge_observation_shot_lanes(
@@ -9124,6 +9188,9 @@ class BotRuntime(object):
             if (not isinstance(source, dict) or
                     not source.get('alive', True) or
                     not sample[1] or _number(now) - sample[0] > maximum_age):
+                if (self._combat_diagnostics is not None and
+                        _number(now) - sample[0] > maximum_age):
+                    self._combat_diagnostics.receipt_expired(lane_key, sample[0])
                 continue
             key = (int(source.get('team', 0)),
                    target_kind, int(target_id))
@@ -9132,6 +9199,12 @@ class BotRuntime(object):
             entry = aggregate.get(key)
             if entry is not None:
                 entry[1].add(int(source_id))
+                if (self._combat_diagnostics is not None and
+                        self._combat_diagnostics.active):
+                    selected = self._selected_visibility_target(source)
+                    self._combat_diagnostics.receipt_published(
+                        lane_key, sample[0],
+                        selected == (target_kind, int(target_id)))
         return True
 
     def _shot_clear(self, source, target, now, force=False,
@@ -9158,6 +9231,8 @@ class BotRuntime(object):
         cached = self._shot_los_cache.get(key)
         if (not force and cached is not None and
                 _number(now) - cached[0] <= SHOT_LANE_SECONDS + 1e-9):
+            if self._combat_diagnostics is not None:
+                self._combat_diagnostics.count('lane_final_cache_reads')
             return cached[1]
         if probe_budget is not None:
             if probe_budget[0] <= 0:
@@ -9170,6 +9245,8 @@ class BotRuntime(object):
         finally:
             self._probe_finished(1, probe_started)
         self._shot_los_cache[key] = (_number(now), value)
+        if self._combat_diagnostics is not None:
+            self._combat_diagnostics.receipt_stored(key, _number(now), value)
         if len(self._shot_los_cache) > 1024:
             oldest = sorted(self._shot_los_cache.items(),
                             key=lambda item: item[1][0])[:256]
@@ -9210,6 +9287,7 @@ class BotRuntime(object):
         self._shot_lane_completed_pairs += 1
         return True
 
+    @timed('bot.observation_pack')
     def _pack_observations(self, aggregate, now):
         """Serialise one lightweight record per canonical team target.
 
@@ -9453,7 +9531,7 @@ class BotRuntime(object):
         shot_yaw = intent['shot_yaw']
         shot_pitch = intent['shot_pitch']
         flight_time = intent['solution']['flight_time']
-        if self._probe_clock is None:
+        if not self._probe_timing_enabled():
             value = self.artillery_launch_probe(
                 _copy_runtime_state(state), dict(target), descriptor,
                 int(shell_index),
@@ -9532,7 +9610,7 @@ class BotRuntime(object):
             burst_index, burst_group_seq,
             base_direction=base_direction)
         try:
-            if self._probe_clock is None:
+            if not self._probe_timing_enabled():
                 raw_origin = self.direct_launch_origin_probe(
                     _copy_runtime_state(state), descriptor, int(shell_index),
                     fire_seq,
@@ -9942,7 +10020,7 @@ class BotRuntime(object):
                 self._cancel_active_burst(
                     state, gun_state, ammo_state, burst_state)
                 break
-            if self._probe_clock is None:
+            if not self._probe_timing_enabled():
                 lane_value = self.friendly_lane_probe(
                     state, target if isinstance(target, dict) else {},
                     descriptor, burst_state.shell_index, preview)
@@ -9980,6 +10058,7 @@ class BotRuntime(object):
             result = min(result, due)
         return result
 
+    @timed('bot.update')
     def update(self, dt, now, players=None, neighbours=None):
         """Advance Bot motion in real time with one control refresh per frame.
 
@@ -10083,6 +10162,7 @@ class BotRuntime(object):
             message['source_batch_horizon_us'] = source_batch_horizon_us
         return outgoing
 
+    @timed('bot.destructible_bodies')
     def _scan_moving_destructible_bodies(self):
         """Scan each moving hull once at its final control-callback pose."""
         scan = self.destructible_body_scan
@@ -10114,10 +10194,17 @@ class BotRuntime(object):
             (self._refresh_control_this_step,
              self._publish_control_this_step) = previous
 
+    @timed('bot.slice')
     def _update_once(self, frame_step, now, players=None, neighbours=None):
         """Advance one stable authority substep and preserve its events."""
         publish = bool(self._publish_control_this_step)
         refresh_control = bool(self._refresh_control_this_step)
+        if self._combat_diagnostics is not None:
+            self._combat_diagnostics.count(
+                'bot_control_refreshes', int(refresh_control))
+            self._combat_diagnostics.count('bot_physical_slices')
+            self._combat_diagnostics.count(
+                'bot_elapsed_us', int(round(frame_step * 1000000.0)))
         self._incoming_lane_budget = 1 if refresh_control else 0
         step_duration_us = max(
             1, int(round(float(frame_step) * 1000000.0)))
@@ -10368,7 +10455,9 @@ class BotRuntime(object):
                     self._friendly_reposition_order(state, targets, now)
                 if (reposition_order is not None and
                         callable(decide_with_order)):
-                    command = decide_with_order(
+                    command = timed_call(
+                        self._combat_diagnostics, 'bot.planner_driver',
+                        decide_with_order,
                         decision_state, reposition_order, sample_clear)
                 elif server_order is not None and callable(decide_with_order):
                     server_order = dict(server_order)
@@ -10380,13 +10469,19 @@ class BotRuntime(object):
                         server_order,
                         targets.get(server_order.get('target_id')),
                         position)
-                    command = decide_with_order(
+                    command = timed_call(
+                        self._combat_diagnostics, 'bot.planner_driver',
+                        decide_with_order,
                         decision_state, server_order,
                         sample_clear)
                 else:
-                    command = self.adapter.decide(
+                    command = timed_call(
+                        self._combat_diagnostics, 'bot.planner_driver',
+                        self.adapter.decide,
                         decision_state, sample_clear)
-                command = self._traffic_coordinator.adjust(
+                command = timed_call(
+                    self._combat_diagnostics, 'bot.traffic',
+                    self._traffic_coordinator.adjust,
                     state['id'], traffic_bodies[state['id']], command,
                     decision_state['neighbours'], now, sample_clear)
                 if reposition_expired:
@@ -10988,14 +11083,18 @@ class BotRuntime(object):
                     # exact resolver must not sweep (and possibly crush) along
                     # a corridor the hull is not travelling this slice.
                     resolved_motion = True
-                    if self._probe_clock is None:
-                        motion_status = self.motion_resolver(
+                    if not self._probe_timing_enabled():
+                        motion_status = timed_call(
+                            self._combat_diagnostics, 'bot.physics',
+                            self.motion_resolver,
                             state['id'], position, state['yaw'], speed,
                             descriptor, step, now)
                     else:
                         probe_started = self._probe_started()
                         try:
-                            motion_status = self.motion_resolver(
+                            motion_status = timed_call(
+                                self._combat_diagnostics, 'bot.physics',
+                                self.motion_resolver,
                                 state['id'], position, state['yaw'], speed,
                                 descriptor, step, now)
                         finally:
@@ -11120,7 +11219,7 @@ class BotRuntime(object):
                         state, target, descriptor, state['shell_index'],
                         gun_state, ballistic_solution, now)
                     if launch_receipt is not None:
-                        if self._probe_clock is None:
+                        if not self._probe_timing_enabled():
                             lane_value = self.artillery_friendly_lane_probe(
                                 state, target, descriptor,
                                 state['shell_index'], launch_receipt)
@@ -11140,7 +11239,7 @@ class BotRuntime(object):
                         state, descriptor, state['shell_index'], gun_state,
                         ballistic_solution)
                     if launch_preview is not None:
-                        if self._probe_clock is None:
+                        if not self._probe_timing_enabled():
                             lane_value = self.friendly_lane_probe(
                                 state, target, descriptor,
                                 state['shell_index'], launch_preview)
@@ -11213,6 +11312,10 @@ class BotRuntime(object):
             self._update_shot_lane_debt_diagnostics(
                 now, shot_lane_refresh_time,
                 self._shot_lane_pending_pairs, shot_lane_refresh_due)
+            if self._combat_diagnostics is not None:
+                self._combat_diagnostics.queue_state(
+                    now, None, selected_lane_priorities,
+                    cover_blocked=refresh_control and bool(self._cover_queue))
         if (shot_lane_refresh_due and refresh_shot_lanes and
                 shot_lanes_ready):
             self._next_shot_lane_refresh = (

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -5187,6 +5187,10 @@ class BotRuntime(object):
             visibility_tick.setdefault('target_pose_snapshots', {})
             if isinstance(visibility_tick, dict) else None)
 
+        hidden_templates = (
+            visibility_tick.setdefault('hidden_target_templates', {})
+            if isinstance(visibility_tick, dict) else {})
+
         def resolve_source_view_range():
             if source_view_range[0] is None:
                 source_view_range[0] = self._source_view_range(
@@ -5202,6 +5206,20 @@ class BotRuntime(object):
                 target.update(remembered)
                 return True
             remembered = self._visible_target_poses.get(key)
+            cache_key = (source_team, id(template), id(remembered))
+            cached = hidden_templates.get(cache_key)
+            if cached is not None:
+                # Retain the original objects with the projection: identities
+                # cannot be recycled during this slice. Only pose removal and
+                # the team's remembered pose are shared, never observer flags.
+                visible = bool(target['visible'] and remembered is not None)
+                direct = target['direct_visible']
+                fresh = target['fresh_visible']
+                target.clear()
+                target.update(cached[2])
+                target.update(visible=visible, direct_visible=direct,
+                              fresh_visible=fresh)
+                return visible
             # Discard every live pose field first: an old observation can lack
             # articulation or velocity that the current hidden entity has.
             for name in _TARGET_POSE_FIELDS:
@@ -5216,8 +5234,12 @@ class BotRuntime(object):
                     'yaw': 0.0, 'speed': 0.0,
                 })
                 target['visible'] = False
-                return False
-            target.update(remembered)
+            else:
+                target.update(remembered)
+            projection = dict(target)
+            for name in ('visible', 'direct_visible', 'fresh_visible'):
+                projection.pop(name, None)
+            hidden_templates[cache_key] = (template, remembered, projection)
             return bool(target.get('visible'))
 
         def visible_to_team(target):
@@ -9065,6 +9087,21 @@ class BotRuntime(object):
                 if diagnostic is not None:
                     diagnostic.count('lane_attempt_not_due')
                 return False
+            target_distance = _distance(
+                _position(source), _position(raw_target))
+            incoming_due = bool(self._incoming_lane_budget and
+                                callable(self.incoming_lane_probe))
+            if (target_distance > self._shot_lane_query_distance(source) and
+                    not incoming_due):
+                # Resolve cheap range rejects at the current service pose,
+                # before copying a full job or spending a native-work slot.
+                # Keep the independent enemy -> own-body probe: the enemy's
+                # gun can reach farther than this source's outgoing lane.
+                self._shot_los_cache[key] = (now, False)
+                self._shot_los_deadlines[key] = cycle_time
+                self._shot_lane_completed_pairs += 1
+                retire(key, 'distance')
+                return False
             if materialized[0] >= maximum_jobs:
                 return False
             source, target, target_key = self._shot_lane_live_records(
@@ -9081,8 +9118,7 @@ class BotRuntime(object):
             # Only this direct-spot-gated queue may inspect incoming geometry.
             # One extra pair per control callback keeps advisory threat work
             # bounded independently of the final-shot safety checks.
-            if (self._incoming_lane_budget and
-                    callable(self.incoming_lane_probe)):
+            if incoming_due:
                 self._incoming_lane_budget -= 1
                 probe_started = self._probe_started()
                 self._probe_totals[1] += 1
@@ -9094,12 +9130,11 @@ class BotRuntime(object):
                     self._probe_finished(1, probe_started)
                 if incoming is not None:
                     self._incoming_lanes[key] = (now, bool(incoming))
-            # Count identities resolved at service time separately from the
-            # native budget. A distant pure-data rejection is still one
-            # bounded job even though it consumes no collision ray.
+            # Bound full current-pose jobs, including the independent incoming
+            # probe. Pure outgoing range rejects above need no such slot.
             materialized[0] += 1
             probes_before = self._probe_totals[1]
-            distance_cache = [None]
+            distance_cache = [target_distance]
             self._refresh_shot_clear(
                 source, target, now, cycle_time, probe_budget,
                 lane_key=key, distance_cache=distance_cache)
@@ -9170,14 +9205,8 @@ class BotRuntime(object):
             cached = self._shot_los_cache.get(key)
             if cached is not None and cached[0] > window_start + 1e-9:
                 continue
-            profile = source.get('profile')
-            profile = profile if isinstance(profile, dict) else {}
-            query_distance = (
-                SPG_SHOT_LANE_QUERY_DISTANCE
-                if str(profile.get('class_tag') or '') == 'SPG'
-                else SHOT_LANE_QUERY_DISTANCE)
             if _distance(_position(source), _position(raw_target)) <= \
-                    query_distance:
+                    self._shot_lane_query_distance(source):
                 budget_deferred += 1
         self._shot_lane_budget_deferred_attempts += budget_deferred
         if diagnostic is not None:
@@ -9216,6 +9245,14 @@ class BotRuntime(object):
                         selected == (target_kind, int(target_id)))
         return True
 
+    @staticmethod
+    def _shot_lane_query_distance(source):
+        profile = source.get('profile')
+        profile = profile if isinstance(profile, dict) else {}
+        return (SPG_SHOT_LANE_QUERY_DISTANCE
+                if str(profile.get('class_tag') or '') == 'SPG'
+                else SHOT_LANE_QUERY_DISTANCE)
+
     def _shot_clear(self, source, target, now, force=False,
                     probe_budget=None, lane_key=None, distance_cache=None):
         """Probe a current static firing lane independently from team spotting."""
@@ -9229,12 +9266,7 @@ class BotRuntime(object):
             target_distance = _distance(_position(source), target_position)
             if distance_cache is not None:
                 distance_cache[0] = target_distance
-        profile = source.get('profile')
-        profile = profile if isinstance(profile, dict) else {}
-        query_distance = (SPG_SHOT_LANE_QUERY_DISTANCE
-                          if str(profile.get('class_tag') or '') == 'SPG'
-                          else SHOT_LANE_QUERY_DISTANCE)
-        if target_distance > query_distance:
+        if target_distance > self._shot_lane_query_distance(source):
             self._shot_los_cache[key] = (_number(now), False)
             return False
         cached = self._shot_los_cache.get(key)
@@ -10203,6 +10235,20 @@ class BotRuntime(object):
             (self._refresh_control_this_step,
              self._publish_control_this_step) = previous
 
+    def _cover_job_current(self, job, now):
+        unused_ready, bot_id, source, target, unused_route, unused_allies = job
+        current_source = self.states.get(int(bot_id))
+        target_key = (source.get('team'), target.get('kind', 'human'),
+                      int(target.get('network_id', 0)))
+        remembered = self._visible_target_poses.get(target_key)
+        current = bool(
+            current_source is not None and
+            current_source.get('alive', True) and
+            current_source.get('team') == source.get('team') and
+            remembered is not None and
+            self._team_spot_time_left(target_key, now) > 0.0)
+        return current, current_source, remembered
+
     @timed('bot.slice')
     def _update_once(self, frame_step, now, players=None, neighbours=None):
         """Advance one stable authority substep and preserve its events."""
@@ -10244,9 +10290,13 @@ class BotRuntime(object):
         collect_observation = publish and observation_due
         shot_lane_refresh_time = self._next_shot_lane_refresh
         shot_lane_refresh_due = now >= shot_lane_refresh_time
+        cover_reserved = bool(
+            refresh_control and self._cover_queue and
+            now + 1e-9 >= self._cover_queue[0][0] and
+            self._cover_job_current(self._cover_queue[0], now)[0])
         refresh_shot_lanes = (
             refresh_control and
-            not self._cover_queue and
+            not cover_reserved and
             (shot_lane_refresh_due or
              (shot_lane_refresh_time > 0.0 and
               now + SHOT_LANE_REFRESH_SECONDS + 1e-9 >=
@@ -11324,7 +11374,7 @@ class BotRuntime(object):
             if self._combat_diagnostics is not None:
                 self._combat_diagnostics.queue_state(
                     now, None, selected_lane_priorities,
-                    cover_blocked=refresh_control and bool(self._cover_queue))
+                    cover_blocked=cover_reserved)
         if (shot_lane_refresh_due and refresh_shot_lanes and
                 shot_lanes_ready):
             self._next_shot_lane_refresh = (
@@ -11358,16 +11408,8 @@ class BotRuntime(object):
             ready_at, bot_id, source, target, route, allies = \
                 self._cover_queue[0]
             if now + 1e-9 >= ready_at:
-                del self._cover_queue[0]
-                current_source = self.states.get(int(bot_id))
-                target_key = (source.get('team'), target.get('kind', 'human'),
-                              int(target.get('network_id', 0)))
-                remembered = self._visible_target_poses.get(target_key)
-                current = (current_source is not None and
-                           current_source.get('alive', True) and
-                           current_source.get('team') == source.get('team') and
-                           remembered is not None and
-                           self._team_spot_time_left(target_key, now) > 0.0)
+                current, current_source, remembered = self._cover_job_current(
+                    self._cover_queue.pop(0), now)
                 if current:
                     source = _copy_runtime_state(current_source)
                     target = dict(target)

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/critical_damage.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/critical_damage.py
@@ -399,6 +399,23 @@ def _offh_internal_layout(td):
 		return None
 
 
+def prewarm_layout(td):
+	"""Prepare the hit layout only after all native component bounds exist.
+
+	An incomplete descriptor must never seed build_layout's configuration
+	cache with a failed layout before the real first shot can use it.
+	"""
+	if td is None:
+		return False
+	from gui.mods.offline_lan_0922 import internal_hit_layouts
+	for parent in internal_hit_layouts.SUPPORTED_PARENTS:
+		bounds, unused_source = internal_hit_layouts._bbox_for_component(td, parent)
+		if bounds is None:
+			return False
+	_offh_internal_layout(td)
+	return True
+
+
 def _offh_internal_ray_hits(target_mock, td, start_pos, end_pos, covered=()):
 	'''Interior modules and crew the shell REALLY passed through.
 

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/destructibles_sensor.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/destructibles_sensor.py
@@ -5887,25 +5887,32 @@ def _transparent_tree_shot_filter_1513(ignored_trees):
 
 
 def shot_world_distance(bigworld, spaceID, start_pos, end_pos, dir_vec,
-		shot=None):
+		shot=None, diagnostic=None):
 	"""Resolve the first native or exact-catalog destructible on a shell ray.
 
 	Passing a shot opts into typed traversal metadata.  Omitting it preserves the
 	legacy float contract for diagnostics and old fixtures.
 	"""
 	import math
+	def measured(stage, function, *args):
+		if diagnostic is None:
+			return function(*args)
+		return diagnostic.call(stage, function, *args)
+
 	ignored_trees = set()
 	tree_filter = _transparent_tree_shot_filter_1513(ignored_trees)
 	tree_hits = 0
 	world_dist = 99999.0
-	world_collision = bigworld.wg_collideSegment(
+	world_collision = measured('native.projectile.world',
+		bigworld.wg_collideSegment,
 		spaceID, start_pos, end_pos, 128)
 	shot_yaw = math.atan2(dir_vec.x, dir_vec.z)
 	decoded = None
 	catalog_hit = None
 	while world_collision is not None:
 		world_dist = (world_collision[0] - start_pos).length
-		mat_info = bigworld.wg_getMatInfoNearPoint(
+		mat_info = measured('native.projectile.material',
+			bigworld.wg_getMatInfoNearPoint,
 			spaceID, start_pos,
 			world_collision[0] + dir_vec.scale(0.3),
 			world_collision[0], lambda *unused: False)
@@ -5936,7 +5943,8 @@ def shot_world_distance(bigworld, spaceID, start_pos, end_pos, dir_vec,
 			if tree_hits > 64:
 				raise RuntimeError(
 					'#1513 transparent tree shot traversal exceeded 64 hits')
-			world_collision = bigworld.wg_collideSegment(
+			world_collision = measured('native.projectile.world',
+				bigworld.wg_collideSegment,
 				spaceID, start_pos, end_pos, 128, tree_filter)
 			continue
 		if destruction_accepted:
@@ -5970,7 +5978,8 @@ def shot_world_distance(bigworld, spaceID, start_pos, end_pos, dir_vec,
 					world_dist, stop_distance=world_dist,
 					stopped_by_destructible=True)
 			# Destructible broken by the shell: re-cast past the debris.
-			second = bigworld.wg_collideSegment(
+			second = measured('native.projectile.world',
+				bigworld.wg_collideSegment,
 				spaceID, world_collision[0] + dir_vec.scale(0.6),
 				end_pos, 128)
 			return ((second[0] - start_pos).length
@@ -6080,7 +6089,8 @@ def shot_world_distance(bigworld, spaceID, start_pos, end_pos, dir_vec,
 		return catalog_hit['distance']
 	recast_distance = catalog_hit['exit_distance'] + _SHOT_RAY_EPSILON
 	recast_start = start_pos + dir_vec.scale(recast_distance)
-	second = bigworld.wg_collideSegment(
+	second = measured('native.projectile.world',
+		bigworld.wg_collideSegment,
 		spaceID, recast_start, end_pos, 128)
 	return ((second[0] - start_pos).length
 		if second is not None else 99999.0)

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/entities/remote_vehicle.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/entities/remote_vehicle.py
@@ -1603,7 +1603,7 @@ def encode_damage_sticker(vehicle, vehicle_matrix, start_point, end_point,
 
 def _collide_vehicle_at_matrix(vehicle, vehicle_matrix, start_point,
                                end_point, math_module, include_world_normal,
-                               chassis_matrix=None):
+                               chassis_matrix=None, diagnostic=None):
     """Run precise descriptor collision at supplied body/chassis matrices.
 
     #1513's native ``Vehicle.collideSegmentExt`` first rejects rays through
@@ -1647,7 +1647,12 @@ def _collide_vehicle_at_matrix(vehicle, vehicle_matrix, start_point,
         # contact below is a pure function of this ray and that distance.
         component_start = component_matrix.applyPoint(start)
         component_end = component_matrix.applyPoint(end)
-        collisions = local_hit_test(component_start, component_end)
+        if diagnostic is None:
+            collisions = local_hit_test(component_start, component_end)
+        else:
+            collisions = diagnostic.call(
+                'native.projectile.armour', local_hit_test,
+                component_start, component_end)
         component_to_vehicle = None
         if include_world_normal:
             component_to_vehicle = math_module.Matrix(component_matrix)
@@ -1694,11 +1699,11 @@ def _collide_vehicle_at_matrix(vehicle, vehicle_matrix, start_point,
 
 def _collide_vehicle_evidence_at_matrix(vehicle, vehicle_matrix, start_point,
                                         end_point, math_module,
-                                        chassis_matrix=None):
+                                        chassis_matrix=None, diagnostic=None):
     """Return world-normal evidence for the authoritative shot resolver."""
     return _collide_vehicle_at_matrix(
         vehicle, vehicle_matrix, start_point, end_point, math_module, True,
-        chassis_matrix=chassis_matrix)
+        chassis_matrix=chassis_matrix, diagnostic=diagnostic)
 
 
 def collide_vehicle_at_matrix(vehicle, vehicle_matrix, start_point,

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/worker_diagnostics.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/worker_diagnostics.py
@@ -1,0 +1,383 @@
+# -*- coding: utf-8 -*-
+"""Bounded, observational timings for the hidden worker's combat workload.
+
+All durations use the injected wall clock. Queue timestamps use authority
+time. Neither clock, a diagnostic failure, nor a captured value controls
+simulation work. Stage totals include children; self time excludes them.
+"""
+
+import collections
+import functools
+import math
+
+
+CAPTURE_SECONDS = 30.0
+CAPTURE_COOLDOWN_SECONDS = 30.0
+MAX_CAPTURES = 3
+MAX_QUEUE_IDENTITIES = 1024
+MAX_WAIT_SAMPLES = 512
+
+
+def call(diagnostic, stage, function, *args, **kwargs):
+    """Measure an injected adapter without changing its callable identity."""
+    if diagnostic is None or not diagnostic.active:
+        return function(*args, **kwargs)
+    token = diagnostic.start()
+    try:
+        return function(*args, **kwargs)
+    finally:
+        diagnostic.stop(stage, token)
+
+
+def timed(stage):
+    """Time an owned Python boundary only during a combat capture."""
+    def decorate(method):
+        @functools.wraps(method)
+        def measured(self, *args, **kwargs):
+            diagnostic = getattr(self, '_combat_diagnostics', None)
+            if diagnostic is None or not diagnostic.active:
+                return method(self, *args, **kwargs)
+            token = diagnostic.start()
+            try:
+                return method(self, *args, **kwargs)
+            finally:
+                diagnostic.stop(stage, token)
+        return measured
+    return decorate
+
+
+class WorkerCombatDiagnostics(object):
+    """Capture three combat windows without retaining entities or poses."""
+
+    def __init__(self, clock, capture_seconds=CAPTURE_SECONDS,
+                 cooldown_seconds=CAPTURE_COOLDOWN_SECONDS,
+                 maximum_captures=MAX_CAPTURES):
+        self.clock = clock
+        self.capture_seconds = float(capture_seconds)
+        self.cooldown_seconds = float(cooldown_seconds)
+        self.maximum_captures = int(maximum_captures)
+        self.reset()
+
+    def reset(self):
+        self.enabled = True
+        self.active = False
+        self.capture = 0
+        self._deadline = None
+        self._next_capture = 0.0
+        self._reason = None
+        self._frame = 0
+        self._now = 0.0
+        self._stack = []
+        self._stages = {}
+        self._counts = {}
+        self._queue = {}
+        self._receipts = {}
+        self._waits = []
+        self._selected_waits = []
+        self._queue_snapshot = {}
+        self._capture_totals = {}
+        self._capture_counts = {}
+        self._capture_queue_maxima = {}
+        self._capture_started = 0.0
+        self._capture_last = 0.0
+        self._capture_frames = 0
+        self._capture_waits = collections.deque(maxlen=MAX_WAIT_SAMPLES)
+        self._capture_selected_waits = collections.deque(
+            maxlen=MAX_WAIT_SAMPLES)
+        self._capture_wait_count = 0
+        self._capture_selected_wait_count = 0
+        self._completed = []
+
+    def _fail(self):
+        self.enabled = False
+        self.active = False
+        self._stack = []
+        self._queue.clear()
+        self._receipts.clear()
+
+    @staticmethod
+    def _finite(value):
+        value = float(value)
+        if math.isnan(value) or math.isinf(value):
+            raise ValueError('non-finite diagnostic clock')
+        return value
+
+    def begin_frame(self, frame, now, trigger=None):
+        """Arm at frame entry; never turn timing on midway through a call."""
+        if not self.enabled:
+            return False
+        try:
+            now = self._finite(now)
+            if self._deadline is not None and now >= self._deadline:
+                self._complete_capture('deadline')
+                self._next_capture = now + self.cooldown_seconds
+                self._deadline = None
+            if (self._deadline is None and trigger and
+                    now >= self._next_capture and
+                    self.capture < self.maximum_captures):
+                self.capture += 1
+                self._reason = str(trigger)
+                self._deadline = now + self.capture_seconds
+                self._capture_totals = {}
+                self._capture_counts = {}
+                self._capture_queue_maxima = {}
+                self._capture_started = now
+                self._capture_last = now
+                self._capture_frames = 0
+                self._capture_waits.clear()
+                self._capture_selected_waits.clear()
+                self._capture_wait_count = 0
+                self._capture_selected_wait_count = 0
+                self._receipts.clear()
+            self._frame = int(frame)
+            self._now = now
+            self.active = self._deadline is not None
+            self._stack = []
+            self._stages = {}
+            self._counts = {}
+            self._waits = []
+            self._selected_waits = []
+            self._queue_snapshot = {}
+            return self.active
+        except Exception:
+            self._fail()
+            return False
+
+    def start(self):
+        if not self.active:
+            return None
+        try:
+            token = [self._finite(self.clock()), 0.0]
+            self._stack.append(token)
+            return token
+        except Exception:
+            self._fail()
+            return None
+
+    def call(self, stage, function, *args, **kwargs):
+        return call(self, stage, function, *args, **kwargs)
+
+    def stop(self, stage, token):
+        if token is None or not self.active:
+            return
+        try:
+            elapsed = max(0.0, self._finite(self.clock()) - token[0])
+            if not self._stack or self._stack[-1] is not token:
+                raise ValueError('diagnostic scope ownership changed')
+            self._stack.pop()
+            if self._stack:
+                self._stack[-1][1] += elapsed
+            row = self._stages.setdefault(stage, [0, 0.0, 0.0, 0.0])
+            row[0] += 1
+            row[1] += elapsed
+            row[2] += max(0.0, elapsed - token[1])
+            row[3] = max(row[3], elapsed)
+        except Exception:
+            self._fail()
+
+    def count(self, name, value=1):
+        if self.active:
+            self._counts[name] = self._counts.get(name, 0) + int(value)
+
+    def queue_added(self, key, now, ready_at):
+        """Keep enqueue times outside captures so waits are not truncated."""
+        if not self.enabled:
+            return
+        if key in self._queue:
+            self.count('lane_deduplicated')
+            return
+        if len(self._queue) >= MAX_QUEUE_IDENTITIES:
+            self.count('lane_tracking_overflow')
+            return
+        self._queue[key] = (now, max(now, ready_at))
+        self.count('lane_added')
+
+    def queue_reset(self):
+        self.count('lane_cycle_retired', len(self._queue))
+        self._queue.clear()
+
+    def queue_retired(self, key, now, reason, selected=False):
+        stamp = self._queue.pop(key, None)
+        if not self.active:
+            return
+        self.count('lane_retired_' + reason)
+        if stamp is not None and reason in ('probe', 'cache', 'distance'):
+            wait = max(0.0, now - stamp[0])
+            self._waits.append(wait)
+            if selected:
+                self._selected_waits.append(wait)
+
+    def queue_state(self, now, eligible_keys, selected_keys,
+                    cover_blocked=False):
+        if not self.active:
+            return
+        due = 0
+        oldest_wait = 0.0
+        oldest_due = 0.0
+        selected_due = 0.0
+        selected_count = 0
+        oldest_key = None
+        selected_key = None
+        tracked = 0
+        eligibility_checked = eligible_keys is not None
+        if eligible_keys is None:
+            eligible_keys = self._queue
+        for key in eligible_keys:
+            stamp = self._queue.get(key)
+            if stamp is None:
+                continue
+            tracked += 1
+            wait = max(0.0, now - stamp[0])
+            overdue = max(0.0, now - stamp[1])
+            if oldest_key is None or wait > oldest_wait:
+                oldest_key = key
+                oldest_wait = wait
+            oldest_due = max(oldest_due, overdue)
+            due += int(now >= stamp[1])
+            if key in selected_keys:
+                selected_count += 1
+                if selected_key is None or overdue > selected_due:
+                    selected_key = key
+                selected_due = max(selected_due, overdue)
+        self._queue_snapshot = {
+            'identities': len(self._queue), 'eligible_tracked': tracked,
+            'due': due, 'selected_pending': selected_count,
+            'oldest_wait_ms': round(oldest_wait * 1000.0, 3),
+            'oldest_due_ms': round(oldest_due * 1000.0, 3),
+            'selected_oldest_due_ms': round(selected_due * 1000.0, 3),
+            'cover_blocked': bool(cover_blocked),
+            'eligibility_checked': eligibility_checked,
+            'oldest_job': oldest_key,
+            'selected_oldest_job': selected_key,
+        }
+        self.count('lane_service_cover_blocked', int(cover_blocked))
+
+    def receipt_stored(self, key, now, clear):
+        if not self.active:
+            return
+        self.count('lane_receipts_positive' if clear else 'lane_receipts_blocked')
+        old = self._receipts.get(key)
+        if old is not None and old[1] and not old[2]:
+            self.count('lane_positive_replaced_unpublished')
+        if key in self._receipts or len(self._receipts) < MAX_QUEUE_IDENTITIES:
+            self._receipts[key] = [now, bool(clear), False]
+
+    def receipt_published(self, key, sampled_at, selected):
+        if not self.active:
+            return
+        self.count('lane_positive_publications')
+        self.count('lane_selected_positive_publications', int(selected))
+        receipt = self._receipts.get(key)
+        if receipt is not None and receipt[0] == sampled_at:
+            if not receipt[2]:
+                self.count('lane_distinct_positive_published')
+            receipt[2] = True
+
+    def receipt_expired(self, key, sampled_at):
+        if not self.active:
+            return
+        receipt = self._receipts.get(key)
+        if receipt is not None and receipt[0] == sampled_at:
+            self._receipts.pop(key, None)
+            if receipt[1]:
+                self.count('lane_positive_expired')
+                if not receipt[2]:
+                    self.count('lane_positive_expired_unpublished')
+
+    @staticmethod
+    def _wait_summary(values, count=None):
+        ordered = sorted(values)
+        def percentile(fraction):
+            if not ordered:
+                return 0.0
+            index = (len(ordered) - 1) * fraction
+            low = int(index)
+            high = min(low + 1, len(ordered) - 1)
+            return round(1000.0 * (
+                ordered[low] + (ordered[high] - ordered[low]) *
+                (index - low)), 3)
+        return {
+            'count': len(values) if count is None else count,
+            'kept': len(values), 'p50_ms': percentile(0.50),
+            'p95_ms': percentile(0.95), 'max_kept_ms': percentile(1.0),
+        }
+
+    @staticmethod
+    def _stage_rows(stages):
+        return dict((name, {
+            'calls': row[0], 'total_ms': round(row[1] * 1000.0, 3),
+            'self_ms': round(row[2] * 1000.0, 3),
+            'max_ms': round(row[3] * 1000.0, 3),
+        }) for name, row in stages.items())
+
+    def finish_frame(self):
+        if not self.active:
+            return None
+        try:
+            if self._stack:
+                raise ValueError('unfinished diagnostic scope')
+            result = {
+                'capture': self.capture, 'trigger': self._reason,
+                'frame': self._frame, 'authority_time': self._now,
+                'stages': self._stage_rows(self._stages),
+                'counts': dict(self._counts),
+                'queue': dict(self._queue_snapshot),
+                'completed_wait': self._wait_summary(self._waits),
+                'selected_completed_wait': self._wait_summary(
+                    self._selected_waits),
+            }
+            for name, row in self._stages.items():
+                total = self._capture_totals.setdefault(
+                    name, [0, 0.0, 0.0, 0.0])
+                for index in (0, 1, 2):
+                    total[index] += row[index]
+                total[3] = max(total[3], row[3])
+            for name, count in self._counts.items():
+                self._capture_counts[name] = (
+                    self._capture_counts.get(name, 0) + count)
+            for name, value in self._queue_snapshot.items():
+                if isinstance(value, (int, float)) and not isinstance(value, bool):
+                    self._capture_queue_maxima[name] = max(
+                        self._capture_queue_maxima.get(name, 0), value)
+            self._capture_last = self._now
+            self._capture_frames += 1
+            self._capture_waits.extend(self._waits)
+            self._capture_selected_waits.extend(self._selected_waits)
+            self._capture_wait_count += len(self._waits)
+            self._capture_selected_wait_count += len(self._selected_waits)
+            self.active = False
+            return result
+        except Exception:
+            self._fail()
+            return None
+
+    def _complete_capture(self, reason):
+        self._completed.append({
+            'capture': self.capture, 'trigger': self._reason,
+            'end_reason': reason,
+            'authority_start': self._capture_started,
+            'authority_last_frame': self._capture_last,
+            'frames': self._capture_frames,
+            'stages': self._stage_rows(self._capture_totals),
+            'counts': dict(self._capture_counts),
+            'queue_maxima': dict(self._capture_queue_maxima),
+            'completed_wait': self._wait_summary(
+                self._capture_waits, self._capture_wait_count),
+            'selected_completed_wait': self._wait_summary(
+                self._capture_selected_waits,
+                self._capture_selected_wait_count),
+        })
+
+    def drain_completed(self):
+        completed = self._completed
+        self._completed = []
+        return completed
+
+    def close(self):
+        if self._deadline is not None:
+            self._complete_capture('round_end')
+        self._deadline = None
+        self.active = False
+        self._stack = []
+        self._queue.clear()
+        self._receipts.clear()

--- a/tests/test_port_0922_battle_projectiles.py
+++ b/tests/test_port_0922_battle_projectiles.py
@@ -299,6 +299,94 @@ def _event():
 
 
 class BattleProjectileTests(unittest.TestCase):
+    def test_combat_capture_preserves_eight_shots_and_local_query_failure(self):
+        from gui.mods.offline_lan_0922.worker_diagnostics import WorkerCombatDiagnostics
+
+        def exercise(shooter_kind, mode):
+            battle, bigworld = _battle()
+            battle._worker_mode = True
+            if shooter_kind == 'bot':
+                record = battle._records.pop('player:7')
+                record['kind'] = 'bot'
+                battle._records['bot:7'] = record
+            reads = [0]
+            def clock():
+                reads[0] += 1
+                if mode == 'broken':
+                    raise RuntimeError('diagnostic clock failed')
+                return reads[0] * 0.000001
+            diagnostic = WorkerCombatDiagnostics(clock) if mode else None
+            battle._combat_diagnostics = diagnostic
+            bigworld.wall_x = 4.0
+            native = bigworld.wg_collideSegment
+            queries = []
+            def world(space, start, end, mask):
+                queries.append((space, tuple(start), tuple(end), mask))
+                if len(queries) == 5:
+                    raise RuntimeError('one native query failed')
+                return native(space, start, end, mask)
+            bigworld.wg_collideSegment = world
+            events = {}
+            for sequence in range(1, 9):
+                event = _event()
+                event.update(projectile_id='%s:7:%d' % (shooter_kind, sequence),
+                             shooter_kind=shooter_kind, shot_seq=sequence,
+                             burst_group_seq=sequence)
+                if shooter_kind == 'bot':
+                    event.pop('attacker')
+                    event.pop('fire_intent_seq')
+                    event.pop('fire_input_seq')
+                    event['attacker_bot'] = 7
+                self.assertTrue(battle._accept_projectile_event(event))
+                events[event['projectile_id']] = event
+            self.assertEqual(8, len(battle._projectiles))
+            frames, traces = [], []
+            with mock.patch('sys.stdout', io.StringIO()):
+                for frame, now in enumerate((0.733, 1.317, 1.5)):
+                    bigworld.now = now
+                    if diagnostic is not None:
+                        diagnostic.begin_frame(frame, now, 'projectiles')
+                    self.assertTrue(battle._advance_projectiles(now))
+                    frames.append((battle._projectiles.snapshot(),
+                                   dict((key, value) for key, value in
+                                        battle._projectile_perf.items()
+                                        if key != 'advance')))
+                    # Terminals wait for the server's progress CAS receipt.
+                    # Reproduce that acknowledgement instead of bypassing it.
+                    if battle.client.progress:
+                        for cursor in battle.client.progress[-1][1]:
+                            acknowledged = dict(events[cursor['projectile_id']])
+                            acknowledged['max_distance'] = acknowledged.pop('maxDistance')
+                            acknowledged.update(cursor)
+                            battle._install_projectile_meta(
+                                battle._projectile_wire_meta(acknowledged))
+                    if diagnostic is not None:
+                        row = diagnostic.finish_frame()
+                        if row:
+                            traces.append(row)
+            self.assertEqual(0, len(battle._projectiles))
+            outcomes = dict((args[1], args[3])
+                            for args, unused in battle.client.resolutions)
+            self.assertEqual(8, len(outcomes), battle.client.resolutions)
+            self.assertEqual(1, list(outcomes.values()).count('expired'))
+            self.assertEqual(7, list(outcomes.values()).count('impact'))
+            return (frames, queries, battle.client.resolutions,
+                    battle.client.progress, battle.client.ricochets), traces
+
+        for shooter_kind in ('player', 'bot'):
+            with self.subTest(shooter=shooter_kind):
+                baseline, unused = exercise(shooter_kind, None)
+                measured, traces = exercise(shooter_kind, 'active')
+                failed, unused = exercise(shooter_kind, 'broken')
+                self.assertEqual(baseline, measured)
+                self.assertEqual(baseline, failed)
+                self.assertEqual(len(measured[1]), sum(row['stages'].get(
+                    'native.projectile.world', {}).get('calls', 0)
+                    for row in traces))
+                self.assertEqual(8, sum(row['stages'].get(
+                    'projectile.terminal', {}).get('calls', 0)
+                    for row in traces))
+
     def _preinstalled_high_precision_player_projectile(self):
         battle, unused_bigworld = _battle(now=10.0)
         battle._worker_mode = True
@@ -1056,7 +1144,7 @@ class BattleProjectileTests(unittest.TestCase):
                     reached = []
 
                     def scene(unused_world, unused_space, start, end,
-                              unused_direction, unused_shot):
+                              unused_direction, unused_shot, diagnostic=None):
                         for prop_distance in (4.0, 11.0):
                             if (end - start).length >= prop_distance:
                                 reached.append(prop_distance)
@@ -4292,7 +4380,7 @@ class BattleProjectileTests(unittest.TestCase):
             def __init__(self):
                 self.calls = 0
 
-            def shot_world_distance(self, *unused_args):
+            def shot_world_distance(self, *unused_args, diagnostic=None):
                 self.calls += 1
                 if self.calls == 1:
                     return {
@@ -4326,7 +4414,7 @@ class BattleProjectileTests(unittest.TestCase):
             def __init__(self):
                 self.calls = 0
 
-            def shot_world_distance(self, *unused_args):
+            def shot_world_distance(self, *unused_args, diagnostic=None):
                 self.calls += 1
                 if self.calls == 1:
                     return {

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -6049,8 +6049,17 @@ class BattleRuntimeContractTests(unittest.TestCase):
     def test_worker_trace_keeps_the_slow_frames_neighbours_without_recursion(self):
         wall = [0.0]
         payloads = []
+
+        def native_log(payload):
+            # #1513 clips a single log line at 8 KiB, including its prefix.
+            payloads.append(''.join(line[:8091] + '\n'
+                                    for line in payload.splitlines()))
+
+        detail_stages = dict(('stage.%02d' % index, {
+            'calls': 29, 'total': 0.123456789, 'self': 0.0987654321,
+            'max': 0.0123456789}) for index in range(45))
         diagnostics = _FrameDiagnostics(
-            clock=lambda: wall[0], writer=payloads.append, window_seconds=30.0)
+            clock=lambda: wall[0], writer=native_log, window_seconds=30.0)
         for frame, gap in enumerate((0.02, 0.02, 0.02, 0.4, 0.08, 0.03, 0.02, 0.02), 1):
             entry = wall[0]
             frame_id = diagnostics.begin(entry, gap)
@@ -6058,21 +6067,47 @@ class BattleRuntimeContractTests(unittest.TestCase):
             diagnostics.finish(
                 frame_id, entry, gap, gap, {'bots_update': 0.003}, {},
                 {'role': 'worker', 'round': 7, 'authority_time': entry},
-                combat={'frame': frame, 'stages': {}})
+                combat={'frame': frame, 'stages': detail_stages})
             wall[0] = entry + gap
         diagnostics.begin(wall[0], 0.02)
         diagnostics.flush()
         rows = [json.loads(line.split('combat_trace ', 1)[1])
                 for line in ''.join(payloads).splitlines()
                 if 'combat_trace ' in line]
-        slow = rows[0]
-        self.assertEqual(4, slow['focus']['cause'])
-        self.assertEqual(400.0, slow['focus']['gap_ms'])
-        self.assertEqual([1, 2, 3], [row['cause'] for row in slow['previous']])
-        self.assertEqual([5, 6, 7], [row['cause'] for row in slow['following']])
-        self.assertEqual(4, slow['focus']['detail']['frame'])
-        self.assertNotIn('previous', slow['previous'][0])
+        slow = rows[0]['frame']
+        self.assertEqual(2, rows[0]['schema'])
+        self.assertEqual(4, slow['cause'])
+        self.assertEqual(400.0, slow['gap_ms'])
+        self.assertEqual([1, 2, 3], [row['frame']['cause'] for row in rows
+                                   if row['relation'] == 'previous'])
+        self.assertEqual([5, 6, 7], [row['frame']['cause'] for row in rows
+                                   if row['relation'] == 'following'])
+        self.assertEqual(4, slow['detail']['frame'])
+        for row in rows:
+            self.assertEqual(detail_stages, row['frame']['detail']['stages'])
+            self.assertNotIn('previous', row['frame'])
         self.assertLessEqual(len(diagnostics._recent_frames), 3)
+
+    def test_oversized_combat_records_reassemble_below_native_log_limit(self):
+        from gui.mods.offline_lan_0922.battle_runtime import _combat_log_lines
+        prefix = '[Offline LAN 0.9.22] PERF '
+        record = {'schema': 2, 'window': 7, 'frame': {
+            'stages': dict(('stage.%d' % index, {'calls': index})
+                           for index in range(300)),
+            'escaped': '\\"\n\u4e2d' * 4000}}
+        for kind in ('combat_trace', 'combat_summary'):
+            with self.subTest(kind=kind):
+                lines = _combat_log_lines(prefix, kind, record).splitlines()
+                self.assertGreater(len(lines), 1)
+                self.assertLessEqual(max(map(len, lines)), 7168)
+                parts = [json.loads(line.split(kind + '_part ', 1)[1])
+                         for line in lines]
+                self.assertEqual(list(range(1, len(parts) + 1)),
+                                 [part['part'] for part in parts])
+                self.assertTrue(all(part['parts'] == len(parts)
+                                    for part in parts))
+                self.assertEqual(record, json.loads(''.join(
+                    part['data'] for part in parts)))
 
     def test_frame_diagnostic_percentile_storage_is_bounded(self):
         diagnostics = _FrameDiagnostics(
@@ -13187,6 +13222,71 @@ class BattleRuntimeContractTests(unittest.TestCase):
         battle._update_spotting.assert_called_once_with(
             10.0, hud_only=True)
         battle._schedule.assert_called_once_with(0.0, battle._frame)
+
+    def test_critical_layout_prewarm_is_bounded_ready_and_countdown_owned(self):
+        battle = BattleRuntime(_runtime())
+        battle._worker_mode = True
+        battle._battle_live = False
+        battle._prebattle_deadline = 20.0
+        entities = {index: types.SimpleNamespace(
+            isStarted=index != 1, typeDescriptor=object())
+                    for index in range(1, 7)}
+        battle._server_entity = entities.get
+        battle._records = {str(index): {
+            'engine_id': index, 'ready': index != 2,
+            'tombstone': index == 3, 'local': index == 4}
+                           for index in range(1, 7)}
+        module = sys.modules[BattleRuntime.__module__]
+        with mock.patch.object(module.critical_damage, 'prewarm_layout',
+                               return_value=True) as warm:
+            self.assertTrue(battle._prewarm_critical_layout())
+            warm.assert_called_once_with(entities[5].typeDescriptor)
+            self.assertTrue(battle._prewarm_critical_layout())
+            self.assertEqual(2, warm.call_count)
+            self.assertEqual((entities[6].typeDescriptor,), warm.call_args[0])
+            self.assertFalse(battle._prewarm_critical_layout())
+            self.assertEqual(2, warm.call_count)
+            entities[1].isStarted = True
+            self.assertTrue(battle._prewarm_critical_layout())
+            self.assertEqual((entities[1].typeDescriptor,), warm.call_args[0])
+            entities[1].typeDescriptor = object()
+            battle._battle_live = True
+            self.assertFalse(battle._prewarm_critical_layout())
+            self.assertEqual(3, warm.call_count)
+            battle._battle_live = False
+            self.assertTrue(battle._prewarm_critical_layout())
+            self.assertEqual(4, warm.call_count)
+            battle._records['2']['ready'] = True
+            battle._worker_mode = False
+            self.assertFalse(battle._prewarm_critical_layout())
+            self.assertEqual(4, warm.call_count)
+
+    def test_critical_layout_prewarm_contains_failure_and_skips_pending_bounds(self):
+        battle = BattleRuntime(_runtime())
+        battle._worker_mode = True
+        battle._battle_live = False
+        battle._prebattle_deadline = 20.0
+        descriptors = [object() for unused in range(3)]
+        battle._records = {str(index): {'engine_id': index, 'ready': True}
+                           for index in range(3)}
+        battle._server_entity = lambda index: types.SimpleNamespace(
+            isStarted=True, typeDescriptor=descriptors[index])
+        module = sys.modules[BattleRuntime.__module__]
+        with mock.patch.object(module.critical_damage, 'prewarm_layout',
+                               side_effect=[False, RuntimeError('bounds failed'),
+                                            False, True, True]) as warm:
+            self.assertTrue(battle._prewarm_critical_layout())
+            self.assertNotIn('critical_layout_prewarmed', battle._records['0'])
+            self.assertIs(descriptors[1],
+                          battle._records['1']['critical_layout_prewarmed'])
+            self.assertTrue(battle._prewarm_critical_layout())
+            self.assertIs(descriptors[2],
+                          battle._records['2']['critical_layout_prewarmed'])
+            self.assertTrue(battle._prewarm_critical_layout())
+            self.assertIs(descriptors[0],
+                          battle._records['0']['critical_layout_prewarmed'])
+            self.assertFalse(battle._prewarm_critical_layout())
+            self.assertEqual(5, warm.call_count)
 
     def test_countdown_tree_prewarm_does_not_require_bot_runtime(self):
         runtime = _runtime()

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -1,5 +1,6 @@
 import contextlib
 import copy
+import json
 import io
 import math
 from pathlib import Path
@@ -3651,6 +3652,40 @@ class RemoteVehicleFactoryTests(unittest.TestCase):
         # Equal-distance duplicates on one component share one contact.
         self.assertEqual(evidence[0].localPoint, evidence[1].localPoint)
 
+    def test_combat_timing_counts_only_callable_native_component_testers(self):
+        from gui.mods.offline_lan_0922.worker_diagnostics import WorkerCombatDiagnostics
+        descriptor = _Descriptor()
+        calls = []
+        def hit(start, end):
+            calls.append((tuple(start), tuple(end)))
+            return [(1.0, None, 1.0, 21)]
+        descriptor.chassis.hitTester = types.SimpleNamespace(localHitTest=hit)
+        descriptor.chassis.materials = {21: types.SimpleNamespace(armor=20.0)}
+        descriptor.hull.hitTester = None
+        descriptor.turret.hitTester = None
+        descriptor.gun.hitTester = None
+        vehicle = _Vehicle(
+            11, descriptor, _Vector(), (0.0, 0.0, 0.0), {'health': 500})
+        args = (vehicle, _Matrix(), _Vector(), _Vector(0.0, 0.0, 10.0),
+                types.SimpleNamespace(Vector3=_Vector, Matrix=_Matrix))
+        baseline = remote_vehicle_module._collide_vehicle_evidence_at_matrix(*args)
+        diagnostic = WorkerCombatDiagnostics(lambda: 1.0)
+        diagnostic.begin_frame(1, 1.0, 'projectiles')
+        measured = remote_vehicle_module._collide_vehicle_evidence_at_matrix(
+            *args, diagnostic=diagnostic)
+        trace = diagnostic.finish_frame()
+        self.assertEqual(baseline, measured)
+        self.assertEqual(calls[0], calls[1])
+        self.assertEqual(1, trace['stages']['native.projectile.armour']['calls'])
+        descriptor.chassis.hitTester.localHitTest = mock.Mock(
+            side_effect=RuntimeError('native tester failed'))
+        diagnostic.begin_frame(2, 1.1)
+        with self.assertRaisesRegex(RuntimeError, 'native tester failed'):
+            remote_vehicle_module._collide_vehicle_evidence_at_matrix(
+                *args, diagnostic=diagnostic)
+        trace = diagnostic.finish_frame()
+        self.assertEqual(1, trace['stages']['native.projectile.armour']['calls'])
+
     def test_public_collision_path_stays_the_four_field_retail_value(self):
         descriptor = _Descriptor()
         material = types.SimpleNamespace(armor=20.0)
@@ -6010,6 +6045,34 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertEqual(1.0, diagnostics._window_seconds)
         diagnostics.reset()
         self.assertEqual(0.25, diagnostics._window_seconds)
+
+    def test_worker_trace_keeps_the_slow_frames_neighbours_without_recursion(self):
+        wall = [0.0]
+        payloads = []
+        diagnostics = _FrameDiagnostics(
+            clock=lambda: wall[0], writer=payloads.append, window_seconds=30.0)
+        for frame, gap in enumerate((0.02, 0.02, 0.02, 0.4, 0.08, 0.03, 0.02, 0.02), 1):
+            entry = wall[0]
+            frame_id = diagnostics.begin(entry, gap)
+            wall[0] = entry + 0.005
+            diagnostics.finish(
+                frame_id, entry, gap, gap, {'bots_update': 0.003}, {},
+                {'role': 'worker', 'round': 7, 'authority_time': entry},
+                combat={'frame': frame, 'stages': {}})
+            wall[0] = entry + gap
+        diagnostics.begin(wall[0], 0.02)
+        diagnostics.flush()
+        rows = [json.loads(line.split('combat_trace ', 1)[1])
+                for line in ''.join(payloads).splitlines()
+                if 'combat_trace ' in line]
+        slow = rows[0]
+        self.assertEqual(4, slow['focus']['cause'])
+        self.assertEqual(400.0, slow['focus']['gap_ms'])
+        self.assertEqual([1, 2, 3], [row['cause'] for row in slow['previous']])
+        self.assertEqual([5, 6, 7], [row['cause'] for row in slow['following']])
+        self.assertEqual(4, slow['focus']['detail']['frame'])
+        self.assertNotIn('previous', slow['previous'][0])
+        self.assertLessEqual(len(diagnostics._recent_frames), 3)
 
     def test_frame_diagnostic_percentile_storage_is_bounded(self):
         diagnostics = _FrameDiagnostics(
@@ -25804,7 +25867,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
         calls = []
 
         def sensor(unused_bigworld, unused_space, start, end,
-                   unused_direction, unused_shot):
+                   unused_direction, unused_shot, diagnostic=None):
             calls.append((start, end))
             if (end - start).length > 5.0:
                 self.fail('vehicle cap exposed the prop behind it')

--- a/tests/test_port_0922_bot_runtime.py
+++ b/tests/test_port_0922_bot_runtime.py
@@ -17386,6 +17386,16 @@ class BotRuntimeTests(unittest.TestCase):
             self.assertFalse(target['fresh_visible'])
             self.assertEqual((10.0, 1.0, 20.0), target['position'])
             self.assertEqual(0.3, target['gun_pitch'])
+        hidden[0].update(x=999.0, gun_pitch=2.0,
+                         direct_visible=True, fresh_visible=True)
+        hidden_again, unused = runtime._contacts_for(
+            {'id': 13, 'team': 1}, [player], 1.0,
+            visibility_tick=tick, processed_bot_ids=set((25,)))
+        for target in hidden_again:
+            self.assertFalse(target['direct_visible'])
+            self.assertFalse(target['fresh_visible'])
+            self.assertEqual(10.0, target['x'])
+            self.assertEqual(0.3, target['gun_pitch'])
         post_motion, unused = runtime._contacts_for(
             {'id': 14, 'team': 1}, [player], 1.0,
             visibility_tick=tick, processed_bot_ids=set((25,)))
@@ -17396,7 +17406,7 @@ class BotRuntimeTests(unittest.TestCase):
             {'id': 15, 'team': 1}, [player], 1.1,
             visibility_tick={}, processed_bot_ids=set())
         self.assertEqual([70.0, 40.0], [target['x'] for target in next_tick])
-        self.assertEqual(10, len(sight_calls))
+        self.assertEqual(12, len(sight_calls))
         for pose in remembered.values():
             self.assertEqual(10.0, pose['x'])
             self.assertEqual(0.3, pose['gun_pitch'])
@@ -17488,6 +17498,136 @@ class BotRuntimeTests(unittest.TestCase):
         runtime._service_shot_lane_work(
             1.1, 0.0, team_visibility, [], {}, set((11, 25)), {}, [16])
         self.assertNotIn(key, runtime._shot_lane_work_set)
+
+    def test_lane_range_rejects_leave_service_slots_for_nearby_targets(self):
+        calls = []
+        runtime = self.module.BotRuntime(
+            1, firing_lane_probe=lambda source, target: calls.append(
+                (source['id'], target['network_id'], target['position'])) or True)
+        runtime.states = {11: {
+            'id': 11, 'team': 1, 'alive': True,
+            'x': 0.0, 'y': 0.0, 'z': 0.0}}
+        for target_id in range(21, 61):
+            runtime.states[target_id] = {
+                'id': target_id, 'team': 2, 'alive': True,
+                'x': 1000.0 if target_id < 41 else 50.0,
+                'y': 0.0, 'z': 0.0}
+        runtime._shot_los_phase = lambda unused: 0.0
+        visible = dict(((1, 'bot', target_id), True)
+                       for target_id in range(21, 61))
+        resolved = []
+        original = runtime._shot_lane_live_records
+        def resolve(key, *args):
+            resolved.append(key)
+            return original(key, *args)
+        runtime._shot_lane_live_records = resolve
+        budget = [16]
+        pending = runtime._service_shot_lane_work(
+            1.0, 1.0, visible, [], {}, set(), {(11, 'bot', 21): 0}, budget)
+
+        self.assertEqual(4, pending)
+        self.assertEqual(16, len(resolved))
+        self.assertEqual(16, len(calls))
+        self.assertEqual(0, budget[0])
+        self.assertTrue(all(row[2] == (50.0, 0.0, 0.0) for row in calls))
+        self.assertEqual(36, runtime._shot_lane_completed_pairs)
+        self.assertTrue(all(runtime._shot_los_cache[(11, 'bot', target_id)] ==
+                            (1.0, False) for target_id in range(21, 41)))
+        # A new cycle resolves current poses, including a formerly far target
+        # selected for firing. No enqueue-time geometry survives movement.
+        runtime.states[21]['x'] = 25.0
+        runtime._service_shot_lane_work(
+            2.0, 2.0, visible, [], {}, set(), {(11, 'bot', 21): 0}, [16])
+        self.assertEqual((11, 21, (25.0, 0.0, 0.0)), calls[16])
+
+    def test_lane_range_gate_preserves_enemy_incoming_probe(self):
+        incoming = []
+        outgoing = []
+        runtime = self.module.BotRuntime(
+            1, firing_lane_probe=lambda *args: outgoing.append(args) or True,
+            incoming_lane_probe=lambda source, target: incoming.append(
+                (source['x'], target['position'])) or True)
+        runtime.states = {
+            11: {'id': 11, 'team': 1, 'alive': True,
+                 'x': 0.0, 'y': 0.0, 'z': 0.0},
+            21: {'id': 21, 'team': 2, 'alive': True,
+                 'x': 1000.0, 'y': 0.0, 'z': 0.0}}
+        runtime._incoming_lane_budget = 1
+        runtime._shot_los_phase = lambda unused: 0.0
+        budget = [16]
+        pending = runtime._service_shot_lane_work(
+            1.0, 1.0, {(1, 'bot', 21): True}, [], {}, set(), {}, budget)
+        self.assertEqual(0, pending)
+        self.assertEqual([], outgoing)
+        self.assertEqual([(0.0, (1000.0, 0.0, 0.0))], incoming)
+        self.assertEqual(16, budget[0])
+        self.assertEqual((1.0, True), runtime._incoming_lanes[(11, 'bot', 21)])
+        self.assertEqual((1.0, False), runtime._shot_los_cache[(11, 'bot', 21)])
+
+    def test_lane_range_gate_matches_human_bot_and_spg_distance_boundaries(self):
+        for kind in ('bot', 'human'):
+            for class_tag, limit in (
+                    ('mediumTank', self.module.SHOT_LANE_QUERY_DISTANCE),
+                    ('SPG', self.module.SPG_SHOT_LANE_QUERY_DISTANCE)):
+                for offset in (-0.001, 0.0, 0.001):
+                    with self.subTest(kind=kind, class_tag=class_tag, offset=offset):
+                        calls = []
+                        runtime = self.module.BotRuntime(
+                            1, firing_lane_probe=lambda *args:
+                                calls.append(args) or True)
+                        runtime.states = {11: {
+                            'id': 11, 'team': 1, 'alive': True,
+                            'x': 0.0, 'y': 0.0, 'z': 0.0,
+                            'profile': {'class_tag': class_tag}}}
+                        target = {'id': 21, 'team': 2, 'alive': True,
+                                  'x': limit + offset, 'y': 0.0, 'z': 0.0}
+                        players = [_admit_player(target)] if kind == 'human' else []
+                        if kind == 'bot':
+                            runtime.states[21] = target
+                        runtime._shot_los_phase = lambda unused: 0.0
+                        budget = [1]
+                        pending = runtime._service_shot_lane_work(
+                            1.0, 1.0, {(1, kind, 21): True}, players,
+                            {}, set(), {}, budget)
+                        self.assertEqual(0, pending)
+                        self.assertEqual(int(offset <= 0.0), len(calls))
+                        self.assertEqual((1.0, offset <= 0.0),
+                                         runtime._shot_los_cache[(11, kind, 21)])
+
+    def test_future_and_stale_cover_jobs_leave_the_lane_window_available(self):
+        for ready, stale, expected in ((1.5, False, 'lane'),
+                                       (0.5, True, 'lane'),
+                                       (0.5, False, 'cover')):
+            with self.subTest(ready=ready, stale=stale):
+                calls = []
+                runtime = self.module.BotRuntime(
+                    1, descriptor_resolver=lambda unused: _combat_descriptor(),
+                    adapter_factory=lambda *args, **kwargs:
+                        _FixedAdapter(self._stationary_command()),
+                    direction_probe=lambda *args: {'clear': True, 'slope': 0.0},
+                    visibility_probe=lambda *args: True,
+                    firing_lane_probe=lambda *args: True,
+                    cover_probe=lambda *args: calls.append('cover') or (),
+                    ground_probe=lambda *args: 0.0,
+                    physics_ground_probe=lambda *args: 0.0,
+                    spawn_resolver=_spawn_resolver, native_motion=True,
+                    baked_graph=_graph(), control_seconds=0.1)
+                runtime.battle_start(dict(self.start, bots=[
+                    {'id': 11, 'team': 1, 'slot': 0, 'name': 'CoverSource'},
+                    {'id': 12, 'team': 2, 'slot': 0, 'name': 'CoverTarget'}]))
+                runtime.debug_logging = False
+                source = dict(runtime.states[11], team=2 if stale else 1)
+                target = {'kind': 'bot', 'network_id': 12}
+                key = (source['team'], 'bot', 12)
+                runtime._visible_target_poses[key] = dict(runtime.states[12])
+                runtime._renew_team_spot(key, 1.0)
+                runtime._cover_queue = [(ready, 11, source, target, (0, 0, 0), ())]
+                runtime._next_cover_refresh = 100.0
+                runtime._service_shot_lane_work = lambda *args: (
+                    calls.append('lane') or 0)
+                runtime.update(0.1, 1.0)
+                self.assertEqual([expected], calls)
+                self.assertEqual(int(ready > 1.0), len(runtime._cover_queue))
 
     def test_lane_budget_debt_counts_only_due_native_work(self):
         native_calls = []

--- a/tests/test_port_0922_bot_runtime.py
+++ b/tests/test_port_0922_bot_runtime.py
@@ -3791,6 +3791,93 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertEqual(3, dict(zip(
             self.module.PROBE_KINDS, runtime.probe_totals()))['ground'])
 
+    def test_combat_timing_preserves_worker_outputs_queries_and_queue_order(self):
+        from gui.mods.offline_lan_0922.worker_diagnostics import WorkerCombatDiagnostics
+        command = self._stationary_command()
+        roster = [
+            {'id': 11 + index, 'team': 1 if index < 14 else 2,
+             'slot': index if index < 14 else index - 14,
+             'name': 'Diagnostic-%d' % index}
+            for index in range(29)]
+
+        class HoldAdapter(_FixedAdapter):
+            def decide_with_order(self, state, order, unused_clear):
+                result = dict(self.command)
+                result['target_id'] = order.get('target_id')
+                result['fire_allowed'] = False
+                return result
+
+        def exercise(mode):
+            reads = [0]
+            def clock():
+                reads[0] += 1
+                if mode == 'broken':
+                    raise RuntimeError('diagnostic clock failed')
+                return reads[0] * 0.000001
+            diagnostic = WorkerCombatDiagnostics(clock) if mode else None
+            queries = []
+            def lane(source, target):
+                queries.append(('lane', source['id'], target['network_id']))
+                return True
+            def visible(source, target, fired_recently=False):
+                queries.append(('visible', source['id'], target['network_id']))
+                return True
+            def ground(x, z, y):
+                queries.append(('ground', x, z, y))
+                return 0.0
+            runtime = self.module.BotRuntime(
+                1, descriptor_resolver=lambda unused: _combat_descriptor(),
+                adapter_factory=lambda *unused, **unused_kwargs: HoldAdapter(command),
+                direction_probe=lambda *unused: {
+                    'clear': True, 'collision': False, 'slope': 0.0},
+                visibility_probe=visible, firing_lane_probe=lane,
+                ground_probe=ground, physics_ground_probe=ground,
+                cover_probe=lambda *unused: (),
+                spawn_resolver=_spawn_resolver, native_motion=True,
+                baked_graph=_graph(), control_seconds=self.module.WORKER_CONTROL_SECONDS,
+                combat_diagnostics=diagnostic)
+            wire = list(runtime.battle_start(dict(self.start, bots=roster)))
+            runtime.debug_logging = False
+            runtime._server_orders[11] = {
+                'target_kind': 'bot', 'target_id': 25,
+                'fire_allowed': False, 'shell_index': 0,
+                'fire_range': 500.0, 'combat_mode': 'engage'}
+            runtime._server_order_tokens[11] = 1
+            traces = []
+            now = 1.0
+            for frame in range(55):
+                dt = (0.1, 0.1, 0.45, 0.035, 0.08)[frame % 5]
+                now += dt
+                if frame == 10:
+                    source = copy.deepcopy(runtime.states[11])
+                    target = runtime._bot_observation_target(25, runtime.states[25])
+                    for offset in (0.0, 0.2, 0.4):
+                        runtime._cover_queue.append((
+                            now + offset, 11, source, target, (0, 0, 0), ()))
+                if diagnostic is not None:
+                    diagnostic.begin_frame(frame, now, 'queue')
+                wire.extend(runtime.update(dt, now))
+                if diagnostic is not None:
+                    row = diagnostic.finish_frame()
+                    if row:
+                        traces.append(row)
+            return (wire, runtime.presentation_states(), queries,
+                    runtime.probe_totals(), runtime._shot_lane_work,
+                    runtime._shot_los_cache), traces
+
+        baseline, unused = exercise(None)
+        measured, traces = exercise('active')
+        failed, unused = exercise('broken')
+        self.assertEqual(baseline, measured)
+        self.assertEqual(baseline, failed)
+        stages = set(name for row in traces for name in row['stages'])
+        self.assertTrue({'bot.slice', 'bot.targets', 'bot.lane_service',
+                         'bot.probe.lane'}.issubset(stages))
+        self.assertGreater(sum(row['counts'].get(
+            'lane_service_cover_blocked', 0) for row in traces), 0)
+        self.assertGreater(max(row['completed_wait']['max_kept_ms']
+                               for row in traces), 1000.0)
+
     def _suspension_case(self, terrain):
         descriptor = _suspension_descriptor()
         calls = []
@@ -17350,7 +17437,7 @@ class BotRuntimeTests(unittest.TestCase):
         key = (11, 'bot', 25)
         team_visibility = {(1, 'bot', 25): True}
         runtime._shot_lane_work_cycle = 0.0
-        runtime._queue_shot_lane_identity(key, 0.0)
+        runtime._queue_shot_lane_identity(key, 0.0, 0.0)
         runtime.states[25]['team'] = 1
         runtime._service_shot_lane_work(
             1.0, 0.0, team_visibility, [], {}, set((11, 25)), {}, [16])
@@ -17358,7 +17445,7 @@ class BotRuntimeTests(unittest.TestCase):
 
         runtime.states[25]['team'] = 2
         runtime.states[25]['alive'] = True
-        runtime._queue_shot_lane_identity(key, 0.0)
+        runtime._queue_shot_lane_identity(key, 0.0, 0.0)
         runtime.states[25]['alive'] = False
         runtime._service_shot_lane_work(
             1.1, 0.0, team_visibility, [], {}, set((11, 25)), {}, [16])

--- a/tests/test_port_0922_critical_damage.py
+++ b/tests/test_port_0922_critical_damage.py
@@ -391,6 +391,27 @@ class CriticalDamageTests(unittest.TestCase):
                     if target['kind'] == 'crew')
                 self.assertEqual(expected, actual)
 
+    def test_layout_prewarm_waits_for_complete_native_bounds(self):
+        descriptor = _layout_descriptor(
+            'ussr:R78_SU_85I',
+            (('commander',), ('gunner',), ('driver',), ('loader', 'radioman')))
+        internal_hit_layouts.clear_cache()
+        self.addCleanup(internal_hit_layouts.clear_cache)
+        bounds = descriptor.gun.hitTester.bbox
+        descriptor.gun.hitTester.bbox = None
+        self.assertFalse(critical_damage.prewarm_layout(descriptor))
+        self.assertEqual({}, internal_hit_layouts._LAYOUT_CACHE)
+        descriptor.gun.hitTester.bbox = bounds
+        self.assertTrue(critical_damage.prewarm_layout(descriptor))
+        warmed = critical_damage._offh_internal_layout(descriptor)
+        self.assertIsNotNone(warmed)
+        self.assertTrue(warmed['valid'])
+        self.assertEqual(1, len(internal_hit_layouts._LAYOUT_CACHE))
+        self.assertTrue(critical_damage.prewarm_layout(descriptor))
+        self.assertIs(warmed, critical_damage._offh_internal_layout(descriptor))
+        for parent in internal_hit_layouts.SUPPORTED_PARENTS:
+            self.assertEqual(0, getattr(descriptor, parent).mapping_calls)
+
     def test_internal_layout_crew_profile_mismatch_remains_fail_closed(self):
         vehicle_name = 'china:Ch02_Type62'
         stale_roles = (

--- a/tests/test_port_0922_solid_hit_pipeline.py
+++ b/tests/test_port_0922_solid_hit_pipeline.py
@@ -21,6 +21,7 @@ sys.path.insert(0, str(TESTS))
 
 from gui.mods.offline_lan_0922 import combat_rules, critical_damage, lan_client
 from gui.mods.offline_lan_0922.battle_runtime import BattleRuntime
+from gui.mods.offline_lan_0922.worker_diagnostics import WorkerCombatDiagnostics
 import test_port_0922_solid_collision_oracle as row_oracle
 
 
@@ -171,6 +172,7 @@ class SolidHitPipelineTests(unittest.TestCase):
             bigworld=_BigWorld(), math=types.SimpleNamespace(
                 Vector3=_PipelineVector, Matrix=Matrix))
         battle = object.__new__(BattleRuntime)
+        battle._combat_diagnostics = None
         battle._runtime = runtime
         battle._avatar = types.SimpleNamespace(spaceID=1)
         battle._records = {}
@@ -188,7 +190,8 @@ class SolidHitPipelineTests(unittest.TestCase):
         battle._equipment_state = None
         return battle
 
-    def _run_first_hit(self, shooter_kind, shell_kind, target_delta):
+    def _run_first_hit(self, shooter_kind, shell_kind, target_delta,
+                       diagnostic=None):
         expected_fraction, expected_impact, expected_cosine = \
             _moving_plane_solution(TARGET_START, target_delta, YAW)
         self.assertGreater(expected_fraction, 0.1)
@@ -207,6 +210,9 @@ class SolidHitPipelineTests(unittest.TestCase):
             isAlive=lambda: True)
         source = types.SimpleNamespace(id=41, typeDescriptor=None)
         battle = self._battle()
+        battle._combat_diagnostics = diagnostic
+        if diagnostic is not None:
+            diagnostic.begin_frame(1, 1.0, 'projectiles')
         source_key = '%s:7' % shooter_kind
         target_key = 'bot:8'
         projectile_id = '%s:7:1' % shooter_kind
@@ -291,6 +297,12 @@ class SolidHitPipelineTests(unittest.TestCase):
         self.assertAlmostEqual(expected_cosine, contact['angle_cos'], places=7)
         self.assertAlmostEqual(expected_piercing, contact['piercing'], places=7)
         self.assertEqual(2, contact['result'])
+        if diagnostic is not None:
+            trace = diagnostic.finish_frame()
+            self.assertEqual(len(tester.calls),
+                             trace['stages']['native.projectile.armour']['calls'])
+            self.assertEqual(1, trace['stages']['projectile.direct']['calls'])
+        return terminal_data['impact'], effect, tester.calls
 
     def test_ap_and_apcr_first_hit_pipeline_for_player_and_bot(self):
         for shooter_kind in ('player', 'bot'):
@@ -300,8 +312,12 @@ class SolidHitPipelineTests(unittest.TestCase):
                         ('constant_velocity', (0.0, 0.0, 4.0))):
                     with self.subTest(shooter=shooter_kind, shell=shell_kind,
                                       target_motion=label):
-                        self._run_first_hit(
+                        baseline = self._run_first_hit(
                             shooter_kind, shell_kind, target_delta)
+                        measured = self._run_first_hit(
+                            shooter_kind, shell_kind, target_delta,
+                            WorkerCombatDiagnostics(lambda: 1.0))
+                        self.assertEqual(baseline, measured)
 
 
 # The root position is selected from the independent analytic equation so

--- a/tests/test_port_0922_worker_diagnostics.py
+++ b/tests/test_port_0922_worker_diagnostics.py
@@ -1,0 +1,151 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PATH = (ROOT / 'src/res/scripts/client/gui/mods/offline_lan_0922' /
+        'worker_diagnostics.py')
+spec = importlib.util.spec_from_file_location('worker_diagnostic_test', PATH)
+diagnostics = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(diagnostics)
+
+
+class WorkerCombatDiagnosticsTests(unittest.TestCase):
+    def test_nested_stages_separate_total_and_self_time(self):
+        clock = iter((1.0, 1.010, 1.030, 1.050))
+        trace = diagnostics.WorkerCombatDiagnostics(lambda: next(clock))
+        trace.begin_frame(1, 20.0, 'projectiles')
+        parent = trace.start()
+        child = trace.start()
+        trace.stop('native.vehicle', child)
+        trace.stop('projectile.vehicle', parent)
+        row = trace.finish_frame()
+        self.assertEqual({'calls': 1, 'total_ms': 50.0,
+                          'self_ms': 30.0, 'max_ms': 50.0},
+                         row['stages']['projectile.vehicle'])
+        self.assertEqual(20.0, row['stages']['native.vehicle']['self_ms'])
+
+    def test_combat_windows_start_after_lobby_and_obey_time_and_count_caps(self):
+        reads = []
+        trace = diagnostics.WorkerCombatDiagnostics(
+            lambda: reads.append(True) or 0.0,
+            capture_seconds=2.0, cooldown_seconds=3.0, maximum_captures=2)
+        self.assertFalse(trace.begin_frame(1, 200.0))
+        self.assertIsNone(trace.start())
+        self.assertEqual([], reads)
+        self.assertTrue(trace.begin_frame(2, 205.0, 'projectiles'))
+        trace.finish_frame()
+        self.assertTrue(trace.begin_frame(3, 206.0))
+        trace.finish_frame()
+        self.assertFalse(trace.begin_frame(4, 207.0, 'slow'))
+        self.assertEqual('deadline', trace.drain_completed()[0]['end_reason'])
+        self.assertFalse(trace.begin_frame(5, 209.0, 'slow'))
+        self.assertTrue(trace.begin_frame(6, 210.0, 'queue'))
+        trace.finish_frame()
+        self.assertFalse(trace.begin_frame(7, 212.0, 'slow'))
+        self.assertFalse(trace.begin_frame(8, 300.0, 'slow'))
+        self.assertEqual(2, trace.capture)
+        trace.reset()
+        self.assertTrue(trace.begin_frame(1, 400.0, 'projectiles'))
+        self.assertEqual(1, trace.capture)
+
+    def test_wait_measures_each_identity_even_when_enqueued_before_capture(self):
+        trace = diagnostics.WorkerCombatDiagnostics(lambda: 0.0)
+        ordinary = (1, 'bot', 8)
+        selected = (2, 'bot', 8)
+        trace.queue_added(ordinary, 10.0, 10.5)
+        trace.queue_added(selected, 11.0, 11.5)
+        trace.begin_frame(1, 12.0, 'queue')
+        trace.queue_state(12.0, (ordinary, selected), {selected})
+        trace.queue_retired(selected, 12.0, 'probe', selected=True)
+        trace.queue_retired(ordinary, 12.0, 'cache')
+        row = trace.finish_frame()
+        self.assertEqual(2000.0, row['queue']['oldest_wait_ms'])
+        self.assertEqual(1500.0, row['queue']['oldest_due_ms'])
+        self.assertEqual(500.0, row['queue']['selected_oldest_due_ms'])
+        self.assertEqual(1500.0, row['completed_wait']['p50_ms'])
+        self.assertEqual(1000.0,
+                         row['selected_completed_wait']['p50_ms'])
+        self.assertEqual({}, trace._queue)
+
+        trace.close()
+        capture = trace.drain_completed()[0]
+        self.assertEqual(1, capture['frames'])
+        self.assertEqual(12.0, capture['authority_start'])
+        self.assertEqual(12.0, capture['authority_last_frame'])
+        self.assertEqual(2000.0, capture['queue_maxima']['oldest_wait_ms'])
+        self.assertEqual(ordinary, row['queue']['oldest_job'])
+        self.assertEqual(selected, row['queue']['selected_oldest_job'])
+
+    def test_receipt_counts_distinguish_publications_and_distinct_results(self):
+        trace = diagnostics.WorkerCombatDiagnostics(lambda: 0.0)
+        key = (1, 'bot', 2)
+        trace.begin_frame(1, 10.0, 'queue')
+        trace.receipt_stored(key, 10.0, True)
+        trace.receipt_stored(key, 10.1, True)
+        trace.receipt_published(key, 10.1, False)
+        trace.receipt_published(key, 10.1, True)
+        trace.receipt_stored(key, 10.2, False)
+        counts = trace.finish_frame()['counts']
+        self.assertEqual(1, counts['lane_positive_replaced_unpublished'])
+        self.assertEqual(2, counts['lane_positive_publications'])
+        self.assertEqual(1, counts['lane_distinct_positive_published'])
+        self.assertEqual(1, counts['lane_selected_positive_publications'])
+
+    def test_decorator_keeps_results_and_original_exceptions_on_clock_failure(self):
+        def broken_clock():
+            raise RuntimeError('clock failed')
+        class Owner:
+            @diagnostics.timed('owned')
+            def call(self, fail=False):
+                if fail:
+                    raise ValueError('operation failed')
+                return self
+        owner = Owner()
+        trace = diagnostics.WorkerCombatDiagnostics(broken_clock)
+        owner._combat_diagnostics = trace
+        trace.begin_frame(1, 1.0, 'queue')
+        self.assertIs(owner, owner.call())
+        self.assertFalse(trace.enabled)
+        with self.assertRaisesRegex(ValueError, 'operation failed'):
+            owner.call(fail=True)
+
+    def test_exception_unwinds_scopes_and_round_end_flushes_partial_capture(self):
+        class Owner:
+            @diagnostics.timed('owned')
+            def call(self):
+                raise ValueError('native query failed')
+        owner = Owner()
+        trace = diagnostics.WorkerCombatDiagnostics(lambda: 1.0)
+        owner._combat_diagnostics = trace
+        trace.begin_frame(1, 1.0, 'queue')
+        with self.assertRaises(ValueError):
+            owner.call()
+        self.assertEqual(1, trace.finish_frame()['stages']['owned']['calls'])
+        trace.close()
+        trace.close()
+        completed = trace.drain_completed()
+        self.assertEqual(1, len(completed))
+        self.assertEqual('round_end', completed[0]['end_reason'])
+
+    def test_queue_tracking_and_percentile_storage_are_bounded(self):
+        trace = diagnostics.WorkerCombatDiagnostics(lambda: 0.0)
+        trace.begin_frame(1, 1.0, 'queue')
+        for index in range(2048):
+            trace.queue_added((index, 'bot', 9), 0.0, 0.0)
+        self.assertEqual(diagnostics.MAX_QUEUE_IDENTITIES, len(trace._queue))
+        for index in range(1024):
+            trace.queue_retired((index, 'bot', 9), 1.0, 'probe')
+        trace.finish_frame()
+        self.assertEqual(diagnostics.MAX_WAIT_SAMPLES,
+                         len(trace._capture_waits))
+        trace.close()
+        row = trace.drain_completed()[0]
+        self.assertEqual(1024, row['completed_wait']['count'])
+        self.assertEqual(512, row['completed_wait']['kept'])
+        self.assertEqual({}, trace._queue)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/benchmark_bot_workload.py
+++ b/tools/benchmark_bot_workload.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Measure the copied Bot loop with 29 real drivers and one shipped navgraph.
+
+Terrain heights come from the graph; native obstacle/visibility/aim queries use
+deterministic test seams. This measures Python work, not Windows frame pacing,
+native collision cost, or a replay of a captured battle. Compare identical
+arguments across checkouts and compare --snapshot files for behavioral parity.
+"""
+
+import argparse
+import contextlib
+import cProfile
+import io
+import json
+import math
+from pathlib import Path
+import random
+import statistics
+import sys
+import time
+
+
+def make_runtime(checkout, map_name):
+    sys.path.insert(0, str(checkout / 'tests'))
+    import test_port_0922_bot_runtime as fixtures
+    from effective_params_fixture import bot_default_crew_factors
+    module = fixtures._load()
+    module.loadout.attribute_factors = bot_default_crew_factors
+    graph = json.loads((checkout / 'navgraphs' / (map_name + '.json')).read_text())
+
+    def ground(x, z, hint=0.0):
+        ix = int(math.floor((x - graph['origin'][0]) / graph['cell_size'] + 0.5))
+        iz = int(math.floor((z - graph['origin'][1]) / graph['cell_size'] + 0.5))
+        if not (0 <= ix < graph['width'] and 0 <= iz < graph['height']):
+            return None
+        height = graph['heights_mm'][iz * graph['width'] + ix]
+        return None if height is None else height / 1000.0
+
+    def spawn(team, slot):
+        point = graph['spawn_formations'][str(team)][slot]
+        return tuple(point[:3]), point[3]
+
+    equipment = fixtures._bot_equipment_contracts(module)
+    runtime = module.BotRuntime(
+        1, descriptor_resolver=lambda unused: fixtures._combat_descriptor(),
+        direction_probe=lambda *unused: {'clear': True, 'slope': 0.0},
+        visibility_probe=lambda *unused: True,
+        firing_lane_probe=lambda *unused: True,
+        ground_probe=ground, physics_ground_probe=ground,
+        spawn_resolver=spawn, baked_graph=graph,
+        direct_launch_origin_probe=lambda state, *unused:
+            (state['x'], state['y'] + 1.0, state['z']),
+        bot_equipment_resolver=lambda: equipment, control_seconds=0.1)
+    roster = [dict(id=11 + index, team=1 if index < 15 else 2,
+                   slot=index if index < 15 else index - 15,
+                   name='Workload-%d' % index) for index in range(29)]
+    runtime.battle_start(dict(round_id=1, map=map_name,
+                             bot_authority_id=1, bots=roster))
+    runtime.debug_logging = False
+    for row in roster:
+        goal = graph['spawn_formations'][
+            '2' if row['team'] == 1 else '1'][row['slot']]
+        runtime._server_orders[row['id']] = dict(
+            combat_mode='route', move_position=tuple(goal[:3]),
+            face_position=tuple(goal[:3]), aim_position=tuple(goal[:3]),
+            fire_allowed=False, shell_index=0, fire_range=500.0)
+        runtime._server_order_tokens[row['id']] = 1
+    return runtime
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--checkout', type=Path,
+                        default=Path(__file__).resolve().parents[1])
+    parser.add_argument('--map', default='01_karelia')
+    parser.add_argument('--seconds', type=float, default=30.0)
+    parser.add_argument('--fps', type=float, default=30.0)
+    parser.add_argument('--repeats', type=int, default=3)
+    parser.add_argument('--snapshot', type=Path)
+    parser.add_argument('--profile', type=Path)
+    args = parser.parse_args()
+    if args.seconds <= 0 or args.fps <= 0 or args.repeats <= 0:
+        parser.error('seconds, fps and repeats must be positive')
+    frames = int(round(args.seconds * args.fps))
+    timings = []
+    result = None
+    profiler = cProfile.Profile() if args.profile else None
+    for repeat in range(args.repeats):
+        random.seed(17)
+        with contextlib.redirect_stdout(io.StringIO()):
+            runtime = make_runtime(args.checkout.resolve(), args.map)
+            messages = []
+            started = time.process_time()
+            if profiler is not None:
+                profiler.enable()
+            for frame in range(frames):
+                dt = 1.0 / args.fps
+                messages.extend(runtime.update(dt, 100.0 + (frame + 1) * dt))
+            if profiler is not None:
+                profiler.disable()
+            timings.append(time.process_time() - started)
+            snapshot = {
+                'messages': messages, 'probes': runtime.probe_totals(),
+                'decisions': runtime._decision_counts,
+            }
+            if result is not None and snapshot != result:
+                raise RuntimeError('deterministic workload changed across repeats')
+            result = snapshot
+        print('repeat=%d cpu_seconds=%.6f' % (repeat + 1, timings[-1]), flush=True)
+    if args.snapshot:
+        args.snapshot.write_text(json.dumps(result, sort_keys=True))
+    if profiler is not None:
+        profiler.dump_stats(str(args.profile))
+    print(json.dumps({
+        'map': args.map, 'bots': 29, 'frames': frames,
+        'cpu_median_seconds': statistics.median(timings),
+        'decisions': sum(runtime._decision_counts.values()),
+        'probes': runtime.probe_totals(), 'native_runtime_measured': False,
+        'profile_enabled': profiler is not None,
+    }, sort_keys=True))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The 29-Bot combat capture showed substantial Bot control work, supplemental lane slots spent on out-of-range pairs, and entire service windows blocked by future cover jobs. The largest frame records also exceeded the exact client's native log-line limit. This change removes repeated Python work, gives useful lane jobs those service opportunities, and preserves the complete timing evidence.

- Read baked topology once per A* expansion and reuse hidden contact projections within one authority slice. Preserve route costs, hazards, expansion limits, pose boundaries, and observer-specific flags.
- Resolve due distance rejects before full job materialization. Keep ordinary/SPG range rules, current poses, selected-target priority, fair traversal, the independent incoming threat probe, and existing native query budgets. In the outgoing-lane regression with 20 far targets before 20 near targets, one 16-slot service now probes 16 near targets; previously that service only completed far rejects.
- Reserve a cover window only for a due, current job. Prepare at most one ready vehicle's internal hit layout per countdown frame, with complete component-bound guards before cache population. Add direct-hit substage timings without changing damage or projectile safety.
- Emit each slow-frame neighbor separately in schema 2. Oversized frames and summaries use reassemblable fragments, with every line below 7168 bytes to survive the observed 8 KiB native limit.

Includes the diagnostic implementation from #66 on the current main branch; #66 does not need to be merged separately for this PR. The optimization itself is commit 3120b10.

Validation:

- Both push and PR CI passed for `3a7becee07650779a8127c7248a09b91bb48b8e1`: 4083 client tests, 494 launcher tests (2 skipped), Windows server startup, CPython 2.7 package validation, and the Windows launcher build/startup checks.
- Final integration also passed the focused lane/battle checks and compilation of all 96 client source files with CPython 2.7.18. Human/Bot moving and stationary AP/APCR parity remains covered.
- Compared 205 routes across all 41 shipped maps, including failed-edge penalties: all paths and 154612 expansion yields matched the baseline.
- Reproduced the lane-slot and future/stale-cover failures against the old code. Native log-cap, oversized JSON reassembly, observer isolation, and incomplete-descriptor prewarm tests pass.

Reproducible Python workload comparison (both checkouts include main 761e656 and #66):

```bash
git worktree add --detach /tmp/wot-workload-baseline 761e656
git -C /tmp/wot-workload-baseline merge --no-edit 104eccafd2db0be124b694a3497bd5aaba3bf311
PYTHONDONTWRITEBYTECODE=1 python3 tools/benchmark_bot_workload.py \
  --checkout /tmp/wot-workload-baseline --map 01_karelia --seconds 30 --repeats 3 \
  --snapshot /tmp/before.json
PYTHONDONTWRITEBYTECODE=1 python3 tools/benchmark_bot_workload.py \
  --map 01_karelia --seconds 30 --repeats 3 --snapshot /tmp/after.json
```

Baseline 69d032e (local merge of main 761e656 and #66): 4.845 s median CPU; this branch: 4.417 s (8.8% lower). All 900 frames' published outputs, probe counts, and 4462 decisions match exactly. The benchmark uses real local drivers and shipped terrain data with deterministic native seams; this is a navigation workload, not Windows FPS or a replay of the captured combat scene.

Independently inspected the generated launcher: x64 PE, nested `0.9.22.zip`, semantic version `0.6.10`, build identity `github-34017583802-1`, and all seven changed runtime modules structurally matching the current source after CPython 2.7 compilation. [Push CI](https://github.com/pengw0048/wot-offline-battles/actions/runs/34017583802) and [PR CI](https://github.com/pengw0048/wot-offline-battles/actions/runs/34017686995) are both green.

Native Windows frame pacing and the specific 87.5 ms terminal spike remain unproved. Prewarming removes a confirmed cold preparation path; it does not establish the cause of that captured spike.
