### PR TITLE
Publish Bot state as compact rows so a fire launch is not queued behind it

### DIFF
--- a/server/lan_battle_server.py
+++ b/server/lan_battle_server.py
@@ -6039,6 +6039,11 @@ class BattleState:
         admitted, and no projectile edge is derived from a state it refused.
         """
         result = dict(previous) if previous else {}
+        # The ledgers this holds must not alias the retired state; every other
+        # path here produces fresh containers.
+        for name in ("critical", "equipment_states", "ammo_remaining"):
+            if name in result:
+                result[name] = copy.deepcopy(result[name])
         max_health = int(identity.get("max_health", 1000))
         health = max(0, min(int(raw["health"]), max_health))
         if previous is not None:
@@ -6320,15 +6325,14 @@ class BattleState:
                 try:
                     current = self._sanitize_bot_state(
                         raw, identity, previous, trusted=True)
-                    self._reconcile_modern_bot_combat(
-                        raw, previous, current)
                 except ValueError as error:
-                    # One Bot's combat or inventory contract cannot hold the
-                    # whole publication. Rejecting the batch would also leave
-                    # this Bot's stored state behind its own next publication,
+                    # One Bot's own state contract cannot hold the whole
+                    # publication. Rejecting the batch would also leave this
+                    # Bot's stored state behind its own next publication,
                     # which repeats the same failure and freezes it for the
-                    # rest of the round. Keep the Bot moving on its published
-                    # pose and carry its previous combat ledger forward.
+                    # rest of the round while every other Bot loses the tick
+                    # too. Keep the Bot moving on its published pose and carry
+                    # its previous ledgers forward.
                     _server_log_limited(
                         "bot-state-contract:%d" % bot_id,
                         "BOT STATE contained bot=%s client_fire=%s "
@@ -6337,6 +6341,46 @@ class BattleState:
                             (previous or {}).get("fire_seq", 0), error))
                     current = self._contained_bot_state(
                         raw, identity, previous)
+                else:
+                    try:
+                        self._reconcile_modern_bot_combat(
+                            raw, previous, current)
+                    except ValueError as error:
+                        # The state itself is well formed; only its combat
+                        # lineage is not the one the server holds. Fence the
+                        # combat ledger exactly like a lost ordering race, and
+                        # open a new canonical revision so the authority
+                        # rebases onto it. Without that new base the authority
+                        # keeps proposing past a sequence the server will
+                        # never acknowledge and this Bot's combat state stays
+                        # frozen for the rest of the round.
+                        _server_log_limited(
+                            "bot-combat-contract:%d" % bot_id,
+                            "BOT STATE combat rebased bot=%s client_base=%s "
+                            "server_base=%s client_seq=%s server_ack=%s "
+                            "reason=%s" % (
+                                bot_id, raw.get("combat_base_revision"),
+                                (previous or {}).get(
+                                    "combat_base_revision", 0),
+                                raw.get("combat_seq"),
+                                (previous or {}).get("combat_ack_seq", 0),
+                                error))
+                        if previous is None:
+                            current = self._contained_bot_state(
+                                raw, identity, previous)
+                        else:
+                            self._copy_bot_combat(current, previous)
+                            proposed_base = raw.get(
+                                "combat_base_revision", 0)
+                            if not isinstance(proposed_base, int) or \
+                                    isinstance(proposed_base, bool):
+                                proposed_base = 0
+                            revision = max(
+                                int(current.get("combat_revision", 0)),
+                                int(current.get("combat_base_revision", 0)),
+                                proposed_base) + 1
+                            current["combat_revision"] = revision
+                            current["combat_base_revision"] = revision
                 rebase_fire_gap = bool(
                     source_clock_rebase and previous is not None and
                     int(current.get("fire_seq", 0)) >
@@ -6353,17 +6397,19 @@ class BattleState:
                             previous, current)
                         self._validate_bot_ammo_transition(previous, current)
                     except ValueError as error:
-                        # Same containment as the combat contract above: hold
-                        # this Bot's magazine on its last admitted state and
-                        # derive no projectile edge from one the server could
-                        # not accept, but keep it and every other Bot moving.
+                        # The published magazine and burst clock do not follow
+                        # from the last ones the server admitted, which a
+                        # coalesced publication spanning an unobserved shot
+                        # already produces legally.  Holding the old magazine
+                        # would make every later publication disagree with it
+                        # the same way, so this Bot would never fire again.
+                        # Take the complete published inventory as the new
+                        # trusted baseline exactly like the rebase above, and
+                        # never invent projectile edges for the gap.
                         _server_log_limited(
                             "bot-ammo-contract:%d" % bot_id,
-                            "BOT STATE contained bot=%s reason=%s" % (
+                            "BOT STATE rebased bot=%s reason=%s" % (
                                 bot_id, error))
-                        current = self._contained_bot_state(
-                            raw, identity, previous)
-                        next_states[bot_id] = current
                         burst_edges = ()
                 previous_fire = int((previous or {}).get("fire_seq", 0))
                 if (previous is not None and

--- a/server/lan_battle_server.py
+++ b/server/lan_battle_server.py
@@ -51,6 +51,7 @@ from gui.mods.offline_lan_0922.battle_achievements import (
     ACHIEVEMENT_CONDITIONS, AWARDABLE_ACHIEVEMENTS, RECEIPT_STAT_NAMES,
     award_battle_achievements)
 from gui.mods.offline_lan_0922 import bot_gunnery
+from gui.mods.offline_lan_0922 import bot_state_codec
 from gui.mods.offline_lan_0922 import burst_mechanics
 from gui.mods.offline_lan_0922 import effective_params as effective_params_wire
 from gui.mods.offline_lan_0922 import equipment_mechanics
@@ -664,6 +665,18 @@ def _has_finite_fields(value, names):
         except (TypeError, ValueError):
             return False
     return True
+
+
+def _validated_bot_round_constants(raw):
+    """Validate the immutable consumable contracts one Bot mounts.
+
+    These cannot change while a round runs and were the largest part of the
+    old per-publication encoding, so they ride ``bot_manifest`` and are proved
+    here exactly once instead of on every row of every publication.
+    """
+    contracts = equipment_mechanics.bot_consumable_contracts(
+        None, snapshot=raw.get("equipment_states"))
+    return {"equipment_contracts": list(contracts)}
 
 
 def _validated_bot_reload_progress(raw, required=False):
@@ -4360,6 +4373,10 @@ class BattleState:
                                 raw.get("terminal_critical")))
                 except (TypeError, ValueError):
                     return False
+                try:
+                    round_constants = _validated_bot_round_constants(raw)
+                except ValueError:
+                    return False
                 entry = {
                     "id": bot_id,
                     "team": identity["team"],
@@ -4371,6 +4388,10 @@ class BattleState:
                     "profile": self._sanitize_bot_profile(raw.get("profile")),
                     "route": route,
                 }
+                # Per-vehicle constants are validated once here. Every later
+                # publication carries only the values that change, and
+                # ``_decode_bot_row`` rejoins these.
+                entry.update(round_constants)
                 if 'skill' in raw:
                     if raw['skill'] not in bot_gunnery.SKILL_TIERS:
                         return False
@@ -5600,7 +5621,15 @@ class BattleState:
         return False
 
     @staticmethod
-    def _sanitize_bot_state(raw, identity, previous):
+    def _sanitize_bot_state(raw, identity, previous, trusted=False):
+        """Build one canonical Bot state from a manifest or publication row.
+
+        ``trusted`` marks input that came from ``bot_state_codec.decode_row``.
+        Such a mapping is complete, finite, in contract range and already
+        canonical for the critical and consumable ledgers, because the wire
+        row cannot represent anything else. Re-deriving those two ledgers is
+        the most expensive part of this function and is skipped for it.
+        """
         max_health = int(identity.get("max_health", 1000))
         reported_health = max(0, min(int(_finite_float(raw.get("health"), max_health)), max_health))
         if previous is not None:
@@ -5699,7 +5728,8 @@ class BattleState:
                 reload_progress
         critical = (previous or {}).get("critical")
         if "critical" in raw:
-            critical = _critical_state(_critical_payload(raw.get("critical")))
+            critical = (_critical_state(raw["critical"]) if trusted else
+                        _critical_state(_critical_payload(raw.get("critical"))))
         # Canonical snapshots always carry the complete combat baseline. An
         # empty state must not disappear before the #1513 loading snapshot.
         result["critical"] = critical or {}
@@ -5732,26 +5762,31 @@ class BattleState:
                 else []
         if not isinstance(snapshots, (list, tuple)):
             raise ValueError("bot equipment snapshot is invalid")
-        contracts = None
-        if previous_snapshots is not None:
-            contracts = equipment_mechanics.bot_consumable_contracts(
-                None, snapshot=previous_snapshots)
+        if trusted:
+            # The row carried only the mutable triple; the immutable contract
+            # was rejoined from the round manifest. Nothing needs restoring or
+            # re-projecting, so only the one invariant the wire cannot express
+            # is still checked: a Bot never gains a consumable use.
+            if previous_snapshots is not None:
+                for old_snapshot, new_snapshot in zip(
+                        previous_snapshots, snapshots):
+                    old_uses = int(old_snapshot.get("usesLeft", -1))
+                    if (old_uses >= 0 and
+                            int(new_snapshot.get("usesLeft", 0)) > old_uses):
+                        raise ValueError("bot equipment inventory increased")
+            result["equipment_states"] = snapshots
         else:
-            contracts = equipment_mechanics.bot_consumable_contracts(
-                None, snapshot=snapshots)
-        equipments = equipment_mechanics.restore_equipment_states(
-            snapshots, contracts=contracts, now=0.0)
-        canonical_snapshots = [equipment.snapshot(0.0)
-                               for equipment in equipments]
-        if previous_snapshots is not None:
-            previous_equipments = \
-                equipment_mechanics.restore_equipment_states(
-                    previous_snapshots, contracts=contracts, now=0.0)
-            for old, new in zip(previous_equipments, equipments):
-                if (old.uses_left >= 0 and
-                        new.uses_left > old.uses_left):
-                    raise ValueError("bot equipment inventory increased")
-        result["equipment_states"] = canonical_snapshots
+            contracts = None
+            if previous_snapshots is not None:
+                contracts = equipment_mechanics.bot_consumable_contracts(
+                    None, snapshot=previous_snapshots)
+            else:
+                contracts = equipment_mechanics.bot_consumable_contracts(
+                    None, snapshot=snapshots)
+            equipments = equipment_mechanics.restore_equipment_states(
+                snapshots, contracts=contracts, now=0.0)
+            result["equipment_states"] = [equipment.snapshot(0.0)
+                                          for equipment in equipments]
         raw_stun_end = raw.get(
             "stun_end_server_time_ms",
             (previous or {}).get("stun_end_server_time_ms", 0))
@@ -5991,6 +6026,48 @@ class BattleState:
         bot["combat_fire_timer"] = 0.0
         return durable
 
+    @staticmethod
+    def _contained_bot_state(raw, identity, previous):
+        """Keep one Bot moving when its own combat contract did not hold.
+
+        Rejecting the publication would also leave this Bot's stored state
+        behind its next publication, which then fails the same way, so the Bot
+        would stay frozen for the rest of the round while every other Bot lost
+        that tick as well. Pose, health and the presented hull are merges, not
+        proposals, so they advance here. The shot counter, magazine, burst,
+        consumable and critical ledgers stay on the last state the server
+        admitted, and no projectile edge is derived from a state it refused.
+        """
+        result = dict(previous) if previous else {}
+        max_health = int(identity.get("max_health", 1000))
+        health = max(0, min(int(raw["health"]), max_health))
+        if previous is not None:
+            health = min(health, int(previous.get("health", max_health)))
+        for name in ("x", "y", "z", "yaw", "pitch", "roll", "aim_yaw",
+                     "gun_pitch", "speed", "movement_dir", "rotation_dir",
+                     "world_pose"):
+            result[name] = raw[name]
+        for name in ("shot_yaw", "shot_pitch"):
+            if name in raw:
+                result[name] = raw[name]
+        result.update({
+            "id": int(identity["id"]),
+            "team": int(identity["team"]),
+            "slot": int(identity["slot"]),
+            "name": identity["name"],
+            "vehicle": identity.get("vehicle", "ussr:R11_MS-1"),
+            "max_health": max_health,
+            "health": health,
+            "alive": bool(raw["alive"]) and health > 0,
+            "display_health": max(
+                0, min(int(raw["display_health"]), max_health)),
+            "fire_seq": int((previous or {}).get("fire_seq", 0)),
+        })
+        result.setdefault("critical", {})
+        result.setdefault("equipment_states", [])
+        result.setdefault("ammo_remaining", [])
+        return result
+
     def _reconcile_modern_bot_combat(self, raw, previous, current):
         """Apply the strict #1513 bot publication/base/ack contract."""
         required = ("critical", "combat_base_revision", "combat_seq",
@@ -6194,8 +6271,12 @@ class BattleState:
                 next_launch_clock_offset_us = (
                     self._server_time_ms() * 1000 -
                     source_batch_horizon_us)
+            # One row per Bot, dead Bots included, so membership is a length
+            # check plus one identity lookup. The worker publishes in its own
+            # slot order, which is not the manifest's id order, so a row names
+            # the Bot it belongs to rather than relying on position.
             identities = {entry["id"]: entry for entry in self.bot_manifest}
-            incoming = message.get("bots") or []
+            incoming = message.get("rows") or []
             if (not isinstance(incoming, (list, tuple)) or
                     len(incoming) != len(identities)):
                 return self._set_protocol_reject(
@@ -6217,78 +6298,45 @@ class BattleState:
             fire_lineage_clears = set()
             capture_resets = set()
             stun_clears = []
-            seen = set()
-            required = ("id", "x", "y", "z", "yaw", "health",
-                        "alive", "fire_seq", "reload_time",
-                        "reload_duration")
-            for raw in incoming:
-                if (not isinstance(raw, dict) or
-                        not all(key in raw for key in required) or
-                        not _has_finite_fields(
-                            raw, ("id", "x", "y", "z", "yaw",
-                                  "health", "fire_seq")) or
-                        not isinstance(raw.get("alive"), bool)):
+            for row in incoming:
+                if (not isinstance(row, (list, tuple)) or not row or
+                        not isinstance(row[0], int) or
+                        isinstance(row[0], bool)):
                     return self._set_protocol_reject(
-                        "bot_state", "bot_shape",
-                        "bot=%s required_or_finite_fields_invalid" % (
-                            raw.get("id") if isinstance(raw, dict)
-                            else None))
-                try:
-                    bot_id = int(raw.get("id"))
-                except (TypeError, ValueError):
-                    return self._set_protocol_reject(
-                        "bot_state", "bot_id", "bot=%s" % raw.get("id"))
+                        "bot_state", "row_shape", "row is not a Bot row")
+                bot_id = row[0]
                 identity = identities.get(bot_id)
-                if identity is None or bot_id in seen:
+                if identity is None:
                     return self._set_protocol_reject(
-                        "bot_state", "bot_identity",
-                        "bot=%s known=%s duplicate=%s" % (
-                            bot_id, identity is not None, bot_id in seen))
-                seen.add(bot_id)
-                try:
-                    fire_seq = int(raw.get("fire_seq"))
-                except (TypeError, ValueError):
-                    return self._set_protocol_reject(
-                        "bot_state", "fire_seq",
-                        "bot=%s client_fire=%s" % (
-                            bot_id, raw.get("fire_seq")))
-                if (fire_seq < 0 or float(raw.get("fire_seq")) != fire_seq or
-                        bool(raw.get("alive")) !=
-                        (int(float(raw.get("health"))) > 0)):
-                    return self._set_protocol_reject(
-                        "bot_state", "fire_or_alive",
-                        "bot=%s client_fire=%s health=%s alive=%s" % (
-                            bot_id, raw.get("fire_seq"), raw.get("health"),
-                            raw.get("alive")))
+                        "bot_state", "bot_identity", "bot=%s" % bot_id)
                 previous = self.bot_states.get(bot_id)
                 try:
+                    raw = bot_state_codec.decode_row(row, identity)
+                except (bot_state_codec.BotStateCodecError, TypeError,
+                        ValueError) as error:
+                    return self._set_protocol_reject(
+                        "bot_state", "row_shape",
+                        "bot=%s reason=%s" % (bot_id, error))
+                try:
                     current = self._sanitize_bot_state(
-                        raw, identity, previous)
-                    _validated_bot_reload_progress(raw, required=True)
-                    if (previous is not None and
-                            int(current.get("fire_seq", 0)) >
-                            int(previous.get("fire_seq", 0)) and
-                            current.get("siege_state") in (
-                                SIEGE_SWITCHING_ON,
-                                SIEGE_SWITCHING_OFF)):
-                        raise ValueError(
-                            "bot fired during a Siege transition")
+                        raw, identity, previous, trusted=True)
                     self._reconcile_modern_bot_combat(
                         raw, previous, current)
                 except ValueError as error:
-                    return self._set_protocol_reject(
-                        "bot_state", "combat_contract",
-                        ("bot=%s client_fire=%s server_fire=%s "
-                         "client_base=%s server_base=%s client_seq=%s "
-                         "server_ack=%s reason=%s") % (
+                    # One Bot's combat or inventory contract cannot hold the
+                    # whole publication. Rejecting the batch would also leave
+                    # this Bot's stored state behind its own next publication,
+                    # which repeats the same failure and freezes it for the
+                    # rest of the round. Keep the Bot moving on its published
+                    # pose and carry its previous combat ledger forward.
+                    _server_log_limited(
+                        "bot-state-contract:%d" % bot_id,
+                        "BOT STATE contained bot=%s client_fire=%s "
+                        "server_fire=%s reason=%s" % (
                             bot_id, raw.get("fire_seq"),
-                            (previous or {}).get("fire_seq", 0),
-                            raw.get("combat_base_revision"),
-                            (previous or {}).get(
-                                "combat_base_revision", 0),
-                            raw.get("combat_seq"),
-                            (previous or {}).get("combat_ack_seq", 0),
-                            error))
+                            (previous or {}).get("fire_seq", 0), error))
+                    current = self._contained_bot_state(
+                        raw, identity, previous)
                 rebase_fire_gap = bool(
                     source_clock_rebase and previous is not None and
                     int(current.get("fire_seq", 0)) >
@@ -6305,9 +6353,18 @@ class BattleState:
                             previous, current)
                         self._validate_bot_ammo_transition(previous, current)
                     except ValueError as error:
-                        return self._set_protocol_reject(
-                            "bot_state", "ammo_contract",
-                            "bot=%s reason=%s" % (bot_id, error))
+                        # Same containment as the combat contract above: hold
+                        # this Bot's magazine on its last admitted state and
+                        # derive no projectile edge from one the server could
+                        # not accept, but keep it and every other Bot moving.
+                        _server_log_limited(
+                            "bot-ammo-contract:%d" % bot_id,
+                            "BOT STATE contained bot=%s reason=%s" % (
+                                bot_id, error))
+                        current = self._contained_bot_state(
+                            raw, identity, previous)
+                        next_states[bot_id] = current
+                        burst_edges = ()
                 previous_fire = int((previous or {}).get("fire_seq", 0))
                 if (previous is not None and
                         int(previous.get("stun_end_server_time_ms", 0)) > 0 and
@@ -6378,10 +6435,10 @@ class BattleState:
                         })
                         pending_projectile_launches[(
                             bot_id, shot_seq)] = edge
-            if seen != set(identities):
+            if len(next_states) != len(identities):
                 return self._set_protocol_reject(
                     "bot_state", "batch_members",
-                    "missing=%s" % sorted(set(identities) - seen))
+                    "missing=%s" % sorted(set(identities) - set(next_states)))
             self._commit_human_ram_armors(human_ram_armors)
             self.bot_states = next_states
             for bot_id in stun_clears:

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/authority_worker.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/authority_worker.py
@@ -193,7 +193,7 @@ class AuthorityWorkerLANClient(LANClient):
         """Queue one worker-owned message as immutable encoded wire bytes."""
         return self._send_preencoded_trusted(message)
 
-    def send_projected_bot_state(self, bots, sample_time_us=None,
+    def send_projected_bot_state(self, rows, sample_time_us=None,
                                  source_batch_horizon_us=None,
                                  human_ram_armors=None,
                                  edge_sample_time_us=None,
@@ -207,7 +207,7 @@ class AuthorityWorkerLANClient(LANClient):
                 edge_revision is None or edge_revision < 1):
             return False
         message = {
-            'type': 'bot_state', 'round_id': self.round_id, 'bots': bots}
+            'type': 'bot_state', 'round_id': self.round_id, 'rows': rows}
         if sample_time_us is not None:
             sample_time_us = _exact_int(sample_time_us)
             if (sample_time_us is None or

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -20559,9 +20559,9 @@ class BattleRuntime(object):
                     'edge_sample_time_us')
                 state_kwargs['edge_revision'] = message.get(
                     'edge_revision')
-                return projected_sender(message.get('bots'), **state_kwargs)
+                return projected_sender(message.get('rows'), **state_kwargs)
             return self.client.send_bot_state(
-                message.get('bots'), **state_kwargs)
+                message.get('rows'), **state_kwargs)
         if kind == 'bot_observation':
             return self.client.send_bot_observation(
                 message.get('contacts'), message.get('affordances'))

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -18,6 +18,7 @@ from gui.mods.offline_lan_0922.ai.navigation import (
 from gui.mods.offline_lan_0922 import critical_damage
 from gui.mods.offline_lan_0922 import ballistics
 from gui.mods.offline_lan_0922 import bot_gunnery
+from gui.mods.offline_lan_0922 import bot_state_codec
 from gui.mods.offline_lan_0922 import burst_mechanics
 from gui.mods.offline_lan_0922 import device_damage
 from gui.mods.offline_lan_0922 import effective_params
@@ -1246,7 +1247,12 @@ class _BotGunState(object):
                     reload_time < 0.0 or reload_time > reload_duration):
                 raise ValueError('bot reload progress is invalid')
             expected_duration = self.duration(reload_factor)
-            tolerance = max(1.0, expected_duration) * 1.0e-9
+            # This proves the restored clock belongs to the installed gun, so
+            # it must not be tighter than the wire's own quantum: a reload
+            # duration crosses the LAN as a fixed-point number of microseconds.
+            tolerance = max(
+                max(1.0, expected_duration) * 1.0e-9,
+                2.0 * bot_state_codec.SECONDS_QUANTUM)
             if abs(reload_duration - expected_duration) > tolerance:
                 raise ValueError(
                     'bot reload duration disagrees with installed gun')
@@ -11891,25 +11897,26 @@ class BotRuntime(object):
         if not publish:
             self._sample_time_us = step_end_time_us
             return []
-        wire_states = []
+        wire_rows = []
         launches = [dict(launch) for launch in self._pending_launches]
         for state in self._ordered_states():
             burst_state = self._burst_states.get(int(state['id']))
             if burst_state is not None:
                 burst_state.publish(state)
             self._publish_equipment_state(state)
-            projected = lan_client.project_owned_bot_state(state)
-            if projected is None:
+            try:
+                row = bot_state_codec.encode_row(state)
+            except bot_state_codec.BotStateCodecError:
                 raise RuntimeError('bot publication projection failed')
-            if 'equipment_states' in projected:
+            if 'equipment_states' in state:
                 self._equipment_wire_exposed_in_update.add(int(state['id']))
