### PR TITLE
Filter the vehicle editor list by stock class and tier

### DIFF
--- a/launcher/tests/test_vehicle_editor_ui.py
+++ b/launcher/tests/test_vehicle_editor_ui.py
@@ -127,13 +127,14 @@ class _Service(object):
         self.extra_fields = []
         self.choices = [
             {"nation": "ussr", "vehicle": "R11_MS-1",
-             "label": "MS-1",
+             "label": "MS-1", "vehicleClass": "lightTank", "level": 1,
              "member": vehicle_editor_ui.DEFAULT_MEMBER},
             {"nation": "ussr", "vehicle": "R12_Test",
-             "label": "Test",
+             "label": "Test", "vehicleClass": "mediumTank", "level": 5,
              "member": "scripts/item_defs/vehicles/ussr/R12_Test.xml"},
             {"nation": "usa", "vehicle": "A01_T1_Cunningham",
-             "label": "T1_Cunningham",
+             "label": "T1_Cunningham", "vehicleClass": "lightTank",
+             "level": 1,
              "member": (
                  "scripts/item_defs/vehicles/usa/A01_T1_Cunningham.xml")},
         ]
@@ -230,6 +231,17 @@ class _Service(object):
             raise self.VehicleOverlayError(self.restore_error)
         self.current = "32"
         return 2
+
+
+def _texts(widget):
+    """Return every static label text in one fake widget tree."""
+    found = []
+    text = widget.options.get("text") if hasattr(widget, "options") else None
+    if isinstance(text, str):
+        found.append(text)
+    for child in getattr(widget, "children", ()):
+        found.extend(_texts(child))
+    return found
 
 
 class VehicleEditorWindowTest(unittest.TestCase):
@@ -336,6 +348,100 @@ class VehicleEditorWindowTest(unittest.TestCase):
         self.assertEqual(("T1_Cunningham",),
                          self.window.vehicle_box.cget("values"))
         self.assertEqual("T1_Cunningham", self.window.vehicle.get())
