### PR TITLE
Give the player's engine sound the copied rotation speed

### DIFF
--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -1548,6 +1548,11 @@ class BattleRuntime(object):
 
     def __init__(self, runtime=None):
         self._runtime = runtime
+        # Keep stable callable objects alive for the native #1513 data-link
+        # setters.  Re-reading a bound method would create a temporary object.
+        self._local_vehicle_speed_link = self._read_local_vehicle_speed
+        self._local_vehicle_rotation_speed_link = \
+            self._read_local_vehicle_rotation_speed
         self._config = None
         self._worker_mode = False
         self._start_message = None
@@ -1708,6 +1713,8 @@ class BattleRuntime(object):
         self._local_native_stabilised_matrix = None
         self._local_camera_velocity = None
         self._local_engine_mode = None
+        self._local_engine_state = None
+        self._local_engine_audio_report = None
         self._spectated_engine_id = None
         self._local_grind = 0
         self._local_motion_soft_block = False
@@ -2018,6 +2025,8 @@ class BattleRuntime(object):
         self._local_native_stabilised_matrix = None
         self._local_camera_velocity = None
         self._local_engine_mode = None
+        self._local_engine_state = None
+        self._local_engine_audio_report = None
         self._spectated_engine_id = None
         self._local_grind = 0
         self._local_motion_soft_block = False
@@ -6142,9 +6151,82 @@ class BattleRuntime(object):
         self._run_optional_feature(
             'local body swinging', self._bind_local_body_swinging,
             (entity, model))
+        self._run_optional_feature(
+            'local engine audio motion',
+            self._bind_local_engine_audio_motion, (entity,))
         self._runtime.compatibility.bind_vehicle_pose_sources(
             self._avatar, entity)
         self._local_model = model
+        return True
+
+    def _read_local_vehicle_speed(self):
+        return float(self._local_speed)
+
+    def _read_local_vehicle_rotation_speed(self):
+        return float(self._local_turn_speed)
+
+    def _report_local_engine_audio(self, available, error=None):
+        """Publish one line per distinct player engine-audio motion outcome."""
+        record = (bool(available), None if error is None else str(error))
+        if record == self._local_engine_audio_report:
+            return False
+        self._local_engine_audio_report = record
+        sys.stdout.write(
+            '[Offline LAN 0.9.22] PRESENTATION '
+            'local_engine_audio_motion=%s%s\n' % (
+                record[0],
+                '' if record[1] is None else ' error=%r' % (record[1],)))
+        return True
+
+    def _bind_local_engine_audio_motion(self, entity):
+        """Feed the player's stock engine audition from the copied motion.
+
+        Exact #1513 ``model_assembler.assembleDetailedEngineState`` links
+        ``vehicleSpeedLink`` and ``rotationSpeedLink`` to the native vehicle
+        filter's ``averageSpeed`` and ``averageRotationSpeed`` for every
+        vehicle, the player's own included.  The native
+        ``DetailedEngineState`` refresh reads both every tick.  The speed
+        link feeds ``RTPC_ext_speed_abs``/``_rel``, ``RTPC_ext_move`` and
+        the engine load; the rotation link feeds
+        ``RTPC_ext_rot_speed_abs``/``_rel``, and also raises the engine load
+        once the vehicle is actually translating.  This port drives the
+        player from a copied pose overlay and never feeds that filter, so
+        all of those inputs stayed at zero for the whole battle: a
+        stationary A/D pivot, whose only non-zero motion is rotation,
+        reached the engine sound as a parked tank.  Forward and reverse
+        motion still made noise only because the published
+        ``ownVehicleAuxPhysicsData`` RPM covers them, and #1513's simulated
+        engine law is speed-only.
+
+        Bot vehicles already publish these two links from copied motion, so
+        the player's own vehicle was the last one left on the dead native
+        filter.  A plain Python callable is the exact boundary #1513 accepts
+        here; ``DataLinks.createFloatLink`` only supports native data-link
+        owners.  This is presentation only: it never feeds authoritative
+        motion, and the copied speed and yaw rate carry the signs and units
+        (m/s, rad/s) the native normalisation expects.
+        """
+        appearance = getattr(entity, 'appearance', None)
+        detailed = getattr(appearance, 'detailedEngineState', None)
+        if detailed is None:
+            self._local_engine_state = None
+            self._report_local_engine_audio(
+                False, 'stock DetailedEngineState is unavailable')
+            return False
+        if detailed is self._local_engine_state:
+            return True
+        try:
+            detailed.vehicleSpeedLink = self._local_vehicle_speed_link
+            detailed.rotationSpeedLink = \
+                self._local_vehicle_rotation_speed_link
+        except Exception as error:
+            # A half-applied pair still reads the copied speed, so keep no
+            # ownership claim and let the next frame retry the whole rebind.
+            self._local_engine_state = None
+            self._report_local_engine_audio(False, error)
+            raise
+        self._local_engine_state = detailed
+        self._report_local_engine_audio(True)
         return True
 
     def _report_local_body_swinging(self, available, error=None):