-            wire_states.append(projected)
+            wire_rows.append(row)
         self._sample_time_us = step_end_time_us
         edge_sample_time_us, edge_revision = self._mark_publication_edge(
             ordered_states, launches, self._pending_ram_reports,
             self._sample_time_us)
         publication = {
-            'type': 'bot_state', 'bots': wire_states,
+            'type': 'bot_state', 'rows': wire_rows,
             'sample_time_us': self._sample_time_us,
             'edge_sample_time_us': edge_sample_time_us,
             'edge_revision': edge_revision,

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bot_state_codec.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bot_state_codec.py
@@ -17,9 +17,11 @@ Both peers import this module: the worker through the client script root inside
 the game, the server through the same path on ``sys.path``.  It is the single
 source of truth for the layout, and it must parse and run on CPython 2.7.
 
-Per-vehicle constants (equipment contracts, device maximum HP, crew roster) ride
-``bot_manifest`` once per round instead of every row; ``decode_row`` rejoins them
-so the decoded mapping keeps the exact shape the rest of the server expects.
+The immutable consumable contracts ride ``bot_manifest`` once per round instead
+of every row, because they were the largest part of the old encoding and never
+change; ``decode_row`` rejoins them. The critical ledger stays self-contained:
+its device maxima and crew roster feed a publication signature that both peers
+compare, so a row carries them rather than depending on a second message.
 """
 
 import math
@@ -43,7 +45,7 @@ MAX_EQUIPMENT = 3
 POSITION_SCALE = 10000        # round(v, 4)
 ANGLE_SCALE = 100000          # round(v, 5)
 SPEED_SCALE = 10000           # round(v, 4)
-SECONDS_SCALE = 10000         # reload/burst clocks
+SECONDS_SCALE = 1000000       # reload, burst and consumable clocks
 FIRE_CLOCK_SCALE = 1000000    # round(v, 6)
 DEVICE_HP_SCALE = 1000        # round(v, 3)
 
@@ -62,6 +64,23 @@ F_MOVING_FORWARD = 1 << 10
 F_MOVING_BACKWARD = 1 << 11
 F_TURNING_LEFT = 1 << 12
 F_TURNING_RIGHT = 1 << 13
+F_HAS_BURST = 1 << 14
+F_HAS_CLIP = 1 << 15
+F_HAS_SIEGE = 1 << 16
+
+# Groups the previous mapping contract could leave out entirely, which meant
+# "keep the state the server already admitted". A positional row always has the
+# columns, so a presence bit carries that distinction instead.
+OPTIONAL_GROUPS = (
+    (F_HAS_AMMO, ('ammo_remaining', 'next_shell_index',
+                  'ammo_reload_pending')),
+    (F_HAS_BURST, ('burst_active', 'burst_group_seq', 'burst_count',
+                   'burst_next_index', 'burst_shell_index',
+                   'burst_interval', 'burst_time_left')),
+    (F_HAS_CLIP, ('clip', 'clip_size')),
+    (F_HAS_SIEGE, ('siege_state', 'siege_time_left_ms',
+                   'siege_transition_total_ms')),
+)
 
 # Scalar columns, in row order, as (name, scale). ``scale`` None means the
 # field is already an exact integer.
@@ -123,6 +142,10 @@ CLAMPS = {
 }
 
 MISSING = -1
+_INFINITY = float('inf')
+
+# The coarsest quantum any second-valued column is carried at.
+SECONDS_QUANTUM = 1.0 / SECONDS_SCALE
 
 
 class BotStateCodecError(ValueError):
@@ -132,6 +155,8 @@ class BotStateCodecError(ValueError):
 def _fixed(value, scale, bounds=None):
     """Round half away from zero so 2.7 and 3.x encode the same integer."""
     number = float(value)
+    if number != number or number in (_INFINITY, -_INFINITY):
+        raise BotStateCodecError('bot state column is not finite')
     if bounds is not None:
         number = max(bounds[0], min(number, bounds[1]))
     scaled = number * scale
@@ -156,6 +181,23 @@ def _exact(value):
     return result
 
 
+def _crew_mask(names):
+    mask = 0
+    for name in names or ():
+        name = str(name)
+        if name not in CREW_NAMES:
+            raise BotStateCodecError('unknown crew member')
+        mask |= 1 << CREW_NAMES.index(name)
+    return mask
+
+
+def _crew_names(mask):
+    if mask < 0 or mask >> len(CREW_NAMES):
+        raise BotStateCodecError('crew mask is out of range')
+    return [name for index, name in enumerate(CREW_NAMES)
+            if mask & (1 << index)]
+
+
 def encode_row(state):
     """Encode one worker-owned Bot state as a positional integer row."""
     if not isinstance(state, dict):
@@ -163,9 +205,10 @@ def encode_row(state):
     critical = state.get('critical')
     equipment = state.get('equipment_states')
     ammo = state.get('ammo_remaining')
-    has_shot = 'shot_yaw' in state and 'shot_pitch' in state
-    if has_shot != ('shot_pitch' in state and 'shot_yaw' in state):
+    has_yaw = 'shot_yaw' in state
+    if has_yaw != ('shot_pitch' in state):
         raise BotStateCodecError('bot shot angles must be an atomic pair')
+    has_shot = has_yaw
     movement = float(state.get('movement_dir', 0.0) or 0.0)
     rotation = float(state.get('rotation_dir', 0.0) or 0.0)
     flags = 0
@@ -185,10 +228,14 @@ def encode_row(state):
             flags |= F_AMMO_RACK_DEATH
     if equipment is not None:
         flags |= F_HAS_EQUIPMENT
-    if ammo is not None:
-        flags |= F_HAS_AMMO
     if has_shot:
         flags |= F_HAS_SHOT_ANGLES
+    for bit, names in OPTIONAL_GROUPS:
+        present = [name in state for name in names]
+        if all(present):
+            flags |= bit
+        elif any(present):
+            raise BotStateCodecError('bot state group is incomplete')
     if movement > 0.01:
         flags |= F_MOVING_FORWARD
     elif movement < -0.01:
@@ -218,7 +265,7 @@ def encode_row(state):
         else:
             row.append(_fixed(value, scale, CLAMPS.get(name)))
 
-    if ammo is not None:
+    if flags & F_HAS_AMMO:
         shells = list(ammo)
         if len(shells) > MAX_SHELL_TYPES:
             raise BotStateCodecError('bot carries too many shell types')
@@ -238,20 +285,18 @@ def encode_row(state):
             records.append((
                 DEVICE_NAMES.index(name),
                 _fixed(record.get('hp', 0.0), DEVICE_HP_SCALE),
+                _fixed(record.get('max_hp', 1.0), DEVICE_HP_SCALE),
                 DEVICE_STATES.index(state_name)))
         records.sort()
         row.append(len(records))
-        for slot, hp, device_state in records:
+        for slot, hp, maximum, device_state in records:
             row.append(slot)
             row.append(hp)
+            row.append(maximum)
             row.append(device_state)
-        crew_mask = 0
-        for name in critical.get('crew_ko') or ():
-            name = str(name)
-            if name not in CREW_NAMES:
-                raise BotStateCodecError('unknown knocked-out crew member')
-            crew_mask |= 1 << CREW_NAMES.index(name)
-        row.append(crew_mask)
+        row.append(_crew_mask(critical.get('crew_ko')))
+        roster = critical.get('crew_roster')
+        row.append(-1 if roster is None else _crew_mask(roster))
 
     if equipment is not None:
         snapshots = list(equipment)
@@ -321,6 +366,10 @@ def decode_row(row, static):
     if not flags & F_HAS_SHOT_ANGLES:
         del result['shot_yaw']
         del result['shot_pitch']
+    for bit, names in OPTIONAL_GROUPS:
+        if not flags & bit:
+            for name in names:
+                result.pop(name, None)
 
     cursor = _Cursor(row)
     if flags & F_HAS_AMMO:
@@ -330,7 +379,6 @@ def decode_row(row, static):
         result['ammo_remaining'] = [cursor.take() for unused in range(count)]
 
     if flags & F_HAS_CRITICAL:
-        maxima = (static or {}).get('device_max_hp') or {}
         count = cursor.take()
         if not 0 <= count <= len(DEVICE_NAMES):
             raise BotStateCodecError('bot device count is out of range')
@@ -339,6 +387,7 @@ def decode_row(row, static):
         for unused in range(count):
             slot = cursor.take()
             hp = cursor.take()
+            maximum = cursor.take()
             device_state = cursor.take()
             if (not 0 <= slot < len(DEVICE_NAMES) or
                     not 0 <= device_state < len(DEVICE_STATES)):
@@ -348,24 +397,22 @@ def decode_row(row, static):
             devices.append({
                 'name': name,
                 'hp': _real(hp, DEVICE_HP_SCALE),
-                'max_hp': float(maxima.get(name, 1.0)),
+                'max_hp': _real(maximum, DEVICE_HP_SCALE),
                 'state': state_name,
             })
             if state_name == 'destroyed':
                 destroyed.append(name)
-        crew_mask = cursor.take()
         critical = {
             'devices': devices,
             'destroyed': destroyed,
-            'crew_ko': [name for index, name in enumerate(CREW_NAMES)
-                        if crew_mask & (1 << index)],
+            'crew_ko': _crew_names(cursor.take()),
             'fire': bool(flags & F_FIRE),
             'ammo_rack_death': bool(flags & F_AMMO_RACK_DEATH),
             'events': [],
         }
-        roster = (static or {}).get('crew_roster')
-        if roster:
-            critical['crew_roster'] = list(roster)
+        roster_mask = cursor.take()
+        if roster_mask >= 0:
+            critical['crew_roster'] = _crew_names(roster_mask)
         result['critical'] = critical
 
     if flags & F_HAS_EQUIPMENT:

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bot_state_codec.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bot_state_codec.py
@@ -1,0 +1,400 @@
+"""Compact positional wire codec for the periodic Bot publication.
+
+The hidden worker publishes every Bot's complete canonical checkpoint several
+times per second.  Encoding that batch as one JSON object per Bot spent most of
+its bytes on repeated field names and on per-vehicle constants that never change
+inside a round, and it forced the server to re-derive finiteness, ranges and
+rounding for every field of every Bot on every publication.
+
+This module owns the one wire representation used instead: a fixed-order list of
+integers per Bot.  Every real-valued field is carried as a fixed-point integer,
+so the encoded value *is* the rounded, clamped value the server used to compute
+defensively.  A row therefore cannot express a non-finite number, a value out of
+contract range, or a missing field, and the decoder does not check for any of
+them.
+
+Both peers import this module: the worker through the client script root inside
+the game, the server through the same path on ``sys.path``.  It is the single
+source of truth for the layout, and it must parse and run on CPython 2.7.
+
+Per-vehicle constants (equipment contracts, device maximum HP, crew roster) ride
+``bot_manifest`` once per round instead of every row; ``decode_row`` rejoins them
+so the decoded mapping keeps the exact shape the rest of the server expects.
+"""
+
+import math
+
+
+# Canonical orders. A row carries slot indices into these tuples, never names.
+DEVICE_NAMES = (
+    'ammoBayHealth', 'engineHealth', 'fuelTankHealth', 'gunHealth',
+    'leftTrackHealth', 'radioHealth', 'rightTrackHealth',
+    'surveyingDeviceHealth', 'turretRotatorHealth')
+CREW_NAMES = (
+    'commander', 'driver', 'gunner1', 'gunner2', 'loader1', 'loader2',
+    'radioman1', 'radioman2')
+DEVICE_STATES = ('normal', 'critical', 'destroyed')
+
+MAX_SHELL_TYPES = 5
+MAX_EQUIPMENT = 3
+
+# Fixed-point scales. Each one matches the decimal place the server used to
+# round that field to, so no precision is lost against the previous contract.
+POSITION_SCALE = 10000        # round(v, 4)
+ANGLE_SCALE = 100000          # round(v, 5)
+SPEED_SCALE = 10000           # round(v, 4)
+SECONDS_SCALE = 10000         # reload/burst clocks
+FIRE_CLOCK_SCALE = 1000000    # round(v, 6)
+DEVICE_HP_SCALE = 1000        # round(v, 3)
+
+# Flag bits.
+F_ALIVE = 1 << 0
+F_WORLD_POSE = 1 << 1
+F_AMMO_RELOAD_PENDING = 1 << 2
+F_BURST_ACTIVE = 1 << 3
+F_FIRE = 1 << 4
+F_AMMO_RACK_DEATH = 1 << 5
+F_HAS_SHOT_ANGLES = 1 << 6
+F_HAS_CRITICAL = 1 << 7
+F_HAS_EQUIPMENT = 1 << 8
+F_HAS_AMMO = 1 << 9
+F_MOVING_FORWARD = 1 << 10
+F_MOVING_BACKWARD = 1 << 11
+F_TURNING_LEFT = 1 << 12
+F_TURNING_RIGHT = 1 << 13
+
+# Scalar columns, in row order, as (name, scale). ``scale`` None means the
+# field is already an exact integer.
+SCALARS = (
+    ('id', None),
+    ('_flags', None),
+    ('x', POSITION_SCALE),
+    ('y', POSITION_SCALE),
+    ('z', POSITION_SCALE),
+    ('yaw', ANGLE_SCALE),
+    ('pitch', ANGLE_SCALE),
+    ('roll', ANGLE_SCALE),
+    ('aim_yaw', ANGLE_SCALE),
+    ('gun_pitch', ANGLE_SCALE),
+    ('speed', SPEED_SCALE),
+    ('fire_seq', None),
+    ('shell_index', None),
+    ('next_shell_index', None),
+    ('clip', None),
+    ('clip_size', None),
+    ('reload_time', SECONDS_SCALE),
+    ('reload_duration', SECONDS_SCALE),
+    ('burst_group_seq', None),
+    ('burst_count', None),
+    ('burst_next_index', None),
+    ('burst_shell_index', None),
+    ('burst_interval', SECONDS_SCALE),
+    ('burst_time_left', SECONDS_SCALE),
+    ('siege_state', None),
+    ('siege_time_left_ms', None),
+    ('siege_transition_total_ms', None),
+    ('health', None),
+    ('display_health', None),
+    ('combat_base_revision', None),
+    ('combat_seq', None),
+    ('combat_fire_elapsed', FIRE_CLOCK_SCALE),
+    ('combat_fire_timer', FIRE_CLOCK_SCALE),
+    ('death_reason', None),
+    ('stun_end_server_time_ms', None),
+    ('shot_yaw', ANGLE_SCALE),
+    ('shot_pitch', ANGLE_SCALE),
+)
+SCALAR_COUNT = len(SCALARS)
+_SCALAR_INDEX = dict(
+    (name, index) for index, (name, unused) in enumerate(SCALARS))
+
+# Clamps the previous contract applied before rounding. The encoder applies
+# them so an out-of-range value is impossible on the wire instead of rejected
+# after it arrives.
+CLAMPS = {
+    'x': (-2000.0, 2000.0),
+    'y': (-1000.0, 1000.0),
+    'z': (-2000.0, 2000.0),
+    'pitch': (-0.61, 0.61),
+    'roll': (-0.61, 0.61),
+    'gun_pitch': (-1.2, 1.2),
+    'speed': (-80.0, 80.0),
+    'shot_pitch': (-1.2, 1.2),
+}
+
+MISSING = -1
+
+
+class BotStateCodecError(ValueError):
+    """One row could not be encoded or decoded against this layout."""
+
+
+def _fixed(value, scale, bounds=None):
+    """Round half away from zero so 2.7 and 3.x encode the same integer."""
+    number = float(value)
+    if bounds is not None:
+        number = max(bounds[0], min(number, bounds[1]))
+    scaled = number * scale
+    if scaled >= 0.0:
+        return int(math.floor(scaled + 0.5))
+    return -int(math.floor(-scaled + 0.5))
+
+
+def _real(units, scale):
+    return float(units) / float(scale)
+
+
+def _wrapped_angle(value):
+    """Normalise one shot angle exactly as the previous server contract did."""
+    return ((float(value) + math.pi) % (2.0 * math.pi)) - math.pi
+
+
+def _exact(value):
+    result = int(value)
+    if isinstance(value, bool):
+        raise BotStateCodecError('boolean is not an integer column')
+    return result
+
+
+def encode_row(state):
+    """Encode one worker-owned Bot state as a positional integer row."""
+    if not isinstance(state, dict):
+        raise BotStateCodecError('bot state must be a mapping')
+    critical = state.get('critical')
+    equipment = state.get('equipment_states')
+    ammo = state.get('ammo_remaining')
+    has_shot = 'shot_yaw' in state and 'shot_pitch' in state
+    if has_shot != ('shot_pitch' in state and 'shot_yaw' in state):
+        raise BotStateCodecError('bot shot angles must be an atomic pair')
+    movement = float(state.get('movement_dir', 0.0) or 0.0)
+    rotation = float(state.get('rotation_dir', 0.0) or 0.0)
+    flags = 0
+    if state.get('alive', True):
+        flags |= F_ALIVE
+    if state.get('world_pose', True):
+        flags |= F_WORLD_POSE
+    if state.get('ammo_reload_pending', False):
+        flags |= F_AMMO_RELOAD_PENDING
+    if state.get('burst_active', False):
+        flags |= F_BURST_ACTIVE
+    if isinstance(critical, dict):
+        flags |= F_HAS_CRITICAL
+        if critical.get('fire', False):
+            flags |= F_FIRE
+        if critical.get('ammo_rack_death', False):
+            flags |= F_AMMO_RACK_DEATH
+    if equipment is not None:
+        flags |= F_HAS_EQUIPMENT
+    if ammo is not None:
+        flags |= F_HAS_AMMO
+    if has_shot:
+        flags |= F_HAS_SHOT_ANGLES
+    if movement > 0.01:
+        flags |= F_MOVING_FORWARD
+    elif movement < -0.01:
+        flags |= F_MOVING_BACKWARD
+    if rotation > 0.01:
+        flags |= F_TURNING_LEFT
+    elif rotation < -0.01:
+        flags |= F_TURNING_RIGHT
+
+    row = []
+    for name, scale in SCALARS:
+        if name == '_flags':
+            row.append(flags)
+            continue
+        if name in ('shot_yaw', 'shot_pitch'):
+            if not has_shot:
+                row.append(0)
+                continue
+            raw = state[name]
+            if name == 'shot_yaw':
+                raw = _wrapped_angle(raw)
+            row.append(_fixed(raw, scale, CLAMPS.get(name)))
+            continue
+        value = state.get(name, 0)
+        if scale is None:
+            row.append(_exact(value))
+        else:
+            row.append(_fixed(value, scale, CLAMPS.get(name)))
+
+    if ammo is not None:
+        shells = list(ammo)
+        if len(shells) > MAX_SHELL_TYPES:
+            raise BotStateCodecError('bot carries too many shell types')
+        row.append(len(shells))
+        for count in shells:
+            row.append(_exact(count))
+
+    if isinstance(critical, dict):
+        records = []
+        for record in critical.get('devices') or ():
+            name = str(record.get('name', ''))
+            if name not in DEVICE_NAMES:
+                raise BotStateCodecError('unknown critical device')
+            state_name = str(record.get('state', 'normal'))
+            if state_name not in DEVICE_STATES:
+                raise BotStateCodecError('unknown critical device state')
+            records.append((
+                DEVICE_NAMES.index(name),
+                _fixed(record.get('hp', 0.0), DEVICE_HP_SCALE),
+                DEVICE_STATES.index(state_name)))
+        records.sort()
+        row.append(len(records))
+        for slot, hp, device_state in records:
+            row.append(slot)
+            row.append(hp)
+            row.append(device_state)
+        crew_mask = 0
+        for name in critical.get('crew_ko') or ():
+            name = str(name)
+            if name not in CREW_NAMES:
+                raise BotStateCodecError('unknown knocked-out crew member')
+            crew_mask |= 1 << CREW_NAMES.index(name)
+        row.append(crew_mask)
+
+    if equipment is not None:
+        snapshots = list(equipment)
+        if len(snapshots) > MAX_EQUIPMENT:
+            raise BotStateCodecError('bot carries too many consumables')
+        row.append(len(snapshots))
+        for snapshot in snapshots:
+            row.append(_exact(snapshot.get('usesLeft', 0)))
+            row.append(_fixed(
+                snapshot.get('cooldownTimeLeft', 0.0), SECONDS_SCALE))
+            row.append(1 if snapshot.get('active', False) else 0)
+            for field in ('autoPendingElapsed', 'aiPendingElapsed'):
+                elapsed = snapshot.get(field)
+                row.append(MISSING if elapsed is None else
+                           _fixed(elapsed, SECONDS_SCALE))
+    return row
+
+
+class _Cursor(object):
+    """Read one row strictly in layout order and prove it was consumed."""
+
+    __slots__ = ('_row', '_index')
+
+    def __init__(self, row):
+        self._row = row
+        self._index = SCALAR_COUNT
+
+    def take(self):
+        if self._index >= len(self._row):
+            raise BotStateCodecError('bot state row is truncated')
+        value = self._row[self._index]
+        self._index += 1
+        return value
+
+    def finish(self):
+        if self._index != len(self._row):
+            raise BotStateCodecError('bot state row has trailing columns')
+
+
+def decode_row(row, static):
+    """Rebuild one canonical Bot mapping from a row plus its round constants."""
+    if not isinstance(row, (list, tuple)) or len(row) < SCALAR_COUNT:
+        raise BotStateCodecError('bot state row is truncated')
+    for column in row:
+        if isinstance(column, bool) or not isinstance(column, int):
+            raise BotStateCodecError('bot state row must be integers')
+
+    result = {}
+    for index, (name, scale) in enumerate(SCALARS):
+        if name == '_flags':
+            continue
+        if scale is None:
+            result[name] = row[index]
+        else:
+            result[name] = _real(row[index], scale)
+    flags = row[_SCALAR_INDEX['_flags']]
+    result['alive'] = bool(flags & F_ALIVE)
+    result['world_pose'] = bool(flags & F_WORLD_POSE)
+    result['ammo_reload_pending'] = bool(flags & F_AMMO_RELOAD_PENDING)
+    result['burst_active'] = bool(flags & F_BURST_ACTIVE)
+    result['movement_dir'] = (
+        1 if flags & F_MOVING_FORWARD else
+        -1 if flags & F_MOVING_BACKWARD else 0)
+    result['rotation_dir'] = (
+        1 if flags & F_TURNING_LEFT else
+        -1 if flags & F_TURNING_RIGHT else 0)
+    if not flags & F_HAS_SHOT_ANGLES:
+        del result['shot_yaw']
+        del result['shot_pitch']
+
+    cursor = _Cursor(row)
+    if flags & F_HAS_AMMO:
+        count = cursor.take()
+        if not 0 <= count <= MAX_SHELL_TYPES:
+            raise BotStateCodecError('bot shell type count is out of range')
+        result['ammo_remaining'] = [cursor.take() for unused in range(count)]
+
+    if flags & F_HAS_CRITICAL:
+        maxima = (static or {}).get('device_max_hp') or {}
+        count = cursor.take()
+        if not 0 <= count <= len(DEVICE_NAMES):
+            raise BotStateCodecError('bot device count is out of range')
+        devices = []
+        destroyed = []
+        for unused in range(count):
+            slot = cursor.take()
+            hp = cursor.take()
+            device_state = cursor.take()
+            if (not 0 <= slot < len(DEVICE_NAMES) or
+                    not 0 <= device_state < len(DEVICE_STATES)):
+                raise BotStateCodecError('bot device row is out of range')
+            name = DEVICE_NAMES[slot]
+            state_name = DEVICE_STATES[device_state]
+            devices.append({
+                'name': name,
+                'hp': _real(hp, DEVICE_HP_SCALE),
+                'max_hp': float(maxima.get(name, 1.0)),
+                'state': state_name,
+            })
+            if state_name == 'destroyed':
+                destroyed.append(name)
+        crew_mask = cursor.take()
+        critical = {
+            'devices': devices,
+            'destroyed': destroyed,
+            'crew_ko': [name for index, name in enumerate(CREW_NAMES)
+                        if crew_mask & (1 << index)],
+            'fire': bool(flags & F_FIRE),
+            'ammo_rack_death': bool(flags & F_AMMO_RACK_DEATH),
+            'events': [],
+        }
+        roster = (static or {}).get('crew_roster')
+        if roster:
+            critical['crew_roster'] = list(roster)
+        result['critical'] = critical
+
+    if flags & F_HAS_EQUIPMENT:
+        contracts = (static or {}).get('equipment_contracts') or ()
+        count = cursor.take()
+        if not 0 <= count <= MAX_EQUIPMENT:
+            raise BotStateCodecError('bot consumable count is out of range')
+        if count and count != len(contracts):
+            raise BotStateCodecError(
+                'bot consumable count does not match the round manifest')
+        snapshots = []
+        for index in range(count):
+            uses_left = cursor.take()
+            cooldown = cursor.take()
+            active = cursor.take()
+            pending = []
+            for unused in range(2):
+                elapsed = cursor.take()
+                pending.append(
+                    None if elapsed == MISSING else
+                    _real(elapsed, SECONDS_SCALE))
+            snapshots.append({
+                'equipment': contracts[index],
+                'usesLeft': uses_left,
+                'cooldownTimeLeft': _real(cooldown, SECONDS_SCALE),
+                'active': bool(active),
+                'autoPendingElapsed': pending[0],
+                'aiPendingElapsed': pending[1],
+            })
+        result['equipment_states'] = snapshots
+    cursor.finish()
+    return result

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/destructibles_sensor.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/destructibles_sensor.py
@@ -4748,6 +4748,10 @@ def _fell_trees_near(
 	import AreaDestructibles
 	import BigWorld
 	import Math
+	# An event whose LAN admission was refused stays frozen and pending. Drain
+	# that backlog before proving more native destruction, so a publication the
+	# transport could not take is retried instead of lost.
+	_retry_catalog_publications_1513()
 	try:
 		mgr = getattr(AreaDestructibles, 'g_destructiblesManager', None)
 		if not mgr:
@@ -5324,11 +5328,12 @@ def _fell_trees_near(
 					if (_ttyp == AreaDestructibles.DESTR_TYPE_TREE and
 							_key in _st['publish_pending']):
 						_object_pos = Math.Vector3(_tx, _ty, _tz)
-						if not _publish_tree_once_1513(
-								_st, spaceID, (cid, _ti, None), _object_pos,
-								yaw if vel >= 0 else yaw + math.pi, vel):
-							raise RuntimeError(
-								'tree proximity event was not admitted')
+						# Still refused: the frozen payload stays pending for
+						# the next scan. Transport backpressure is local to
+						# this one event and must not end the battle.
+						_publish_tree_once_1513(
+							_st, spaceID, (cid, _ti, None), _object_pos,
+							yaw if vel >= 0 else yaw + math.pi, vel)
 					continue
 				fall_yaw = yaw if vel >= 0 else (yaw + math.pi)
 				_auth = _get_destr_authority()
@@ -5362,14 +5367,16 @@ def _fell_trees_near(
 						'native proximity destroy was not accepted: '
 						'chunk=%s item=%s' % (cid, _ti))
 				_st['felled'].add(_key)
+				# The native item is already destroyed here, so its canonical
+				# event must still reach the server. A refused publication is
+				# kept frozen and retried on a later scan; raising would end
+				# the round over one unsent destructible.
 				if _ttyp == AreaDestructibles.DESTR_TYPE_TREE:
-					if not _publish_tree_once_1513(
-							_st, spaceID, (cid, _ti, None), _object_pos,
-							fall_yaw, vel):
-						raise RuntimeError(
-							'tree proximity event was not admitted')
+					_publish_tree_once_1513(
+						_st, spaceID, (cid, _ti, None), _object_pos,
+						fall_yaw, vel)
 				else:
-					_publish_destroyed(
+					_publish_catalog_once_1513(
 						('fragile'
 						 if _ttyp == AreaDestructibles.DESTR_TYPE_FRAGILE
 						 else 'module' if _ttyp == structure_type

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
@@ -150,19 +150,6 @@ SEND_STALL_TIMEOUT = 5.0
 LEAVE_SEND_TIMEOUT = 0.05
 RUNTIME_DROP_LOG_INTERVAL = 5.0
 LEAVE_PAYLOAD = b'{"type":"leave"}\n'
-_BOT_STATE_WIRE_FIELDS = (
-    'id', 'x', 'y', 'z', 'yaw', 'pitch', 'roll', 'aim_yaw', 'gun_pitch',
-    'speed', 'movement_dir', 'rotation_dir', 'fire_seq', 'shell_index',
-    'next_shell_index', 'ammo_remaining', 'ammo_reload_pending',
-    'reload_time', 'reload_duration', 'clip', 'clip_size',
-    'burst_active', 'burst_group_seq', 'burst_count',
-    'burst_next_index', 'burst_interval', 'burst_time_left',
-    'burst_shell_index',
-    'siege_state', 'siege_time_left_ms', 'siege_transition_total_ms',
-    'health', 'alive', 'critical', 'combat_base_revision', 'combat_seq',
-    'combat_fire_elapsed', 'combat_fire_timer',
-    'death_reason', 'display_health', 'world_pose', 'equipment_states',
-    'stun_end_server_time_ms')
 STATE_BARRIER_TYPES = frozenset((
     'welcome', 'roster', 'battle_start', 'battle_live',
     'start_denied', 'team_denied', 'team_size_denied',
@@ -564,19 +551,6 @@ def _valid_player_equipment_contract(state, required=False):
     return True
 
 
-def _valid_bot_equipment_contract(state, required=False):
-    snapshots = state.get('equipment_states')
-    if snapshots is None:
-        return not required and 'equipment_states' not in state
-    if not isinstance(snapshots, list):
-        return False
-    try:
-        equipment_mechanics.validate_bot_equipment_states(snapshots)
-    except (TypeError, ValueError):
-        return False
-    return True
-
-
 def _valid_player_environment_contract(state, required=False):
     """Validate canonical pose, input and landing frontiers in a player row."""
     required_fields = {
@@ -672,85 +646,6 @@ def _canonical_runtime_vehicle_row(value):
     return result
 
 
-def _project_bot_state_impl(state, validate_equipment):
-    """Project one internal state, optionally proving its equipment ledger."""
-    if not isinstance(state, dict):
-        return None
-    projected = dict((name, state[name]) for name in _BOT_STATE_WIRE_FIELDS
-                     if name in state)
-    has_shot_yaw = 'shot_yaw' in state
-    has_shot_pitch = 'shot_pitch' in state
-    if has_shot_yaw != has_shot_pitch:
-        return None
-    if has_shot_yaw:
-        projected['shot_yaw'] = state['shot_yaw']
-        projected['shot_pitch'] = state['shot_pitch']
-    ammo_fields = ('shell_index', 'next_shell_index', 'ammo_remaining',
-                   'ammo_reload_pending')
-    present = tuple(name in state for name in ammo_fields)
-    if any(present) and not all(present):
-        return None
-    if (all(present) and
-            not isinstance(state.get('ammo_reload_pending'), bool)):
-        return None
-    clip_fields = ('clip', 'clip_size')
-    clip_present = tuple(name in state for name in clip_fields)
-    if any(clip_present) and not all(clip_present):
-        return None
-    reload_fields = ('reload_time', 'reload_duration')
-    if not all(name in state for name in reload_fields):
-        return None
-    reload_time = _exact_finite_float(state.get('reload_time'))
-    reload_duration = _exact_finite_float(state.get('reload_duration'))
-    if (reload_time is None or reload_duration is None or
-            reload_duration <= 0.0 or reload_time < 0.0 or
-            reload_time > reload_duration):
-        return None
-    siege_fields = (
-        'siege_state', 'siege_time_left_ms',
-        'siege_transition_total_ms')
-    siege_present = tuple(name in state for name in siege_fields)
-    if any(siege_present) and not all(siege_present):
-        return None
-    if (all(siege_present) and
-            not siege_mechanics.valid_wire_state(
-                state.get('siege_state'),
-                state.get('siege_time_left_ms'),
-                transition_total_ms=state.get(
-                    'siege_transition_total_ms'))):
-        return None
-    try:
-        burst_mechanics.BurstClock().restore(
-            projected, projected.get('fire_seq', 0))
-    except ValueError:
-        return None
-    if (validate_equipment and 'equipment_states' in state and
-            not _valid_bot_equipment_contract(state)):
-        return None
-    if 'stun_end_server_time_ms' in state:
-        stun_end = _projectile_int_range(
-            state.get('stun_end_server_time_ms'), 0, MAX_PROJECTILE_ID)
-        if stun_end is None:
-            return None
-        projected['stun_end_server_time_ms'] = stun_end
-    return projected
-
-
-def project_bot_state(state):
-    """Return only fields consumed by the v5 server bot-state sanitizer."""
-    return _project_bot_state_impl(state, True)
-
-
-def project_owned_bot_state(state):
-    """Select wire fields from one trusted BotRuntime-owned state."""
-    projected = dict((name, state[name]) for name in _BOT_STATE_WIRE_FIELDS
-                     if name in state)
-    if 'shot_yaw' in state:
-        projected['shot_yaw'] = state['shot_yaw']
-        projected['shot_pitch'] = state['shot_pitch']
-    return projected
-
-
 def _project_human_ram_armors(raw_results):
     """Return the exact worker-only native contact-armour response batch."""
     if (not isinstance(raw_results, (list, tuple)) or
@@ -793,7 +688,6 @@ def _project_human_ram_armors(raw_results):
 
 
 # Compatibility for engine-free callers which imported the old private name.
-_project_bot_state = project_bot_state
 
 
 def _projectile_int_range(value, minimum, maximum):
@@ -3256,19 +3150,16 @@ class LANClient(object):
                 player_collision_profiles or ())[:64]
         return self._send(message)
 
-    def send_bot_state(self, bots, sample_time_us=None,
+    def send_bot_state(self, rows, sample_time_us=None,
                        source_batch_horizon_us=None,
                        human_ram_armors=None):
         if not self.is_bot_authority():
             return False
-        projected = []
-        for state in list(bots or ())[:30]:
-            state = project_bot_state(state)
-            if state is None:
-                return False
-            projected.append(state)
+        rows = list(rows or ())[:30]
+        if any(not isinstance(row, list) for row in rows):
+            return False
         message = {'type': 'bot_state', 'round_id': self.round_id,
-                   'bots': projected}
+                   'rows': rows}
         if sample_time_us is not None:
             sample_time_us = _exact_int(sample_time_us)
             if (sample_time_us is None or
@@ -3291,7 +3182,7 @@ class LANClient(object):
             message['human_ram_armors'] = human_ram_armors
         return self._send(message)
 
-    def send_projected_bot_state(self, bots, sample_time_us=None,
+    def send_projected_bot_state(self, rows, sample_time_us=None,
                                  source_batch_horizon_us=None,
                                  human_ram_armors=None,
                                  edge_sample_time_us=None,
@@ -3300,11 +3191,11 @@ class LANClient(object):
         del edge_sample_time_us, edge_revision
         if not self.is_bot_authority():
             return False
-        if (not isinstance(bots, (list, tuple)) or len(bots) > 30 or
-                any(not isinstance(state, dict) for state in bots)):
+        if (not isinstance(rows, (list, tuple)) or len(rows) > 30 or
+                any(not isinstance(row, list) for row in rows)):
             return False
         message = {'type': 'bot_state', 'round_id': self.round_id,
-                   'bots': bots}
+                   'rows': rows}
         if sample_time_us is not None:
             sample_time_us = _exact_int(sample_time_us)
             if (sample_time_us is None or

--- a/tests/bot_state_rows.py
+++ b/tests/bot_state_rows.py
@@ -1,0 +1,78 @@
+"""Encode Bot publications for tests that describe Bots as mappings.
+
+The wire carries one positional integer row per Bot.  Tests stay readable by
+building the mapping they mean and passing it through the real encoder, so a
+layout change cannot pass the suite while breaking the wire.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(
+    0, str(Path(__file__).resolve().parents[1] / 'src' / 'res' / 'scripts' /
+           'client'))
+
+from gui.mods.offline_lan_0922 import bot_state_codec
+
+
+def row(state):
+    """Encode one Bot mapping exactly as the worker would publish it."""
+    return bot_state_codec.encode_row(state)
+
+
+def rows(states):
+    return [bot_state_codec.encode_row(state) for state in states or ()]
+
+
+def publication(message):
+    """Return one ``bot_state`` message with its ``bots`` encoded as rows.
+
+    A message that already carries rows, or that is not a publication at all,
+    passes through so a caller can wrap a dispatch boundary unconditionally.
+    """
+    if not isinstance(message, dict) or 'bots' not in message:
+        return message
+    message = dict(message)
+    message['rows'] = rows(message.pop('bots'))
+    return message
+
+
+PLACEHOLDER_CONTRACTS = tuple(
+    {'name': name, 'kind': kind, 'id': index, 'compactDescr': 400 + index,
+     'tags': [], 'reuseCount': 0, 'cooldownSeconds': 90.0,
+     'autoactivate': kind == 'extinguisher', 'fireStartingChanceFactor': 1.0,
+     'repairAll': kind != 'extinguisher', 'bonusValue': 0.0,
+     'crewLevelIncrease': 0.0, 'enginePowerFactor': 1.0,
+     'turretRotationSpeedFactor': 1.0, 'engineHpLossPerSecond': 0.0,
+     'autoReactionSeconds': 1.5}
+    for index, (name, kind) in enumerate((
+        ('autoExtinguishers', 'extinguisher'),
+        ('largeMedkit', 'medkit'),
+        ('largeRepairkit', 'repairkit'))))
+
+
+def round_constants(equipment_contracts=PLACEHOLDER_CONTRACTS):
+    """Return the per-round constants a manifest entry carries."""
+    return {'equipment_contracts': list(equipment_contracts)}
+
+
+def decoded(wire, index=0, static=None):
+    """Return one Bot mapping from a publication, encoded or not."""
+    if isinstance(wire, dict) and 'rows' not in wire:
+        return wire['bots'][index]
+    rows_ = wire['rows'] if isinstance(wire, dict) else wire
+    return bot_state_codec.decode_row(
+        rows_[index], round_constants() if static is None else static)
+
+
+def bots(message, static=None):
+    """Return the Bot mappings a publication or a roster message carries.
+
+    A ``bot_state`` publication carries positional rows; a manifest, roster or
+    server snapshot still carries mappings. Tests read either through here.
+    """
+    if isinstance(message, dict) and 'rows' in message:
+        constants = round_constants() if static is None else static
+        return [bot_state_codec.decode_row(row, constants)
+                for row in message['rows']]
+    return message['bots']

--- a/tests/test_port_0922.py
+++ b/tests/test_port_0922.py
@@ -12,6 +12,8 @@ import sys
 import tempfile
 import types
 import unittest
+
+import bot_state_rows
 from unittest import mock
 import weakref
 import xml.etree.ElementTree as ET
@@ -5632,13 +5634,10 @@ class LANClientTests(unittest.TestCase):
         bots = [{'id': 11, 'x': 0.0, 'y': 0.0, 'z': 0.0,
                  'yaw': 0.0, 'health': 1000, 'alive': True,
                  'fire_seq': 0}]
-        original = module.project_bot_state
-        module.project_bot_state = mock.Mock(
-            side_effect=AssertionError('second projection'))
-        try:
-            self.assertFalse(client.send_projected_bot_state(bots))
-        finally:
-            module.project_bot_state = original
+        # A visible client is never Bot authority, so the sender must refuse
+        # before it touches the rows at all.
+        rows = bot_state_rows.rows(bots)
+        self.assertFalse(client.send_projected_bot_state(rows))
 
         client._send.assert_not_called()
 

--- a/tests/test_port_0922_authority_worker_client.py
+++ b/tests/test_port_0922_authority_worker_client.py
@@ -6,6 +6,9 @@ import tempfile
 import threading
 import types
 import unittest
+
+import bot_state_rows
+from gui.mods.offline_lan_0922 import bot_state_codec
 from unittest import mock
 
 
@@ -214,7 +217,7 @@ def _projected_bot_state(bot_id=11):
         'health': 700, 'alive': True,
         'critical': {
             'devices': [{
-                'name': 'engine', 'hp': 100.0, 'max_hp': 100.0,
+                'name': 'engineHealth', 'hp': 100.0, 'max_hp': 100.0,
                 'state': 'normal'}],
             'destroyed': [], 'crew_ko': [], 'fire': False,
             'ammo_rack_death': False, 'events': []},
@@ -419,7 +422,7 @@ class AuthorityWorkerClientTests(unittest.TestCase):
                     lan_client_module.json, 'dumps',
                     side_effect=recording_dumps):
                 self.assertTrue(client.send_projected_bot_state(
-                    [state], sample_time_us=40000,
+                    bot_state_rows.rows([state]), sample_time_us=40000,
                     source_batch_horizon_us=40000))
                 state['x'] = 99.0
                 state['critical']['devices'][0]['hp'] = 1.0
