### PR TITLE
Keep one unusable live payload from freezing a replica

### DIFF
--- a/server/lan_battle_server.py
+++ b/server/lan_battle_server.py
@@ -77,6 +77,16 @@ BOT_PLANNER_INTERVAL_TICKS = max(1, int(round(TICK_HZ)))
 REPLICA_SNAPSHOT_HZ = 15.0
 REPLICA_SNAPSHOT_TICKS = max(
     1, int(round(TICK_HZ / REPLICA_SNAPSHOT_HZ)))
+# A lineage section is recorded as delivered when its payload reaches the
+# socket, and no replica acknowledges it. One frame a client could not consume
+# therefore used to cost it that section for the rest of the round: a lost
+# manifest froze its whole roster, and a lost destructible revision left it
+# drawing a wall the world no longer has. Republish each section on a slow
+# cadence so any single loss heals. The rosters are at most thirty rows; the
+# destructible ledger holds only what has actually been reported destroyed.
+BOT_MANIFEST_REFRESH_TICKS = max(1, int(round(TICK_HZ * 5.0)))
+BOT_ORDER_REFRESH_TICKS = max(1, int(round(TICK_HZ * 5.0)))
+DESTRUCTIBLE_REFRESH_TICKS = max(1, int(round(TICK_HZ * 10.0)))
 RESULT_RESET_SECONDS = 5.0
 MAX_TICK_FAILURE_DIAGNOSTIC_CHARS = 512
 MAX_CONSECUTIVE_TICK_FAILURES = 2
@@ -1975,6 +1985,9 @@ class Player(_EndpointSendMixin):
     bot_manifest_round_id_sent: int = -1
     bot_manifest_authority_epoch_sent: int = -1
     bot_manifest_revision_sent: int = -1
+    bot_manifest_tick_sent: int = -1
+    bot_order_tick_sent: int = -1
+    destructible_tick_sent: int = -1
 
 
 @dataclass
@@ -2000,6 +2013,9 @@ class SimulationWorker(_EndpointSendMixin):
     bot_manifest_round_id_sent: int = -1
     bot_manifest_authority_epoch_sent: int = -1
     bot_manifest_revision_sent: int = -1
+    bot_manifest_tick_sent: int = -1
+    bot_order_tick_sent: int = -1
+    destructible_tick_sent: int = -1
 
 
 class BattleState:
@@ -3194,11 +3210,17 @@ class BattleState:
             player.gun_pitch = 0.0
             player.bot_order_revision_sent = -1
             player.destructible_revision_sent = -1
+            player.bot_manifest_tick_sent = -1
+            player.bot_order_tick_sent = -1
+            player.destructible_tick_sent = -1
             player.battle_ready_round = 0
         worker = self.simulation_worker
         if worker is not None and worker.connected:
             worker.bot_order_revision_sent = -1
             worker.destructible_revision_sent = -1
+            worker.bot_manifest_tick_sent = -1
+            worker.bot_order_tick_sent = -1
+            worker.destructible_tick_sent = -1
             worker.battle_ready_round = 0
             worker.simulation_progress_round_id = 0
             worker.simulation_progress_authority_epoch = -1
@@ -12866,7 +12888,9 @@ class BattleState:
                 player.bot_manifest_revision_sent !=
                 snapshot_manifest_revision or
                 player.bot_manifest_authority_epoch_sent !=
