### PR TITLE
Make Bot competence one rating that gates each tactic per occasion

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,13 +101,20 @@ whose profile changed after it started must be restarted first.
 - Automatically generated Bot lineups contain no self-propelled artillery.
   Player vehicles and manually assigned Bot lineups remain unrestricted;
   tank destroyers are not artillery and remain in the automatic pool.
-- Bot gunnery skill: every Bot is a rookie, regular, veteran or elite gunner.
-  The tier picks the crew level its vehicle is trained to, and how long that
-  gunner takes to react, how patiently it waits for the aiming circle, how
-  far off centre it lays the gun and how badly it leads a moving target. The
-  waiting room chooses the whole roster's mix - easy, relaxed, pub mix, hard
-  or brutal - and the launcher's exact Bot lineup can pin one slot's tier,
-  with or without also pinning its vehicle.
+- Bot competence is a spectrum, not a tier. Each Bot gets one rating that
+  sets the crew level its vehicle is trained to, how long that gunner takes
+  to react, how patiently it waits for the aiming circle, how far off centre
+  it lays the gun and how badly it leads a moving target. The same rating is
+  the chance it does the tactically right thing each time the situation
+  comes up: reaching for cover, peeking out of it, angling its hull, picking
+  the round that beats the armour in front of it, aiming at the part it can
+  actually hurt, turning on whoever just hit it, breaking off when it should,
+  avoiding a crossfire and going around a flank. A weak Bot is not a Bot that
+  does everything slightly worse; it is one that does not think of some of
+  it. The waiting room chooses how competence is spread over the whole roster
+  - easy, relaxed, pub mix, hard or brutal - and the launcher's exact Bot
+  lineup can still pin one slot to a named tier, with or without also pinning
+  its vehicle.
 - Live combat statistics, a damage log with assists, hit and critical-damage
   messages, target outlines, vehicle fires, wrecks, and a consumables panel
   that counts down each cooldown.

--- a/server/lan_battle_server.py
+++ b/server/lan_battle_server.py
@@ -3224,7 +3224,7 @@ class BattleState:
         self.bot_launch_clock_offset_us = None
         self.bot_last_projectile_launch_time_us = {}
         self.motion_time_offset_us = 0
-        self.bot_planner.reset()
+        self.bot_planner.reset(self.round_id)
         self.bot_orders = {"revision": 0, "orders": []}
         self.team_commands = OrderedDict()
         self._next_bot_planner_tick = 0
@@ -4377,6 +4377,14 @@ class BattleState:
                     # Keep the worker's resolved tier on canonical identity;
                     # snapshots and takeover messages are rebuilt from it.
                     entry['skill'] = raw['skill']
+                if 'skill_rating' in raw:
+                    rating = _finite_float(raw['skill_rating'], -1.0)
+                    if rating < 0.0 or rating > 1.0:
+                        return False
+                    # The rating is what the tactical planner reads. It rides
+                    # canonical identity beside the tier name so a takeover
+                    # reinstalls the same Bot rather than re-drawing one.
+                    entry['skill_rating'] = rating
                 manifest.append(entry)
                 states[bot_id] = self._sanitize_bot_state(
                     raw, entry, self.bot_states.get(bot_id))