+
+    def test_type_and_tier_options_come_from_the_original_catalog(self):
+        self.assertEqual(
+            ("All", "Light tank", "Medium tank"),
+            self.window.vehicle_class_box.cget("values"))
+        self.assertEqual(
+            ("All", "1", "5"), self.window.tier_box.cget("values"))
+        self.assertEqual("readonly",
+                         self.window.vehicle_class_box.cget("state"))
+        self.assertEqual("readonly", self.window.tier_box.cget("state"))
+        self.assertEqual("All", self.window.vehicle_class.get())
+        self.assertEqual("All", self.window.tier.get())
+
+    def test_selecting_a_type_narrows_the_list_and_loads_the_first_match(self):
+        self.window.vehicle_class.set("Medium tank")
+
+        self.assertTrue(self.window.refresh_vehicles())
+
+        self.assertEqual(("Test",), self.window.vehicle_box.cget("values"))
+        self.assertEqual("Test", self.window.vehicle.get())
+        self.assertEqual(
+            ("C:/WoT", "scripts/item_defs/vehicles/ussr/R12_Test.xml"),
+            self.service.topology_calls[-1])
+
+    def test_tier_filter_composes_with_the_nation_and_the_typed_search(self):
+        self.window.tier.set("1")
+
+        self.assertTrue(self.window.refresh_vehicles())
+
+        self.assertEqual(("MS-1",), self.window.vehicle_box.cget("values"))
+        self.assertEqual("MS-1", self.window.vehicle.get())
+
+        self.window.vehicle.set("tes")
+        self.assertFalse(self.window.filter_vehicles())
+        self.assertEqual((), self.window.vehicle_box.cget("values"))
+        self.assertIn("No vehicles match", self.window.status.get())
+
+        self.window.nation.set("usa")
+        self.assertTrue(self.window.refresh_vehicles())
+        self.assertEqual(("T1_Cunningham",),
+                         self.window.vehicle_box.cget("values"))
+
+    def test_an_empty_type_and_tier_combination_names_both_filters(self):
+        self.window.nation.set("usa")
+        self.window.vehicle_class.set("Medium tank")
+
+        self.assertFalse(self.window.refresh_vehicles())
+
+        self.assertEqual((), self.window.vehicle_box.cget("values"))
+        self.assertIn("No vehicles match the selected nation, type and tier.",
+                      self.window.status.get())
+        self.assertEqual("-", self.window.original.get())
+
+    def test_restoring_the_selection_keeps_the_active_filters(self):
+        self.window.vehicle_class.set("Medium tank")
+        self.assertTrue(self.window.refresh_vehicles())
+        self.window.vehicle.set("not a tank")
+        self.assertFalse(self.window.filter_vehicles())
+
+        self.assertTrue(self.window.restore_vehicle_selection())
+
+        self.assertEqual("Test", self.window.vehicle.get())
+        self.assertEqual(("Test",), self.window.vehicle_box.cget("values"))
+
+    def test_dropdown_selection_redisplays_only_the_filtered_vehicles(self):
+        self.window.tier.set("5")
+        self.assertTrue(self.window.refresh_vehicles())
+        self.window.vehicle_box.current(0)
+
+        self.assertTrue(self.window.select_vehicle_from_dropdown())
+
+        self.assertEqual(("Test",), self.window.vehicle_box.cget("values"))
+        self.assertEqual(
+            ("C:/WoT", "scripts/item_defs/vehicles/ussr/R12_Test.xml"),
+            self.service.topology_calls[-1])
+
+    def test_an_unclassified_catalog_entry_stays_reachable_under_all(self):
+        service = _Service()
+        service.choices.append({
+            "nation": "ussr", "vehicle": "R14_Unclassified",
+            "label": "Unclassified", "vehicleClass": None, "level": None,
+            "member": (
+                "scripts/item_defs/vehicles/ussr/R14_Unclassified.xml")})
+        window = vehicle_editor_ui.VehicleEditorWindow(
+            self.parent, "C:/WoT", "Fast MS-1", _FakeTk, _FakeTtk,
+            self.messagebox, service=service)
+
+        self.assertEqual(("MS-1", "Test", "Unclassified"),
+                         window.vehicle_box.cget("values"))
+
+        window.vehicle_class.set("Light tank")
+        self.assertTrue(window.refresh_vehicles())
+
+        self.assertEqual(("MS-1",), window.vehicle_box.cget("values"))
 
     def test_typing_filters_without_loading_until_enter_is_pressed(self):
         topology_count = len(self.service.topology_calls)
@@ -498,9 +604,31 @@ class VehicleEditorWindowTest(unittest.TestCase):
         self.assertEqual(
             "0.9.22 车辆属性方案：Fast MS-1",
             window.root.cget("title"))
+        explanation = next(
+            text for text in _texts(window.root)
+            if text.startswith("正在编辑方案"))
+        self.assertIn("请依次选择系别、车辆、类别和属性。", explanation)
+        self.assertIn("或您开房时固定该方案时生效", explanation)
+        self.assertIn("类型", _texts(window.root))
+        self.assertIn("级别", _texts(window.root))
+        self.assertIn("按原始数据中的车型或级别筛选车辆列表。",
+                      _texts(window.root))
         self.assertFalse(hasattr(window, "inspect_button"))
         self.assertEqual(("车辆", "火炮"),
                          window.category_box.cget("values"))
+        self.assertEqual(("全部", "轻型坦克", "中型坦克"),
+                         window.vehicle_class_box.cget("values"))
+        self.assertEqual(("全部", "1", "5"),
+                         window.tier_box.cget("values"))
+        window.vehicle_class.set("中型坦克")
+        self.assertTrue(window.refresh_vehicles())
+        self.assertEqual(("Test",), window.vehicle_box.cget("values"))
+        window.nation.set("usa")
+        self.assertFalse(window.refresh_vehicles())
+        self.assertIn("所选系别、类型和级别没有匹配的车辆。", window.status.get())
+        window.nation.set("ussr")
+        window.vehicle_class.set("全部")
+        self.assertTrue(window.refresh_vehicles())
         self.assertEqual(("速度限制 / 前进速度",),
                          window.field_box.cget("values"))
         self.assertEqual("整数", window.packed_type.get())

