### PR TITLE
Retire the terrain traces component while an enemy is unspotted

### DIFF
--- a/src/res/scripts/client/gui/mods/offline_lan_0922/entities/native_remote_vehicle.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/entities/native_remote_vehicle.py
@@ -44,9 +44,10 @@ def set_draw_visibility(entity, visible):
     # keeps drawing over a hidden tank.  Gate the attachments too.
     set_model_attachment_visibility(
         getattr(appearance, 'compoundModel', None), visible)
-    # That flag is one unproven native property.  Close the two stock owners
-    # it would have covered directly as well: the ground occlusion decals and
-    # the camera-distance dust/exhaust selectors.
+    # That flag is one unproven native property.  Close the stock owners it
+    # would have covered directly as well: the ground occlusion decals, the
+    # camera-distance dust/exhaust selectors and the terrain track marks,
+    # which are a separate component and no attachment at all.
     close_stock_presentation_extras(appearance, visible)
     return True
 

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/entities/remote_vehicle.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/entities/remote_vehicle.py
@@ -81,17 +81,25 @@ def set_model_attachment_visibility(model, visible):
 # One line per process for each stock surface the runtime could not reach.
 _ground_effect_gate_reported = False
 _ground_decal_gate_reported = False
+_ground_traces_gate_reported = False
+_ground_traces_rebuild_reported = False
 _ground_effect_failure_reported = False
 _ground_decal_failure_reported = False
+_ground_traces_failure_reported = False
 
 
 def _report_ground_gate_failure(kind, error):
     """Log one bounded failure for an optional stock presentation owner."""
     global _ground_effect_failure_reported, _ground_decal_failure_reported
+    global _ground_traces_failure_reported
     if kind == 'effects':
         if _ground_effect_failure_reported:
             return False
         _ground_effect_failure_reported = True
+    elif kind == 'traces':
+        if _ground_traces_failure_reported:
+            return False
+        _ground_traces_failure_reported = True
     else:
         if _ground_decal_failure_reported:
             return False
@@ -307,18 +315,119 @@ def clear_ground_decal_visibility_state(appearance):
     return reached
 
 
