### PR TITLE
Route bots around a wreck instead of pushing it

### DIFF
--- a/src/res/scripts/client/gui/mods/offline_lan_0922/ai/driver.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/ai/driver.py
@@ -390,6 +390,53 @@ class LocalDriver(object):
 				continue
 		return None
 
+	def _static_hull_ahead(self, position, candidate_yaw, neighbours,
+			half_length, half_width):
+		"""Reject a candidate whose near hull sweep is occupied by a wreck.
+
+		Living traffic is deliberately not a steering veto: it clears by itself
+		and the simultaneous contact solver owns the impending collision. A
+		destroyed hull never moves and never yields, so a heading that ends
+		inside one is not a direction this tank can drive, and re-selecting it
+		is exactly the visible grind against a corpse. Only a neighbour that
+		explicitly reports itself dead is treated this way, so a caller that
+		does not publish aliveness keeps the previous behaviour.
+
+		The reach matches the reverse check: this is the space the hull is
+		about to enter, not a long-range forecast, so a wreck further along the
+		route never withdraws a heading that is still usable.
+		"""
+		reach = half_length * 1.6
+		sweep = (
+			float(position[0]) + math.sin(candidate_yaw) * reach * 0.5,
+			float(position[1]),
+			float(position[2]) + math.cos(candidate_yaw) * reach * 0.5)
+		sweep_length = half_length + reach * 0.5
+		for neighbour in neighbours or ():
+			if not isinstance(neighbour, dict) or neighbour.get('alive', True):
+				continue
+			other = self._neighbour_position(neighbour)
+			if other is None:
+				continue
+			try:
+				if abs(float(other[1]) - float(position[1])) > 5.0:
+					continue
+			except Exception:
+				pass
+			try:
+				other_yaw = float(neighbour.get('yaw', 0.0) or 0.0)
+				other_length = float(
+					neighbour.get('half_length', half_length) or half_length)
+				other_width = float(
+					neighbour.get('half_width', half_width) or half_width)
+				if self._obb_overlap(
+						sweep, float(candidate_yaw), sweep_length, half_width,
+						other, other_yaw, other_length, other_width):
+					return True
+			except Exception:
+				continue
+		return False
+
 	def _recovery_occupancy(self, position, yaw, direction, neighbours,
 			half_length, half_width):
 		"""Count occupied sampled poses in one in-place recovery turn."""
@@ -461,7 +508,9 @@ class LocalDriver(object):
 				return False
 		return True
 
-	def _choose_yaw(self, state, desired_yaw, direction_clear):
+	def _choose_yaw(self, state, desired_yaw, direction_clear,
+			position=None, neighbours=None,
+			half_length=3.5, half_width=1.7):
 		# Teammate proximity never replaces the route with a repulsion heading.
 		# Crossing priority is coordinated separately; real contact owns overlap.
 		candidates = []
@@ -479,7 +528,10 @@ class LocalDriver(object):
 		# Probe in score order and return the first fully viable direction. Most
 		# frames need one terrain ray set instead of probing all seven candidates.
 		for unused_score, candidate in candidates:
-			if self._clear(direction_clear, candidate):
+			if (self._clear(direction_clear, candidate) and
+					not (position is not None and self._static_hull_ahead(
+						position, candidate, neighbours,
+						half_length, half_width))):
 				state['steering_reason'] = (
 					'route' if abs(_angle_delta(candidate, desired_yaw)) <= 0.05
 					else 'obstacle')
@@ -687,11 +739,15 @@ class LocalDriver(object):
 		if (old_yaw is not None and state['plan_age'] < hold_seconds and
 				abs(_angle_delta(desired_yaw, old_yaw)) < 2.15 and
 				self._failure_penalty(state, old_yaw) <= 0.0 and
-				self._clear(direction_clear, old_yaw)):
+				self._clear(direction_clear, old_yaw) and
+				not self._static_hull_ahead(
+					position, old_yaw, neighbours,
+					own_half_length, own_half_width)):
 			chosen_yaw = old_yaw
 		if chosen_yaw is None:
 			chosen_yaw = self._choose_yaw(
-				state, desired_yaw, direction_clear)
+				state, desired_yaw, direction_clear, position, neighbours,
+				own_half_length, own_half_width)
 			state['plan_age'] = 0.0
 		if chosen_yaw is None:
 			# No forward ray is usable.  Start a timed recovery on the next tick

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
@@ -145,6 +145,7 @@ class TerrainGrid(object):
 		self._failed_edges = {}
 		self._static_hull_edges = {}
 		self._static_hull_key = None