--- a/launcher/tests/test_vehicle_overlays.py
+++ b/launcher/tests/test_vehicle_overlays.py
@@ -228,14 +228,17 @@ class VehicleOverlayTest(unittest.TestCase):
                 (b"shortUserString", scalar(
                     packed.TYPE_STRING, b"#ussr_vehicles:R11_MS-1_short")),
                 (b"tags", scalar(packed.TYPE_STRING, b"lightTank")),
+                (b"level", scalar(packed.TYPE_INTEGER, 1)),
             ])),
             (b"R12_Test", element([
                 (b"tags", scalar(
                     packed.TYPE_STRING, b"secret lightTank")),
+                (b"level", scalar(packed.TYPE_INTEGER, 3)),
             ])),
             (b"Observer", element([
                 (b"tags", scalar(
                     packed.TYPE_STRING, b"secret observer lightTank")),
+                (b"level", scalar(packed.TYPE_INTEGER, 1)),
             ])),
         ])
         return {
@@ -283,6 +286,7 @@ class VehicleOverlayTest(unittest.TestCase):
         roster.children.append((b"R13_Siege", element([
             (b"tags", scalar(
                 packed.TYPE_STRING, b"AT-SPG siegeMode")),
+            (b"level", scalar(packed.TYPE_INTEGER, 8)),
         ])))
         self.members[self.LIST] = packed.write_packed_xml(roster)
         self.members[self.SIEGE_VEHICLE] = packed.write_packed_xml(normal)
@@ -771,6 +775,37 @@ class VehicleOverlayTest(unittest.TestCase):
         self.assertEqual("R11_MS-1", ms1["vehicle"])
         self.assertEqual(self.VEHICLE, ms1["member"])
         self.assertIn("lightTank", ms1["tags"])
+        self.assertEqual("lightTank", ms1["vehicleClass"])
+        self.assertEqual(1, ms1["level"])
+
+    def test_roster_reports_the_stock_class_tag_and_tier_for_each_vehicle(
+            self):
+        roster = packed.read_packed_xml(self.members[self.LIST])
+        # A roster entry with no class tag and a non-integer tier is still
+        # offered; only the two list filters cannot place it.
+        roster.children.append((b"R14_Unclassified", element([
+            (b"tags", scalar(packed.TYPE_STRING, b"HD")),
+            (b"level", scalar(packed.TYPE_STRING, b"6")),
+        ])))
+        self.members[self.LIST] = packed.write_packed_xml(roster)
+        self.members[
+            "scripts/item_defs/vehicles/ussr/R14_Unclassified.xml"] = (
+                self.members[self.VEHICLE])
+        self._write_package()
+
+        with mock.patch.object(
+                vehicle_overlays, "_vehicle_translations", return_value=None):
+            choices = dict(
+                (choice["vehicle"], choice)
+                for choice in vehicle_overlays.list_vehicle_choices(self.game))
+
+        self.assertEqual(
+            ("lightTank", 3), (choices["R12_Test"]["vehicleClass"],
+                               choices["R12_Test"]["level"]))
+        self.assertEqual(
+            (None, None), (choices["R14_Unclassified"]["vehicleClass"],
+                           choices["R14_Unclassified"]["level"]))
+        self.assertNotIn("Observer", choices)
 
     def test_type_5_heavy_is_read_from_the_japanese_roster(self):
         class _Translations(object):
@@ -792,6 +827,7 @@ class VehicleOverlayTest(unittest.TestCase):
                     packed.TYPE_STRING,
                     b"#japan_vehicles:J20_Type_2605_short")),
                 (b"tags", scalar(packed.TYPE_STRING, b"heavyTank")),
+                (b"level", scalar(packed.TYPE_INTEGER, 10)),
             ])),
         ])
         self.members[list_member] = packed.write_packed_xml(roster)
@@ -808,6 +844,8 @@ class VehicleOverlayTest(unittest.TestCase):
                      if choice["vehicle"] == "J20_Type_2605")
         self.assertEqual("五式重战", type5["label"])
         self.assertEqual(vehicle_member, type5["member"])