+# Sentinel for an appearance that has no stock traces component field at
+# all, which must not be confused with a component this gate removed.
+_TRACES_FIELD_ABSENT = object()
+
+# The exact #1513 module that owns traces assembly, resolved on first use so
+# this module keeps importing outside a client process.
+_stock_traces_assembler = None
+
+
+def _traces_assembler():
+    """Return the exact #1513 ``vehicle_systems.model_assembler`` module."""
+    global _stock_traces_assembler
+    if _stock_traces_assembler is None:
+        from vehicle_systems import model_assembler
+        _stock_traces_assembler = model_assembler
+    return _stock_traces_assembler
+
+
+def set_vehicle_traces_visibility(appearance, visible):
+    """Own the ground track marks no stock compound draw flag reaches.
+
+    #1513 gives every non-damaged vehicle a ``Vehicular.VehicleTraces``
+    component: ``vehicle_assembler._assembleParts`` ->
+    ``__assembleNonDamagedOnly`` -> ``model_assembler.assembleVehicleTraces``.
+    It prints terrain track decals from ``filter.movementInfo`` and reads no
+    compound draw flag, so ``Vehicle.show`` and
+    ``CompoundAppearance.changeVisibility`` leave an unspotted enemy drawing
+    a trail of track marks over ground the player may not see.  The SPG
+    strategic camera looks straight down at exactly that ground, which is
+    where the leak reads as a wallhack.
+
+    Retail never has to solve this: an unspotted enemy is outside the client
+    AOI, so neither its entity nor its traces component exists, and its trail
+    disappears with it.  Reproduce that state through the exact stock pair.
+    ``CompoundAppearance.__prepareSystemsForDamagedVehicle`` already assigns
+    ``vehicleTraces = None`` on a live, activated appearance, and the only
+    other stock reader, ``__updateCurrTerrainMatKinds``, tests the attribute
+    against None on every terrain sample, so a living vehicle without the
+    component is a state this build already supports.  Reveal re-runs the
+    exact stock assembly call; both of its inputs are still live on the
+    appearance (``filter`` and ``lodCalculator.lodStateLink``, which
+    ``_assembleParts`` reads from the same two places).
+
+    A wreck carries no traces in stock either, and the caller keeps a
+    destroyed vehicle drawn, so never assemble onto a damaged model.
+    """
+    global _ground_traces_gate_reported, _ground_traces_rebuild_reported
+    if appearance is None:
+        return False
+    visible = bool(visible)
+    traces = getattr(appearance, 'vehicleTraces', _TRACES_FIELD_ABSENT)
+    if traces is _TRACES_FIELD_ABSENT:
+        if not _ground_traces_gate_reported:
+            _ground_traces_gate_reported = True
+            sys.stdout.write(
+                '[Offline LAN 0.9.22] compound appearance exposes no vehicle '
+                'traces component; a hidden vehicle may still print track '
+                'marks\n')
+        return False
+    if not visible:
+        if traces is None:
+            return True
+        try:
+            # Stock's own retire line.  The descriptor removes the component
+            # from the native system before the field goes to None, so a
+            # partial failure cannot leave a detached component drawing.
+            appearance.vehicleTraces = None
+        except Exception as error:
+            _report_ground_gate_failure('traces', error)
+            return False
+        return True
+    if traces is not None:
+        return True
+    damage_state = getattr(appearance, 'damageState', None)
+    is_damaged = getattr(damage_state, 'isCurrentModelDamaged', None)
+    vehicle_filter = getattr(appearance, 'filter', None)
+    lod_state_link = getattr(
+        getattr(appearance, 'lodCalculator', None), 'lodStateLink', None)
+    if is_damaged is None or vehicle_filter is None or lod_state_link is None:
+        if not _ground_traces_rebuild_reported:
+            _ground_traces_rebuild_reported = True
+            sys.stdout.write(
+                '[Offline LAN 0.9.22] compound appearance cannot rebuild its '
+                'vehicle traces; a revealed vehicle may print no track '
+                'marks\n')
+        return False
+    if is_damaged:
+        return True
+    try:
+        _traces_assembler().assembleVehicleTraces(
+            appearance, vehicle_filter, lod_state_link)
+    except Exception as error:
+        # Assembly builds a fresh component and publishes it last, so a
+        # failure leaves the field None and the next reveal may retry.
+        _report_ground_gate_failure('traces', error)
+        return False
+    return True
+
+
 def close_stock_presentation_extras(appearance, visible):
     """Apply every draw gate the stock compound flags do not cover.
 
     ``changeVisibility`` writes ``compoundModel.visible``, the stickers and
-    the crashed-track controller.  It reaches neither the node attachments nor
-    the camera-distance effect selectors, and both keep drawing over a hidden
-    enemy.  Each surface is optional on its own: a build that does not expose
-    one logs a single line and the round continues.
+    the crashed-track controller.  It reaches neither the node attachments,
+    the camera-distance effect selectors nor the terrain traces component,
+    and all three keep drawing over a hidden enemy.  Each surface is optional
+    on its own: a build that does not expose one logs a single line and the
+    round continues.
     """
     if appearance is None:
         return False
     reached = set_ground_decal_visibility(appearance, visible)
+    reached = set_vehicle_traces_visibility(appearance, visible) or reached
     if not visible:
         reached = stop_ground_effects(appearance) or reached
     return reached

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -701,6 +701,75 @@ class _VehicleDecal(object):
         self.hull_node.detach(self.decal)
 
 
