### PR TITLE
Attribute worker combat hotspots with bounded control sampling

### DIFF
--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -601,6 +601,50 @@ be incomplete. `PERF combat_summary` reports each closed capture's stage
 totals, frame/time span, queue maxima, and counters. Detailed clocks are
 inactive between captures; the small frame ring remains available.
 
+The deeper Bot probes sample one callback per group of four control callbacks,
+rotating the selected slot across groups and including every Bot and catch-up
+slice in that callback. Selection follows actual Bot control work, so
+render-frame cadence cannot alias away all samples; rotation also spreads
+samples across slower decision phases. Existing
+coarse stages and lane-ledger accounting remain active throughout each capture.
+`detail_sampled` labels individual frames; a capture's `detail.frames`,
+`detail.stages` and `detail.counts` describe only that matched sample. Use these
+matched totals for the detailed cost breakdown; do not compare a sampled child
+total directly to an all-frame parent total or treat sampled counts as a census.
+The sampling reduces average observer cost; it cannot remove observer overhead
+from an individual sampled frame. An unsampled slow frame retains coarse timing.
+
+The new scopes separate Bot state/critical/parameter preparation, pose copying,
+longitudinal and traverse integration, publication, route selection, shared A*
+work, local driving, world-collision preparation, ground profiles, and
+destructible registration/candidate scans. `native.motion.ray/ground` and
+`native.destructible.*` time existing native calls with their original arguments
+and exception behavior. Reason counters distinguish expired or geometrically
+invalid motion receipts, superseded/failed/retained path requests, A* expansions,
+streaming misses, and empty-cell reuse. Same-geometry counters identify repeated
+ray or hull-box inputs within a Bot slice; they do not prove that intervening
+world mutations made reuse safe.
+
+`slices` records elapsed authority time, control refresh and publication intent
+at slice entry; a later contact barrier can still require an extra publication.
+The bounded `actors` rows identify Bot IDs and slices, with at most six reported
+per frame and 64 Bots in a capture summary. A frame tracks at most 128 Bot/slice
+pairs and 2048 geometry keys; overflow counters expose dropped diagnostic detail.
+`bot.actor` self time is residual work inside that Bot's block. Shared navigator
+batch time is attributed to its initiating caller, not exclusively to that
+Bot's own search. Pure-helper observation is bound only during synchronous owned
+calls on the current thread and restored on return, exception or reentry; it
+installs no native hooks and retains no entities or native vectors.
+
+`tools/benchmark_bot_workload.py --scenario combat` runs the real copied Bot,
+world-collision, ground and destructible-scan Python paths with deterministic
+native test seams, a finite hard wall, and nearby opposing teams. It includes
+spotting, lanes and acknowledged fire admission; projectile terminal processing
+has separate human/Bot pipeline parity tests. `--diagnostics` enables the shipped
+one-in-four detail sample; `--diagnostic-stride 1` measures full-detail overhead.
+Identical snapshot output includes every native collision call's geometry. This
+synthetic workload is not a captured-battle replay or a Windows performance test.
+
 The supplemental-lane shadow ledger retains at most 1024 identities and
 records actual enqueue-to-completion wait separately from phase-deadline
 overdue time and the existing whole-refresh-cycle overdue metric. It counts

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/ai/adapter.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/ai/adapter.py
@@ -6,6 +6,8 @@ movement command, and optional fire intent.  The caller remains responsible
 for visibility, collision probes, and applying commands to any client entity.
 """
 
+from gui.mods.offline_lan_0922.worker_diagnostics import observed
+
 import math
 
 from gui.mods.offline_lan_0922.ai.driver import (
@@ -87,6 +89,7 @@ class BotAdapter(object):
         return self._drive_order(
             bot_id, state, position, strategic, direction_clear)
 
+    @observed('driver.order')
     def _drive_order(self, bot_id, state, position, strategic,
                      direction_clear):
         aim_position = strategic.get('aim_position')

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/ai/driver.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/ai/driver.py
@@ -6,6 +6,8 @@ for the current collision/terrain query; this module chooses only throttle and
 steering, so it is safe to exercise outside the BigWorld client.
 """
 
+from gui.mods.offline_lan_0922.worker_diagnostics import observed
+
 import math
 
 
@@ -317,6 +319,7 @@ class LocalDriver(object):
 				return False
 		return True
 
+	@observed('driver.reverse_contacts')
 	def _reverse_blocked_by_vehicle(self, position, yaw, neighbours,
 			half_length, half_width):
 		"""Reject a blind reverse whose reachable hull sweep is occupied.
@@ -401,6 +404,7 @@ class LocalDriver(object):
 					continue
 		return occupied
 
+	@observed('driver.recovery')
 	def _select_recovery_side(self, state, position, yaw, neighbours,
 			half_length, half_width):
 		"""Prefer the less occupied pivot arc, then use stable slot parity."""
@@ -414,6 +418,7 @@ class LocalDriver(object):
 			return 1.0
 		return self._fallback_recovery_side(state)
 
+	@observed('driver.choose_yaw')
 	def _choose_yaw(self, state, desired_yaw, direction_clear):
 		# Teammate proximity never replaces the route with a repulsion heading.
 		# Crossing priority is coordinated separately; real contact owns overlap.
@@ -439,6 +444,7 @@ class LocalDriver(object):
 				return candidate
 		return None
 
+	@observed('driver.drive')
 	def drive(self, bot_id, team_slot, position, yaw, speed, dt, target,
 			neighbours, direction_clear, velocity=None,
 			half_length=3.5, half_width=1.7,

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
@@ -8,6 +8,9 @@ The implementation is engine-free; the caller supplies terrain and collision
 probes so it can be tested outside the legacy client.
 """
 
+from gui.mods.offline_lan_0922.worker_diagnostics import (
+    observed, count as combat_count)
+
 import heapq
 import math
 from collections import deque
@@ -793,6 +796,7 @@ class TerrainGrid(object):
 			if queued_cost != cost_so_far.get(current):
 				continue
 			expansions += 1
+			combat_count('nav_astar_expansions')
 			goal_distance = math.sqrt(
 				(current[0] - goal_cell[0]) ** 2 +
 				(current[1] - goal_cell[1]) ** 2)
@@ -903,6 +907,7 @@ class TerrainGrid(object):
 		yield self._smooth(
 			tuple(path), now, prefer_clearance, hard_edge_penalties)
 
+	@observed('nav.smooth')
 	def _smooth(self, path, now=0.0, prefer_clearance=False,
 			edge_penalties=None):
 		if len(path) < 3:
@@ -1056,6 +1061,7 @@ class TerrainNavigator(object):
 				for state in self.bot_direct_progress.values()),
 		}
 
+	@observed('nav.fallback')
 	def _fallback_target(self, bot_id, current, goal, now, avoid_points, state,
 			allow_safe_local=True):
 		"""Keep moving without treating an unproved long segment as drivable.
@@ -1093,6 +1099,7 @@ class TerrainNavigator(object):
 		self._set_fallback_mode(bot_id, 'reactive')
 		return tuple(goal)
 
+	@observed('nav.pending')
 	def _pending_target(self, bot_id, current, goal, now, state,
 			avoid_points=None, allow_last_target=True,
 			immediate_safe_local=False):
@@ -1231,6 +1238,7 @@ class TerrainNavigator(object):
 		state['replans'] = int(state.get('replans', 0)) + 1
 		return tuple(escape)
 
+	@observed('nav.macro_replan')
 	def _start_macro_replan(self, bot_id, state, current, target, now):
 		"""Reroute one bot without changing shared terrain or hazard state."""
 		escape = self.grid.safe_local_target(
@@ -1462,8 +1470,10 @@ class TerrainNavigator(object):
 		self.paths[key] = path
 		self.path_times[key] = float(now)
 		if path:
+			combat_count('nav_search_completed')
 			self.search_completed += 1
 		else:
+			combat_count('nav_search_failed')
 			self.search_failed += 1
 
 	def _cancel_bot_searches(self, bot_id, keep_key=None, kind=None):
@@ -1480,6 +1490,7 @@ class TerrainNavigator(object):
 				owned = False
 			if (owned and key != keep_key and
 					(kind is None or path_key[0] == kind)):
+				combat_count('nav_search_superseded')
 				self.searches.pop(key, None)
 				self.search_times.pop(key, None)
 
@@ -1524,6 +1535,7 @@ class TerrainNavigator(object):
 		self.search_frame_serial += 1
 		self._accrue_search_credit(elapsed)
 
+	@observed('nav.search_batch')
 	def _advance_searches(self, now):
 		"""Give every pending A* task a deterministic fair frame share.
 
@@ -1538,6 +1550,7 @@ class TerrainNavigator(object):
 		if not self.search_frame_open:
 			self._begin_automatic_frame(now)
 		if self.search_processed_frame == self.search_frame_serial:
+			combat_count('nav_batch_already_processed')
 			return
 		self.search_processed_frame = self.search_frame_serial
 		self.search_frame_time = float(now)
@@ -1554,6 +1567,7 @@ class TerrainNavigator(object):
 			max(0, int(self.search_credit)),
 			max(0, int(self.search_frame_budget)))
 		processed = 0
+		combat_count('nav_batch_pending_jobs', len(queue))
 		while budget > 0 and queue:
 			key = queue.pop(0)
 			search = self.searches.get(key)
@@ -1571,6 +1585,9 @@ class TerrainNavigator(object):
 		self.search_frame_budget = max(
 			0, int(self.search_frame_budget) - processed)
 		self.search_next_key = queue[0] if queue else None
+		combat_count('nav_search_steps', processed)
+		if queue and budget <= 0:
+			combat_count('nav_batch_budget_exhausted')
 		self._trim_cache(now)
 
 	def tick(self, now):
@@ -1586,6 +1603,7 @@ class TerrainNavigator(object):
 				self._active_macro_edge_penalties(bot_id, now)
 			self.grid.trim_caches()
 
+	@observed('nav.path')
 	def _path(self, path_key, start, goal, now, avoid_points):
 		key = self._cache_key(path_key, goal)
 		owner = self._path_owner(path_key)
@@ -1611,13 +1629,17 @@ class TerrainNavigator(object):
 					not self.grid.path_has_edge_penalty(
 						path, hard_edge_penalties)):
 				self.path_times[key] = float(now)
+				combat_count('nav_path_cached')
 				return key, path
 			if path:
+				combat_count('nav_path_penalty_invalidated')
 				del self.paths[key]
 				self.path_times.pop(key, None)
 			else:
 				if float(now) - self.path_times.get(key, 0.0) < 8.0:
+					combat_count('nav_failed_path_cooldown')
 					return key, path
+				combat_count('nav_failed_path_retry')
 				del self.paths[key]
 				self.path_times.pop(key, None)
 				self.grid.clear_negative_cache()
@@ -1637,6 +1659,7 @@ class TerrainNavigator(object):
 				path = (tuple(start), tuple(goal))
 				self.paths[key] = path
 				self.path_times[key] = float(now)
+				combat_count('nav_path_direct')
 				return key, path
 			# Moving tanks do not belong in a cached static terrain path. Including all
 			# 28 peers made every expansion scan transient positions, permanently baked
@@ -1650,6 +1673,9 @@ class TerrainNavigator(object):
 				hard_edge_penalties=hard_edge_penalties)
 			self.searches[key] = search
 			self.search_times[key] = float(now)
+			combat_count('nav_search_created')
+		else:
+			combat_count('nav_search_retained')
 		self._advance_searches(now)
 		if key in self.paths:
 			return key, self.paths[key]
@@ -1707,6 +1733,7 @@ class TerrainNavigator(object):
 		return self.grid.segment_has_baked_hazard(
 			path[index - 1], target, BAKED_SHALLOW_WATER)
 
+	@observed('nav.lookahead')
 	def _lookahead_index(self, current, path, index, path_key, now,
 			lookahead_distance):
 		"""Select a proved corridor point far enough ahead for current speed."""
@@ -1739,6 +1766,7 @@ class TerrainNavigator(object):
 				break
 		return lookahead
 
+	@observed('nav.next_target')
 	def next_target(self, bot_id, current, goal, path_key, now,
 			anchor=None, avoid_points=None, lookahead_distance=None,
 			movement_intent=True):
@@ -1791,6 +1819,8 @@ class TerrainNavigator(object):
 		request_transition = bool(had_request and request_changed)
 		allow_pending_last_target = True
 		if request_changed:
+			combat_count('nav_request_changed' if had_request else
+			             'nav_request_first')
 			# A new route segment or combat target is not evidence that the previous
 			# request stalled. A locally safe old target may bridge an asynchronous
 			# search only when it still advances the new intent.

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -1874,7 +1874,7 @@ class BattleRuntime(object):
         self._config = dict(config or {})
         self._worker_mode = bool(self._config.get('worker_mode', False))
         self._combat_diagnostics = (
-            WorkerCombatDiagnostics(_PROFILE_CLOCK)
+            WorkerCombatDiagnostics(_PROFILE_CLOCK, detail_stride=4)
             if self._worker_mode and PERFORMANCE_DIAGNOSTICS else None)
         if self._worker_mode:
             self._config['native_remote_vehicles'] = False
@@ -17183,6 +17183,7 @@ class BattleRuntime(object):
                             descriptor, dt, now, commit_enabled=True,
                             motion_yaw=None):
         """Resolve Bot contact: static world first, then exact catalog."""
+        diagnostic = getattr(self, '_combat_diagnostics', None)
         pos = self._vector(position)
         bot_state = getattr(self._bots, 'states', {}).get(int(bot_id), {})
         airborne = bool(bot_state.get('airborne', False))
@@ -17213,7 +17214,17 @@ class BattleRuntime(object):
                 not self._destructibles._catalog_hull_contact(
                     pos, yaw, speed, descriptor, dt,
                     **destructible_motion)):
+            if diagnostic is not None:
+                diagnostic.count('motion_world_reused')
             return 'clear'
+        if diagnostic is not None:
+            diagnostic.count('motion_world_fallback')
+            if airborne:
+                diagnostic.count('motion_world_airborne')
+            elif movement_dir * float(speed) <= 0.0:
+                diagnostic.count('motion_world_coast_or_reverse')
+            elif rotation_dir != 0 or abs(turn_speed) > 0.01:
+                diagnostic.count('motion_world_turning')
         allow_crush_drive = (
             not airborne and
             movement_dir * float(speed) > 0.0)

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -2,6 +2,9 @@ from __future__ import print_function
 
 """Authority-side, engine-free bridge from v5 bots to the local AI package."""
 
+from gui.mods.offline_lan_0922.worker_diagnostics import (
+    observed, observed_call, current as current_combat, count as combat_count)
+
 import copy
 import math
 import random
@@ -790,6 +793,7 @@ def _critical_parts(state):
     return _parse_critical_parts(critical)
 
 
+@observed('bot.critical_prepare')
 def _cache_critical_parts_for_tick(state):
     """Parse one stable post-repair payload for the current Bot tick."""
     critical = state.get('critical')
@@ -802,6 +806,7 @@ def _clear_critical_parts_tick_cache(state):
     state.pop(_CRITICAL_PARTS_TICK_CACHE, None)
 
 
+@observed('bot.state_copy')
 def _copy_runtime_state(state):
     """Copy authority state without private runtime-only caches."""
     copied = dict(state)
@@ -810,6 +815,7 @@ def _copy_runtime_state(state):
     return copied
 
 
+@observed('bot.critical_factor')
 def _critical_factor(state, descriptor, stat):
     devices, destroyed, crew_ko, yellow = _critical_parts(state)
     return (device_damage.crew_stat_factor(crew_ko, stat) *
@@ -2631,12 +2637,15 @@ class BotRuntime(object):
             return abs(_number(result.get('slope', 0.0))) <= 0.55
         return bool(result)
 
+    @observed('bot.parameters')
     def _physics_params_for(self, bot_id):
         """Return one Bot's installed physics, rebuilding only its cache."""
         bot_id = int(bot_id)
         params = self._physics_params.get(bot_id)
         if params is not None:
+            combat_count('physics_parameters_cached')
             return params
+        combat_count('physics_parameters_rebuilt')
         descriptor = self._descriptors.get(bot_id)
         if descriptor is None or (isinstance(descriptor, dict) and
                                   not descriptor):
@@ -2663,6 +2672,7 @@ class BotRuntime(object):
             state['grounded_once'] = False
 
     @staticmethod
+    @observed('bot.pose_snapshot')
     def _snapshot_bot_suspension_state(state):
         """Freeze the suspension-owned pose at a rollback boundary."""
         snapshot = {}
@@ -2844,6 +2854,7 @@ class BotRuntime(object):
         self._equipment_now += max(0.0, step)
         return self._equipment_now
 
+    @observed('bot.equipment_pack')
     def _publish_equipment_state(self, state):
         bot_id = int(state['id'])
         states = self._equipment_states.get(bot_id, ())
@@ -2878,6 +2889,7 @@ class BotRuntime(object):
             equipment.trusted_snapshot_edge(self._equipment_now)
             for equipment in self._equipment_states.get(int(bot_id), ()))
 
+    @observed('bot.publication_signature')
     def _current_publication_edge_signature(
             self, states, launches, ram_reports):
         """Describe every non-coalescible worker-owned publication edge."""
@@ -2962,6 +2974,7 @@ class BotRuntime(object):
             int(state['id']), state, siege_state)
         return True
 
+    @observed('bot.siege_tick')
     def _advance_bot_siege(self, state, step):
         pair = self._descriptor_pairs.get(int(state['id']))
         if pair is None or pair[1] is None:
@@ -3005,6 +3018,7 @@ class BotRuntime(object):
             SIEGE_LONG_TRAVEL_METRES)
         return legal_target and not long_travel
 
+    @observed('bot.siege_intent')
     def _update_bot_siege_intent(self, state, command, target, step):
         pair = self._descriptor_pairs.get(int(state['id']))
         if pair is None or pair[1] is None:
@@ -3638,6 +3652,7 @@ class BotRuntime(object):
         self._turn_speeds[int(state['id'])] = 0.0
         return True
 
+    @observed('bot.combat_pack')
     def _mark_combat_publication(self, state):
         sync = self._combat_sync_state(state)
         signature = _combat_signature(state)
@@ -3943,6 +3958,7 @@ class BotRuntime(object):
         self._publish_equipment_state(state)
         return effects
 
+    @observed('bot.critical_tick')
     def _advance_bot_critical(self, state, step, now, record_step=True,
                               advance_fire=True, equipment_effects=None):
         # Repair, consumables and fire may replace the canonical payload. Never
@@ -4027,6 +4043,7 @@ class BotRuntime(object):
                  tuple(dict(effect) for effect in equipment_effects)))
         return changed
 