+        self.assertEqual("heavyTank", type5["vehicleClass"])
+        self.assertEqual(10, type5["level"])
 
     def test_catalog_prefix_is_hidden_only_in_human_facing_fields(self):
         record = vehicle_overlays._choice_record(

--- a/launcher/vehicle_editor_ui.py
+++ b/launcher/vehicle_editor_ui.py
@@ -14,6 +14,19 @@ DEFAULT_MEMBER = "scripts/item_defs/vehicles/ussr/R11_MS-1.xml"
 DEFAULT_FIELD = "speedLimits/forward"
 DEFAULT_NATION = "ussr"
 DEFAULT_VEHICLE = "R11_MS-1"
+ALL_FILTER = "All"
+
+# The stock #1513 class tags in retail tech-tree order, with the label the
+# editor shows for each.  A roster entry that carries no unique class tag or
+# no integer tier stays reachable, but only while the matching filter is
+# ``All``.
+VEHICLE_CLASS_LABELS = (
+    ("lightTank", "Light tank"),
+    ("mediumTank", "Medium tank"),
+    ("heavyTank", "Heavy tank"),
+    ("AT-SPG", "Tank destroyer"),
+    ("SPG", "SPG"),
+)
 
 
 _CHINESE = {
@@ -30,9 +43,14 @@ _CHINESE = {
     "Nation": "系别",
     "Only nations found in the original vehicle definitions.":
         "只显示原始车辆数据中存在的系别。",
+    "Type": "类型",
+    "Tier": "级别",
+    "All": "全部",
+    "Narrow the vehicle list to one original vehicle class or tier.":
+        "按原始数据中的车型或级别筛选车辆列表。",
     "Vehicle": "车辆",
-    "Type to search the selected nation's vehicles, then choose one or press "
-    "Enter.": "输入名称搜索所选系别的车辆，然后选中或按回车。",
+    "Type to search the vehicles left by these filters, then choose one or "
+    "press Enter.": "输入名称搜索筛选后的车辆，然后选中或按回车。",
     "Category": "类别",
     "Only categories with an existing safe field are shown.":
         "只显示包含可安全修改属性的类别。",
@@ -57,6 +75,8 @@ _CHINESE = {
         "scripts.pkg 中没有找到受支持的车辆。",
     "The selected nation has no supported vehicles.":
         "所选系别中没有受支持的车辆。",
+    "No vehicles match the selected nation, type and tier.":
+        "所选系别、类型和级别没有匹配的车辆。",
     "Choose one listed vehicle.": "请选择列表中的一辆车。",
     "No vehicles match this search.": "没有匹配当前搜索的车辆。",
     "Choose a matching vehicle or press Enter to load the first result.":
@@ -81,6 +101,12 @@ _CATEGORY_CHINESE = {
     "Vehicle": "车辆", "Chassis": "悬挂装置", "Turret": "炮塔",
     "Engine": "发动机", "Fuel tank": "油箱", "Gun": "火炮",
     "Radio": "电台", "Shell": "炮弹",
+}
+
+_VEHICLE_CLASS_CHINESE = {
+    "Light tank": "轻型坦克", "Medium tank": "中型坦克",
+    "Heavy tank": "重型坦克", "Tank destroyer": "反坦克炮",
+    "SPG": "自行火炮",
 }
 
 _FIELD_CHINESE = {
@@ -171,6 +197,8 @@ class VehicleEditorWindow(object):
         self._vehicle_choices = []
         self._selected_vehicle_choice = None
         self._filtered_vehicle_choices = []
+        self._class_by_label = {}
+        self._tier_by_label = {}
         self._fields = []
         self._field_by_label = {}
         self._field_by_key = {}
@@ -189,16 +217,18 @@ class VehicleEditorWindow(object):
         explanation = self._t(
             "Editing profile '%s'. Choose a nation and vehicle, then a "
             "category and field. Changes are saved outside res_mods and are "
-            "materialized only while this profile runs in single player. "
-            "Shared guns, engines and other components show every vehicle "
-            "they affect. IDs, resource paths, topology and unknown fields "
-            "remain locked.") % self._profile_name
+            "materialized while this profile runs in single player or is "
+            "pinned by a LAN room you host. Shared guns, engines and other "
+            "components show every vehicle they affect. IDs, resource paths, "
+            "topology and unknown fields remain locked.") % self._profile_name
         tk.Label(frame, text=explanation, justify="left", anchor="w",
                  wraplength=720).grid(
                      row=0, column=0, columnspan=3, sticky="we",
                      pady=(0, 10))
 
         self.nation = tk.StringVar(value=DEFAULT_NATION)
+        self.vehicle_class = tk.StringVar(value=self._t(ALL_FILTER))
+        self.tier = tk.StringVar(value=self._t(ALL_FILTER))
         self.vehicle = tk.StringVar(value=DEFAULT_VEHICLE)
         self.category = tk.StringVar(value=self._category_label("Vehicle"))
         self.field = tk.StringVar(value="")
@@ -218,11 +248,18 @@ class VehicleEditorWindow(object):
         row, self.nation_box = self._selector_row(
             frame, row, self._t("Nation"), self.nation,
             self._t("Only nations found in the original vehicle definitions."))
+        row, (self.vehicle_class_box, self.tier_box) = self._filter_row(
+            frame, row,
+            self._t(
+                "Narrow the vehicle list to one original vehicle class or "
+                "tier."),
+            ((self._t("Type"), self.vehicle_class, 18),
+             (self._t("Tier"), self.tier, 8)))
         row, self.vehicle_box = self._selector_row(
             frame, row, self._t("Vehicle"), self.vehicle,
             self._t(
-                "Type to search the selected nation's vehicles, then choose "
-                "one or press Enter."), editable=True)
+                "Type to search the vehicles left by these filters, then "
+                "choose one or press Enter."), editable=True)
         row, self.category_box = self._selector_row(
             frame, row, self._t("Category"), self.category,
             self._t("Only categories with an existing safe field are shown."))
@@ -230,6 +267,9 @@ class VehicleEditorWindow(object):
             frame, row, self._t("Field"), self.field,
             self._t("The exact package member and field path stay internal."))
         self.nation_box.bind("<<ComboboxSelected>>", self.refresh_vehicles)
+        self.vehicle_class_box.bind(
+            "<<ComboboxSelected>>", self.refresh_vehicles)
+        self.tier_box.bind("<<ComboboxSelected>>", self.refresh_vehicles)
         self.vehicle_box.bind(
             "<<ComboboxSelected>>", self.select_vehicle_from_dropdown)
         self.vehicle_box.bind("<KeyRelease>", self.filter_vehicles)
@@ -302,6 +342,11 @@ class VehicleEditorWindow(object):
     def _category_label(self, label):
         if self._language == i18n.LANGUAGE_CHINESE:
             return _CATEGORY_CHINESE.get(label, label)
+        return label
+
+    def _vehicle_class_label(self, label):
+        if self._language == i18n.LANGUAGE_CHINESE:
+            return _VEHICLE_CLASS_CHINESE.get(label, label)
         return label
 
     def _field_label(self, label):
@@ -384,6 +429,29 @@ class VehicleEditorWindow(object):
             pady=(0, 5))
         return row + 1, box
 
