### PR TITLE
Give #1513 vehicle hit effects their stock sound identity

### DIFF
--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -12039,11 +12039,18 @@ class BattleRuntime(object):
         self._report_effect(
             'wreck_hit', 'armorHit', effects_index, impact, direction)
         try:
+            # Same #1513 impact trio as a hit on a live vehicle: without the
+            # shooter and target identities the group can only play its
+            # other-tanks mix.
             add_effect(
                 hit_position, effects, stages, None, dir=direction,
                 start=hit_position - direction.scale(0.4),
                 end=hit_position + direction.scale(0.4),
-                showShockWave=False, showFlashBang=False)
+                showShockWave=False, showFlashBang=False,
+                isPlayerVehicle=bool(target_record.get('local')),
+                entity_id=int(target_record.get('engine_id') or 0),
+                attackerID=self._projectile_attacker_engine_id(meta),
+                damageFactor=0.0, hitdir=direction)
         except Exception as error:
             self._warn_optional_failure(
                 'projectile impact presentation', error)
@@ -13509,6 +13516,17 @@ class BattleRuntime(object):
             return None
         meta['source_descriptor'] = descriptor
         return descriptor
+
+    def _projectile_attacker_engine_id(self, meta):
+        """Return the engine id #1513 hit sounds compare against the player."""
+        record = self._records.get(
+            '%s:%s' % (meta.get('shooter_kind'), meta.get('shooter_id')))
+        if record is None:
+            return 0
+        try:
+            return int(record.get('engine_id') or 0)
+        except (TypeError, ValueError, OverflowError):
+            return 0
 
     def _projectile_source_entity(self, meta):
         key = '%s:%s' % (meta.get('shooter_kind'), meta.get('shooter_id'))

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -9540,6 +9540,81 @@ class BattleRuntime(object):
                 impulse, bool(presented)))
         return True
 
+    def _hit_damage_factor(self, event, target_record):
+        """Return retail's ``damageFactor``: hull damage as a health percent.
+
+        Exact #1513 hands this straight to ``SWITCH_ext_damage_size``:
+        ``_SoundEffectDesc.create`` compares it against 43.35 and 89.25, and
+        ``Vehicle.onStaticCollision`` scales its own 0..1 hull damage by 100
+        before passing it to the same descriptor, so the unit is a percentage
+        of the target's maximum health.
+        """
+        damage = max(0, int(event.get('damage', 0) or 0))
+        if damage <= 0:
+            return 0.0
+        state = target_record.get('state') or {}
+        maximum = _number(state.get('max_health'), 0.0)
+        if maximum <= 0.0:
+            target = self._server_entity(target_record.get('engine_id'))
+            maximum = _number(_field(
+                getattr(target, 'typeDescriptor', None), 'maxHealth', 0.0))
+        if maximum <= 0.0:
+            return 0.0
+        return max(0.0, min(100.0, 100.0 * damage / maximum))
+
+    def _present_splash_hit(self, target_record, effects_descr, effects_index,
+                            impact_position, direction, damage_factor):
+        """Present one HE near miss the way ``showSplashHitEffect`` does.
+
+        ``Vehicle.showDamageFromExplosion`` binds ``armorSplashHit`` to the
+        target's own hull node through ``ModelBoundEffects.addNewToNode`` and
+        passes the entity itself.  The only #1513 effect in that group is a
+        ``splashSound``, and ``_NodeSoundEffectDesc.create`` returns without
+        playing anything unless ``entity`` is a live, started vehicle, so the
+        static-scene owner used for direct hits presents nothing at all here.
+        """
+        try:
+            effects_list = effects_descr['armorSplashHit']
+        except (KeyError, TypeError):
+            return False
+        if not effects_list:
+            return False
+        try:
+            stages, effects, unused = effects_list
+        except (TypeError, ValueError):
+            return False
+        target = self._server_entity(target_record.get('engine_id'))
+        if (target is None or not getattr(target, 'isStarted', False) or
+                not self._record_alive(target_record, target)):
+            return False
+        if not self._optional_feature_enabled(
+                'projectile impact presentation'):
+            return False
+        hull_name = getattr(
+            getattr(self._runtime, 'tank_part_names', None), 'HULL', None)
+        if hull_name is None:
+            raise RuntimeError('#1513 HULL part name is unavailable')
+        try:
+            # The compound-only fallback builds its bound-effect owner
+            # lazily and raises while its compound is absent.
+            add_effect = getattr(
+                target.appearance.boundEffects, 'addNewToNode', None)
+            if not callable(add_effect):
+                return False
+            matrix = self._runtime.math.Matrix()
+            matrix.setTranslate((0.0, 0.0, 0.0))
+            self._report_effect(
+                'armour_splash', 'armorSplashHit', effects_index,
+                impact_position, direction)
+            add_effect(
+                hull_name, matrix, effects, stages, entity=target,
+                damageFactor=damage_factor)
+        except Exception as error:
+            self._warn_optional_failure(
+                'projectile impact presentation', error)
+            return False
+        return True
+
     def _present_combat_hit(self, event, target_record, attacker_record,
                             attacker_id):
         """Port the mature 0.8.2 hit feedback through exact #1513 APIs."""