--- a/server/server_bot_ai.py
+++ b/server/server_bot_ai.py
@@ -18,6 +18,7 @@ _CLIENT_SCRIPT_ROOT = os.path.join(
 if _CLIENT_SCRIPT_ROOT not in sys.path:
     sys.path.insert(0, _CLIENT_SCRIPT_ROOT)
 
+from gui.mods.offline_lan_0922 import bot_gunnery
 from gui.mods.offline_lan_0922.ai.cover import (
     normalize_candidate,
     score_candidates,
@@ -134,6 +135,21 @@ def _route_point_reached(bx, bz, waypoints, index, route_limit):
     return math.hypot(closest_x - bx, closest_z - bz) <= ROUTE_ARRIVAL_RADIUS
 
 
+def _bot_rating(raw):
+    """Return one manifest entry's competence rating.
+
+    An entry carrying neither field predates the rating.  It keeps this
+    project's original behaviour - every Bot executing every tactic - rather
+    than silently becoming a 34 percent Bot because the plumbing failed.
+    """
+    if "skill_rating" in raw:
+        return bot_gunnery.normalize_rating(raw.get("skill_rating"))
+    skill = raw.get("skill")
+    if skill in bot_gunnery.SKILL_TIERS:
+        return bot_gunnery.rating_for_skill(skill)
+    return 1.0
+
+
 def _order_signature(order):
     """Return the strategic fields which advance the order revision."""
     signature = dict(order or {})
@@ -153,6 +169,7 @@ class BotPlanner(object):
 
     def __init__(self):
         self.revision = 0
+        self._round_id = 0
         self._contacts = {1: {}, 2: {}}
         self._last_orders = None
         self._last_order_signature = None
@@ -172,8 +189,16 @@ class BotPlanner(object):
         self._artillery_anchors = {}
         self._recent_hits = {}
 
-    def reset(self):
+    def reset(self, round_id=None):
+        """Start a clean round.
+
+        ``round_id`` salts every competence draw, so a roster slot that never
+        angled last round is not condemned to the same habit for the life of
+        the server process.
+        """
         self.revision = 0
+        if round_id is not None:
+            self._round_id = _integer(round_id)
         self._contacts = {1: {}, 2: {}}
         self._last_orders = None
         self._last_order_signature = None
@@ -192,6 +217,25 @@ class BotPlanner(object):
         self._base_capture = {1: {}, 2: {}}
         self._artillery_anchors = {}
         self._recent_hits = {}
+
+    def _capable(self, bot, capability, *occasion):
+        """Return whether one Bot does the tactically right thing this time.
+
+        A latched capability is seeded with round and Bot identity alone, so
+        the answer holds for the battle and a roster keeps Bots with a
+        recognisable habit.  Every other capability is seeded with the
+        identity of the single decision - a target lease, a cover manoeuvre,
+        one hit - so a Bot hesitates instead of being uniformly incapable,
+        and the answer still cannot flip inside one manoeuvre.
+
+        Nothing is stored.  An order rebuilt on the next tick, or by a
+        replacement authority after a failover, reaches the same answer.
+        """
+        if capability in bot_gunnery.LATCHED_CAPABILITIES:
+            occasion = ()
+        return bot_gunnery.capability_allowed(
+            bot.get("rating"), capability, self._round_id, bot.get("id"),
+            *occasion)
 
     def report_damage(self, victim_bot_id, attacker_kind, attacker_id,
                       damage, now):
@@ -841,6 +885,7 @@ class BotPlanner(object):
                 "id": bot_id,
                 "team": _integer(raw.get("team")),
                 "slot": _integer(raw.get("slot")),
+                "rating": _bot_rating(raw),
                 "profile": raw.get("profile") if isinstance(raw.get("profile"), dict) else {},
                 "route": raw.get("route") if isinstance(raw.get("route"), dict) else {},
                 "state": state,
@@ -1460,8 +1505,18 @@ class BotPlanner(object):
             sum(max(0, _integer(value)) for value in remaining) > 0)
 
     def _hit_requires_withdrawal(self, bot, hit, threat, team_bots):
-        """Escalate damage only when it is material or cannot be answered."""
+        """Escalate damage only when it is material or cannot be answered.
+
+        Reading one hit as a reason to break contact is a competence, decided
+        once per hit. Without it the Bot keeps fighting where it stands. The
+        low-health retreat is deliberately not gated here: that is survival,
+        not judgement, and removing it would only feed the other team.
+        """
         if not isinstance(hit, dict):
+            return False
+        if not self._capable(
+                bot, bot_gunnery.CAPABILITY_WITHDRAW,
+                hit.get("attacker"), round(_number(hit.get("reported_at")), 3)):
             return False
         state = bot.get("state") if isinstance(bot.get("state"), dict) else {}
         max_health = max(1.0, _number(state.get("max_health"), 1.0))
@@ -1696,9 +1751,26 @@ class BotPlanner(object):
         assigned = {}
         candidates = []
         by_bot = {}
+        priority = {}
         for bot in bots:
             bx = _number(bot["state"].get("x"))
             bz = _number(bot["state"].get("z"))
+            # Ranking a whole contact list by how nearly dead each target is,
+            # and turning on whoever last hit you, is a competence. The
+            # occasion is the target lease this assignment already runs on,
+            # not the wall clock: a Bot that re-decided on a timer would
+            # change its mind mid-lease, and every candidate's score would
+            # move at once for no reason the enemy gave it. Decided once per
+            # call and reused below, so the score and the attacker override
+            # cannot disagree. Distance and the point-blank override survive
+            # either way: closing to your own gun and answering a tank in
+            # your face are not tactics.
+            lease = self._target_assignments.get(bot["id"])
+            reads_priority = self._capable(
+                bot, bot_gunnery.CAPABILITY_TARGET_PRIORITY,
+                round(_number(lease.get("until")), 3)
+                if isinstance(lease, dict) else None)
+            priority[bot["id"]] = reads_priority
             for contact in contacts:
                 if (not contact.get("visible") or
                         bot["id"] not in contact.get(
@@ -1710,10 +1782,12 @@ class BotPlanner(object):
                 if distance > self._engagement_range(bot, contact):
                     continue
                 score = 0.0
-                score += contact["health"] / float(max(1, contact["max_health"])) * 28.0
+                if reads_priority:
+                    score += contact["health"] / float(
+                        max(1, contact["max_health"])) * 28.0
                 score += distance * 0.018
                 hit = self._recent_hit(bot["id"], now)
-                if (hit is not None and
+                if (reads_priority and hit is not None and
                         hit.get("attacker") == (
                             str(contact.get("target_kind") or ""),
                             _integer(contact.get("id")))):
@@ -1811,7 +1885,8 @@ class BotPlanner(object):
             hit = self._recent_hit(bot["id"], now)
             attacker_override = bool(
                 hit is not None and best_key == hit.get("attacker") and
-                best_key != previous.get("target"))
+                best_key != previous.get("target") and
+                priority.get(bot["id"], True))
             if close_override or attacker_override:
                 continue
             if (lease_expired and
@@ -2352,13 +2427,20 @@ class BotPlanner(object):
         return max(candidates, key=lambda value: value[:2])[2]
 
     @staticmethod
-    def _shell_index(profile, contact, personality, state=None):
+    def _shell_index(profile, contact, personality, state=None,
+                     plans_shell=True):
         """Plan the next round: standard first, HE soft, premium hard.
 
         Descriptor order supplies the standard baseline. A later non-HE round
         is treated as premium only when it has materially higher penetration;
         store prices are not part of the stable LAN profile. Depleted rounds
         are never requested.
+
+        ``plans_shell`` is the competence to read a target and answer it with
+        the right round. Without it the Bot fires whatever the descriptor
+        loads first and still has in the racks, which is what not knowing
+        looks like: it neither switches to premium against armour it cannot
+        beat, nor picks HE for a soft or nearly dead target.
         """
         shells = profile.get("shells") if isinstance(profile.get("shells"), list) else []
         if not shells:
@@ -2377,6 +2459,11 @@ class BotPlanner(object):
             available.append(shell)
         if not available:
             return max(0, _integer((state or {}).get("shell_index", 0)))
+        if not plans_shell:
+            return max(0, _integer(min(
+                available,
+                key=lambda shell: _integer(shell.get("index"))
+            ).get("index")))
         armor = max(0.0, _number(contact.get("armor")))
         health = max(0.0, _number(contact.get("health")))
         non_he = []
@@ -2543,6 +2630,17 @@ class BotPlanner(object):
 
     def _apply_cover_order(self, order, bot, focus, personality, now,
                            urgent=False, hold_only=False):
+        # One engagement is one decision to use cover, so the answer cannot
+        # change between the approach and the return and leave a Bot driving
+        # in and out of the same position. Reaching for hard cover under fire
+        # is a different, easier competence than choosing a firing position.
+        capability = (bot_gunnery.CAPABILITY_URGENT_COVER
+                      if urgent or hold_only
+                      else bot_gunnery.CAPABILITY_TACTICAL_COVER)
+        if not self._capable(bot, capability, focus.get("target_kind"),
+                             focus.get("id")):
+            self._cover_states.pop(bot["id"], None)
+            return False
         selected_state = None
         for unused_attempt in range(2):
             selected_state = self._cover_candidate(
@@ -2588,7 +2686,9 @@ class BotPlanner(object):
                 order.get("face_position") or focus["position"])
         elif (phase == "hold" and not urgent and not hold_only and
               _number(now) >= _number(state.get("phase_until")) and
-              self._weapon_ready(bot)):
+              self._weapon_ready(bot) and
+              self._capable(bot, bot_gunnery.CAPABILITY_COVER_PEEK,
+                            candidate["id"])):
             phase = "peek"
             self._begin_cover_phase(state, phase, now, peek_distance)
             state["peek_fire_seq"] = _integer(
@@ -2661,8 +2761,7 @@ class BotPlanner(object):
         if order.get("target_id") is None:
             order["face_position"] = dict(anchor["face"])
 
-    @staticmethod
-    def _set_target(order, bot, contact, profile, personality,
+    def _set_target(self, order, bot, contact, profile, personality,
                     fire_allowed):
         order["target_id"] = contact["id"]
         order["target_kind"] = contact.get("target_kind")
@@ -2670,8 +2769,13 @@ class BotPlanner(object):
         order["face_position"] = dict(contact["position"])
         order["fire_allowed"] = bool(
             fire_allowed and BotPlanner._weapon_ready(bot))
+        # One engagement is one shell decision. Re-rolling per tick would
+        # leave a Bot swapping rounds in front of the same tank.
         order["shell_index"] = BotPlanner._shell_index(
-            profile, contact, personality, bot.get("state"))
+            profile, contact, personality, bot.get("state"),
+            plans_shell=self._capable(
+                bot, bot_gunnery.CAPABILITY_SHELL_CHOICE,
+                contact.get("target_kind"), contact.get("id")))
 
     @staticmethod
     def _angled_face_point(bot, target, personality):
@@ -2714,7 +2818,9 @@ class BotPlanner(object):
                     "under_fire_withdraw", "crossfire_withdraw") or
                 _number(order.get("throttle_override"), 1.0) != 0.0 or
                 not order.get("fire_allowed") or
-                not self._may_angle_hull(profile)):
+                not self._may_angle_hull(profile) or
+                not self._capable(
+                    bot, bot_gunnery.CAPABILITY_HULL_ANGLING)):
             return
         target_key = (order.get("target_kind"), order.get("target_id"))
         anchor = self._engage_anchors.get(bot["id"])
@@ -2907,7 +3013,9 @@ class BotPlanner(object):
             return order
 
         if (crossfire_risk is not None and crossfire_risk >= 0.35 and
-                support_score < 0.70):
+                support_score < 0.70 and
+                self._capable(bot, bot_gunnery.CAPABILITY_CROSSFIRE,
+                              focus.get("target_kind"), focus.get("id"))):
             self._engage_anchors.pop(bot["id"], None)
             self._combat_states.pop(bot["id"], None)
             if (distance <= fire_range * 1.15 and
@@ -2953,6 +3061,7 @@ class BotPlanner(object):
 
         self._retreat_states.pop(bot["id"], None)
         if (distance > close_limit and distance <= fire_range and
+                self._capable(bot, bot_gunnery.CAPABILITY_FLANK) and
                 self._should_flank(bot, focus, team_bots or ())):
             self._engage_anchors.pop(bot["id"], None)
             self._combat_states.pop(bot["id"], None)

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -20023,8 +20023,22 @@ class BattleRuntime(object):
                 if samples[index] not in attempts:
                     attempts.append(samples[index])
             entry['selected'] = None
+            # A gunner who has not worked out where this tank is soft still
+            # aims at something exposed. It ranks the tested parts only when
+            # its own competence roll succeeds for the current aiming epoch,
+            # so the same Bot finds the weak spot in one engagement and not
+            # in the next. A failed roll keeps whichever exposed part the
+            # rotating cursor offered, which is uncorrelated with armour -
+            # not knowing where to aim is that, and not the inverted armour
+            # solve it would take to deliberately pick the worst plate.
+            # No reachable Bot runtime means no rating to read, so the part
+            # ranking stays on. A Bot must never lose a competence because
+            # the plumbing that scores it went missing.
+            ranks = (self._bots is None or
+                     self._bots.bot_aim_selection_allowed(source, target))
             best = None
             best_score = None
+            exposed = None
             for sample in attempts:
                 point = shot_geometry.vehicle_aim_point(sample, target)
                 hit = self._runtime.bigworld.wg_collideSegment(
@@ -20034,15 +20048,22 @@ class BattleRuntime(object):
                     continue
                 score = self._bot_aim_damage_score(
                     descriptor, entry, source, target, origin, point)
-                if best is None or (score is not None and
+                if exposed is None:
+                    exposed = sample
+                # A part the armour resolver proved cannot be hurt is never a
+                # deliberate choice at any competence, only a last resort
+                # when nothing else in this job was clear.
+                if score == 0.0:
+                    continue
+                if best is None or (ranks and score is not None and
                         best_score is not None and score > best_score):
                     best, best_score = sample, score
                 # Missing material evidence cannot authorize a weak-spot
                 # claim. Preserve the exposed-part behaviour in that case.
-                if score is None:
+                if score is None or not ranks:
                     break
-            entry['selected'] = best
-            return best is not None
+            entry['selected'] = best if best is not None else exposed
+            return entry['selected'] is not None
         except Exception:
             if entry is not None:
                 entry['selected'] = None

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bot_gunnery.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bot_gunnery.py
@@ -22,6 +22,17 @@ aim-point bias and an imperfect lead on a moving target.  Those numbers are an
 explicit product choice for this project.  They are not retail data, they are
 not derived from client files, and they must not be presented as either.
 
+A Bot's competence is one continuous ``rating`` in [0, 1], not a tier.  The
+four reviewed tier bundles survive as the anchors that rating interpolates
+between, so every existing calibration is still exactly itself at its own
+anchor; the tier names remain the wire, launcher-profile and log vocabulary.
+
+The same rating is also the probability that a Bot does the tactically right
+thing on one occasion, which is what ``capability_allowed`` answers.  That
+half is consumed by the server planner, not here: this module owns the number
+and the draw, so worker, server and launcher reach the same answer from
+identity alone.
+
 Every draw is seeded from stable round, Bot and target identity, so authority
 takeover reproduces the same gunner rather than re-rolling one mid-engagement.
 The radius law matches ``bot_runtime._dispersed_barrel_angles`` so the project
@@ -43,6 +54,52 @@ SKILL_ELITE = 'elite'
 SKILL_TIERS = (SKILL_ROOKIE, SKILL_REGULAR, SKILL_VETERAN, SKILL_ELITE)
 DEFAULT_SKILL = SKILL_REGULAR
 
+# Where each tier name sits on the continuous axis.  Index-aligned with
+# SKILL_TIERS: the names are a label for a rating, not a separate ladder.
+RATING_ANCHORS = (0.00, 0.34, 0.67, 1.00)
+DEFAULT_RATING = RATING_ANCHORS[SKILL_TIERS.index(DEFAULT_SKILL)]
+
+# Crew levels this project has actually seen #1513 train.  A level the client
+# refuses makes ``_bot_default_crew_factors`` fall back to the full default
+# crew, which moves a weak Bot the wrong way, so the interpolated level snaps
+# to a proven one instead of trusting an unverified value.
+PROVEN_CREW_LEVELS = (75, 90, 100)
+
+# Tactical capabilities the rating gates.  The rating is the probability that
+# a Bot does the right thing on one occasion; the caller decides how wide an
+# occasion is by choosing what identity it seeds the draw with.  Two of them
+# are latched to the round and slot on purpose, so a roster holds Bots with a
+# recognisable habit ("that one never angles") instead of only Bots that
+# hesitate uniformly.
+CAPABILITY_WEAK_SPOT = 'weak_spot'
+CAPABILITY_SHELL_CHOICE = 'shell_choice'
+CAPABILITY_TARGET_PRIORITY = 'target_priority'
+CAPABILITY_URGENT_COVER = 'urgent_cover'
+CAPABILITY_TACTICAL_COVER = 'tactical_cover'
+CAPABILITY_COVER_PEEK = 'cover_peek'
+CAPABILITY_CROSSFIRE = 'crossfire'
+CAPABILITY_WITHDRAW = 'withdraw'
+CAPABILITY_HULL_ANGLING = 'hull_angling'
+CAPABILITY_FLANK = 'flank'
+
+CAPABILITIES = (
+    CAPABILITY_WEAK_SPOT, CAPABILITY_SHELL_CHOICE,
+    CAPABILITY_TARGET_PRIORITY, CAPABILITY_URGENT_COVER,
+    CAPABILITY_TACTICAL_COVER, CAPABILITY_COVER_PEEK,
+    CAPABILITY_CROSSFIRE, CAPABILITY_WITHDRAW,
+    CAPABILITY_HULL_ANGLING, CAPABILITY_FLANK)
+
+# Rolled once for the whole round from round and slot identity.
+LATCHED_CAPABILITIES = frozenset((
+    CAPABILITY_HULL_ANGLING, CAPABILITY_FLANK))
+
+# Maps the rating onto the capability probability.  1.0 is the reviewed
+# product choice: the gunnery half and the tactical half read the same number.
+# It exists because those two halves are calibrated on different scales, and
+# one exponent is the whole correction if playtesting says the tactical half
+# bites harder than the gunnery half.
+CAPABILITY_EXPONENT = 1.0
+
 # One aim-point bias is held for this long before the gunner re-lays the gun.
 # A single frozen bias would make a whole engagement uniformly lucky or
 # unlucky; re-drawing every frame would read as jitter rather than as aim.
@@ -58,6 +115,9 @@ VERTICAL_BIAS_SHARE = 0.45
 # growing; the shot is already a clean miss.
 MAX_AIM_OFFSET_METRES = 8.0
 
+# The four reviewed bundles are the anchors of the continuous rating axis.
+# ``rating_parameters`` interpolates between them, so an anchor rating still
+# returns exactly the bundle below it and no existing calibration moves.
 _PARAMETERS = {
     SKILL_ROOKIE: {
         # #1513 crew level, fed to generateDefaultCrew.  The crew level also
@@ -121,12 +181,21 @@ SKILL_MODES = (
     SKILL_MODE_HARD, SKILL_MODE_BRUTAL)
 DEFAULT_SKILL_MODE = SKILL_MODE_MIXED
 
-_MODE_WEIGHTS = {
-    SKILL_MODE_EASY: (0.85, 0.15, 0.00, 0.00),
-    SKILL_MODE_RELAXED: (0.45, 0.40, 0.15, 0.00),
-    SKILL_MODE_MIXED: (0.20, 0.45, 0.25, 0.10),
-    SKILL_MODE_HARD: (0.00, 0.25, 0.45, 0.30),
-    SKILL_MODE_BRUTAL: (0.00, 0.00, 0.00, 1.00),
+# Each preset is one roster's rating distribution, written as the five
+# control points of a piecewise-linear inverse CDF at u = 0, .25, .5, .75, 1.
+# One ``random()`` draw per slot indexes it, so Python 2.7 and Python 3 agree
+# bit for bit without depending on a library distribution's implementation.
+#
+# The product specification is the mean of each row: .10 / .30 / .60 / .80 /
+# 1.00.  ``_mode_mean`` recomputes it and a test holds the table to it.  The
+# spans are deliberate: ``mixed`` is the widest, so one pub roster really does
+# hold a hopeless Bot and a dangerous one, while the ends stay predictable.
+_MODE_RATING_POINTS = {
+    SKILL_MODE_EASY: (0.00, 0.03, 0.08, 0.14, 0.30),
+    SKILL_MODE_RELAXED: (0.05, 0.16, 0.28, 0.40, 0.67),
+    SKILL_MODE_MIXED: (0.12, 0.42, 0.62, 0.80, 1.00),
+    SKILL_MODE_HARD: (0.52, 0.70, 0.82, 0.92, 1.00),
+    SKILL_MODE_BRUTAL: (1.00, 1.00, 1.00, 1.00, 1.00),
 }
 
 
@@ -152,33 +221,167 @@ def normalize_skill_mode(value):
     return value if value in SKILL_MODES else DEFAULT_SKILL_MODE
 
 
+def normalize_rating(value):
+    """Return one usable competence rating in [0, 1].
+
+    An unusable value becomes the default rather than raising: a Bot with a
+    corrupt rating still has to fight this round.
+    """
+    try:
+        rating = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return DEFAULT_RATING
+    if math.isnan(rating) or math.isinf(rating):
+        return DEFAULT_RATING
+    return max(0.0, min(1.0, rating))
+
+
+def rating_for_skill(skill):
+    """Return the rating one tier name stands for."""
+    return RATING_ANCHORS[SKILL_TIERS.index(normalize_skill(skill))]
+
+
+def skill_for_rating(rating):
+    """Return the nearest tier name, for the wire, a log line or a panel.
+
+    Ties round down.  A label may understate a Bot; it must never claim a
+    competence the Bot does not have.
+    """
+    rating = normalize_rating(rating)
+    best_index = 0
+    best_distance = None
+    for index, anchor in enumerate(RATING_ANCHORS):
+        distance = abs(rating - anchor)
+        if best_distance is None or distance < best_distance - 1e-12:
+            best_index, best_distance = index, distance
+    return SKILL_TIERS[best_index]
+
+
+def _interpolate(points, position):
+    """Return the piecewise-linear value of evenly spaced control points."""
+    span = len(points) - 1
+    scaled = max(0.0, min(1.0, position)) * span
+    index = int(scaled)
+    if index >= span:
+        return float(points[-1])
+    fraction = scaled - index
+    lower = float(points[index])
+    return lower + (float(points[index + 1]) - lower) * fraction
+
+
+def _anchor_segment(rating):
+    """Return the (index, fraction) of the anchor segment holding a rating."""
+    last = len(RATING_ANCHORS) - 2
+    for index in range(last + 1):
+        lower = RATING_ANCHORS[index]
+        upper = RATING_ANCHORS[index + 1]
+        if rating <= upper or index == last:
+            if upper <= lower:
+                return index, 0.0
+            return index, max(0.0, min(1.0, (rating - lower) /
+                                       (upper - lower)))
+    return last, 1.0
+
+
+def _anchor_value(points, rating):
+    """Return one reviewed row's value at a rating, exact on every anchor.
+
+    The anchors are not evenly spaced, and ``a + (b - a) * 1.0`` is not
+    reliably ``b`` in binary floating point.  Returning the endpoint verbatim
+    is what keeps an anchor rating identical to the tier it stands for, which
+    is the whole reason the tier bundles survived as anchors.
+    """
+    index, fraction = _anchor_segment(rating)
+    if fraction <= 0.0:
+        return float(points[index])
+    if fraction >= 1.0:
+        return float(points[index + 1])
+    lower = float(points[index])
+    return lower + (float(points[index + 1]) - lower) * fraction
+
+
+def rating_parameters(rating):
+    """Return one Bot's gunner bundle, interpolated between the anchors.
+
+    The bundle is built per call, so a caller may not rely on identity and
+    cannot mutate a shared row.  ``crew_level`` is snapped to a level #1513
+    is known to train instead of trusting an interpolated one.
+    """
+    rating = normalize_rating(rating)
+    rows = [_PARAMETERS[skill] for skill in SKILL_TIERS]
+    result = {}
+    for name in ('reaction_seconds', 'patience_seconds', 'converged_factor',
+                 'aim_bias_factor', 'lead_error'):
+        result[name] = _anchor_value([row[name] for row in rows], rating)
+    level = _anchor_value([row['crew_level'] for row in rows], rating)
+    result['crew_level'] = min(
+        PROVEN_CREW_LEVELS, key=lambda proven: (abs(proven - level), proven))
+    return result
+
+
 def skill_parameters(skill):
-    """Return the shared parameter bundle for one tier.  Do not mutate it."""
-    return _PARAMETERS[normalize_skill(skill)]
+    """Return the parameter bundle at one tier's own anchor."""
+    return rating_parameters(rating_for_skill(skill))
+
+
+def rating_crew_level(rating):
+    """Return the #1513 crew level one rating trains its Bot to."""
+    return int(rating_parameters(rating)['crew_level'])
 
 
 def crew_level(skill):
-    """Return the #1513 crew level this tier trains its Bots to."""
-    return int(skill_parameters(skill)['crew_level'])
+    """Return the #1513 crew level one tier trains its Bots to."""
+    return rating_crew_level(rating_for_skill(skill))
 
 
-def resolve_skill(mode, round_id, team, slot):
-    """Pick one roster slot's tier from a preset, without shared state.
+def _mode_mean(mode):
+    """Return one preset's mean rating, the number the presets specify."""
+    points = _MODE_RATING_POINTS[normalize_skill_mode(mode)]
+    span = len(points) - 1
+    return sum((points[index] + points[index + 1]) * 0.5 / span
+               for index in range(span))
+
+
+def resolve_rating(mode, round_id, team, slot):
+    """Pick one roster slot's rating from a preset, without shared state.
 
     The draw depends only on the round and the slot, so the worker, the
     server and any UI reach the same answer for the same Bot without the
-    tier having to travel between them first.
+    rating having to travel between them first.
     """
     mode = normalize_skill_mode(mode)
-    weights = _MODE_WEIGHTS[mode]
     roll = random.Random(
-        _stable_seed('bot-skill-v1', round_id, mode, team, slot)).random()
-    total = 0.0
-    for index, weight in enumerate(weights):
-        total += weight
-        if roll < total:
-            return SKILL_TIERS[index]
-    return SKILL_TIERS[-1]
+        _stable_seed('bot-skill-rating-v1', round_id, mode, team,
+                     slot)).random()
+    return _interpolate(_MODE_RATING_POINTS[mode], roll)
+
+
+def resolve_skill(mode, round_id, team, slot):
+    """Return the tier name labelling one roster slot's drawn rating."""
+    return skill_for_rating(resolve_rating(mode, round_id, team, slot))
+
+
+def capability_allowed(rating, capability, *occasion):
+    """Return whether one Bot does the tactically right thing this time.
+
+    ``occasion`` is the identity of the single decision being made, and it is
+    what decides how long an answer lasts.  Seeding it with a target lease,
+    an aiming epoch or a cover-manoeuvre instance gives a Bot that hesitates;
+    seeding it with the round and slot latches the answer for the battle.
+    Nothing is stored either way, so the planner may recompute an order every
+    tick and an authority takeover cannot make a Bot change its mind.
+
+    A rating of 0 never succeeds and a rating of 1 always does, so the ends
+    of a preset stay honest.
+    """
+    rating = normalize_rating(rating)
+    if rating <= 0.0:
+        return False
+    probability = rating ** CAPABILITY_EXPONENT
+    if probability >= 1.0:
+        return True
+    parts = ('bot-capability-v1', capability) + occasion
+    return random.Random(_stable_seed(*parts)).random() < probability
 
 
 def bias_epoch(hold_seconds):
@@ -192,16 +395,16 @@ def bias_epoch(hold_seconds):
     return int(held / AIM_BIAS_SECONDS)
 
 
-def engagement_error(skill, round_id, bot_id, target_key, epoch):
+def engagement_error(rating, round_id, bot_id, target_key, epoch):
     """Return one gunner's frozen error for one aiming epoch.
 
     ``radius`` is a truncated half-normal in [0, 1]; the caller scales it by
-    the tier's bias factor and the gun's own dispersion.  ``lead_scale``
+    the Bot's bias factor and the gun's own dispersion.  ``lead_scale``
     multiplies the target velocity fed to the intercept solve, so a weak
     gunner under- or over-leads a moving target for the whole epoch instead
     of correcting between shots.
     """
-    params = skill_parameters(skill)
+    params = rating_parameters(rating)
     generator = random.Random(_stable_seed(
         'bot-gunner-v1', round_id, bot_id, target_key, epoch))
     radius = abs(generator.gauss(0.0, 0.5))
@@ -215,13 +418,13 @@ def engagement_error(skill, round_id, bot_id, target_key, epoch):
     }
 
 
-def aim_offset_metres(skill, error, dispersion_angle, distance):
+def aim_offset_metres(rating, error, dispersion_angle, distance):
     """Return the (lateral, vertical) aim-point error for one shot, in metres.
 
     The caller maps these onto the line of sight.  The error is angular so it
     grows with range exactly like the aiming circle it is measured against.
     """
-    params = skill_parameters(skill)
+    params = rating_parameters(rating)
     try:
         angle = float(dispersion_angle)
         reach = float(distance)
@@ -239,7 +442,7 @@ def aim_offset_metres(skill, error, dispersion_angle, distance):
             magnitude * math.sin(azimuth) * VERTICAL_BIAS_SHARE)
 
 
-def may_fire(skill, hold_seconds, laying_seconds, dispersion_factor,
+def may_fire(rating, hold_seconds, laying_seconds, dispersion_factor,
              opening_shot=True):
     """Return whether this gunner has reacted and finished laying.
 
@@ -249,14 +452,13 @@ def may_fire(skill, hold_seconds, laying_seconds, dispersion_factor,
     a multiple of the fully-aimed circle, so 1.0 is fully aimed.
 
     Only the opening shot of an engagement waits for the circle.  Every gun
-    blooms after firing, so a better tier - which accepts a tighter circle
+    blooms after firing, so a better gunner - which accepts a tighter circle
     and waits longer for it - would otherwise fire a fast or clip gun less
-    often than a worse tier holding the same gun, and the whole ladder would
+    often than a worse one holding the same gun, and the whole ladder would
     invert.  After the opening shot the gun's own reload owns the cadence;
-    the aim-point bias and the lead error still separate the tiers on every
-    round.
+    the aim-point bias and the lead error still separate Bots on every round.
     """
-    params = skill_parameters(skill)
+    params = rating_parameters(rating)
     try:
         held = float(hold_seconds)
         laying = float(laying_seconds)

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -2119,7 +2119,7 @@ class BotRuntime(object):
         self._reset_shot_lane_work()
         self._reset_shot_lane_diagnostics()
         self._physics_params = {}
-        self._bot_skills = {}
+        self._bot_ratings = {}
         self._bot_skill_mode = bot_gunnery.DEFAULT_SKILL_MODE
         self._bot_skill_pins = {}
         self._gunnery_holds = {}
@@ -3061,17 +3061,21 @@ class BotRuntime(object):
                 continue
         return pins
 
-    def _resolve_bot_skill(self, raw):
-        """Return one Bot's gunnery tier for this round.
+    def _resolve_bot_rating(self, raw):
+        """Return one Bot's competence rating for this round.
 
-        A takeover manifest already carries the tier the previous authority
-        installed, so it wins.  Then the host's explicit lineup pin.  Then the
-        room preset, which resolves from round and slot identity alone, so
-        every process reaches the same tier without it travelling first.
+        A takeover manifest already carries the rating the previous authority
+        installed, so it wins; an older manifest carrying only a tier name is
+        read at that tier's anchor.  Then the host's explicit lineup pin.
+        Then the room preset, which resolves from round and slot identity
+        alone, so every process reaches the same rating without it travelling
+        first.
         """
+        if 'skill_rating' in raw:
+            return bot_gunnery.normalize_rating(raw.get('skill_rating'))
         published = raw.get('skill')
         if published in bot_gunnery.SKILL_TIERS:
-            return published
+            return bot_gunnery.rating_for_skill(published)
         try:
             team = int(raw.get('team', 1))
             slot = int(raw.get('slot', 0))
@@ -3079,17 +3083,47 @@ class BotRuntime(object):
             raise ValueError('authority manifest Bot slot identity is invalid')
         pinned = self._bot_skill_pins.get((team, slot))
         if pinned in bot_gunnery.SKILL_TIERS:
-            return pinned
-        return bot_gunnery.resolve_skill(
+            return bot_gunnery.rating_for_skill(pinned)
+        return bot_gunnery.resolve_rating(
             self._bot_skill_mode, self.round_id, team, slot)
 
+    def bot_rating(self, bot_id):
+        """Return the competence rating installed for one Bot this round."""
+        return self._bot_ratings.get(
+            int(bot_id), bot_gunnery.DEFAULT_RATING)
+
     def bot_skill(self, bot_id):
-        """Return the gunnery tier installed for one Bot this round."""
-        return self._bot_skills.get(int(bot_id), bot_gunnery.DEFAULT_SKILL)
+        """Return the tier name labelling one Bot's rating, for the wire."""
+        return bot_gunnery.skill_for_rating(self.bot_rating(bot_id))
 
     def bot_crew_level(self, bot_id):
-        """Return the #1513 crew level this Bot's tier trains it to."""
-        return bot_gunnery.crew_level(self.bot_skill(bot_id))
+        """Return the #1513 crew level this Bot's rating trains it to."""
+        return bot_gunnery.rating_crew_level(self.bot_rating(bot_id))
+
+    def bot_aim_selection_allowed(self, state, target):
+        """Return whether this Bot's gunner picks the part it can hurt most.
+
+        The presentation client owns the armour ranking, but not this clock:
+        the answer has to change on the same aiming epoch the aim-point bias
+        already uses, or a per-frame flip would invalidate the solved shot
+        through ``_direct_aim_matches`` and re-solve the ballistics every
+        tick.  Reading the existing hold record keeps one owner for that
+        epoch; this accessor never creates or advances one.
+        """
+        try:
+            bot_id = int(state['id'])
+        except (KeyError, TypeError, ValueError, OverflowError):
+            return False
+        record = self._gunnery_holds.get(bot_id)
+        key = (self._observer_target_key(target)
+               if isinstance(target, dict) else None)
+        epoch = 0
+        if (record is not None and key is not None and
+                record.get('key') == key):
+            epoch = int(record.get('epoch') or 0)
+        return bot_gunnery.capability_allowed(
+            self.bot_rating(bot_id), bot_gunnery.CAPABILITY_WEAK_SPOT,
+            self.round_id, bot_id, key, epoch)
 
     def battle_start(self, message):
         """Build a local authority manifest from the server roster once per round."""
@@ -3132,7 +3166,7 @@ class BotRuntime(object):
             self._reset_shot_lane_work()
             self._reset_shot_lane_diagnostics()
             self._physics_params = {}
-            self._bot_skills = {}
+            self._bot_ratings = {}
             self._gunnery_holds = {}
             self._suspension_params = {}
             self._suspension_param_failures = 0
@@ -3313,8 +3347,9 @@ class BotRuntime(object):
             wire_total = int(raw_wire_total)
             siege_time_left = wire_time / 1000.0
             siege_transition_total = wire_total / 1000.0
-            self._bot_skills[bot_id] = self._resolve_bot_skill(raw)
-            crew_level = bot_gunnery.crew_level(self._bot_skills[bot_id])
+            self._bot_ratings[bot_id] = self._resolve_bot_rating(raw)
+            crew_level = bot_gunnery.rating_crew_level(
+                self._bot_ratings[bot_id])
             self._descriptor_pairs[bot_id] = descriptor_pair
             descriptor = siege_mechanics.active_descriptor(
                 descriptor_pair, siege_state)
@@ -4283,8 +4318,11 @@ class BotRuntime(object):
                 'siege_time_left_ms', 'siege_transition_total_ms',
                 'equipment_states', 'stun_end_server_time_ms')
         result = dict((key, state[key]) for key in keys)
-        # The tier rides the manifest so a takeover installs the same gunner
-        # rather than re-rolling one from a preset mid-round.
+        # The rating rides the manifest so a takeover installs the same
+        # gunner rather than re-rolling one from a preset mid-round.  The
+        # tier name rides with it because saved launcher profiles, the room
+        # panel and the server's own validation still speak that vocabulary.
+        result['skill_rating'] = self.bot_rating(state['id'])
         result['skill'] = self.bot_skill(state['id'])
         descriptor = self._descriptors.get(state['id'], {})
         terminal = _terminal_critical(state, descriptor, 'shot')
@@ -8801,7 +8839,7 @@ class BotRuntime(object):
         if record['epoch'] != epoch or record['error'] is None:
             record['epoch'] = epoch
             record['error'] = bot_gunnery.engagement_error(
-                self.bot_skill(bot_id), self.round_id, bot_id,
+                self.bot_rating(bot_id), self.round_id, bot_id,
                 record['key'], epoch)
         return record['error']
 
@@ -8832,7 +8870,7 @@ class BotRuntime(object):
         if horizontal <= 1.0:
             return target
         lateral, vertical = bot_gunnery.aim_offset_metres(
-            self.bot_skill(bot_id), error,
+            self.bot_rating(bot_id), error,
             gun_state.fully_aimed_dispersion, _distance(origin, position))
         velocity = self._target_velocity(target)
         scale = float(error['lead_scale'])
@@ -8851,7 +8889,7 @@ class BotRuntime(object):
         if held is None:
             return False
         return bot_gunnery.may_fire(
-            self.bot_skill(int(state['id'])), held[0], held[1],
+            self.bot_rating(int(state['id'])), held[0], held[1],
             gun_state.current_dispersion_factor, held[2])
 
     def _ballistic_solution(self, state, target, descriptor, shell_index,

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -10881,6 +10881,71 @@ class BattleRuntimeContractTests(unittest.TestCase):
                   gravity * time_at_wall ** 2 * 0.5)
         self.assertGreater(height, 1.8)
 
+    def test_a_weak_gunner_keeps_the_part_the_cursor_offered(self):
+        """Not knowing where to aim is an unranked choice, not a bad one."""
+        runtime, battle, source, target, unused = self._bot_lane_scene()
+        scored = []
+
+        runtime.bigworld.wg_collideSegment = lambda *unused_args: None
+        battle._bot_aim_damage_score = (
+            lambda unused_descriptor, unused_entry, unused_source,
+            unused_target, unused_origin, point: scored.append(point) or
+            (900.0 if point[1] > 2.0 else 100.0))
+
+        battle._bots = types.SimpleNamespace(
+            bot_aim_selection_allowed=lambda unused_source, unused_target:
+            False)
+        self.assertTrue(battle._bot_firing_lane(source, target))
+        weak = battle._bot_aim_point(source, target)
+        # One tested part, taken as offered: no second ray, no comparison.
+        self.assertEqual(1, len(scored))
+
+        scored[:] = []
+        battle._records['bot:11'].pop('bot_aim_targets', None)
+        battle._bots = types.SimpleNamespace(
+            bot_aim_selection_allowed=lambda unused_source, unused_target:
+            True)
+        self.assertTrue(battle._bot_firing_lane(source, target))
+        strong = battle._bot_aim_point(source, target)
+
+        self.assertEqual(2, len(scored))
+        self.assertGreater(strong['aim_position'][1], 2.0)
+        self.assertLess(weak['aim_position'][1], strong['aim_position'][1])
+
+    def test_no_gunner_deliberately_aims_at_a_part_it_cannot_hurt(self):
+        """Not knowing which plate is thinnest is ordinary; this is not."""
+        runtime, battle, source, target, unused = self._bot_lane_scene()
+        tested = []
+
+        runtime.bigworld.wg_collideSegment = lambda *unused_args: None
+        battle._bot_aim_damage_score = (
+            lambda unused_descriptor, unused_entry, unused_source,
+            unused_target, unused_origin, point: tested.append(point) or
+            (0.0 if point[1] < 2.0 else 250.0))
+        battle._bots = types.SimpleNamespace(
+            bot_aim_selection_allowed=lambda unused_source, unused_target:
+            False)
+
+        self.assertTrue(battle._bot_firing_lane(source, target))
+        selected = battle._bot_aim_point(source, target)
+
+        self.assertEqual(2, len(tested))
+        self.assertGreater(selected['aim_position'][1], 2.0)
+
+    def test_a_useless_part_is_still_fired_at_when_it_is_all_there_is(self):
+        """Holding fire would read as a broken Bot, not a weak one."""
+        runtime, battle, source, target, unused = self._bot_lane_scene()
+
+        runtime.bigworld.wg_collideSegment = lambda *unused_args: None
+        battle._bot_aim_damage_score = (
+            lambda *unused_args: 0.0)
+        battle._bots = types.SimpleNamespace(
+            bot_aim_selection_allowed=lambda unused_source, unused_target:
+            True)
+
+        self.assertTrue(battle._bot_firing_lane(source, target))
+        self.assertIsNotNone(battle._bot_aim_point(source, target))
+
     def test_bot_firing_lane_rotates_real_samples_with_two_ray_budget(self):
         runtime, battle, source, target, unused = self._bot_lane_scene()
         rays = []

--- a/tests/test_port_0922_bot_gunnery.py
+++ b/tests/test_port_0922_bot_gunnery.py
@@ -31,6 +31,11 @@ def _load(module_name):
 
 gunnery = _load('bot_gunnery')
 
+ROOKIE = gunnery.rating_for_skill(gunnery.SKILL_ROOKIE)
+REGULAR = gunnery.rating_for_skill(gunnery.SKILL_REGULAR)
+VETERAN = gunnery.rating_for_skill(gunnery.SKILL_VETERAN)
+ELITE = gunnery.rating_for_skill(gunnery.SKILL_ELITE)
+
 
 class SkillTierTableTests(unittest.TestCase):
     def test_the_tiers_are_ordered_from_the_weakest_to_the_best_gunner(self):
@@ -77,12 +82,31 @@ class SkillTierTableTests(unittest.TestCase):
             self.assertEqual(gunnery.DEFAULT_SKILL_MODE,
                              gunnery.normalize_skill_mode(value))
 
-    def test_every_preset_is_a_complete_distribution(self):
+    def test_every_preset_is_a_usable_rating_distribution(self):
         for mode in gunnery.SKILL_MODES:
-            weights = gunnery._MODE_WEIGHTS[mode]
-            self.assertEqual(len(gunnery.SKILL_TIERS), len(weights), mode)
-            self.assertAlmostEqual(1.0, sum(weights), places=6, msg=mode)
-            self.assertTrue(all(weight >= 0.0 for weight in weights), mode)
+            points = gunnery._MODE_RATING_POINTS[mode]
+            self.assertEqual(5, len(points), mode)
+            self.assertTrue(
+                all(0.0 <= point <= 1.0 for point in points), mode)
+            # An inverse CDF may not run backwards.
+            self.assertEqual(sorted(points), list(points), mode)
+
+    def test_each_preset_hits_the_mean_rating_it_specifies(self):
+        """The presets are specified by their mean, not by their shape."""
+        expected = {'easy': 0.10, 'relaxed': 0.30, 'mixed': 0.60,
+                    'hard': 0.80, 'brutal': 1.00}
+        for mode in gunnery.SKILL_MODES:
+            self.assertAlmostEqual(
+                expected[mode], gunnery._mode_mean(mode), places=6, msg=mode)
+
+    def test_the_pub_default_is_the_widest_spread(self):
+        """One mixed roster has to hold a hopeless Bot and a dangerous one."""
+        spans = {}
+        for mode in gunnery.SKILL_MODES:
+            points = gunnery._MODE_RATING_POINTS[mode]
+            spans[mode] = points[-1] - points[0]
+        self.assertEqual('mixed', max(spans, key=lambda mode: spans[mode]))
+        self.assertEqual(0.0, spans['brutal'])
 
 
 class SkillResolutionTests(unittest.TestCase):
@@ -112,17 +136,15 @@ class SkillResolutionTests(unittest.TestCase):
             seen.update(self._roster('mixed', round_id))
         self.assertEqual(set(gunnery.SKILL_TIERS), seen)
 
-    def test_a_preset_roughly_matches_its_own_weights(self):
-        counts = dict((skill, 0) for skill in gunnery.SKILL_TIERS)
-        rounds = 400
-        for round_id in range(rounds):
-            for skill in self._roster('mixed', round_id):
-                counts[skill] += 1
-        total = float(sum(counts.values()))
-        for index, skill in enumerate(gunnery.SKILL_TIERS):
-            expected = gunnery._MODE_WEIGHTS['mixed'][index]
+    def test_a_preset_samples_the_mean_rating_it_specifies(self):
+        for mode in gunnery.SKILL_MODES:
+            drawn = [gunnery.resolve_rating(mode, round_id, team, slot)
+                     for round_id in range(400)
+                     for team in (1, 2) for slot in range(15)]
             self.assertAlmostEqual(
-                expected, counts[skill] / total, delta=0.03, msg=skill)
+                gunnery._mode_mean(mode), sum(drawn) / float(len(drawn)),
+                delta=0.01, msg=mode)
+            self.assertTrue(all(0.0 <= value <= 1.0 for value in drawn), mode)
 
     def test_an_unknown_preset_still_resolves_a_supported_tier(self):
         self.assertIn(
@@ -131,50 +153,52 @@ class SkillResolutionTests(unittest.TestCase):
 
 class EngagementErrorTests(unittest.TestCase):
     def test_the_same_engagement_epoch_reproduces_the_same_gunner(self):
-        first = gunnery.engagement_error('regular', 5, 11, ('human', 2), 3)
-        second = gunnery.engagement_error('regular', 5, 11, ('human', 2), 3)
+        first = gunnery.engagement_error(REGULAR, 5, 11, ('human', 2), 3)
+        second = gunnery.engagement_error(REGULAR, 5, 11, ('human', 2), 3)
         self.assertEqual(first, second)
 
     def test_a_new_epoch_re_lays_the_gun(self):
-        errors = [gunnery.engagement_error('regular', 5, 11, ('human', 2), n)
+        errors = [gunnery.engagement_error(REGULAR, 5, 11, ('human', 2), n)
                   for n in range(6)]
         self.assertGreater(len(set(error['radius'] for error in errors)), 1)
 
     def test_the_radius_stays_inside_the_tier_envelope(self):
         for epoch in range(500):
             error = gunnery.engagement_error(
-                'rookie', 5, 11, ('bot', 12), epoch)
+                ROOKIE, 5, 11, ('bot', 12), epoch)
             self.assertGreaterEqual(error['radius'], 0.0)
             self.assertLessEqual(error['radius'], 1.0)
             self.assertGreaterEqual(error['azimuth'], 0.0)
 
-    def test_the_lead_error_is_bounded_by_the_tier(self):
+    def test_the_lead_error_is_bounded_by_the_rating(self):
         for skill in gunnery.SKILL_TIERS:
-            bound = gunnery.skill_parameters(skill)['lead_error']
+            rating = gunnery.rating_for_skill(skill)
+            bound = gunnery.rating_parameters(rating)['lead_error']
             for epoch in range(200):
                 scale = gunnery.engagement_error(
-                    skill, 5, 11, ('human', 2), epoch)['lead_scale']
+                    rating, 5, 11, ('human', 2), epoch)['lead_scale']
                 self.assertGreaterEqual(scale, 1.0 - bound - 1e-9)
                 self.assertLessEqual(scale, 1.0 + bound + 1e-9)
 
     def test_the_aim_offset_grows_with_range_and_with_the_gun_circle(self):
         error = {'radius': 1.0, 'azimuth': 0.0}
-        near = gunnery.aim_offset_metres('rookie', error, 0.0035, 100.0)
-        far = gunnery.aim_offset_metres('rookie', error, 0.0035, 200.0)
-        wide = gunnery.aim_offset_metres('rookie', error, 0.0070, 100.0)
+        near = gunnery.aim_offset_metres(ROOKIE, error, 0.0035, 100.0)
+        far = gunnery.aim_offset_metres(ROOKIE, error, 0.0035, 200.0)
+        wide = gunnery.aim_offset_metres(ROOKIE, error, 0.0070, 100.0)
         self.assertAlmostEqual(2.0 * near[0], far[0], places=6)
         self.assertAlmostEqual(2.0 * near[0], wide[0], places=6)
 
     def test_a_better_gunner_lays_the_gun_closer_to_the_centre(self):
         error = {'radius': 1.0, 'azimuth': 0.0}
         offsets = [abs(gunnery.aim_offset_metres(
-            skill, error, 0.0035, 300.0)[0]) for skill in gunnery.SKILL_TIERS]
+            gunnery.rating_for_skill(skill), error, 0.0035, 300.0)[0])
+            for skill in gunnery.SKILL_TIERS]
         self.assertEqual(sorted(offsets, reverse=True), offsets)
 
     def test_a_long_shot_never_aims_at_the_sky(self):
         error = {'radius': 1.0, 'azimuth': 0.5 * 3.14159265}
         lateral, vertical = gunnery.aim_offset_metres(
-            'rookie', error, 0.0035, 100000.0)
+            ROOKIE, error, 0.0035, 100000.0)
         self.assertLessEqual(abs(lateral), gunnery.MAX_AIM_OFFSET_METRES)
         self.assertLessEqual(
             abs(vertical),
@@ -183,74 +207,228 @@ class EngagementErrorTests(unittest.TestCase):
     def test_a_missing_gun_circle_removes_the_bias_instead_of_raising(self):
         error = {'radius': 1.0, 'azimuth': 0.0}
         self.assertEqual(
-            (0.0, 0.0), gunnery.aim_offset_metres('rookie', error, 0.0, 100.0))
+            (0.0, 0.0), gunnery.aim_offset_metres(ROOKIE, error, 0.0, 100.0))
         self.assertEqual(
             (0.0, 0.0),
-            gunnery.aim_offset_metres('rookie', error, 0.0035, 0.0))
+            gunnery.aim_offset_metres(ROOKIE, error, 0.0035, 0.0))
         self.assertEqual(
-            (0.0, 0.0), gunnery.aim_offset_metres('rookie', {}, 0.0035, 100.0))
+            (0.0, 0.0), gunnery.aim_offset_metres(ROOKIE, {}, 0.0035, 100.0))
 
 
 class FireGateTests(unittest.TestCase):