+    @observed('bot.drowning')
     def _advance_bot_drowning(self, state, step):
         """Apply #1513 WaterSensor danger and its ten-second death clock."""
         if (not state.get('alive', False) or
@@ -4073,6 +4090,7 @@ class BotRuntime(object):
         state['target_id'] = None
         return True
 
+    @observed('bot.overturn')
     def _advance_bot_overturn(self, state, step):
         """Apply #1513 overturn warning, input lock and terminal countdown."""
         if (not state.get('alive', False) or
@@ -5460,6 +5478,7 @@ class BotRuntime(object):
         return refreshed
 
     @staticmethod
+    @observed('motion.receipt_contains')
     def _world_receipt_contains(receipt, position, travel_yaw, speed, dt):
         """Return whether exact typed rays still contain this hull sweep.
 
@@ -5469,14 +5488,17 @@ class BotRuntime(object):
         may retain it while the current hull sweep remains a strict subset.
         """
         if not isinstance(receipt, dict):
+            combat_count('receipt_missing')
             return False
         origin = receipt.get('origin')
         if not isinstance(origin, (list, tuple)) or len(origin) != 3:
+            combat_count('receipt_origin_invalid')
             return False
         receipt_yaw = _number(receipt.get('yaw'))
         receipt_sign = int(_number(receipt.get('direction')))
         current_sign = -1 if _number(speed) < 0.0 else 1
         if receipt_sign not in (-1, 1) or receipt_sign != current_sign:
+            combat_count('receipt_direction_changed')
             return False
         rdx = _number(position[0]) - _number(origin[0])
         rdy = abs(_number(position[1]) - _number(origin[1]))
@@ -5490,11 +5512,19 @@ class BotRuntime(object):
         frame_step = max(0.0, min(0.2, _number(dt)))
         current_reach = max(
             0.4, abs(_number(speed)) * frame_step + 0.2)
-        return bool(
+        contained = bool(
             receipt_forward >= -0.0001 and
             receipt_forward + leading + current_reach <= distance and
             rdy <= 0.0001 and receipt_lateral <= 0.0001 and
             receipt_angle <= 0.00001)
+        if current_combat() is not None:
+            reason = ('hit' if contained else
+                      'behind' if receipt_forward < -0.0001 else
+                      'reach' if receipt_forward + leading + current_reach >
+                      distance else 'height' if rdy > 0.0001 else
+                      'lateral' if receipt_lateral > 0.0001 else 'yaw')
+            combat_count('receipt_contains_' + reason)
+        return contained
 
     @staticmethod
     def _world_receipt_refresh_due(receipt, position, travel_yaw, speed, dt):
@@ -5535,20 +5565,24 @@ class BotRuntime(object):
         return None
 
     @staticmethod
+    @observed('motion.cache_check')
     def _motion_probe_reusable(cached, position, travel_yaw, speed, now,
                                settled=False, dt=None,
                                ignore_deadline=False):
         """Prove that a cached hull corridor still contains this motion ray."""
         if not isinstance(cached, dict):
+            combat_count('motion_cache_missing')
             return False
         if isinstance(cached.get('result'), dict) and cached['result'].get(
                 'deferred', False):
             # Exhausting the shared native recast budget proves neither a wall
             # nor a soft path. Retry next frame instead of pinning this Bot's
             # fixed-id cache to a false answer.
+            combat_count('motion_cache_deferred')
             return False
         sample_position = cached.get('position')
         if not isinstance(sample_position, (list, tuple)) or len(sample_position) != 3:
+            combat_count('motion_cache_pose_invalid')
             return False
         sample_yaw = _number(cached.get('yaw'))
         dx = _number(position[0]) - _number(sample_position[0])
@@ -5562,11 +5596,15 @@ class BotRuntime(object):
         # established slope while its pose and heading stay exact; the first
         # movement, turn, collision push or slide restores the normal expiry.
         if settled:
-            return bool(
+            reusable = bool(
                 abs(forward) <= 0.05 and lateral <= 0.05 and dy <= 0.05 and
                 angle <= 0.005)
+            combat_count('motion_cache_settled_hit' if reusable else
+                         'motion_cache_settled_pose_changed')
+            return reusable
         if (not ignore_deadline and
                 now >= cached.get('deadline', 0.0)):
+            combat_count('motion_cache_deadline')
             return False
         lookahead = 20.0 if abs(_number(speed)) > 5.0 else 15.0
         forward_budget = MOTION_PROBE_FORWARD_BUDGET
@@ -5590,12 +5628,19 @@ class BotRuntime(object):
             -0.1 <= forward <= forward_budget and
             lateral + heading_drift <= MOTION_PROBE_LATERAL_BUDGET)
         if not reusable:
+            if current_combat() is not None:
+                combat_count('motion_cache_' + (
+                    'behind' if forward < -0.1 else
+                    'reach' if forward > forward_budget else
+                    'lateral_or_heading'))
             return False
         receipt = (cached.get('result') or {}).get('world_receipt')
         if (receipt is not None and
                 not BotRuntime._world_receipt_contains(
                     receipt, position, travel_yaw, speed, dt)):
+            combat_count('motion_cache_exact_receipt_rejected')
             return False
+        combat_count('motion_cache_hit')
         return True
 
     @staticmethod
@@ -5624,6 +5669,7 @@ class BotRuntime(object):
         return self._motion_probe_reusable(
             cached, position, travel_yaw, speed, now, False, dt)
 
+    @observed('motion.corridor_check')
     def motion_world_corridor_reusable(self, bot_id, position, travel_yaw,
                                        speed, now, dt):
         """Reuse exact rays or a generic sweep awaiting its exact receipt.
@@ -5689,6 +5735,7 @@ class BotRuntime(object):
             })
         return result
 
+    @observed('bot.traffic_snapshot')
     def _traffic_snapshot(self, supplied):
         """Build one immutable local-traffic snapshot for this authority tick."""
         bodies = {}
@@ -6074,6 +6121,7 @@ class BotRuntime(object):
             return 1
         return 2
 
+    @observed('bot.corridor_hazards')
     def _planner_corridor_clear(self, position, yaw, speed,
                                 wet_escape=False, allow_shallow=False,
                                 hazard_only=False):
@@ -6220,6 +6268,7 @@ class BotRuntime(object):
                 'bot passive motion resolver returned an invalid status')
         return status
 
+    @observed('bot.contact_response')
     def _hard_contact_response(self, state, position, yaw, speed,
                                descriptor, step, now):
         """Probe the shared glancing paths and apply copied hull damping."""
@@ -6811,6 +6860,7 @@ class BotRuntime(object):
             max(0.0, z + extent_z - maximum_z),
         )
 
+    @observed('bot.boundary')
     def _baked_pose_progress_clear(self, state, before_position, before_yaw,
                                    after_position, after_yaw):
         """Allow a legal pose or recovery that worsens no boundary edge."""
@@ -7233,6 +7283,7 @@ class BotRuntime(object):
         bot_state['_route_lane_goal'] = tuple(goal)
         return (tuple(goal), (0, 0))
 
+    @observed('bot.route_lane')
     def _route_lane_target(
             self, bot_id, position, goal, selected, strategic, now):
         """Offset one proved non-join route target through its stable lane."""
@@ -7369,6 +7420,7 @@ class BotRuntime(object):
         own['_radio_ground_goal'] = (key, result)
         return result
 
+    @observed('bot.navigation_target')
     def _navigation_target(self, bot_id, position, goal, strategic, state):
         mode = strategic.get('combat_mode', 'route')
         stop_at_goal = mode not in ('route', 'advance')
@@ -7526,6 +7578,7 @@ class BotRuntime(object):
             current = following
         return float('inf')
 
+    @observed('bot.stopping_distance')
     def _cached_traffic_stopping_distance(
             self, source, command, physics_params):
         """Memoize the exact coast integral for unchanged physical inputs."""
@@ -10140,6 +10193,7 @@ class BotRuntime(object):
         self._queue_pending_launch(launch)
         return True
 
+    @observed('bot.fire')
     def _fire(self, state, gun_state, reload_factor, descriptor,
               launch_receipt=None, ammo_state=None, launch_preview=None,
               launch_time_us=None):
@@ -10215,6 +10269,7 @@ class BotRuntime(object):
         burst_state.publish(state)
         return True
 
+    @observed('bot.burst_tick')
     def _advance_active_burst(
             self, state, gun_state, ammo_state, reload_factor, descriptor,
             target, ballistic_solution, step, destroyed_devices,
@@ -10330,6 +10385,8 @@ class BotRuntime(object):
                     return []
             elif self._accumulator + 1e-9 < self._control_seconds:
                 return []
+            if self._combat_diagnostics is not None:
+                self._combat_diagnostics.begin_control()
             # Exact world-receipt work is capped per render callback, not per
             # control step. Do not open an empty receipt frame on intervening
             # high-FPS callbacks: finishing one without a control step would
@@ -10401,14 +10458,19 @@ class BotRuntime(object):
         if scan is None:
             return False
         scanned = False
+        diagnostic = current_combat()
         for state in self._ordered_states():
             if (not state['alive'] or state['health'] <= 0.0 or
                     abs(state['speed']) < DESTRUCTIBLE_SCAN_MIN_SPEED):
                 continue
+            if diagnostic is not None:
+                diagnostic.actor(state['id'])
             scan(
                 state['id'], (state['x'], state['y'], state['z']),
                 state['yaw'], state['speed'])
             scanned = True
+        if diagnostic is not None:
+            diagnostic.actor(None)
         return scanned
 
     def _run_update_once(self, frame_step, now, players, neighbours,
@@ -10445,6 +10507,10 @@ class BotRuntime(object):
         """Advance one stable authority substep and preserve its events."""
         publish = bool(self._publish_control_this_step)
         refresh_control = bool(self._refresh_control_this_step)
+        diagnostic = self._combat_diagnostics
+        if diagnostic is not None and diagnostic.active:
+            diagnostic.begin_slice(frame_step, refresh_control, publish)
+        diagnostic = current_combat()
         if self._combat_diagnostics is not None:
             self._combat_diagnostics.count(
                 'bot_control_refreshes', int(refresh_control))
@@ -10528,6 +10594,9 @@ class BotRuntime(object):
         siege_locked_poses = {}
         integrated = set()
         for state in self.states.values():
+            if diagnostic is not None:
+                diagnostic.actor(state['id'])
+                diagnostic.phase('bot.prepare')
             if not state['alive']:
                 self._cancel_active_burst(state)
                 continue
@@ -10566,6 +10635,8 @@ class BotRuntime(object):
                 self._snapshot_bot_suspension_state(state)
             tick_safe[state['id']] = prebaked_navigation.pose_is_safe(
                 self.baked_graph, position, shoulder_cells=0)
+            if diagnostic is not None:
+                diagnostic.phase('bot.command')
             server_order = self._server_orders.get(state['id'])
             decide_with_order = getattr(self.adapter, 'decide_with_order', None)
             cache_key = (('server', self._server_order_tokens.get(
@@ -10579,6 +10650,16 @@ class BotRuntime(object):
                 refresh_control and
                 (not decision_cache_valid or
                  now >= decision_cache[1]))
+            if diagnostic is not None:
+                diagnostic.count(
+                    'decision_refresh' if decision_due else
+                    'decision_reused' if decision_cache_valid else
+                    'decision_physical_hold')
+                if decision_due:
+                    diagnostic.count(
+                        'decision_deadline' if decision_cache_valid else
+                        'decision_cache_missing' if decision_cache is None else
+                        'decision_order_changed')
             decision_deadline = None
             raw_command = None
             planner_probe_samples = {}
@@ -10761,6 +10842,8 @@ class BotRuntime(object):
             # bot observes poses integrated by earlier bots in this same tick.
             # Human records do not change inside update, so index them once at
             # the first live bot instead of rebuilding the map for every bot.
+            if diagnostic is not None:
+                diagnostic.phase('bot.target_refresh')
             if live_players is None:
                 live_players = self._index_live_players(players)
             if refresh_shot_lanes and not collect_observation:
@@ -10832,6 +10915,8 @@ class BotRuntime(object):
                 self._update_bot_siege_intent(
                     state, command, target, step) or
                 siege_motion_locked)
+            if diagnostic is not None:
+                diagnostic.phase('bot.weapon_prepare')
             descriptor = self._descriptors.get(state['id'], {})
             profile = state.get('profile')
             profile = profile if isinstance(profile, dict) else {}
@@ -10888,6 +10973,8 @@ class BotRuntime(object):
                     command['throttle'] = 0.0
                     command['turn'] = 0.0
                     command['movement_intent'] = False
+            if diagnostic is not None:
+                diagnostic.phase('bot.motion_prepare')
             throttle = max(-1.0, min(1.0, command['throttle']))
             turn = max(-1.0, min(1.0, command.get('turn', 0.0)))
             aim_fallback = (target.get('position') if target is not None
@@ -11226,6 +11313,8 @@ class BotRuntime(object):
             self._log_motion_stall(
                 state, command, throttle, turn, path_clear, motion_probe, now,
                 pose_frozen)
+            if diagnostic is not None:
+                diagnostic.phase('bot.integrate')
             if not self.native_motion:
                 params = self._physics_params_for(state['id'])
                 # The selected corridor's ground sample is also the copied
@@ -11411,6 +11500,8 @@ class BotRuntime(object):
                         bot_id = int(state['id'])
                         self._hard_contact_grinds[bot_id] = max(
                             0, self._hard_contact_grinds.get(bot_id, 0) - 1)
+            if diagnostic is not None:
+                diagnostic.phase('bot.aim_fire')
             ammo_state.publish(state)
             ballistic_solution, local_action_fresh = \
                 self._cadenced_ballistic_solution(
@@ -11528,6 +11619,8 @@ class BotRuntime(object):
                         # moving SPG must discard it and prove the next shot
                         # again after its normal safe-driver motion completes.
                         self._cancel_artillery_intent(state['id'])
+            if diagnostic is not None:
+                diagnostic.phase('bot.cover_prepare')
             mode = command.get('combat_mode')
             if (collect_cover_jobs and
                     target is not None and target.get('visible') and
@@ -11543,6 +11636,8 @@ class BotRuntime(object):
                                    command.get('move_position', position)))
             _clear_critical_parts_tick_cache(state)
             processed_bot_ids.add(int(state['id']))
+        if diagnostic is not None:
+            diagnostic.actor(None)
         # A static firing lane is useful only while the team has a current
         # direct spot. Keep one queue of compact identities across callbacks;
         # resolve at most the bounded service cohort against current poses.
@@ -11649,6 +11744,8 @@ class BotRuntime(object):
         ballistic_ticks = {}
         for state in ordered_states:
             if state.get('alive', True) and state['id'] in integrated:
+                if diagnostic is not None:
+                    diagnostic.actor(state['id'])
                 attempted_yaw = attempted_yaws.get(
                     state['id'], state.get('yaw', 0.0))
                 was_airborne = bool(state.get('airborne', False))
@@ -11660,6 +11757,8 @@ class BotRuntime(object):
                     was_airborne or state.get('airborne', False))
                 settled_poses[state['id']] = _position(state)
                 slope_candidates.append(state)
+        if diagnostic is not None:
+            diagnostic.actor(None)
         # Ram vertical overlap and native plate proof must use this slice's
         # settled Y/pitch/roll, not the previous suspension pose. Resolve the
         # complete roster only after every live body reaches that boundary.
@@ -11688,6 +11787,8 @@ class BotRuntime(object):
             # bounded proximity validation and silently discard a real hit.
             publish = True
         for state in slope_candidates:
+            if diagnostic is not None:
+                diagnostic.actor(state['id'])
             bot_id = int(state['id'])
             attempted_yaw = attempted_yaws.get(
                 bot_id, state.get('yaw', 0.0))
@@ -11717,6 +11818,8 @@ class BotRuntime(object):
                     (tick_suspension_states.get(bot_id)
                      if self._suspension_params.get(bot_id) is not None
                      else None))
+        if diagnostic is not None:
+            diagnostic.actor(None)
         self._alive_bot_ticks += len(slope_candidates)
         if refresh_control and slope_candidates:
             start = self._slope_pose_cursor % len(slope_candidates)
@@ -11739,16 +11842,21 @@ class BotRuntime(object):
         wire_states = []
         launches = [dict(launch) for launch in self._pending_launches]
         for state in self._ordered_states():
+            if diagnostic is not None:
+                diagnostic.actor(state['id'])
             burst_state = self._burst_states.get(int(state['id']))
             if burst_state is not None:
                 burst_state.publish(state)
             self._publish_equipment_state(state)
-            projected = lan_client.project_owned_bot_state(state)
+            projected = observed_call(
+                'bot.wire_projection', lan_client.project_owned_bot_state, state)
             if projected is None:
                 raise RuntimeError('bot publication projection failed')
             if 'equipment_states' in projected:
                 self._equipment_wire_exposed_in_update.add(int(state['id']))
             wire_states.append(projected)
+        if diagnostic is not None:
+            diagnostic.actor(None)
         self._sample_time_us = step_end_time_us
         edge_sample_time_us, edge_revision = self._mark_publication_edge(
             ordered_states, launches, self._pending_ram_reports,

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/destructibles_sensor.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/destructibles_sensor.py
@@ -5,6 +5,10 @@ The three sensor bodies below are dedented copies from ``offline_battle.py``.
 Only their former closure dependencies are supplied at module scope.
 """
 
+from gui.mods.offline_lan_0922.worker_diagnostics import (
+    observed, observed_call, observed_ray,
+    current as current_combat, count as combat_count)
+
 _event_sink = None
 
 _DESTRUCTIBLE_BIN_METRES = 8.0
@@ -573,6 +577,7 @@ def _item_name_cache_victim_1513(cache):
 		key=lambda value: (int(value[1].get('last_access', 0)), value[0]))[0]
 
 
+@observed('destructible.name_alignment')
 def _chunk_item_names_1513(bigworld, area_destructibles, space_id, chunk_id,
 		native_count, names):
 	"""Incrementally rebuild one chunk's exact per-item native filenames.
@@ -710,7 +715,9 @@ def _chunk_item_names_1513(bigworld, area_destructibles, space_id, chunk_id,
 			_release_item_name_query_focus_1513(space_id, chunk_id)
 			return entry['result']
 		try:
-			native_type = query(space_id, chunk_id, item_index, -1)
+			native_type = observed_call(
+				'native.destructible.category', query,
+				space_id, chunk_id, item_index, -1)
 		except Exception as error:
 			# The native name loop resolves through the same provider and omits
 			# this item.  Preserve that alignment fact, but quarantine the live
@@ -747,6 +754,7 @@ def _chunk_item_names_1513(bigworld, area_destructibles, space_id, chunk_id,
 	return entry['result']
 
 
+@observed('destructible.chunk_names')
 def _chunk_native_name_list_1513(bigworld, space_id, chunk_id, native_count):
 	"""Read and validate one chunk's possibly compacted native name list.
 
@@ -766,11 +774,14 @@ def _chunk_native_name_list_1513(bigworld, space_id, chunk_id, native_count):
 	entry = cache.get(key)
 	if entry is not None:
 		if entry['native_count'] == int(native_count):
+			combat_count('destructible_name_list_cached')
 			_touch_item_name_cache_entry_1513(entry)
 			return entry['names'], 'ready'
 		cache.pop(key, None)
 	try:
-		names = bigworld.wg_getChunkDestrFilenames(space_id, chunk_id)
+		names = observed_call(
+			'native.destructible.filenames',
+			bigworld.wg_getChunkDestrFilenames, space_id, chunk_id)
 	except Exception as error:
 		_isolate_destructible_1513(
 			'filename_query', chunk_id, detail=error)
@@ -1417,6 +1428,7 @@ def _spatial_revision_1513():
 
 
 def _receipt_stat_1513(name, amount=1):
+	combat_count('destructible_receipt_' + name, amount)
 	stats = globals().setdefault('g_offh_destr_receipt_stats', {})
 	stats[name] = int(stats.get(name, 0)) + int(amount)
 
@@ -1585,6 +1597,7 @@ def _receipt_cache_delete_1513(name, key):
 	return True
 
 
+@observed('destructible.empty_contact_check')
 def _empty_contact_receipt_valid_1513(key):
 	name = 'g_offh_destr_empty_contact_receipts'
 	state = globals().get(name)
@@ -1630,6 +1643,7 @@ def _proximity_receipt_key_1513(spaceID, current_chunk, pos, vehicle_box):
 		_bin_rectangle_signature_1513(_box_xz_bounds(vehicle_box)))
 
 
+@observed('destructible.empty_proximity_check')
 def _empty_proximity_receipt_valid_1513(
 		key, manager, chunk_registry):
 	"""Reuse only a complete, unchanged streamed empty-cell receipt."""
@@ -1674,6 +1688,7 @@ def _nearby_destructibles(registry, pos, vehicle_box=None):
 				if item[0] in seen:
 					continue
 				seen.add(item[0])
+				combat_count('destructible_nearby_items')
 				yield item
 
 def _symmetric_quantize(value, scale):
@@ -2030,7 +2045,9 @@ def _stream_baked_shot_instance_1513(spaceID, identity):
 			chunk_id, item_index):
 		return None
 	try:
-		chunk_matrix = BigWorld.wg_getChunkMatrix(spaceID, chunk_id)
+		chunk_matrix = observed_call(
+			'native.destructible.chunk_matrix', BigWorld.wg_getChunkMatrix,
+			spaceID, chunk_id)
 		chunk_translation = getattr(chunk_matrix, 'translation', None)
 	except Exception as error:
 		_isolate_destructible_1513(
@@ -2039,7 +2056,8 @@ def _stream_baked_shot_instance_1513(spaceID, identity):
 	if chunk_translation is None:
 		return None
 	try:
-		matrix = Math.Matrix(BigWorld.wg_getDestructibleMatrix(
+		matrix = Math.Matrix(observed_call(
+			'native.destructible.item_matrix', BigWorld.wg_getDestructibleMatrix,
 			spaceID, chunk_id, item_index))
 	except Exception as error:
 		_isolate_destructible_1513(
@@ -2264,6 +2282,7 @@ def _catalog_shot_intersection(spaceID, start, end, maximum_distance=None):
 
 
 @_batched_spatial_mutations_1513
+@observed('destructible.stream_motion')
 def _stream_baked_motion_instances_1513(spaceID, vehicle_box):
 	"""Live-validate catalog wires covering one exact vehicle sweep."""
 	catalog = _destructible_catalog or {}
@@ -2276,7 +2295,9 @@ def _stream_baked_motion_instances_1513(spaceID, vehicle_box):
 			catalog.get('baked_shot_bins', {}).get(bin_key, ()))
 	instances = globals().get('g_offh_destr_instances', {})
 	for identity in sorted(identities):
+		combat_count('destructible_stream_candidates')
 		if identity not in instances:
+			combat_count('destructible_stream_missing')
 			_stream_baked_shot_instance_1513(spaceID, identity)
 
 
@@ -2543,6 +2564,7 @@ def _point_near_tree_sweep_1513(x, z, sweep_box,
 		contact_radius * contact_radius + 1.0e-8)
 
 
+@observed('destructible.tree_candidates')
 def _tree_candidates_for_sweeps_1513(
 		chunk_id, registry, sweep_boxes, tree_type,
 		contact_radius=_SOLID_CONTACT_RADIUS_1513):
@@ -2615,6 +2637,7 @@ def _vehicle_contact_box(pos, yaw, bbox, epsilon=0.075, travel=0.0,
 	return center, half_axes
 
 
+@observed('destructible.intersections')
 def _catalog_intersections(world_boxes, vehicle_box):
 	result = []
 	for world_box in world_boxes:
@@ -2781,7 +2804,11 @@ def clear_local_prediction(token):
 	return changed
 
 
+@observed('destructible.contact_candidates')
 def _catalog_contact_candidates(vehicle_box):
+	diagnostic = current_combat()
+	if diagnostic is not None:
+		diagnostic.geometry('destructible_contact_box', vehicle_box)
 	instances = globals().get('g_offh_destr_instances', {})
 	contact_bins = globals().get('g_offh_destr_contact_bins', {})
 	bounds = _box_xz_bounds(vehicle_box)
@@ -2796,10 +2823,12 @@ def _catalog_contact_candidates(vehicle_box):
 		if members:
 			had_members = True
 		for chunk_id, item_index in sorted(members):
+			combat_count('destructible_contact_bin_items')
 			identity = (int(chunk_id), int(item_index))
 			if _destructible_isolated_1513(*identity):
 				continue
 			if identity in seen:
+				combat_count('destructible_contact_duplicate_bin_item')
 				continue
 			seen.add(identity)
 			instance = instances.get(identity)
@@ -2819,6 +2848,7 @@ def _catalog_contact_candidates(vehicle_box):
 			'g_offh_destr_empty_contact_receipts', receipt_key,
 			{'cell_signature': _spatial_cell_signature_1513((receipt_key,))},
 			_EMPTY_CONTACT_RECEIPT_LIMIT)
+	combat_count('destructible_contact_candidates', len(candidates))
 	return candidates
 
 
@@ -2998,7 +3028,8 @@ def _catalog_soft_static_path(spaceID, segment_start, segment_end,
 			if not recast_budget or int(recast_budget[0]) <= 0:
 				return 'pending_hard' if pending_contact else 'deferred'
 			recast_budget[0] = int(recast_budget[0]) - 1
-		current_hit = BigWorld.wg_collideSegment(
+		current_hit = observed_ray(
+			'native.destructible.ray', BigWorld.wg_collideSegment,
 			spaceID, next_start, segment_end, 128)
 		if current_hit is None:
 			return 'kinetic' if kinetic_contact else True
@@ -3202,6 +3233,7 @@ def _catalog_pending_at_hull(pos, yaw, vel, td, now, dt=0.04,
 	return False
 
 
+@observed('destructible.hull_guard')
 def _catalog_hull_contact(pos, yaw, vel, td, dt=0.04,
 		motion_yaw=None):
 	"""Cheap contact-bin guard for the copied player/Bot pose integrators."""
@@ -3235,6 +3267,7 @@ def _catalog_motion_result(status, token=None, accepted_now=False,
 	return legacy_status if return_status else legacy_status != 'clear'
 
 
+@observed('destructible.motion')
 def _catalog_motion_blocked(spaceID, pos, yaw, vel, td, now,
 		return_status=False, dt=0.04, kinetic_speed=None,
 		return_detail=False, kinetic_commit=False, commit_enabled=True,
@@ -3638,6 +3671,7 @@ def _falling_native_state_1513(spaceID, chunkID, itemIndex, math_module):
 
 
 @_batched_spatial_mutations_1513
+@observed('destructible.falling_refresh')
 def _refresh_destroyed_falling_instances_1513(spaceID, authority, now):
 	"""Follow each destroyed falling atom's live native transform exactly."""
 	instances = globals().get('g_offh_destr_instances', {})
@@ -3703,7 +3737,8 @@ def _refresh_destroyed_falling_instances_1513(spaceID, authority, now):
 			active[identity]['last_refresh'] = float(now)
 			continue
 		try:
-			matrix = Math.Matrix(BigWorld.wg_getDestructibleMatrix(
+			matrix = Math.Matrix(observed_call(
+				'native.destructible.item_matrix', BigWorld.wg_getDestructibleMatrix,
 				spaceID, chunk_id, item_index))
 		except Exception as error:
 			_isolate_destructible_1513(
@@ -4286,6 +4321,7 @@ def prewarm_tree_registry(spaceID, pos, yaw, td=None, now=None,
 	}
 
 
+@observed('destructible.tree_motion')
 def _tree_motion_resolution_1513(
 		spaceID, start_pos, start_yaw, end_pos, end_yaw, speed, td, now,
 		dt, requested_chunks=None):
@@ -4478,9 +4514,11 @@ def _trusted_tree_event_position_1513(
 	try:
 		import BigWorld
 		import Math
-		chunk_matrix = Math.Matrix(BigWorld.wg_getChunkMatrix(
+		chunk_matrix = Math.Matrix(observed_call(
+			'native.destructible.chunk_matrix', BigWorld.wg_getChunkMatrix,
 			spaceID, identity[0]))
-		item_matrix = Math.Matrix(BigWorld.wg_getDestructibleMatrix(
+		item_matrix = Math.Matrix(observed_call(
+			'native.destructible.item_matrix', BigWorld.wg_getDestructibleMatrix,
 			spaceID, identity[0], identity[1]))
 		chunk_translation = chunk_matrix.translation
 		item_translation = item_matrix.translation
@@ -4736,6 +4774,7 @@ def commit_tree_contacts(
 
 
 @_batched_spatial_mutations_1513
+@observed('destructible.body_scan')
 def _fell_trees_near(
 		spaceID, pos, yaw, vel, td=None, registration_only=False,
 		priority_chunks=None):
@@ -4863,6 +4902,7 @@ def _fell_trees_near(
 				-_prewarm_priority.get(cid, (0.0, 0.0))[0],
 				-_prewarm_priority.get(cid, (0.0, 0.0))[1], cid))
 		for cid in _cid_order:
+			combat_count('destructible_body_chunks')
 			if _destructible_isolated_1513(cid):
 				continue
 			registry = _st['chunks'].get(cid)
@@ -4873,6 +4913,7 @@ def _fell_trees_near(
 				_drop_streamed_chunk_registry_1513(_st, cid)
 				registry = None
 			if registry is None:
+				combat_count('destructible_body_unregistered_chunk')
 				if _native_count is None:
 					if _destructible_isolated_1513(cid):
 						continue
@@ -4917,7 +4958,8 @@ def _fell_trees_near(
 				}
 				_retry_registry = False
 				try:
-					_cm_t = BigWorld.wg_getChunkMatrix(
+					_cm_t = observed_call(
+						'native.destructible.chunk_matrix', BigWorld.wg_getChunkMatrix,
 						spaceID, cid).translation
 				except Exception as error:
 					_isolate_destructible_1513(
@@ -4940,7 +4982,8 @@ def _fell_trees_near(
 							(_baked_slot is not None and
 								_baked_slot.get('kind') == 'falling'))
 						try:
-							_m = Math.Matrix(BigWorld.wg_getDestructibleMatrix(
+							_m = Math.Matrix(observed_call(
+								'native.destructible.item_matrix', BigWorld.wg_getDestructibleMatrix,
 								spaceID, cid, _ti))
 						except Exception as error:
 							_isolate_destructible_1513(
@@ -5726,7 +5769,8 @@ def _try_destroy_solid_hit(spaceID, segment_start, hit_pt, surf_normal,
 			_probes += ((hit_pt + _incoming.scale(3.0),
 				hit_pt - _incoming.scale(2.0)),)
 		for _seg_a, _seg_b in _probes:
-			_mi = BigWorld.wg_getMatInfoNearPoint(
+			_mi = observed_call(
+				'native.destructible.material', BigWorld.wg_getMatInfoNearPoint,
 				spaceID, _seg_a, _seg_b, hit_pt, lambda *a: False)
 			_decoded = _decode_mat_info_1513(_mi)
 			if not _solid_destructible_candidate_1513(

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/vehicle_physics.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/vehicle_physics.py
@@ -19,6 +19,8 @@ This module must stay importable with nothing but the stdlib: it sits right
 above paths.py at the bottom of the offhangar import graph.
 '''
 
+from gui.mods.offline_lan_0922.worker_diagnostics import observed
+
 import math
 
 # ---- Wargaming's own tuning, extracted from scripts/common/physics_shared.pyc
@@ -399,6 +401,7 @@ def _native_power_ratio(td, power_w):
 	return 1.0
 
 
+@observed('physics.derive_params')
 def derive_params(td, factors=None):
 	'''Real per-vehicle parameter set from a VehicleDescr. Every consumer
 	(player tick, each bot) MUST source its numbers from here - this is the
@@ -1773,6 +1776,7 @@ def _grip_decel(p, slope_pitch):
 	return slope_cohesion(ny) * GRAVITY * (ny if ny > 0.1 else 0.1)
 
 
+@observed('physics.longitudinal')
 def longitudinal_step(p, v, throttle, steering, slope_pitch, dt,
                       airborne=False, terrainIdx=0, handbrake=False):
 	'''One integration step of forward (along-hull) speed. Returns the new v.
@@ -1924,6 +1928,7 @@ def longitudinal_step(p, v, throttle, steering, slope_pitch, dt,
 	return nv
 
 
+@observed('physics.traverse')
 def traverse_step(p, omega, steer_dir, v, dt, terrainIdx=0, drive_intent=0.0):
 	'''One integration step of hull rotation speed (rad/s). WG 0.8.2: driving
 	speed does NOT slow the traverse (SPEED_AFFECT_ROT_DECREASE = 0.0) and the

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/worker_diagnostics.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/worker_diagnostics.py
@@ -245,7 +245,7 @@ class WorkerCombatDiagnostics(object):
             return
         self.count(name + '_queries')
         try:
-            signature = (self._actor_key, name, key)
+            signature = (self._slice, self._actor_key, name, key)
             if signature in self._geometry:
                 self.count(name + '_same_geometry_in_slice')
             elif len(self._geometry) < MAX_GEOMETRY_KEYS:

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/worker_diagnostics.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/worker_diagnostics.py
@@ -9,6 +9,7 @@ simulation work. Stage totals include children; self time excludes them.
 import collections
 import functools
 import math
+import threading
 
 
 CAPTURE_SECONDS = 30.0
@@ -16,17 +17,78 @@ CAPTURE_COOLDOWN_SECONDS = 30.0
 MAX_CAPTURES = 3
 MAX_QUEUE_IDENTITIES = 1024
 MAX_WAIT_SAMPLES = 512
+MAX_ACTOR_SLICES = 128
+MAX_CAPTURE_ACTORS = 64
+MAX_FRAME_ACTORS_REPORTED = 6
+MAX_GEOMETRY_KEYS = 2048
+
+# Only synchronous, instrumented Python calls bind this observer. No native
+# hook, entity, scheduled callback or process-global simulation state is owned.
+_observer = threading.local()
+
+
+def current():
+    diagnostic = getattr(_observer, 'current', None)
+    return (diagnostic if diagnostic is not None and diagnostic.active and
+            diagnostic.detail_active else None)
+
+
+def count(name, value=1):
+    diagnostic = current()
+    if diagnostic is not None:
+        diagnostic.count(name, value)
+
+
+def observed_call(stage, function, *args, **kwargs):
+    diagnostic = current()
+    if diagnostic is None:
+        return function(*args, **kwargs)
+    return _invoke(diagnostic, stage, function, args, kwargs)
+
+
+def observed_ray(stage, function, space, start, end, *args):
+    diagnostic = current()
+    if diagnostic is None:
+        return function(space, start, end, *args)
+    try:
+        diagnostic.geometry(stage, (
+            space, (start.x, start.y, start.z), (end.x, end.y, end.z)))
+    except Exception:
+        diagnostic.count('ray_geometry_unavailable')
+    return _invoke(diagnostic, stage, function, (space, start, end) + args, {})
+
+
+def observed(stage):
+    """Observe a pure helper only inside its synchronous worker owner."""
+    def decorate(function):
+        @functools.wraps(function)
+        def measured(*args, **kwargs):
+            diagnostic = current()
+            if diagnostic is None:
+                return function(*args, **kwargs)
+            return _invoke(diagnostic, stage, function, args, kwargs)
+        return measured
+    return decorate
+
+
+def _invoke(diagnostic, stage, function, args, kwargs):
+    previous = getattr(_observer, 'current', None)
+    _observer.current = diagnostic
+    token = diagnostic.start()
+    try:
+        return function(*args, **kwargs)
+    finally:
+        try:
+            diagnostic.stop(stage, token)
+        finally:
+            _observer.current = previous
 
 
 def call(diagnostic, stage, function, *args, **kwargs):
     """Measure an injected adapter without changing its callable identity."""
     if diagnostic is None or not diagnostic.active:
         return function(*args, **kwargs)
-    token = diagnostic.start()
-    try:
-        return function(*args, **kwargs)
-    finally:
-        diagnostic.stop(stage, token)
+    return _invoke(diagnostic, stage, function, args, kwargs)
 
 
 def timed(stage):
@@ -37,30 +99,29 @@ def timed(stage):
             diagnostic = getattr(self, '_combat_diagnostics', None)
             if diagnostic is None or not diagnostic.active:
                 return method(self, *args, **kwargs)
-            token = diagnostic.start()
-            try:
-                return method(self, *args, **kwargs)
-            finally:
-                diagnostic.stop(stage, token)
+            return _invoke(diagnostic, stage, method, (self,) + args, kwargs)
         return measured
     return decorate
 
 
 class WorkerCombatDiagnostics(object):
-    """Capture three combat windows without retaining entities or poses."""
+    """Capture three combat windows without retaining native objects."""
 
     def __init__(self, clock, capture_seconds=CAPTURE_SECONDS,
                  cooldown_seconds=CAPTURE_COOLDOWN_SECONDS,
-                 maximum_captures=MAX_CAPTURES):
+                 maximum_captures=MAX_CAPTURES, detail_stride=1):
         self.clock = clock
         self.capture_seconds = float(capture_seconds)
         self.cooldown_seconds = float(cooldown_seconds)
         self.maximum_captures = int(maximum_captures)
+        self.detail_stride = max(1, int(detail_stride))
         self.reset()
 
     def reset(self):
         self.enabled = True
         self.active = False
+        self.detail_active = False
+        self._detail_ticks = 0
         self.capture = 0
         self._deadline = None
         self._next_capture = 0.0
@@ -87,6 +148,22 @@ class WorkerCombatDiagnostics(object):
         self._capture_wait_count = 0
         self._capture_selected_wait_count = 0
         self._completed = []
+        self._capture_actors = {}
+        self._capture_detail_stages = {}
+        self._capture_detail_counts = {}
+        self._capture_detail_frames = 0
+        self._reset_actor_frame()
+
+    def _reset_actor_frame(self):
+        self._actor_key = None
+        self._actor_token = None
+        self._phase_token = None
+        self._phase_name = None
+        self._actors = {}
+        self._slices = []
+        self._slice = 0
+        self._control_selected = False
+        self._geometry = set()
 
     def _fail(self):
         self.enabled = False
@@ -94,6 +171,89 @@ class WorkerCombatDiagnostics(object):
         self._stack = []
         self._queue.clear()
         self._receipts.clear()
+        self._reset_actor_frame()
+
+    def begin_control(self):
+        if not self.active or self._control_selected:
+            return
+        # Sample complete control callbacks, never every N render frames:
+        # render/modulo sampling can alias the 10 Hz control cadence and miss
+        # every Bot update. Rotate the selected slot within each group so
+        # slower decision cadences do not always select the same Bot cohort.
+        # All catch-up slices keep this decision.
+        self._control_selected = True
+        self._detail_ticks += 1
+        tick = self._detail_ticks - 1
+        self.detail_active = (tick % self.detail_stride ==
+                              (tick // self.detail_stride) % self.detail_stride)
+
+    def begin_slice(self, elapsed, refresh_control, publish):
+        if not self.active:
+            return
+        self.actor(None)
+        self.begin_control()
+        self._slice += 1
+        if len(self._slices) < MAX_ACTOR_SLICES:
+            self._slices.append({
+                'slice': self._slice, 'elapsed_ms': round(elapsed * 1000.0, 3),
+                'control': bool(refresh_control),
+                'publish_requested': bool(publish),
+                'detail': self.detail_active,
+            })
+
+    def actor(self, bot_id):
+        """Attribute a synchronous Bot work block, including its residual time.
+
+        Explicitly close between roster loops. The enclosing timed scope also
+        closes its unfinished actor on exception, before unwinding itself.
+        """
+        if not self.active or not self.detail_active:
+            return
+        self.phase(None)
+        token = self._actor_token
+        self._actor_token = None
+        if token is not None:
+            self.stop('bot.actor', token)
+        self._actor_key = None
+        if bot_id is None or not self.active:
+            return
+        key = (self._slice, int(bot_id))
+        if key not in self._actors:
+            if len(self._actors) >= MAX_ACTOR_SLICES:
+                self.count('actor_tracking_overflow')
+                return
+            self._actors[key] = {'stages': {}, 'counts': {}}
+        self._actor_key = key
+        self._actor_token = self.start()
+
+    def phase(self, name):
+        """Partition inline Bot work without moving simulation statements."""
+        if not self.active or not self.detail_active:
+            return
+        token, previous_name = self._phase_token, self._phase_name
+        self._phase_token = None
+        self._phase_name = None
+        if token is not None:
+            self.stop(previous_name, token)
+        if name is not None and self._actor_key is not None and self.active:
+            self._phase_name = name
+            self._phase_token = self.start()
+
+    def geometry(self, name, key):
+        """Count repeated geometry, without asserting unchanged world state."""
+        if not self.active:
+            return
+        self.count(name + '_queries')
+        try:
+            signature = (self._actor_key, name, key)
+            if signature in self._geometry:
+                self.count(name + '_same_geometry_in_slice')
+            elif len(self._geometry) < MAX_GEOMETRY_KEYS:
+                self._geometry.add(signature)
+            else:
+                self.count('geometry_tracking_overflow')
+        except Exception:
+            self.count('geometry_tracking_unavailable')
 
     @staticmethod
     def _finite(value):
@@ -129,15 +289,21 @@ class WorkerCombatDiagnostics(object):
                 self._capture_wait_count = 0
                 self._capture_selected_wait_count = 0
                 self._receipts.clear()
+                self._capture_actors = {}
+                self._capture_detail_stages = {}
+                self._capture_detail_counts = {}
+                self._capture_detail_frames = 0
             self._frame = int(frame)
             self._now = now
             self.active = self._deadline is not None
+            self.detail_active = self.active and self.detail_stride == 1
             self._stack = []
             self._stages = {}
             self._counts = {}
             self._waits = []
             self._selected_waits = []
             self._queue_snapshot = {}
+            self._reset_actor_frame()
             return self.active
         except Exception:
             self._fail()
@@ -147,7 +313,7 @@ class WorkerCombatDiagnostics(object):
         if not self.active:
             return None
         try:
-            token = [self._finite(self.clock()), 0.0]
+            token = [self._finite(self.clock()), 0.0, self._actor_key]
             self._stack.append(token)
             return token
         except Exception:
@@ -161,23 +327,47 @@ class WorkerCombatDiagnostics(object):
         if token is None or not self.active:
             return
         try:
+            if (self._phase_token is not None and len(self._stack) >= 3 and
+                    self._stack[-1] is self._phase_token and
+                    self._stack[-2] is self._actor_token and
+                    self._stack[-3] is token):
+                self.actor(None)
+                if not self.active:
+                    return
+            if (self._actor_token is not None and len(self._stack) >= 2 and
+                    self._stack[-1] is self._actor_token and
+                    self._stack[-2] is token):
+                self.actor(None)
+                if not self.active:
+                    return
             elapsed = max(0.0, self._finite(self.clock()) - token[0])
             if not self._stack or self._stack[-1] is not token:
                 raise ValueError('diagnostic scope ownership changed')
             self._stack.pop()
             if self._stack:
                 self._stack[-1][1] += elapsed
-            row = self._stages.setdefault(stage, [0, 0.0, 0.0, 0.0])
-            row[0] += 1
-            row[1] += elapsed
-            row[2] += max(0.0, elapsed - token[1])
-            row[3] = max(row[3], elapsed)
+            own = max(0.0, elapsed - token[1])
+            self._add_stage(self._stages, stage, elapsed, own)
+            if token[2] in self._actors:
+                self._add_stage(
+                    self._actors[token[2]]['stages'], stage, elapsed, own)
         except Exception:
             self._fail()
 
     def count(self, name, value=1):
         if self.active:
             self._counts[name] = self._counts.get(name, 0) + int(value)
+            if self._actor_key in self._actors:
+                counts = self._actors[self._actor_key]['counts']
+                counts[name] = counts.get(name, 0) + int(value)
+
+    @staticmethod
+    def _add_stage(stages, name, elapsed, own):
+        row = stages.setdefault(name, [0, 0.0, 0.0, 0.0])
+        row[0] += 1
+        row[1] += elapsed
+        row[2] += own
+        row[3] = max(row[3], elapsed)
 
     def queue_added(self, key, now, ready_at):
         """Keep enqueue times outside captures so waits are not truncated."""
@@ -321,6 +511,11 @@ class WorkerCombatDiagnostics(object):
                 'frame': self._frame, 'authority_time': self._now,
                 'stages': self._stage_rows(self._stages),
                 'counts': dict(self._counts),
+                'slices': list(self._slices),
+                'actors_tracked': len(self._actors),
+                'detail_sampled': self.detail_active,
+                'actors': self._actor_rows(
+                    self._actors, MAX_FRAME_ACTORS_REPORTED),
                 'queue': dict(self._queue_snapshot),
                 'completed_wait': self._wait_summary(self._waits),
                 'selected_completed_wait': self._wait_summary(
@@ -335,6 +530,32 @@ class WorkerCombatDiagnostics(object):
             for name, count in self._counts.items():
                 self._capture_counts[name] = (
                     self._capture_counts.get(name, 0) + count)
+            if self.detail_active:
+                self._capture_detail_frames += 1
+                for name, row in self._stages.items():
+                    total = self._capture_detail_stages.setdefault(
+                        name, [0, 0.0, 0.0, 0.0])
+                    for index in (0, 1, 2):
+                        total[index] += row[index]
+                    total[3] = max(total[3], row[3])
+                for name, count in self._counts.items():
+                    self._capture_detail_counts[name] = (
+                        self._capture_detail_counts.get(name, 0) + count)
+            for (unused_slice, bot_id), actor in self._actors.items():
+                key = (0, bot_id)
+                if key not in self._capture_actors:
+                    if len(self._capture_actors) >= MAX_CAPTURE_ACTORS:
+                        continue
+                    self._capture_actors[key] = {'stages': {}, 'counts': {}}
+                total = self._capture_actors[key]
+                for name, row in actor['stages'].items():
+                    summed = total['stages'].setdefault(
+                        name, [0, 0.0, 0.0, 0.0])
+                    for index in (0, 1, 2):
+                        summed[index] += row[index]
+                    summed[3] = max(summed[3], row[3])
+                for name, count in actor['counts'].items():
+                    total['counts'][name] = total['counts'].get(name, 0) + count
             for name, value in self._queue_snapshot.items():
                 if isinstance(value, (int, float)) and not isinstance(value, bool):
                     self._capture_queue_maxima[name] = max(
@@ -351,6 +572,16 @@ class WorkerCombatDiagnostics(object):
             self._fail()
             return None
 
+    def _actor_rows(self, actors, limit=None):
+        ordered = sorted(actors.items(), key=lambda item: (
+            -item[1]['stages'].get('bot.actor', (0, 0.0))[1], item[0]))
+        if limit is not None:
+            ordered = ordered[:limit]
+        return [{'slice': key[0], 'bot': key[1],
+                 'stages': self._stage_rows(row['stages']),
+                 'counts': dict(row['counts'])}
+                for key, row in ordered]
+
     def _complete_capture(self, reason):
         self._completed.append({
             'capture': self.capture, 'trigger': self._reason,
@@ -360,6 +591,14 @@ class WorkerCombatDiagnostics(object):
             'frames': self._capture_frames,
             'stages': self._stage_rows(self._capture_totals),
             'counts': dict(self._capture_counts),
+            'actors': self._actor_rows(self._capture_actors),
+            'detail': {
+                'stride': self.detail_stride,
+                'selection': 'rotating_control_slot',
+                'frames': self._capture_detail_frames,
+                'stages': self._stage_rows(self._capture_detail_stages),
+                'counts': dict(self._capture_detail_counts),
+            },
             'queue_maxima': dict(self._capture_queue_maxima),
             'completed_wait': self._wait_summary(
                 self._capture_waits, self._capture_wait_count),
@@ -381,3 +620,4 @@ class WorkerCombatDiagnostics(object):
         self._stack = []
         self._queue.clear()
         self._receipts.clear()
+        self._reset_actor_frame()

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/world_collision.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/world_collision.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 """Dedented 0.8.2 horizontal world-collision law."""
 
+from gui.mods.offline_lan_0922.worker_diagnostics import (
+    observed, observed_ray)
+
 from gui.mods.offline_lan_0922.destructibles_sensor import (
 	_catalog_soft_static_path, _diagnostic_static_recast_1513,
 	_try_destroy_solid_hit, _vehicle_hull_bbox,
@@ -24,8 +27,11 @@ def _collide_horizontal(spaceID, start, end,
 	if broken_filter is _UNPREPARED_COLLISION_FILTER:
 		broken_filter = horizontal_collision_filter(start, end)
 	if broken_filter is None:
-		return BigWorld.wg_collideSegment(spaceID, start, end, 128)
-	return BigWorld.wg_collideSegment(
+		return observed_ray(
+			'native.motion.ray', BigWorld.wg_collideSegment,
+			spaceID, start, end, 128)
+	return observed_ray(
+		'native.motion.ray', BigWorld.wg_collideSegment,
 		spaceID, start, end, 128, broken_filter)
 
 
@@ -78,6 +84,7 @@ def _drivable_surface(collision, maximum_gradient=_MAX_DRIVABLE_GRADIENT):
 		return False
 
 
+@observed('motion.ground_profile')
 def _ground_profile(spaceID, Math, pos, sx, sz, sin_y, cos_y, direction,
 		look, segment_count=6, ground_plane=None):
 	"""Sample the lane that produced a lower-hull hit."""
@@ -170,6 +177,7 @@ def _hull_pose_endpoint(local_start, local_end, half_width,
 		start_forward + delta_forward * fraction)
 
 
+@observed('motion.ground_top')
 def _ground_top(spaceID, Math, pos, x, z, look, ground_plane=None):
 	"""Return support below the occupied lane, not an overhead deck.
 
@@ -193,15 +201,19 @@ def _ground_top(spaceID, Math, pos, x, z, look, ground_plane=None):
 		start = Math.Vector3(x, start_y, z)
 		end = Math.Vector3(x, pos.y - probe_down, z)
 		broken_filter = ground_collision_filter(x, z)
-		ground = (BigWorld.wg_collideSegment(spaceID, start, end, 128)
+		ground = (observed_ray(
+			'native.motion.ground', BigWorld.wg_collideSegment,
+			spaceID, start, end, 128)
 			if broken_filter is None else
-			BigWorld.wg_collideSegment(
+			observed_ray(
+				'native.motion.ground', BigWorld.wg_collideSegment,
 				spaceID, start, end, 128, broken_filter))
 		return None if ground is None else float(ground[0].y)
 	except (AttributeError, IndexError, TypeError, ValueError):
 		return None
 
 
+@observed('motion.ground_ahead')
 def _lane_ground_ahead(spaceID, Math, pos, start_x, start_z,
 		footprint_x, footprint_z, end_x, end_z, look, ground_plane=None):
 	"""Conservatively extend the ground observed inside the hull footprint.
@@ -306,6 +318,7 @@ def _raised_ray_has_wall(spaceID, Math, pos, x1, z1, x2, z2,
 	return False
 
 
+@observed('motion.solid_recast')
 def _solid_contact_cleared(spaceID, segment_start, segment_end, vel, td,
 		collision_filter=_UNPREPARED_COLLISION_FILTER):
 	"""Admit only a clear ray or a bounded chain of proved light props.
@@ -327,6 +340,7 @@ def _solid_contact_cleared(spaceID, segment_start, segment_end, vel, td,
 		[_WORLD_SOFT_RECAST_BUDGET])
 
 
+@observed('motion.destroy_recast')
 def _destroy_and_recast(spaceID, segment_start, segment_end, collision,
 		yaw, vel, td, crush_state=None, allow_kinetic=False,
 		kinetic_speed=None, commit_enabled=True,
@@ -411,6 +425,7 @@ def check_horizontal_collision(bigworld, math_module, *args, **kwargs):
 			sys.modules['Math'] = old_math
 
 
+@observed('motion.world')
 def _check_horizontal_collision(spaceID, pos, yaw, vel, td=None,
 		airborne=False, dt=0.04, return_status=False,
 		allow_kinetic=False, kinetic_speed=None, commit_enabled=True,

--- a/tests/test_port_0922_bot_runtime.py
+++ b/tests/test_port_0922_bot_runtime.py
@@ -3833,7 +3833,9 @@ class BotRuntimeTests(unittest.TestCase):
                 if mode == 'broken':
                     raise RuntimeError('diagnostic clock failed')
                 return reads[0] * 0.000001
-            diagnostic = WorkerCombatDiagnostics(clock) if mode else None
+            diagnostic = (WorkerCombatDiagnostics(
+                clock, detail_stride=4 if mode == 'sampled' else 1)
+                          if mode else None)
             queries = []
             def lane(source, target):
                 queries.append(('lane', source['id'], target['network_id']))
@@ -3886,9 +3888,14 @@ class BotRuntimeTests(unittest.TestCase):
 
         baseline, unused = exercise(None)
         measured, traces = exercise('active')
+        sampled, sampled_traces = exercise('sampled')
         failed, unused = exercise('broken')
         self.assertEqual(baseline, measured)
+        self.assertEqual(baseline, sampled)
         self.assertEqual(baseline, failed)
+        detailed_frames = sum(row['detail_sampled'] for row in sampled_traces)
+        self.assertGreater(detailed_frames, 0)
+        self.assertLess(detailed_frames, len(sampled_traces))
         stages = set(name for row in traces for name in row['stages'])
         self.assertTrue({'bot.slice', 'bot.targets', 'bot.lane_service',
                          'bot.probe.lane'}.issubset(stages))

--- a/tests/test_port_0922_worker_diagnostics.py
+++ b/tests/test_port_0922_worker_diagnostics.py
@@ -1,4 +1,6 @@
 import importlib.util
+import itertools
+import threading
 from pathlib import Path
 import unittest
 
@@ -12,6 +14,177 @@ spec.loader.exec_module(diagnostics)
 
 
 class WorkerCombatDiagnosticsTests(unittest.TestCase):
+    def test_detail_sampling_cannot_alias_render_cadence_or_split_catchup(self):
+        trace = diagnostics.WorkerCombatDiagnostics(lambda: 1.0, detail_stride=4)
+        rows = []
+
+        @diagnostics.observed('physics.fine')
+        def integrate():
+            diagnostics.count('integrations')
+
+        def update(frame):
+            if frame % 4:
+                return
+            trace.begin_control()
+            for step in range(2):
+                trace.begin_slice(0.05, step == 0, True)
+                trace.actor(11)
+                integrate()
+                trace.actor(None)
+
+        for frame in range(1, 65):
+            trace.begin_frame(frame, frame * 0.025, 'combat')
+            diagnostics.call(trace, 'bot.update', update, frame)
+            rows.append(trace.finish_frame())
+        self.assertEqual([4, 24, 44, 64], [row['frame'] for row in rows
+                                      if row['detail_sampled']])
+        for row in rows:
+            if row['slices']:
+                self.assertEqual([row['detail_sampled']] * 2,
+                                 [step['detail'] for step in row['slices']])
+        trace.close()
+        summary = trace.drain_completed()[0]
+        self.assertEqual(64, summary['stages']['bot.update']['calls'])
+        self.assertEqual(4, summary['detail']['frames'])
+        self.assertEqual(8, summary['detail']['stages']['physics.fine']['calls'])
+        self.assertEqual(8, summary['detail']['counts']['integrations'])
+
+    def test_actor_substeps_separate_residual_work_and_shared_parent(self):
+        clock = iter((1.0, 1.001, 1.002, 1.004, 1.006, 1.010))
+        trace = diagnostics.WorkerCombatDiagnostics(lambda: next(clock))
+        trace.begin_frame(1, 20.0, 'projectiles')
+
+        @diagnostics.observed('physics.integrate')
+        def integrate():
+            diagnostics.count('integrations')
+            return 7
+
+        def update():
+            trace.begin_slice(0.1, True, True)
+            trace.actor(11)
+            self.assertEqual(7, integrate())
+            trace.actor(None)
+
+        diagnostics.call(trace, 'bot.slice', update)
+        row = trace.finish_frame()
+        actor = row['actors'][0]
+        self.assertEqual((1, 11), (actor['slice'], actor['bot']))
+        self.assertEqual(5.0, actor['stages']['bot.actor']['total_ms'])
+        self.assertEqual(3.0, actor['stages']['bot.actor']['self_ms'])
+        self.assertEqual(5.0, row['stages']['bot.slice']['self_ms'])
+        self.assertEqual({'integrations': 1}, actor['counts'])
+        self.assertEqual([{'slice': 1, 'elapsed_ms': 100.0,
+                           'control': True, 'publish_requested': True,
+                           'detail': True}], row['slices'])
+        self.assertIsNone(diagnostics.current())
+        trace.close()
+        self.assertEqual(11, trace.drain_completed()[0]['actors'][0]['bot'])
+
+    def test_exception_closes_actor_before_parent_and_releases_current(self):
+        clock = itertools.count(1.0, 0.001)
+        trace = diagnostics.WorkerCombatDiagnostics(lambda: next(clock))
+        trace.begin_frame(1, 20.0, 'projectiles')
+
+        def update():
+            trace.begin_slice(0.1, False, True)
+            trace.actor(21)
+            trace.phase('bot.motion_prepare')
+            diagnostics.count('attempted')
+            raise ValueError('original failure')
+
+        with self.assertRaisesRegex(ValueError, 'original failure'):
+            diagnostics.call(trace, 'bot.slice', update)
+        self.assertTrue(trace.enabled)
+        self.assertIsNone(diagnostics.current())
+        self.assertIsNone(trace._actor_token)
+        self.assertIsNone(trace._phase_token)
+        row = trace.finish_frame()
+        self.assertEqual(1, row['actors'][0]['counts']['attempted'])
+        self.assertIn('bot.slice', row['stages'])
+        self.assertIn('bot.motion_prepare', row['stages'])
+
+    def test_synchronous_reentry_restores_outer_observer(self):
+        outer = diagnostics.WorkerCombatDiagnostics(lambda: 1.0)
+        inner = diagnostics.WorkerCombatDiagnostics(lambda: 2.0)
+        outer.begin_frame(1, 20.0, 'projectiles')
+        inner.begin_frame(1, 20.0, 'projectiles')
+
+        def native_with_callback():
+            self.assertIs(outer, diagnostics.current())
+            diagnostics.call(inner, 'callback', diagnostics.count, 'inner')
+            self.assertIs(outer, diagnostics.current())
+            diagnostics.count('outer')
+
+        diagnostics.call(outer, 'native', native_with_callback)
+        self.assertEqual({'outer': 1}, outer.finish_frame()['counts'])
+        self.assertEqual({'inner': 1}, inner.finish_frame()['counts'])
+        self.assertIsNone(diagnostics.current())
+
+    def test_background_helper_cannot_borrow_the_frame_observer(self):
+        trace = diagnostics.WorkerCombatDiagnostics(lambda: 1.0)
+        trace.begin_frame(1, 20.0, 'combat')
+        results = []
+
+        @diagnostics.observed('background')
+        def background():
+            results.append(diagnostics.current())
+            diagnostics.count('background_work')
+
+        def frame_work():
+            thread = threading.Thread(target=background)
+            thread.start()
+            thread.join()
+            self.assertIs(trace, diagnostics.current())
+            diagnostics.count('frame_work')
+
+        diagnostics.call(trace, 'frame', frame_work)
+        row = trace.finish_frame()
+        self.assertEqual([None], results)
+        self.assertEqual({'frame_work': 1}, row['counts'])
+        self.assertNotIn('background', row['stages'])
+
+    def test_actor_and_geometry_storage_are_bounded_and_reset_each_frame(self):
+        trace = diagnostics.WorkerCombatDiagnostics(lambda: 1.0)
+        trace.begin_frame(1, 20.0, 'projectiles')
+
+        def update():
+            trace.begin_slice(0.1, True, True)
+            for bot in range(diagnostics.MAX_ACTOR_SLICES + 20):
+                trace.actor(bot)
+                trace.geometry('hull', (1, 2, 3))
+                trace.geometry('hull', (1, 2, 3))
+            trace.actor(None)
+            for key in range(diagnostics.MAX_GEOMETRY_KEYS + 20):
+                trace.geometry('ray', key)
+
+        diagnostics.call(trace, 'bot.slice', update)
+        self.assertEqual(diagnostics.MAX_GEOMETRY_KEYS, len(trace._geometry))
+        row = trace.finish_frame()
+        self.assertEqual(diagnostics.MAX_ACTOR_SLICES, row['actors_tracked'])
+        self.assertEqual(diagnostics.MAX_FRAME_ACTORS_REPORTED,
+                         len(row['actors']))
+        self.assertEqual(1, row['actors'][0]['counts']['hull_same_geometry_in_slice'])
+        self.assertGreater(row['counts']['geometry_tracking_overflow'], 0)
+        trace.begin_frame(2, 20.1)
+        self.assertEqual({}, trace._actors)
+        self.assertEqual(set(), trace._geometry)
+        trace.finish_frame()
+        trace.close()
+        self.assertEqual(diagnostics.MAX_CAPTURE_ACTORS,
+                         len(trace.drain_completed()[0]['actors']))
+
+    def test_unhashable_geometry_does_not_change_the_observed_operation(self):
+        trace = diagnostics.WorkerCombatDiagnostics(lambda: 1.0)
+        trace.begin_frame(1, 20.0, 'collision')
+
+        def operation():
+            trace.geometry('box', [1, 2, 3])
+            return 'clear'
+
+        self.assertEqual('clear', diagnostics.call(trace, 'motion', operation))
+        self.assertEqual(1, trace.finish_frame()['counts'][
+            'geometry_tracking_unavailable'])
+
     def test_nested_stages_separate_total_and_self_time(self):
         clock = iter((1.0, 1.010, 1.030, 1.050))
         trace = diagnostics.WorkerCombatDiagnostics(lambda: next(clock))

--- a/tests/test_port_0922_worker_diagnostics.py
+++ b/tests/test_port_0922_worker_diagnostics.py
@@ -185,6 +185,17 @@ class WorkerCombatDiagnosticsTests(unittest.TestCase):
         self.assertEqual(1, trace.finish_frame()['counts'][
             'geometry_tracking_unavailable'])
 
+    def test_shared_geometry_repetition_stays_inside_its_authority_slice(self):
+        trace = diagnostics.WorkerCombatDiagnostics(lambda: 1.0)
+        trace.begin_frame(1, 20.0, 'collision')
+        for unused in range(2):
+            trace.begin_slice(0.05, True, True)
+            trace.geometry('shared_ray', (1, 2, 3))
+            trace.geometry('shared_ray', (1, 2, 3))
+        counts = trace.finish_frame()['counts']
+        self.assertEqual(4, counts['shared_ray_queries'])
+        self.assertEqual(2, counts['shared_ray_same_geometry_in_slice'])
+
     def test_nested_stages_separate_total_and_self_time(self):
         clock = iter((1.0, 1.010, 1.030, 1.050))
         trace = diagnostics.WorkerCombatDiagnostics(lambda: next(clock))

--- a/tests/test_port_0922_world_collision.py
+++ b/tests/test_port_0922_world_collision.py
@@ -95,6 +95,38 @@ class _ItemMatrix(object):
 
 class WorldCollisionTests(unittest.TestCase):
 
+    def test_combat_timing_preserves_recasts_and_every_native_argument(self):
+        from gui.mods.offline_lan_0922 import worker_diagnostics
+
+        def snapshot(result):
+            verdict, native = result
+            calls = []
+            for call in native.call_args_list:
+                calls.append(tuple(
+                    (value.x, value.y, value.z) if isinstance(value, _Vector)
+                    else value for value in call.args))
+            return verdict, calls
+
+        for centers, wall in (((2.0,), None), ((2.0, 5.0), 8.0),
+                              ((2.0, 3.0, 4.0, 5.0, 6.0), None)):
+            with self.subTest(centers=centers, wall=wall):
+                baseline = snapshot(self._run_soft_recast(centers, wall))
+                diagnostic = worker_diagnostics.WorkerCombatDiagnostics(
+                    lambda: 1.0)
+                diagnostic.begin_frame(1, 10.0, 'collision')
+                measured = snapshot(worker_diagnostics.call(
+                    diagnostic, 'bot.physics', self._run_soft_recast,
+                    centers, wall))
+                row = diagnostic.finish_frame()
+                self.assertEqual(baseline, measured)
+                self.assertEqual(len(measured[1]),
+                                 sum(value['calls'] for name, value in
+                                     row['stages'].items() if name in (
+                                         'native.motion.ray',
+                                         'native.destructible.ray')))
+                self.assertIn('motion.destroy_recast', row['stages'])
+                self.assertIsNone(worker_diagnostics.current())
+
     def setUp(self):
         destructibles_sensor.set_diagnostics(False)
 

--- a/tools/benchmark_bot_workload.py
+++ b/tools/benchmark_bot_workload.py
@@ -18,9 +18,11 @@ import random
 import statistics
 import sys
 import time
+import types
+from unittest import mock
 
 
-def make_runtime(checkout, map_name):
+def make_runtime(checkout, map_name, scenario='navigation'):
     sys.path.insert(0, str(checkout / 'tests'))
     import test_port_0922_bot_runtime as fixtures
     from effective_params_fixture import bot_default_crew_factors
@@ -36,8 +38,32 @@ def make_runtime(checkout, map_name):
         height = graph['heights_mm'][iz * graph['width'] + ix]
         return None if height is None else height / 1000.0
 
+    formations = graph['spawn_formations']
+    if scenario == 'combat':
+        # Bring the opposing team within spotting range on valid shipped cells.
+        # This is a deterministic synthetic engagement, not captured input.
+        first = formations['1'][0]
+        second = formations['2'][0]
+        length = math.hypot(second[0] - first[0], second[2] - first[2])
+        offset = ((second[0] - first[0]) * 140.0 / length,
+                  (second[2] - first[2]) * 140.0 / length)
+        cells = [(graph['origin'][0] + (i % graph['width']) * graph['cell_size'],
+                  height / 1000.0,
+                  graph['origin'][1] + (i // graph['width']) * graph['cell_size'])
+                 for i, height in enumerate(graph['heights_mm'])
+                 if height is not None and graph['hazards'][i] == 0]
+        enemy = []
+        for point in formations['1']:
+            wanted = (point[0] + offset[0], point[2] + offset[1])
+            nearest = min(cells, key=lambda cell:
+                          (cell[0] - wanted[0]) ** 2 +
+                          (cell[2] - wanted[1]) ** 2)
+            cells.remove(nearest)
+            enemy.append(nearest + (math.atan2(-offset[0], -offset[1]),))
+        formations = {'1': formations['1'], '2': enemy}
+
     def spawn(team, slot):
-        point = graph['spawn_formations'][str(team)][slot]
+        point = formations[str(team)][slot]
         return tuple(point[:3]), point[3]
 
     equipment = fixtures._bot_equipment_contracts(module)
@@ -58,14 +84,85 @@ def make_runtime(checkout, map_name):
                              bot_authority_id=1, bots=roster))
     runtime.debug_logging = False
     for row in roster:
-        goal = graph['spawn_formations'][
+        goal = formations[
             '2' if row['team'] == 1 else '1'][row['slot']]
         runtime._server_orders[row['id']] = dict(
-            combat_mode='route', move_position=tuple(goal[:3]),
+            combat_mode='engage' if scenario == 'combat' else 'route',
+            move_position=tuple(goal[:3]),
             face_position=tuple(goal[:3]), aim_position=tuple(goal[:3]),
-            fire_allowed=False, shell_index=0, fire_range=500.0)
+            fire_allowed=scenario == 'combat', shell_index=0, fire_range=500.0)
+        if scenario == 'combat':
+            enemies = [other for other in roster if other['team'] != row['team']]
+            target = enemies[row['slot'] % len(enemies)]
+            runtime._server_orders[row['id']].update(
+                target_id=target['id'], target_kind='bot')
         runtime._server_order_tokens[row['id']] = 1
-    return runtime
+    return runtime, ground
+
+
+@contextlib.contextmanager
+def combat_native_queries(runtime, ground):
+    """Run production world/candidate/body code against deterministic natives.
+
+    The test scene contains terrain and one finite hard wall. The destructible
+    registry exercises streamed empty-cell reuse; positive destruction/recast
+    parity is covered by the world-collision and destructible tests.
+    """
+    import test_port_0922_destructibles as fixtures
+    from gui.mods.offline_lan_0922 import destructibles_sensor as sensor
+    from gui.mods.offline_lan_0922.battle_runtime import BattleRuntime
+    fixture = fixtures.DestructiblesCompatibilityTests()
+    unused_manager, unused_mapper, area, bigworld, math_module, unused_td = (
+        fixture._empty_catalog_scan_fixture())
+    queries = []
+    center_x = sum(state['x'] for state in runtime.states.values()) / 29.0
+    center_z = sum(state['z'] for state in runtime.states.values()) / 29.0
+    vector = math_module.Vector3
+
+    def collide(space, start, end, mask, *filters):
+        queries.append((space, (start.x, start.y, start.z),
+                        (end.x, end.y, end.z), mask, len(filters)))
+        if abs(start.x - end.x) < 1e-9 and abs(start.z - end.z) < 1e-9:
+            height = ground(start.x, start.z)
+            if height is not None and min(start.y, end.y) <= height <= max(start.y, end.y):
+                return vector(start.x, height, start.z), vector(0, 1, 0), 0
+            return None
+        if abs(end.z - start.z) > 1e-9:
+            fraction = (center_z - start.z) / (end.z - start.z)
+            hit_x = start.x + (end.x - start.x) * fraction
+            if 0.0 <= fraction <= 1.0 and abs(hit_x - center_x) <= 18.0:
+                return (vector(hit_x, start.y + (end.y - start.y) * fraction,
+                               center_z), vector(0, 0, -1), 75)
+        return None
+
+    bigworld.wg_collideSegment = collide
+    bigworld.wg_getMatInfoNearPoint = lambda *unused: (
+        False, vector(), vector(), 0, '', 0, 0)
+    bigworld.wg_getChunkDestrFilenames = lambda *unused: ()
+    bigworld.wg_getChunkMatrix = lambda *unused: types.SimpleNamespace(
+        translation=vector())
+    bigworld.time = lambda: runtime._sample_time_us / 1000000.0
+    area.chunkIDFromPosition = lambda unused: 22
+    authority = types.SimpleNamespace(is_destroyed=lambda *unused: False)
+    holder = types.SimpleNamespace(
+        _runtime=types.SimpleNamespace(bigworld=bigworld, math=math_module),
+        _avatar=types.SimpleNamespace(spaceID=1), _bots=runtime,
+        _destructibles=sensor, _bot_motion_kinds={},
+        _combat_diagnostics=runtime._combat_diagnostics,
+        _vector=lambda point: vector(*point),
+        _records={'bot:%d' % bot: {'ready': True, 'engine_id': bot}
+                  for bot in runtime.states},
+        _server_entity=lambda bot: types.SimpleNamespace(
+            typeDescriptor=runtime._descriptors[bot]))
+    runtime.motion_resolver = lambda *args, **kwargs: (
+        BattleRuntime._resolve_bot_motion(holder, *args, **kwargs))
+    runtime.destructible_body_scan = lambda *args: (
+        BattleRuntime._scan_bot_destructible_body(holder, *args))
+    with mock.patch.dict(sys.modules, {
+            'AreaDestructibles': area, 'BigWorld': bigworld, 'Math': math_module}), \
+            mock.patch.object(sensor, '_get_destr_authority', return_value=authority):
+        yield queries
+    sensor.set_catalog(None)
 
 
 def main():
@@ -73,11 +170,16 @@ def main():
     parser.add_argument('--checkout', type=Path,
                         default=Path(__file__).resolve().parents[1])
     parser.add_argument('--map', default='01_karelia')
+    parser.add_argument('--scenario', choices=('navigation', 'combat'),
+                        default='navigation')
     parser.add_argument('--seconds', type=float, default=30.0)
     parser.add_argument('--fps', type=float, default=30.0)
     parser.add_argument('--repeats', type=int, default=3)
     parser.add_argument('--snapshot', type=Path)
     parser.add_argument('--profile', type=Path)
+    parser.add_argument('--diagnostics', action='store_true')
+    parser.add_argument('--diagnostic-stride', type=int, default=4)
+    parser.add_argument('--diagnostic-summary', type=Path)
     args = parser.parse_args()
     if args.seconds <= 0 or args.fps <= 0 or args.repeats <= 0:
         parser.error('seconds, fps and repeats must be positive')
@@ -88,21 +190,51 @@ def main():
     for repeat in range(args.repeats):
         random.seed(17)
         with contextlib.redirect_stdout(io.StringIO()):
-            runtime = make_runtime(args.checkout.resolve(), args.map)
+            runtime, ground = make_runtime(
+                args.checkout.resolve(), args.map, args.scenario)
+            diagnostic = None
+            if args.diagnostics:
+                from gui.mods.offline_lan_0922.worker_diagnostics import WorkerCombatDiagnostics
+                diagnostic = WorkerCombatDiagnostics(
+                    time.perf_counter, capture_seconds=args.seconds + 1.0,
+                    detail_stride=args.diagnostic_stride)
+                runtime._combat_diagnostics = diagnostic
             messages = []
-            started = time.process_time()
-            if profiler is not None:
-                profiler.enable()
-            for frame in range(frames):
-                dt = 1.0 / args.fps
-                messages.extend(runtime.update(dt, 100.0 + (frame + 1) * dt))
-            if profiler is not None:
-                profiler.disable()
-            timings.append(time.process_time() - started)
+            query_context = (combat_native_queries(runtime, ground)
+                             if args.scenario == 'combat' else
+                             contextlib.nullcontext([]))
+            with query_context as native_queries:
+                started = time.process_time()
+                if profiler is not None:
+                    profiler.enable()
+                for frame in range(frames):
+                    dt = 1.0 / args.fps
+                    if diagnostic is not None:
+                        diagnostic.begin_frame(
+                            frame, 100.0 + (frame + 1) * dt, 'benchmark')
+                    outgoing = runtime.update(dt, 100.0 + (frame + 1) * dt)
+                    messages.extend(outgoing)
+                    for message in outgoing:
+                        for launch in message.get('launches', ()):
+                            runtime.ack_projectile_launch(
+                                launch['id'], launch['fire_seq'])
+                    if diagnostic is not None:
+                        if diagnostic.finish_frame() is None:
+                            raise RuntimeError('diagnostic capture failed')
+                if profiler is not None:
+                    profiler.disable()
+                timings.append(time.process_time() - started)
+            if diagnostic is not None:
+                diagnostic.close()
+                captures = diagnostic.drain_completed()
+                if args.diagnostic_summary:
+                    args.diagnostic_summary.write_text(json.dumps(captures))
             snapshot = {
                 'messages': messages, 'probes': runtime.probe_totals(),
                 'decisions': runtime._decision_counts,
             }
+            if args.scenario == 'combat':
+                snapshot['native_queries'] = native_queries
             if result is not None and snapshot != result:
                 raise RuntimeError('deterministic workload changed across repeats')
             result = snapshot
@@ -113,10 +245,15 @@ def main():
         profiler.dump_stats(str(args.profile))
     print(json.dumps({
         'map': args.map, 'bots': 29, 'frames': frames,
+        'scenario': args.scenario,
         'cpu_median_seconds': statistics.median(timings),
         'decisions': sum(runtime._decision_counts.values()),
         'probes': runtime.probe_totals(), 'native_runtime_measured': False,
         'profile_enabled': profiler is not None,
+        'diagnostics_enabled': args.diagnostics,
+        'native_query_count': len(native_queries),
+        'launches': sum(len(message.get('launches', ())) for message in messages),
+        'projectile_terminals_simulated': False,
     }, sort_keys=True))
 
 


### PR DESCRIPTION
The existing combat captures leave substantial time inside the Bot loop, driver, motion resolver, and destructible body scan unattributed. This diagnostic build separates those paths into inline phases, Python helpers, and existing native calls, with per-Bot and per-catch-up-slice attribution.

- Sample one complete control callback per group of four, rotating the selected slot to avoid render/control cadence aliasing. Keep the existing coarse stages and lane ledger throughout each capture; expose matched sampled totals separately.
- Record decision/path refresh reasons, actual A* expansions, receipt rejection/reuse reasons, candidate counts, streaming misses, and repeated ray/hull geometry. Repetition alone does not assert safe cache reuse.
- Bound actor and geometry storage. Bind the observer only to synchronous work on the current thread and restore it on exceptions and reentry. Preserve original native arguments, guards, exceptions, collision budgets, and gameplay ordering.
- Extend the deterministic 29-Bot workload with nearby opposing teams, the real Python motion/destructible paths, and recorded native-call geometry. Document the sampling and evidence limits in COMPATIBILITY_REVIEW.md.

Validation on `75c2d522f9f9525a39acd496895064ff655d336e`:

- [Push CI](https://github.com/pengw0048/wot-offline-battles/actions/runs/34027725855) and [PR CI](https://github.com/pengw0048/wot-offline-battles/actions/runs/34027728036) both passed all three jobs. This includes 4,145 client tests, 494 launcher tests (2 skipped), CPython 2.7 packaging, validation of 116 archive members, and Windows server and bundled-launcher startup checks.
- Diagnostic-off/full/sampled/failing-clock Bot parity, actor ownership/reentry/thread isolation, capture sampling, native argument preservation, and per-slice geometry counters have focused regression coverage. All 96 client source files compile under CPython 2.7.18.
- A generated 29-Bot summary reassembles exactly; its longest emitted fragment is below 3 KiB.
- Independently inspected the [Windows diagnostic launcher](https://github.com/pengw0048/wot-offline-battles/actions/runs/34027725855/artifacts/9987675736): x64 PE, nested `0.9.22.zip`, one #1513 `.wotmod`, semantic version `0.6.10`, build identity `github-34027725855-1`. All 96 packaged client PYC modules structurally match the final source compiled under CPython 2.7.18, excluding only `co_filename`.


This branch includes main 1c94a81, including the already merged #74. This PR adds only the deeper diagnostic probes and their validation. It does not claim a Windows performance improvement. Native frame pacing and actual captured hotspot attribution require the exact Windows client.

Reproducible observer-cost check on the final source (three repeats each):

```bash
git worktree add --detach /tmp/wot-hotspot-main 1c94a8163314e4475a66b7b507c0442ef1159739
PYTHONDONTWRITEBYTECODE=1 python3 tools/benchmark_bot_workload.py \
  --checkout /tmp/wot-hotspot-main --scenario combat --seconds 10 --repeats 3 \
  --snapshot /tmp/main.json
PYTHONDONTWRITEBYTECODE=1 python3 tools/benchmark_bot_workload.py \
  --scenario combat --seconds 10 --repeats 3 --snapshot /tmp/off.json
PYTHONDONTWRITEBYTECODE=1 python3 tools/benchmark_bot_workload.py \
  --scenario combat --seconds 10 --repeats 3 --diagnostics \
  --snapshot /tmp/sampled.json --diagnostic-summary /tmp/summary.json
```

`/tmp/wot-hotspot-main` is a detached checkout of main `1c94a8163314e4475a66b7b507c0442ef1159739`. All three snapshots match exactly: 300 frames, 29 Bots, 1,472 driver decisions, 649 acknowledged launch admissions, and all 49,095 native collision-call geometries. The sampled capture covers 25 control callbacks, 29 Bots, 80 stages, and 58 counters.

Median process CPU: main 3.090 s, probe branch with diagnostics off 3.469 s, sampled capture 3.916 s. This is approximately 1.3 ms/callback of inactive wrapper overhead plus 1.5 ms/callback while capturing, about 2.8 ms/callback combined in this synthetic Python workload. JSON log formatting/writing is outside this benchmark; the existing `diag_emit` stage measures that separately at runtime. These measurements establish observer cost, not a Windows FPS result or a reproduction of the captured combat scene.