@@ -9613,9 +9688,13 @@ class BattleRuntime(object):
         # Retail presents an HE near-miss through
         # Vehicle.showDamageFromExplosion/armorSplashHit.  Direct hits keep
         # the three protocol outcomes: ricochet, resisted and pierced.
-        effect_group = ('armorSplashHit' if event.get('splash', False) else
-                        ('armorRicochet', 'armorResisted', 'armorHit')[
-                            shot_result])
+        damage_factor = self._hit_damage_factor(event, target_record)
+        if event.get('splash', False):
+            return self._present_splash_hit(
+                target_record, effects_descr, effects_index, impact_position,
+                direction, damage_factor)
+        effect_group = ('armorRicochet', 'armorResisted', 'armorHit')[
+            shot_result]
         stages, effects, unused = effects_descr[effect_group]
         hit_position = self._vector(impact_position)
         terrain_effects = getattr(self._avatar, 'terrainEffects', None)
@@ -9630,12 +9709,23 @@ class BattleRuntime(object):
             (_number(event.get('x')), _number(event.get('y')),
              _number(event.get('z'))), direction)
         try:
+            # #1513's armour-hit sound is a `_SoundEffectDesc` whose only
+            # events are the impact trio.  Without the shooter and target
+            # identities it always resolves to impactNPC_NPC, the mix meant
+            # for two other tanks, instead of impactPC_NPC for the player's
+            # own hit or impactNPC_PC for a hit on the player.  Retail's
+            # Vehicle.showDamageFromShot passes all four of these.
             add_effect(
                 hit_position, effects, stages, None, dir=direction,
                 start=hit_position - direction.scale(0.4),
                 end=hit_position + direction.scale(0.4),
                 showShockWave=bool(target_record.get('local')),
-                showFlashBang=bool(target_record.get('local')))
+                showFlashBang=bool(target_record.get('local')),
+                isPlayerVehicle=bool(target_record.get('local')),
+                entity_id=int(target_record['engine_id']),
+                attackerID=int(attacker_id or 0),
+                damageFactor=damage_factor,
+                hitdir=direction)
         except Exception as error:
             self._warn_optional_failure(
                 'projectile impact presentation', error)

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -9547,6 +9547,32 @@ class BattleRuntime(object):
                 impulse, bool(presented)))
         return True
 