-    def test_no_tier_fires_before_it_has_reacted(self):
-        for skill in gunnery.SKILL_TIERS:
-            reaction = gunnery.skill_parameters(skill)['reaction_seconds']
-            self.assertFalse(gunnery.may_fire(skill, reaction - 0.01, 99.0,
+    def test_no_gunner_fires_before_it_has_reacted(self):
+        for rating in (ROOKIE, REGULAR, VETERAN, ELITE, 0.2, 0.55, 0.9):
+            reaction = gunnery.rating_parameters(rating)['reaction_seconds']
+            self.assertFalse(gunnery.may_fire(rating, reaction - 0.01, 99.0,
                                               1.0))
-            self.assertTrue(gunnery.may_fire(skill, reaction, 0.0, 1.0))
+            self.assertTrue(gunnery.may_fire(rating, reaction, 0.0, 1.0))
 
     def test_a_converged_circle_fires_without_spending_the_patience(self):
-        params = gunnery.skill_parameters('veteran')
+        params = gunnery.rating_parameters(VETERAN)
         self.assertTrue(gunnery.may_fire(
-            'veteran', params['reaction_seconds'], 0.0,
+            VETERAN, params['reaction_seconds'], 0.0,
             params['converged_factor']))
         self.assertFalse(gunnery.may_fire(
-            'veteran', params['reaction_seconds'], 0.0,
+            VETERAN, params['reaction_seconds'], 0.0,
             params['converged_factor'] + 0.01))
 
-    def test_a_better_tier_never_opens_fire_later_than_its_own_patience(self):
-        for skill in gunnery.SKILL_TIERS:
-            params = gunnery.skill_parameters(skill)
+    def test_no_gunner_opens_fire_later_than_its_own_patience(self):
+        for rating in (ROOKIE, REGULAR, VETERAN, ELITE, 0.2, 0.55, 0.9):
+            params = gunnery.rating_parameters(rating)
             self.assertTrue(gunnery.may_fire(
-                skill,
+                rating,
                 params['reaction_seconds'] + params['patience_seconds'],
                 params['patience_seconds'], float('inf')))
 
     def test_a_moving_bot_still_fires_once_its_patience_expires(self):
-        params = gunnery.skill_parameters('elite')
+        params = gunnery.rating_parameters(ELITE)
         self.assertFalse(gunnery.may_fire(
-            'elite', 30.0, params['patience_seconds'] - 0.01, 6.0))
+            ELITE, 30.0, params['patience_seconds'] - 0.01, 6.0))
         self.assertTrue(gunnery.may_fire(
-            'elite', 30.0, params['patience_seconds'], 6.0))
+            ELITE, 30.0, params['patience_seconds'], 6.0))
 
     def test_only_the_opening_shot_waits_for_the_aiming_circle(self):
         """After the first shot the gun's own reload owns the cadence."""