+    def _filter_row(self, frame, row, hint, entries):
+        """Place the compact list filters and one shared hint on two rows."""
+        tk = self._tk
+        tk.Label(frame, text=entries[0][0], anchor="w").grid(
+            row=row, column=0, sticky="w")
+        holder = tk.Frame(frame)
+        holder.grid(row=row, column=1, columnspan=2, sticky="w", padx=(8, 0))
+        boxes = []
+        for index, (label, variable, width) in enumerate(entries):
+            if index:
+                tk.Label(holder, text=label, anchor="w").grid(
+                    row=0, column=2 * index, sticky="w", padx=(18, 0))
+            box = self._ttk.Combobox(
+                holder, textvariable=variable, values=(), width=width,
+                state="readonly")
+            box.grid(row=0, column=2 * index + 1, sticky="w", padx=(8, 0))
+            boxes.append(box)
+        row += 1
+        tk.Label(frame, text=hint, anchor="w").grid(
+            row=row, column=1, columnspan=2, sticky="w", padx=(8, 0),
+            pady=(0, 5))
+        return row + 1, tuple(boxes)
+
     def _selection(self):
         record = self._field_by_label.get(self.field.get().strip())
         if record is None:
@@ -442,7 +510,50 @@ class VehicleEditorWindow(object):
         if self.nation.get().strip() not in nations:
             self.nation.set(
                 DEFAULT_NATION if DEFAULT_NATION in nations else nations[0])
+        self._refresh_filter_options()
         return self.refresh_vehicles()