+    def _impact_sound_identity(self, target_record, attacker_id, direction,
+                               damage_factor):
+        """Return the arguments a #1513 hit sound resolves its event from.
+
+        ``_SoundEffectDesc.create`` dereferences
+        ``BigWorld.entity(playerVehicleID).isAlive()`` as soon as either
+        identity is present, so only publish them while that stock lookup
+        resolves.  Without them the descriptor can only play its
+        two-other-tanks impact event.
+        """
+        player_id = int(getattr(self._avatar, 'playerVehicleID', 0) or 0)
+        lookup = getattr(self._runtime.bigworld, 'entity', None)
+        if player_id <= 0 or not callable(lookup) or lookup(player_id) is None:
+            return {}
+        try:
+            attacker_id = int(attacker_id or 0)
+        except (TypeError, ValueError, OverflowError):
+            attacker_id = 0
+        return {
+            'isPlayerVehicle': bool(target_record.get('local')),
+            'entity_id': int(target_record.get('engine_id') or 0),
+            'attackerID': attacker_id,
+            'damageFactor': damage_factor,
+            'hitdir': direction,
+        }
+
     def _hit_damage_factor(self, event, target_record):
         """Return retail's ``damageFactor``: hull damage as a health percent.
 
@@ -9728,11 +9754,8 @@ class BattleRuntime(object):
                 end=hit_position + direction.scale(0.4),
                 showShockWave=bool(target_record.get('local')),
                 showFlashBang=bool(target_record.get('local')),
-                isPlayerVehicle=bool(target_record.get('local')),
-                entity_id=int(target_record['engine_id']),
-                attackerID=int(attacker_id or 0),
-                damageFactor=damage_factor,
-                hitdir=direction)
+                **self._impact_sound_identity(
+                    target_record, attacker_id, direction, damage_factor))
         except Exception as error:
             self._warn_optional_failure(
                 'projectile impact presentation', error)
@@ -12054,10 +12077,10 @@ class BattleRuntime(object):
                 start=hit_position - direction.scale(0.4),
                 end=hit_position + direction.scale(0.4),
                 showShockWave=False, showFlashBang=False,
-                isPlayerVehicle=bool(target_record.get('local')),
-                entity_id=int(target_record.get('engine_id') or 0),
-                attackerID=self._projectile_attacker_engine_id(meta),
-                damageFactor=0.0, hitdir=direction)
+                **self._impact_sound_identity(
+                    target_record,
+                    self._projectile_attacker_engine_id(meta), direction,
+                    0.0))
         except Exception as error:
             self._warn_optional_failure(
                 'projectile impact presentation', error)

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -9474,17 +9474,20 @@ class BattleRuntime(object):
                 'vehicle hit impulse', error, disable=False)
             return None
 
-    def _present_hit_impulse(self, event, target_record, effects_descr):
+    def _present_hit_impulse(self, event, target_record, effects_descr,
+                             splash_direction=None):
         """Present retail's hull shot impulse on one vehicle this shot hit.
 