-        self.assertFalse(gunnery.may_fire('elite', 300.0, 0.0, 6.0))
+        self.assertFalse(gunnery.may_fire(ELITE, 300.0, 0.0, 6.0))
         self.assertTrue(
-            gunnery.may_fire('elite', 300.0, 0.0, 6.0, opening_shot=False))
+            gunnery.may_fire(ELITE, 300.0, 0.0, 6.0, opening_shot=False))
 
-    def test_a_better_tier_never_fires_a_follow_up_later_than_a_worse_one(self):
-        """The ladder must not invert on a fast or clip gun."""
+    def test_a_better_gunner_never_fires_a_follow_up_later_than_a_worse_one(
+            self):
+        """The spectrum must not invert on a fast or clip gun."""
+        ratings = [index / 20.0 for index in range(21)]
         for bloom in (1.0, 2.0, 4.2, float('inf')):
             for laying in (0.0, 0.3, 1.0, 3.0):
-                allowed = [gunnery.may_fire(skill, 300.0, laying, bloom,
+                allowed = [gunnery.may_fire(rating, 300.0, laying, bloom,
                                             opening_shot=False)
-                           for skill in gunnery.SKILL_TIERS]
+                           for rating in ratings]
                 self.assertEqual(
                     sorted(allowed), allowed,
                     'bloom=%r laying=%r' % (bloom, laying))
 
     def test_an_unusable_clock_holds_fire_instead_of_guessing(self):
-        self.assertFalse(gunnery.may_fire('regular', float('nan'), 0.0, 1.0))
-        self.assertFalse(gunnery.may_fire('regular', 5.0, 0.0, float('nan')))
-        self.assertFalse(gunnery.may_fire('regular', None, 0.0, 1.0))
+        self.assertFalse(gunnery.may_fire(REGULAR, float('nan'), 0.0, 1.0))
+        self.assertFalse(gunnery.may_fire(REGULAR, 5.0, 0.0, float('nan')))
+        self.assertFalse(gunnery.may_fire(REGULAR, None, 0.0, 1.0))
 
     def test_an_infinite_circle_waits_for_the_patience_bound(self):
-        params = gunnery.skill_parameters('regular')
+        params = gunnery.rating_parameters(REGULAR)
         self.assertFalse(gunnery.may_fire(
-            'regular', 30.0, params['patience_seconds'] - 0.01, float('inf')))
+            REGULAR, 30.0, params['patience_seconds'] - 0.01, float('inf')))
         self.assertTrue(gunnery.may_fire(
-            'regular', 30.0, params['patience_seconds'], float('inf')))
+            REGULAR, 30.0, params['patience_seconds'], float('inf')))
+
+
+class RatingSpectrumTests(unittest.TestCase):
+    """The tiers survive as anchors on one continuous competence axis."""
+
+    NAMES = ('reaction_seconds', 'patience_seconds', 'converged_factor',
+             'aim_bias_factor', 'lead_error', 'crew_level')
+
+    def test_every_anchor_reproduces_its_reviewed_bundle_exactly(self):
+        """The reviewed calibration must survive becoming an anchor.
+
+        Anchors are not evenly spaced and float interpolation does not have
+        to land on an endpoint, so this is a real property, not a tautology.
+        """
+        for skill in gunnery.SKILL_TIERS:
+            reviewed = gunnery._PARAMETERS[skill]
+            interpolated = gunnery.rating_parameters(
+                gunnery.rating_for_skill(skill))
+            for name in self.NAMES:
+                self.assertEqual(
+                    reviewed[name], interpolated[name],
+                    '%s %s' % (skill, name))
+
+    def test_every_gunnery_knob_moves_one_way_across_the_spectrum(self):
+        ratings = [index / 50.0 for index in range(51)]
+        rows = [gunnery.rating_parameters(rating) for rating in ratings]
+        for name in ('reaction_seconds', 'converged_factor',
+                     'aim_bias_factor', 'lead_error'):
+            values = [row[name] for row in rows]
+            self.assertEqual(sorted(values, reverse=True), values, name)
+        for name in ('patience_seconds',):
+            values = [row[name] for row in rows]
+            self.assertEqual(sorted(values), values, name)
+        levels = [row['crew_level'] for row in rows]
+        self.assertEqual(sorted(levels), levels)
+
+    def test_a_crew_level_is_never_one_this_project_has_not_seen(self):
+        """An unproven level silently degrades to a full default crew."""
+        for index in range(101):
+            level = gunnery.rating_crew_level(index / 100.0)
+            self.assertIn(level, gunnery.PROVEN_CREW_LEVELS)
+
+    def test_the_anchor_crew_levels_are_unchanged(self):
+        self.assertEqual(
+            [75, 90, 100, 100],
+            [gunnery.crew_level(skill) for skill in gunnery.SKILL_TIERS])
+
+    def test_a_label_never_claims_more_competence_than_the_rating(self):
+        for index in range(201):
+            rating = index / 200.0
+            label = gunnery.skill_for_rating(rating)
+            anchor = gunnery.rating_for_skill(label)
+            self.assertLessEqual(
+                anchor - rating, 0.17 + 1e-9, 'rating=%r' % (rating,))
+
+    def test_an_anchor_labels_itself(self):
+        for skill in gunnery.SKILL_TIERS:
+            self.assertEqual(skill, gunnery.skill_for_rating(
+                gunnery.rating_for_skill(skill)))
+
+    def test_an_unusable_rating_becomes_the_default_instead_of_raising(self):
+        for value in (None, '', 'elite', float('nan'), float('inf'),
+                      object()):
+            self.assertEqual(gunnery.DEFAULT_RATING,
+                             gunnery.normalize_rating(value))
+        self.assertEqual(0.0, gunnery.normalize_rating(-3.0))
+        self.assertEqual(1.0, gunnery.normalize_rating(9.0))
+
+    def test_one_slot_resolves_the_same_rating_everywhere(self):
+        first = gunnery.resolve_rating('mixed', 9, 2, 4)
+        self.assertEqual(first, gunnery.resolve_rating('mixed', 9, 2, 4))
+
+    def test_the_easy_preset_never_draws_a_competent_bot(self):
+        ceiling = gunnery._MODE_RATING_POINTS['easy'][-1]
+        for round_id in range(60):
+            for team in (1, 2):
+                for slot in range(15):
+                    self.assertLessEqual(
+                        gunnery.resolve_rating('easy', round_id, team, slot),
+                        ceiling)
+
+    def test_the_brutal_preset_draws_a_complete_bot_every_time(self):
+        for round_id in range(20):
+            for slot in range(15):
+                self.assertEqual(
+                    1.0, gunnery.resolve_rating('brutal', round_id, 1, slot))
+
+
+class CapabilityTests(unittest.TestCase):
+    """The rating is also the chance of doing the right thing once."""
+
+    def test_the_ends_of_the_spectrum_are_honest(self):
+        for capability in gunnery.CAPABILITIES:
+            self.assertFalse(gunnery.capability_allowed(
+                0.0, capability, 7, 11, 'occasion'), capability)
+            self.assertTrue(gunnery.capability_allowed(
+                1.0, capability, 7, 11, 'occasion'), capability)
+
+    def test_one_occasion_reaches_the_same_answer_every_time(self):
+        """A planner rebuilds an order every tick and after a failover."""
+        for rating in (0.2, 0.5, 0.8):
+            first = gunnery.capability_allowed(
+                rating, gunnery.CAPABILITY_TACTICAL_COVER, 4, 9, 'bot', 3)
+            for unused_repeat in range(5):
+                self.assertEqual(first, gunnery.capability_allowed(
+                    rating, gunnery.CAPABILITY_TACTICAL_COVER, 4, 9,
+                    'bot', 3))
+
+    def test_a_new_occasion_is_a_new_decision(self):
+        answers = set(
+            gunnery.capability_allowed(
+                0.5, gunnery.CAPABILITY_TACTICAL_COVER, 4, 9, 'bot', index)
+            for index in range(40))
+        self.assertEqual(set((True, False)), answers)
+
+    def test_two_capabilities_never_share_one_draw(self):
+        """Otherwise a Bot would know everything or nothing at 0.5."""
+        for rating in (0.35, 0.5, 0.65):
+            answers = set(
+                gunnery.capability_allowed(rating, capability, 4, 9, 'x')
+                for capability in gunnery.CAPABILITIES)
+            self.assertEqual(set((True, False)), answers, rating)
+
+    def test_a_rating_succeeds_at_about_its_own_rate(self):
+        for rating in (0.1, 0.3, 0.6, 0.8):
+            hits = sum(
+                1 for index in range(4000)
+                if gunnery.capability_allowed(
+                    rating, gunnery.CAPABILITY_COVER_PEEK, 1, index))
+            self.assertAlmostEqual(
+                rating, hits / 4000.0, delta=0.025, msg=rating)
+
+    def test_competence_never_costs_a_bot_a_capability(self):
+        """More competence must never mean fewer right decisions."""
+        occasions = [(1, index) for index in range(600)]
+        counts = []
+        for index in range(11):
+            rating = index / 10.0
+            counts.append(sum(
+                1 for occasion in occasions
+                if gunnery.capability_allowed(
+                    rating, gunnery.CAPABILITY_FLANK, *occasion)))
+        self.assertEqual(sorted(counts), counts)
+
+    def test_the_latched_capabilities_are_real_capabilities(self):
+        self.assertTrue(gunnery.LATCHED_CAPABILITIES)
+        for capability in gunnery.LATCHED_CAPABILITIES:
+            self.assertIn(capability, gunnery.CAPABILITIES)
+
+    def test_the_exponent_is_the_reviewed_product_choice(self):
+        """One knob answers "the tactical half bites harder than gunnery"."""
+        self.assertEqual(1.0, gunnery.CAPABILITY_EXPONENT)
 
 
 class SkillVocabularyParityTests(unittest.TestCase):