@@ -6484,6 +6566,9 @@ class BattleRuntime(object):
         self._run_optional_feature(
             'local body swinging', self._bind_local_body_swinging,
             (entity, self._local_model))
+        self._run_optional_feature(
+            'local engine audio motion',
+            self._bind_local_engine_audio_motion, (entity,))
         self._sample_local_acceleration_swinging(entity, dt)
         self._run_optional_feature(
             'local track animation', self._update_local_tracks, (entity,))
@@ -6627,6 +6712,8 @@ class BattleRuntime(object):
         self._local_native_stabilised_matrix = None
         self._local_camera_velocity = None
         self._local_engine_mode = None
+        self._local_engine_state = None
+        self._local_engine_audio_report = None
         return True
 
     def _on_client_ready(self):
@@ -23832,6 +23919,8 @@ class BattleRuntime(object):
         self._local_native_stabilised_matrix = None
         self._local_camera_velocity = None
         self._local_engine_mode = None
+        self._local_engine_state = None
+        self._local_engine_audio_report = None
         self._spectated_engine_id = None
         self._local_grind = 0
         self._local_vertical_speed = 0.0

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -28584,3 +28584,153 @@ class LocalBodySwingingTests(unittest.TestCase):
         self.assertEqual([], writes)
         self.assertIsNone(battle._local_swinging_animator)
         self.assertIsNone(battle._local_swinging_restore)