-                snapshot_authority_epoch)
+                snapshot_authority_epoch or
+                snapshot_tick - player.bot_manifest_tick_sent >=
+                BOT_MANIFEST_REFRESH_TICKS)
             supports_lean_manifest = bool(
                 LEAN_SNAPSHOT_MANIFEST_CAPABILITY in player.capabilities)
             snapshot_due = bool(
@@ -12885,12 +12909,16 @@ class BattleState:
             needs_manifest = snapshot_lineage_due
             includes_manifest = bool(
                 needs_manifest or not supports_lean_manifest)
-            needs_orders = (
+            needs_orders = bool(
                 player.bot_order_revision_sent !=
-                snapshot_order_revision)
-            needs_destructibles = (
+                snapshot_order_revision or
+                snapshot_tick - player.bot_order_tick_sent >=
+                BOT_ORDER_REFRESH_TICKS)
+            needs_destructibles = bool(
                 player.destructible_revision_sent !=
-                snapshot_destructible_revision)
+                snapshot_destructible_revision or
+                snapshot_tick - player.destructible_tick_sent >=
+                DESTRUCTIBLE_REFRESH_TICKS)
             if (not includes_manifest or needs_orders or
                     needs_destructibles):
                 outgoing = dict(snapshot)
@@ -12916,7 +12944,12 @@ class BattleState:
                 if offered:
                     player.snapshot_round_id_sent = snapshot_round_id
                     player.snapshot_tick_sent = snapshot_tick
+                    if needs_orders:
+                        player.bot_order_tick_sent = snapshot_tick
+                    if needs_destructibles:
+                        player.destructible_tick_sent = snapshot_tick
                     if needs_manifest:
+                        player.bot_manifest_tick_sent = snapshot_tick
                         player.bot_manifest_round_id_sent = (
                             snapshot_round_id)
                         player.bot_manifest_authority_epoch_sent = (

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -7813,7 +7813,16 @@ class BattleRuntime(object):
                 self._bots.apply_snapshot(self._last_snapshot)
                 self._remember_ram_bot_snapshot(self._last_snapshot)
             if self._sync is not None:
-                self._sync.snapshot(message)
+                try:
+                    self._sync.snapshot(message)
+                except Exception as error:
+                    # The Bot state store has already consumed this frame.
+                    # Rolling the whole snapshot back here would leave the
+                    # authority poses permanently ahead of the replicas drawn
+                    # from them, which reads in game as frozen hulls that
+                    # shells pass through. Contain the presentation timeline
+                    # alone and keep the applied state.
+                    self._ignore_live_payload('snapshot_sync', error, message)
             return True
         except Exception as error:
             self._last_snapshot = previous_snapshot

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
@@ -149,6 +149,11 @@ SENDER_JOIN_TIMEOUT = 0.1
 SEND_STALL_TIMEOUT = 5.0
 LEAVE_SEND_TIMEOUT = 0.05
 RUNTIME_DROP_LOG_INTERVAL = 5.0
+# A live round publishes snapshots at 30 Hz. Two seconds without one accepted
+# is far outside ordinary jitter, and it is the exact condition that used to
+# be invisible: the replica keeps drawing its last accepted frame, so every Bot
+# stands still and nothing the player shoots reports back.
+SNAPSHOT_STALL_SECONDS = 2.0
 LEAVE_PAYLOAD = b'{"type":"leave"}\n'
 _BOT_STATE_WIRE_FIELDS = (
     'id', 'x', 'y', 'z', 'yaw', 'pitch', 'roll', 'aim_yaw', 'gun_pitch',
@@ -392,46 +397,6 @@ def _valid_player_siege_contract(player):
             (state in (0, 2) and time_left == 0))
 
 
-def _valid_bot_siege_contract(bot):
-    if not isinstance(bot, dict):
-        return False
-    fields = (
-        'siege_state', 'siege_time_left_ms',
-        'siege_transition_total_ms')
-    present = tuple(name in bot for name in fields)
-    if not any(present):
-        return True
-    if not all(present):
-        return False
-    return siege_mechanics.valid_wire_state(
-        bot.get('siege_state'), bot.get('siege_time_left_ms'),
-        transition_total_ms=bot.get('siege_transition_total_ms'))
-
-
-def _valid_stun_contract(vehicle):
-    if not isinstance(vehicle, dict):
-        return False
-    names = (
-        'stun_end_server_time_ms', 'stun_attacker_kind',
-        'stun_attacker_id')
-    present = tuple(name in vehicle for name in names)
-    if not any(present):
-        return True
-    if not all(present):
-        return False
-    end = _projectile_int_range(
-        vehicle.get('stun_end_server_time_ms'), 0, MAX_PROJECTILE_ID)
-    attacker_id = _projectile_int_range(
-        vehicle.get('stun_attacker_id'), 0, MAX_PROJECTILE_ID)
-    attacker_kind = vehicle.get('stun_attacker_kind')
-    if end is None or attacker_id is None:
-        return False
-    return bool(
-        (end == 0 and attacker_kind == '' and attacker_id == 0) or
-        (end > 0 and attacker_kind in ('player', 'bot') and
-         attacker_id > 0))
-
-
 def _canonical_angle(value, default=0.0):
     """Return one mathematically equivalent angle inside [-pi, pi].
 
@@ -511,27 +476,6 @@ def _valid_player_gun_checkpoint_contract(player):
             player.get('gun_checkpoint')) is not None)
 
 
-def _valid_bot_combat_contract(bot):
-    if not isinstance(bot, dict) or not isinstance(bot.get('critical'), dict):
-        return False
-    revision = _exact_int(bot.get('combat_revision'))
-    base_revision = _exact_int(bot.get('combat_base_revision'))
-    ack_seq = _exact_int(bot.get('combat_ack_seq'))
-    fire_elapsed = _exact_finite_float(bot.get('combat_fire_elapsed'))
-    fire_timer = _exact_finite_float(bot.get('combat_fire_timer'))
-    if (revision is None or revision < 0 or
-            base_revision is None or base_revision < 0 or
-            base_revision > revision or ack_seq is None or ack_seq < 0 or
-            fire_elapsed is None or fire_elapsed < 0.0 or
-            fire_elapsed > 10.0 or fire_timer is None or
-            fire_timer < 0.0 or fire_timer >= 1.0):
-        return False
-    if (not bool(bot['critical'].get('fire', False)) and
-            (fire_elapsed != 0.0 or fire_timer != 0.0)):
-        return False
-    return True
-
-
 def _valid_player_equipment_contract(state, required=False):
     """Validate the complete canonical player equipment ledger."""
     fields = {
@@ -577,47 +521,6 @@ def _valid_bot_equipment_contract(state, required=False):
     return True
 
 
-def _valid_player_environment_contract(state, required=False):
-    """Validate canonical pose, input and landing frontiers in a player row."""
-    required_fields = {
-        'input_seq', 'up_cosine', 'landing_observation_seq'}
-    if not required_fields.issubset(state):
-        return not required and not (set(state) & required_fields)
-    input_sequence = _projectile_int_range(
-        state.get('input_seq'), 0, MAX_PROJECTILE_ID)
-    landing_sequence = _projectile_int_range(
-        state.get('landing_observation_seq'), 0, MAX_PROJECTILE_ID)
-    up_cosine = _exact_finite_float(state.get('up_cosine'))
-    processed_sequence = input_sequence
-    if 'input_processed_seq' in state:
-        processed_sequence = _projectile_int_range(
-            state.get('input_processed_seq'), 0, MAX_PROJECTILE_ID)
-    pose_bounds = (
-        ('x', PLAYER_INPUT_WORLD_BOUNDS[0]),
-        ('y', PLAYER_INPUT_WORLD_BOUNDS[1]),
-        ('z', PLAYER_INPUT_WORLD_BOUNDS[2]),
-        ('pitch', MAX_PLAYER_INPUT_ATTITUDE),
-        ('roll', MAX_PLAYER_INPUT_ATTITUDE),
-        ('gun_pitch', MAX_PLAYER_GUN_PITCH),
-        ('speed', MAX_PLAYER_INPUT_SPEED),
-        ('forward', 1.0), ('turn', 1.0),
-    )
-    for name, bound in pose_bounds:
-        if name not in state:
-            continue
-        value = _exact_finite_float(state.get(name))
-        if value is None or abs(value) > bound:
-            return False
-    for name in ('yaw', 'aim_yaw'):
-        if name in state and _exact_finite_float(state.get(name)) is None:
-            return False
-    return bool(
-        input_sequence is not None and landing_sequence is not None and
-        processed_sequence is not None and
-        processed_sequence >= input_sequence and
-        up_cosine is not None and -1.0 <= up_cosine <= 1.0)
-
-
 def _mapping_list(value, limit=30):
     if not isinstance(value, (list, tuple)):
         return []
@@ -641,6 +544,20 @@ _RUNTIME_VEHICLE_INT_FIELDS = (
     'stun_end_server_time_ms')
 
 
+# Pose scalars reach native matrices and animation keyframes. Finiteness is
+# not enough there: a finite but absurd coordinate is still a bad native write,
+# and the client already clamps its own outbound input to exactly these bounds.
+_RUNTIME_VEHICLE_POSE_BOUNDS = {
+    'x': PLAYER_INPUT_WORLD_BOUNDS[0],
+    'y': PLAYER_INPUT_WORLD_BOUNDS[1],
+    'z': PLAYER_INPUT_WORLD_BOUNDS[2],
+    'pitch': MAX_PLAYER_INPUT_ATTITUDE,
+    'roll': MAX_PLAYER_INPUT_ATTITUDE,
+    'gun_pitch': MAX_PLAYER_GUN_PITCH,
+    'speed': MAX_PLAYER_INPUT_SPEED,
+}
+
+
 def _canonical_runtime_vehicle_row(value):
     """Canonicalize shared pose scalars once at the snapshot boundary."""
     if not isinstance(value, dict):
@@ -651,6 +568,9 @@ def _canonical_runtime_vehicle_row(value):
             continue
         parsed = _exact_finite_float(result.get(name))
         if parsed is None:
+            return None
+        bound = _RUNTIME_VEHICLE_POSE_BOUNDS.get(name)
+        if bound is not None and abs(parsed) > bound:
             return None
         result[name] = parsed
     for name in _RUNTIME_VEHICLE_INT_FIELDS:
@@ -1753,6 +1673,11 @@ class LANClient(object):
         self._landing_observation_queue = []
         self._projectile_lock = threading.Lock()
         self._runtime_drop_diagnostics = {}
+        self._degraded_snapshot_log = None
+        self._snapshot_accepted_time = None
+        self._snapshot_stall_log = None
+        self._snapshot_drop_streak = 0
+        self._snapshot_drop_reason = ''
 
     def start(self):
         with self._outbound_lock:
@@ -1783,6 +1708,11 @@ class LANClient(object):
             self._landing_observation_pending = None
             self._landing_observation_queue = []
             self._runtime_drop_diagnostics = {}
+            self._degraded_snapshot_log = None
+            self._snapshot_accepted_time = None
+            self._snapshot_stall_log = None
+            self._snapshot_drop_streak = 0
+            self._snapshot_drop_reason = ''
         with self._pending_lock:
             self._pending = []
             self._recv_buffer = u''
@@ -3970,6 +3900,7 @@ class LANClient(object):
         if latest_snapshot is not None:
             self._handle_message(latest_snapshot)
         now = _monotonic_time()
+        self._report_snapshot_stall(now)
         if self.connected and now - self._last_ping >= PING_INTERVAL:
             self._last_ping = now
             self._ping_seq += 1
@@ -4042,6 +3973,81 @@ class LANClient(object):
         self._combat_timing_round_id = round_id
         self._combat_timing_tick = server_tick
         return True
+
+    def _report_snapshot_stall(self, now):
+        """Say out loud that the replica is drawing a frozen world.
+
+        Discarding one live payload is recoverable and stays quiet. A replica
+        that has accepted nothing for seconds is not recovering: every Bot and
+        every remote hull is held at its last accepted pose while the round
+        keeps running, so the log has to carry the reason that produced it.
+        """
+        if self.phase != 'battle':
+            return False
+        accepted = self._snapshot_accepted_time
+        if accepted is None:
+            return False
+        age = now - accepted
+        if age < SNAPSHOT_STALL_SECONDS:
+            return False
+        last_time = self._snapshot_stall_log
+        if last_time is not None and now - last_time < RUNTIME_DROP_LOG_INTERVAL:
+            return False
+        self._snapshot_stall_log = now
+        print(
+            '[Offline LAN 0.9.22] snapshot stream stalled age=%.1fs '
+            'round=%s dropped=%d last_reason=%s' % (
+                age, self.round_id, int(self._snapshot_drop_streak),
+                self._snapshot_drop_reason or 'none'))
+        return True
+
+    def _log_degraded_snapshot(self, round_id, server_tick, manifest_stale,
+                               uncanonical_rows):
+        """Report an applied but degraded snapshot at the drop log cadence."""
+        now = _monotonic_time()
+        last_time = self._degraded_snapshot_log
+        if last_time is not None and now - last_time < RUNTIME_DROP_LOG_INTERVAL:
+            return False
+        self._degraded_snapshot_log = now
+        print(
+            '[Offline LAN 0.9.22] applied degraded snapshot round=%s tick=%s '
+            'manifest_lineage_stale=%s retained_rows=%d' % (
+                round_id, server_tick, bool(manifest_stale),
+                int(uncanonical_rows)))
+        return True
+
+    def _canonical_runtime_rows(self, rows, field):
+        """Canonicalize one runtime row list, retaining unusable rows.
+
+        ``SnapshotSync`` destroys any entity a snapshot omits, so dropping an
+        unusable row would delete that vehicle from the world - a worse
+        outcome than the stale pose it was meant to avoid. Substitute the last
+        accepted row for that id instead, and only omit a row that this replica
+        has never seen, which can create nothing and so destroys nothing.
+        """
+        previous_rows = {}
+        previous = self.last_snapshot
+        if isinstance(previous, dict):
+            for value in previous.get(field) or ():
+                if not isinstance(value, dict):
+                    continue
+                identity = _exact_int(value.get('id'))
+                if identity is not None:
+                    previous_rows[identity] = value
+        canonical = []
+        retained = 0
+        for value in rows:
+            row = _canonical_runtime_vehicle_row(value)
+            if row is not None:
+                canonical.append(row)
+                continue
+            identity = (_exact_int(value.get('id'))
+                        if isinstance(value, dict) else None)
+            substitute = previous_rows.get(identity)
+            if substitute is not None:
+                canonical.append(dict(substitute))
+            retained += 1
+        return canonical, retained
 
     def _runtime_recovery_enabled(self):
         """Return whether one bad live-state payload may be ignored.
@@ -4682,15 +4688,11 @@ class LANClient(object):
                 if has_bot_state_time else None)
             projectiles = message.get('projectiles')
             players = _strict_mapping_list(message.get('players'), 64)
-            player_runtime_rows_valid = players is not None
-            if player_runtime_rows_valid:
-                canonical_players = [
-                    _canonical_runtime_vehicle_row(value)
-                    for value in players]
-                player_runtime_rows_valid = all(
-                    value is not None for value in canonical_players)
-                if player_runtime_rows_valid:
-                    players = canonical_players
+            uncanonical_rows = 0
+            if players is not None:
+                players, retained = self._canonical_runtime_rows(
+                    players, 'players')
+                uncanonical_rows += retained
             prepared_players = (
                 self._prepare_player_static_inputs(
                     players, allow_lean=True,
@@ -4703,14 +4705,9 @@ class LANClient(object):
             player_effective_params_valid = bool(
                 prepared_players is not None and prepared_players[2])
             bots = _strict_mapping_list(message.get('bots'), 30)
-            bot_runtime_rows_valid = bots is not None
-            if bot_runtime_rows_valid:
-                canonical_bots = [
-                    _canonical_runtime_vehicle_row(value) for value in bots]
-                bot_runtime_rows_valid = all(
-                    value is not None for value in canonical_bots)
-                if bot_runtime_rows_valid:
-                    bots = canonical_bots
+            if bots is not None:
+                bots, retained = self._canonical_runtime_rows(bots, 'bots')
+                uncanonical_rows += retained
             manifest = None
             if 'bot_manifest' in message:
                 manifest = _strict_mapping_list(
@@ -4728,34 +4725,13 @@ class LANClient(object):
                     message.get('destructibles'), 4096)
                 destructible_revision = _exact_int(
                     message.get('destructible_revision'))
-            player_critical_contract = all(
-                _exact_int(player.get('critical_revision')) is not None and
-                _exact_int(player.get('critical_revision')) >= 0 and
-                _exact_int(player.get('critical_base_revision')) is not None and
-                _exact_int(player.get('critical_base_revision')) >= 0 and
-                _exact_int(player.get('critical_ack_seq')) is not None and
-                _exact_int(player.get('critical_ack_seq')) >= 0
-                for player in players or ())
-            player_equipment_contract = all(
-                _valid_player_equipment_contract(player, required=True)
-                for player in players or ())
-            player_environment_contract = all(
-                _valid_player_environment_contract(player, required=True)
-                for player in players or ())
-            player_siege_contract = all(
-                _valid_player_siege_contract(player)
-                for player in players or ())
-            player_gun_checkpoint_contract = all(
-                _valid_player_gun_checkpoint_contract(player)
-                for player in players or ())
-            player_stun_contract = all(
-                _valid_stun_contract(player) for player in players or ())
-            bot_combat_contract = all(
-                _valid_bot_combat_contract(bot) for bot in bots or ())
-            bot_siege_contract = all(
-                _valid_bot_siege_contract(bot) for bot in bots or ())
-            bot_stun_contract = all(
-                _valid_stun_contract(bot) for bot in bots or ())
+            # A live snapshot is produced by the trusted LAN server from the
+            # trusted worker's own publication, and both already enforce these
+            # ledgers before they ship. Re-deriving them here bought no
+            # recovery: the replica has no second source and no repair, so the
+            # only outcome of a failed re-derivation was discarding a frame it
+            # could have drawn. Round identity, ordering and the canonical
+            # numbers below remain enforced; handshake barriers stay strict.
             ledger_required = self.has_projectile_ledger()
             previous_bot_state_revision = None
             previous_snapshot = None
@@ -4788,17 +4764,17 @@ class LANClient(object):
                     previous_bot_state_time = _projectile_int_range(
                         previous_snapshot.get('bot_state_time_us'), 0,
                         MAX_MOTION_TIME_US)
+                    # Only the monotonic frontier decides whether this frame
+                    # is newer than the one already drawn. How the producer
+                    # paired its revision with its sample clock is its own
+                    # bookkeeping; asserting that pairing here discarded live
+                    # motion the replica had no other way to obtain.
                     motion_timing_valid = bool(
                         has_motion_time and
                         previous_motion_time is not None and
                         previous_bot_state_time is not None and
                         motion_time_us >= previous_motion_time and
-                        ((bot_state_revision ==
-                          previous_bot_state_revision and
-                          bot_state_time_us == previous_bot_state_time) or
-                         (bot_state_revision >
-                          previous_bot_state_revision and
-                          bot_state_time_us > previous_bot_state_time)))
+                        bot_state_time_us >= previous_bot_state_time)
             valid_projectiles = (not ledger_required or (
                 server_time_ms is not None and authority_epoch is not None and
                 projectile_revision is not None and
@@ -4806,16 +4782,26 @@ class LANClient(object):
                  authority_epoch >= self.authority_epoch) and
                 _valid_active_projectiles(
                     projectiles, authority_epoch, server_time_ms)))
+            retained_manifest = (
+                previous_snapshot.get('bot_manifest')
+                if previous_snapshot is not None else None)
             lean_manifest_valid = bool(
                 'bot_manifest' not in message and
                 LEAN_SNAPSHOT_MANIFEST_CAPABILITY in
                 self.server_capabilities and
-                previous_snapshot is not None and
-                isinstance(previous_snapshot.get('bot_manifest'), list) and
-                message.get('bot_authority_id') ==
-                previous_snapshot.get('bot_authority_id') and
-                message.get('authority_epoch') ==
-                previous_snapshot.get('authority_epoch'))
+                isinstance(retained_manifest, list))
+            # The server records a manifest as delivered when it writes it to
+            # the socket, so a replica that could not consume that one frame is
+            # never offered the lineage barrier again. Refusing every later
+            # lean snapshot then froze the whole roster for the rest of the
+            # round. Static identity one lineage behind is strictly better, so
+            # inherit the retained roster and say so.
+            lean_manifest_stale = bool(
+                lean_manifest_valid and
+                (message.get('bot_authority_id') !=
+                 previous_snapshot.get('bot_authority_id') or
+                 message.get('authority_epoch') !=
+                 previous_snapshot.get('authority_epoch')))
             invalid_reasons = []
             if server_tick is None or server_tick < 0:
                 invalid_reasons.append('server_tick')