--- a/tests/test_port_0922_bot_runtime.py
+++ b/tests/test_port_0922_bot_runtime.py
@@ -8313,6 +8313,77 @@ class BotRuntimeTests(unittest.TestCase):
 
         self.assertEqual('elite', successor.bot_skill(11))
 
+    def test_the_manifest_publishes_each_bot_rating_beside_its_label(self):
+        messages = self.runtime.battle_start(
+            dict(self.start, bot_skill_mode='brutal'))
+
+        published = [state for message in messages
+                     for state in message.get('bots') or ()]
+        self.assertEqual([1.0], [row['skill_rating'] for row in published])
+        self.assertEqual(['elite'], [row['skill'] for row in published])
+
+    def test_a_room_preset_draws_a_rating_inside_its_own_envelope(self):
+        self.runtime.battle_start(dict(self.start, bot_skill_mode='easy'))
+
+        ceiling = self.module.bot_gunnery._MODE_RATING_POINTS['easy'][-1]
+        self.assertLessEqual(self.runtime.bot_rating(11), ceiling)
+
+    def test_a_takeover_reinstalls_the_exact_rating_not_its_label(self):
+        """Snapping a rating to its nearest tier would move the gunner.
+
+        The crew level a rating trains is baked into the published reload
+        duration, so a successor that re-labelled a Bot would also fail the
+        installed-gun guard. Reinstalling the exact number is what keeps a
+        mid-spectrum gunner identical across a failover.
+        """
+        manifest = self.runtime.battle_start(
+            dict(self.start, bot_skill_mode='mixed'))[0]
+        expected = self.runtime.bot_rating(11)
+        self.assertNotIn(expected, self.module.bot_gunnery.RATING_ANCHORS)
+        entry = manifest['bots'][0]
+
+        successor = self.module.BotRuntime(
+            2, descriptor_resolver=lambda unused: _combat_descriptor(),
+            adapter_factory=lambda *args: _Adapter(*args),
+            direction_probe=lambda *unused: {'clear': True, 'slope': 0.0},
+            ground_probe=lambda *unused: 0.0,
+            physics_ground_probe=lambda *unused: 0.0,
+            spawn_resolver=_spawn_resolver, baked_graph=_graph())
+        successor.battle_start(dict(
+            self.start, bot_authority_id=2, bot_skill_mode='easy',
+            bot_manifest=[entry]))
+
+        self.assertEqual(expected, successor.bot_rating(11))
+
+    def test_the_aim_selection_gate_holds_for_one_aiming_epoch(self):
+        """A per-frame flip would re-solve the ballistics every tick."""
+        self.runtime.battle_start(dict(self.start, bot_skill_mode='mixed'))
+        state = {'id': 11}
+        target = {'kind': 'human', 'network_id': 2, 'id': 2}
+
+        first = self.runtime.bot_aim_selection_allowed(state, target)
+        for unused_repeat in range(5):
+            self.assertEqual(
+                first,
+                self.runtime.bot_aim_selection_allowed(state, target))
+        # The accessor may not create or advance the hold that owns the epoch.
+        self.assertEqual({}, self.runtime._gunnery_holds)
+
+    def test_the_top_of_the_spectrum_always_looks_for_the_weak_spot(self):
+        self.runtime.battle_start(dict(self.start, bot_skill_mode='brutal'))
+
+        self.assertTrue(self.runtime.bot_aim_selection_allowed(
+            {'id': 11}, {'kind': 'human', 'network_id': 2, 'id': 2}))
+
+    def test_a_bot_with_no_competence_never_looks_for_the_weak_spot(self):
+        self.runtime.battle_start(dict(
+            self.start, bot_skill_mode='brutal',
+            bot_lineup=[{'team': 2, 'slot': 0, 'skill': 'rookie'}]))
+
+        self.assertEqual(0.0, self.runtime.bot_rating(11))
+        self.assertFalse(self.runtime.bot_aim_selection_allowed(
+            {'id': 11}, {'kind': 'human', 'network_id': 2, 'id': 2}))
+
     def test_a_weak_gunner_lays_the_gun_off_the_target_centre(self):
         command = self._gunnery_command()
         player = _admit_player(

--- a/tests/test_port_0922_server_bot_ai.py
+++ b/tests/test_port_0922_server_bot_ai.py
@@ -164,13 +164,15 @@ class _CountingPlanner(object):
         self.state = state
         self.build_ticks = []
         self.reset_count = 0
+        self.reset_round_id = None
 
     def build_orders(self, *unused_args, **unused_kwargs):
         self.build_ticks.append(self.state.tick)
         return {"revision": len(self.build_ticks), "orders": []}
 
-    def reset(self):
+    def reset(self, round_id=None):
         self.reset_count += 1
+        self.reset_round_id = round_id
 
 
 class ServerBotTacticsTests(unittest.TestCase):
@@ -1872,6 +1874,271 @@ class ServerBotTacticsTests(unittest.TestCase):
             order for order in state.bot_orders['orders']
             if order['id'] == 11)
         self.assertEqual(2, order['target_id'])