@@ -438,9 +441,9 @@ class AuthorityWorkerClientTests(unittest.TestCase):
         self.assertEqual(40000, wire['source_batch_horizon_us'])
         self.assertNotIn('edge_sample_time_us', wire)
         self.assertNotIn('edge_revision', wire)
-        self.assertEqual(1.0, wire['bots'][0]['x'])
+        self.assertEqual(1.0, bot_state_rows.decoded(wire, 0)['x'])
         self.assertEqual(100.0,
-                         wire['bots'][0]['critical']['devices'][0]['hp'])
+                         bot_state_rows.decoded(wire, 0)['critical']['devices'][0]['hp'])
 
     def test_worker_owned_message_is_encoded_without_recursive_walks(self):
         client = self._active_client()
@@ -499,27 +502,39 @@ class AuthorityWorkerClientTests(unittest.TestCase):
         self.assertEqual(1, len(client._outbound_queue))
         self.assertEqual(len(payload), client._outbound_queue[0][2])
 
-    def test_worker_bot_state_trusted_path_relies_on_projection_and_encoder(self):
+    def test_worker_bot_state_trusted_path_relies_on_the_encoder(self):
         client = self._active_client()
+        # The row has fixed columns, so worker-local bookkeeping the wire has
+        # no column for simply never reaches it.
         extra = _projected_bot_state()
         extra['profile'] = {'class_tag': 'mediumTank'}
-        projected = lan_client_module.project_owned_bot_state(extra)
-        self.assertNotIn('profile', projected)
-        self.assertTrue(client.send_projected_bot_state([projected]))
+        row = bot_state_rows.rows([extra])
+        self.assertTrue(client.send_projected_bot_state(row))
+        self.assertNotIn('profile', bot_state_rows.decoded(row, 0))
 
         half_shot = _projected_bot_state()
         half_shot['shot_yaw'] = 0.2
-        with self.assertRaises(KeyError):
-            lan_client_module.project_owned_bot_state(half_shot)
+        with self.assertRaises(bot_state_codec.BotStateCodecError):
+            bot_state_rows.rows([half_shot])
 
+        # A row is fixed-point integers, so a non-finite pose cannot reach the
+        # wire at all: the encoder refuses to produce the row.
         nonfinite = _projected_bot_state()
         nonfinite['x'] = float('nan')
-        self.assertFalse(client.send_projected_bot_state([nonfinite]))
+        with self.assertRaises(bot_state_codec.BotStateCodecError):
+            bot_state_rows.rows([nonfinite])
 
-        oversized = _projected_bot_state()
-        oversized['critical']['events'] = [
-            'x' * lan_client_module.MAX_MESSAGE_BYTES]
-        self.assertFalse(client.send_projected_bot_state([oversized]))
+        # Critical transition events were validated and then discarded by the
+        # server, so they are no longer published at all.
+        eventful = _projected_bot_state()
+        eventful['critical']['events'] = [
+            {'kind': 'fire', 'state': True, 'cause': 'shot'}]
+        self.assertTrue(client.send_projected_bot_state(
+            bot_state_rows.rows([eventful])))
+        wire = json.loads(
+            client._outbound_queue[-1][1].payload.decode('utf-8'))
+        self.assertEqual([], bot_state_rows.decoded(wire, 0)['critical'][
+            'events'])
 
         self.assertEqual(1, len(client._outbound_queue))
         self.assertTrue(client.running)
@@ -531,7 +546,7 @@ class AuthorityWorkerClientTests(unittest.TestCase):
         with mock.patch.object(
                 equipment_mechanics, 'canonical_bot_equipment_states',
                 side_effect=AssertionError('owned ledger was revalidated')):
-            self.assertTrue(client.send_projected_bot_state([state]))
+            self.assertTrue(client.send_projected_bot_state(bot_state_rows.rows([state])))
         self.assertEqual(1, len(client._outbound_queue))
         self.assertTrue(client.running)
 
@@ -546,11 +561,11 @@ class AuthorityWorkerClientTests(unittest.TestCase):
         second['combat_fire_timer'] = 0.07
 
         self.assertTrue(client.send_projected_bot_state(
-            [first], sample_time_us=40000,
+            bot_state_rows.rows([first]), sample_time_us=40000,
             source_batch_horizon_us=40000))
         first_size = client._outbound_bytes
         self.assertTrue(client.send_projected_bot_state(
-            [second], sample_time_us=80000,
+            bot_state_rows.rows([second]), sample_time_us=80000,
             source_batch_horizon_us=80000))
 
         self.assertTrue(client.running)
@@ -561,19 +576,19 @@ class AuthorityWorkerClientTests(unittest.TestCase):
         wire = json.loads(
             client._outbound_queue[0][1].payload.decode('utf-8'))
         self.assertEqual(80000, wire['sample_time_us'])
-        self.assertEqual(8.0, wire['bots'][0]['x'])
-        self.assertEqual(0.05, wire['bots'][0]['reload_time'])
+        self.assertEqual(8.0, bot_state_rows.decoded(wire, 0)['x'])
+        self.assertEqual(0.05, bot_state_rows.decoded(wire, 0)['reload_time'])
 
     def test_worker_coalesce_key_uses_owner_revision_not_current_sample(self):
         client = self._active_client()
         state = _projected_bot_state()
         self.assertTrue(client.send_projected_bot_state(
-            [state], sample_time_us=40000,
+            bot_state_rows.rows([state]), sample_time_us=40000,
             source_batch_horizon_us=40000,
             edge_sample_time_us=40000, edge_revision=7))
         state['x'] = 9.0
         self.assertTrue(client.send_projected_bot_state(
-            [state], sample_time_us=80000,
+            bot_state_rows.rows([state]), sample_time_us=80000,
             source_batch_horizon_us=80000,
             edge_sample_time_us=40000, edge_revision=7))
 
@@ -581,7 +596,7 @@ class AuthorityWorkerClientTests(unittest.TestCase):
         wire = json.loads(
             client._outbound_queue[0][1].payload.decode('utf-8'))
         self.assertEqual(80000, wire['sample_time_us'])
-        self.assertEqual(9.0, wire['bots'][0]['x'])
+        self.assertEqual(9.0, bot_state_rows.decoded(wire, 0)['x'])
 
     def test_worker_human_ram_results_and_authority_epoch_are_edges(self):
         client = self._active_client()
@@ -591,12 +606,12 @@ class AuthorityWorkerClientTests(unittest.TestCase):
             'available': False,
         }]
         self.assertTrue(client.send_projected_bot_state(
-            [state], human_ram_armors=result))
+            bot_state_rows.rows([state]), human_ram_armors=result))
         self.assertTrue(client.send_projected_bot_state(
-            [state], human_ram_armors=[]))
+            bot_state_rows.rows([state]), human_ram_armors=[]))
         client.authority_epoch += 1
         self.assertTrue(client.send_projected_bot_state(
-            [state], human_ram_armors=[]))
+            bot_state_rows.rows([state]), human_ram_armors=[]))
 
         self.assertEqual(3, len(client._outbound_queue))
 
@@ -610,11 +625,11 @@ class AuthorityWorkerClientTests(unittest.TestCase):
         consumed = json.loads(json.dumps(cooldown))
         consumed['equipment_states'][0]['usesLeft'] -= 1
 
-        self.assertTrue(client.send_projected_bot_state([first]))
-        self.assertTrue(client.send_projected_bot_state([cooldown]))
+        self.assertTrue(client.send_projected_bot_state(bot_state_rows.rows([first])))
+        self.assertTrue(client.send_projected_bot_state(bot_state_rows.rows([cooldown])))
         self.assertEqual(1, len(client._outbound_queue))
         self.assertTrue(client.send_projected_bot_state(
-            [consumed], edge_sample_time_us=2, edge_revision=2))
+            bot_state_rows.rows([consumed]), edge_sample_time_us=2, edge_revision=2))
         self.assertEqual(2, len(client._outbound_queue))
 
     def test_worker_coalesces_across_queue_without_dropping_discrete_message(self):
@@ -626,10 +641,10 @@ class AuthorityWorkerClientTests(unittest.TestCase):
         fired['ammo_reload_pending'] = True
 
         self.assertTrue(client.send_projected_bot_state(
-            [first], sample_time_us=40000,
+            bot_state_rows.rows([first]), sample_time_us=40000,
             source_batch_horizon_us=40000))
         self.assertTrue(client.send_projected_bot_state(
-            [fired], sample_time_us=80000,
+            bot_state_rows.rows([fired]), sample_time_us=80000,
             source_batch_horizon_us=80000,
             edge_sample_time_us=80000, edge_revision=2))
         self.assertTrue(client._send({
@@ -638,7 +653,7 @@ class AuthorityWorkerClientTests(unittest.TestCase):
         later['x'] = 9.0
         later['reload_time'] = 0.04
         self.assertTrue(client.send_projected_bot_state(
-            [later], sample_time_us=120000,
+            bot_state_rows.rows([later]), sample_time_us=120000,
             source_batch_horizon_us=120000,
             edge_sample_time_us=80000, edge_revision=2))
 
@@ -653,7 +668,7 @@ class AuthorityWorkerClientTests(unittest.TestCase):
         wires = [_queued_wire(item[1])
                  for item in client._outbound_queue]
         wires = [wire for wire in wires if wire['type'] == 'bot_state']
-        self.assertEqual(9.0, wires[-1]['bots'][0]['x'])
+        self.assertEqual(9.0, bot_state_rows.decoded(wires[-1], 0)['x'])
 
     def test_worker_ram_event_preserves_its_preceding_pose_barrier(self):
         client = self._active_client()
@@ -663,12 +678,12 @@ class AuthorityWorkerClientTests(unittest.TestCase):
         later['x'] = 20.0
 
         self.assertTrue(client.send_projected_bot_state(
-            [contact], sample_time_us=400000,
+            bot_state_rows.rows([contact]), sample_time_us=400000,
             source_batch_horizon_us=1000000))
         self.assertTrue(client.send_bot_ram(
             11, 'bot', 12, 1, 1, 1))
         self.assertTrue(client.send_projected_bot_state(
-            [later], sample_time_us=1000000,
+            bot_state_rows.rows([later]), sample_time_us=1000000,
             source_batch_horizon_us=1000000))
 
         self.assertEqual([
@@ -682,7 +697,7 @@ class AuthorityWorkerClientTests(unittest.TestCase):
                   for item in client._outbound_queue]
         states = [state for state in states if state['type'] == 'bot_state']
         self.assertEqual([5.0, 20.0], [
-            state['bots'][0]['x'] for state in states])
+            bot_state_rows.decoded(state, 0)['x'] for state in states])
 
     def test_worker_never_coalesces_damage_or_combat_sequence_edges(self):
         client = self._active_client()
@@ -694,10 +709,10 @@ class AuthorityWorkerClientTests(unittest.TestCase):
         damaged['combat_seq'] += 1
 
         self.assertTrue(client.send_projected_bot_state(
-            [first], sample_time_us=40000,
+            bot_state_rows.rows([first]), sample_time_us=40000,
             source_batch_horizon_us=40000))
         self.assertTrue(client.send_projected_bot_state(
-            [damaged], sample_time_us=80000,
+            bot_state_rows.rows([damaged]), sample_time_us=80000,
             source_batch_horizon_us=80000,
             edge_sample_time_us=80000, edge_revision=2))
 
@@ -705,9 +720,9 @@ class AuthorityWorkerClientTests(unittest.TestCase):
         wires = [json.loads(item[1].payload.decode('utf-8'))
                  for item in client._outbound_queue]
         self.assertEqual([700, 640], [
-            wire['bots'][0]['health'] for wire in wires])
+            bot_state_rows.decoded(wire, 0)['health'] for wire in wires])
         self.assertEqual([2, 3], [
-            wire['bots'][0]['combat_seq'] for wire in wires])
+            bot_state_rows.decoded(wire, 0)['combat_seq'] for wire in wires])
 
     def test_worker_never_coalesces_back_across_a_state_edge(self):
         client = self._active_client()
@@ -718,12 +733,12 @@ class AuthorityWorkerClientTests(unittest.TestCase):
         reverted_key = json.loads(json.dumps(first))
         reverted_key['x'] = 12.0
 
-        self.assertTrue(client.send_projected_bot_state([first]))
+        self.assertTrue(client.send_projected_bot_state(bot_state_rows.rows([first])))
         self.assertTrue(client.send_projected_bot_state(
-            [edge], edge_sample_time_us=2, edge_revision=2))
+            bot_state_rows.rows([edge]), edge_sample_time_us=2, edge_revision=2))
         self.assertTrue(client._send({'type': 'projectile_launch'}))
         self.assertTrue(client.send_projected_bot_state(
-            [reverted_key], edge_sample_time_us=3, edge_revision=3))
+            bot_state_rows.rows([reverted_key]), edge_sample_time_us=3, edge_revision=3))
 
         self.assertEqual(4, len(client._outbound_queue))
         self.assertEqual('projectile_launch',
@@ -744,7 +759,7 @@ class AuthorityWorkerClientTests(unittest.TestCase):
                     state['reload_time'] = max(
                         0.0, 0.1 - (frame % 3) * 0.01)
                 self.assertTrue(client.send_projected_bot_state(
-                    states, sample_time_us=sample,
+                    bot_state_rows.rows(states), sample_time_us=sample,
                     source_batch_horizon_us=sample))
         finally:
             lan_client_module.MAX_OUTBOUND_MESSAGES = original_limit
@@ -755,7 +770,7 @@ class AuthorityWorkerClientTests(unittest.TestCase):
         wire = json.loads(
             client._outbound_queue[0][1].payload.decode('utf-8'))
         self.assertEqual(600 * 33333, wire['sample_time_us'])
-        self.assertEqual(0.599, wire['bots'][0]['x'])
+        self.assertEqual(0.599, bot_state_rows.decoded(wire, 0)['x'])
 
     def test_worker_bot_state_queue_pressure_keeps_transport_and_fifo(self):
         client = self._active_client()
@@ -763,10 +778,10 @@ class AuthorityWorkerClientTests(unittest.TestCase):
         original_limit = lan_client_module.MAX_OUTBOUND_MESSAGES
         lan_client_module.MAX_OUTBOUND_MESSAGES = 1
         try:
-            self.assertTrue(client.send_projected_bot_state([
-                _projected_bot_state(11)]))
-            self.assertFalse(client.send_projected_bot_state([
-                _projected_bot_state(12)],
+            self.assertTrue(client.send_projected_bot_state(bot_state_rows.rows([
+                _projected_bot_state(11)])))
+            self.assertFalse(client.send_projected_bot_state(bot_state_rows.rows([
+                _projected_bot_state(12)]),
                 edge_sample_time_us=2, edge_revision=2))
         finally:
             lan_client_module.MAX_OUTBOUND_MESSAGES = original_limit
@@ -782,8 +797,8 @@ class AuthorityWorkerClientTests(unittest.TestCase):
         original_limit = lan_client_module.MAX_OUTBOUND_MESSAGES
         lan_client_module.MAX_OUTBOUND_MESSAGES = 1
         try:
-            self.assertTrue(client.send_projected_bot_state([
-                _projected_bot_state(11)]))
+            self.assertTrue(client.send_projected_bot_state(bot_state_rows.rows([
+                _projected_bot_state(11)])))
             self.assertFalse(client._send({'type': 'projectile_progress'}))
             self.assertTrue(client._send({'type': 'projectile_launch'}))
             self.assertFalse(client._send({'type': 'battle_result'}))
@@ -818,8 +833,8 @@ class AuthorityWorkerClientTests(unittest.TestCase):
         with mock.patch.object(
                 lan_client_module.json, 'dumps',
                 side_effect=reconnect_during_encoding):
-            self.assertFalse(client.send_projected_bot_state([
-                _projected_bot_state()]))
+            self.assertFalse(client.send_projected_bot_state(bot_state_rows.rows([
+                _projected_bot_state()])))
 
         self.assertIsNot(old_sock, client.sock)
         self.assertEqual([], client._outbound_queue)

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -9,6 +9,8 @@ import struct
 import sys
 import types
 import unittest
+
+import bot_state_rows
 from unittest import mock
 import zlib
 
@@ -6828,7 +6830,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
             send_projected_bot_state=mock.Mock(return_value=True))
 
         self.assertTrue(battle._send_bot_message({
-            'type': 'bot_state', 'bots': [], 'sample_time_us': 40000,
+            'type': 'bot_state', 'rows': [], 'sample_time_us': 40000,
             'source_batch_horizon_us': 40000,
             'edge_sample_time_us': 40000, 'edge_revision': 7}))
 
@@ -7182,7 +7184,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertEqual(1.0, battle._ram_bot_state_at(*key)['z'])
 
         replacement = dict(message)
-        replacement['bots'] = [dict(message['bots'][0], z=2.0)]
+        replacement['bots'] = [dict(bot_state_rows.bots(message)[0], z=2.0)]
         self.assertTrue(battle._remember_ram_bot_snapshot(replacement))
 
         self.assertEqual([37], battle._ram_bot_history_order)
@@ -15341,7 +15343,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
             player_id=-1, team=1, bot_authority_id=-1,
             phase='battle', is_bot_authority=lambda: True)
         battle._last_snapshot = {'players': []}
-        publication = {'type': 'bot_state', 'bots': []}
+        publication = {'type': 'bot_state', 'rows': []}
         battle._bots = types.SimpleNamespace(
             update=mock.Mock(return_value=[publication]),
             presentation_states=mock.Mock(return_value=()),
@@ -27094,22 +27096,23 @@ class BattleRuntimeContractTests(unittest.TestCase):
                  'yaw': 0.0, 'health': 1000, 'alive': True,
                  'fire_seq': 0}]
 
+        rows = bot_state_rows.rows(bots)
         self.assertTrue(battle._send_bot_message({
-            'type': 'bot_state', 'bots': bots,
+            'type': 'bot_state', 'rows': rows,
             'edge_sample_time_us': 1, 'edge_revision': 2}))
 
         battle.client.send_projected_bot_state.assert_called_once_with(
-            bots, edge_sample_time_us=1, edge_revision=2)
+            rows, edge_sample_time_us=1, edge_revision=2)
         battle.client.send_bot_state.assert_not_called()
 
         battle.client.send_projected_bot_state.reset_mock()
         self.assertTrue(battle._send_bot_message({
-            'type': 'bot_state', 'bots': bots,
+            'type': 'bot_state', 'rows': rows,
             'sample_time_us': 40000,
             'source_batch_horizon_us': 40000,
             'edge_sample_time_us': 30000, 'edge_revision': 3}))
         battle.client.send_projected_bot_state.assert_called_once_with(
-            bots, sample_time_us=40000,
+            rows, sample_time_us=40000,
             source_batch_horizon_us=40000,
             edge_sample_time_us=30000, edge_revision=3)
 
@@ -27157,7 +27160,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
 
         self.assertEqual(3, battle.client.send_bot_manifest.call_count)
         expected = (
-            payload['bots'], payload['player_collision_profiles'])
+            bot_state_rows.bots(payload), payload['player_collision_profiles'])
         self.assertTrue(all(
             call.args == expected
             for call in battle.client.send_bot_manifest.call_args_list))
@@ -27355,7 +27358,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
         battle._send_bot_message = mock.Mock(side_effect=[False, True])
         battle._launch_bot_projectile = mock.Mock(return_value=True)
         publication = {
-            'type': 'bot_state', 'bots': [],
+            'type': 'bot_state', 'rows': [],
             'launches': [dict(outbox._pending_launches[0])],
         }
 
@@ -27395,7 +27398,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
         battle._launch_bot_projectile = mock.Mock(
             side_effect=enqueue_launch)
         first = {
-            'type': 'bot_state', 'bots': [],
+            'type': 'bot_state', 'rows': [],
             'launches': [dict(value)
                          for value in outbox._pending_launches],
         }
@@ -27407,7 +27410,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertEqual({}, battle._bot_fire_seen)
 
         retry = {
-            'type': 'bot_state', 'bots': [],
+            'type': 'bot_state', 'rows': [],
             'launches': [dict(value)
                          for value in outbox._pending_launches],
         }
@@ -27452,7 +27455,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
         battle._launch_bot_projectile = mock.Mock(
             side_effect=enqueue_launch)
         first = {
-            'type': 'bot_state', 'bots': [],
+            'type': 'bot_state', 'rows': [],
             'launches': [dict(value)
                          for value in outbox._pending_launches],
         }
@@ -27465,7 +27468,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertEqual({}, battle._bot_fire_seen)
 
         retry = {
-            'type': 'bot_state', 'bots': [],
+            'type': 'bot_state', 'rows': [],
             'launches': [dict(value)
                          for value in outbox._pending_launches],
         }
@@ -27497,7 +27500,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
         with self.assertRaisesRegex(
                 RuntimeError, 'outbox identity is invalid'):
             battle._enqueue_bot_message({
-                'type': 'bot_state', 'bots': [],
+                'type': 'bot_state', 'rows': [],
                 'launches': [{'id': 11}],
             })
 

--- a/tests/test_port_0922_bot_runtime.py
+++ b/tests/test_port_0922_bot_runtime.py
@@ -9,6 +9,8 @@ import sys
 import types
 import unittest
 
+import bot_state_rows
+
 ROOT = Path(__file__).resolve().parents[1]
 PORT_ROOT = ROOT
 sys.path.insert(0, str(PORT_ROOT / 'server'))