+
+
+class LocalEngineAudioMotionTests(unittest.TestCase):
+    """The player's stock engine audition follows the copied LAN motion.
+
+    Exact #1513 ``model_assembler.assembleDetailedEngineState`` links
+    ``vehicleSpeedLink`` and ``rotationSpeedLink`` to the native vehicle
+    filter for every vehicle, the player's own included, and the native
+    refresh publishes the speed, rotation-speed and engine-load RTPCs from
+    them.  This port never drives that filter for the player, so a
+    stationary A/D pivot - whose only non-zero motion is rotation - reached
+    the engine sound as a parked tank.
+    """
+
+    def _battle(self, engine_state=True):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle.client = _Client()
+        battle._avatar = runtime.bigworld.avatar
+        entity = _Vehicle(10, _Descriptor(), _Vector(2, 3, 4), (0, 0, 0),
+                          {'health': 500})
+        if engine_state:
+            entity.appearance.detailedEngineState = types.SimpleNamespace(
+                vehicleSpeedLink=None, rotationSpeedLink=None)
+        runtime.bigworld.entities[10] = entity
+        battle._server = types.SimpleNamespace(vehicle_id=10)
+        battle._sender = types.SimpleNamespace(
+            forward=0.0, turn=0.0, handbrake=False,
+            send_current=lambda: True)
+        battle._local_position = (2.0, 3.0, 4.0)
+        battle._local_descriptor = entity.typeDescriptor
+        return battle, entity
+
+    def test_a_stationary_pivot_publishes_the_copied_rotation_speed(self):
+        battle, entity = self._battle()
+
+        with mock.patch('sys.stdout', io.StringIO()):
+            battle._attach_local_presentation()
+
+        detailed = entity.appearance.detailedEngineState
+        battle._local_speed = 0.0
+        battle._local_turn_speed = 0.45
+
+        # Exact #1513 normalises this by physics['rotationSpeedLimit'], which
+        # items.vehicles stores in radians per second, and feeds
+        # RTPC_ext_rot_speed_abs/_rel plus the engine load.
+        self.assertEqual(0.0, detailed.vehicleSpeedLink())
+        self.assertEqual(0.45, detailed.rotationSpeedLink())
+
+    def test_the_links_track_signed_forward_and_reverse_speed(self):
+        battle, entity = self._battle()
+
+        with mock.patch('sys.stdout', io.StringIO()):
+            battle._attach_local_presentation()
+
+        detailed = entity.appearance.detailedEngineState
+        battle._local_speed = -3.25
+        battle._local_turn_speed = -0.1
+
+        # The native refresh divides a negative speed by speedLimits[1], so
+        # the sign must survive the copied motion.
+        self.assertEqual(-3.25, detailed.vehicleSpeedLink())
+        self.assertEqual(-0.1, detailed.rotationSpeedLink())
+
+    def test_a_stock_appearance_refresh_does_not_drop_the_rebind(self):
+        battle, entity = self._battle()
+        with mock.patch('sys.stdout', io.StringIO()):
+            battle._attach_local_presentation()
+
+        rebuilt = types.SimpleNamespace(
+            vehicleSpeedLink=None, rotationSpeedLink=None)
+        entity.appearance.detailedEngineState = rebuilt
+        battle._local_turn_speed = 0.3
+
+        with mock.patch('sys.stdout', io.StringIO()):
+            battle._update_local_presentation(entity, 0.1)
+
+        self.assertIs(rebuilt, battle._local_engine_state)
+        self.assertEqual(0.3, rebuilt.rotationSpeedLink())
+
+    def test_an_unchanged_engine_state_is_not_rewritten_every_frame(self):
+        battle, entity = self._battle()
+        writes = []
+
+        class _CountingEngineState(object):
+            def __setattr__(self, name, value):
+                writes.append(name)
+                object.__setattr__(self, name, value)
+
+        counting = _CountingEngineState()
+        entity.appearance.detailedEngineState = counting
+        with mock.patch('sys.stdout', io.StringIO()):
+            battle._attach_local_presentation()
+        self.assertEqual(
+            ['vehicleSpeedLink', 'rotationSpeedLink'], writes)
+        del writes[:]
+
+        with mock.patch('sys.stdout', io.StringIO()):
+            battle._update_local_presentation(entity, 0.1)
+
+        self.assertEqual([], writes)
+
+    def test_a_missing_engine_state_reports_once_without_failing_startup(self):
+        battle, entity = self._battle(engine_state=False)
+        stream = io.StringIO()
+
+        with mock.patch('sys.stdout', stream):
+            self.assertTrue(battle._attach_local_presentation())
+            battle._update_local_presentation(entity, 0.1)
+
+        self.assertIsNone(battle._local_engine_state)
+        self.assertEqual(
+            1, stream.getvalue().count('local_engine_audio_motion=False'))
+        self.assertNotIn(
+            'local engine audio motion',
+            battle._disabled_optional_features)
+
+    def test_a_native_setter_failure_retires_only_this_feature(self):
+        battle, entity = self._battle()
+
+        class _RejectingEngineState(object):
+            def __setattr__(self, name, value):
+                raise RuntimeError('native link rejected: %s' % name)
+
+        entity.appearance.detailedEngineState = _RejectingEngineState()
+        stream = io.StringIO()
+
+        with mock.patch('sys.stdout', stream):
+            self.assertTrue(battle._attach_local_presentation())
+
+        self.assertIsNone(battle._local_engine_state)
+        self.assertIn('local_engine_audio_motion=False', stream.getvalue())
+        self.assertIn(
+            'local engine audio motion',
+            battle._disabled_optional_features)
+
+    def test_teardown_clears_the_bound_engine_state(self):
+        battle, entity = self._battle()
+        with mock.patch('sys.stdout', io.StringIO()):
+            battle._attach_local_presentation()
+        self.assertIsNotNone(battle._local_engine_state)
+
+        with mock.patch('sys.stdout', io.StringIO()):
+            self.assertTrue(battle._detach_local_presentation())
+
+        self.assertIsNone(battle._local_engine_state)
+        self.assertIsNone(battle._local_engine_audio_report)
+        # A native link that outlives teardown must still be answerable.
+        self.assertEqual(0.0, battle._read_local_vehicle_speed())
+        self.assertEqual(0.0, battle._read_local_vehicle_rotation_speed())


### PR DESCRIPTION
## Symptom

Turning in place with A/D makes no engine sound on the player's own tank.
Driving forward or backward does.

## Root cause (exact #1513 evidence)