@@ -4832,34 +4818,12 @@ class LANClient(object):
                 invalid_reasons.append('bot_authority')
             if players is None:
                 invalid_reasons.append('players')
-            elif not player_runtime_rows_valid:
-                invalid_reasons.append('player_runtime_numbers')
             if not player_outfits_valid:
                 invalid_reasons.append('player_outfits')
             if not player_effective_params_valid:
                 invalid_reasons.append('player_effective_params')
             if bots is None:
                 invalid_reasons.append('bots')
-            elif not bot_runtime_rows_valid:
-                invalid_reasons.append('bot_runtime_numbers')
-            if not player_critical_contract:
-                invalid_reasons.append('player_critical')
-            if not player_equipment_contract:
-                invalid_reasons.append('player_equipment')
-            if not player_environment_contract:
-                invalid_reasons.append('player_environment')
-            if not player_siege_contract:
-                invalid_reasons.append('player_siege')
-            if not player_gun_checkpoint_contract:
-                invalid_reasons.append('player_gun_checkpoint')
-            if not player_stun_contract:
-                invalid_reasons.append('player_stun')
-            if not bot_combat_contract:
-                invalid_reasons.append('bot_combat')
-            if not bot_siege_contract:
-                invalid_reasons.append('bot_siege')
-            if not bot_stun_contract:
-                invalid_reasons.append('bot_stun')
             if 'bot_manifest' in message and manifest is None:
                 invalid_reasons.append('bot_manifest')
             if ('bot_manifest' not in message and
@@ -4875,33 +4839,18 @@ class LANClient(object):
                      destructible_revision < 0)):
                 invalid_reasons.append('destructibles')
             if invalid_reasons:
+                self._snapshot_drop_streak += 1
+                self._snapshot_drop_reason = ','.join(invalid_reasons)
                 if self._ignore_runtime_payload(
                         kind, 'invalid_snapshot:' +
-                        ','.join(invalid_reasons), message):
+                        self._snapshot_drop_reason, message):
                     return
-                bad_bot = next((
-                    value for value in bots or ()
-                    if not _valid_bot_combat_contract(value)), None)
-                bad_bot_detail = None
-                if isinstance(bad_bot, dict):
-                    bad_bot_critical = bad_bot.get('critical')
-                    bad_bot_detail = {
-                        'id': bad_bot.get('id'),
-                        'revision': bad_bot.get('combat_revision'),
-                        'base': bad_bot.get('combat_base_revision'),
-                        'ack': bad_bot.get('combat_ack_seq'),
-                        'fire': (bad_bot_critical.get('fire')
-                                 if isinstance(bad_bot_critical, dict)
-                                 else None),
-                        'elapsed': bad_bot.get('combat_fire_elapsed'),
-                        'timer': bad_bot.get('combat_fire_timer'),
-                    }
                 print(
                     '[Offline LAN 0.9.22] snapshot rejected reasons=%s '
                     'round=%s tick=%s bot_revision=%s previous_revision=%s '
                     'motion_us=%s previous_motion_us=%s bot_state_us=%s '
                     'previous_bot_state_us=%s projectiles=%s bots=%s '
-                    'players=%s bad_bot=%s' % (
+                    'players=%s' % (
                         ','.join(invalid_reasons), round_id, server_tick,
                         bot_state_revision, previous_bot_state_revision,
                         motion_time_us, previous_motion_time,
@@ -4909,8 +4858,7 @@ class LANClient(object):
                         (len(projectiles)
                          if isinstance(projectiles, list) else None),
                         (len(bots) if bots is not None else None),
-                        (len(players) if players is not None else None),
-                        bad_bot_detail))
+                        (len(players) if players is not None else None)))
                 self.last_error = 'invalid snapshot message'
                 self.stop()
                 return
@@ -4937,9 +4885,15 @@ class LANClient(object):
                     lean_manifest_valid):
                 message = dict(message)
                 message['bot_manifest'] = [
-                    dict(value)
-                    for value in previous_snapshot.get('bot_manifest') or ()]
+                    dict(value) for value in retained_manifest or ()]
+            if lean_manifest_stale or uncanonical_rows:
+                self._log_degraded_snapshot(
+                    round_id, server_tick, lean_manifest_stale,
+                    uncanonical_rows)
             self.last_snapshot = message
