### PR TITLE
Play the stock battle-results music by ending the round on AFTERBATTLE

### DIFF
--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -10618,14 +10618,39 @@ class BattleRuntime(object):
         callback = getattr(self._avatar, 'onRoundFinished', None)
         if not callable(callback):
             raise RuntimeError('Avatar.onRoundFinished is unavailable')
+        winner = max(0, min(int(result.get('winner', 0)), 2))
         base_team = max(0, min(int(result.get('base_team', 0)), 2))
         if base_team in (1, 2):
             captured = getattr(self._avatar.arena, 'onTeamBaseCaptured', None)
             if callable(captured):
                 captured(base_team, 0)
-        callback(max(0, min(int(result.get('winner', 0)), 2)), reason)
+        # Retail ends the round by moving the arena to AFTERBATTLE, and every
+        # stock end-of-battle consumer reads that transition rather than
+        # ``Avatar.onRoundFinished``.  ``ArenaPeriodController`` stores the
+        # winner as ``BattleContext.lastArenaWinStatus``, which survives into
+        # the lobby and selects the battle-results music; the same publication
+        # latches ``MusicController.__lastBattleResultEventName`` from the
+        # arena's ``wwmusicSetup`` and stops the combat ambient.  Publish the
+        # period first so both owners hold the outcome before the notification
+        # runs.  The LAN round has no separate afterbattle server window, so
+        # the period carries no countdown, exactly as retail behaves once its
+        # own afterbattle window has elapsed.  A failure here is end-of-battle
+        # presentation only; it must never swallow the terminal notification
+        # or the result bookkeeping that follows it.
+        self._run_optional_feature(
+            'afterbattle arena period', self._publish_afterbattle_period,
+            (winner, reason))
+        callback(winner, reason)
         self._round_finished_notified = True
         self._report_memory('round_end')
+        return True
+
+    def _publish_afterbattle_period(self, winner, reason):
+        """Move the stock arena to AFTERBATTLE with the round's outcome."""
+        if self._binding is None:
+            raise RuntimeError('#1513 arena-period binding is unavailable')
+        self._binding.arena_period(
+            'afterbattle', winner_team=int(winner), finish_reason=int(reason))
         return True
 
     def _apply_rules(self, rules):

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/entities/bigworld_binding.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/entities/bigworld_binding.py
@@ -125,6 +125,7 @@ class BigWorldVehicleBinding(object):
             self._need(self._constants.ARENA_UPDATE, name)
         self._need(self._constants.ARENA_PERIOD, 'PREBATTLE')
         self._need(self._constants.ARENA_PERIOD, 'BATTLE')
+        self._need(self._constants.ARENA_PERIOD, 'AFTERBATTLE')
         self._need(self._constants.VEHICLE_PHYSICS_MODE, 'STANDARD')
         for name in ('DISABLED', 'SWITCHING_ON', 'ENABLED',
                      'SWITCHING_OFF'):
@@ -394,24 +395,48 @@ class BigWorldVehicleBinding(object):
         self._avatar.updateArena(self._constants.ARENA_UPDATE.AVATAR_READY,
                                  _pickle.dumps(self._avatar.playerVehicleID))
 
-    def arena_period(self, period, duration=0.0):
+    def arena_period(self, period, duration=0.0, winner_team=None,
+                     finish_reason=None):
         """Publish one native #1513 arena-period tuple.
 
         The stock HUD derives both its prebattle countdown and battle clock
         from ``periodEndTime``.  Publishing BATTLE immediately made the local
         Avatar playable as soon as it entered the world and skipped the same
         PREBATTLE barrier that the 0.8.2 runtime preserves.
+
+        ``ClientArena.__onPeriodInfoUpdate`` stores the whole tuple as
+        ``periodInfo`` and forwards it to ``onPeriodChange``, so the fourth
+        member becomes ``arena.periodAdditionalInfo``.  Exact #1513 reads it
+        only for AFTERBATTLE, where both
+        ``arena_info.listeners._getPeriodAdditionalInfo`` and
+        ``MusicControllerWWISE.MusicController.__onArenaStateChanged`` require
+        the two-member ``(winnerTeam, finishReason)`` pair.  Every other
+        period ships the empty list the retail server sends.
         """
         if period == 'prebattle':
             value = self._constants.ARENA_PERIOD.PREBATTLE
         elif period == 'battle':
             value = self._constants.ARENA_PERIOD.BATTLE
+        elif period == 'afterbattle':
+            value = self._constants.ARENA_PERIOD.AFTERBATTLE
         else:
             raise CapabilityError('unsupported arena period: %s' % period)