+
+    def _refresh_filter_options(self):
+        """Offer only the classes and tiers the original catalog contains."""
+        all_label = self._t(ALL_FILTER)
+        present = set(choice.get("vehicleClass")
+                      for choice in self._vehicle_choices)
+        self._class_by_label = {all_label: None}
+        class_labels = [all_label]
+        for name, label in VEHICLE_CLASS_LABELS:
+            if name not in present:
+                continue
+            text = self._vehicle_class_label(label)
+            self._class_by_label[text] = name
+            class_labels.append(text)
+        self.vehicle_class_box.config(values=tuple(class_labels))
+        if self.vehicle_class.get().strip() not in self._class_by_label:
+            self.vehicle_class.set(all_label)
+
+        self._tier_by_label = {all_label: None}
+        tier_labels = [all_label]
+        for level in sorted(set(
+                choice["level"] for choice in self._vehicle_choices
+                if isinstance(choice.get("level"), int))):
+            text = str(level)
+            self._tier_by_label[text] = level
+            tier_labels.append(text)
+        self.tier_box.config(values=tuple(tier_labels))
+        if self.tier.get().strip() not in self._tier_by_label:
+            self.tier.set(all_label)
+
+    def _selected_vehicle_class(self):
+        return self._class_by_label.get(self.vehicle_class.get().strip())
+
+    def _selected_tier(self):
+        return self._tier_by_label.get(self.tier.get().strip())
+
+    def _no_vehicle_message(self):
+        if (self._selected_vehicle_class() is None and
+                self._selected_tier() is None):
+            return self._t("The selected nation has no supported vehicles.")
+        return self._t(
+            "No vehicles match the selected nation, type and tier.")
 
     def refresh_members(self):
         """Compatibility alias for callers that refresh the editor."""
@@ -450,12 +561,11 @@ class VehicleEditorWindow(object):
 
     def refresh_vehicles(self, unused_event=None):
         nation = self.nation.get().strip()
-        choices = self._nation_vehicle_choices(nation)
+        choices = self._visible_vehicle_choices(nation)
         self._show_vehicle_choices(choices)
         if not choices:
             return self._show_error(
-                self._t("The selected nation has no supported vehicles."),
-                clear_contract=True)
+                self._no_vehicle_message(), clear_contract=True)
         selected = self.vehicle.get().strip()
         selected_choice = self._resolve_vehicle_choice(
             selected, choices=choices)
@@ -486,10 +596,17 @@ class VehicleEditorWindow(object):
                 return label[:-len(suffix)].rstrip()
         return label
 
-    def _nation_vehicle_choices(self, nation=None):
+    def _visible_vehicle_choices(self, nation=None):
+        """Return the catalog narrowed by nation, class and tier."""
         nation = self.nation.get().strip() if nation is None else nation
-        return [choice for choice in self._vehicle_choices
-                if choice["nation"] == nation]
+        vehicle_class = self._selected_vehicle_class()
+        level = self._selected_tier()
+        return [
+            choice for choice in self._vehicle_choices
+            if (choice["nation"] == nation and
+                (vehicle_class is None or
+                 choice.get("vehicleClass") == vehicle_class) and
+                (level is None or choice.get("level") == level))]
 
     def _show_vehicle_choices(self, choices):
         self._filtered_vehicle_choices = list(choices)
@@ -508,7 +625,7 @@ class VehicleEditorWindow(object):
 
     def _resolve_vehicle_choice(self, value, choices=None,
                                 allow_partial=False):