+            self._snapshot_accepted_time = _monotonic_time()
+            self._snapshot_drop_streak = 0
+            self._snapshot_drop_reason = ''
             local_player = next((
                 player for player in players
                 if _exact_int(player.get('id')) == self.player_id), None)

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/snapshot_sync.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/snapshot_sync.py
@@ -486,18 +486,12 @@ class SnapshotSync(object):
             if (self._last_bot_state_time_us is not None and
                     bot_state_time_us < self._last_bot_state_time_us):
                 raise ValueError('bot state time regressed')
-            if (previous_revision is not None and
-                    revision == previous_revision and
-                    self._last_bot_state_time_us is not None and
-                    bot_state_time_us != self._last_bot_state_time_us):
-                raise ValueError(
-                    'unchanged bot revision changed its sample time')
-            if (previous_revision is not None and
-                    revision > previous_revision and
-                    self._last_bot_state_time_us is not None and
-                    bot_state_time_us <= self._last_bot_state_time_us):
-                raise ValueError(
-                    'advanced bot revision did not advance sample time')
+            # How the producer paired its revision with its sample clock is
+            # its own bookkeeping. Both frontiers are already fenced against
+            # regression above, which is all the presentation timeline needs.
+            # Asserting the pairing here raised out of the caller after it had
+            # already applied the same frame to the Bot state store, leaving
+            # the authority poses ahead of the replicas drawn from them.
         elif self._timed_bot_poses:
             raise ValueError('bot pose timing disappeared')
 

--- a/tests/test_port_0922.py
+++ b/tests/test_port_0922.py
@@ -6187,9 +6187,15 @@ class LANClientTests(unittest.TestCase):
         self.assertEqual('invalid snapshot message', client.last_error)
 
     def test_snapshot_bot_pose_timing_is_atomic_and_monotonic(self):
+        # Atomic: the pair is present or absent together, and once a round
+        # publishes it, it may not disappear. Monotonic: neither frontier may
+        # rewind. How the producer paired its revision with its sample clock
+        # is its own bookkeeping and no longer costs the replica a frame.
         _, client, _, _ = self._client()
         client.running = True
         client.round_id = 3
+        # A live round contains a rejected live payload instead of ending.
+        client.phase = 'battle'
         client._handle_message({
             'type': 'snapshot', 'protocol': 5,
             'round_id': 3, 'server_tick': 4,
@@ -6199,6 +6205,7 @@ class LANClientTests(unittest.TestCase):
             'players': [], 'bots': []})
         self.assertTrue(client.running)
 
+        # An unchanged revision whose sample clock moved is applied.
         client._handle_message({
             'type': 'snapshot', 'protocol': 5,
             'round_id': 3, 'server_tick': 5,
@@ -6206,57 +6213,51 @@ class LANClientTests(unittest.TestCase):
             'motion_time_us': 150000, 'bot_state_time_us': 100000,
             'bot_authority_id': -1, 'bot_manifest': [],
             'players': [], 'bots': []})
-        self.assertFalse(client.running)
-        self.assertEqual('invalid snapshot message', client.last_error)
+        self.assertTrue(client.running)
+        self.assertIsNone(client.last_error)
+        self.assertEqual(5, client.last_snapshot['server_tick'])
 
-        _, client, _, _ = self._client()
-        client.running = True
-        client.round_id = 3
+        # An advanced revision that repeats its sample time is applied too.
         client._handle_message({
             'type': 'snapshot', 'protocol': 5,
-            'round_id': 3, 'server_tick': 4,
-            'bot_state_revision': 5,
-            'motion_time_us': 120000, 'bot_state_time_us': 90000,
+            'round_id': 3, 'server_tick': 6,
+            'bot_state_revision': 6,
+            'motion_time_us': 160000, 'bot_state_time_us': 100000,
             'bot_authority_id': -1, 'bot_manifest': [],
             'players': [], 'bots': []})
+        self.assertTrue(client.running)
+        self.assertEqual(6, client.last_snapshot['server_tick'])
+
+        # A rewound sample clock is not newer than the frame already drawn.
         client._handle_message({
             'type': 'snapshot', 'protocol': 5,
-            'round_id': 3, 'server_tick': 5,
-            'bot_state_revision': 6,
+            'round_id': 3, 'server_tick': 7,
+            'bot_state_revision': 7,
+            'motion_time_us': 170000, 'bot_state_time_us': 90000,
             'bot_authority_id': -1, 'bot_manifest': [],
             'players': [], 'bots': []})
-        self.assertFalse(client.running)
-        self.assertEqual('invalid snapshot message', client.last_error)
+        self.assertTrue(client.running)
+        self.assertEqual(6, client.last_snapshot['server_tick'])
 
-        _, client, _, _ = self._client()
-        client.running = True
-        client.round_id = 3
+        # Timing may not disappear once the round has published it.
         client._handle_message({
             'type': 'snapshot', 'protocol': 5,
-            'round_id': 3, 'server_tick': 4,
-            'bot_state_revision': 5,
-            'motion_time_us': 120000, 'bot_state_time_us': 90000,
+            'round_id': 3, 'server_tick': 8,
+            'bot_state_revision': 8,
+            'bot_authority_id': -1, 'bot_manifest': [],
             'players': [], 'bots': []})
-        client._handle_message({
-            'type': 'snapshot', 'protocol': 5,
-            'round_id': 3, 'server_tick': 5,
-            'bot_state_revision': 6,
-            'motion_time_us': 150000, 'bot_state_time_us': 90000,
-            'players': [], 'bots': []})
-        self.assertFalse(client.running)
-        self.assertEqual('invalid snapshot message', client.last_error)
+        self.assertTrue(client.running)
+        self.assertEqual(6, client.last_snapshot['server_tick'])
 
-        _, client, _, _ = self._client()
-        client.running = True
-        client.round_id = 3
+        # Half a pair is never a valid header.
         client._handle_message({
             'type': 'snapshot', 'protocol': 5,
-            'round_id': 3, 'server_tick': 4,
-            'bot_state_revision': 5,
-            'motion_time_us': 120000,
+            'round_id': 3, 'server_tick': 9,
+            'bot_state_revision': 8, 'motion_time_us': 180000,
+            'bot_authority_id': -1, 'bot_manifest': [],
             'players': [], 'bots': []})
-        self.assertFalse(client.running)
-        self.assertEqual('invalid snapshot message', client.last_error)
+        self.assertTrue(client.running)
+        self.assertEqual(6, client.last_snapshot['server_tick'])
 
     def test_state_message_without_protocol_fails_closed(self):
         _, client, _, _ = self._client()

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -11970,7 +11970,11 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertEqual([], battle._event_journal)
         battle._fail.assert_not_called()
 
-    def test_snapshot_exception_keeps_last_good_state_and_round_running(self):
+    def test_presentation_timeline_failure_keeps_the_applied_frame(self):
+        # The Bot state store consumes the frame before the presentation
+        # timeline does. Rolling the whole snapshot back on a timeline failure
+        # left authority permanently ahead of the replicas drawn from it,
+        # which reads in game as frozen hulls that shells pass through.
         battle = BattleRuntime(_runtime())
         battle.state = 'running'
         battle._last_snapshot = {'server_tick': 7}