+class _VehicleTraces(object):
+    """One assembled #1513 ``Vehicular.VehicleTraces`` component."""
+
+    def __init__(self, appearance, vehicle_filter, lod_state_link):
+        self.appearance = appearance
+        self.movementInfo = getattr(vehicle_filter, 'movementInfo', None)
+        self.lodStateLink = lod_state_link
+
+
+class _TracesAssembler(object):
+    """Reproduce exact #1513 ``model_assembler.assembleVehicleTraces``.
+
+    Stock builds a fresh component, feeds it the chassis trace textures, the
+    compound, the flying links, the LOD link and the filter's movement info,
+    and publishes it through the appearance's component descriptor last.
+    """
+
+    def __init__(self):
+        self.calls = []
+        self.error = None
+
+    def assembleVehicleTraces(self, appearance, vehicleFilter, lodStateLink):
+        self.calls.append((appearance, vehicleFilter, lodStateLink))
+        if self.error is not None:
+            raise self.error
+        appearance.vehicleTraces = _VehicleTraces(
+            appearance, vehicleFilter, lodStateLink)
+
+
+class _Appearance(types.SimpleNamespace):
+    """A compound appearance that owns components the way #1513 does.
+
+    ``svarog_script.py_component_system.ComponentDescriptor.__set__`` removes
+    the previous component from the native component system before it stores
+    a replacement, and adds a non-None one.  A fake that only rebound an
+    attribute could not tell a retired traces component from a live one.
+    """
+
+    def __init__(self, **fields):
+        self.components = []
+        self._traces = None
+        types.SimpleNamespace.__init__(self, **fields)
+
+    def addComponent(self, component, name=''):
+        self.components.append((name, component))
+
+    def removeComponent(self, component):
+        self.components = [entry for entry in self.components
+                           if entry[1] is not component]
+
+    @property
+    def vehicleTraces(self):
+        return self._traces
+
+    @vehicleTraces.setter
+    def vehicleTraces(self, value):
+        if self._traces is not None:
+            self.removeComponent(self._traces)
+        if value is not None:
+            self.addComponent(value, 'vehicleTraces')
+        self._traces = value
+
+
+# The client resolves ``vehicle_systems.model_assembler`` lazily, so a
+# pure-data test can pin the exact stock entry point to a recording fake.
+_TRACES_ASSEMBLER = _TracesAssembler()
+remote_vehicle_module._stock_traces_assembler = _TRACES_ASSEMBLER
+
+
 class _Vehicle(object):
     def __init__(self, entity_id, descriptor, position, rotation, properties):
         self.id = entity_id
@@ -731,7 +800,7 @@ class _Vehicle(object):
         self.custom_effects = _CustomEffectManager()
         self.custom_effects.enable(True, _CustomEffectManager.SETTING_DUST)
         self.custom_effects.enable(True, _CustomEffectManager.SETTING_EXHAUST)