`model_assembler.assembleDetailedEngineState` binds, for **every** vehicle
including the player's own:

```python
engineState.vehicleSpeedLink  = DataLinks.createFloatLink(vehicleFilter, 'averageSpeed')
engineState.rotationSpeedLink = DataLinks.createFloatLink(vehicleFilter, 'averageRotationSpeed')
```

The native `Vehicular.DetailedEngineState` refresh (`0x7958c0` in the pinned
`WorldOfTanks.exe`) reads both on every tick, and the audition update
(`0x793600`-`0x794000`) turns them into WWise RTPCs:

| RTPC | engine-state field | source link |
|---|---|---|
| `RTPC_ext_speed_abs` | `+0x19c` | `vehicleSpeedLink` (raw) |
| `RTPC_ext_speed_rel` / `_rel2` / `_rel_global` | `+0x1c0` | `vehicleSpeedLink` / speed limit |
| `RTPC_ext_move` | `+0x19c` | `vehicleSpeedLink` (`100` above 1 m/s, else `0`) |
| `RTPC_ext_rot_speed_abs` | `+0x174` | `rotationSpeedLink` (raw) |
| `RTPC_ext_rot_speed_rel` | `+0x178` | `rotationSpeedLink` / `rotationSpeedLimit` |
| `RTPC_ext_physic_load` / `_global` | `+0x1bc` | engine load, computed from both |

This port drives the player from a copied pose overlay and never feeds the
native `WGVehicleFilter`, so **all of those inputs read 0 for the entire
battle**. The only working engine input the player had was
`ownVehicleAuxPhysicsData[5]`, which the native player branch (selected by
`isPlayerVehicle` at `0x7959c7`) uses as the RPM. That value comes from
`_simulated_rpm_and_gear`, a copy of #1513's simulated engine law - the same
law as `_RpmStateHandler.__simRpm` and as the native NPC branch - and that
law is **speed-only**. A pure pivot has no linear speed, so it published
`rpm=0.0, gear=0` and every other input was already dead: the engine sound
heard a parked tank.

Bot vehicles already publish these two links from copied motion in
`native_remote_vehicle._bind_stock_motion`, so the player's own vehicle was
the last one left on the dead filter.

## Change

Bind the player's `detailedEngineState.vehicleSpeedLink` /
`rotationSpeedLink` to the copied local speed and yaw rate through the same
plain-callable boundary the Bot path uses, re-assert it after a stock
appearance refresh (`__prepareSystemsForDamagedVehicle` / compound refresh
rebuild the component), and clear the ownership claim on teardown. Units and
signs already match: the native divides a negative speed by `speedLimits[1]`
and normalises rotation by `physics['rotationSpeedLimit']`, which
`items.vehicles._readChassis` stores in radians per second.

Failures are contained by `_run_optional_feature`; a missing
`DetailedEngineState` reports once and leaves startup alone.

## Scope note

This also changes **forward and reverse** driving sound, not only pivots:
`RTPC_ext_speed_*`, `RTPC_ext_move` and `RTPC_ext_physic_load` go from
permanently dead to real values. A different engine timbre at speed is the
fix working, not a regression.

`VehicleAudition.setSpeedInfo(filter.angularSpeed, filter.strafeSpeed)`
reads the same dead filter but drives `RTPC_ext_slide_friction`, and the
copied physics has no lateral-slip scalar to publish, so it is deliberately
left alone.

## Validation

- `python3 -m unittest tests.test_port_0922_battle_runtime` - 798 tests, OK
  (7 new in `LocalEngineAudioMotionTests`)
- `python3 -m unittest discover -s tests` - 4143 tests, OK (pre-amend tree;
  the amend only rewrote a docstring)
- CPython 2.7 source compile gate over `src/res/scripts/client` - 96 files, OK

## Not proved here

Audibility is a Windows boundary. The static tree proves the published
values become non-zero; whether WWise turns them into a louder pivot is
acceptance on the exact client. Discriminating check: Bots run the same two
links on the native `isPlayerVehicle=False` path, so during a Bot pivot they
already get the identical RTPC set the player now gets. If Bots pivoting in
place are audible, the player will match. If Bots are also silent while
pivoting, rotation speed alone is not enough and the remaining gap is the
RPM itself - which on retail comes from cell physics and has no
client-provable law, so that is where client-side evidence stops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)