+        if period == 'afterbattle':
+            if winner_team is None or finish_reason is None:
+                raise CapabilityError(
+                    'afterbattle arena period has no round outcome')
+            self._require_int('arena winnerTeam', winner_team, 0, 2)
+            self._require_int('arena finishReason', finish_reason, 0, 255)
+            additional_info = (int(winner_team), int(finish_reason))
+        elif winner_team is not None or finish_reason is not None:
+            raise CapabilityError(
+                'arena period %s carries no round outcome' % period)
+        else:
+            additional_info = []
         duration = max(0.0, float(duration))
         end_time = (float(self._bigworld.serverTime()) + duration
                     if duration > 0.0 else 0.0)
-        payload = (value, end_time, duration, [])
+        payload = (value, end_time, duration, additional_info)
         self._avatar.updateArena(self._constants.ARENA_UPDATE.PERIOD,
                                  zlib.compress(_pickle.dumps(payload)))
 

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -2023,7 +2023,8 @@ def _runtime():
         ARENA_UPDATE=types.SimpleNamespace(
             VEHICLE_ADDED=2, PERIOD=3, VEHICLE_STATISTICS=5,
             VEHICLE_KILLED=6, AVATAR_READY=7, TEAM_KILLER=10),
-        ARENA_PERIOD=types.SimpleNamespace(PREBATTLE=2, BATTLE=3),
+        ARENA_PERIOD=types.SimpleNamespace(
+            PREBATTLE=2, BATTLE=3, AFTERBATTLE=4),
         VEHICLE_PHYSICS_MODE=types.SimpleNamespace(STANDARD=0),
         VEHICLE_SIEGE_STATE=types.SimpleNamespace(
             DISABLED=0, SWITCHING_ON=1, ENABLED=2, SWITCHING_OFF=3),
@@ -25400,6 +25401,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
         runtime = _runtime()
         battle = BattleRuntime(runtime)
         battle._avatar = runtime.bigworld.avatar