-        Retail reaches ``CompoundAppearance.receiveShotImpulse`` only inside
-        ``Vehicle.showDamageFromShot``'s decoded direct-hit branch, so an HE
-        near miss presents ``armorSplashHit`` with no hull reaction at all.
-        The impulse is the shot effect group's own ``targetImpulse``: retail
-        scales it by neither damage nor calibre.
+        Retail reaches ``CompoundAppearance.receiveShotImpulse`` from two
+        places.  ``Vehicle.showDamageFromShot`` passes the decoded direct-hit
+        axis and the shot effect group's own ``targetImpulse``, scaled by
+        neither damage nor calibre.  ``Vehicle.showDamageFromExplosion``
+        rocks the hull away from the blast centre at a quarter of the same
+        impulse, so an HE near miss is not motionless.
         """
         state = target_record.get('state') or {}
-        if event.get('splash', False) or event.get('dead', False):
+        splash = bool(event.get('splash', False))
+        if event.get('dead', False):
             return False
         if not bool(state.get('alive', True)) or int(
                 state.get('health', 1) or 0) <= 0:
@@ -9492,8 +9495,12 @@ class BattleRuntime(object):
         impulse = _number(_field(effects_descr, 'targetImpulse', 0.0))
         if impulse <= 0.0:
             return False
-        direction = self._decoded_hit_impulse_direction(
-            event, target_record)
+        if splash:
+            impulse = impulse / 4.0
+            direction = splash_direction
+        else:
+            direction = self._decoded_hit_impulse_direction(
+                event, target_record)
         if direction is None:
             return False
         if target_record.get('local'):
@@ -9684,7 +9691,7 @@ class BattleRuntime(object):
         # failed terrain effect must not swallow the hull reaction.
         self._run_optional_feature(
             'vehicle hit impulse', self._present_hit_impulse,
-            (event, target_record, effects_descr))
+            (event, target_record, effects_descr, direction))
         # Retail presents an HE near-miss through
         # Vehicle.showDamageFromExplosion/armorSplashHit.  Direct hits keep
         # the three protocol outcomes: ricochet, resisted and pierced.

--- a/tests/test_port_0922_battle_projectiles.py
+++ b/tests/test_port_0922_battle_projectiles.py
@@ -2128,6 +2128,9 @@ class BattleProjectileTests(unittest.TestCase):
             'engine_id': 55, 'network_id': 17, 'kind': 'bot',
             'local': False, 'spot_visible': False,
             'state': {'health': 0, 'alive': False}}
+        battle._records['player:7'] = {
+            'engine_id': 61, 'network_id': 7, 'kind': 'player',
+            'local': True, 'state': {'health': 500, 'alive': True}}
         battle._projectile_meta['p1'] = {
             'shooter_kind': 'player', 'shooter_id': 7,
             'shell_index': 0, 'terminal_velocity': (10.0, 0.0, 0.0)}
@@ -2151,6 +2154,12 @@ class BattleProjectileTests(unittest.TestCase):
         effect = add_effect.call_args
         self.assertEqual(('wreckFx', 'wreckStages'),
                          (effect.args[1], effect.args[2]))
+        # The armour-hit group's #1513 sound needs both identities to pick
+        # the player's own impact event over the other-tanks mix.
+        self.assertEqual(61, effect.kwargs['attackerID'])
+        self.assertEqual(55, effect.kwargs['entity_id'])
+        self.assertFalse(effect.kwargs['isPlayerVehicle'])
+        self.assertIs(effect.kwargs['dir'], effect.kwargs['hitdir'])
         battle._remote_factory.stop_projectile_tracer.assert_called_once_with(
             'p1', [5.0, 1.0, 0.0], explosion=None, missed=False)
 

--- a/tests/test_port_0922_battle_projectiles.py
+++ b/tests/test_port_0922_battle_projectiles.py
@@ -2116,6 +2116,12 @@ class BattleProjectileTests(unittest.TestCase):
         add_effect = mock.Mock()
         battle._avatar.terrainEffects = types.SimpleNamespace(
             addNew=add_effect)
+        # #1513 hit sounds read the player's own entity while resolving
+        # which impact event to play.
+        battle._avatar.playerVehicleID = 41
+        bigworld_entity = types.SimpleNamespace(isAlive=lambda: True)
+        battle._runtime.bigworld.entity = lambda entity_id: (
+            bigworld_entity if entity_id == 41 else None)
         battle._remote_factory = types.SimpleNamespace(
             stop_projectile_tracer=mock.Mock(return_value=True))
         target = types.SimpleNamespace(
@@ -2128,9 +2134,6 @@ class BattleProjectileTests(unittest.TestCase):
             'engine_id': 55, 'network_id': 17, 'kind': 'bot',
             'local': False, 'spot_visible': False,
             'state': {'health': 0, 'alive': False}}
-        battle._records['player:7'] = {
-            'engine_id': 61, 'network_id': 7, 'kind': 'player',
-            'local': True, 'state': {'health': 500, 'alive': True}}
         battle._projectile_meta['p1'] = {
             'shooter_kind': 'player', 'shooter_id': 7,
             'shell_index': 0, 'terminal_velocity': (10.0, 0.0, 0.0)}
@@ -2156,7 +2159,7 @@ class BattleProjectileTests(unittest.TestCase):
                          (effect.args[1], effect.args[2]))
         # The armour-hit group's #1513 sound needs both identities to pick
         # the player's own impact event over the other-tanks mix.
-        self.assertEqual(61, effect.kwargs['attackerID'])
+        self.assertEqual(41, effect.kwargs['attackerID'])
         self.assertEqual(55, effect.kwargs['entity_id'])
         self.assertFalse(effect.kwargs['isPlayerVehicle'])
         self.assertIs(effect.kwargs['dir'], effect.kwargs['hitdir'])

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -701,6 +701,36 @@ class _VehicleDecal(object):
         self.hull_node.detach(self.decal)
 
 
+class _VehicleBoundEffects(object):
+    """``helpers.bound_effects.ModelBoundEffects`` over one vehicle compound.
+
+    #1513 fills ``armorSplashHit`` with a single ``splashSound``, and
+    ``_NodeSoundEffectDesc.create`` returns without playing anything unless
+    ``entity`` is a live, started vehicle, so reproduce that guard here: only
+    a call carrying the owning entity reaches ``played``.
+    """
+
+    def __init__(self, owner):
+        self._owner = owner
+        self.calls = []
+        self.played = []
+
+    def addNew(self, matProv, effectsList, keyPoints, waitForKeyOff=False,
+               **args):
+        return self.addNewToNode(
+            '', matProv, effectsList, keyPoints, waitForKeyOff, **args)
+
+    def addNewToNode(self, node, matProv, effectsList, keyPoints,
+                     waitForKeyOff=False, **args):
+        self.calls.append((node, matProv, effectsList, keyPoints, args))
+        entity = args.get('entity')
+        if (entity is not None and entity.isStarted and
+                entity.isAlive()):
+            self.played.append((node, effectsList, args.get('damageFactor')))
+        return types.SimpleNamespace(
+            stop=lambda **unused: None, keyOff=lambda: None)
+
+
 class _Vehicle(object):
     def __init__(self, entity_id, descriptor, position, rotation, properties):
         self.id = entity_id
@@ -731,7 +761,9 @@ class _Vehicle(object):
         self.custom_effects = _CustomEffectManager()
         self.custom_effects.enable(True, _CustomEffectManager.SETTING_DUST)
         self.custom_effects.enable(True, _CustomEffectManager.SETTING_EXHAUST)
+        self.bound_effects = _VehicleBoundEffects(self)
         self.appearance = types.SimpleNamespace(
+            boundEffects=self.bound_effects,
             compoundModel=self.model, turretMatrix=_Matrix(),
             gunMatrix=_Matrix(),
             highlighter=types.SimpleNamespace(enabled=False),
@@ -12530,9 +12562,117 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertTrue(battle._present_combat_hit(
             event, target_record, attacker_record, 11))
 
+        # Exact #1513 ``showSplashHitEffect`` binds armorSplashHit to the
+        # target's own hull node and hands its ``splashSound`` the entity.
+        battle._avatar.terrainEffects.addNew.assert_not_called()
+        self.assertEqual(
+            [('hull', 'splashFx', 8.0)], target.bound_effects.played)
+        node, matrix, effects, stages, args = target.bound_effects.calls[0]
+        self.assertEqual(('hull', 'splashFx', 'splashStages'),
+                         (node, effects, stages))
+        self.assertIs(target, args['entity'])
+        translation = matrix.translation
+        self.assertEqual(
+            (0.0, 0.0, 0.0),
+            (translation.x, translation.y, translation.z))
+
+    def test_he_splash_on_a_dead_target_presents_nothing(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        target = _Vehicle(10, _Descriptor(), _Vector(), (0, 0, 0),
+                          {'health': 0})
+        target.health = 0
+        attacker = _Vehicle(11, _Descriptor(), _Vector(10, 0, 0),
+                            (0, 0, 0), {'health': 500})
+        runtime.bigworld.entities.update({10: target, 11: attacker})
+        target_record = {
+            'engine_id': 10, 'state': {'health': 0, 'alive': False},
+            'kind': 'bot', 'network_id': 1, 'local': False,
+            'spot_visible': True}
+        attacker_record = {
+            'engine_id': 11,
+            'state': {'health': 500, 'x': 10.0, 'y': 0.0, 'z': 0.0},
+            'kind': 'bot', 'network_id': 2, 'local': False}
+        event = {
+            'kind': 'bot_bot_hit', 'world_pose': True,
+            'x': 0.5, 'y': 1.0, 'z': 0.0, 'shell_index': 0,
+            'shot_result': 2, 'damage': 40, 'source': 'shot',
+            'splash': True}
+
+        # Retail reaches showSplashHitEffect only past showDamageFromExplosion's
+        # own isAlive gate.
+        self.assertFalse(battle._present_combat_hit(
+            event, target_record, attacker_record, 11))
+        self.assertEqual([], target.bound_effects.calls)
+        battle._avatar.terrainEffects.addNew.assert_not_called()
+
+    def test_direct_hit_effect_carries_the_stock_sound_identity(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        target = _Vehicle(10, _Descriptor(), _Vector(), (0, 0, 0),
+                          {'health': 500})
+        attacker = _Vehicle(11, _Descriptor(), _Vector(10, 0, 0),
+                            (0, 0, 0), {'health': 500})
+        runtime.bigworld.entities.update({10: target, 11: attacker})
+        target_record = {
+            'engine_id': 10, 'spot_visible': True,
+            'state': {'health': 500, 'x': 0.0, 'y': 0.0, 'z': 0.0},
+            'kind': 'bot', 'network_id': 1, 'local': False}
+        attacker_record = {
+            'engine_id': 11,
+            'state': {'health': 500, 'x': 10.0, 'y': 0.0, 'z': 0.0},
+            'kind': 'player', 'network_id': 2, 'local': True}
+        event = {
+            'kind': 'hit', 'world_pose': True,
+            'x': 0.5, 'y': 1.0, 'z': 0.0, 'shell_index': 0,
+            'shot_result': 2, 'damage': 250, 'source': 'shot'}
+
+        self.assertTrue(battle._present_combat_hit(
+            event, target_record, attacker_record, 11))
+
+        # #1513's armour-hit sound is the impact trio.  Without these four
+        # arguments _SoundEffectDesc.create always resolves impactNPC_NPC,
+        # the mix meant for two other tanks, instead of the player's own
+        # impactPC_NPC.
         effect = battle._avatar.terrainEffects.addNew.call_args
-        self.assertEqual(('splashFx', 'splashStages'),
-                         (effect.args[1], effect.args[2]))
+        self.assertEqual(11, effect.kwargs['attackerID'])
+        self.assertEqual(10, effect.kwargs['entity_id'])
+        self.assertFalse(effect.kwargs['isPlayerVehicle'])
+        self.assertAlmostEqual(50.0, effect.kwargs['damageFactor'])
+        self.assertIs(effect.kwargs['dir'], effect.kwargs['hitdir'])
+
+    def test_hit_on_the_player_reports_the_player_as_the_effect_target(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        target = _Vehicle(10, _Descriptor(), _Vector(), (0, 0, 0),
+                          {'health': 500})
+        attacker = _Vehicle(11, _Descriptor(), _Vector(10, 0, 0),
+                            (0, 0, 0), {'health': 500})
+        runtime.bigworld.entities.update({10: target, 11: attacker})
+        battle._local_position = (0.0, 0.0, 0.0)
+        target_record = {
+            'engine_id': 10, 'state': {'health': 500},
+            'kind': 'player', 'network_id': 1, 'local': True}
+        attacker_record = {
+            'engine_id': 11,
+            'state': {'health': 500, 'x': 10.0, 'y': 0.0, 'z': 0.0},
+            'kind': 'bot', 'network_id': 2, 'local': False}
+        event = {
+            'kind': 'bot_human_hit', 'world_pose': True,
+            'x': 0.5, 'y': 1.0, 'z': 0.0, 'shell_index': 0,
+            'shot_result': 1, 'damage': 0, 'source': 'shot'}
+
+        self.assertTrue(battle._present_combat_hit(
+            event, target_record, attacker_record, 11))
+
+        effect = battle._avatar.terrainEffects.addNew.call_args
+        self.assertEqual(11, effect.kwargs['attackerID'])
+        self.assertEqual(10, effect.kwargs['entity_id'])
+        self.assertTrue(effect.kwargs['isPlayerVehicle'])
+        self.assertEqual(0.0, effect.kwargs['damageFactor'])
 
     def test_self_splash_with_degenerate_direction_is_presentation_safe(self):
         runtime = _runtime()
@@ -12553,7 +12693,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertTrue(battle._present_combat_hit(
             event, record, record, 10))
 
-        battle._avatar.terrainEffects.addNew.assert_called_once()
+        self.assertEqual(1, len(vehicle.bound_effects.played))
         self.assertEqual([], battle._avatar.hit_directions)
 
     def test_visible_remote_combat_keeps_the_vehicle_impact_effect(self):

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -12652,6 +12652,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
             'kind': 'hit', 'world_pose': True,
             'x': 0.5, 'y': 1.0, 'z': 0.0, 'shell_index': 0,
             'shot_result': 2, 'damage': 250, 'source': 'shot'}
+        battle._avatar.playerVehicleID = 11
 
         self.assertTrue(battle._present_combat_hit(
             event, target_record, attacker_record, 11))
@@ -12688,6 +12689,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
             'kind': 'bot_human_hit', 'world_pose': True,
             'x': 0.5, 'y': 1.0, 'z': 0.0, 'shell_index': 0,
             'shot_result': 1, 'damage': 0, 'source': 'shot'}
+        battle._avatar.playerVehicleID = 10
 
         self.assertTrue(battle._present_combat_hit(
             event, target_record, attacker_record, 11))
@@ -12697,6 +12699,18 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertEqual(10, effect.kwargs['entity_id'])
         self.assertTrue(effect.kwargs['isPlayerVehicle'])
         self.assertEqual(0.0, effect.kwargs['damageFactor'])
+
+        # _SoundEffectDesc dereferences BigWorld.entity(playerVehicleID)
+        # as soon as either identity is present, so a player who has left
+        # the world keeps the old event instead of disabling the effect.
+        del runtime.bigworld.entities[10]
+        self.assertTrue(battle._present_combat_hit(
+            event, target_record, attacker_record, 11))
+        effect = battle._avatar.terrainEffects.addNew.call_args
+        self.assertNotIn('attackerID', effect.kwargs)
+        self.assertNotIn(
+            'projectile impact presentation',
+            battle._disabled_optional_features)
 
     def test_self_splash_with_degenerate_direction_is_presentation_safe(self):
         runtime = _runtime()

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -724,8 +724,10 @@ class _VehicleBoundEffects(object):
                      waitForKeyOff=False, **args):
         self.calls.append((node, matProv, effectsList, keyPoints, args))
         entity = args.get('entity')
-        if (entity is not None and entity.isStarted and
-                entity.isAlive()):
+        # ``_NodeSoundEffectDesc.create`` also dereferences the local matrix
+        # this owner passes as ``position``; a static-scene call has none.
+        if (entity is not None and matProv is not None and
+                entity.isStarted and entity.isAlive()):
             self.played.append((node, effectsList, args.get('damageFactor')))
         return types.SimpleNamespace(
             stop=lambda **unused: None, keyOff=lambda: None)
@@ -12561,7 +12563,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertIs(
             shooting_extra, descriptor.extrasDict['shoot'])
 
-    def test_he_splash_uses_the_stock_vehicle_explosion_effect(self):
+    def test_he_splash_binds_to_the_target_hull_node_with_its_entity(self):
         runtime = _runtime()
         battle = BattleRuntime(runtime)
         battle._avatar = runtime.bigworld.avatar

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -3300,7 +3300,7 @@ class RemoteVehicleFactoryTests(unittest.TestCase):
         self.assertNotIn(
             'vehicle hit impulse', battle._disabled_optional_features)
 
-    def test_splash_and_killing_hits_present_no_retail_hull_impulse(self):
+    def test_splash_rocks_the_hull_at_a_quarter_of_the_impulse(self):
         runtime, factory, unused_binding, vehicle_id, vehicle = \
             self._swinging_native_factory()
         battle = BattleRuntime(runtime)
@@ -3312,8 +3312,32 @@ class RemoteVehicleFactoryTests(unittest.TestCase):
             'spot_visible': True, 'state': {'health': 500, 'alive': True}}
         effects_descr = runtime.vehicles.g_cache.shotEffects[3]
 
+        # Exact #1513 Vehicle.showDamageFromExplosion pushes the hull away
+        # from the blast centre with targetImpulse / 4.
+        self.assertTrue(battle._present_hit_impulse(
+            {'splash': True}, target_record, effects_descr,
+            runtime.math.Vector3(0.0, 0.0, 1.0)))
+        impulse_call = vehicle.appearance.receiveShotImpulse.call_args
+        self.assertAlmostEqual(87.5, impulse_call.args[1])
+        vehicle.appearance.receiveShotImpulse.reset_mock()
+
+        # A splash without a blast direction stays a no-op rather than
+        # inventing one.
         self.assertFalse(battle._present_hit_impulse(
             {'splash': True}, target_record, effects_descr))
+
+    def test_killing_hits_present_no_retail_hull_impulse(self):
+        runtime, factory, unused_binding, vehicle_id, vehicle = \
+            self._swinging_native_factory()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        battle._remote_factory = factory
+        runtime.vehicles.g_cache.shotEffects[3]['targetImpulse'] = 350.0
+        target_record = {
+            'engine_id': vehicle_id, 'local': False, 'native_remote': True,
+            'spot_visible': True, 'state': {'health': 500, 'alive': True}}
+        effects_descr = runtime.vehicles.g_cache.shotEffects[3]
+
         self.assertFalse(battle._present_hit_impulse(
             {'dead': True}, target_record, effects_descr))
         self.assertFalse(battle._present_hit_impulse(


### PR DESCRIPTION
Reported: artillery HE hitting a tank has no explosion sound, while hitting
the ground does.

## What the exact client proves

`scripts/item_defs/vehicles/common/shot_effects.xml` ships inside the pinned
`scripts.pkg`, so the shot effect data is readable here. Every armour group -
`armorHit`, `armorCriticalHit`, `armorResisted`, and
`armorRicochet`/`armorBasicRicochet`, which default to `armorResisted` - holds
one `<sound>` (`_SoundEffectDesc`) whose only events are the impact trio.
`hugeHighExplosive` `armorHit`, for example:

    <impactNPC_PC>imp_huge_pierce_HE_NPC_PC</impactNPC_PC>
    <impactPC_NPC>imp_huge_pierce_HE_PC_NPC</impactPC_NPC>
    <impactNPC_NPC>imp_huge_pierce_HE_NPC_NPC</impactNPC_NPC>
    <SWITCH_ext_shell_type>SWITCH_ext_shell_type_HE</SWITCH_ext_shell_type>

`helpers/EffectsList._SoundEffectDesc.create` selects one of the three from
`attackerID` (is this the player's own shell?) and `entity_id` (was the player
hit?). This runtime passed neither, so every hit on a vehicle - HE, AP, the
player's shot or a bot's - resolved `impactNPC_NPC`, the mix meant for two
other tanks. Ground hits sounded right because `groundHit` still played a
surface event through the stock `ProjectileMover`, which carries the real
`attackerID` in its own projectile row.

Penetration therefore selects the effect *group*, not whether there is a
sound: no stock group is silent. The HE fireball on armour is that group's own
`armorHit_HE_4.xml` pixie, so suppressing the world explosion on a vehicle
terminal stays correct.

`armorSplashHit` is the other half: its only #1513 effect is a `splashSound`
(`_NodeSoundEffectDesc`), which returns without playing anything unless
`entity` is a live, started vehicle, and it dereferences the local matrix that
only a model-bound owner supplies. Presented through the static scene owner,
an HE near miss on a tank produced literally nothing.

## Changes

1. **Hit sound identity** - direct hits now pass retail's `attackerID`,
   `entity_id`, `isPlayerVehicle`, `hitdir` and `damageFactor`.
   `damageFactor` is damage as a percentage of maximum health, proven by
   `Vehicle.onStaticCollision` scaling its 0..1 hull damage by 100 into the
   same 43.35 / 89.25 `SWITCH_ext_damage_size` thresholds.
2. **Splash** - `armorSplashHit` moves to
   `appearance.boundEffects.addNewToNode(HULL, identity, ..., entity=target)`,
   exactly `Vehicle.showSplashHitEffect`, behind the same `isAlive` gate
   `showDamageFromExplosion` applies. A splash on a bot stays silent by data
   (only `wwsoundPC` is defined), as in retail.
3. **Retained wrecks** - the same armour group, so the same two identities.
4. **Splash hull impulse** - `showDamageFromExplosion` calls
   `receiveShotImpulse` with the blast direction and a quarter of
   `targetImpulse`; this runtime rejected every splash and recorded the
   opposite claim in a docstring. Droppable on its own commit: it is hull
   motion, not sound.
5. A guard so the two identities are published only while
   `BigWorld.entity(playerVehicleID)` resolves, because
   `_SoundEffectDesc.create` dereferences it and a raise inside the stock
   effect list would retire impact presentation for the whole round.

## Audited, deliberately unchanged

- The ground explosion's unknown-id fallback keeps `attackerID` 0. That is
  #1513's own temporary dictionary, not a defect.
- Group selection is still `(armorRicochet, armorResisted, armorHit)`, so
  `armorCriticalHit` and `armorBasicRicochet` never play. #1513's decoder
  table is `('armorBasicRicochet', 'armorRicochet', 'armorResisted',
  'armorResisted', 'armorHit', 'armorCriticalHit')`; mapping onto it needs a
  worker hit-code rule and is a separate change.

## Validation

- `python3 -m unittest discover -s tests -p "test_*.py"`: 4142 tests, OK.
- CPython 2.7 source compile of `src/res/scripts/client`: 96 files.

Unproved here: which WWise mix is actually audible. Source and shipped data
prove which event is selected; only the Windows client proves how loud
`impactPC_NPC` is next to `impactNPC_NPC`.