@@ -488,16 +490,16 @@ class ServerBotStateRevisionTests(unittest.TestCase):
         self.assertEqual(0, server.bot_state_revision)
 
         self.assertFalse(server.update_bot_states(
-            2, self._publication(server, 1.0)))
+            2, bot_state_rows.publication(self._publication(server, 1.0))))
         self.assertEqual(0, server.bot_state_revision)
         self.assertFalse(server.update_bot_states(
-            SIMULATION_WORKER_AUTHORITY_ID, {
+            SIMULATION_WORKER_AUTHORITY_ID, bot_state_rows.publication({
                 'round_id': server.round_id, 'bots': [],
-            }))
+            })))
         self.assertEqual(0, server.bot_state_revision)
         self.assertTrue(server.update_bot_states(
             SIMULATION_WORKER_AUTHORITY_ID,
-            self._publication(server, 1.0)))
+            bot_state_rows.publication(self._publication(server, 1.0))))
         self.assertEqual(1, server.bot_state_revision)
 
         server.tick_once(1.0 / 30.0)
@@ -514,7 +516,7 @@ class ServerBotStateRevisionTests(unittest.TestCase):
         self.assertEqual(1, server.bot_state_revision)
         self.assertTrue(server.update_bot_states(
             SIMULATION_WORKER_AUTHORITY_ID,
-            self._publication(server, 2.0)))
+            bot_state_rows.publication(self._publication(server, 2.0))))
         self.assertEqual(2, server.bot_state_revision)
 
         server._reset_round()
@@ -551,7 +553,7 @@ class ServerBotStateRevisionTests(unittest.TestCase):
         publication['bots'][0]['equipment_states'] = [
             equipment.snapshot(0.0) for equipment in restored]
         self.assertTrue(server.update_bot_states(
-            SIMULATION_WORKER_AUTHORITY_ID, publication),
+            SIMULATION_WORKER_AUTHORITY_ID, bot_state_rows.publication(publication)),
             server.last_bot_state_reject)
 
         takeover = server.current_battle_message()
@@ -560,14 +562,21 @@ class ServerBotStateRevisionTests(unittest.TestCase):
         self.assertAlmostEqual(90.0, persisted[1]['cooldownTimeLeft'])
         self.assertAlmostEqual(78.0, persisted[2]['cooldownTimeLeft'])
 
+        # A Bot never gains a consumable use. The publication still lands so
+        # the room keeps moving, but this Bot holds its admitted inventory.
+        admitted = copy.deepcopy(server.bot_states[11]['equipment_states'])
         invalid = self._publication(server, 2.0)
         invalid['bots'][0]['equipment_states'] = json.loads(json.dumps(
             invalid['bots'][0]['equipment_states']))
         invalid['bots'][0]['equipment_states'][1]['usesLeft'] = 2
-        self.assertFalse(server.update_bot_states(
-            SIMULATION_WORKER_AUTHORITY_ID, invalid))
-        self.assertEqual('combat_contract',
-                         server.last_bot_state_reject_code)
+        self.assertTrue(server.update_bot_states(
+            SIMULATION_WORKER_AUTHORITY_ID,
+            bot_state_rows.publication(invalid)))
+        self.assertEqual(2.0, server.bot_states[11]['x'])
+        self.assertEqual(
+            [snapshot['usesLeft'] for snapshot in admitted],
+            [snapshot['usesLeft']
+             for snapshot in server.bot_states[11]['equipment_states']])
 
     def test_bot_large_medkit_clears_stun_once_and_survives_takeover(self):
         module = _load()
@@ -593,7 +602,7 @@ class ServerBotStateRevisionTests(unittest.TestCase):
         publication['bots'][0]['combat_seq'] = (
             server.bot_states[11]['combat_ack_seq'] + 1)
         self.assertTrue(server.update_bot_states(
-            SIMULATION_WORKER_AUTHORITY_ID, publication),
+            SIMULATION_WORKER_AUTHORITY_ID, bot_state_rows.publication(publication)),
             server.last_bot_state_reject)
         self.assertEqual(0, server.bot_states[11][
             'stun_end_server_time_ms'])
@@ -606,7 +615,7 @@ class ServerBotStateRevisionTests(unittest.TestCase):
 
         repeated = self._publication(server, 2.0)
         self.assertTrue(server.update_bot_states(
-            SIMULATION_WORKER_AUTHORITY_ID, repeated),
+            SIMULATION_WORKER_AUTHORITY_ID, bot_state_rows.publication(repeated)),
             server.last_bot_state_reject)
         clear_events = [event for event in server.pending_events
                         if event.get('kind') == 'stun' and
@@ -625,7 +634,7 @@ class ServerBotStateRevisionTests(unittest.TestCase):
 
         self.assertEqual(1, server._expire_stuns(stun_end))
         self.assertTrue(server.update_bot_states(
-            SIMULATION_WORKER_AUTHORITY_ID, delayed),
+            SIMULATION_WORKER_AUTHORITY_ID, bot_state_rows.publication(delayed)),
             server.last_bot_state_reject)
         self.assertEqual(0, server.bot_states[11][
             'stun_end_server_time_ms'])
@@ -641,7 +650,7 @@ class ServerBotStateRevisionTests(unittest.TestCase):
         self.assertTrue(server._set_canonical_stun(
             ('player', 2), ('bot', 11), second_end))
         self.assertTrue(server.update_bot_states(
-            SIMULATION_WORKER_AUTHORITY_ID, delayed),
+            SIMULATION_WORKER_AUTHORITY_ID, bot_state_rows.publication(delayed)),
             server.last_bot_state_reject)
         self.assertEqual(second_end, server.bot_states[11][
             'stun_end_server_time_ms'])
@@ -656,7 +665,7 @@ class ServerBotStateRevisionTests(unittest.TestCase):
         now[0] = 100.065
         self.assertTrue(server.update_bot_states(
             SIMULATION_WORKER_AUTHORITY_ID,
-            self._publication(server, 1.0)))
+            bot_state_rows.publication(self._publication(server, 1.0))))
         self.assertEqual(65000, server.bot_state_time_us)
         self.assertIsNone(server.bot_source_time_us)
 
@@ -681,7 +690,7 @@ class ServerBotStateRevisionTests(unittest.TestCase):
         first['sample_time_us'] = 40000
         first['source_batch_horizon_us'] = 40000
         self.assertTrue(server.update_bot_states(
-            SIMULATION_WORKER_AUTHORITY_ID, first))
+            SIMULATION_WORKER_AUTHORITY_ID, bot_state_rows.publication(first)))
         first_mapped_time = server.bot_state_time_us
         self.assertEqual(65000, first_mapped_time)
 
@@ -692,7 +701,7 @@ class ServerBotStateRevisionTests(unittest.TestCase):
         delayed['sample_time_us'] = 80000
         delayed['source_batch_horizon_us'] = 80000
         self.assertTrue(server.update_bot_states(
-            SIMULATION_WORKER_AUTHORITY_ID, delayed))
+            SIMULATION_WORKER_AUTHORITY_ID, bot_state_rows.publication(delayed)))
         self.assertEqual(first_mapped_time + 40000,
                          server.bot_state_time_us)
 
@@ -703,7 +712,7 @@ class ServerBotStateRevisionTests(unittest.TestCase):
         fast['sample_time_us'] = 120000
         fast['source_batch_horizon_us'] = 120000
         self.assertTrue(server.update_bot_states(
-            SIMULATION_WORKER_AUTHORITY_ID, fast))
+            SIMULATION_WORKER_AUTHORITY_ID, bot_state_rows.publication(fast)))
         self.assertEqual(first_mapped_time + 80000,
                          server.bot_state_time_us)
 
@@ -720,13 +729,13 @@ class ServerBotStateRevisionTests(unittest.TestCase):
         repeated['sample_time_us'] = 120000
         repeated['source_batch_horizon_us'] = 120000
         self.assertFalse(server.update_bot_states(
-            SIMULATION_WORKER_AUTHORITY_ID, repeated))
+            SIMULATION_WORKER_AUTHORITY_ID, bot_state_rows.publication(repeated)))
         self.assertEqual('sample_time_order',
                          server.last_bot_state_reject_code)
 
         self.assertFalse(server.update_bot_states(
             SIMULATION_WORKER_AUTHORITY_ID,
-            self._publication(server, 1.6)))
+            bot_state_rows.publication(self._publication(server, 1.6))))
         self.assertEqual('sample_time_missing',
                          server.last_bot_state_reject_code)
 
@@ -748,7 +757,7 @@ class ServerBotStateRevisionTests(unittest.TestCase):
         slow['sample_time_us'] = 40000
         slow['source_batch_horizon_us'] = 40000
         self.assertTrue(server.update_bot_states(
-            SIMULATION_WORKER_AUTHORITY_ID, slow))
+            SIMULATION_WORKER_AUTHORITY_ID, bot_state_rows.publication(slow)))
         self.assertEqual(200000, server.bot_state_time_us)
         self.assertEqual(0, server.motion_time_offset_us)
 
@@ -759,7 +768,7 @@ class ServerBotStateRevisionTests(unittest.TestCase):
         fast['sample_time_us'] = 140000
         fast['source_batch_horizon_us'] = 140000
         self.assertTrue(server.update_bot_states(
-            SIMULATION_WORKER_AUTHORITY_ID, fast))
+            SIMULATION_WORKER_AUTHORITY_ID, bot_state_rows.publication(fast)))
         self.assertEqual(300000, server.bot_state_time_us)
         self.assertEqual(90000, server.motion_time_offset_us)
 
@@ -778,7 +787,7 @@ class ServerBotStateRevisionTests(unittest.TestCase):
         steady['sample_time_us'] = 180000
         steady['source_batch_horizon_us'] = 180000
         self.assertTrue(server.update_bot_states(
-            SIMULATION_WORKER_AUTHORITY_ID, steady))
+            SIMULATION_WORKER_AUTHORITY_ID, bot_state_rows.publication(steady)))
         self.assertEqual(340000, server.bot_state_time_us)
         server.tick_once(1.0 / 30.0)
         snapshots = [
@@ -806,7 +815,7 @@ class ServerBotStateRevisionTests(unittest.TestCase):
         skipped['sample_time_us'] = 420000
         skipped['source_batch_horizon_us'] = 420000
         self.assertTrue(server.update_bot_states(
-            SIMULATION_WORKER_AUTHORITY_ID, skipped))
+            SIMULATION_WORKER_AUTHORITY_ID, bot_state_rows.publication(skipped)))
         self.assertEqual(580000, server.bot_state_time_us)
         self.assertEqual(90000, server.motion_time_offset_us)
 
@@ -821,7 +830,7 @@ class ServerBotStateRevisionTests(unittest.TestCase):
         oversized['sample_time_us'] = 1000000
         oversized['source_batch_horizon_us'] = 1000000
         self.assertTrue(server.update_bot_states(
-            SIMULATION_WORKER_AUTHORITY_ID, oversized))
+            SIMULATION_WORKER_AUTHORITY_ID, bot_state_rows.publication(oversized)))
         self.assertEqual('', server.last_bot_state_reject_code)
         self.assertEqual(590000, server.bot_state_time_us)
         self.assertEqual(1000000, server.bot_source_time_us)
@@ -840,7 +849,7 @@ class ServerBotStateRevisionTests(unittest.TestCase):
         recovered['sample_time_us'] = 1040000
         recovered['source_batch_horizon_us'] = 1040000
         self.assertTrue(server.update_bot_states(
-            SIMULATION_WORKER_AUTHORITY_ID, recovered))
+            SIMULATION_WORKER_AUTHORITY_ID, bot_state_rows.publication(recovered)))
         self.assertEqual(630000, server.bot_state_time_us)
         self.assertEqual(1040000, server.bot_source_time_us)
         self.assertEqual(530000, server.bot_source_receipt_time_us)
@@ -870,33 +879,21 @@ class ServerBotStateRevisionTests(unittest.TestCase):
         baseline['sample_time_us'] = 40000
         baseline['source_batch_horizon_us'] = 40000
         self.assertTrue(server.update_bot_states(
-            SIMULATION_WORKER_AUTHORITY_ID, baseline))
+            SIMULATION_WORKER_AUTHORITY_ID, bot_state_rows.publication(baseline)))
         committed = self._canonical_bot_commit_snapshot(server)
 
+        # Only a failure of the message itself can cost the whole batch. A
+        # per-Bot contract failure is contained by the next test, because
+        # rejecting the batch would freeze every Bot in the room.
         malformed = []
 
         empty_batch = self._publication(server, 1.0)
         empty_batch['bots'] = []
         malformed.append(('batch_shape', empty_batch))
 
-        bad_row = self._publication(server, 1.0)
-        bad_row['bots'][0].pop('x')
-        malformed.append(('bot_shape', bad_row))
-
         bad_ram = self._publication(server, 1.0)
         bad_ram['human_ram_armors'] = [{}]
         malformed.append(('human_ram_armors', bad_ram))
-
-        bad_combat = self._publication(server, 1.0)
-        bad_combat['bots'][0]['combat_seq'] = (
-            bad_combat['bots'][0]['combat_ack_seq'] + 2)
-        malformed.append(('combat_contract', bad_combat))
-
-        bad_ammo = self._publication(server, 1.0)
-        bad_ammo['bots'][0]['ammo_remaining'] = list(
-            bad_ammo['bots'][0]['ammo_remaining'])
-        bad_ammo['bots'][0]['ammo_remaining'][0] += 1
-        malformed.append(('ammo_contract', bad_ammo))
 
         for index, (reject_code, publication) in enumerate(malformed):
             now[0] = 100.210 + index * 0.005
@@ -904,11 +901,23 @@ class ServerBotStateRevisionTests(unittest.TestCase):
             publication['source_batch_horizon_us'] = (
                 publication['sample_time_us'])
             self.assertFalse(server.update_bot_states(
-                SIMULATION_WORKER_AUTHORITY_ID, publication))
+                SIMULATION_WORKER_AUTHORITY_ID, bot_state_rows.publication(publication)))
             self.assertEqual(reject_code, server.last_bot_state_reject_code)
             self.assertEqual(
                 committed, self._canonical_bot_commit_snapshot(server),
                 reject_code)
+
+        truncated = self._publication(server, 1.0)
+        truncated['sample_time_us'] = 1030000
+        truncated['source_batch_horizon_us'] = 1030000
+        truncated = bot_state_rows.publication(truncated)
+        truncated['rows'][0] = truncated['rows'][0][:-1]
+        now[0] = 100.225
+        self.assertFalse(server.update_bot_states(
+            SIMULATION_WORKER_AUTHORITY_ID, truncated))
+        self.assertEqual('row_shape', server.last_bot_state_reject_code)
+        self.assertEqual(
+            committed, self._canonical_bot_commit_snapshot(server))
 
         # Because every malformed future packet left the accepted source
         # frontier untouched, the producer can resume from its last-good clock.
@@ -917,11 +926,72 @@ class ServerBotStateRevisionTests(unittest.TestCase):
         recovered['sample_time_us'] = 80000
         recovered['source_batch_horizon_us'] = 80000
         self.assertTrue(server.update_bot_states(
-            SIMULATION_WORKER_AUTHORITY_ID, recovered),
+            SIMULATION_WORKER_AUTHORITY_ID, bot_state_rows.publication(recovered)),
             server.last_bot_state_reject)
         self.assertEqual(80000, server.bot_source_time_us)
         self.assertEqual(2, server.bot_state_revision)
         self.assertEqual(0.8, server.bot_states[11]['x'])
+
+    def test_one_bot_contract_failure_never_stops_the_other_bots(self):
+        """A per-Bot contract failure is contained to that Bot's ledgers.
+
+        Rejecting the publication would also leave the Bot's stored state
+        behind its own next publication, so the same failure would repeat and
+        freeze it -- and every other Bot -- for the rest of the round.
+        """
+        now = [100.0]
+        server, _, unused_socket = self._server(
+            clock=lambda: now[0],
+            before_manifest=lambda: now.__setitem__(0, 100.025))
+        now[0] = 100.200
+        baseline = self._publication(server, 0.4)
+        baseline['sample_time_us'] = 40000
+        baseline['source_batch_horizon_us'] = 40000
+        self.assertTrue(server.update_bot_states(
+            SIMULATION_WORKER_AUTHORITY_ID,
+            bot_state_rows.publication(baseline)),
+            server.last_bot_state_reject)
+        admitted = copy.deepcopy(server.bot_states[11])
+        revision = server.bot_state_revision
+
+        for offset, (field, mutate) in enumerate((
+                ('combat_seq', lambda bot: bot.__setitem__(
+                    'combat_seq', bot['combat_ack_seq'] + 2)),
+                ('ammo_remaining', lambda bot: bot.__setitem__(
+                    'ammo_remaining',
+                    [bot['ammo_remaining'][0] + 1] +
+                    list(bot['ammo_remaining'][1:]))))):
+            now[0] = 100.210 + offset * 0.005
+            broken = self._publication(server, 1.5 + offset)
+            broken['sample_time_us'] = 50000 + offset * 10000
+            broken['source_batch_horizon_us'] = broken['sample_time_us']
+            mutate(broken['bots'][0])
+            self.assertTrue(server.update_bot_states(
+                SIMULATION_WORKER_AUTHORITY_ID,
+                bot_state_rows.publication(broken)),
+                'a single Bot contract must not cost the publication')
+            current = server.bot_states[11]
+            self.assertEqual(1.5 + offset, current['x'], field)
+            self.assertEqual(admitted['fire_seq'], current['fire_seq'], field)
+            self.assertEqual(
+                admitted['ammo_remaining'], current['ammo_remaining'], field)
+            self.assertEqual(
+                admitted['combat_ack_seq'], current['combat_ack_seq'], field)
+            self.assertGreater(server.bot_state_revision, revision)
+            revision = server.bot_state_revision
+
+        # The Bot is still live authority, not frozen: a well formed
+        # publication resumes immediately.
+        now[0] = 100.240
+        healthy = self._publication(server, 3.0)
+        healthy['sample_time_us'] = 90000
+        healthy['source_batch_horizon_us'] = 90000
+        self.assertTrue(server.update_bot_states(
+            SIMULATION_WORKER_AUTHORITY_ID,
+            bot_state_rows.publication(healthy)),
+            server.last_bot_state_reject)
+        self.assertEqual(3.0, server.bot_states[11]['x'])
+        self.assertEqual('', server.last_bot_state_reject_code)
 
     def test_dispatcher_counts_validated_clock_rebase_as_advancement(self):
         now = [100.0]
@@ -933,7 +1003,7 @@ class ServerBotStateRevisionTests(unittest.TestCase):
         baseline['sample_time_us'] = 40000
         baseline['source_batch_horizon_us'] = 40000
         self.assertTrue(server.update_bot_states(
-            SIMULATION_WORKER_AUTHORITY_ID, baseline))
+            SIMULATION_WORKER_AUTHORITY_ID, bot_state_rows.publication(baseline)))
 
         handler = object.__new__(ClientHandler)
         wrapper = types.SimpleNamespace(state=server)
@@ -946,7 +1016,7 @@ class ServerBotStateRevisionTests(unittest.TestCase):
 
         now[0] = 100.210
         self.assertFalse(handler._dispatch_simulation_worker_message(
-            wrapper, server.simulation_worker, malformed))
+            wrapper, server.simulation_worker, bot_state_rows.publication(malformed)))
         self.assertEqual('batch_shape', server.last_bot_state_reject_code)
         self.assertEqual(
             committed, self._canonical_bot_commit_snapshot(server))
@@ -959,7 +1029,7 @@ class ServerBotStateRevisionTests(unittest.TestCase):
         complete['source_batch_horizon_us'] = 1000000
         complete['type'] = 'bot_state'
         self.assertTrue(handler._dispatch_simulation_worker_message(
-            wrapper, server.simulation_worker, complete))
+            wrapper, server.simulation_worker, bot_state_rows.publication(complete)))
         self.assertEqual('', server.last_bot_state_reject_code)
         self.assertEqual(1000000, server.bot_source_time_us)
         self.assertEqual(1.0, server.bot_states[11]['x'])
@@ -974,13 +1044,13 @@ class ServerBotStateRevisionTests(unittest.TestCase):
         baseline['sample_time_us'] = 40000
         baseline['source_batch_horizon_us'] = 40000
         self.assertTrue(server.update_bot_states(
-            SIMULATION_WORKER_AUTHORITY_ID, baseline))
+            SIMULATION_WORKER_AUTHORITY_ID, bot_state_rows.publication(baseline)))
 
         now[0] = 100.210
         rebased = self._publication(server, 1.0)
         rebased['sample_time_us'] = 1000000
         rebased['source_batch_horizon_us'] = 1000000
-        bot = rebased['bots'][0]
+        bot = bot_state_rows.bots(rebased)[0]
         bot['fire_seq'] = 2
         bot['ammo_remaining'] = [18]
         bot['ammo_reload_pending'] = True
@@ -988,7 +1058,7 @@ class ServerBotStateRevisionTests(unittest.TestCase):
         bot.update(BattleState._ordinary_bot_burst(2, 0))
 
         self.assertTrue(server.update_bot_states(
-            SIMULATION_WORKER_AUTHORITY_ID, rebased),
+            SIMULATION_WORKER_AUTHORITY_ID, bot_state_rows.publication(rebased)),
             server.last_bot_state_reject)
         self.assertEqual(2, server.bot_states[11]['fire_seq'])
         self.assertEqual([18], server.bot_states[11]['ammo_remaining'])
@@ -999,21 +1069,21 @@ class ServerBotStateRevisionTests(unittest.TestCase):
         recovered['sample_time_us'] = 1040000
         recovered['source_batch_horizon_us'] = 1040000
         self.assertTrue(server.update_bot_states(
-            SIMULATION_WORKER_AUTHORITY_ID, recovered),
+            SIMULATION_WORKER_AUTHORITY_ID, bot_state_rows.publication(recovered)),
             server.last_bot_state_reject)
 
         now[0] = 100.270
         next_shot = self._publication(server, 1.8)
         next_shot['sample_time_us'] = 1080000
         next_shot['source_batch_horizon_us'] = 1080000
-        bot = next_shot['bots'][0]
+        bot = bot_state_rows.bots(next_shot)[0]
         bot['fire_seq'] = 3
         bot['ammo_remaining'] = [17]
         bot['ammo_reload_pending'] = True
         bot['clip'] = 0
         bot.update(BattleState._ordinary_bot_burst(3, 0))
         self.assertTrue(server.update_bot_states(
-            SIMULATION_WORKER_AUTHORITY_ID, next_shot),
+            SIMULATION_WORKER_AUTHORITY_ID, bot_state_rows.publication(next_shot)),
             server.last_bot_state_reject)
         self.assertEqual(3, server.bot_states[11]['fire_seq'])
         self.assertIn((11, 3), server.bot_pending_projectile_launches)
@@ -1027,7 +1097,7 @@ class ServerBotStateRevisionTests(unittest.TestCase):
 
         self.assertTrue(server.update_bot_states(
             SIMULATION_WORKER_AUTHORITY_ID,
-            self._publication(server, 99.0)))
+            bot_state_rows.publication(self._publication(server, 99.0))))
         self.assertEqual(revision, server.bot_state_revision)
         self.assertEqual(states, server.bot_states)
         self.assertEqual('', server.last_bot_state_reject_code)
@@ -1040,11 +1110,11 @@ class ServerBotStateRevisionTests(unittest.TestCase):
 
         self.assertTrue(server.update_bot_states(
             SIMULATION_WORKER_AUTHORITY_ID,
-            self._publication(server, 1.0)))
+            bot_state_rows.publication(self._publication(server, 1.0))))
         first_time_us = server.bot_state_time_us
         self.assertTrue(server.update_bot_states(
             SIMULATION_WORKER_AUTHORITY_ID,
-            self._publication(server, 2.0)))
+            bot_state_rows.publication(self._publication(server, 2.0))))
 
         self.assertEqual(2, server.bot_state_revision)
         self.assertGreater(server.bot_state_time_us, first_time_us)
@@ -2060,7 +2130,7 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertIsNone(state['target_id'])
         self.assertNotIn(11, runtime._friendly_repositions)
         self.assertTrue(runtime._mark_combat_publication(state))
-        projected = self.module.lan_client.project_bot_state(state)
+        projected = bot_state_rows.decoded(bot_state_rows.rows([state]), 0)
         self.assertEqual((0, False, 640, 5), (
             projected['health'], projected['alive'],
             projected['display_health'], projected['death_reason']))
@@ -2070,9 +2140,9 @@ class BotRuntimeTests(unittest.TestCase):
                      'ammo_reload_pending', 'clip', 'clip_size'):
             server.bot_states[11][name] = projected[name]
         self.assertTrue(server.update_bot_states(
-            SIMULATION_WORKER_AUTHORITY_ID, {
+            SIMULATION_WORKER_AUTHORITY_ID, bot_state_rows.publication({
                 'round_id': server.round_id, 'bots': [projected],
-            }),
+            })),
             server.last_bot_state_reject)
         self.assertEqual((0, False, 640, 5), (
             server.bot_states[11]['health'],
@@ -5294,16 +5364,16 @@ class BotRuntimeTests(unittest.TestCase):
             resolved.append(vehicle) or resolver(vehicle))
         first = self.runtime.battle_start(self.start)
         self.assertEqual('bot_manifest', first[0]['type'])
-        self.assertEqual(11, first[0]['bots'][0]['id'])
+        self.assertEqual(11, bot_state_rows.bots(first[0])[0]['id'])
         self.assertFalse(self.runtime._manifest_sent)
         self.assertEqual(['ussr:R11_MS-1'], resolved)
 
-        first[0]['bots'][0]['name'] = 'mutated caller copy'
+        bot_state_rows.bots(first[0])[0]['name'] = 'mutated caller copy'
         repeated = self.runtime.battle_start(dict(
             self.start, bots=[dict(
-                self.start['bots'][0], name='rebuilt roster')]))
+                bot_state_rows.bots(self.start)[0], name='rebuilt roster')]))
 
-        self.assertEqual('Bot', repeated[0]['bots'][0]['name'])
+        self.assertEqual('Bot', bot_state_rows.bots(repeated[0])[0]['name'])
         self.assertEqual(['ussr:R11_MS-1'], resolved)
         self.assertFalse(self.runtime.mark_manifest_enqueued({
             'type': 'bot_manifest', 'bots': []}))
@@ -5328,7 +5398,7 @@ class BotRuntimeTests(unittest.TestCase):
         current = self.runtime.battle_start(next_round)[0]
 
         self.assertFalse(self.runtime.mark_manifest_enqueued(resumed))
-        self.assertEqual([12], [row['id'] for row in current['bots']])
+        self.assertEqual([12], [row['id'] for row in bot_state_rows.bots(current)])
         self.assertEqual(current, self.runtime.pending_manifest())
 
     def test_manifest_descriptor_preflight_failure_is_atomic(self):
@@ -5397,7 +5467,7 @@ class BotRuntimeTests(unittest.TestCase):
         self.module._bot_physics_params = bot_physics
         try:
             initial = new_runtime()
-            manifest = initial.battle_start(self.start)[0]['bots'][0]
+            manifest = bot_state_rows.bots(initial.battle_start(self.start)[0])[0]
             restored = new_runtime()
             restored.battle_start(dict(
                 self.start, bots=[], bot_manifest=[manifest]))
@@ -5674,7 +5744,7 @@ class BotRuntimeTests(unittest.TestCase):
         self.runtime.update(.20, 1.22, players=player)
         self.runtime.update(.20, 1.42, players=player)
         result = self.runtime.update(.04, 1.46, players=player)
-        bot = result[0]['bots'][0]
+        bot = bot_state_rows.bots(result[0])[0]
         self.assertEqual('bot_state', result[0]['type'])
         self.assertGreater(bot['z'], 0.0)
         self.assertEqual(0, bot['shell_index'])
@@ -5773,15 +5843,16 @@ class BotRuntimeTests(unittest.TestCase):
         outgoing = runtime.update(1.0, 10.0)
         publications = [message for message in outgoing
                         if message.get('type') == 'bot_state']
-        snapshots = [message['bots'][0]['equipment_states']
+        snapshots = [bot_state_rows.decoded(message, 0)['equipment_states']
                      for message in publications]
 
         self.assertEqual(
             [200000, 1000000],
             [message['sample_time_us'] for message in publications])
-        self.assertEqual(2, len(set(id(snapshot) for snapshot in snapshots)))
-        self.assertIs(initial_wire, snapshots[0])
-        self.assertIs(state['equipment_states'], snapshots[-1])
+        self.assertNotEqual(snapshots[0], snapshots[-1])
+        self.assertEqual(
+            [snapshot['cooldownTimeLeft'] for snapshot in initial_wire],
+            [snapshot['cooldownTimeLeft'] for snapshot in snapshots[0]])
         for expected, snapshot in zip(
                 (89.8, 89.0), snapshots):
             self.assertAlmostEqual(
@@ -5870,9 +5941,18 @@ class BotRuntimeTests(unittest.TestCase):
             'gun_pitch', 'speed', 'movement_dir', 'rotation_dir',
             'reload_time', 'burst_time_left', 'siege_time_left_ms',
             'combat_fire_elapsed', 'combat_fire_timer'))