+        battle._binding = mock.Mock()
         battle.state = 'running'
 
         battle.on_events({'events': [{
@@ -25413,6 +25415,59 @@ class BattleRuntimeContractTests(unittest.TestCase):
             [(2, runtime.constants.FINISH_REASON.EXTERMINATION)],
             runtime.bigworld.avatar.round_finished)
         self.assertTrue(battle._round_finished_notified)
+        # The stock end-of-battle music owners read the arena period, not
+        # ``Avatar.onRoundFinished``, and a replayed result must not move the
+        # arena twice.
+        battle._binding.arena_period.assert_called_once_with(
+            'afterbattle', winner_team=2,
+            finish_reason=runtime.constants.FINISH_REASON.EXTERMINATION)
+
+    def test_terminal_result_moves_the_arena_before_notifying(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        battle.state = 'running'
+        order = []
+        battle._binding = mock.Mock()
+        battle._binding.arena_period.side_effect = (
+            lambda *args, **kwargs: order.append(('period',) + args))
+        battle._avatar.onRoundFinished = mock.Mock(
+            side_effect=lambda winner, reason: order.append(
+                ('finished', winner, reason)))
+
+        self.assertTrue(battle._apply_battle_result({
+            'winner': 0, 'reason': 'battle_timeout'}))
+
+        # ``BattleContext.lastArenaWinStatus`` and
+        # ``MusicController.__lastBattleResultEventName`` must both hold this
+        # round's outcome before any onRoundFinished consumer runs.
+        self.assertEqual(
+            [('period', 'afterbattle'),
+             ('finished', 0, runtime.constants.FINISH_REASON.TIMEOUT)],
+            order)
+        self.assertEqual(
+            {'winner_team': 0,
+             'finish_reason': runtime.constants.FINISH_REASON.TIMEOUT},
+            battle._binding.arena_period.call_args[1])
+
+    def test_afterbattle_period_failure_still_notifies_the_native_hud(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        battle.state = 'running'
+        battle._binding = mock.Mock()
+        battle._binding.arena_period.side_effect = RuntimeError(
+            'arena period rejected')
+
+        self.assertTrue(battle._apply_battle_result({
+            'winner': 1, 'reason': 'team_eliminated'}))
+
+        self.assertEqual(
+            [(1, runtime.constants.FINISH_REASON.EXTERMINATION)],
+            runtime.bigworld.avatar.round_finished)
+        self.assertTrue(battle._round_finished_notified)
+        self.assertEqual({'winner': 1, 'reason': 'team_eliminated'},
+                         battle._battle_result)
 
     def test_worker_terminal_result_stops_simulation_without_hud(self):
         runtime = _runtime()
@@ -25422,12 +25477,16 @@ class BattleRuntimeContractTests(unittest.TestCase):
         battle._battle_live = True
         battle.state = 'running'
 
+        battle._binding = mock.Mock()
+
         self.assertTrue(battle._apply_battle_result({
             'winner': 2, 'reason': 'battle_timeout'}))
 
         self.assertFalse(battle._battle_live)
         self.assertTrue(battle._round_finished_notified)
         self.assertEqual([], runtime.bigworld.avatar.round_finished)
+        # A hidden worker owns no stock GUI, arena period or music.
+        battle._binding.arena_period.assert_not_called()
 
     def test_base_capture_uses_exact_1513_event_shapes(self):
         runtime = _runtime()
@@ -25462,12 +25521,16 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertEqual(update_count,
                          len(runtime.bigworld.avatar.base_points))
 
+        battle._binding = mock.Mock()
         self.assertTrue(battle._apply_battle_result({
             'winner': 2, 'reason': 'base captured', 'base_team': 1}))
         self.assertEqual([(1, 0)], runtime.bigworld.avatar.base_captured)
         self.assertEqual([
             (2, runtime.constants.FINISH_REASON.BASE),
         ], runtime.bigworld.avatar.round_finished)
+        battle._binding.arena_period.assert_called_once_with(
+            'afterbattle', winner_team=2,
+            finish_reason=runtime.constants.FINISH_REASON.BASE)
 
     def test_ammo_hud_producer_obeys_exact_integer_wire_ranges(self):
         runtime = _runtime()

--- a/tests/test_port_0922_entities.py
+++ b/tests/test_port_0922_entities.py
@@ -66,6 +66,7 @@ class _ArenaUpdate(object):
 class _ArenaPeriod(object):
     PREBATTLE = 2
     BATTLE = 5
+    AFTERBATTLE = 7
 
 
 class _SiegeState(object):
@@ -491,6 +492,55 @@ class BigWorldBindingTests(unittest.TestCase):
             (2, 115.0, 15.0, []),
             pickle.loads(zlib.decompress(avatar.updates[0][1])))
 
+    def test_afterbattle_period_carries_the_native_round_outcome(self):
+        # ``arena_info.listeners._getPeriodAdditionalInfo`` unpacks exactly
+        # two members, and ``MusicController.__onArenaStateChanged`` indexes
+        # ``periodAdditionalInfo[0]`` for the winning team.
+        module = _binding_module()
+        bigworld = _BigWorld()
+        avatar = _Avatar()
+        binding = module.BigWorldVehicleBinding(
+            bigworld, avatar, _Constants, _VehicleDescr,
+            lambda yaw, pitch, limits: 321,
+            outfit_provider=lambda descriptor: '')
+
+        binding.arena_period('afterbattle', winner_team=2, finish_reason=1)
+
+        self.assertEqual(
+            (7, 0.0, 0.0, (2, 1)),
+            pickle.loads(zlib.decompress(avatar.updates[0][1])))
+
+    def test_afterbattle_period_keeps_a_draw_winner_team(self):
+        module = _binding_module()
+        avatar = _Avatar()
+        binding = module.BigWorldVehicleBinding(
+            _BigWorld(), avatar, _Constants, _VehicleDescr,
+            lambda yaw, pitch, limits: 321,
+            outfit_provider=lambda descriptor: '')
+
+        binding.arena_period('afterbattle', winner_team=0, finish_reason=3)
+
+        self.assertEqual(
+            (7, 0.0, 0.0, (0, 3)),
+            pickle.loads(zlib.decompress(avatar.updates[0][1])))
+
+    def test_arena_period_rejects_a_mismatched_round_outcome(self):
+        module = _binding_module()
+        avatar = _Avatar()
+        binding = module.BigWorldVehicleBinding(
+            _BigWorld(), avatar, _Constants, _VehicleDescr,
+            lambda yaw, pitch, limits: 321,
+            outfit_provider=lambda descriptor: '')
+
+        self.assertRaises(
+            module.CapabilityError, binding.arena_period, 'afterbattle')
+        self.assertRaises(
+            module.CapabilityError, binding.arena_period, 'afterbattle',
+            0.0, 3, 1)
+        self.assertRaises(
+            module.CapabilityError, binding.arena_period, 'battle', 5.0, 1, 1)
+        self.assertEqual([], avatar.updates)
+
     def test_exact_property_schema_rejects_jointly_wrong_producer_values(self):
         module = _binding_module()
         binding = module.BigWorldVehicleBinding(
@@ -591,8 +641,10 @@ class _BridgeBinding(object):
     def avatar_ready(self):
         self.events.append(('avatar_ready',))
 
-    def arena_period(self, period, duration=0.0):
-        self.events.append(('period', period, duration))
+    def arena_period(self, period, duration=0.0, winner_team=None,
+                     finish_reason=None):
+        self.events.append(
+            ('period', period, duration, winner_team, finish_reason))
 
     def arena_vehicle_removed(self, vehicle_id):
         self.events.append(('removed', vehicle_id))
@@ -887,8 +939,9 @@ class AvatarServerBridgeTests(unittest.TestCase):
             sender)
         original_arena_period = binding.arena_period
 
-        def arena_period(period, duration=0.0):
-            original_arena_period(period, duration)
+        def arena_period(period, duration=0.0, winner_team=None,
+                         finish_reason=None):
+            original_arena_period(period, duration, winner_team, finish_reason)
             bridge.vehicle_moveWith(0)
 
         binding.arena_period = arena_period


### PR DESCRIPTION
## Observed problem

After a LAN round ends, the battle-results window opens silently. Retail
plays different music for victory, draw and defeat.

## Root cause (confirmed from #1513 bytecode, evidence layer 2)

`BigWorldVehicleBinding.arena_period` only knew `prebattle` and `battle`, so
the arena never reached `ARENA_PERIOD.AFTERBATTLE`. Both stock owners of the
results music read that transition, not `Avatar.onRoundFinished`:

- `gui/battle_control/arena_info/listeners._getPeriodAdditionalInfo` builds a
  `WinStatus` **only** when `period == AFTERBATTLE`, unpacking exactly two
  members from `arena.periodAdditionalInfo`. Without it,
  `ArenaPeriodController._setArenaWinStatus` gets `None` and never calls
  `BattleContext.setLastArenaWinStatus`. `BattleContext.stop()` deliberately
  does **not** clear that value, and
  `gui/sounds/ambients.BattleResultsEnv.start()` reads it in the lobby to pick
  `MUSIC_EVENT_COMBAT_VICTORY` / `_DRAW` / `_LOSE`; a `None` value selects
  `EmptySound`.
- `MusicControllerWWISE.MusicController.__onArenaStateChanged` latches
  `MusicController.__lastBattleResultEventName` from
  `arena.arenaType.wwmusicSetup` on AFTERBATTLE, comparing
  `arena.periodAdditionalInfo[0]` with `BigWorld.player().team`. That class
  attribute is the **only** producer of the name `__getArenaSoundEvent`
  returns for the three battle-result music events. Every #1513 arena def
  ships `wwmusicResultWin=music_victory`, `wwmusicResultDrawn=music_drawn_game`,
  `wwmusicResultDefeat=music_defeat` and
  `wwmusicEndbattleStop=music_dron_endbattle_stop_temporary`.

So even the correct win status alone would have resolved to an empty WWISE
event name. Both effects need the same publication.

## Change

- `arena_period` gains `afterbattle`, carrying the exact
  `(winnerTeam, finishReason)` pair those consumers unpack; the other periods
  still ship the empty list the retail server sends, and are now rejected if a
  caller passes an outcome. `self_check` requires `ARENA_PERIOD.AFTERBATTLE`.
- `_apply_battle_result` publishes the AFTERBATTLE period **before**
  `Avatar.onRoundFinished`, so both owners hold the outcome before any
  notification consumer runs. Hidden workers still publish nothing.
- The publication is end-of-battle presentation, so it runs through
  `_run_optional_feature`: a failure is contained to that operation and still
  leaves the terminal notification, reload and result bookkeeping intact.

The LAN round has no separate afterbattle server window, so the period carries
no countdown — the same state retail reaches once its own afterbattle window
elapses.

## In-scope side effects of the same transition (stock behaviour)

- `gui/sounds/ambients.BattleSpaceEnv._setAfterBattleAmbient` switches combat
  music to `NoMusic`, and `__onArenaStateChanged` calls `stopAmbient()` plus
  the `wwmusicEndbattleStop` stinger.
- `PlayerAvatar.__onArenaPeriodChange` calls `__setIsOnArena(period == BATTLE)`,
  so the gun rotator stops and the server gun marker hides. That is retail at
  battle end and agrees with the runtime's own gates: `shoot()` already
  rejects with `battle_not_live` and `_drive_local_step` already stops once a
  result exists. Every remaining `gunRotator` reader in the mod uses plain
  attribute reads / `getCurShotPosition()`, which do not need `__isStarted`.
- `FinishSoundPlayer.__checkTimeCondition` keys on `BATTLE`, so the in-battle
  time-over sound is unaffected.

## Validation

- `python3 -m unittest discover -s tests -p "test_*.py"` — 4143 tests, OK.
- CPython 2.7.18 source compile of `src/res/scripts/client` — 96 files, passed.
- New coverage: the binding emits the exact 4-tuple with a two-member
  additional info for afterbattle (including a draw, winner team 0) and still
  `[]` otherwise; mismatched outcomes are rejected; `_apply_battle_result`
  publishes the period exactly once, before `onRoundFinished`, never in worker
  mode, and a publication failure still notifies the HUD.

## Not proved here

Actually hearing victory / draw / defeat music in the results window, the
combat-ambient stop, and the input-lock side effect all need acceptance on the
exact Windows client (#1513). The static tree proves the reviewed call and
payload shape only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)