@@ -11978,7 +11982,20 @@ class BattleRuntimeContractTests(unittest.TestCase):
             snapshot=mock.Mock(side_effect=ValueError('stale snapshot')))
         battle._fail = mock.Mock()
 
-        self.assertFalse(battle.on_snapshot({'server_tick': 8}))
+        self.assertTrue(battle.on_snapshot({'server_tick': 8}))
+
+        self.assertEqual({'server_tick': 8}, battle._last_snapshot)
+        battle._fail.assert_not_called()
+
+    def test_snapshot_exception_keeps_last_good_state_and_round_running(self):
+        battle = BattleRuntime(_runtime())
+        battle.state = 'running'
+        battle._last_snapshot = {'server_tick': 7}
+        battle._apply_rules = mock.Mock(
+            side_effect=ValueError('broken rules'))
+        battle._fail = mock.Mock()
+
+        self.assertFalse(battle.on_snapshot({'server_tick': 8, 'rules': {}}))
 
         self.assertEqual({'server_tick': 7}, battle._last_snapshot)
         battle._fail.assert_not_called()

--- a/tests/test_port_0922_bot_runtime.py
+++ b/tests/test_port_0922_bot_runtime.py
@@ -483,6 +483,38 @@ class ServerBotStateRevisionTests(unittest.TestCase):
             'battle_result': copy.deepcopy(server.battle_result),
         }
 
+    def test_lost_lineage_sections_are_republished_on_a_cadence(self):
+        # Every lineage section is recorded as delivered when it is written to
+        # the socket. Without a periodic republication one frame a replica
+        # could not consume cost it that section for the whole round.
+        from lan_battle_server import (
+            BOT_MANIFEST_REFRESH_TICKS, LEAN_SNAPSHOT_MANIFEST_CAPABILITY)
+
+        server, unused_manifest_bot, unused_socket = self._server()
+        player = server.players[1]
+        player.capabilities = (LEAN_SNAPSHOT_MANIFEST_CAPABILITY,)
+        self.assertTrue(server.update_bot_states(
+            SIMULATION_WORKER_AUTHORITY_ID, self._publication(server, 1.0)))
+
+        def sent_snapshots():
+            return [json.loads(payload.decode('utf-8'))
+                    for payload in player.conn.payloads
+                    if json.loads(
+                        payload.decode('utf-8')).get('type') == 'snapshot']
+
+        server.tick_once(1.0 / 30.0)
+        self.assertIn('bot_manifest', sent_snapshots()[-1])
+
+        before = len(sent_snapshots())
+        for unused in range(4):
+            server.tick_once(1.0 / 30.0)
+        self.assertGreater(len(sent_snapshots()), before)
+        self.assertNotIn('bot_manifest', sent_snapshots()[-1])
+
+        server.tick += BOT_MANIFEST_REFRESH_TICKS
+        server.tick_once(1.0 / 30.0)
+        self.assertIn('bot_manifest', sent_snapshots()[-1])
+
     def test_revision_survives_player_departure_and_resets(self):
         server, manifest_bot, authority_socket = self._server()
         self.assertEqual(0, server.bot_state_revision)

--- a/tests/test_port_0922_lan_protocol.py
+++ b/tests/test_port_0922_lan_protocol.py
@@ -3,6 +3,7 @@ import math
 import os
 import re
 import sys
+import time
 from pathlib import Path
 import unittest
 from unittest import mock
@@ -17,8 +18,7 @@ from gui.mods.offline_lan_0922.lan_client import (
     LEAN_SNAPSHOT_MANIFEST_CAPABILITY, MAX_PROJECTILE_ID,
     _canonical_runtime_vehicle_row,
     _project_human_ram_armors, _projectile_wire_round,
-    _strict_projectile_effect,
-    _valid_player_environment_contract, project_bot_state)
+    _strict_projectile_effect, project_bot_state)
 from gui.mods.offline_lan_0922.authority_worker import (
     AuthorityWorkerLANClient)
 from gui.mods.offline_lan_0922.snapshot_sync import SnapshotSync
@@ -864,22 +864,6 @@ class LanProtocolTests(unittest.TestCase):
         self.assertIsNone(self.client.last_error)
         self.assertIn('events', self.client._runtime_drop_diagnostics)
 
-    def test_snapshot_missing_bot_combat_contract_keeps_last_good_state(self):
-        self.client.running = True
-        self.client._handle_message({
-            'type': 'snapshot', 'protocol': 5, 'round_id': 7,
-            'server_tick': 1,
-            'players': [{
-                'id': 1, 'critical_revision': 0,
-                'critical_base_revision': 0, 'critical_ack_seq': 0}],
-            'bots': [{'id': 11, 'health': 500, 'alive': True}],
-        })
-
-        self.assertTrue(self.client.running)
-        self.assertIsNone(self.client.last_error)
-        self.assertEqual('battle', self.client.phase)
-        self.assertIsNone(self.client.last_snapshot)
-
     def test_lean_snapshot_inherits_the_last_static_bot_manifest(self):
         self.client.server_capabilities = (
             LEAN_SNAPSHOT_MANIFEST_CAPABILITY,)
@@ -948,7 +932,90 @@ class LanProtocolTests(unittest.TestCase):
         self.assertIsNone(self.client.last_error)
         self.assertIs(accepted, self.client.last_snapshot)
 