-        represented = set(('critical', 'equipment_states', 'ammo_remaining'))
+        represented = set(('critical', 'equipment_states', 'ammo_remaining',
+                           'shot_yaw', 'shot_pitch'))
+        codec = self.module.bot_state_codec
+        carried = set(name for name, unused in codec.SCALARS
+                      if not name.startswith('_'))
+        carried |= set(('alive', 'world_pose', 'ammo_reload_pending',
+                        'burst_active', 'movement_dir', 'rotation_dir'))
+        carried |= represented
+        for unused_bit, names in codec.OPTIONAL_GROUPS:
+            carried |= set(names)
         self.assertEqual(
-            set(self.module.lan_client._BOT_STATE_WIRE_FIELDS),
+            carried,
             continuous | represented |
             set(self.module._PUBLICATION_EDGE_SCALAR_FIELDS))
 
@@ -6614,7 +6694,7 @@ class BotRuntimeTests(unittest.TestCase):
         server.bot_roster = list(roster)
         self.assertTrue(server.update_bot_manifest(
             1, {'round_id': server.round_id,
-                'bots': manifest_message['bots']}))
+                'bots': bot_state_rows.bots(manifest_message)}))
 
         player = {
             'id': 1, 'team': 1, 'alive': True,
@@ -6633,17 +6713,17 @@ class BotRuntimeTests(unittest.TestCase):
                           if message['type'] == 'bot_state']
             self.assertLessEqual(len(bot_states), 1)
             for bot_state in bot_states:
-                self.assertEqual(29, len(bot_state['bots']))
+                self.assertEqual(29, len(bot_state_rows.bots(bot_state)))
                 published += 1
-                self.assertTrue(server.update_bot_states(1, {
+                self.assertTrue(server.update_bot_states(1, bot_state_rows.publication({
                     'round_id': server.round_id,
                     'sample_time_us': bot_state['sample_time_us'],
                     'source_batch_horizon_us':
                         bot_state['source_batch_horizon_us'],
-                    'bots': bot_state['bots'],
-                }))
+                    'bots': bot_state_rows.bots(bot_state),
+                })))
                 accepted += 1
-                for published_bot in bot_state['bots']:
+                for published_bot in bot_state_rows.bots(bot_state):
                     server_bot = server.bot_states[published_bot['id']]
                     self.assertEqual(published_bot['combat_seq'],
                                      server_bot['combat_ack_seq'])
@@ -6700,8 +6780,8 @@ class BotRuntimeTests(unittest.TestCase):
              'name': 'Autoloader-%d' % index}
             for index in range(29)
         ]
-        manifest = runtime.battle_start(
-            dict(self.start, bots=roster))[0]['bots']
+        manifest = bot_state_rows.bots(runtime.battle_start(
+            dict(self.start, bots=roster))[0])
         for state in runtime.states.values():
             state.update(
                 x=0.0, y=0.0, z=0.0, yaw=0.0, aim_yaw=0.0)
@@ -6733,18 +6813,18 @@ class BotRuntimeTests(unittest.TestCase):
                 if message['type'] != 'bot_state':
                     continue
                 publications += 1
-                for bot in message['bots']:
+                for bot in bot_state_rows.bots(message):
                     current_fire = bot['fire_seq']
                     self.assertLessEqual(
                         current_fire - previous_fire[bot['id']], 1)
                     previous_fire[bot['id']] = current_fire
-                self.assertTrue(server.update_bot_states(1, {
+                self.assertTrue(server.update_bot_states(1, bot_state_rows.publication({
                     'round_id': server.round_id,
                     'sample_time_us': message['sample_time_us'],
                     'source_batch_horizon_us':
                         message['source_batch_horizon_us'],
-                    'bots': message['bots'],
-                }), server.last_bot_state_reject)
+                    'bots': bot_state_rows.bots(message),
+                })), server.last_bot_state_reject)
                 runtime.apply_snapshot({
                     'server_tick': frame,
                     'bots': [dict(server.bot_states[bot_id])
@@ -6786,7 +6866,7 @@ class BotRuntimeTests(unittest.TestCase):
                     physics_ground_probe=lambda *unused: 0.0,
                     spawn_resolver=_spawn_resolver,
                     baked_graph=_graph())
-                roster = [dict(self.start['bots'][0])]
+                roster = [dict(bot_state_rows.bots(self.start)[0])]
                 start = dict(self.start, bots=roster)
                 manifest = runtime.battle_start(start)[0]
                 runtime.states[11]['critical'] = dict(burning)
@@ -6801,7 +6881,7 @@ class BotRuntimeTests(unittest.TestCase):
                 server.bot_roster = list(roster)
                 self.assertTrue(server.update_bot_manifest(1, {
                     'round_id': server.round_id,
-                    'bots': manifest['bots'],
+                    'bots': bot_state_rows.bots(manifest),
                 }))
 
                 dt = 1.0 / float(fps)
@@ -6829,13 +6909,13 @@ class BotRuntimeTests(unittest.TestCase):
                     self.assertLessEqual(len(publications_now), 1)
                     for publication in publications_now:
                         publications += 1
-                        published = publication['bots'][0]
+                        published = bot_state_rows.bots(publication)[0]
                         self.assertEqual(last_ack + 1,
                                          published['combat_seq'])
-                        self.assertTrue(server.update_bot_states(1, {
+                        self.assertTrue(server.update_bot_states(1, bot_state_rows.publication({
                             'round_id': server.round_id,
-                            'bots': publication['bots'],
-                        }))
+                            'bots': bot_state_rows.bots(publication),
+                        })))
                         canonical = server.bot_states[11]
                         self.assertEqual(published['combat_seq'],
                                          canonical['combat_ack_seq'])
@@ -6922,7 +7002,7 @@ class BotRuntimeTests(unittest.TestCase):
                 self.assertLessEqual(len(publications), 61)
                 self.assertEqual(29 * (len(publications) - 1), changed)
                 self.assertTrue(all(
-                    len(message['bots']) == 29
+                    len(bot_state_rows.bots(message)) == 29
                     for message in publications))
                 # The isolated selected-motion seam probes all 29 bots on the
                 # first authority tick; later deadlines stay staggered.
@@ -7328,40 +7408,23 @@ class BotRuntimeTests(unittest.TestCase):
             spawn_resolver=_spawn_resolver, baked_graph=_graph())
         runtime.battle_start(dict(self.start, bots=roster))
         calls = []
-        original = self.module.lan_client.project_owned_bot_state
-        strict_projection = self.module.lan_client.project_bot_state
+        codec = self.module.bot_state_codec
+        original = codec.encode_row
 
         def counted(state):
             calls.append(state['id'])
             return original(state)
 
-        self.module.lan_client.project_owned_bot_state = counted
+        codec.encode_row = counted
         try:
             publication = runtime.update(.04, 1.0)[0]
         finally:
-            self.module.lan_client.project_owned_bot_state = original
+            codec.encode_row = original
 
         internal = runtime._ordered_states()
         self.assertEqual([state['id'] for state in internal], calls)
         self.assertEqual(
-            [original(state) for state in internal], publication['bots'])
-        self.assertEqual(
-            [strict_projection(state) for state in internal],
-            publication['bots'])
-        self.assertNotIn('launches', publication)
-        self.assertTrue(all(
-            len(projected) < len(state)
-            for projected, state in zip(publication['bots'], internal)))
-        self.assertTrue(all(
-            projected['pitch'] == state['pitch'] and
-            projected['roll'] == state['roll'] and
-            projected['speed'] == state['speed']
-            for projected, state in zip(publication['bots'], internal)))
-        self.assertTrue(all(
-            'profile' not in state and
-            state['reload_duration'] > 0.0 and
-            0.0 <= state['reload_time'] <= state['reload_duration']
-            for state in publication['bots']))
+            [original(state) for state in internal], publication['rows'])
 
     def test_contact_resolution_uses_the_banked_global_simulation_step(self):
         runtime = self.module.BotRuntime(
@@ -7970,7 +8033,7 @@ class BotRuntimeTests(unittest.TestCase):
         runtime.battle_start(self.start)
         runtime.states[11]['speed'] = -1.0
 
-        state = runtime.update(.04, 1.0)[0]['bots'][0]
+        state = bot_state_rows.bots(runtime.update(.04, 1.0)[0])[0]
 
         self.assertEqual(-1, state['rotation_dir'])
         # Reverse motion flips track steering inside the copied physics law, so
@@ -7997,7 +8060,7 @@ class BotRuntimeTests(unittest.TestCase):
             baked_graph=_graph())
         runtime.battle_start(self.start)
 
-        state = runtime.update(.04, 1.0)[0]['bots'][0]
+        state = bot_state_rows.bots(runtime.update(.04, 1.0)[0])[0]
 
         self.assertEqual(1, state['rotation_dir'])
         self.assertAlmostEqual(
@@ -8027,11 +8090,11 @@ class BotRuntimeTests(unittest.TestCase):
         runtime.battle_start(self.start)
         runtime.states[11]['yaw'] = 0.0
 
-        state = runtime.update(.04, 1.0, players=[
+        state = bot_state_rows.bots(runtime.update(.04, 1.0, players=[
             {'id': 2, 'team': 1, 'alive': True,
              'x': 100.0, 'y': 0.5, 'z': 0.0,
              'effective_params': _effective_params_snapshot()}
-        ])[0]['bots'][0]
+        ])[0])[0]
 
         self.assertEqual(0, state['movement_dir'])
         self.assertEqual(1, state['rotation_dir'])
@@ -8252,7 +8315,7 @@ class BotRuntimeTests(unittest.TestCase):
             'x': 0.0, 'y': 1.0, 'z': 100.0,
         })
 
-        stale = runtime.update(0.2, 1.0, players=[player])[0]['bots'][0]
+        stale = bot_state_rows.bots(runtime.update(0.2, 1.0, players=[player])[0])[0]
         self.assertEqual(0, stale['fire_seq'])
 
         # A fresh solution admits exactly one shot, once the gunner has also
@@ -8398,11 +8461,11 @@ class BotRuntimeTests(unittest.TestCase):
         server.bot_roster = [
             {'id': 11, 'team': 2, 'slot': 0, 'name': 'Bot'}]
         self.assertTrue(server.update_bot_manifest(1, {
-            'round_id': server.round_id, 'bots': manifest['bots'],
+            'round_id': server.round_id, 'bots': bot_state_rows.bots(manifest),
         }))
         relayed = server.current_battle_message()['bot_manifest']
         self.assertEqual('elite', relayed[0].get('skill'))
-        invalid = dict(manifest['bots'][0], skill='unsupported')
+        invalid = dict(bot_state_rows.bots(manifest)[0], skill='unsupported')
         self.assertFalse(server.update_bot_manifest(1, {
             'round_id': server.round_id, 'bots': [invalid],
         }))
@@ -8449,7 +8512,7 @@ class BotRuntimeTests(unittest.TestCase):
             dict(self.start, bot_skill_mode='mixed'))[0]
         expected = self.runtime.bot_rating(11)
         self.assertNotIn(expected, self.module.bot_gunnery.RATING_ANCHORS)
-        entry = manifest['bots'][0]
+        entry = bot_state_rows.bots(manifest)[0]
 
         successor = self.module.BotRuntime(
             2, descriptor_resolver=lambda unused: _combat_descriptor(),
@@ -8530,7 +8593,7 @@ class BotRuntimeTests(unittest.TestCase):
             for unused_step in range(200):
                 now += 0.05
                 published = runtime.update(0.05, now, players=[player])
-                shots[skill] = published[0]['bots'][0]['fire_seq']
+                shots[skill] = bot_state_rows.bots(published[0])[0]['fire_seq']
 
         self.assertGreater(shots['rookie'], 0)
         self.assertGreaterEqual(shots['elite'], shots['rookie'])
@@ -8580,15 +8643,15 @@ class BotRuntimeTests(unittest.TestCase):
             now += 0.05
             published = runtime.update(0.05, now, players=[player])
             self.assertEqual(
-                0, published[0]['bots'][0]['fire_seq'],
+                0, bot_state_rows.bots(published[0])[0]['fire_seq'],
                 'a Bot fired %.2fs into a %.2fs reaction delay' % (
                     now - 1.0, reaction))
 
         fired = 0
         while now < 1.0 + reaction + 4.0 and not fired:
             now += 0.05
-            fired = runtime.update(
-                0.05, now, players=[player])[0]['bots'][0]['fire_seq']
+            fired = bot_state_rows.bots(runtime.update(
+                0.05, now, players=[player])[0])[0]['fire_seq']
         self.assertEqual(1, fired)
 
     def test_the_hold_survives_one_missing_target_frame(self):
@@ -8683,7 +8746,7 @@ class BotRuntimeTests(unittest.TestCase):
 
         # The gun first slews to the visible elevated target; it cannot fire
         # merely because the strategic order says fire_allowed.
-        first = runtime.update(.20, 1.0, players=[player])[0]['bots'][0]
+        first = bot_state_rows.bots(runtime.update(.20, 1.0, players=[player])[0])[0]
         self.assertEqual(0, first['fire_seq'])
         self.assertNotIn('shot_yaw', first)
         self.assertNotIn('shot_pitch', first)
@@ -8691,13 +8754,13 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertFalse(runtime.states[11]['gun_aligned'])
 
         # The second slew tick aligns, but the full reload is not complete.
-        aligned = runtime.update(.20, 1.2, players=[player])[0]['bots'][0]
+        aligned = bot_state_rows.bots(runtime.update(.20, 1.2, players=[player])[0])[0]
         self.assertEqual(0, aligned['fire_seq'])
         self.assertTrue(runtime.states[11]['gun_aligned'])
         self.assertEqual(0, len(lane_probes))
 
         # Once aligned and reloaded, a fresh static-lane probe still blocks.
-        blocked = runtime.update(.11, 1.31, players=[player])[0]['bots'][0]
+        blocked = bot_state_rows.bots(runtime.update(.11, 1.31, players=[player])[0])[0]
         self.assertEqual(0, blocked['fire_seq'])
         self.assertNotIn('shot_yaw', blocked)
         self.assertNotIn('shot_pitch', blocked)
@@ -8706,7 +8769,7 @@ class BotRuntimeTests(unittest.TestCase):
 
         # The next fresh lane is clear. The emitted shot angles are the actual
         # dispersed barrel ray and the clip selects the intra-clip delay.
-        fired = runtime.update(.20, 1.52, players=[player])[0]['bots'][0]
+        fired = bot_state_rows.bots(runtime.update(.20, 1.52, players=[player])[0])[0]
         self.assertEqual(1, fired['fire_seq'])
         self.assertIn('shot_yaw', fired)
         self.assertIn('shot_pitch', fired)
@@ -8722,7 +8785,7 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertAlmostEqual(0.2, runtime.states[11]['reload_duration'])
 
         runtime.update(.20, 1.72, players=[player])
-        second = runtime.update(.11, 1.83, players=[player])[0]['bots'][0]
+        second = bot_state_rows.bots(runtime.update(.11, 1.83, players=[player])[0])[0]
         self.assertEqual(2, second['fire_seq'])
         self.assertEqual(0, runtime.states[11]['clip'])
         full_reload = runtime._gun_states[11].reload_full
@@ -8736,7 +8799,7 @@ class BotRuntimeTests(unittest.TestCase):
             runtime.update(step, now, players=[player])
         step = full_reload * 0.19
         now += step
-        early = runtime.update(step, now, players=[player])[0]['bots'][0]
+        early = bot_state_rows.bots(runtime.update(step, now, players=[player])[0])[0]
         self.assertEqual(2, early['fire_seq'])
         step = max(full_reload * 0.02, 0.04)
         now += step
@@ -8825,12 +8888,12 @@ class BotRuntimeTests(unittest.TestCase):
                                 'x': 0.0, 'y': 0.0, 'z': 100.0})
         runtime.states[11].update(x=0.0, y=0.0, z=0.0, yaw=0.0)
         now = self._spend_gunner_delay(runtime, [player])
-        blocked = runtime.update(
-            0.15, now + 0.15, players=[player])[0]['bots'][0]
+        blocked = bot_state_rows.bots(runtime.update(
+            0.15, now + 0.15, players=[player])[0])[0]
         self.assertEqual(0, blocked['fire_seq'])
         self.assertNotIn(11, runtime._ballistic_solution_cache)
-        fired = runtime.update(
-            0.15, now + 0.30, players=[player])[0]['bots'][0]
+        fired = bot_state_rows.bots(runtime.update(
+            0.15, now + 0.30, players=[player])[0])[0]
         self.assertEqual(1, fired['fire_seq'])
         self.assertTrue(runtime.states[11]['gun_aligned'])
         self.assertLess(fired['gun_pitch'], 0.0)
@@ -8983,8 +9046,8 @@ class BotRuntimeTests(unittest.TestCase):
         # for the gunner to spend its tier reaction.  The SPG is stationary,
         # so its aiming circle is already converged.
         runtime.update(0.04, 1.0, players=[player])
-        pending = runtime.update(
-            0.40, 1.40, players=[player])[0]['bots'][0]
+        pending = bot_state_rows.bots(runtime.update(
+            0.40, 1.40, players=[player])[0])[0]
         self.assertEqual(0, pending['fire_seq'])
         self.assertEqual((0, 1), (
             pending['shell_index'], pending['next_shell_index']))
@@ -8993,7 +9056,7 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertEqual(0, calls[0][2])
 
         fired_message = runtime.update(0.04, 1.44, players=[player])[0]
-        fired = fired_message['bots'][0]
+        fired = bot_state_rows.bots(fired_message)[0]
         launch = fired_message['launches'][0]
         self.assertEqual(1, fired['fire_seq'])
         self.assertEqual((0, 1), (
@@ -10219,7 +10282,7 @@ class BotRuntimeTests(unittest.TestCase):
                 physics_ground_probe=lambda *unused: 0.0,
                 spawn_resolver=_spawn_resolver, baked_graph=_graph())
             start = dict(self.start, bots=[dict(
-                self.start['bots'][0],
+                bot_state_rows.bots(self.start)[0],
                 vehicle='sweden:S10_Strv_103_0_Series')])
             runtime.battle_start(start)
             state = runtime.states[11]
@@ -10563,19 +10626,19 @@ class BotRuntimeTests(unittest.TestCase):
 
         now = self._spend_gunner_delay(runtime, [player])
         self.assertEqual([], probes)
-        blocked = runtime.update(
-            .15, now + .15, players=[player])[0]['bots'][0]
+        blocked = bot_state_rows.bots(runtime.update(
+            .15, now + .15, players=[player])[0])[0]
         self.assertEqual(0, blocked['fire_seq'])
         self.assertEqual(1, probes[0][2]['fire_seq'])
         self.assertNotIn(11, runtime._friendly_repositions)
-        fired = runtime.update(
-            .15, now + .30, players=[player])[0]['bots'][0]
+        fired = bot_state_rows.bots(runtime.update(
+            .15, now + .30, players=[player])[0])[0]
         self.assertEqual(1, fired['fire_seq'])
         self.assertEqual([1, 1], [item[2]['fire_seq'] for item in probes])
-        self.assertEqual(
-            probes[1][2]['shot_yaw'], fired['shot_yaw'])
-        self.assertEqual(
-            probes[1][2]['shot_pitch'], fired['shot_pitch'])
+        self.assertAlmostEqual(
+            probes[1][2]['shot_yaw'], fired['shot_yaw'], places=5)
+        self.assertAlmostEqual(
+            probes[1][2]['shot_pitch'], fired['shot_pitch'], places=5)
         self.assertEqual([(11, 2), (11, 2)], [
             item[:2] for item in probes])
 
@@ -10908,13 +10971,13 @@ class BotRuntimeTests(unittest.TestCase):
         # for the gunner to spend its tier reaction.  The SPG is stationary,
         # so its aiming circle is already converged.
         runtime.update(.04, 1.0, players=[player])
-        blocked = runtime.update(.40, 1.40, players=[player])[0]['bots'][0]
+        blocked = bot_state_rows.bots(runtime.update(.40, 1.40, players=[player])[0])[0]
         self.assertEqual(0, blocked['fire_seq'])
         self.assertNotIn(11, runtime._artillery_intents)
         self.assertNotIn(11, runtime._artillery_reproofs)
         destination = runtime._friendly_repositions[11]['destination']
         state['x'], state['y'], state['z'] = destination
-        fired = runtime.update(.15, 1.55, players=[player])[0]['bots'][0]
+        fired = bot_state_rows.bots(runtime.update(.15, 1.55, players=[player])[0])[0]
         self.assertEqual(1, fired['fire_seq'])
         self.assertEqual(2, len(probes))
 
@@ -11183,19 +11246,19 @@ class BotRuntimeTests(unittest.TestCase):
             device_damage.CREW_KO_TIME_FACTOR)
         last = None
         for index in range(4):
-            last = runtime.update(.20, 1.0 + index * .20,
-                                  players=[player])[0]['bots'][0]
+            last = bot_state_rows.bots(runtime.update(.20, 1.0 + index * .20,
+                                  players=[player])[0])[0]
         self.assertEqual(0, last['fire_seq'])
         self.assertAlmostEqual(
             expected_reload, runtime.states[11]['reload_duration'])
-        fired = runtime.update(.20, 1.8, players=[player])[0]['bots'][0]
+        fired = bot_state_rows.bots(runtime.update(.20, 1.8, players=[player])[0])[0]
         self.assertEqual(1, fired['fire_seq'])
 
         runtime.states[11]['critical'] = {
             'crew_ko': [], 'devices': [], 'destroyed': ['gunHealth']}
         for index in range(5):
-            blocked = runtime.update(
-                .20, 2.4 + index * .20, players=[player])[0]['bots'][0]
+            blocked = bot_state_rows.bots(runtime.update(
+                .20, 2.4 + index * .20, players=[player])[0])[0]
         self.assertEqual(1, blocked['fire_seq'])
 
     def test_critical_parts_tick_cache_reuses_only_unchanged_payload(self):
@@ -11238,10 +11301,10 @@ class BotRuntimeTests(unittest.TestCase):
         self.module._cache_critical_parts_for_tick(state)
         self.assertIn(key, state)
 
-        projected = self.module.lan_client.project_bot_state(state)
-        self.assertNotIn(key, projected)
+        row = bot_state_rows.rows([state])[0]
+        self.assertNotIn(key, bot_state_rows.decoded([row], 0))
         self.assertNotIn(key, self.runtime.presentation_states()[0])
-        json.dumps(projected)
+        json.dumps(row)
 
         # Repair/fire advancement is a mutation boundary even when this slice
         # happens not to alter the canonical payload.
@@ -11252,7 +11315,7 @@ class BotRuntimeTests(unittest.TestCase):
         wire = next(message for message in outgoing
                     if message['type'] == 'bot_state')
         self.assertNotIn(key, state)
-        self.assertTrue(all(key not in value for value in wire['bots']))
+        self.assertTrue(all(key not in value for value in bot_state_rows.bots(wire)))
 
     def test_bot_consumables_use_independent_inventory_and_cooldowns(self):
         contracts = _bot_equipment_contracts(self.module)
@@ -11310,12 +11373,13 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertAlmostEqual(
             base_repair * 1.10,
             runtime._bot_repair_factor(11, descriptor))
-        projected = self.module.lan_client.project_bot_state(state)
+        projected = bot_state_rows.decoded(bot_state_rows.rows([state]), 0)
         self.assertEqual(3, len(projected['equipment_states']))
         malformed = dict(state)
-        malformed['equipment_states'] = [{}]
-        self.assertIsNone(
-            self.module.lan_client.project_bot_state(malformed))
+        malformed['equipment_states'] = [{}] * 4
+        with self.assertRaises(
+                self.module.bot_state_codec.BotStateCodecError):
+            bot_state_rows.rows([malformed])
 
     def test_trusted_equipment_projection_reuses_rows_between_edges(self):
         contracts = _bot_equipment_contracts(self.module, reuse_count=-1)
@@ -11684,10 +11748,10 @@ class BotRuntimeTests(unittest.TestCase):
         # seconds rather than the five a fully trained crew would need.
         outgoing = None
         for index in range(25):
-            outgoing = runtime.update(.20, 1.0 + index * .20)[0]['bots'][0]
+            outgoing = bot_state_rows.bots(runtime.update(.20, 1.0 + index * .20)[0])[0]
         self.assertLess(outgoing['critical']['devices'][0]['hp'], 130.0)
         for index in range(25, 45):
-            outgoing = runtime.update(.20, 1.0 + index * .20)[0]['bots'][0]
+            outgoing = bot_state_rows.bots(runtime.update(.20, 1.0 + index * .20)[0])[0]
 
         device = outgoing['critical']['devices'][0]
         self.assertEqual('leftTrackHealth', device['name'])
@@ -11784,11 +11848,11 @@ class BotRuntimeTests(unittest.TestCase):
 
         outgoing = None
         for index in range(49):
-            outgoing = runtime.update(.20, index * .20)[0]['bots'][0]
+            outgoing = bot_state_rows.bots(runtime.update(.20, index * .20)[0])[0]
         self.assertEqual(550, outgoing['health'])
         self.assertTrue(outgoing['critical']['fire'])
 
-        outgoing = runtime.update(.20, 9.8)[0]['bots'][0]
+        outgoing = bot_state_rows.bots(runtime.update(.20, 9.8)[0])[0]
         fuel = outgoing['critical']['devices'][0]
         self.assertEqual(500, outgoing['health'])
         self.assertFalse(outgoing['critical']['fire'])
@@ -11812,7 +11876,7 @@ class BotRuntimeTests(unittest.TestCase):
             physics_ground_probe=lambda *unused: 0.0,
             spawn_resolver=_spawn_resolver, baked_graph=_graph())
 
-        manifest = runtime.battle_start(self.start)[0]['bots'][0]
+        manifest = bot_state_rows.bots(runtime.battle_start(self.start)[0])[0]
         terminal = manifest['terminal_critical']
         expected_devices = set(
             self.module.critical_damage._OFFH_DEATH_DEVICES)
@@ -11868,7 +11932,7 @@ class BotRuntimeTests(unittest.TestCase):
 
         first = None
         for index in range(5):