-        self.appearance = types.SimpleNamespace(
+        self.appearance = _Appearance(
             compoundModel=self.model, turretMatrix=_Matrix(),
             gunMatrix=_Matrix(),
             highlighter=types.SimpleNamespace(enabled=False),
@@ -760,7 +829,18 @@ class _Vehicle(object):
         self.speed = 0.0
         self.filter = types.SimpleNamespace(
             longitudinalSpeed=0.0, angularSpeed=0.0,
+            movementInfo=object(),
             notifyInputKeysDown=mock.Mock())
+        # Exact #1513 assembles a traces component for every non-damaged
+        # vehicle and reads both of its rebuild inputs off the appearance.
+        self.appearance.filter = self.filter
+        self.appearance.damageState = types.SimpleNamespace(
+            isCurrentModelDamaged=False)
+        self.appearance.lodCalculator = types.SimpleNamespace(
+            lodStateLink=object())
+        self.appearance.vehicleTraces = _VehicleTraces(
+            self.appearance, self.filter,
+            self.appearance.lodCalculator.lodStateLink)
         self.ammo_bay_effects = []
         self.shows = []
         self.draw_pass_visible = True
@@ -22417,6 +22497,108 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertEqual([], vehicle.custom_effects.running())
         self.assertTrue(set_draw_visibility(vehicle, True))
         self.assertIn(vehicle.splodge, vehicle.hull_node.attachments)
+
+    def test_hidden_remote_retires_its_ground_track_marks(self):
+        """An unspotted enemy must not print track marks on the terrain.
+
+        Exact #1513 assembles a ``Vehicular.VehicleTraces`` component for
+        every non-damaged vehicle and drives it from ``filter.movementInfo``.
+        It reads no compound draw flag, so ``Vehicle.show(False)`` and
+        ``changeVisibility(False)`` left a hidden tank drawing a trail of
+        track marks - the leak Peng saw from the SPG strategic camera, which
+        looks straight down at ground he is not allowed to see.
+        """
+        vehicle = _Vehicle(
+            1000, _Descriptor(), _Vector(), (0.0, 0.0, 0.0),
+            {'health': 500, 'publicInfo': {'team': 2}})
+        appearance = vehicle.appearance
+        assembled = appearance.vehicleTraces
+        self.assertIsNotNone(assembled)
+        self.assertEqual(
+            [('vehicleTraces', assembled)], appearance.components)
+        del _TRACES_ASSEMBLER.calls[:]
+
+        self.assertTrue(set_draw_visibility(vehicle, False))
+
+        # Stock's own retire line: the descriptor removes the component from
+        # the native system, so nothing is left to print a mark.
+        self.assertIsNone(appearance.vehicleTraces)
+        self.assertEqual([], appearance.components)
+        self.assertEqual([], _TRACES_ASSEMBLER.calls)
+
+        # A repeated hide edge must not retire an already retired component.
+        self.assertTrue(set_draw_visibility(vehicle, False))
+        self.assertIsNone(appearance.vehicleTraces)
+
+        self.assertTrue(set_draw_visibility(vehicle, True))
+
+        restored = appearance.vehicleTraces
+        self.assertIsNotNone(restored)
+        self.assertIsNot(assembled, restored)
+        self.assertEqual(
+            [('vehicleTraces', restored)], appearance.components)
+        # Reveal runs the exact stock assembly call with the two inputs
+        # ``vehicle_assembler._assembleParts`` reads off the appearance.
+        self.assertEqual(1, len(_TRACES_ASSEMBLER.calls))
+        rebuilt_appearance, rebuilt_filter, rebuilt_lod = (
+            _TRACES_ASSEMBLER.calls[0])
+        self.assertIs(appearance, rebuilt_appearance)
+        self.assertIs(appearance.filter, rebuilt_filter)
+        self.assertIs(appearance.lodCalculator.lodStateLink, rebuilt_lod)
+
+        # A repeated reveal must not build a second component.
+        self.assertTrue(set_draw_visibility(vehicle, True))
+        self.assertEqual(1, len(_TRACES_ASSEMBLER.calls))
+        self.assertIs(restored, appearance.vehicleTraces)
+
+    def test_revealed_wreck_keeps_the_stock_absence_of_track_marks(self):
+        """A destroyed vehicle stays drawn but owns no traces component.
+
+        ``_set_record_spot_visibility`` keeps a wreck enabled for the stock
+        renderer, so the reveal edge fires for it.  Exact #1513
+        ``CompoundAppearance.__prepareSystemsForDamagedVehicle`` retires
+        ``vehicleTraces`` when the model becomes damaged and
+        ``vehicle_assembler`` never assembles one for a damaged model, so
+        this port must not invent one either.
+        """
+        vehicle = _Vehicle(
+            1000, _Descriptor(), _Vector(), (0.0, 0.0, 0.0),
+            {'health': 500, 'publicInfo': {'team': 2}})
+        appearance = vehicle.appearance
+        self.assertTrue(set_draw_visibility(vehicle, False))
+        self.assertIsNone(appearance.vehicleTraces)
+        appearance.damageState.isCurrentModelDamaged = True
+        del _TRACES_ASSEMBLER.calls[:]
+
+        self.assertTrue(set_draw_visibility(vehicle, True))
+
+        self.assertTrue(vehicle.model.visible)
+        self.assertIsNone(appearance.vehicleTraces)
+        self.assertEqual([], _TRACES_ASSEMBLER.calls)
+
+    def test_failed_track_mark_rebuild_stays_local_to_that_appearance(self):
+        """A traces rebuild failure must not break the visibility edge."""
+        vehicle = _Vehicle(
+            1000, _Descriptor(), _Vector(), (0.0, 0.0, 0.0),
+            {'health': 500, 'publicInfo': {'team': 2}})
+        appearance = vehicle.appearance
+        self.assertTrue(set_draw_visibility(vehicle, False))
+        del _TRACES_ASSEMBLER.calls[:]
+        _TRACES_ASSEMBLER.error = RuntimeError('traces buffer is unavailable')
+        try:
+            self.assertTrue(set_draw_visibility(vehicle, True))
+        finally:
+            _TRACES_ASSEMBLER.error = None
+
+        # The rest of the reveal still ran, and the field stays empty so a
+        # later reveal can retry a fresh component.
+        self.assertTrue(vehicle.model.visible)
+        self.assertIn(vehicle.splodge, vehicle.hull_node.attachments)
+        self.assertIsNone(appearance.vehicleTraces)
+        self.assertEqual(1, len(_TRACES_ASSEMBLER.calls))
+
+        self.assertTrue(set_draw_visibility(vehicle, True))
+        self.assertIsNotNone(appearance.vehicleTraces)
 
     def test_ground_splodge_rebind_uses_only_the_current_model_generation(self):
         vehicle = _Vehicle(


### PR DESCRIPTION
## Observed problem

From the SPG strategic camera, an unspotted enemy still prints a trail of
terrain track marks. The tank itself is correctly hidden, so the trail is a
pure information leak: it draws exactly where the player is not allowed to
see anything.

## Root cause

Exact #1513 assembles one more world-space presentation owner that no
compound draw flag reaches:

* `vehicle_assembler._assembleParts` -> `__assembleNonDamagedOnly` ->
  `model_assembler.assembleVehicleTraces(appearance, appearance.filter,
  appearance.lodCalculator.lodStateLink)` builds a
  `Vehicular.VehicleTraces` component for **every** non-damaged vehicle.
* It prints terrain decals from `filter.movementInfo` and reads no draw
  flag, so `Vehicle.show(False)` and `CompoundAppearance.changeVisibility(
  False)` never touch it. `changeVisibility` only writes
  `compoundModel.visible`, `showStickers` and the crashed-track controller.
* `PyVehicleTraces` exposes only `setCompound`, `setMovementInfo`,
  `setTrackTraces`, `setCurrTerrainMatKinds`, `setFlyingInfo`, `setLodLink`
  and `setLodSettings` - there is no visibility, enable or activate switch
  to close.

This is the fourth owner in the same class as the ground occlusion decals,
the `BigWorld.Splodge` and the camera-distance dust/exhaust selectors that
`close_stock_presentation_extras` already gates. The SPG camera makes it
loudest because it sits over the ground the trail is printed on.

## Fix

Retail never has to solve this: an unspotted enemy is outside the client
AOI, so neither its entity nor its traces component exists and its trail
disappears with it. This port creates every replica locally, so reproduce
that state with the exact stock pair, at the existing choke point
(`close_stock_presentation_extras`, reached by `set_draw_visibility` and by
the compatibility enter-world gate):

* **Hide**: `appearance.vehicleTraces = None`. This is stock's own retire
  line - `CompoundAppearance.__prepareSystemsForDamagedVehicle` runs it on a
  live, activated appearance - and the descriptor removes the component from
  the native `Svarog.ComponentSystem` before the field goes to None. The
  only other stock reader, `__updateCurrTerrainMatKinds`, already guards the
  field against None on every terrain sample, so a living vehicle without
  the component is a state this build supports.
* **Reveal**: re-run `model_assembler.assembleVehicleTraces` with the two
  inputs `_assembleParts` reads from the same appearance (`filter`,
  `lodCalculator.lodStateLink`). A fresh component is built each time,
  exactly as at assembly.
* A damaged model never gets one, matching stock, so a wreck - which the
  caller deliberately keeps drawn - is skipped.

The gate reads the live field on every edge, so a compound refresh that
re-assembles traces under a hidden enemy is closed again on the
`onModelChanged` re-apply. Every failure is contained to that appearance
with one bounded log line; the round continues.

## Validation

* `python3 -m unittest discover -s tests -p "test_*.py"` - full client
  suite green.
* CPython 2.7 source compile over `src/res/scripts/client` (96 files).
* Three new tests in `tests/test_port_0922_battle_runtime.py`. The fake
  appearance now reproduces `ComponentDescriptor.__set__` (remove the
  previous component, add a non-None replacement), so the tests prove the
  component pairing and not an attribute flip. All three fail without the
  production change.

## What this does NOT prove - needs the Windows client

Hide is stock-proven. **Reveal is not**: adding a component back to an
already activated `Svarog.ComponentSystem` is something stock never does.
If the native add silently no-ops, nothing raises and nothing is logged, so
this cannot be checked by grepping `python.log`. It has to be seen:

1. Unspotted enemy driving under the SPG camera -> no track marks.
2. The **same** enemy after it is re-spotted, driving -> marks resume.
   This is the unproven edge.
3. Spot flicker at the view-range edge -> no hitch. Each reveal allocates a
   native trace buffer from `traces.bufferPrefs`; the churn cost is
   unmeasured.

Worst case if (2) fails: spotted enemies stop printing track marks for the
rest of the round. That is cosmetic, it cannot crash (assembly is native
setters plus a descriptor store), and it is strictly better than shipping
the current wallhack - but it is a real trade and it is Peng's call.