+
+
+class ServerBotCompetenceTests(unittest.TestCase):
+    """The rating gates which tactics a Bot actually reaches for."""
+
+    def setUp(self):
+        self.route = _route('lane', [
+            (0, -100, False), (0, 100, False), (0, 500, False),
+        ])
+        self.manifest = [_bot(
+            11, 1, 0, self.route, 'mediumTank', {'support': 1.0})]
+        self.manifest[0]['profile'].update({
+            'armor': 120.0,
+            'dominant_role': 'support',
+            'desired_range': 180.0,
+            'fire_range': 520.0,
+        })
+        self.states = [_state(11, 1, 0, 0)]
+
+    def _rate(self, rating):
+        self.manifest[0]['skill_rating'] = rating
+
+    def _report(self, planner, contacts):
+        players = [
+            {'id': raw['target_id'], 'team': 2, 'alive': True}
+            for raw in contacts
+        ]
+        self.assertEqual(len(contacts), planner.report_contacts(
+            contacts, planner.known_targets(self.states, players), 1.0))
+        return players
+
+    def _cover_ladder(self, planner, players):
+        modes = []
+        for index, now in enumerate((1.1, 1.2, 5.0, 7.2)):
+            if index == 1:
+                self.states[0]['x'] = 12.0
+            modes.append(planner.build_orders(
+                self.manifest, self.states, players, now)['orders'][0][
+                    'combat_mode'])
+        return modes
+
+    def _armed_cover(self, planner, players):
+        known_bots = planner.known_bots(self.manifest, self.states)
+        known_targets = planner.known_targets(self.states, players)
+        self.assertEqual(1, planner.report_affordances(
+            [_cover_report(11, 2)], known_bots, known_targets, 1.0))
+        planner.report_damage(11, 'player', 2, 200, 1.1)
+
+    def test_an_unrated_manifest_entry_keeps_full_competence(self):
+        """A missing rating is a plumbing failure, not a weak Bot."""
+        planner = BotPlanner()
+        self.assertEqual(
+            1.0, planner._alive_bots(self.manifest, self.states)[0]['rating'])
+
+    def test_a_published_rating_reaches_the_live_bot_row(self):
+        planner = BotPlanner()
+        self._rate(0.25)
+        self.assertEqual(
+            0.25, planner._alive_bots(self.manifest, self.states)[0]['rating'])
+
+    def test_a_tier_name_alone_is_read_at_its_own_anchor(self):
+        planner = BotPlanner()
+        self.manifest[0]['skill'] = 'rookie'
+        self.assertEqual(
+            0.0, planner._alive_bots(self.manifest, self.states)[0]['rating'])
+
+    def test_a_complete_bot_still_works_its_way_through_cover(self):
+        planner = BotPlanner()
+        self._rate(1.0)
+        contacts = [_contact(2, 0, 260, [11])]
+        players = self._report(planner, contacts)
+        self._armed_cover(planner, players)
+
+        self.assertEqual(
+            ['take_cover', 'cover_hold', 'cover_hold', 'cover_peek'],
+            self._cover_ladder(planner, players))
+
+    def test_a_hopeless_bot_never_reaches_for_cover(self):
+        planner = BotPlanner()
+        self._rate(0.0)
+        contacts = [_contact(2, 0, 260, [11])]
+        players = self._report(planner, contacts)
+        self._armed_cover(planner, players)
+
+        for mode in self._cover_ladder(planner, players):
+            self.assertNotIn(mode, ('take_cover', 'cover_hold', 'cover_peek',
+                                    'cover_return'))
+
+    def test_a_hopeless_bot_keeps_fighting_where_it_stands_after_a_hit(self):
+        planner = BotPlanner()
+        self._rate(0.0)
+        contacts = [_contact(2, 0, 150, [11])]
+        players = self._report(planner, contacts)
+        self.assertTrue(planner.report_damage(11, 'player', 2, 100, 1.1))
+
+        order = planner.build_orders(
+            self.manifest, self.states, players, 1.1)['orders'][0]
+
+        self.assertEqual('engage', order['combat_mode'])
+
+    def test_a_hopeless_bot_does_not_turn_on_whoever_shot_it(self):
+        planner = BotPlanner()
+        self._rate(0.0)
+        contacts = [
+            _contact(2, 0, 260, [11]),
+            _contact(3, 0, 35, [11]),
+        ]
+        players = self._report(planner, contacts)
+        first = planner.build_orders(
+            self.manifest, self.states, players, 1.0)['orders'][0]
+        self.assertEqual(3, first['target_id'])
+        self.assertTrue(planner.report_damage(11, 'player', 2, 240, 1.1))
+
+        reaction = planner.build_orders(
+            self.manifest, self.states, players, 1.1)['orders'][0]
+
+        self.assertEqual(3, reaction['target_id'])
+
+    def test_a_point_blank_enemy_is_answered_at_every_competence(self):
+        """Self-defence is not a tactic a Bot has to have learned."""
+        for rating in (0.0, 1.0):
+            planner = BotPlanner()
+            self._rate(rating)
+            contacts = [
+                _contact(2, 0, 300, [11]),
+                _contact(3, 0, 30, [11]),
+            ]
+            players = self._report(planner, contacts)
+            order = planner.build_orders(
+                self.manifest, self.states, players, 1.0)['orders'][0]
+            self.assertEqual(3, order['target_id'], rating)
+
+    def test_a_hopeless_bot_fires_the_round_the_racks_offer_first(self):
+        planner = BotPlanner()
+        self._rate(0.0)
+        self.manifest[0]['profile']['shells'] = [
+            {'index': 0, 'kind': 'armor_piercing', 'penetration': 100.0,
+             'damage': 250.0},
+            {'index': 1, 'kind': 'armor_piercing_cr', 'penetration': 250.0,
+             'damage': 250.0},
+        ]
+        self.states[0]['ammo_remaining'] = [20, 10]
+        contacts = [_contact(2, 0, 150, [11])]
+        contacts[0]['armor'] = 200.0
+        players = self._report(planner, contacts)
+
+        order = planner.build_orders(
+            self.manifest, self.states, players, 1.0)['orders'][0]
+
+        self.assertEqual(0, order['shell_index'])
+
+    def test_a_complete_bot_answers_armour_with_the_round_that_beats_it(self):
+        planner = BotPlanner()
+        self._rate(1.0)
+        self.manifest[0]['profile']['shells'] = [
+            {'index': 0, 'kind': 'armor_piercing', 'penetration': 100.0,
+             'damage': 250.0},
+            {'index': 1, 'kind': 'armor_piercing_cr', 'penetration': 250.0,
+             'damage': 250.0},
+        ]
+        self.states[0]['ammo_remaining'] = [20, 10]
+        contacts = [_contact(2, 0, 150, [11])]
+        contacts[0]['armor'] = 200.0
+        players = self._report(planner, contacts)
+
+        order = planner.build_orders(
+            self.manifest, self.states, players, 1.0)['orders'][0]
+
+        self.assertEqual(1, order['shell_index'])
+
+    def test_a_hopeless_bot_presents_its_flat_front(self):
+        planner = BotPlanner()
+        self._rate(0.0)
+        contacts = [_contact(2, 0, 150, [11])]
+        players = self._report(planner, contacts)
+
+        order = planner.build_orders(
+            self.manifest, self.states, players, 1.0)['orders'][0]
+
+        self.assertEqual('engage', order['combat_mode'])
+        self.assertNotIn('hull_angle_degrees', order)
+
+    def test_a_complete_bot_still_angles(self):
+        planner = BotPlanner()
+        self._rate(1.0)
+        contacts = [_contact(2, 0, 150, [11])]
+        players = self._report(planner, contacts)
+
+        order = planner.build_orders(
+            self.manifest, self.states, players, 1.0)['orders'][0]
+
+        self.assertGreaterEqual(abs(order['hull_angle_degrees']), 12.0)
+
+    def test_target_priority_holds_for_one_lease_not_one_clock_tick(self):
+        """A Bot may not change its mind because a timer rolled over."""
+        planner = BotPlanner()
+        self._rate(0.5)
+        contacts = [
+            _contact(2, 0, 260, [11]),
+            _contact(3, 0, 200, [11]),
+        ]
+        players = self._report(planner, contacts)
+        chosen = []
+        for step in range(24):
+            now = 1.0 + step * 0.25
+            planner.report_contacts(
+                contacts, planner.known_targets(self.states, players), now)
+            chosen.append(planner.build_orders(
+                self.manifest, self.states, players, now)[
+                    'orders'][0]['target_id'])
+
+        # The lease may hand the Bot a new target when it expires; it may not
+        # hand it a new one because a wall-clock bucket rolled over.
+        self.assertLessEqual(len(set(chosen)), 2)
+        lease = planner._target_assignments[11]
+        first = planner._capable(
+            planner._alive_bots(self.manifest, self.states)[0],
+            'target_priority', round(lease['until'], 3))
+        self.assertEqual(first, planner._capable(
+            planner._alive_bots(self.manifest, self.states)[0],
+            'target_priority', round(lease['until'], 3)))
+
+    def test_a_latched_capability_ignores_the_occasion(self):
+        """A habit may not flip between two ticks of one battle."""
+        planner = BotPlanner()
+        planner.reset(4)
+        bot = {'id': 11, 'team': 1, 'slot': 0, 'rating': 0.5}
+        answers = set(
+            planner._capable(bot, 'hull_angling', occasion)
+            for occasion in range(50))
+        self.assertEqual(1, len(answers))
+
+    def test_an_unlatched_capability_is_decided_per_occasion(self):
+        planner = BotPlanner()
+        planner.reset(4)
+        bot = {'id': 11, 'team': 1, 'slot': 0, 'rating': 0.5}
+        answers = set(
+            planner._capable(bot, 'tactical_cover', occasion)
+            for occasion in range(50))
+        self.assertEqual(set((True, False)), answers)
+
+    def test_a_new_round_re_rolls_a_latched_habit(self):
+        """A slot must not be condemned to one habit for the whole server."""
+        answers = set()
+        for round_id in range(30):
+            planner = BotPlanner()
+            planner.reset(round_id)
+            answers.add(planner._capable(
+                {'id': 11, 'team': 1, 'slot': 0, 'rating': 0.5},
+                'hull_angling'))
+        self.assertEqual(set((True, False)), answers)
+
+    def test_a_failover_cannot_make_a_bot_change_its_mind(self):
+        """Capability is derived, never stored, so a fresh planner agrees."""
+        first = BotPlanner()
+        first.reset(9)
+        second = BotPlanner()
+        second.reset(9)
+        second.clear_observations()
+        bot = {'id': 11, 'team': 1, 'slot': 0, 'rating': 0.5}
+        for capability in ('hull_angling', 'tactical_cover', 'flank',
+                           'withdraw', 'shell_choice'):
+            self.assertEqual(
+                first._capable(bot, capability, 'x'),
+                second._capable(bot, capability, 'x'), capability)
 
 
 class ServerBotArtilleryTests(unittest.TestCase):