-        choices = (self._nation_vehicle_choices() if choices is None
+        choices = (self._visible_vehicle_choices() if choices is None
                    else list(choices))
         needle = value.strip().casefold()
         exact = [
@@ -535,7 +652,7 @@ class VehicleEditorWindow(object):
             return True
         query = self.vehicle.get().strip()
         choices = [
-            choice for choice in self._nation_vehicle_choices()
+            choice for choice in self._visible_vehicle_choices()
             if self._vehicle_search_matches(choice, query)]
         self._show_vehicle_choices(choices)
         selected_label = (
@@ -558,23 +675,22 @@ class VehicleEditorWindow(object):
         choice = self._resolve_vehicle_choice(
             self.vehicle.get(), allow_partial=True)
         if choice is None:
-            self._show_vehicle_choices(self._nation_vehicle_choices())
+            self._show_vehicle_choices(self._visible_vehicle_choices())
             return self._show_error(
                 self._t("No vehicles match this search."))
         self.vehicle.set(self._choice_label(choice))
-        self._show_vehicle_choices(self._nation_vehicle_choices())
+        self._show_vehicle_choices(self._visible_vehicle_choices())
         return self._load_vehicle_fields(choice)
 
     def restore_vehicle_selection(self, unused_event=None):
-        choices = self._nation_vehicle_choices()
+        choices = self._visible_vehicle_choices()
         self._show_vehicle_choices(choices)
         choice = self._selected_vehicle_choice
         if choice not in choices:
             choice = choices[0] if choices else None
         if choice is None:
             return self._show_error(
-                self._t("The selected nation has no supported vehicles."),
-                clear_contract=True)
+                self._no_vehicle_message(), clear_contract=True)
         self.vehicle.set(self._choice_label(choice))
         return self._load_vehicle_fields(choice)
 
@@ -586,7 +702,7 @@ class VehicleEditorWindow(object):
         if 0 <= index < len(self._filtered_vehicle_choices):
             choice = self._filtered_vehicle_choices[index]
             self.vehicle.set(self._choice_label(choice))
-            self._show_vehicle_choices(self._nation_vehicle_choices())
+            self._show_vehicle_choices(self._visible_vehicle_choices())
             return self._load_vehicle_fields(choice)
         return self.refresh_vehicle_fields()
 
@@ -596,7 +712,7 @@ class VehicleEditorWindow(object):
         if choice is None:
             return self._show_error(
                 self._t("Choose one listed vehicle."), clear_contract=True)
-        self._show_vehicle_choices(self._nation_vehicle_choices())
+        self._show_vehicle_choices(self._visible_vehicle_choices())
         return self._load_vehicle_fields(choice)
 
     def _load_vehicle_fields(self, choice):

--- a/launcher/vehicle_overlays.py
+++ b/launcher/vehicle_overlays.py
@@ -73,6 +73,13 @@ _NON_EDITABLE_VEHICLE_TAGS = frozenset((
 _NON_EDITABLE_VEHICLE_SUFFIXES = ("_bot", "_training")
 _NON_EDITABLE_VEHICLES = frozenset(("germany:Env_Artillery",))
 
+# Every one of the 680 stock 0.9.22.0.1 #1513 roster entries carries exactly
+# one of these class tags and an integer ``level`` between 1 and 10.  Both
+# only narrow the editor's vehicle list, so an entry that states neither is
+# still offered; it simply cannot be placed by the matching list filter.
+VEHICLE_CLASSES = ("lightTank", "mediumTank", "heavyTank", "AT-SPG", "SPG")
+_VEHICLE_CLASS_TAGS = frozenset(VEHICLE_CLASSES)
+
 _TYPE_NAMES = {
     packed_xml.TYPE_STRING: "string",
     packed_xml.TYPE_INTEGER: "integer",
@@ -765,7 +772,7 @@ def list_vehicle_choices(game_root):
                 status["path"], nation)
         label = _vehicle_label(record, translators[nation])
         choice = dict((key, record[key]) for key in (
-            "nation", "vehicle", "member", "tags"))
+            "nation", "vehicle", "member", "tags", "vehicleClass", "level"))
         choice["label"] = label
         choices.append(choice)
     return choices
@@ -835,6 +842,25 @@ def _vehicle_is_selectable(type_name, tags):
             type_name.endswith(_NON_EDITABLE_VEHICLE_SUFFIXES))))
 
 
+def _roster_vehicle_class(tags):
+    """Return the single stock class tag, or None when it is not unique."""
+    classes = _VEHICLE_CLASS_TAGS.intersection(tags)
+    if len(classes) != 1:
+        return None
+    return next(iter(classes))
+
+
+def _roster_level(element):
+    """Return the stock tier as an integer, or None when it is not stated."""
+    values = [child for name, child in element.children if name == b"level"]
+    if len(values) != 1 or values[0].value_type != packed_xml.TYPE_INTEGER:
+        return None
+    try:
+        return int(values[0].value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+
 def _vehicle_roster_from_archive(archive, counts, nation=None):
     """Resolve vehicle definitions from each nation's stock list.xml."""
     list_members = []
@@ -902,7 +928,9 @@ def _vehicle_roster_from_archive(archive, counts, nation=None):
                 "tags": tuple(tags.split()),
                 "userString": user_strings.get("userString", ""),
                 "shortUserString": user_strings.get("shortUserString", ""),
+                "level": _roster_level(value.value),
             }