-    def test_lean_snapshot_requires_existing_same_lineage_manifest(self):
+    def test_lean_snapshot_after_a_lineage_change_keeps_the_roster(self):
+        # The server records a manifest as delivered when it writes it, so a
+        # replica that could not consume that frame is never offered another.
+        # Refusing every later lean snapshot froze the whole roster; carrying
+        # the retained one keeps the round playable.
+        self.client.running = True
+        self.client.server_capabilities = (
+            LEAN_SNAPSHOT_MANIFEST_CAPABILITY,)
+        player = _snapshot_player()
+        manifest = [{'id': 11, 'vehicle': 'ussr:R11_MS-1'}]
+        first = {
+            'type': 'snapshot', 'protocol': 5, 'round_id': 7,
+            'server_tick': 1, 'bot_state_revision': 0,
+            'players': [player],
+            'bots': [{'id': 11, 'x': 1.0, 'y': 0.0, 'z': 2.0}],
+            'bot_manifest': manifest,
+            'bot_authority_id': -1, 'authority_epoch': 1,
+        }
+        drifted = dict(
+            first, server_tick=2, bot_state_revision=1, authority_epoch=2,
+            bots=[{'id': 11, 'x': 5.0, 'y': 0.0, 'z': 6.0}])
+        drifted.pop('bot_manifest')
+
+        self.client._handle_message(first)
+        self.client._handle_message(drifted)
+
+        self.assertTrue(self.client.running)
+        self.assertIsNone(self.client.last_error)
+        self.assertEqual(2, self.client.last_snapshot['server_tick'])
+        self.assertEqual(
+            manifest, self.client.last_snapshot['bot_manifest'])
+        self.assertEqual(5.0, self.client.last_snapshot['bots'][0]['x'])
+
+    def test_unusable_runtime_row_keeps_the_last_accepted_pose(self):
+        # SnapshotSync destroys any entity a snapshot omits, so an unusable
+        # row must not remove that vehicle and must not cost the whole frame.
+        self.client.running = True
+        self.client.server_capabilities = (
+            LEAN_SNAPSHOT_MANIFEST_CAPABILITY,)
+        player = _snapshot_player()
+        first = {
+            'type': 'snapshot', 'protocol': 5, 'round_id': 7,
+            'server_tick': 1, 'bot_state_revision': 0,
+            'players': [player],
+            'bots': [{'id': 11, 'x': 1.0, 'y': 0.0, 'z': 2.0},
+                     {'id': 12, 'x': 3.0, 'y': 0.0, 'z': 4.0}],
+            'bot_manifest': [], 'bot_authority_id': -1,
+        }
+        second = dict(
+            first, server_tick=2, bot_state_revision=1,
+            bots=[{'id': 11, 'x': float('nan'), 'y': 0.0, 'z': 2.0},
+                  {'id': 12, 'x': 9.0, 'y': 0.0, 'z': 4.0}])
+
+        self.client._handle_message(first)
+        self.client._handle_message(second)
+
+        self.assertTrue(self.client.running)
+        self.assertIsNone(self.client.last_error)
+        self.assertEqual(2, self.client.last_snapshot['server_tick'])
+        accepted = dict(
+            (row['id'], row) for row in self.client.last_snapshot['bots'])
+        self.assertEqual(sorted(accepted), [11, 12])
+        self.assertEqual(1.0, accepted[11]['x'])
+        self.assertEqual(9.0, accepted[12]['x'])
+
+    def test_poll_reports_a_stalled_snapshot_stream(self):
+        self.client.running = True
+        self.client.connected = False
+        self.client.bigworld = mock.Mock()
+        self.client.bigworld.callback.return_value = 1
+        self.client._snapshot_accepted_time = time.monotonic() - 4.0
+        self.client._snapshot_drop_streak = 7
+        self.client._snapshot_drop_reason = 'motion_timing'
+
+        with mock.patch('builtins.print') as printed:
+            self.client._poll()
+
+        reported = ' '.join(
+            str(call[0][0]) for call in printed.call_args_list)
+        self.assertIn('snapshot stream stalled', reported)
+        self.assertIn('dropped=7', reported)
+        self.assertIn('last_reason=motion_timing', reported)
+
+    def test_lean_snapshot_requires_a_manifest_and_worker_authority(self):
         self.client.running = True
         player = _snapshot_player()
         self.client.server_capabilities = (
@@ -983,85 +1050,6 @@ class LanProtocolTests(unittest.TestCase):
         self.assertTrue(missing.running)
         self.assertIsNone(missing.last_error)
         self.assertIsNone(missing.last_snapshot)
-
-    def test_snapshot_drops_non_exact_bot_combat_revisions(self):
-        cases = (
-            ('combat_revision', True),
-            ('combat_base_revision', True),
-            ('combat_ack_seq', True),
-            ('combat_base_revision', 2),
-            ('combat_ack_seq', -1),
-            ('combat_fire_elapsed', float('nan')),
-            ('combat_fire_elapsed', -0.1),
-            ('combat_fire_elapsed', 10.1),
-            ('combat_fire_timer', True),
-            ('combat_fire_timer', 1.0),
-        )
-        for field, value in cases:
-            client = LANClient(
-                '127.0.0.1', 28782, 'P', 'ussr:MS-1')
-            client.running = True
-            client.ready = True
-            client.phase = 'battle'
-            client.round_id = 7
-            client._send = lambda unused: True
-            bot = {
-                'id': 11, 'health': 500, 'alive': True,
-                'critical': {},
-                'combat_revision': 1, 'combat_base_revision': 1,
-                'combat_ack_seq': 0,
-                'combat_fire_elapsed': 0.0,
-                'combat_fire_timer': 0.0,
-            }
-            bot[field] = value
-
-            client._handle_message({
-                'type': 'snapshot', 'protocol': 5, 'round_id': 7,
-                'server_tick': 1,
-                'players': [{
-                    'id': 1, 'critical_revision': 0,
-                    'critical_base_revision': 0, 'critical_ack_seq': 0}],
-                'bots': [bot],
-            })
-
-            self.assertTrue(client.running, '%s=%r' % (field, value))
-            self.assertIsNone(client.last_error, '%s=%r' % (field, value))
-            self.assertEqual('battle', client.phase)
-            self.assertIsNone(client.last_snapshot)
-
-    def test_snapshot_drops_missing_or_non_object_bot_critical(self):
-        for critical in (None, [], 'broken'):
-            client = LANClient('127.0.0.1', 28782, 'P', 'ussr:MS-1')
-            client.running = True
-            client.ready = True
-            client.phase = 'battle'
-            client.round_id = 7
-            client._send = lambda unused: True
-            bot = {
-                'id': 11, 'health': 500, 'alive': True,
-                'critical': critical,
-                'combat_revision': 1, 'combat_base_revision': 1,
-                'combat_ack_seq': 0,
-                'combat_fire_elapsed': 0.0,
-                'combat_fire_timer': 0.0,
-            }
-            if critical is None:
-                bot.pop('critical')
-
-            client._handle_message({
-                'type': 'snapshot', 'protocol': 5, 'round_id': 7,
-                'server_tick': 1,
-                'players': [{
-                    'id': 1, 'critical_revision': 0,
-                    'critical_base_revision': 0,
-                    'critical_ack_seq': 0}],
-                'bots': [bot],
-            })
-
-            self.assertTrue(client.running)
-            self.assertIsNone(client.last_error)
-            self.assertEqual('battle', client.phase)
-            self.assertIsNone(client.last_snapshot)
 
     def test_loading_ready_and_battle_live_form_one_transition(self):
         self.client.phase = 'loading'
@@ -1400,33 +1388,20 @@ class ShippingClientInputContractTests(unittest.TestCase):
         self.assertFalse(self.client._adopt_player_input_frontier([
             _snapshot_player(input_seq=8, input_processed_seq=6)]))
 
-    def test_snapshot_validation_covers_the_terminal_frontier_relation(self):
-        self.assertTrue(_valid_player_environment_contract(
-            _snapshot_player(input_seq=4), required=True))
-        self.assertTrue(_valid_player_environment_contract(
-            _snapshot_player(input_seq=4, input_processed_seq=6),
-            required=True))
-        self.assertFalse(_valid_player_environment_contract(
-            _snapshot_player(input_seq=4, input_processed_seq=3),
-            required=True))
-        self.assertFalse(_valid_player_environment_contract(
-            _snapshot_player(input_seq=4, input_processed_seq=True),
-            required=True))
-
-    def test_snapshot_validation_covers_pose_number_boundaries(self):
-        self.assertTrue(_valid_player_environment_contract(
+    def test_canonical_rows_keep_pose_numbers_inside_native_bounds(self):
+        self.assertIsNotNone(_canonical_runtime_vehicle_row(
             _snapshot_player(
                 x=1.0, y=-2.0, z=3.0, yaw=math.pi,
                 pitch=0.25, roll=-0.25, aim_yaw=-math.pi,
-                gun_pitch=0.1, speed=12.5, forward=1.0, turn=-1.0),
-            required=True))
+                gun_pitch=0.1, speed=12.5, forward=1.0, turn=-1.0)))
         for field, value in (
                 ('x', float('nan')), ('z', float('inf')),
                 ('yaw', float('-inf')), ('speed', 1000.0),
-                ('forward', 1.01), ('turn', -1.01)):
+                ('x', 5000.0), ('gun_pitch', 3.0),
+                ('pitch', 1.5)):
             with self.subTest(field=field, value=value):