### PR DESCRIPTION
## Outcome

A Bot was only ever a gunner. The four skill tiers moved reaction, aiming patience, aim bias, lead error and crew level; the tactical planner never looked at skill at all. **Every Bot, at every tier, executed every tactic 100% of the time** — cover, peek, hull angling, shell selection against armour, weak-spot aiming, turning on its attacker, breaking off under fire, crossfire avoidance, flanking. A weak Bot missed more; it never failed to *think of* something.

Competence is now one continuous rating in `[0, 1]` that is both the gunnery interpolation coordinate and the probability that a Bot does the tactically right thing each time the situation arises.

## The model

**Anchors.** The four reviewed tier bundles are the anchors of the rating axis, so no existing calibration moved. This is a real property, not a tautology: the anchors are not evenly spaced and `a + (b - a) * 1.0` is not reliably `b` in binary floating point, so `_anchor_value` returns the endpoint verbatim. A test holds every anchor to its reviewed bundle exactly.

**Capabilities and their occasions.** Each capability names the unit of decision it is drawn for, so an answer cannot flip inside a manoeuvre already under way:

| Capability | One occasion is | Where |
|---|---|---|
| weak spot | one 1.5 s aiming epoch | `battle_runtime._bot_firing_lane` |
| shell choice | one engagement with one contact | `_set_target` → `_shell_index` |
| target priority | one target lease | `_assign_targets` |
| urgent / tactical cover | one cover manoeuvre vs one contact | `_apply_cover_order` |
| peek | one cover candidate | the `hold → peek` transition |
| crossfire avoidance | one withdrawal decision | `_order_for` |
| withdrawal after a hit | one hit | `_hit_requires_withdrawal` |
| hull angling | **latched** to round + Bot | `_apply_stationary_angling` |
| flank | **latched** to round + Bot | `_order_for` |