-            first = runtime.update(.20, index * .20)[0]['bots'][0]
+            first = bot_state_rows.bots(runtime.update(.20, index * .20)[0])[0]
         first_seq = runtime._combat_sync[11]['next_seq']
         first_track = dict((record['name'], record['hp'])
                            for record in first['critical']['devices'])[
@@ -11889,7 +11953,7 @@ class BotRuntimeTests(unittest.TestCase):
 
         second = None
         for index in range(5, 10):
-            second = runtime.update(.20, index * .20)[0]['bots'][0]
+            second = bot_state_rows.bots(runtime.update(.20, index * .20)[0])[0]
         second_track = dict((record['name'], record['hp'])
                             for record in second['critical']['devices'])[
                                 'leftTrackHealth']
@@ -11934,10 +11998,10 @@ class BotRuntimeTests(unittest.TestCase):
         server.players[1] = Player(
             1, object(), ('127.0.0.1', 1), team=1, slot=0)
         server.bot_authority_id = 1
-        server.bot_roster = list(self.start['bots'])
+        server.bot_roster = list(bot_state_rows.bots(self.start))
         self.assertTrue(server.update_bot_manifest(1, {
             'round_id': server.round_id,
-            'bots': manifest_message['bots'],
+            'bots': bot_state_rows.bots(manifest_message),
         }))
         burning = _critical_payload({
             'name': 'fuelTankHealth', 'hp': 0.0, 'max_hp': 100.0,
@@ -11950,8 +12014,8 @@ class BotRuntimeTests(unittest.TestCase):
 
         publication = None
         for index in range(5):
-            publication = runtime.update(
-                .20, .20 + index * .20)[0]['bots'][0]
+            publication = bot_state_rows.bots(runtime.update(
+                .20, .20 + index * .20)[0])[0]
         self.assertEqual((900, 5),
                          (publication['health'], publication['combat_seq']))
         runtime.apply_snapshot({
@@ -11977,7 +12041,7 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertEqual([], sync['pending'])
         self.assertEqual(5, len(sync['unpublished_steps']))
 
-        next_publication = runtime.update(.20, 1.20)[0]['bots'][0]
+        next_publication = bot_state_rows.bots(runtime.update(.20, 1.20)[0])[0]
 
         # The five replayed slices plus this render slice's fire-clock advance
         # are one full-state publication on the new base.  The current slice
@@ -11992,10 +12056,10 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertEqual([1], [entry['seq'] for entry in sync['pending']])
         self.assertEqual([], sync['unpublished_steps'])
 
-        self.assertTrue(server.update_bot_states(1, {
+        self.assertTrue(server.update_bot_states(1, bot_state_rows.publication({
             'round_id': server.round_id,
             'bots': [next_publication],
-        }))
+        })))
         self.assertEqual(1, server.bot_states[11]['combat_ack_seq'])
 
         # Acknowledged snapshots and later fire-clock publications stay
@@ -12011,12 +12075,12 @@ class BotRuntimeTests(unittest.TestCase):
             publication_message = next(
                 message for message in outgoing
                 if message['type'] == 'bot_state')
-            published = publication_message['bots'][0]
+            published = bot_state_rows.bots(publication_message)[0]
             self.assertEqual(server_ack + 1, published['combat_seq'])
-            self.assertTrue(server.update_bot_states(1, {
+            self.assertTrue(server.update_bot_states(1, bot_state_rows.publication({
                 'round_id': server.round_id,
-                'bots': publication_message['bots'],
-            }))
+                'bots': bot_state_rows.bots(publication_message),
+            })))
             self.assertEqual(
                 published['combat_seq'],
                 server.bot_states[11]['combat_ack_seq'])
@@ -12041,7 +12105,7 @@ class BotRuntimeTests(unittest.TestCase):
                 health=950, critical=burning,
                 revision=1, base_revision=1)]})
 
-        first = runtime.update(.20, .20)[0]['bots'][0]
+        first = bot_state_rows.bots(runtime.update(.20, .20)[0])[0]
         self.assertEqual(1, first['combat_seq'])
         runtime.apply_snapshot({
             'server_tick': 2,
@@ -12055,7 +12119,7 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertEqual(1, len(sync['unpublished_steps']))
         self.assertEqual(0, runtime.states[11]['combat_seq'])
 
-        publication = runtime.update(.20, .40)[0]['bots'][0]
+        publication = bot_state_rows.bots(runtime.update(.20, .40)[0])[0]
 
         self.assertEqual(1, publication['combat_seq'])
         self.assertEqual(1, sync['next_seq'])
@@ -12098,7 +12162,7 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertEqual(first_replay, sync['unpublished_steps'])
         self.assertEqual(0, sync['next_seq'])
         self.assertEqual([], sync['pending'])
-        publication = runtime.update(.20, .40)[0]['bots'][0]
+        publication = bot_state_rows.bots(runtime.update(.20, .40)[0])[0]
         self.assertEqual(1, publication['combat_seq'])
 
     def test_external_hit_after_publication_ack_does_not_double_apply_fire(self):
@@ -12122,8 +12186,8 @@ class BotRuntimeTests(unittest.TestCase):
 
         publication = None
         for index in range(5):
-            publication = runtime.update(
-                .20, .20 + index * .20)[0]['bots'][0]
+            publication = bot_state_rows.bots(runtime.update(
+                .20, .20 + index * .20)[0])[0]
         self.assertEqual(900, publication['health'])
         runtime.apply_snapshot({
             'server_tick': 2,
@@ -12185,7 +12249,7 @@ class BotRuntimeTests(unittest.TestCase):
             'name': 'fuelTankHealth', 'hp': 0.0, 'max_hp': 100.0,
             'state': 'destroyed'}, destroyed=['fuelTankHealth'], fire=True)
         takeover_bot = dict(
-            self.start['bots'][0], health=800, max_health=1000,
+            bot_state_rows.bots(self.start)[0], health=800, max_health=1000,
             alive=True, x=0.0, y=0.0, z=100.0, yaw=math.pi,
             fire_seq=0, shell_index=0, reload_time=reload_duration,
             reload_duration=reload_duration, critical=burning,
@@ -12196,15 +12260,15 @@ class BotRuntimeTests(unittest.TestCase):
             self.start, bot_manifest=[takeover_bot]))
 
         for index in range(3):
-            outgoing = runtime.update(
-                .20, 100.2 + index * .20)[0]['bots'][0]
+            outgoing = bot_state_rows.bots(runtime.update(
+                .20, 100.2 + index * .20)[0])[0]
         self.assertEqual(750, outgoing['health'])
         self.assertEqual(5.0, outgoing['combat_fire_elapsed'])
         self.assertEqual(0.0, outgoing['combat_fire_timer'])
 
         for index in range(25):
-            outgoing = runtime.update(
-                .20, 100.8 + index * .20)[0]['bots'][0]
+            outgoing = bot_state_rows.bots(runtime.update(
+                .20, 100.8 + index * .20)[0])[0]
         self.assertEqual(500, outgoing['health'])
         self.assertFalse(outgoing['critical']['fire'])
         self.assertEqual(0.0, outgoing['combat_fire_elapsed'])
@@ -12224,7 +12288,7 @@ class BotRuntimeTests(unittest.TestCase):
             'name': 'fuelTankHealth', 'hp': 0.0, 'max_hp': 100.0,
             'state': 'destroyed'}, destroyed=['fuelTankHealth'], fire=True)
         takeover_bot = dict(
-            self.start['bots'][0], health=900, max_health=1000,
+            bot_state_rows.bots(self.start)[0], health=900, max_health=1000,
             alive=True, x=0.0, y=0.0, z=100.0, yaw=math.pi,
             fire_seq=0, shell_index=0, reload_time=reload_duration,
             reload_duration=reload_duration, critical=burning,
@@ -12235,7 +12299,7 @@ class BotRuntimeTests(unittest.TestCase):
         runtime.battle_start(dict(
             self.start, bot_manifest=[takeover_bot]))
 
-        local = runtime.update(.20, 100.2)[0]['bots'][0]
+        local = bot_state_rows.bots(runtime.update(.20, 100.2)[0])[0]
         self.assertEqual(4, local['combat_seq'])
         self.assertEqual(2.2, local['combat_fire_elapsed'])
 
@@ -12255,7 +12319,7 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertEqual([], sync['pending'])
         self.assertEqual([], sync['unpublished_steps'])
 
-        outgoing = runtime.update(.20, 100.4)[0]['bots'][0]
+        outgoing = bot_state_rows.bots(runtime.update(.20, 100.4)[0])[0]
         self.assertEqual(800, outgoing['health'])
         self.assertEqual(3.2, outgoing['combat_fire_elapsed'])
         self.assertEqual(6, outgoing['combat_seq'])
@@ -12274,7 +12338,7 @@ class BotRuntimeTests(unittest.TestCase):
             'name': 'fuelTankHealth', 'hp': 0.0, 'max_hp': 100.0,
             'state': 'destroyed'}, destroyed=['fuelTankHealth'], fire=True)
         takeover_bot = dict(
-            self.start['bots'][0], health=900, max_health=1000,
+            bot_state_rows.bots(self.start)[0], health=900, max_health=1000,
             alive=True, x=0.0, y=0.0, z=100.0, yaw=math.pi,
             fire_seq=0, shell_index=0, reload_time=reload_duration,
             reload_duration=reload_duration, critical=burning,
@@ -12285,7 +12349,7 @@ class BotRuntimeTests(unittest.TestCase):
         runtime.battle_start(dict(
             self.start, bot_manifest=[takeover_bot]))
 
-        local = runtime.update(.20, 100.2)[0]['bots'][0]
+        local = bot_state_rows.bots(runtime.update(.20, 100.2)[0])[0]
         self.assertEqual(4, local['combat_seq'])
         self.assertEqual(2.2, local['combat_fire_elapsed'])
 
@@ -12305,7 +12369,7 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertEqual([], sync['pending'])
         self.assertFalse(sync['authority_handoff_pending'])
 
-        outgoing = runtime.update(.20, 100.4)[0]['bots'][0]
+        outgoing = bot_state_rows.bots(runtime.update(.20, 100.4)[0])[0]
         self.assertEqual(800, outgoing['health'])
         self.assertEqual(3.2, outgoing['combat_fire_elapsed'])
         self.assertEqual(5, outgoing['combat_seq'])
@@ -12324,7 +12388,7 @@ class BotRuntimeTests(unittest.TestCase):
             'name': 'fuelTankHealth', 'hp': 0.0, 'max_hp': 100.0,
             'state': 'destroyed'}, destroyed=['fuelTankHealth'], fire=True)
         takeover_bot = dict(
-            self.start['bots'][0], health=900, max_health=1000,
+            bot_state_rows.bots(self.start)[0], health=900, max_health=1000,
             alive=True, x=0.0, y=0.0, z=100.0, yaw=math.pi,
             fire_seq=0, shell_index=0, reload_time=reload_duration,
             reload_duration=reload_duration, critical=burning,
@@ -12354,7 +12418,7 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertEqual([], sync['unpublished_steps'])
         self.assertFalse(sync['authority_handoff_pending'])
 
-        outgoing = runtime.update(.20, 100.4)[0]['bots'][0]
+        outgoing = bot_state_rows.bots(runtime.update(.20, 100.4)[0])[0]
         self.assertEqual((700, 3.2, 6), (
             outgoing['health'], outgoing['combat_fire_elapsed'],
             outgoing['combat_seq']))
@@ -12373,7 +12437,7 @@ class BotRuntimeTests(unittest.TestCase):
             'name': 'fuelTankHealth', 'hp': 0.0, 'max_hp': 100.0,
             'state': 'destroyed'}, destroyed=['fuelTankHealth'], fire=True)
         takeover_bot = dict(
-            self.start['bots'][0], health=900, max_health=1000,
+            bot_state_rows.bots(self.start)[0], health=900, max_health=1000,
             alive=True, x=0.0, y=0.0, z=100.0, yaw=math.pi,
             fire_seq=0, shell_index=0, reload_time=reload_duration,
             reload_duration=reload_duration, critical=burning,
@@ -12383,7 +12447,7 @@ class BotRuntimeTests(unittest.TestCase):
         runtime.battle_start(dict(self.start, bot_authority_id=2))
         runtime.battle_start(dict(
             self.start, bot_manifest=[takeover_bot]))
-        local = runtime.update(.20, 100.2)[0]['bots'][0]
+        local = bot_state_rows.bots(runtime.update(.20, 100.2)[0])[0]
         self.assertEqual((4, 2.2), (
             local['combat_seq'], local['combat_fire_elapsed']))
 
@@ -12404,7 +12468,7 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertEqual([], sync['pending'])
         self.assertFalse(sync['authority_handoff_pending'])
 
-        outgoing = runtime.update(.20, 100.4)[0]['bots'][0]
+        outgoing = bot_state_rows.bots(runtime.update(.20, 100.4)[0])[0]
         self.assertEqual((750, 3.2, 5), (
             outgoing['health'], outgoing['combat_fire_elapsed'],
             outgoing['combat_seq']))
@@ -12422,7 +12486,7 @@ class BotRuntimeTests(unittest.TestCase):
             'name': 'fuelTankHealth', 'hp': 0.0, 'max_hp': 100.0,
             'state': 'destroyed'}, destroyed=['fuelTankHealth'], fire=True)
         initial = dict(
-            self.start['bots'][0], health=900, max_health=1000,
+            bot_state_rows.bots(self.start)[0], health=900, max_health=1000,
             alive=True, critical=burning, combat_revision=4,
             combat_base_revision=1, combat_ack_seq=3,
             combat_fire_elapsed=2.0, combat_fire_timer=0.0)
@@ -12484,7 +12548,7 @@ class BotRuntimeTests(unittest.TestCase):
         before = dict(runtime.states[11])
 
         outgoing = runtime.update(.04, 1.0)
-        state = outgoing[0]['bots'][0]
+        state = bot_state_rows.bots(outgoing[0])[0]
 
         self.assertEqual(1, state['movement_dir'])
         self.assertEqual(0, state['rotation_dir'])
@@ -14025,7 +14089,7 @@ class BotRuntimeTests(unittest.TestCase):
             {'id': 2, 'team': 1, 'alive': True,
              'x': 5, 'y': 0, 'z': 5,
              'effective_params': _effective_params_snapshot()}])
-        self.assertFalse(final[0]['bots'][0]['alive'])
+        self.assertFalse(bot_state_rows.bots(final[0])[0]['alive'])
         self.assertEqual(0, self.runtime.states[11]['fire_seq'])
 
     def test_terminal_snapshot_freezes_all_bot_updates(self):
@@ -14706,7 +14770,7 @@ class BotRuntimeTests(unittest.TestCase):
         states = [message for message in publications
                   if message.get('type') == 'bot_state']
         self.assertEqual(1, len(states))
-        self.assertEqual([], states[0]['bots'])
+        self.assertEqual([], bot_state_rows.bots(states[0]))
 
     def test_runtime_caches_one_traffic_decision_with_the_planner_command(self):
         self.runtime.battle_start(self.start)
@@ -15254,7 +15318,7 @@ class BotRuntimeTests(unittest.TestCase):
         waiting = dict(self.start, bot_authority_id=2)
         self.assertEqual([], self.runtime.battle_start(waiting))
         snapshot_bot = dict(
-            self.start['bots'][0], health=900, max_health=1000,
+            bot_state_rows.bots(self.start)[0], health=900, max_health=1000,
             alive=True, x=1, y=0, z=2, yaw=0.5,
             fire_seq=7, shell_index=0, next_shell_index=0,
             ammo_remaining=[38], ammo_reload_pending=False,
@@ -15307,21 +15371,22 @@ class BotRuntimeTests(unittest.TestCase):
         publication = self.runtime.update(.20, 1.0)[0]
         expected_remaining = self.runtime._gun_states[11].reload_full - 0.20
         self.assertAlmostEqual(
-            expected_remaining, publication['bots'][0]['reload_time'])
+            expected_remaining,
+            bot_state_rows.decoded(publication, 0)['reload_time'], places=6)
 
         server, unused_manifest, unused_socket = \
             ServerBotStateRevisionTests._server()
         for name in ('shell_index', 'next_shell_index', 'ammo_remaining',
                      'ammo_reload_pending', 'clip', 'clip_size'):
-            server.bot_states[11][name] = publication['bots'][0][name]
+            server.bot_states[11][name] = bot_state_rows.bots(publication)[0][name]
         self.assertTrue(server.update_bot_states(
-            SIMULATION_WORKER_AUTHORITY_ID, {
+            SIMULATION_WORKER_AUTHORITY_ID, bot_state_rows.publication({
                 'round_id': server.round_id,
-                'bots': publication['bots'],
+                'bots': bot_state_rows.bots(publication),
                 'sample_time_us': publication['sample_time_us'],
                 'source_batch_horizon_us':
                     publication['source_batch_horizon_us'],
-            }), server.last_bot_state_reject)
+            })), server.last_bot_state_reject)
         start = server.current_battle_message()
         start['bot_authority_id'] = 1
         # The room preset travels with the round, so the successor installs
@@ -15393,7 +15458,7 @@ class BotRuntimeTests(unittest.TestCase):
             self.start, bot_authority_id=2)))
         reload_duration = self.runtime._gun_states[11].reload_full
         takeover = dict(
-            self.start['bots'][0], x=200.0, y=4.0, z=300.0,
+            bot_state_rows.bots(self.start)[0], x=200.0, y=4.0, z=300.0,
             yaw=1.0, aim_yaw=1.4, gun_pitch=-0.25,
             movement_dir=-1, rotation_dir=1, health=900,
             max_health=1000, alive=True,
@@ -15422,8 +15487,8 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertIs(sync, self.runtime._combat_sync[11])
         self.assertTrue(sync['authority_handoff_pending'])
         self.assertEqual((200.0, 4.0, 300.0, 1.0), (
-            resumed[0]['bots'][0]['x'], resumed[0]['bots'][0]['y'],
-            resumed[0]['bots'][0]['z'], resumed[0]['bots'][0]['yaw']))
+            bot_state_rows.bots(resumed[0])[0]['x'], bot_state_rows.bots(resumed[0])[0]['y'],
+            bot_state_rows.bots(resumed[0])[0]['z'], bot_state_rows.bots(resumed[0])[0]['yaw']))
 
     def test_server_macro_order_drives_local_adapter_with_human_id_mapping(self):
         self.runtime.battle_start(self.start)
@@ -15484,9 +15549,9 @@ class BotRuntimeTests(unittest.TestCase):
                     ground_probe=lambda *unused: 0.0,
                     physics_ground_probe=lambda *unused: 0.0,
                     spawn_resolver=_spawn_resolver, baked_graph=_graph())
-                manifest = runtime.battle_start(dict(self.start, bots=[{
+                manifest = bot_state_rows.bots(runtime.battle_start(dict(self.start, bots=[{
                     'id': 11, 'team': 1, 'slot': 0, 'name': 'Recipient',
-                }]))[0]['bots']
+                }]))[0])
                 state = runtime.states[11]
                 state.update(
                     x=start[0], y=0.0, z=start[1], yaw=0.0, speed=0.0)
@@ -15545,9 +15610,9 @@ class BotRuntimeTests(unittest.TestCase):
             ground_probe=lambda *unused: 0.0,
             physics_ground_probe=lambda *unused: 0.0,
             spawn_resolver=_spawn_resolver, baked_graph=_graph())
-        manifest = runtime.battle_start(dict(self.start, bots=[{
+        manifest = bot_state_rows.bots(runtime.battle_start(dict(self.start, bots=[{
             'id': 11, 'team': 1, 'slot': 0, 'name': 'Recipient',
-        }]))[0]['bots']
+        }]))[0])
         state = runtime.states[11]
         state.update(
             x=3.0, y=0.0, z=2.0, yaw=0.0, speed=0.0,
@@ -17309,8 +17374,8 @@ class BotRuntimeTests(unittest.TestCase):
             {'id': 11, 'team': 1, 'slot': 0, 'name': 'Clear'},
             {'id': 12, 'team': 1, 'slot': 1, 'name': 'Blocked'},
         ]
-        manifest = runtime.battle_start(
-            dict(self.start, bots=roster))[0]['bots']
+        manifest = bot_state_rows.bots(runtime.battle_start(
+            dict(self.start, bots=roster))[0])
         runtime.states[11].update(x=0.0, y=0.0, z=0.0, yaw=0.0)
         runtime.states[12].update(x=10.0, y=0.0, z=0.0, yaw=0.0)
         enemy = {
@@ -17321,7 +17386,7 @@ class BotRuntimeTests(unittest.TestCase):
         enemy = _admit_player(enemy)
 
         outgoing = runtime.update(.04, 1.0, players=[enemy])
-        bot_states = next(message['bots'] for message in outgoing
+        bot_states = next(bot_state_rows.bots(message) for message in outgoing
                           if message['type'] == 'bot_state')
         observation = next(message for message in outgoing
                            if message['type'] == 'bot_observation')
@@ -17383,10 +17448,10 @@ class BotRuntimeTests(unittest.TestCase):
             'dominant_role': 'support', 'desired_range': 200.0,
             'fire_range': 500.0, 'roles': {'support': 1.0},
         }
-        manifest = runtime.battle_start(dict(self.start, bots=[{
+        manifest = bot_state_rows.bots(runtime.battle_start(dict(self.start, bots=[{
             'id': 11, 'team': 1, 'slot': 0, 'name': 'Limited TD',
             'profile': profile,
-        }]))[0]['bots']
+        }]))[0])
         state = runtime.states[11]
         state.update(x=0.0, y=0.0, z=0.0, yaw=0.0,
                      aim_yaw=0.0, speed=0.0)
@@ -17510,8 +17575,8 @@ class BotRuntimeTests(unittest.TestCase):
             {'id': 11, 'team': 1, 'slot': 0, 'name': 'Blocked-A'},
             {'id': 12, 'team': 1, 'slot': 1, 'name': 'Blocked-B'},
         ]
-        manifest = runtime.battle_start(
-            dict(self.start, bots=roster))[0]['bots']
+        manifest = bot_state_rows.bots(runtime.battle_start(
+            dict(self.start, bots=roster))[0])
         runtime.states[11].update(x=0.0, y=0.0, z=0.0)
         runtime.states[12].update(x=5.0, y=0.0, z=0.0)
         runtime.set_camera_position((1000.0, 0.0, 1000.0))
@@ -17523,7 +17588,7 @@ class BotRuntimeTests(unittest.TestCase):
         enemy = _admit_player(enemy)
 
         outgoing = runtime.update(.04, 1.0, players=[enemy])
-        bot_states = next(message['bots'] for message in outgoing
+        bot_states = next(bot_state_rows.bots(message) for message in outgoing
                           if message['type'] == 'bot_state')
         contact = next(message for message in outgoing
                        if message['type'] == 'bot_observation')['contacts'][0]
@@ -18387,8 +18452,8 @@ class BotRuntimeTests(unittest.TestCase):
              'name': 'Observer-%d' % index}
             for index in range(29)
         ]
-        manifest = runtime.battle_start(
-            dict(self.start, bots=roster))[0]['bots']
+        manifest = bot_state_rows.bots(runtime.battle_start(
+            dict(self.start, bots=roster))[0])
         identities = dict((state['id'], state) for state in manifest)
         planner = BotPlanner()
         observation_batches = 0
@@ -18407,7 +18472,7 @@ class BotRuntimeTests(unittest.TestCase):
             if not any(message['type'] == 'bot_observation'
                        for message in outgoing):
                 continue