-                self.assertFalse(_valid_player_environment_contract(
-                    _snapshot_player(**{field: value}), required=True))
+                self.assertIsNone(_canonical_runtime_vehicle_row(
+                    _snapshot_player(**{field: value})))
 
     def test_runtime_vehicle_numbers_are_canonicalized_once(self):
         source = {

--- a/tests/test_port_0922_snapshot_sync.py
+++ b/tests/test_port_0922_snapshot_sync.py
@@ -1086,7 +1086,7 @@ class SnapshotSyncTests(unittest.TestCase):
         self.assertEqual(['destroy'],
                          [event['type'] for event in destroyed])
 
-    def test_bot_pose_timing_is_atomic_monotonic_and_revision_bound(self):
+    def test_bot_pose_timing_is_atomic_and_monotonic(self):
         bot = player(7, 0.0)
         self.sync.manifest({'round_id': 1, 'bots': [bot]})
         self.sync.snapshot({
@@ -1095,26 +1095,33 @@ class SnapshotSyncTests(unittest.TestCase):
             'motion_time_us': 100000, 'bot_state_time_us': 90000,
             'bots': [bot]})
 
-        with self.assertRaisesRegex(ValueError, 'sample time'):
+        # How the producer paired its revision with its sample clock is its
+        # own bookkeeping. Both frontiers are fenced against regression, which
+        # is all the presentation timeline needs.
+        self.sync.snapshot({
+            'round_id': 1, 'server_tick': 2,
+            'bot_state_revision': 1,
+            'motion_time_us': 120000, 'bot_state_time_us': 100000,
+            'bots': [bot]})
+        self.sync.snapshot({
+            'round_id': 1, 'server_tick': 3,
+            'bot_state_revision': 2,
+            'motion_time_us': 130000, 'bot_state_time_us': 100000,
+            'bots': [bot]})
+        self.assertEqual(130000, self.sync._last_motion_time_us)
+        self.assertEqual(100000, self.sync._last_bot_state_time_us)
+
+        with self.assertRaisesRegex(ValueError, 'motion time regressed'):
             self.sync.snapshot({
-                'round_id': 1, 'server_tick': 2,
-                'bot_state_revision': 1,
+                'round_id': 1, 'server_tick': 4,
+                'bot_state_revision': 3,
                 'motion_time_us': 120000, 'bot_state_time_us': 100000,
                 'bots': [bot]})
-
-        advanced = self.module.SnapshotSync(
-            1, clock=lambda: self.now[0])
-        advanced.manifest({'round_id': 1, 'bots': [bot]})
-        advanced.snapshot({
-            'round_id': 1, 'server_tick': 1,
-            'bot_state_revision': 1,
-            'motion_time_us': 100000, 'bot_state_time_us': 90000,
-            'bots': [bot]})
-        with self.assertRaisesRegex(ValueError, 'did not advance'):
-            advanced.snapshot({
-                'round_id': 1, 'server_tick': 2,
-                'bot_state_revision': 2,
-                'motion_time_us': 120000, 'bot_state_time_us': 90000,
+        with self.assertRaisesRegex(ValueError, 'bot state time regressed'):
+            self.sync.snapshot({
+                'round_id': 1, 'server_tick': 4,
+                'bot_state_revision': 3,
+                'motion_time_us': 140000, 'bot_state_time_us': 90000,
                 'bots': [bot]})
 
         fresh = self.module.SnapshotSync(1, clock=lambda: self.now[0])


### PR DESCRIPTION
Two players reported a mid-battle state where every Bot stopped moving and
shots appeared to pass through. This is the design defect that can produce
exactly that, plus the server-side loss that can make it permanent.

## What was wrong

The visible client discarded a **whole** snapshot when any one of about
twenty contracts failed, and `_ignore_runtime_payload` tolerates that
**silently and without limit** for the whole battle phase. There is no
snapshot-age watchdog. So any persistent condition froze every Bot and every
remote hull at its last accepted pose - no health, kill, destructible or
projectile updates, no feedback for anything the player shot - while the
server and worker ran normally and the round never ended.

Most of those contracts re-derived the producer's own ledgers. A live
snapshot comes from the trusted LAN server, built from the trusted worker's
publication; both already enforce those ledgers before shipping. The replica
has no second source and no repair, so a failed re-derivation could only
discard a frame it could have drawn.

Separately, the server records a lineage section (Bot manifest, Bot orders,
destructible ledger) as delivered when its payload reaches the socket. No
replica acknowledges it and it is only offered again when its revision
changes, so one unconsumed frame cost a client that section for the rest of
the round.

## What changed

**Client**
- Removed from the live snapshot path: the player critical, equipment,
  environment, siege, gun-checkpoint and stun contracts, and the Bot combat,
  siege and stun contracts. Handshake barriers (roster, `battle_start`) stay
  strict; round identity, ordering, authority identity and the canonical
  runtime numbers stay enforced.
- Kept the pose bounds the environment contract carried, moved into
  `_canonical_runtime_vehicle_row` - those scalars reach native matrices and
  finiteness alone is not enough there.
- An unusable row no longer nullifies the frame. `SnapshotSync` destroys any
  entity a snapshot omits, so the row is replaced with the last accepted row
  for that id; only an unknown id is left out.
- Dropped the revision-to-sample-time pairing rule in both the snapshot header
  and `SnapshotSync`. Both frontiers are still fenced against regression.
- A lean snapshot whose manifest lineage drifted inherits the retained roster
  instead of being refused forever.
- A `SnapshotSync` failure is contained on its own. The Bot state store
  consumes the frame first, so rolling the whole snapshot back left authority
  permanently ahead of the replicas drawn from it.
- A replica that has accepted no snapshot for two seconds during battle now
  logs `snapshot stream stalled` with the drop streak and last reason.

**Server**
- The manifest and Bot orders are republished every five seconds and the
  destructible ledger every ten, so a single lost frame heals.

## Validation

- `python -m unittest discover -s tests -p "test_*.py"` - 4137 tests, OK
- `launcher` suite - 494 tests, OK (2 skipped)
- CPython 2.7.18 compile of `src/res/scripts/client/` - 96 files, passed

Three existing tests asserted the removed rules and were rewritten to assert
what still holds; four new tests cover the lineage drift, the retained row,
the stall report and the server republication cadence.

## What this does not prove

Static tests only. Whether this is the cause of the two field reports is not
established - no mid-battle trigger has been identified yet. The new
`snapshot stream stalled` line is what will prove or disprove it on the next
Windows session; `ignored recoverable snapshot payload reason=invalid_snapshot:`
in `python.log` remains the direct evidence to look for.

The separate "Bots turning in place" report is unrelated to this PR: that is
the traffic/driver loop already fixed on main by 1024bb4 / 1b5249d / 3b602fd,
none of which shipped because v0.6.11 was reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)