Latching two keeps recognisable habits on a roster ("that one never angles") instead of only Bots that hesitate uniformly. Flanking was also the one capability with no per-instance state record, so latching it avoided inventing one.

The weak-spot occasion deliberately reuses `bot_gunnery.bias_epoch` — a per-frame flip would change `aim_token`, trip `_direct_aim_matches` and re-solve the ballistics every tick. `BotRuntime.bot_aim_selection_allowed` is read-only with respect to `_gunnery_holds`; it never creates or advances the epoch it reads.

**Nothing is stored.** Every draw is seeded from identity, so the planner may rebuild an order each tick, and a replacement authority after `clear_observations()` reaches the same answer. Tested.

**`p = rating` exactly.** `CAPABILITY_EXPONENT = 1.0`. It exists because the gunnery half and the tactical half are calibrated on different scales; one constant is the whole correction if playtesting says the tactical half bites harder.

**Presets are distributions** with a specified mean of `.10 / .30 / .60 / .80 / 1.00`, written as the control points of a piecewise-linear inverse CDF and indexed by one `random()` draw, so Python 2.7 and Python 3 agree without depending on a library distribution's implementation. `mixed` is the widest spread on purpose: one pub roster holds a hopeless Bot and a dangerous one. A test holds the table to its specified means.

## Net difficulty is not predictable from these numbers

At `mixed` the two halves move in **opposite** directions:

- gunnery: 0.42 → 0.60 on the anchor scale (stronger — faster reaction, tighter bias)
- tactics: 100% → 60% correct decisions (weaker — this is new)

Which dominates is unmeasured and is a playtest question.

## Two fallbacks so a plumbing failure cannot quietly weaken a Bot

- `server_bot_ai._bot_rating`: a manifest entry with neither `skill_rating` nor `skill` reads as **1.0**, not as a 34% Bot.
- `battle_runtime._bot_firing_lane`: no reachable Bot runtime leaves the armour ranking **on**.

Both degrade to the behaviour already shipped. This is also why all 70 pre-existing planner tests pass untouched — their manifests carry no rating, so they are the unchanged baseline.

## Aiming: not knowing ≠ choosing badly

A failed weak-spot roll keeps whichever exposed part the existing rotating cursor offered — uncorrelated with armour. Deliberately picking the *worst* plate would take the same armour solve as picking the best; that is inverted knowledge, not absent knowledge. A part the resolver proved cannot be hurt (`score == 0.0`) is never a deliberate choice at any competence, and is fired at only when nothing else in that job was clear — holding fire would read as a broken Bot, not a weak one.

## Takeover fidelity

The rating rides the manifest **unrounded**. An earlier revision of this branch rounded it to 6 decimals; that reinstalls a different gunner after a failover, and since the crew level a rating trains is baked into the published reload duration, a re-labelled Bot also fails the installed-gun guard. A test asserts a mid-spectrum rating survives a takeover exactly.

## Out of scope, not forgotten

- **SPG is unaffected by the weak-spot gate** — artillery goes through `self._artillery.request` and never enters `_bot_firing_lane`. It does get the tier aim bias and lead error, because `_ballistic_solution` applies `_aimed_target` before the SPG branch.
- **`ai/planner.py`'s `BattleDirector` fallback is still competence-blind.** It drives only through `adapter.decide()` when no server order exists (order gaps, early startup) and has its own target/angling/shell logic. Left alone deliberately.
- Navigation, traffic yielding, water/bounds and throttle cadence are **not** difficulty knobs — degrading them reproduces the walk-stop-walk bug class, which reads as jank, not as a weak Bot.
- `_selected_shell_damage` still ranks optimistically for focus-cap fairness. Verified the sign: higher nominal damage saturates focus *sooner*, so fewer Bots pile on one target — the safe direction.

## Validation

- `python3 -m unittest discover -s tests` — **4110 tests, OK**
- `launcher`: `python3 -m unittest discover -s tests` — **494 tests, OK (skipped=2)**
- CPython 2.7.18 source compile of `src/res/scripts/client` — **95 files, passed**

## Unproved

Feel. Only acceptance on the exact Windows client can say whether a `mixed` roster's easy-end Bots (rating 0.12–0.30) read as *菜* or as *broken*. That is the first thing to look at in a playtest, and `CAPABILITY_EXPONENT` is the knob if the tactical half bites too hard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)