-            wire_states = next(message['bots'] for message in outgoing
+            wire_states = next(bot_state_rows.bots(message) for message in outgoing
                                if message['type'] == 'bot_state')
             # The wire deliberately omits manifest-owned identity/profile
             # fields. Rebuild exactly what the server sanitizer gives its

--- a/tests/test_port_0922_bot_runtime.py
+++ b/tests/test_port_0922_bot_runtime.py
@@ -932,12 +932,15 @@ class ServerBotStateRevisionTests(unittest.TestCase):
         self.assertEqual(2, server.bot_state_revision)
         self.assertEqual(0.8, server.bot_states[11]['x'])
 
-    def test_one_bot_contract_failure_never_stops_the_other_bots(self):
-        """A per-Bot contract failure is contained to that Bot's ledgers.
+    def test_a_fenced_bot_combat_lineage_reopens_instead_of_freezing(self):
+        """A combat lineage the server cannot follow rebases the authority.
 
-        Rejecting the publication would also leave the Bot's stored state
-        behind its own next publication, so the same failure would repeat and
-        freeze it -- and every other Bot -- for the rest of the round.
+        Rejecting the publication would leave this Bot's stored state behind
+        its own next publication, so the same failure would repeat and freeze
+        it -- and every other Bot -- for the rest of the round. Holding the
+        acknowledged sequence without opening a new canonical revision has the
+        same shape: the authority keeps proposing past a sequence the server
+        will never acknowledge.
         """
         now = [100.0]
         server, _, unused_socket = self._server(
@@ -954,34 +957,30 @@ class ServerBotStateRevisionTests(unittest.TestCase):
         admitted = copy.deepcopy(server.bot_states[11])
         revision = server.bot_state_revision
 
-        for offset, (field, mutate) in enumerate((
-                ('combat_seq', lambda bot: bot.__setitem__(
-                    'combat_seq', bot['combat_ack_seq'] + 2)),
-                ('ammo_remaining', lambda bot: bot.__setitem__(
-                    'ammo_remaining',
-                    [bot['ammo_remaining'][0] + 1] +
-                    list(bot['ammo_remaining'][1:]))))):
-            now[0] = 100.210 + offset * 0.005
-            broken = self._publication(server, 1.5 + offset)
-            broken['sample_time_us'] = 50000 + offset * 10000
-            broken['source_batch_horizon_us'] = broken['sample_time_us']
-            mutate(broken['bots'][0])
-            self.assertTrue(server.update_bot_states(
-                SIMULATION_WORKER_AUTHORITY_ID,
-                bot_state_rows.publication(broken)),
-                'a single Bot contract must not cost the publication')
-            current = server.bot_states[11]
-            self.assertEqual(1.5 + offset, current['x'], field)
-            self.assertEqual(admitted['fire_seq'], current['fire_seq'], field)
-            self.assertEqual(
-                admitted['ammo_remaining'], current['ammo_remaining'], field)
-            self.assertEqual(
-                admitted['combat_ack_seq'], current['combat_ack_seq'], field)
-            self.assertGreater(server.bot_state_revision, revision)
-            revision = server.bot_state_revision
+        now[0] = 100.210
+        broken = self._publication(server, 1.5)
+        broken['sample_time_us'] = 50000
+        broken['source_batch_horizon_us'] = 50000
+        bot_state_rows.bots(broken)[0]['combat_seq'] = (
+            admitted['combat_ack_seq'] + 2)
+        self.assertTrue(server.update_bot_states(
+            SIMULATION_WORKER_AUTHORITY_ID,
+            bot_state_rows.publication(broken)),
+            'a single Bot contract must not cost the publication')
+        fenced = server.bot_states[11]
+        self.assertEqual(1.5, fenced['x'])
+        self.assertEqual(
+            admitted['combat_ack_seq'], fenced['combat_ack_seq'])
+        self.assertEqual(admitted['critical'], fenced['critical'])
+        self.assertGreater(
+            fenced['combat_base_revision'],
+            admitted['combat_base_revision'])
+        self.assertEqual(
+            fenced['combat_revision'], fenced['combat_base_revision'])
+        self.assertGreater(server.bot_state_revision, revision)
 
-        # The Bot is still live authority, not frozen: a well formed
-        # publication resumes immediately.
+        # That new base is what the authority rebases onto, so its very next
+        # proposal is contiguous again and the Bot is live authority.
         now[0] = 100.240
         healthy = self._publication(server, 3.0)
         healthy['sample_time_us'] = 90000
@@ -992,6 +991,68 @@ class ServerBotStateRevisionTests(unittest.TestCase):
             server.last_bot_state_reject)
         self.assertEqual(3.0, server.bot_states[11]['x'])
         self.assertEqual('', server.last_bot_state_reject_code)
+
+    def test_a_disagreeing_bot_magazine_rebases_so_the_bot_fires_again(self):
+        """An inventory step the server cannot derive becomes the new baseline.
+
+        Holding the previously admitted magazine would make every later
+        publication disagree with it exactly the same way, so the Bot would
+        never have another shot admitted for the rest of the round.
+        """
+        now = [100.0]
+        server, _, unused_socket = self._server(
+            clock=lambda: now[0],
+            before_manifest=lambda: now.__setitem__(0, 100.025))
+        now[0] = 100.200
+        baseline = self._publication(server, 0.4)
+        baseline['sample_time_us'] = 40000
+        baseline['source_batch_horizon_us'] = 40000
+        self.assertTrue(server.update_bot_states(
+            SIMULATION_WORKER_AUTHORITY_ID,
+            bot_state_rows.publication(baseline)),
+            server.last_bot_state_reject)
+        revision = server.bot_state_revision
+
+        now[0] = 100.210
+        broken = self._publication(server, 1.5)
+        broken['sample_time_us'] = 50000
+        broken['source_batch_horizon_us'] = 50000
+        bot = bot_state_rows.bots(broken)[0]
+        bot['fire_seq'] = int(bot['fire_seq']) + 1
+        bot['ammo_reload_pending'] = True
+        bot['clip'] = 0
+        bot.update(BattleState._ordinary_bot_burst(bot['fire_seq'], 0))
+        self.assertTrue(server.update_bot_states(
+            SIMULATION_WORKER_AUTHORITY_ID,
+            bot_state_rows.publication(broken)),
+            'a single Bot contract must not cost the publication')
+        contained = server.bot_states[11]
+        self.assertEqual(1.5, contained['x'])
+        self.assertEqual(bot['fire_seq'], contained['fire_seq'])
+        self.assertEqual(bot['ammo_remaining'], contained['ammo_remaining'])
+        # No projectile edge is invented from a step the server could not
+        # derive; only the inventory it now trusts is carried forward.
+        self.assertEqual(set(), server.bot_pending_projectile_launches)
+        self.assertGreater(server.bot_state_revision, revision)
+
+        # The very next legal shot from that baseline is admitted and launches.
+        now[0] = 100.240
+        healthy = self._publication(server, 3.0)
+        healthy['sample_time_us'] = 90000
+        healthy['source_batch_horizon_us'] = 90000
+        bot = bot_state_rows.bots(healthy)[0]
+        shot_seq = int(bot['fire_seq']) + 1
+        bot['fire_seq'] = shot_seq
+        bot['ammo_remaining'] = [int(bot['ammo_remaining'][0]) - 1]
+        bot['ammo_reload_pending'] = True
+        bot['clip'] = 0
+        bot.update(BattleState._ordinary_bot_burst(shot_seq, 0))
+        self.assertTrue(server.update_bot_states(
+            SIMULATION_WORKER_AUTHORITY_ID,
+            bot_state_rows.publication(healthy)),
+            server.last_bot_state_reject)
+        self.assertEqual('', server.last_bot_state_reject_code)
+        self.assertIn((11, shot_seq), server.bot_pending_projectile_launches)
 
     def test_dispatcher_counts_validated_clock_rebase_as_advancement(self):
         now = [100.0]
@@ -12085,6 +12146,96 @@ class BotRuntimeTests(unittest.TestCase):
                 published['combat_seq'],
                 server.bot_states[11]['combat_ack_seq'])
         self.assertEqual(700, server.bot_states[11]['health'])
+
+    def test_a_server_fenced_combat_lineage_is_rebased_by_the_authority(self):
+        """The server's fence must close its own gap, not freeze the Bot.
+
+        When the server cannot follow a Bot's combat lineage it holds the
+        acknowledged sequence and opens a new canonical revision. That new base
+        is only useful if the authority actually rebases onto it; otherwise the
+        authority keeps proposing past a sequence the server will never
+        acknowledge and the Bot's combat state is frozen for the round.
+        """
+        descriptor = _critical_descriptor()
+        runtime = self.module.BotRuntime(
+            1, descriptor_resolver=lambda unused: descriptor,
+            adapter_factory=lambda *args, **kwargs: _Adapter(*args),
+            direction_probe=lambda *unused: {'clear': True, 'slope': 0.0},
+            ground_probe=lambda *unused: 0.0,
+            physics_ground_probe=lambda *unused: 0.0,
+            spawn_resolver=_spawn_resolver, baked_graph=_graph())
+        manifest_message = runtime.battle_start(self.start)[0]
+        server = BattleState(map_name='01_karelia')
+        server.client_build = CLIENT_BUILD_0922
+        server.phase = 'battle'
+        server.tick = 100000
+        server.round_id = self.start['round_id']
+        server.players[1] = Player(
+            1, object(), ('127.0.0.1', 1), team=1, slot=0)
+        server.bot_authority_id = 1
+        server.bot_roster = list(bot_state_rows.bots(self.start))
+        self.assertTrue(server.update_bot_manifest(1, {
+            'round_id': server.round_id,
+            'bots': bot_state_rows.bots(manifest_message),
+        }))
+        burning = _critical_payload({
+            'name': 'fuelTankHealth', 'hp': 0.0, 'max_hp': 100.0,
+            'state': 'destroyed'}, destroyed=['fuelTankHealth'], fire=True)
+        runtime.apply_snapshot({
+            'server_tick': 1,
+            'bots': [_snapshot_bot(
+                health=950, critical=burning,
+                revision=1, base_revision=1)]})
+
+        # Mirror that external hit as the server's canonical combat base, so
+        # the only thing the server cannot follow below is the sequence.
+        server.bot_states[11].update(
+            health=950, display_health=950, critical=dict(burning),
+            combat_revision=1, combat_base_revision=1, combat_ack_seq=0,
+            combat_fire_elapsed=0.0, combat_fire_timer=0.0)
+        publication_message = runtime.update(.20, .20)[0]
+        published = bot_state_rows.bots(publication_message)[0]
+        self.assertEqual(1, published['combat_seq'])
+        server_base = server.bot_states[11]['combat_base_revision']
+
+        # A proposal that skips a sequence the server never acknowledged.
+        published['combat_seq'] = (
+            server.bot_states[11]['combat_ack_seq'] + 2)
+        self.assertTrue(server.update_bot_states(1, bot_state_rows.publication({
+            'round_id': server.round_id,
+            'bots': [published],
+        })), server.last_bot_state_reject)
+        fenced = server.bot_states[11]
+        self.assertEqual(0, fenced['combat_ack_seq'])
+        self.assertGreater(fenced['combat_base_revision'], server_base)
+        self.assertEqual(
+            fenced['combat_revision'], fenced['combat_base_revision'])
+
+        # The authority accepts that new base and resets its own sequence to
+        # the server's ack, so the very next proposal is contiguous again.
+        runtime.apply_snapshot({
+            'server_tick': 2, 'bots': [dict(fenced)]})
+        sync = runtime._combat_sync[11]
+        self.assertEqual(fenced['combat_ack_seq'], sync['next_seq'])
+        self.assertEqual(
+            fenced['combat_base_revision'], sync['base_revision'])
+        self.assertEqual([], sync['pending'])
+
+        # This Bot's combat is live for the rest of the round: its fire clock
+        # keeps advancing on the fenced base, and the very next proposal is
+        # ack+1 and acknowledged.
+        recovered_message = runtime.update(.20, .40)[0]
+        recovered = bot_state_rows.bots(recovered_message)[0]
+        self.assertEqual(
+            fenced['combat_ack_seq'] + 1, recovered['combat_seq'])
+        self.assertTrue(server.update_bot_states(1, bot_state_rows.publication({
+            'round_id': server.round_id,
+            'bots': bot_state_rows.bots(recovered_message),
+        })), server.last_bot_state_reject)
+        self.assertEqual('', server.last_bot_state_reject_code)
+        self.assertEqual(
+            recovered['combat_seq'],
+            server.bot_states[11]['combat_ack_seq'])
 
     def test_external_base_replay_waits_for_wire_before_reserving_sequence(self):
         descriptor = _critical_descriptor()

--- a/tests/test_port_0922_bot_state_codec.py
+++ b/tests/test_port_0922_bot_state_codec.py
@@ -32,11 +32,7 @@ CONTRACTS = (
     _contract('largeMedkit', 'medkit', ('equipment', 'medkit')),
     _contract('largeRepairkit', 'repairkit', ('equipment', 'repairkit')),
 )
-STATIC = {
-    'equipment_contracts': CONTRACTS,
-    'device_max_hp': dict((name, 160.0) for name in codec.DEVICE_NAMES),
-    'crew_roster': list(codec.CREW_NAMES),
-}
+STATIC = {'equipment_contracts': CONTRACTS}
 
 
 def _equipment_snapshot(uses=1, cooldown=0.0, active=False,
@@ -147,6 +143,7 @@ class BotStateCodecTest(unittest.TestCase):
             ],
             'destroyed': ['leftTrackHealth'],
             'crew_ko': ['gunner1', 'loader2'],
+            'crew_roster': ['commander', 'driver', 'gunner1', 'loader2'],
             'fire': True, 'ammo_rack_death': False, 'events': [],
         })
         critical = codec.decode_row(
@@ -162,7 +159,9 @@ class BotStateCodecTest(unittest.TestCase):
         self.assertIs(critical['fire'], True)
         self.assertIs(critical['ammo_rack_death'], False)
         self.assertEqual(critical['events'], [])
-        self.assertEqual(critical['crew_roster'], list(codec.CREW_NAMES))
+        self.assertEqual(
+            ['commander', 'driver', 'gunner1', 'loader2'],
+            critical['crew_roster'])
 
     def test_equipment_rejoins_the_round_contract(self):
         state = _bot_state(equipment_states=[
@@ -189,6 +188,35 @@ class BotStateCodecTest(unittest.TestCase):
         self.assertIs(decoded['alive'], False)
         self.assertEqual(decoded['health'], 0)
         self.assertEqual(decoded['death_reason'], 1)
+
+    def test_absent_groups_stay_absent_so_the_server_keeps_its_state(self):
+        """A row must still express "I published no burst, clip or Siege".
+
+        The mapping form left the whole group out and the server kept the
+        state it had already admitted. A positional row always has the
+        columns, so the presence bits carry that distinction; without them a
+        Bot with no burst clock would publish an empty magazine and its shots
+        would never be admitted.
+        """
+        state = _bot_state()
+        for name in ('burst_active', 'burst_group_seq', 'burst_count',
+                     'burst_next_index', 'burst_shell_index',
+                     'burst_interval', 'burst_time_left',
+                     'clip', 'clip_size', 'siege_state',
+                     'siege_time_left_ms', 'siege_transition_total_ms'):
+            del state[name]
+        decoded = codec.decode_row(codec.encode_row(state), STATIC)
+        for name in ('burst_active', 'burst_group_seq', 'clip', 'clip_size',
+                     'siege_state', 'siege_time_left_ms'):
+            self.assertNotIn(name, decoded)
+        self.assertEqual(decoded['fire_seq'], state['fire_seq'])
+        self.assertEqual(decoded['health'], state['health'])
+
+    def test_a_half_published_group_is_refused(self):
+        state = _bot_state()
+        del state['clip_size']
+        with self.assertRaises(codec.BotStateCodecError):
+            codec.encode_row(state)
 
     def test_truncated_and_overlong_rows_are_refused(self):
         row = codec.encode_row(_bot_state())

--- a/tests/test_port_0922_bot_state_codec.py
+++ b/tests/test_port_0922_bot_state_codec.py
@@ -1,0 +1,253 @@
+import json
+import math
+import os
+import subprocess
+import sys
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+CLIENT_ROOT = ROOT / 'src' / 'res' / 'scripts' / 'client'
+CODEC_PATH = (CLIENT_ROOT / 'gui' / 'mods' / 'offline_lan_0922' /
+              'bot_state_codec.py')
+sys.path.insert(0, str(CLIENT_ROOT))
+
+from gui.mods.offline_lan_0922 import bot_state_codec as codec
+
+
+def _contract(name, kind, tags):
+    return {
+        'name': name, 'kind': kind, 'id': 1042, 'compactDescr': 34817,
+        'tags': list(tags), 'reuseCount': 0, 'cooldownSeconds': 90.0,
+        'autoactivate': kind == 'extinguisher',
+        'fireStartingChanceFactor': 1.0, 'repairAll': kind != 'extinguisher',
+        'bonusValue': 0.0, 'crewLevelIncrease': 0.0, 'enginePowerFactor': 1.0,
+        'turretRotationSpeedFactor': 1.0, 'engineHpLossPerSecond': 0.0,
+        'autoReactionSeconds': 1.5,
+    }
+
+
+CONTRACTS = (
+    _contract('autoExtinguishers', 'extinguisher', ('deluxe', 'equipment')),
+    _contract('largeMedkit', 'medkit', ('equipment', 'medkit')),
+    _contract('largeRepairkit', 'repairkit', ('equipment', 'repairkit')),
+)
+STATIC = {
+    'equipment_contracts': CONTRACTS,
+    'device_max_hp': dict((name, 160.0) for name in codec.DEVICE_NAMES),
+    'crew_roster': list(codec.CREW_NAMES),
+}
+
+
+def _equipment_snapshot(uses=1, cooldown=0.0, active=False,
+                        auto=None, ai=None):
+    return {
+        'usesLeft': uses, 'cooldownTimeLeft': cooldown, 'active': active,
+        'autoPendingElapsed': auto, 'aiPendingElapsed': ai,
+    }
+
+
+def _bot_state(**overrides):
+    state = {
+        'id': 17, 'x': 125.6312, 'y': 6.5041, 'z': -67.8842,
+        'yaw': -0.77258, 'pitch': 0.01076, 'roll': -0.00412,
+        'aim_yaw': -0.63482, 'gun_pitch': 0.04117, 'speed': 8.4213,
+        'movement_dir': 1.0, 'rotation_dir': 0.0, 'fire_seq': 7,
+        'shell_index': 0, 'next_shell_index': 0,
+        'ammo_remaining': [38, 12, 6], 'ammo_reload_pending': False,
+        'reload_time': 4.2317, 'reload_duration': 9.4,
+        'clip': 0, 'clip_size': 1,
+        'burst_active': False, 'burst_group_seq': 7, 'burst_count': 1,
+        'burst_next_index': 0, 'burst_interval': 0.0, 'burst_time_left': 0.0,
+        'burst_shell_index': 0,
+        'siege_state': 0, 'siege_time_left_ms': 0,
+        'siege_transition_total_ms': 0,
+        'health': 1115, 'alive': True,
+        'critical': {
+            'devices': [], 'destroyed': [], 'crew_ko': [],
+            'fire': False, 'ammo_rack_death': False, 'events': [],
+        },
+        'combat_base_revision': 12, 'combat_seq': 41,
+        'combat_fire_elapsed': 0.0, 'combat_fire_timer': 0.0,
+        'death_reason': 0, 'display_health': 1115, 'world_pose': True,
+        'stun_end_server_time_ms': 0,
+        'shot_yaw': -0.63482, 'shot_pitch': 0.04117,
+        'equipment_states': [_equipment_snapshot() for _ in range(3)],
+    }
+    state.update(overrides)
+    return state
+
+
+class BotStateCodecTest(unittest.TestCase):
+
+    def test_round_trip_preserves_every_contract_field(self):
+        state = _bot_state()
+        decoded = codec.decode_row(codec.encode_row(state), STATIC)
+        for name in ('id', 'fire_seq', 'shell_index', 'next_shell_index',
+                     'clip', 'clip_size', 'burst_group_seq', 'burst_count',
+                     'burst_next_index', 'burst_shell_index', 'siege_state',
+                     'siege_time_left_ms', 'siege_transition_total_ms',
+                     'health', 'display_health', 'combat_base_revision',
+                     'combat_seq', 'death_reason',
+                     'stun_end_server_time_ms'):
+            self.assertEqual(decoded[name], state[name], name)
+        for name in ('x', 'y', 'z', 'yaw', 'pitch', 'roll', 'aim_yaw',
+                     'gun_pitch', 'speed', 'reload_time', 'reload_duration',
+                     'burst_interval', 'burst_time_left',
+                     'combat_fire_elapsed', 'combat_fire_timer',
+                     'shot_yaw', 'shot_pitch'):
+            self.assertAlmostEqual(decoded[name], state[name], places=5, msg=name)
+        self.assertEqual(decoded['ammo_remaining'], [38, 12, 6])
+        self.assertIs(decoded['alive'], True)
+        self.assertIs(decoded['world_pose'], True)
+        self.assertEqual(decoded['movement_dir'], 1)
+        self.assertEqual(decoded['rotation_dir'], 0)
+
+    def test_encode_is_stable_across_a_decode_round_trip(self):
+        row = codec.encode_row(_bot_state())
+        self.assertEqual(codec.encode_row(codec.decode_row(row, STATIC)), row)
+
+    def test_fixed_point_matches_the_previous_rounded_contract(self):
+        state = _bot_state(x=1.00005, yaw=0.123455, speed=-0.00005)
+        decoded = codec.decode_row(codec.encode_row(state), STATIC)
+        for name, places in (('x', 4), ('yaw', 5), ('speed', 4)):
+            self.assertLessEqual(
+                abs(decoded[name] - state[name]), 10.0 ** -places, name)
+
+    def test_out_of_contract_values_are_clamped_not_rejected(self):
+        state = _bot_state(x=9000.0, z=-9000.0, gun_pitch=3.0, speed=500.0,
+                           pitch=-2.0)
+        decoded = codec.decode_row(codec.encode_row(state), STATIC)
+        self.assertEqual(decoded['x'], 2000.0)
+        self.assertEqual(decoded['z'], -2000.0)
+        self.assertEqual(decoded['gun_pitch'], 1.2)
+        self.assertEqual(decoded['speed'], 80.0)
+        self.assertEqual(decoded['pitch'], -0.61)
+
+    def test_shot_angles_are_an_atomic_optional_pair(self):
+        state = _bot_state()
+        del state['shot_yaw']
+        del state['shot_pitch']
+        decoded = codec.decode_row(codec.encode_row(state), STATIC)
+        self.assertNotIn('shot_yaw', decoded)
+        self.assertNotIn('shot_pitch', decoded)
+
+    def test_shot_yaw_is_wrapped_into_the_canonical_turn(self):
+        decoded = codec.decode_row(
+            codec.encode_row(_bot_state(shot_yaw=math.pi * 3.0)), STATIC)
+        self.assertAlmostEqual(decoded['shot_yaw'], -math.pi, places=4)
+
+    def test_damaged_devices_rebuild_names_states_and_maxima(self):
+        state = _bot_state(critical={
+            'devices': [
+                {'name': 'leftTrackHealth', 'hp': 0.0, 'max_hp': 160.0,
+                 'state': 'destroyed'},
+                {'name': 'engineHealth', 'hp': 88.125, 'max_hp': 160.0,
+                 'state': 'critical'},
+            ],
+            'destroyed': ['leftTrackHealth'],
+            'crew_ko': ['gunner1', 'loader2'],
+            'fire': True, 'ammo_rack_death': False, 'events': [],
+        })
+        critical = codec.decode_row(
+            codec.encode_row(state), STATIC)['critical']
+        by_name = dict((row['name'], row) for row in critical['devices'])
+        self.assertEqual(sorted(by_name), ['engineHealth', 'leftTrackHealth'])
+        self.assertEqual(by_name['engineHealth']['state'], 'critical')
+        self.assertAlmostEqual(by_name['engineHealth']['hp'], 88.125)
+        self.assertEqual(by_name['engineHealth']['max_hp'], 160.0)
+        self.assertEqual(by_name['leftTrackHealth']['state'], 'destroyed')
+        self.assertEqual(critical['destroyed'], ['leftTrackHealth'])
+        self.assertEqual(critical['crew_ko'], ['gunner1', 'loader2'])
+        self.assertIs(critical['fire'], True)
+        self.assertIs(critical['ammo_rack_death'], False)
+        self.assertEqual(critical['events'], [])
+        self.assertEqual(critical['crew_roster'], list(codec.CREW_NAMES))
+
+    def test_equipment_rejoins_the_round_contract(self):
+        state = _bot_state(equipment_states=[
+            _equipment_snapshot(uses=0, cooldown=12.5, active=True,
+                                auto=1.25, ai=None),
+            _equipment_snapshot(),
+            _equipment_snapshot(uses=2),
+        ])
+        snapshots = codec.decode_row(
+            codec.encode_row(state), STATIC)['equipment_states']
+        self.assertEqual(len(snapshots), 3)
+        self.assertEqual(snapshots[0]['equipment'], CONTRACTS[0])
+        self.assertEqual(snapshots[0]['usesLeft'], 0)
+        self.assertAlmostEqual(snapshots[0]['cooldownTimeLeft'], 12.5)
+        self.assertIs(snapshots[0]['active'], True)
+        self.assertAlmostEqual(snapshots[0]['autoPendingElapsed'], 1.25)
+        self.assertIsNone(snapshots[0]['aiPendingElapsed'])
+        self.assertEqual(snapshots[2]['usesLeft'], 2)
+
+    def test_dead_bot_row_keeps_the_same_column_contract(self):
+        state = _bot_state(alive=False, health=0, display_health=0,
+                           death_reason=1, speed=0.0)
+        decoded = codec.decode_row(codec.encode_row(state), STATIC)
+        self.assertIs(decoded['alive'], False)
+        self.assertEqual(decoded['health'], 0)
+        self.assertEqual(decoded['death_reason'], 1)
+
+    def test_truncated_and_overlong_rows_are_refused(self):
+        row = codec.encode_row(_bot_state())
+        with self.assertRaises(codec.BotStateCodecError):
+            codec.decode_row(row[:-1], STATIC)
+        with self.assertRaises(codec.BotStateCodecError):
+            codec.decode_row(list(row) + [0], STATIC)
+
+    def test_non_integer_columns_are_refused(self):
+        row = codec.encode_row(_bot_state())
+        row[2] = 125.6312
+        with self.assertRaises(codec.BotStateCodecError):
+            codec.decode_row(row, STATIC)
+
+    def test_consumable_count_must_match_the_round_manifest(self):
+        state = _bot_state(equipment_states=[_equipment_snapshot()])
+        with self.assertRaises(codec.BotStateCodecError):
+            codec.decode_row(codec.encode_row(state), STATIC)
+
+    def test_a_full_lineup_publication_stays_small(self):
+        rows = [codec.encode_row(_bot_state(id=index))
+                for index in range(1, 30)]
+        encoded = json.dumps(
+            {'type': 'bot_state', 'round_id': 1, 'rows': rows},
+            separators=(',', ':')).encode('utf-8')
+        # The JSON object form of this publication was about 67 KB, which
+        # saturated the server's worker ingress in a 15v15 round.
+        self.assertLess(len(encoded), 8 * 1024)
+
+    def test_worker_python_27_encodes_the_same_row(self):
+        """The worker runs CPython 2.7; both peers must agree bit for bit."""
+        interpreter = os.environ.get('WOT_0922_PY27') or 'python2.7'
+        # The state travels as JSON so the 2.7 child never imports this
+        # module; the shared codec is the only thing both sides load.
+        # ``gui`` and ``gui.mods`` are namespace directories supplied by the
+        # game package, so load the module file directly under 2.7.
+        program = (
+            'import imp, json, sys\n'
+            'codec = imp.load_source("bot_state_codec", %r)\n'
+            'state = json.loads(sys.stdin.read())\n'
+            'json.dump(codec.encode_row(state), sys.stdout)\n'
+        ) % (str(CODEC_PATH),)
+        states = [_bot_state(), _bot_state(x=1.00005, yaw=0.123455,
+                                          speed=-0.00005, roll=-0.000005)]
+        for state in states:
+            try:
+                child = subprocess.Popen(
+                    [interpreter, '-c', program], stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            except OSError as error:
+                raise unittest.SkipTest(
+                    'CPython 2.7 is unavailable for the worker parity '
+                    'check: %s' % (error,))
+            stdout, stderr = child.communicate(
+                json.dumps(state).encode('utf-8'))
+            self.assertEqual(child.returncode, 0, stderr.decode('utf-8'))
+            self.assertEqual(
+                json.loads(stdout.decode('utf-8')), codec.encode_row(state))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_port_0922_lan_client_queue.py
+++ b/tests/test_port_0922_lan_client_queue.py
@@ -6,6 +6,9 @@ import threading
 import time
 import unittest
 
+import bot_state_rows
+from gui.mods.offline_lan_0922 import bot_state_codec
+
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(
@@ -386,7 +389,7 @@ class LanClientQueueTests(unittest.TestCase):
             full_message, [0])
 
         self.assertTrue(client.send_bot_state(
-            states, sample_time_us=40000,
+            bot_state_rows.rows(states), sample_time_us=40000,
             source_batch_horizon_us=40000))
 
         queued = client._outbound_queue[0]
@@ -394,20 +397,27 @@ class LanClientQueueTests(unittest.TestCase):
         self.assertEqual(40000, queued_wire['sample_time_us'])
         self.assertEqual(
             40000, queued_wire['source_batch_horizon_us'])
-        queued_bots = queued_wire['bots']
+        queued_bots = bot_state_rows.bots(queued_wire)
+        # These Bots publish no burst clock and no Siege state, so the row's
+        # presence bits keep those groups off the wire entirely and the server
+        # keeps the state it already admitted for them.
         expected = {
             'id', 'x', 'y', 'z', 'yaw', 'pitch', 'roll',
             'aim_yaw', 'gun_pitch', 'speed',
             'movement_dir', 'rotation_dir', 'fire_seq', 'shell_index',
             'next_shell_index', 'ammo_remaining', 'ammo_reload_pending',
             'reload_time', 'reload_duration', 'clip', 'clip_size',
+            'world_pose', 'stun_end_server_time_ms',
             'health', 'alive', 'critical', 'combat_base_revision',
             'combat_seq', 'combat_fire_elapsed', 'combat_fire_timer',
             'death_reason', 'display_health', 'shot_yaw', 'shot_pitch',
         }
         self.assertEqual(29, len(queued_bots))
-        self.assertTrue(all(set(state) == expected for state in queued_bots))
-        self.assertLess(queued[2], full_size)
+        for state in queued_bots:
+            self.assertEqual(expected, set(state))
+        # The positional row carries the same contract in a fraction of the
+        # bytes the mapping form needed.
+        self.assertLess(queued[2], full_size // 8)
         self.assertIn('profile', states[0])
         self.assertIn('shot_origin', states[0])
         self.assertIn('shot_proof_key', states[0])
@@ -415,39 +425,36 @@ class LanClientQueueTests(unittest.TestCase):
         self.assertNotIn('shot_origin', queued_bots[0])
         self.assertNotIn('shot_proof_key', queued_bots[0])
 
-    def test_bot_state_projection_rejects_half_shot_pair(self):
-        client = self.activate(worker=True)
-        client.ready = True
-        client.phase = 'battle'
-        client.round_id = 7
-        client.bot_authority_id = lan_client_module.WORKER_AUTHORITY_ID
+    def test_bot_state_encoder_rejects_a_half_shot_pair(self):
+        """A shot angle pair is atomic; a row cannot carry half of it."""
+        with self.assertRaises(bot_state_codec.BotStateCodecError):
+            bot_state_rows.rows([{
+                'id': 1, 'x': 0.0, 'y': 0.0, 'z': 0.0, 'yaw': 0.0,
+                'health': 100, 'alive': True, 'fire_seq': 1,
+                'shot_yaw': 0.2,
+            }])
 
-        self.assertFalse(client.send_bot_state([{
-            'id': 1, 'x': 0.0, 'y': 0.0, 'z': 0.0, 'yaw': 0.0,
-            'health': 100, 'alive': True, 'fire_seq': 1,
-            'shot_yaw': 0.2,
-        }]))
-        self.assertEqual([], client._outbound_queue)
+    def test_bot_state_row_carries_a_bare_reload_state_as_flag_and_clock(self):
+        """Reload state is a flag bit and two fixed-point clocks on the wire.
 
-    def test_bot_state_projection_requires_boolean_atomic_reload_state(self):
-        client = self.activate(worker=True)
-        client.ready = True
-        client.phase = 'battle'
-        client.round_id = 7
-        client.bot_authority_id = lan_client_module.WORKER_AUTHORITY_ID
+        The mapping form needed an atomic-boolean check because a caller could
+        publish any type or omit the field; a positional row can express only
+        the contract, so the previous rejection has nothing left to reject.
+        """
         state = {
             'id': 1, 'x': 0.0, 'y': 0.0, 'z': 0.0, 'yaw': 0.0,
             'health': 100, 'alive': True, 'fire_seq': 1,
             'shell_index': 0, 'next_shell_index': 1,
-            'ammo_remaining': [2, 1],
+            'ammo_remaining': [2, 1], 'ammo_reload_pending': 1,
+            'reload_time': 1.5, 'reload_duration': 4.0,
         }
+        decoded = bot_state_rows.decoded(bot_state_rows.rows([state]), 0)
+        self.assertIs(True, decoded['ammo_reload_pending'])
+        self.assertAlmostEqual(1.5, decoded['reload_time'], places=6)
+        self.assertAlmostEqual(4.0, decoded['reload_duration'], places=6)
+        self.assertEqual([2, 1], decoded['ammo_remaining'])
 
-        self.assertFalse(client.send_bot_state([state]))
-        state['ammo_reload_pending'] = 1
-        self.assertFalse(client.send_bot_state([state]))
-        self.assertEqual([], client._outbound_queue)
-
-    def test_bot_state_projection_rejects_partial_clip_checkpoint(self):
+    def test_bot_state_encoder_rejects_a_partial_clip_checkpoint(self):
         state = {
             'id': 1, 'x': 0.0, 'y': 0.0, 'z': 0.0, 'yaw': 0.0,
             'health': 100, 'alive': True, 'fire_seq': 1,
@@ -455,7 +462,8 @@ class LanClientQueueTests(unittest.TestCase):
             'clip': 1,
         }
 
-        self.assertIsNone(lan_client_module.project_bot_state(state))
+        with self.assertRaises(bot_state_codec.BotStateCodecError):
+            bot_state_rows.rows([state])
 
     def test_sender_owns_json_encoding_and_socket_write(self):
         client = self.activate()

--- a/tests/test_port_0922_lan_protocol.py
+++ b/tests/test_port_0922_lan_protocol.py
@@ -5,6 +5,8 @@ import re
 import sys
 from pathlib import Path
 import unittest
+
+import bot_state_rows
 from unittest import mock
 
 
@@ -18,7 +20,7 @@ from gui.mods.offline_lan_0922.lan_client import (
     _canonical_runtime_vehicle_row,
     _project_human_ram_armors, _projectile_wire_round,
     _strict_projectile_effect,
-    _valid_player_environment_contract, project_bot_state)
+    _valid_player_environment_contract)
 from gui.mods.offline_lan_0922.authority_worker import (
     AuthorityWorkerLANClient)
 from gui.mods.offline_lan_0922.snapshot_sync import SnapshotSync
@@ -102,8 +104,8 @@ class LanProtocolTests(unittest.TestCase):
         self.assertTrue(self.client.leave_battle())
         worker = self._worker_client()
         self.assertTrue(worker.send_bot_manifest([{'id': 1}] * 40))
-        self.assertTrue(worker.send_bot_state([{
-            'id': 1, 'reload_time': 0.5, 'reload_duration': 0.5}]))
+        self.assertTrue(worker.send_bot_state(bot_state_rows.rows([{
+            'id': 1, 'reload_time': 0.5, 'reload_duration': 0.5}])))
         self.assertTrue(worker.send_bot_observation([{}] * 70, [{}] * 20))
         self.assertTrue(worker.send_bot_ram(
             1, 'human', 2, 4, 620, 880))
@@ -118,7 +120,7 @@ class LanProtocolTests(unittest.TestCase):
             'fall_yaw': 0.5, 'speed': 12.0, 'is_shot': False}))
         self.assertTrue(worker.send_battle_result(1, 'elimination'))
         self.assertEqual('leave_battle', self.sent[0]['type'])
-        self.assertEqual(30, len(self.sent[1]['bots']))
+        self.assertEqual(30, len(bot_state_rows.bots(self.sent[1])))
         self.assertEqual(64, len(self.sent[3]['contacts']))
         self.assertEqual('bot_ram_report', self.sent[4]['type'])
         self.assertEqual(620, self.sent[4]['damage_to_bot'])
@@ -148,7 +150,7 @@ class LanProtocolTests(unittest.TestCase):
         self.assertIsNone(_project_human_ram_armors([
             dict(result, first_id=2, second_id=1)]))
         self.assertTrue(worker.send_projected_bot_state(
-            [], sample_time_us=40000,
+            bot_state_rows.rows([]), sample_time_us=40000,
             source_batch_horizon_us=40000,
             edge_sample_time_us=40000, edge_revision=1,
             human_ram_armors=[result]))
@@ -388,10 +390,10 @@ class LanProtocolTests(unittest.TestCase):
             'vehicle': 'ussr:R11_MS-1', 'max_health': 500,
         }
 
-        projected = project_bot_state(source)
+        projected = bot_state_rows.decoded(bot_state_rows.rows([source]), 0)
         self.assertEqual(6.25, projected['speed'])
         sanitized = BattleState._sanitize_bot_state(
-            projected, identity, None)
+            projected, identity, None, trusted=True)
         self.assertEqual(6.25, sanitized['speed'])
 
         events = SnapshotSync(
@@ -636,7 +638,7 @@ class LanProtocolTests(unittest.TestCase):
     def test_only_authority_can_send_bot_or_rule_messages(self):
         self.client.bot_authority_id = 2
         self.assertFalse(self.client.send_bot_manifest([{'id': 1}]))
-        self.assertFalse(self.client.send_bot_state([{'id': 1}]))
+        self.assertFalse(self.client.send_bot_state(bot_state_rows.rows([{'id': 1}])))
         self.assertFalse(self.client.send_bot_observation([{}]))
         self.assertFalse(self.client.send_bot_ram(
             1, 'human', 2, 1, 20, 80))

--- a/tests/test_port_0922_postbattle.py
+++ b/tests/test_port_0922_postbattle.py
@@ -5,6 +5,8 @@ import sys
 import tempfile
 from pathlib import Path
 import unittest
+
+import bot_state_rows
 from unittest import mock
 import zlib
 
@@ -612,7 +614,7 @@ class PostBattleContractTests(unittest.TestCase):
             [(value['avatarDamageDealt'], value['avatarKills'])
              for value in avatar_calls])
         self.assertEqual(3, vehicle_calls[0]['killerID'])
-        self.assertEqual((60002, b'Atlas-17'), common['bots'][3])
+        self.assertEqual((60002, b'Atlas-17'), bot_state_rows.bots(common)[3])
 
     def test_server_receipt_survives_graceful_early_leave_and_is_idempotent(self):
         state = BattleState(map_name='01_karelia')

--- a/tests/test_port_0922_server_capture.py
+++ b/tests/test_port_0922_server_capture.py
@@ -3,6 +3,8 @@ import json
 import sys
 import unittest
 
+import bot_state_rows
+
 
 PORT_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(PORT_ROOT / 'server'))
@@ -184,9 +186,9 @@ class ServerCaptureTests(unittest.TestCase):
             'combat_fire_elapsed': 0.0, 'combat_fire_timer': 0.0,
             'stun_end_server_time_ms': 0,
         }
-        self.assertTrue(state.update_bot_states(1, {
+        self.assertTrue(state.update_bot_states(1, bot_state_rows.publication({
             'round_id': state.round_id, 'bots': [publication],
-        }))
+        })))
         self.assertTrue(state.bot_states[16]['world_pose'])
         self.assertTrue(self._capture_tick(state))
         self.assertEqual(1, state.rules_state['bases']['1']['points'])

--- a/tests/test_port_0922_server_combat_lineage.py
+++ b/tests/test_port_0922_server_combat_lineage.py
@@ -5,6 +5,8 @@ import sys
 import types
 import unittest
 
+import bot_state_rows
+
 
 PORT_ROOT = Path(__file__).resolve().parents[1]
 PACKAGE_ROOT = (PORT_ROOT / 'src' / 'res' / 'scripts' / 'client' /
@@ -209,7 +211,7 @@ class ServerCombatLineageIntegrationTests(unittest.TestCase):
         server.bot_authority_id = 1
         server.bot_roster = list(roster)
         self.assertTrue(server.update_bot_manifest(1, {
-            'round_id': server.round_id, 'bots': manifest['bots']}))
+            'round_id': server.round_id, 'bots': bot_state_rows.bots(manifest)}))
         return runtime, server, roster
 
     def test_same_source_batch_horizon_preserves_slow_callback_burst_edges(
@@ -252,20 +254,20 @@ class ServerCombatLineageIntegrationTests(unittest.TestCase):
         # One slow worker callback can expose its first physical edge before
         # the callback's final source horizon. The later publication belongs
         # to the same callback even though almost no server wall time elapsed.
-        self.assertTrue(server.update_bot_states(1, {
+        self.assertTrue(server.update_bot_states(1, bot_state_rows.publication({
             'round_id': server.round_id,
             'bots': publication(1, 44, 2, True, 1, 0.1),
             'sample_time_us': 200000,
             'source_batch_horizon_us': 1000000,
-        }), server.last_bot_state_reject)
+        })), server.last_bot_state_reject)
         first_mapped_time_us = server.bot_state_time_us
 
-        self.assertTrue(server.update_bot_states(1, {
+        self.assertTrue(server.update_bot_states(1, bot_state_rows.publication({
             'round_id': server.round_id,
             'bots': publication(3, 42, 0, False, 3, 0.0),
             'sample_time_us': 1000000,
             'source_batch_horizon_us': 1000000,
-        }), server.last_bot_state_reject)
+        })), server.last_bot_state_reject)
 
         launches = sorted(server.bot_pending_projectile_launches)
         metadata = server.bot_pending_projectile_metadata
@@ -294,11 +296,11 @@ class ServerCombatLineageIntegrationTests(unittest.TestCase):
         human = _human()
         first = runtime.update(
             1.0 / 24.0, 1.0, players=[human])[0]
-        self.assertTrue(server.update_bot_states(1, {
-            'round_id': server.round_id, 'bots': first['bots'],
+        self.assertTrue(server.update_bot_states(1, bot_state_rows.publication({
+            'round_id': server.round_id, 'bots': bot_state_rows.bots(first),
             'sample_time_us': first['sample_time_us'],
             'source_batch_horizon_us':
-                first['source_batch_horizon_us']}))
+                first['source_batch_horizon_us']})))
 
         critical = {
             'devices': [{
@@ -323,27 +325,27 @@ class ServerCombatLineageIntegrationTests(unittest.TestCase):
         })
         repeated = runtime.update(
             1.0 / 24.0, 1.1, players=[human])[0]
-        wire = next(bot for bot in repeated['bots'] if bot['id'] == 11)
+        wire = next(bot for bot in bot_state_rows.bots(repeated) if bot['id'] == 11)
         self.assertEqual(['driver', 'gunner1'],
                          wire['critical']['crew_roster'])
         self.assertEqual(0, wire['combat_seq'])
-        self.assertTrue(server.update_bot_states(1, {
-            'round_id': server.round_id, 'bots': repeated['bots'],
+        self.assertTrue(server.update_bot_states(1, bot_state_rows.publication({
+            'round_id': server.round_id, 'bots': bot_state_rows.bots(repeated),
             'sample_time_us': repeated['sample_time_us'],
             'source_batch_horizon_us':
                 repeated['source_batch_horizon_us'],
-        }), server.last_bot_state_reject)
+        })), server.last_bot_state_reject)
         for frame in range(1, 25):
             publication = runtime.update(
                 1.0 / 24.0, 1.1 + frame / 24.0,
                 players=[human])[0]
-            self.assertTrue(server.update_bot_states(1, {
+            self.assertTrue(server.update_bot_states(1, bot_state_rows.publication({
                 'round_id': server.round_id,
-                'bots': publication['bots'],
+                'bots': bot_state_rows.bots(publication),
                 'sample_time_us': publication['sample_time_us'],
                 'source_batch_horizon_us':
                     publication['source_batch_horizon_us'],
-            }), server.last_bot_state_reject)
+            })), server.last_bot_state_reject)
             if server.bot_pending_projectile_launches:
                 break
         self.assertTrue(any(

--- a/tests/test_port_0922_server_projectiles.py
+++ b/tests/test_port_0922_server_projectiles.py
@@ -5,6 +5,8 @@ import sys
 import threading
 import types
 import unittest
+
+import bot_state_rows
 from unittest import mock
 
 
@@ -2427,7 +2429,7 @@ class ServerProjectileLedgerTests(unittest.TestCase):
         handler = object.__new__(ClientHandler)
 
         self.assertFalse(handler._dispatch_simulation_worker_message(
-            types.SimpleNamespace(state=state), worker, launch))
+            types.SimpleNamespace(state=state), worker, bot_state_rows.publication(launch)))
 
         terminal = {
             'type': 'fire_intent_result', 'round_id': state.round_id,
@@ -2454,7 +2456,7 @@ class ServerProjectileLedgerTests(unittest.TestCase):
         malformed['direct']['damage'] = 1
 
         self.assertFalse(handler._dispatch_simulation_worker_message(
-            types.SimpleNamespace(state=state), worker, malformed))
+            types.SimpleNamespace(state=state), worker, bot_state_rows.publication(malformed)))
         self.assertIs(state.simulation_worker, worker)
         self.assertTrue(worker.connected)
         self.assertEqual(0, record['ricochet_count'])
@@ -2471,7 +2473,7 @@ class ServerProjectileLedgerTests(unittest.TestCase):
             '1:p:1:1', direct=_effect(target_id=1))
 
         self.assertFalse(handler._dispatch_simulation_worker_message(
-            types.SimpleNamespace(state=state), worker, malformed))
+            types.SimpleNamespace(state=state), worker, bot_state_rows.publication(malformed)))
 
         self.assertIs(state.simulation_worker, worker)
         self.assertTrue(worker.connected)
@@ -2640,16 +2642,16 @@ class ServerProjectileLedgerTests(unittest.TestCase):
         }
         first = dict(publication, fire_seq=0)
         self.assertTrue(state.update_bot_states(
-            SIMULATION_WORKER_AUTHORITY_ID, {
+            SIMULATION_WORKER_AUTHORITY_ID, bot_state_rows.publication({
             'round_id': 1, 'sample_time_us': 100000,
             'source_batch_horizon_us': 200000,
-            'bots': [first]}),
+            'bots': [first]})),
             state.last_bot_state_reject)
         self.assertTrue(state.update_bot_states(
-            SIMULATION_WORKER_AUTHORITY_ID, {
+            SIMULATION_WORKER_AUTHORITY_ID, bot_state_rows.publication({
             'round_id': 1, 'sample_time_us': 200000,
             'source_batch_horizon_us': 200000,
-            'bots': [publication]}),
+            'bots': [publication]})),
             state.last_bot_state_reject)
         self.assertEqual(
             state._server_time_ms() * 1000 - 200000,
@@ -2680,10 +2682,10 @@ class ServerProjectileLedgerTests(unittest.TestCase):
 
         next_publication = dict(publication, fire_seq=2)
         self.assertTrue(state.update_bot_states(
-            SIMULATION_WORKER_AUTHORITY_ID, {
+            SIMULATION_WORKER_AUTHORITY_ID, bot_state_rows.publication({
             'round_id': 1, 'sample_time_us': 300000,
             'source_batch_horizon_us': 300000,
-            'bots': [next_publication]}),
+            'bots': [next_publication]})),
             state.last_bot_state_reject)
         future = _launch(
             shooter_id=16, shooter_kind='bot', shot_seq=2,

--- a/tests/test_port_0922_server_team_size.py
+++ b/tests/test_port_0922_server_team_size.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 import sys
 import unittest
+
+import bot_state_rows
 from unittest import mock
 
 
@@ -253,7 +255,7 @@ class ServerTeamSizeTests(unittest.TestCase):
         occupied = {(player.team, player.slot) for player in players}
         self.assertFalse(occupied & {
             (bot['team'], bot['slot']) for bot in state.bot_roster})
-        self.assertEqual(8 - len(players), len(start['bots']))
+        self.assertEqual(8 - len(players), len(bot_state_rows.bots(start)))
 
     def test_worker_drowning_proposal_is_committed_without_descriptors(self):
         state = BattleState(team_size=1)
@@ -449,7 +451,7 @@ class ServerTeamSizeTests(unittest.TestCase):
         self.assertIsNone(error)
         self.assertEqual(1, random_player.team)
         self.assertEqual(1, random_player.slot)
-        self.assertEqual(1, len(first_start['bots']))
+        self.assertEqual(1, len(bot_state_rows.bots(first_start)))
 
         state._reset_round()
         self.assertEqual((0, -1), (
@@ -467,7 +469,7 @@ class ServerTeamSizeTests(unittest.TestCase):
         human_slots = {
             (player.team, player.slot) for player in state.players.values()}
         bot_slots = {
-            (bot['team'], bot['slot']) for bot in second_start['bots']}
+            (bot['team'], bot['slot']) for bot in bot_state_rows.bots(second_start)}
         self.assertFalse(human_slots & bot_slots)
         self.assertEqual(1, len(bot_slots))
 
@@ -492,7 +494,7 @@ class ServerTeamSizeTests(unittest.TestCase):
         start, error = state.request_start(host.player_id)
         self.assertIsNone(error)
         self.assertEqual({'1': 2, '2': 5}, start['team_sizes'])
-        self.assertEqual(7 - 1, len(start['bots']))
+        self.assertEqual(7 - 1, len(bot_state_rows.bots(start)))
 
     def test_non_host_cannot_resize_a_team(self):
         state = BattleState(team_size=3)

--- a/tests/test_port_0922_simulation_worker.py
+++ b/tests/test_port_0922_simulation_worker.py
@@ -6,6 +6,8 @@ import sys
 import threading
 import time
 import unittest
+
+import bot_state_rows
 from unittest import mock
 
 
@@ -683,7 +685,7 @@ class SimulationWorkerStateTests(unittest.TestCase):
         self.assertIsNone(error)
         start, error = state.request_start(player.player_id)
         self.assertIsNone(error)
-        manifest = _manifest(start['bots'])
+        manifest = _manifest(bot_state_rows.bots(start))
         self.assertTrue(state.update_bot_manifest(
             SIMULATION_WORKER_AUTHORITY_ID,
             {'round_id': state.round_id, 'bots': manifest,
@@ -715,7 +717,7 @@ class SimulationWorkerStateTests(unittest.TestCase):
         self.assertIsNone(error)
         start, error = state.request_start(player.player_id)
         self.assertIsNone(error)
-        manifest = _manifest(start['bots'])
+        manifest = _manifest(bot_state_rows.bots(start))
         self.assertTrue(state.update_bot_manifest(
             SIMULATION_WORKER_AUTHORITY_ID,
             {'round_id': state.round_id, 'bots': manifest,
@@ -779,7 +781,7 @@ class SimulationWorkerStateTests(unittest.TestCase):
         self.assertIsNone(error)
         start, error = state.request_start(player.player_id)
         self.assertIsNone(error)
-        manifest = _manifest(start['bots'])
+        manifest = _manifest(bot_state_rows.bots(start))
         self.assertTrue(state.update_bot_manifest(
             SIMULATION_WORKER_AUTHORITY_ID,
             {'round_id': state.round_id, 'bots': manifest,
@@ -834,7 +836,7 @@ class SimulationWorkerStateTests(unittest.TestCase):
         self.assertIsNone(error)
         start, error = state.request_start(player.player_id)
         self.assertIsNone(error)
-        manifest = _manifest(start['bots'])
+        manifest = _manifest(bot_state_rows.bots(start))
         self.assertTrue(state.update_bot_manifest(
             SIMULATION_WORKER_AUTHORITY_ID,
             {'round_id': state.round_id, 'bots': manifest,
@@ -906,7 +908,7 @@ class SimulationWorkerStateTests(unittest.TestCase):
         self.assertIsNone(error)
         start, error = state.request_start(player.player_id)
         self.assertIsNone(error)
-        manifest = _manifest(start['bots'])
+        manifest = _manifest(bot_state_rows.bots(start))
         self.assertTrue(state.update_bot_manifest(
             SIMULATION_WORKER_AUTHORITY_ID,
             {'round_id': state.round_id, 'bots': manifest,
@@ -945,7 +947,7 @@ class SimulationWorkerStateTests(unittest.TestCase):
         self.assertIsNone(error)
         start, error = state.request_start(first.player_id)
         self.assertIsNone(error)
-        manifest = _manifest(start['bots'])
+        manifest = _manifest(bot_state_rows.bots(start))
         self.assertTrue(state.update_bot_manifest(
             SIMULATION_WORKER_AUTHORITY_ID,
             {'round_id': state.round_id, 'bots': manifest,
@@ -1050,7 +1052,7 @@ class SimulationWorkerSocketTests(unittest.TestCase):
             'type': 'start_battle', 'round_id': self.state.round_id})
         player.receive_until('battle_start')
         worker_start = worker.receive_until('battle_start')
-        manifest = _manifest(worker_start['bots'])
+        manifest = _manifest(bot_state_rows.bots(worker_start))
         worker.send({
             'type': 'bot_manifest', 'round_id': self.state.round_id,
             'bots': manifest,
@@ -1210,7 +1212,7 @@ class SimulationWorkerSocketTests(unittest.TestCase):
         self.assertNotIn(SIMULATION_WORKER_AUTHORITY_ID,
                          self.state.round_participants)
 
-        manifest = _manifest(worker_start['bots'])
+        manifest = _manifest(bot_state_rows.bots(worker_start))
         worker.send({
             'type': 'bot_manifest', 'round_id': self.state.round_id,
             'bots': manifest,
@@ -1230,7 +1232,7 @@ class SimulationWorkerSocketTests(unittest.TestCase):
         publication = _bot_publication(manifest, x_offset=1.0)
         player.send({
             'type': 'bot_state', 'round_id': self.state.round_id,
-            'bots': publication})
+            'rows': bot_state_rows.rows(publication)})
         player.send({'type': 'ping', 'seq': 2})
         player.receive_until('pong')
         # Modern visible commands are rejected by the dispatcher before
@@ -1240,7 +1242,7 @@ class SimulationWorkerSocketTests(unittest.TestCase):
 
         worker.send({
             'type': 'bot_state', 'round_id': self.state.round_id,
-            'bots': publication})
+            'rows': bot_state_rows.rows(publication)})
         worker.send({'type': 'ping', 'seq': 3})
         worker.receive_until('pong')
         self.assertEqual(revision + 1, self.state.bot_state_revision)
@@ -1287,7 +1289,7 @@ class SimulationWorkerSocketTests(unittest.TestCase):
         rejected_publication = _bot_publication(manifest, x_offset=2.0)
         player.send({
             'type': 'bot_state', 'round_id': self.state.round_id,
-            'bots': rejected_publication})
+            'rows': bot_state_rows.rows(rejected_publication)})
         player.send({'type': 'ping', 'seq': 5})
         player.receive_until('pong')
         self.assertNotEqual(2.0 + manifest[0]['x'],
@@ -1305,7 +1307,7 @@ class SimulationWorkerSocketTests(unittest.TestCase):
             'type': 'start_battle', 'round_id': self.state.round_id})
         player.receive_until('battle_start')
         worker_start = worker.receive_until('battle_start')
-        manifest = _manifest(worker_start['bots'])
+        manifest = _manifest(bot_state_rows.bots(worker_start))
         worker.send({
             'type': 'bot_manifest', 'round_id': self.state.round_id,
             'bots': manifest,
@@ -1349,7 +1351,7 @@ class SimulationWorkerSocketTests(unittest.TestCase):
         publication = _bot_publication(manifest)
         worker.send({
             'type': 'bot_state', 'round_id': self.state.round_id,
-            'bots': publication,
+            'rows': bot_state_rows.rows(publication),
         })
         worker.send({'type': 'ping', 'seq': 1})
         worker.receive_until('pong')
@@ -1359,18 +1361,21 @@ class SimulationWorkerSocketTests(unittest.TestCase):
         rejected[0]['combat_seq'] = 2
         worker.send({
             'type': 'bot_state', 'round_id': self.state.round_id,
-            'bots': rejected,
+            'rows': bot_state_rows.rows(rejected),
         })
         worker.send({'type': 'ping', 'seq': 2})
         self.assertEqual(2, worker.receive_until('pong')['seq'])
 
+        # The publication lands: one Bot's combat contract is contained to
+        # that Bot rather than costing the batch, the worker or the round.
         self.assertIsNotNone(self.state.simulation_worker)
         self.assertIsNone(self.state.battle_result)
-        self.assertEqual(1, self.state.bot_state_revision)
-        self.assertEqual('combat_contract',
-                         self.state.last_bot_state_reject_code)
-        self.assertNotEqual(99.0 + manifest[0]['x'],
-                            self.state.bot_states[manifest[0]['id']]['x'])
+        self.assertEqual(2, self.state.bot_state_revision)
+        self.assertEqual('', self.state.last_bot_state_reject_code)
+        self.assertEqual(99.0 + manifest[0]['x'],
+                         self.state.bot_states[manifest[0]['id']]['x'])
+        self.assertEqual(
+            0, self.state.bot_states[manifest[0]['id']]['combat_ack_seq'])
 
     def test_silent_open_worker_timeout_terminates_round(self):
         with mock.patch.object(
@@ -1487,7 +1492,7 @@ class SimulationWorkerSocketTests(unittest.TestCase):
 
             worker.send({
                 'type': 'bot_state', 'round_id': self.state.round_id,
-                'bots': _bot_publication(manifest),
+                'rows': bot_state_rows.rows(_bot_publication(manifest)),
             })
             worker.send({'type': 'ping', 'seq': 0})
             self.assertEqual(0, worker.receive_until('pong')['seq'])


### PR DESCRIPTION
## Why

A 15v15 report (`~/slow-report.zip`, v0.6.10) had the player's own shots appear
four to five seconds after the trigger. The delay is entirely between the
worker's `FIRE LAUNCH` and the `FIRE COMMIT` that comes back to it
(`launch_to_commit_ms` 341 ms rising to 4634 ms across round 1), while the
opposite leg -- the visible client's trigger reaching the worker -- stayed at
87-350 ms in the same round. Both legs cross the same loopback and the same
server, so the slow one is the worker's own upstream. Rounds 2 and 3 of the same
session carried 11 and 13 Bots and stayed at 86-373 ms.

The periodic Bot publication saturated that upstream. Each Bot rode as a JSON
object of about 2.4 KB, of which about 1.4 KB was the immutable consumable
contract that cannot change inside a round. A 29-Bot publication was 67 KB and
the worker sends one per control step (7.3-8.6 Hz in that round), so it offered
about 580 KB/s. The server then re-derived finiteness, range and rounding for
every field of every Bot on every publication, revalidated three 16-field
contracts per Bot, and round-tripped the consumable ledger through
restore/snapshot -- all while holding the state lock the 30 Hz tick thread and
the player handler also need. A `projectile_launch` queues behind that on the
same TCP stream.

## What changed

**One positional row of integers per Bot.** A new module,
`src/res/scripts/client/gui/mods/offline_lan_0922/bot_state_codec.py`, is
imported by both the CPython 2.7 mod and the Python 3 server, so the layout has
exactly one owner. Every real value is a fixed-point integer at the decimal
place the previous contract rounded to, so the encoded value *is* the rounded,
clamped value: a row cannot express a non-finite number, an out-of-contract
value or a missing field, and the decoder no longer tests for any of them. The
encoder rounds half away from zero explicitly rather than relying on either
interpreter's `round()`, and a test runs the real 2.7 interpreter and asserts
both produce identical rows.

Per-vehicle constants (`equipment_contracts`) are validated once in
`update_bot_manifest` and rejoined by reference in `decode_row`, so they leave
the per-tick wire. `_sanitize_bot_state(..., trusted=True)` keeps only the one
invariant the wire cannot express: a Bot never gains a consumable use.

Groups the old mapping could omit entirely -- ammunition, burst, magazine,
Siege, shot angles -- keep that meaning through presence bits, so a Bot with no
burst clock still has its shots admitted.

**Containment.** One Bot's contract no longer costs the publication, and it no
longer freezes that Bot either. Rejecting the batch left the Bot's stored state
behind its own next publication, which then repeats the same failure, so the Bot
-- and every other Bot in the room, on every tick -- stayed frozen for the rest
of the round. Three shapes now:

- inventory or burst step the server cannot derive: the published state becomes
  the new trusted baseline and no projectile edge is derived for the gap, the
  same rule `rebase_fire_gap` already applies to a coalesced publication;
- combat lineage the server cannot follow: the combat ledger is fenced to the
  server's state exactly like a lost ordering race, **and** a new canonical
  revision is opened so the authority rebases onto it (`bot_runtime`'s new-base
  path resets `next_seq` to the server's ack, which closes the sequence gap
  instead of leaving the authority proposing past an ack that never advances);
- the state's own contract fails: pose, health and the presented hull advance,
  the ledgers hold, nothing is launched.

Every one is rate-limited to one log line per Bot.

**Separate defect (`079008a`).** The same round ended as a system-error draw
with `winner=0 reason=worker_disconnected`. The worker had not crashed:
`destructibles_sensor._fell_trees_near` raised `tree proximity event was not
admitted` out of `BattleRuntime._frame` because one destructible publication was
refused by the LAN client's outbound boundary, in the last eight seconds of the
round when the upstream was already seconds behind. Transport backpressure on
one event is local and recoverable and must not end the round for everyone. The
two publish sites now behave like every other publisher in that module: the
native item stays felled, its frozen payload stays pending, and a later scan
republishes it.

## Measured

Locally on this box with the real encoder, 29 Bots:

| | before | after | |
|---|---|---|---|
| all healthy | 67.4 KB (580 KB/s) | 5.9 KB (50 KB/s) | 11.5x |
| all damaged | 87.7 KB (754 KB/s) | 10.2 KB (88 KB/s) | 8.6x |

Head-of-line delay a fire launch can inherit behind one publication, at a
pessimistic 5 MB/s: 13.8 ms to 1.2 ms. A separate TCP lane for fire messages is
therefore not needed.

Positional JSON was chosen over base64-`struct`: it measured smaller and needs
no framing change.

## Validation

- `python3 -m unittest discover -s tests -p "test_*.py"` -- `Ran 4157 tests`, `OK`.
- CPython 2.7 source compile passed on all 97 client files.
- A 2.7-vs-3.x row parity test runs the real 2.7 interpreter.
- A server-to-worker round trip test drives a real `BattleState` and a real
  `BotRuntime`: the server fences a publication it cannot place, the authority
  rebases onto the new base, and its next real combat change is proposed at
  ack+1 and acknowledged.

## Not done here

- The server-to-client/worker `snapshot` still ships `bot_states` verbatim,
  contracts included (`decode_row` rejoins them by reference), and
  `copy.deepcopy(snapshot)` still runs per tick under `state.lock`. The worker
  receives a full snapshot every tick (`replica_limited` is False for it).
  Different message, different consumers, and no reported symptom.
- Known residual with the same fail-forever shape, one branch over: the third
  containment above still holds the ledgers, so any `_sanitize_bot_state(...,
  trusted=True)` raiser that compares against the stored state repeats on every
  later publication and holds that Bot's `fire_seq` for the round. Reachable
  ones are `bot equipment inventory increased`, `bot equipment snapshot is
  invalid`, `bot clip size changed mid-round`, `bot planned ammunition is
  exhausted`, and the two stun raisers. Every legal race is already exempt (a
  stale combat base is explicitly allowed, and the codec's atomic groups make
  the shape raisers unreachable), so this needs a worker bug to reach -- and it
  previously ended the round for everyone instead.

## Unproved

Whether the backlog sat in kernel socket buffers or in a lock/GIL-starved server
reader thread was never distinguished; the evidence only shows the worker's
upstream progressing slowly (`SEND_STALL_TIMEOUT` never fired). Whether 50 KB/s
clears the knee on the ARM64 VM emulating x86 can only be answered by a 15v15
round on the Windows client with `launch_to_commit_ms` in the log.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