+            record["vehicleClass"] = _roster_vehicle_class(record["tags"])
             record["selectable"] = _vehicle_is_selectable(
                 "%s:%s" % (roster_nation, vehicle), record["tags"])
             records.append(record)


### PR DESCRIPTION
## Problem

In the launcher's vehicle data editor (坦克修改器) the Vehicle dropdown offered a
whole nation's roster at once — 139 entries for the USSR on the exact
0.9.22.0.1 #1513 client — and the typed search box was the only way to narrow
it. There was no way to ask for, say, "tier 10 heavies".

## Data the stock roster already states

Read from `~/scripts.pkg` of the exact #1513 client, every
`scripts/item_defs/vehicles/<nation>/list.xml` entry carries both facts:

| Check | Result over all 10 nations |
| --- | --- |
| roster entries | 680 |
| entries with exactly one of `lightTank` / `mediumTank` / `heavyTank` / `AT-SPG` / `SPG` | 680 (0 with none, 0 with several) |
| entries with an integer `level` | 680, all between 1 and 10 |
| class split | mediumTank 196, heavyTank 147, lightTank 145, AT-SPG 136, SPG 56 |
| selectable by the editor's existing rule | 614 |

`list_vehicle_choices` now forwards these as `vehicleClass` and `level`.
Neither is a data-safety boundary, so an entry that states neither stays
selectable and simply cannot be placed by the matching list filter — the strict
roster errors are untouched.

## Editor change

One `Type` and one `Tier` selector sit above the vehicle box. Both offer only
the classes and tiers the original catalog actually contains, both default to
`All`, and both are localized.

The nation predicate became a single `_visible_vehicle_choices` helper that also
applies class and tier, and **all seven** call sites that rebuilt the dropdown
now go through it (`refresh_vehicles`, `_resolve_vehicle_choice`,
`filter_vehicles`, `commit_vehicle_search` ×2, `restore_vehicle_selection`,
`select_vehicle_from_dropdown`, `refresh_vehicle_fields`). Missing one would
have made a dropdown pick, `Enter` or `Escape` silently restore the nation's
whole roster.

An empty nation/class/tier combination is a legal state — `usa` + `SPG` +
tier 1 really is empty on #1513 — so it reports its own message instead of
claiming the nation has no supported vehicles.

Measured against the real package: USSR narrows 139 → 7 with Heavy tank +
tier 10 (`Object_260`, `Object_777`, `Object_257`, `Object_705_A`, `IS-7`,
`IS-7_fallout`, `IS_4M`).

## Also fixed here

The English explanation paragraph in the editor had drifted from the key in the
Chinese table: `f19c071` updated the translation to the LAN-pinned wording but
left the English source string at `2518f53`'s text, so the lookup missed and the
Chinese editor has been showing an English paragraph ever since. Restored to the
accurate wording, which the Chinese entry already matched. Not requested — it is
the same string I had to touch, and it is now covered by a test.

## Tests

- `launcher`: 503 tests, OK (494 before; 9 new).
- `tests/test_port_0922_bot_lineup_integration.py` +
  `tests/test_port_0922_vehicle_overlay.py`: 28 tests, OK — they consume the same
  choice records.
- Every new test was confirmed red against the base implementation.

## Not done / not proved

- Actual Tk rendering of the new Type/Tier row is unproved — this box has no
  display. Everything else here is fully provable locally; no Windows-only
  boundary is involved.
- `launcher/bot_lineup_ui.py` has the same unfiltered roster dropdown, ×30 Bot
  slots. Observation only, not built — out of scope for this request.
- No documentation change: `README.md` and `LAUNCHER_README.txt` describe what a
  vehicle profile is, not the editor's individual controls (they do not mention
  the nation box or the search box either).

🤖 Generated with [Claude Code](https://claude.com/claude-code)