+		self.static_hull_revision = 0
 
 	def _install_baked_graph(self, graph):
 		if (graph.get('format') != BAKED_FORMAT_NAME or
@@ -395,18 +396,21 @@ class TerrainGrid(object):
 				except Exception:
 					break
 
-	def _failed_edge_penalty(self, first_cell, second_cell, now):
-		key = tuple(sorted((first_cell, second_cell)))
-		# A published wreck never expires on a timer: it stays until the hull
-		# is retired from the roster.
-		penalty = self._static_hull_edges.get(key, 0.0)
+	def _failed_edge_timed_penalty(self, key, now):
 		value = self._failed_edges.get(key)
 		if value is None:
-			return penalty
+			return 0.0
 		if float(now) >= value[0]:
 			self._failed_edges.pop(key, None)
-			return penalty
-		return max(penalty, value[1])
+			return 0.0
+		return value[1]
+
+	def _failed_edge_penalty(self, first_cell, second_cell, now):
+		key = tuple(sorted((first_cell, second_cell)))
+		# A published wreck never expires on a timer: it stays marked until the
+		# hull leaves the roster.
+		return max(self._static_hull_edges.get(key, 0.0),
+		           self._failed_edge_timed_penalty(key, now))
 
 	def set_static_hulls(self, hulls):
 		"""Publish the destroyed hulls that now occupy baked navigation cells.
@@ -428,6 +432,7 @@ class TerrainGrid(object):
 		if key == self._static_hull_key:
 			return False
 		self._static_hull_key = key
+		self.static_hull_revision += 1
 		edges = {}
 		half_extent = self.cell_size * 0.5
 		for unused_id, x, z, yaw, half_length, half_width in key:
@@ -571,11 +576,28 @@ class TerrainGrid(object):
 		        self.segment_clear(start, end))
 
 	def path_has_penalty(self, path, now):
-		if not self._failed_edges and not self._static_hull_edges:
+		if not self._failed_edges:
 			return False
 		for index in range(len(path) - 1):
-			if self.segment_penalty(path[index], path[index + 1], now) > 0.0:
-				return True
+			for key in self._edge_keys_for_segment(path[index], path[index + 1]):
+				if self._failed_edge_timed_penalty(key, now) > 0.0:
+					return True
+		return False
+
+	def path_crosses_static_hull(self, path):
+		"""Return whether a planned path runs through a published wreck.
+
+		This is separate from the timed failure above because a wreck does not
+		expire. A caller retires a path once, when the hull set that invalidates
+		it is newer than the plan; re-planning with the same wrecks in place is
+		the best answer available even where the route still has to pass one.
+		"""
+		if not self._static_hull_edges:
+			return False
+		for index in range(len(path) - 1):
+			for key in self._edge_keys_for_segment(path[index], path[index + 1]):
+				if key in self._static_hull_edges:
+					return True
 		return False
 
 	def path_has_edge_penalty(self, path, edge_penalties):
@@ -1118,6 +1140,7 @@ class TerrainNavigator(object):
 		                        baked_graph=baked_graph)
 		self.paths = {}
 		self.path_times = {}
+		self.path_hull_revisions = {}
 		self.searches = {}
 		self.search_times = {}
 		self.bot_states = {}
@@ -1607,6 +1630,7 @@ class TerrainNavigator(object):
 		for key, _timestamp in ordered[:len(ordered) - 80]:
 			self.paths.pop(key, None)
 			self.path_times.pop(key, None)
+			self.path_hull_revisions.pop(key, None)
 
 	def _finish_search(self, key, search, now):
 		path = search.result or ()
@@ -1614,6 +1638,7 @@ class TerrainNavigator(object):
 		self.search_times.pop(key, None)
 		self.paths[key] = path
 		self.path_times[key] = float(now)
+		self.path_hull_revisions[key] = self.grid.static_hull_revision
 		if path:
 			self.search_completed += 1
 		else:
@@ -1760,19 +1785,33 @@ class TerrainNavigator(object):
 				owner, now)
 			# A probe can fail while distant chunks are still streaming. Successful
 			# paths are permanent for the battle; failed ones get another chance.
-			if (path and not self.grid.path_has_penalty(path, now) and
+			#
+			# The one exception is a wreck published after this plan, which
+			# retires it exactly once. A path replanned with the same hulls
+			# already marked is the best answer the graph has, even where it
+			# still has to run past one, so it must not be discarded and
+			# researched again on every following tick.
+			retired_by_hull = bool(
+				self.path_hull_revisions.get(key) !=
+				self.grid.static_hull_revision and
+				self.grid.path_crosses_static_hull(path))
+			if (path and not retired_by_hull and
+					not self.grid.path_has_penalty(path, now) and
 					not self.grid.path_has_edge_penalty(
 						path, hard_edge_penalties)):
 				self.path_times[key] = float(now)
+				self.path_hull_revisions[key] = self.grid.static_hull_revision
 				return key, path
 			if path:
 				del self.paths[key]
 				self.path_times.pop(key, None)
+				self.path_hull_revisions.pop(key, None)
 			else:
 				if float(now) - self.path_times.get(key, 0.0) < 8.0:
 					return key, path
 				del self.paths[key]
 				self.path_times.pop(key, None)
+				self.path_hull_revisions.pop(key, None)
 				self.grid.clear_negative_cache()
 		search = self.searches.get(key)
 		if search is None:
@@ -1790,6 +1829,8 @@ class TerrainNavigator(object):
 				path = (tuple(start), tuple(goal))
 				self.paths[key] = path
 				self.path_times[key] = float(now)
+				self.path_hull_revisions[key] = (
+					self.grid.static_hull_revision)
 				return key, path
 			# Moving tanks do not belong in a cached static terrain path. Including all
 			# 28 peers made every expansion scan transient positions, permanently baked

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
@@ -37,6 +37,11 @@ BLOCKED_STEP_REPLAN_SECONDS = 1.0
 BLOCKED_STEP_REPLAN_VERDICTS = 4
 BLOCKED_STEP_EDGE_TTL = 12.0
 BLOCKED_STEP_EDGE_PENALTY = 240.0
+# A destroyed vehicle is permanent static geometry, so a search must prefer a
+# real detour over the lane it occupies. The penalty stays soft, in the same
+# class as the other edge penalties, so a single-lane choke keeps a connected
+# graph and ends in an honest hold instead of an unplannable map.
+STATIC_HULL_EDGE_PENALTY = 240.0
 # LocalDriver deliberately owns short-lived contact recovery, but displacement
 # alone cannot detect a tank that rocks or circles without advancing its route.
 # Track progress towards the navigator's stable local target and, after a long
@@ -70,6 +75,32 @@ def _distance_2d(first, second):
 	dx = float(first[0]) - float(second[0])
 	dz = float(first[2]) - float(second[2])
 	return math.sqrt(dx * dx + dz * dz)
+
+
+def _hull_covers_cell(centre_x, centre_z, half_extent,
+		hull_x, hull_z, sine, cosine, half_length, half_width):
+	"""Return whether a hull box overlaps one axis-aligned graph cell square.
+
+	Testing the cell square rather than its centre matters: a 3.4 metre wide
+	hull can sit entirely between the centres of a four-metre bake and cover
+	neither of them while still blocking both.
+	"""
+	dx = float(hull_x) - float(centre_x)
+	dz = float(hull_z) - float(centre_z)
+	# The two cell axes, then the two hull axes: forward is (sin, cos) and the
+	# side is (cos, -sin), matching this module's atan2(x, z) yaw convention.
+	if abs(dx) > (half_extent + abs(sine) * half_length +
+			abs(cosine) * half_width):
+		return False
+	if abs(dz) > (half_extent + abs(cosine) * half_length +
+			abs(sine) * half_width):
+		return False
+	cell_radius = half_extent * (abs(sine) + abs(cosine))
+	if abs(dx * sine + dz * cosine) > half_length + cell_radius:
+		return False
+	if abs(dx * cosine - dz * sine) > half_width + cell_radius:
+		return False
+	return True
 
 
 class TerrainGrid(object):
@@ -112,6 +143,8 @@ class TerrainGrid(object):
 		self._edge_cache = {}
 		self._segment_cache = {}
 		self._failed_edges = {}
+		self._static_hull_edges = {}
+		self._static_hull_key = None
 
 	def _install_baked_graph(self, graph):
 		if (graph.get('format') != BAKED_FORMAT_NAME or
@@ -364,16 +397,68 @@ class TerrainGrid(object):
 
 	def _failed_edge_penalty(self, first_cell, second_cell, now):
 		key = tuple(sorted((first_cell, second_cell)))
+		# A published wreck never expires on a timer: it stays until the hull
+		# is retired from the roster.
+		penalty = self._static_hull_edges.get(key, 0.0)
 		value = self._failed_edges.get(key)
 		if value is None:
-			return 0.0
+			return penalty
 		if float(now) >= value[0]:
 			self._failed_edges.pop(key, None)
-			return 0.0
-		return value[1]
+			return penalty
+		return max(penalty, value[1])
+
+	def set_static_hulls(self, hulls):
+		"""Publish the destroyed hulls that now occupy baked navigation cells.
+
+		A wreck is exact new static geometry, not traffic: it never moves
+		again, so no plan through it can succeed and no amount of waiting
+		clears it. Marking the graph edges it occupies routes later searches
+		around it, refuses the direct shortcut, and drops the cached paths that
+		used to run through it. Only the cells the hull box really overlaps are
+		marked, so a wide road keeps every column the wreck does not occupy.
+
+		Returns whether the published set changed.
+		"""
+		key = tuple(sorted(
+			(int(hull[0]), round(float(hull[1]), 2), round(float(hull[2]), 2),
+			 round(float(hull[3]), 3), round(float(hull[4]), 2),
+			 round(float(hull[5]), 2))
+			for hull in hulls or ()))
+		if key == self._static_hull_key:
+			return False
+		self._static_hull_key = key
+		edges = {}
+		half_extent = self.cell_size * 0.5
+		for unused_id, x, z, yaw, half_length, half_width in key:
+			half_length = max(0.5, half_length)
+			half_width = max(0.3, half_width)
+			sine = math.sin(yaw)
+			cosine = math.cos(yaw)
+			radius = math.sqrt(half_length * half_length +
+			                   half_width * half_width)
+			first = self.cell_for((x - radius, 0.0, z - radius))
+			last = self.cell_for((x + radius, 0.0, z + radius))
+			for cell_z in range(first[1], last[1] + 1):
+				for cell_x in range(first[0], last[0] + 1):
+					centre = self.point_for((cell_x, cell_z), 0.0)
+					if not _hull_covers_cell(
+							centre[0], centre[2], half_extent,
+							x, z, sine, cosine, half_length, half_width):
+						continue
+					for step_z in (-1, 0, 1):
+						for step_x in (-1, 0, 1):
+							if step_x == 0 and step_z == 0:
+								continue
+							edges[tuple(sorted((
+								(cell_x, cell_z),
+								(cell_x + step_x, cell_z + step_z))))] = (
+									STATIC_HULL_EDGE_PENALTY)
+		self._static_hull_edges = edges
+		return True
 
 	def segment_penalty(self, start, end, now):
-		if not self._failed_edges:
+		if not self._failed_edges and not self._static_hull_edges:
 			return 0.0
 		penalty = 0.0
 		for key in self._edge_keys_for_segment(start, end):
@@ -486,7 +571,7 @@ class TerrainGrid(object):
 		        self.segment_clear(start, end))
 
 	def path_has_penalty(self, path, now):
-		if not self._failed_edges:
+		if not self._failed_edges and not self._static_hull_edges:
 			return False
 		for index in range(len(path) - 1):
 			if self.segment_penalty(path[index], path[index + 1], now) > 0.0:
@@ -913,7 +998,8 @@ class TerrainGrid(object):
 				            self._penalty(
 				                next_cell, avoid_points, prefer_clearance) +
 				            (self._failed_edge_penalty(current, next_cell, now)
-				             if self._failed_edges else 0.0) +
+				             if (self._failed_edges or
+				                 self._static_hull_edges) else 0.0) +
 				            local_penalty)
 				if next_cell not in cost_so_far or new_cost < cost_so_far[next_cell]:
 					cost_so_far[next_cell] = new_cost

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -8302,6 +8302,44 @@ class BotRuntime(object):
         self._ram_contacts = frozenset(current_ram_contacts)
         return reports
 
+    def _publish_static_hulls(self, players):
+        """Give the navigator this tick's wrecks as static graph geometry.
+
+        A destroyed vehicle is exact new world geometry that appears mid-round.
+        Without it the terrain graph keeps returning the lane the wreck now
+        occupies, so every following search, direct shortcut and cached path
+        still drives into it. The navigator recomputes only when this set
+        actually changes, which is once per death.
+        """
+        grid = getattr(self.navigator, 'grid', None)
+        publish = getattr(grid, 'set_static_hulls', None)
+        if not callable(publish):
+            return
+        hulls = []
+        for bot_id, state in self.states.items():
+            if state.get('alive', True):
+                continue
+            hulls.append((
+                int(bot_id), _number(state.get('x')), _number(state.get('z')),
+                _number(state.get('yaw')),
+                _number(state.get('half_length'), 3.5),
+                _number(state.get('half_width'), 1.7)))
+        for raw in players or ():
+            if (not isinstance(raw, dict) or raw.get('id') is None or
+                    raw.get('alive', True)):
+                continue
+            try:
+                shape = self._player_collision_profile(raw)['shape']
+                player_id = HUMAN_TARGET_ID_BASE + int(raw['id'])
+            except (TypeError, ValueError, KeyError, OverflowError):
+                # A human wreck without a resolved descriptor is still solid to
+                # the contact solver; it simply cannot be published this tick.
+                continue
+            hulls.append((
+                player_id, _number(raw.get('x')), _number(raw.get('z')),
+                _number(raw.get('yaw')), shape[1], shape[0]))
+        publish(hulls)
+
     @staticmethod
     def _target_velocity(target):
         if target is None:
@@ -10543,6 +10581,8 @@ class BotRuntime(object):
         shot_lanes_ready = True
         shot_lane_pending_pairs = 0
         neighbours = list(neighbours or []) + self._player_neighbours(players)
+        if refresh_control:
+            self._publish_static_hulls(players)
         # Native terrain and visibility probes run on BigWorld's render thread.
         # Build the local-overlap view lazily, only when a staggered decision is
         # due. It steers apart hulls which already touch; it never predicts

--- a/tests/test_port_0922_ai.py
+++ b/tests/test_port_0922_ai.py
@@ -1822,6 +1822,48 @@ class BotAiPortTests(unittest.TestCase):
         self.assertEqual(1.0, order['throttle'])
         self.assertAlmostEqual(0.0, order['target_yaw'])
 
+    def test_a_wreck_ahead_withdraws_that_heading_but_a_live_hull_does_not(
+            self):
+        wreck = {
+            'position': (0.0, 0.0, 8.0), 'yaw': 0.0,
+            'alive': False, 'half_length': 3.5, 'half_width': 1.7,
+        }
+        live = dict(wreck, alive=True)
+
+        against_live = LocalDriver().drive(
+            141, 0, (0.0, 0.0, 0.0), 0.0, 0.0, 0.1, (0.0, 0.0, 50.0),
+            (live,), lambda unused_yaw: True)
+        against_wreck = LocalDriver().drive(
+            142, 0, (0.0, 0.0, 0.0), 0.0, 0.0, 0.1, (0.0, 0.0, 50.0),
+            (wreck,), lambda unused_yaw: True)
+
+        # Living traffic clears by itself and the contact solver owns it.
+        self.assertAlmostEqual(0.0, against_live['target_yaw'])
+        self.assertEqual(1.0, against_live['throttle'])
+        # A corpse never clears, so the straight heading is not a direction the
+        # hull can drive and the fan must pick a real way around it.
+        self.assertGreater(abs(against_wreck['target_yaw']), 0.4)
+
+    def test_a_wreck_the_hull_is_wedged_against_stops_the_drive(self):
+        wreck = {
+            'position': (0.0, 0.0, 6.6), 'yaw': 0.0,
+            'alive': False, 'half_length': 3.5, 'half_width': 1.7,
+        }
+        # A lane too narrow to steer out of: every terrain-clear heading ends
+        # inside the wreck, so the only honest answer is to stop driving.
+        narrow_lane = lambda yaw: math.cos(yaw) > 0.88
+
+        order = LocalDriver().drive(
+            143, 0, (0.0, 0.0, 0.0), 0.0, 0.0, 0.1, (0.0, 0.0, 50.0),
+            (wreck,), narrow_lane)
+
+        self.assertEqual('blocked', order['recovery_mode'])
+        self.assertEqual(0.0, order['throttle'])
+        # The same lane without the corpse is still driven.
+        self.assertEqual('drive', LocalDriver().drive(
+            144, 0, (0.0, 0.0, 0.0), 0.0, 0.0, 0.1, (0.0, 0.0, 50.0),
+            (dict(wreck, alive=True),), narrow_lane)['recovery_mode'])
+
     def test_front_contact_does_not_divert_a_route_turn(self):
         driver = LocalDriver()
         position = (0.0, 0.0, 0.0)

--- a/tests/test_port_0922_navigation.py
+++ b/tests/test_port_0922_navigation.py
@@ -453,5 +453,99 @@ class ArenaRectangleClipTests(unittest.TestCase):
                 self.PROKHOROVKA_ARENA[2])
 
 
+class StaticHullNavigationTests(unittest.TestCase):
+    """A destroyed hull is exact static geometry the graph has to carry."""
+
+    @staticmethod
+    def _flat_graph(cell_size=4.0, cells=21):
+        directions = ((-1, -1), (0, -1), (1, -1), (-1, 0),
+                      (1, 0), (-1, 1), (0, 1), (1, 1))
+        links = []
+        for z in range(cells):
+            for x in range(cells):
+                links.append(sum(
+                    1 << index for index, (dx, dz) in enumerate(directions)
+                    if 0 <= x + dx < cells and 0 <= z + dz < cells))
+        return {
+            'format': 'offline-lan-0922-navgraph', 'version': 2,
+            'game_version': '0.9.22.0.1-cn-1513', 'map': '01_karelia',
+            'cell_size': cell_size, 'origin': (0.0, 0.0),
+            'bounds': (-1.0, -1.0, cells * cell_size, cells * cell_size),
+            'width': cells, 'height': cells,
+            'heights_mm': [0] * (cells * cells),
+            'links': links, 'hazards': [0] * (cells * cells),
+            'spawn_anchors': ((0.0, 0.0), (0.0, 0.0)),
+            'objective_bases': ((0.0, 0.0), (0.0, 0.0)),
+            'spawn_formations': {'1': (), '2': ()},
+            'routes': {'1': (), '2': ()},
+            'bake': {'max_grade': 0.30},
+        }
+
+    def _grid(self, cell_size=4.0):
+        return TerrainNavigator(
+            lambda *unused: None,
+            baked_graph=self._flat_graph(cell_size)).grid
+
+    def test_a_hull_between_cell_centres_still_marks_both_cells(self):
+        grid = self._grid()
+        # A 3.4 metre wide hull straddling the x=18 boundary of a four-metre
+        # bake covers neither the x=16 nor the x=20 cell centre. Ranking the
+        # cell square instead of its centre keeps both columns blocking.
+        self.assertTrue(grid.set_static_hulls(
+            ((7, 18.0, 40.0, 0.0, 3.5, 1.7),)))
+        edges = grid._static_hull_edges
+
+        self.assertEqual((16.0, 0.0, 40.0), grid.point_for((4, 10), 0.0))
+        self.assertEqual((20.0, 0.0, 40.0), grid.point_for((5, 10), 0.0))
+        # Both columns the hull straddles are entered through a marked edge.
+        self.assertIn(((4, 10), (5, 10)), edges)
+        self.assertIn(((3, 10), (4, 10)), edges)
+        self.assertIn(((5, 10), (6, 10)), edges)
+        # Only edges that touch the hull are marked; the next lane is free.
+        self.assertNotIn(((2, 10), (3, 10)), edges)
+        self.assertNotIn(((6, 10), (7, 10)), edges)
+        self.assertGreater(
+            grid.segment_penalty((18.0, 0.0, 32.0), (18.0, 0.0, 48.0), 0.0),
+            0.0)
+        self.assertFalse(
+            grid.dry_segment_clear((18.0, 0.0, 32.0), (18.0, 0.0, 48.0), 0.0))
+        # A lane the wreck does not reach stays free for everyone else.
+        self.assertEqual(
+            0.0,
+            grid.segment_penalty((8.0, 0.0, 32.0), (8.0, 0.0, 48.0), 0.0))
+
+    def test_an_unchanged_hull_set_is_not_recomputed(self):
+        grid = self._grid()
+        hulls = ((7, 20.0, 40.0, 0.0, 3.5, 1.7),)
+
+        self.assertTrue(grid.set_static_hulls(hulls))
+        edges = grid._static_hull_edges
+        self.assertFalse(grid.set_static_hulls(hulls))
+        self.assertIs(edges, grid._static_hull_edges)
+        self.assertTrue(grid.set_static_hulls(()))
+        self.assertEqual({}, grid._static_hull_edges)
+
+    def test_a_published_hull_retires_the_cached_path_through_it(self):
+        grid = self._grid()
+        path = ((20.0, 0.0, 32.0), (20.0, 0.0, 40.0), (20.0, 0.0, 48.0))
+
+        self.assertFalse(grid.path_has_penalty(path, 0.0))
+        grid.set_static_hulls(((7, 20.0, 40.0, 0.0, 3.5, 1.7),))
+        self.assertTrue(grid.path_has_penalty(path, 0.0))
+
+    def test_a_search_prefers_the_free_lane_beside_a_wreck(self):
+        grid = self._grid()
+        start = (20.0, 0.0, 20.0)
+        goal = (20.0, 0.0, 60.0)
+        grid.set_static_hulls(((7, 20.0, 40.0, 0.0, 3.5, 1.7),))
+
+        path = grid.plan(start, goal, prefer_clearance=False)
+
+        self.assertTrue(path)
+        self.assertFalse(grid.path_has_penalty(path, 0.0))
+        self.assertGreater(
+            max(abs(point[0] - 20.0) for point in path), 0.0)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_port_0922_navigation.py
+++ b/tests/test_port_0922_navigation.py
@@ -528,10 +528,36 @@ class StaticHullNavigationTests(unittest.TestCase):
     def test_a_published_hull_retires_the_cached_path_through_it(self):
         grid = self._grid()
         path = ((20.0, 0.0, 32.0), (20.0, 0.0, 40.0), (20.0, 0.0, 48.0))
+        clear = ((8.0, 0.0, 32.0), (8.0, 0.0, 48.0))
 
-        self.assertFalse(grid.path_has_penalty(path, 0.0))
+        self.assertFalse(grid.path_crosses_static_hull(path))
         grid.set_static_hulls(((7, 20.0, 40.0, 0.0, 3.5, 1.7),))
-        self.assertTrue(grid.path_has_penalty(path, 0.0))
+        self.assertTrue(grid.path_crosses_static_hull(path))
+        self.assertFalse(grid.path_crosses_static_hull(clear))
+        # A wreck is not a timed failure, so it must not be reported as one:
+        # the caller retires a plan once per hull revision instead.
+        self.assertFalse(grid.path_has_penalty(path, 0.0))
+
+    def test_a_sealed_route_is_researched_once_not_every_tick(self):
+        navigator = TerrainNavigator(
+            lambda *unused: None, baked_graph=self._flat_graph())
+        key = ('route', 1, 'direct', 0)
+        start = (20.0, 0.0, 20.0)
+        goal = (20.0, 0.0, 60.0)
+        navigator.next_target(1, start, goal, key, 0.0)
+        # Seal every lane so no replan can avoid the wrecks.
+        navigator.grid.set_static_hulls(tuple(
+            (index, 4.0 * index, 40.0, 0.0, 3.5, 2.1)
+            for index in range(21)))
+
+        searches = []
+        for tick in range(1, 61):
+            before = navigator.search_completed + navigator.search_failed
+            navigator.next_target(1, start, goal, key, tick * 0.1)
+            searches.append(
+                navigator.search_completed + navigator.search_failed - before)
+
+        self.assertLessEqual(sum(searches), 4)
 
     def test_a_search_prefers_the_free_lane_beside_a_wreck(self):
         grid = self._grid()

--- a/tests/test_port_0922_wreck_route.py
+++ b/tests/test_port_0922_wreck_route.py
@@ -1,0 +1,246 @@
+"""Route bots around a destroyed hull instead of grinding against it.
+
+A wreck is exact new static geometry: it never moves and no amount of waiting
+clears it.  The corridor below is authored once and used by both the baked
+navigation graph and the terrain probe, so the planner and the local driver
+agree about the walls and only the wreck is new information.
+"""
+
+import collections
+import math
+import sys
+import unittest
+
+import test_port_0922_bot_runtime as runtime_fixtures
+from effective_params_fixture import bot_default_crew_factors
+
+
+CELL = 2.0
+ORIGIN = (-40.0, -40.0)
+CELLS = 61
+# The synthetic probe stands in for a native hull sweep, so it keeps slightly
+# less clearance than the 1.7 metre hull half width the collision solver uses.
+CLEARANCE = 1.2
+WRECK = (0.0, 0.0, 22.0)
+START = (0.0, 0.0, -14.0)
+GOAL = (0.0, 0.0, 50.0)
+PARKED = (20.0, 0.0, 55.0)
+
+
+def _main_lane(x, z):
+    return -4.0 <= x <= 4.0 and -22.0 <= z <= 75.0
+
+
+def _in_corridor(x, z):
+    """One authored map: a main lane and a signposted bypass around it."""
+    return (
+        # Main lane running north. The wreck stands in it at z=22, between
+        # both connectors, and no hull can pass it inside an eight-metre lane.
+        _main_lane(x, z) or
+        # South connector on to the bypass.
+        (-4.0 <= x <= 26.0 and -6.0 <= z <= 12.0) or
+        # Bypass lane.
+        (16.0 <= x <= 26.0 and -6.0 <= z <= 44.0) or
+        # North connector back on to the main lane.
+        (-4.0 <= x <= 26.0 and 30.0 <= z <= 44.0))
+
+
+def _drivable(x, z):
+    return all(_in_corridor(x + dx, z + dz)
+               for dx, dz in ((0.0, 0.0), (CLEARANCE, 0.0),
+                              (-CLEARANCE, 0.0), (0.0, CLEARANCE),
+                              (0.0, -CLEARANCE)))
+
+
+def _corridor_graph():
+    graph = runtime_fixtures._graph()
+    directions = ((-1, -1), (0, -1), (1, -1), (-1, 0),
+                  (1, 0), (-1, 1), (0, 1), (1, 1))
+    open_cells = [
+        _drivable(ORIGIN[0] + x * CELL, ORIGIN[1] + z * CELL)
+        for z in range(CELLS) for x in range(CELLS)]
+    links = []
+    heights = []
+    for z in range(CELLS):
+        for x in range(CELLS):
+            if not open_cells[z * CELLS + x]:
+                links.append(0)
+                heights.append(None)
+                continue
+            heights.append(0)
+            mask = 0
+            for bit, (step_x, step_z) in enumerate(directions):
+                next_x, next_z = x + step_x, z + step_z
+                if (0 <= next_x < CELLS and 0 <= next_z < CELLS and
+                        open_cells[next_z * CELLS + next_x]):
+                    mask |= 1 << bit
+            links.append(mask)
+    graph.update({
+        'cell_size': CELL, 'origin': ORIGIN,
+        'bounds': (ORIGIN[0] - 1.0, ORIGIN[1] - 1.0,
+                   ORIGIN[0] + CELLS * CELL + 1.0,
+                   ORIGIN[1] + CELLS * CELL + 1.0),
+        'width': CELLS, 'height': CELLS,
+        'heights_mm': heights, 'links': links,
+        'hazards': [0] * (CELLS * CELLS),
+    })
+    return graph
+
+
+def _direction_probe(position, yaw, speed=0.0, descriptor=None,
+                     maximum_distance=None):
+    distance = (12.0 if maximum_distance is None else
+                min(12.0, max(1.0, float(maximum_distance))))
+    sine, cosine = math.sin(float(yaw)), math.cos(float(yaw))
+    travelled = 0.0
+    while travelled <= distance:
+        if not _drivable(float(position[0]) + sine * travelled,
+                         float(position[2]) + cosine * travelled):
+            return {'clear': False, 'collision': True, 'slope': 0.0}
+        travelled += 0.5
+    return {'clear': True, 'collision': False, 'slope': 0.0}
+
+
+class WreckRouteTests(unittest.TestCase):
+    def setUp(self):
+        self._gui_modules = dict(
+            (key, value) for key, value in sys.modules.items()
+            if key == 'gui' or key.startswith('gui.'))
+        self.module = runtime_fixtures._load()
+        original_factors = self.module.loadout.attribute_factors
+        self.module.loadout.attribute_factors = bot_default_crew_factors
+        self.addCleanup(setattr, self.module.loadout, 'attribute_factors',
+                        original_factors)
+
+    def tearDown(self):
+        for key in list(sys.modules):
+            if key == 'gui' or key.startswith('gui.'):
+                sys.modules.pop(key, None)
+        sys.modules.update(self._gui_modules)
+
+    def _seal_the_bypass(self):
+        """Retire the bypass so the wreck blocks the only route there is."""
+        module = sys.modules[__name__]
+        original = module._in_corridor
+        module._in_corridor = _main_lane
+        self.addCleanup(setattr, module, '_in_corridor', original)
+
+    def _drive_to_goal(self, wreck_at, seconds=75.0):
+        """Return ``(arrival_seconds, modes, furthest_east, runtime)``."""
+        runtime = self.module.BotRuntime(
+            1, descriptor_resolver=(
+                lambda unused: runtime_fixtures._combat_descriptor()),
+            direction_probe=_direction_probe,
+            ground_probe=lambda *unused: 0.0,
+            physics_ground_probe=lambda *unused: 0.0,
+            spawn_resolver=lambda team, slot: (
+                (START if slot == 0 else wreck_at), 0.0),
+            baked_graph=_corridor_graph(),
+            control_seconds=0.1,
+            visibility_probe=lambda *unused: False,
+            firing_lane_probe=lambda *unused: False)
+        runtime.battle_start({
+            'round_id': 1, 'map': '01_karelia', 'bot_authority_id': 1,
+            'bots': [{
+                'id': slot + 1, 'team': 1, 'slot': slot,
+                'name': 'Fixture', 'vehicle': 'fake',
+                'profile': {
+                    'class_tag': 'heavyTank', 'dominant_role': 'brawler',
+                    'roles': {'brawler': 1.0}, 'shells': [],
+                    'desired_range': 200, 'fire_range': 500,
+                },
+            } for slot in range(2)],
+        })
+        runtime._apply_orders({
+            'bot_order_revision': 1, 'bot_orders': [
+                {'id': 1, 'move_position': GOAL, 'face_position': GOAL,
+                 'combat_mode': 'route', 'fire_allowed': False},
+                {'id': 2, 'move_position': wreck_at,
+                 'face_position': (wreck_at[0], 0.0, wreck_at[2] + 100.0),
+                 'combat_mode': 'artillery_hold',
+                 'throttle_override': 0.0, 'fire_allowed': False},
+            ],
+        })
+        wreck = runtime.states[2]
+        wreck['health'] = 0
+        wreck['alive'] = False
+        wreck['speed'] = 0.0
+
+        modes = collections.Counter()
+        original_drive = runtime.adapter.driver.drive
+
+        def drive(*args, **kwargs):
+            order = original_drive(*args, **kwargs)
+            if args[0] == 1:
+                modes[order['recovery_mode']] += 1
+            return order
+
+        runtime.adapter.driver.drive = drive
+        arrived = None
+        furthest_east = START[0]
+        self.pushing_frames = 0
+        for frame in range(1, int(seconds * 30) + 1):
+            runtime.update(1.0 / 30.0, frame / 30.0)
+            # The server owns terminal health; keep the wreck destroyed while
+            # the authority keeps simulating the round.
+            wreck['health'] = 0
+            wreck['alive'] = False
+            state = runtime.states[1]
+            furthest_east = max(furthest_east, state['x'])
+            if (int(state.get('movement_dir', 0)) > 0 and
+                    abs(state['x'] - wreck['x']) < 3.4 and
+                    abs(state['z'] - wreck['z']) < 7.0):
+                self.pushing_frames += 1
+            if (arrived is None and math.hypot(
+                    GOAL[0] - state['x'], GOAL[2] - state['z']) <= 3.0):
+                arrived = frame / 30.0
+        return arrived, modes, furthest_east, runtime
+
+    def test_a_clear_lane_is_still_driven_straight_through(self):
+        arrived, unused_modes, unused_east, unused_runtime = (
+            self._drive_to_goal(PARKED))
+        self.assertIsNotNone(
+            arrived, 'the control lane is no longer drivable')
+        self.assertLess(arrived, 20.0)
+
+    def test_a_wreck_in_the_lane_is_routed_around_not_pushed(self):
+        arrived, modes, furthest_east, unused_runtime = self._drive_to_goal(
+            WRECK)
+        self.assertIsNotNone(
+            arrived,
+            'the bot never reached its goal past the wreck; modes=%s' %
+            (dict(modes),))
+        # Reaching the goal by grinding through the wreck is not a pass: the
+        # bypass is the only route past it, so the hull must have driven it.
+        self.assertGreater(furthest_east, 12.0)
+
+    def test_a_sealed_lane_holds_instead_of_grinding_against_the_wreck(self):
+        self._seal_the_bypass()
+
+        arrived, unused_modes, unused_east, unused_runtime = (
+            self._drive_to_goal(WRECK))
+
+        # There is no way past, which is an honest hold. Driving into the
+        # corpse for the rest of the round is not.
+        self.assertIsNone(arrived)
+        self.assertEqual(0, self.pushing_frames)
+
+    def test_the_navigator_marks_the_wreck_cells(self):
+        unused_arrived, unused_modes, unused_east, runtime = (
+            self._drive_to_goal(WRECK, seconds=1.0))
+        grid = runtime.navigator.grid
+        self.assertTrue(grid._static_hull_edges)
+        wreck_cell = grid.cell_for(WRECK)
+        self.assertGreater(
+            grid.segment_penalty(
+                (0.0, 0.0, 16.0), (0.0, 0.0, 28.0), 1.0), 0.0)
+        self.assertEqual(
+            0.0,
+            grid.segment_penalty((0.0, 0.0, -20.0), (0.0, 0.0, -8.0), 1.0))
+        self.assertIn(
+            wreck_cell,
+            set(cell for edge in grid._static_hull_edges for cell in edge))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Reported behaviour

A Bot that meets a destroyed tank on its route drives into it and keeps
pushing, for the rest of the round.

## Reproduced

A corridor fixture whose walls are shared by the baked navigation graph and
the terrain probe, with a signposted bypass around the blocked lane:

| scene | `origin/main` | this branch |
| --- | --- | --- |
| wreck in the lane, bypass available | never arrives in 75 s | arrives, drives the bypass |
| wreck seals the only lane | 1576 frames driving into the corpse | 0 |
| clear lane (control) | arrives in ~11 s | unchanged |

## Why

A destroyed vehicle is exact new static geometry that appears in the middle
of a round, and only the contact solver knew about it. It correctly treats a
wreck as an immovable body, but nothing else did:

- the terrain graph kept returning the lane the wreck now occupies, and its
  cached path stayed valid for the whole battle;
- `dry_segment_clear` still accepted the crossing segment, so the direct
  shortcut aimed straight at it;
- the local steering fan ranked the heading that ends inside the hull as
  clear, because `direction_clear` only answers for terrain.

The only reaction left was the stuck timer, which reverses and then
re-selects the same lane. That loop is the grind.

## Change

**Navigation.** `BotRuntime._publish_static_hulls` gives the navigator the
current wrecks once per control tick — dead Bots and dead humans. The grid
marks the graph edges they occupy. Only the cells a hull box really overlaps
are marked, ranked against the cell **square** rather than its centre,
because a 3.4 m hull can sit between the centres of a four-metre bake and
cover neither while blocking both; a wider road keeps every column the wreck
does not occupy. The penalty is soft and in the same class as the existing
edge penalties, so a single-lane choke keeps a connected graph and ends in an
honest hold rather than an unplannable map.

This reuses the shared failed-edge consumers that were already wired into
A\*, the direct shortcut and cached-path invalidation. The producer that was
retired for causing a replan storm inferred bad edges from stalls — traffic
jams, pushes, pivots. This one is exact, monotone data, so replans are
bounded by deaths, not by stalls.

**Retire a plan once, not every tick.** A wreck is not a timed failure, so it
stays out of `path_has_penalty`. The grid keeps a hull revision and an
explicit `path_crosses_static_hull`; a cached plan is dropped exactly once,
when the hull set that invalidates it is newer than the plan, and the replan
is stamped and kept. Without this, a sealed lane cost 251 shared route
searches in 33 s because every replan produced a plan that still had to pass
the wreck.

**Driver.** A steering candidate whose near hull sweep is occupied by a wreck
is withdrawn, over the reach the reverse check already uses. Living traffic is
still not a steering veto — it clears by itself and the contact solver owns
the impending collision. Only a neighbour that reports itself dead is treated
this way, so a caller that does not publish aliveness keeps the previous
behaviour.

## Cost

A column of eight Bots already following one cached route when a tank dies in
front of them: one extra shared route replan. The join and recovery search
counts are unchanged from `origin/main` (26 vs 26 over the following 33 s).

## Not changed

- Friendly ram damage stays disabled and the collision response is untouched;
  `resolve_tank` already treated a wreck as immovable and still does.
- A human wreck stops being published at the same moment it stops being a
  collision body — when that player leaves the battle and the server clears
  `participating`. Consistent, and pre-existing.

## Validation

- `python3 -m unittest discover -s tests` — 4145 tests, OK.
- launcher suite — OK.
- CPython 2.7.18 source compile of `src/res/scripts/client` — 96 files, OK.
- Every new test was confirmed to fail on `origin/main`.

**Unproved:** no Windows evidence. The claim is that Bots route around a
corpse and stop pushing one they cannot pass; gameplay feel, frame pacing and
presentation on the exact #1513 client are not proved by this.

Branched from `3b602fd`; `main` has since added `1c94a81`, which touches no
file in this change.