### PR TITLE
Stop treating ordinary navigable water as a navigation hazard

### DIFF
--- a/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
@@ -18,8 +18,15 @@ from gui.mods.offline_lan_0922.ai.driver import (
 
 SQRT_TWO = math.sqrt(2.0)
 BAKED_FATAL_HAZARDS = 1 | 2
-# Shallow water remains passable when no dry route exists, but the baked graph
-# assigns it a large traction/risk cost so ordinary shortcuts stay on land.
+# A reviewed ford cell whose scoped depth limit admits it beyond the baked
+# graph's ordinary navigable water limit. It stays passable when no dry route
+# exists, but carries a large traction/risk cost and the controlled-ford
+# discipline below, because such a ford is a hand-authored single-file
+# corridor. Ordinary navigable water carries no hazard bit: the baker and
+# bot_runtime.BOT_WATER_AVOID_DEPTH share one line, and penalising every
+# puddle below it queued whole teams on the dry bank of a 20 cm ditch. A
+# graph baked before that alignment still flags its shallow apron, which
+# only makes these consumers more conservative.
 BAKED_SHALLOW_WATER = 4
 # Cache compact answers, not crossed-cell lists, in the 32-bit worker.
 MAX_BAKED_CORRIDOR_CACHE = 2048

--- a/tests/test_port_0922_navigation_baker.py
+++ b/tests/test_port_0922_navigation_baker.py
@@ -1199,7 +1199,9 @@ class CompiledSpace0922Test(unittest.TestCase):
             HAZARD_WATER=1,
             HAZARD_EDGE=2,
             HAZARD_SHALLOW_WATER=4,
-            SHALLOW_WATER_THRESHOLD=0.15,
+            # The shipped baker keeps this on the navigable water limit, so
+            # only a reviewed ford's scoped depth can raise the shallow class.
+            SHALLOW_WATER_THRESHOLD=0.9,
             WATER_DEPTH_LIMIT=0.9,
             VEHICLE_HALF_WIDTH=2.15,
             BRIDGE_OBSTACLE_MARGIN=1.0,
@@ -1351,6 +1353,82 @@ class CompiledSpace0922Test(unittest.TestCase):
 
         self.assertEqual(1.0, record['maximum_water_depth'])
         self.assertEqual(4, graph['hazards'][middle])
+        self.assertIsNone(graph['heights_mm'][side])
+        self.assertEqual(1, graph['hazards'][side])
+
+    def test_shallow_water_class_shares_the_baseline_navigable_limit(self):
+        # Ordinary navigable water must not also be a route hazard.  A split
+        # between these two constants is what made bots queue on the dry bank
+        # of a twenty-centimetre ditch while the native probe was willing to
+        # drive it, so the baker refuses to bake when they disagree.
+        legacy = baker._legacy_baker()
+
+        self.assertEqual(legacy.WATER_DEPTH_LIMIT,
+                         baker.SHALLOW_WATER_THRESHOLD)
+        self.assertEqual(0.9, baker.SHALLOW_WATER_THRESHOLD)
+
+    def test_reviewed_contracts_never_expect_shallow_water_on_a_closed_cell(self):
+        # A cell the baker rejected carries only deep water and edge state.
+        # Ordinary navigable water no longer sets HAZARD_SHALLOW_WATER, so a
+        # contract that still expected it would describe a graph this baker
+        # cannot produce and would fail its own pre-mutation assertion.
+        legacy = baker._legacy_baker()
+        contracts = []
+        for records in baker._REVIEWED_TERRAIN_PATH_CONTRACTS.values():
+            contracts.extend(records)
+        for records in baker._REVIEWED_NARROW_CORNER_CONTRACTS.values():
+            contracts.extend(records)
+        self.assertTrue(contracts)
+        for contract in contracts:
+            for key in ('missing_states', 'side_states'):
+                for point, hazard in (contract.get(key) or {}).items():
+                    with self.subTest(contract=contract['id'], point=point):
+                        self.assertFalse(
+                            int(hazard) & legacy.HAZARD_SHALLOW_WATER)
+
+    def test_reviewed_ford_leaves_ordinary_navigable_water_unflagged(self):
+        # One ford, both sides of the limit: the deep cell keeps the shallow
+        # class and its controlled-ford discipline, while the knee-deep cell
+        # the runtime probe would drive without complaint becomes plain ground.
+        graph = self._reviewed_adapter_graph(width=5, height=2)
+        points = ((0.0, 4.0), (4.0, 4.0), (8.0, 4.0), (12.0, 4.0), (16.0, 4.0))
+        for point in (points[0], points[2], points[4]):
+            graph['heights_mm'][self._adapter_index(graph, point)] = 0
+        deep = self._adapter_index(graph, points[1])
+        knee = self._adapter_index(graph, points[3])
+        graph['hazards'][deep] = 1
+        graph['hazards'][knee] = 2
+        side = self._adapter_index(graph, (4.0, 0.0))
+        graph['hazards'][side] = 1
+        contract = {
+            'id': 'test_ford',
+            'kind': 'ford',
+            'points': points,
+            'missing_states': {(4.0, 4.0): 1, (12.0, 4.0): 2},
+            'side_states': {(4.0, 0.0): 1},
+            'maximum_water_depth': 1.1,
+        }
+
+        def water(x, unused_z, unused_ground):
+            if 2.0 <= x <= 6.0:
+                return 1.0
+            if 10.0 <= x <= 14.0:
+                return 0.5
+            return 0.0
+
+        terrain, obstacles, legacy = self._reviewed_adapter_dependencies(
+            water=water,
+            edge=lambda x, unused_z, unused_ground: not 2.0 <= x <= 14.0)
+
+        record = baker.install_reviewed_terrain_path(
+            graph, terrain, obstacles, legacy, contract)
+
+        self.assertEqual(1.0, record['maximum_water_depth'])
+        self.assertEqual(2, record['revived_nodes'])
+        self.assertEqual(legacy.HAZARD_SHALLOW_WATER, graph['hazards'][deep])
+        self.assertEqual(0, graph['hazards'][knee])
+        self.assertEqual(0, graph['heights_mm'][deep])
+        self.assertEqual(0, graph['heights_mm'][knee])
         self.assertIsNone(graph['heights_mm'][side])
         self.assertEqual(1, graph['hazards'][side])
 

--- a/tools/bake_navigation_0922.py
+++ b/tools/bake_navigation_0922.py
@@ -55,6 +55,21 @@ NAVIGATION_BASELINE_SHA256 = {
         'f6b71578f032a0fa1e442ebf7fc241a23d76171c8ea72cbde5ca728591e4d9e0'),
 }
 
+# Ordinary #1513 navigable water is not a navigation hazard.  The 0.8.2
+# baseline flagged every cell deeper than 0.12 m as shallow water, which cost
+# five times the cell length in A*, closed the shortcut, smoothing, pending,
+# route-lane and spawn-chord checks across it, and clamped the driver fan to
+# the controlled-ford cone.  Bots therefore queued on the dry bank of a 20 cm
+# ditch: the fan veto fires from dry ground looking in, while a hull already
+# standing in the water falls through to the native probe and drives freely.
+# bot_runtime.BOT_WATER_AVOID_DEPTH has always accepted water up to the
+# baseline's own WATER_DEPTH_LIMIT, so the two layers disagreed by 7.5x and
+# the baked class won by short-circuiting the native probe.  Align them on one
+# line: water the baseline itself calls navigable stays plain ground, and
+# HAZARD_SHALLOW_WATER marks only what needed it - a reviewed ford cell that
+# its own scoped depth limit admits beyond WATER_DEPTH_LIMIT.
+SHALLOW_WATER_THRESHOLD = 0.90
+
 _GREAT_WALL_MAP = '59_asia_great_wall'
 _GREAT_WALL_GRID_CELL_SIZE = 4.0
 _GREAT_WALL_ARENA_BOUNDS = (-500.0, -500.0, 500.0, 500.0)
@@ -122,20 +137,20 @@ _REVIEWED_TERRAIN_PATH_CONTRACTS = {
                 (-150.0, 374.0), (-146.0, 374.0),
             ),
             'missing_states': {
-                (-162.0, 366.0): 6,
+                (-162.0, 366.0): 2,
                 (-158.0, 370.0): 1,
                 (-154.0, 370.0): 1,
-                (-150.0, 374.0): 6,
+                (-150.0, 374.0): 2,
             },
             'side_states': {
-                (-162.0, 370.0): 6,
+                (-162.0, 370.0): 2,
                 (-162.0, 362.0): 2,
                 (-158.0, 374.0): 1,
-                (-158.0, 366.0): 6,
+                (-158.0, 366.0): 2,
                 (-154.0, 374.0): 1,
                 (-154.0, 366.0): 1,
-                (-150.0, 378.0): 6,
-                (-150.0, 370.0): 6,
+                (-150.0, 378.0): 2,
+                (-150.0, 370.0): 2,
             },
             'maximum_water_depth': 1.01,
         },
@@ -148,20 +163,20 @@ _REVIEWED_TERRAIN_PATH_CONTRACTS = {
                 (-146.0, -234.0), (-142.0, -234.0),
             ),
             'missing_states': {
-                (-158.0, -242.0): 6,
+                (-158.0, -242.0): 2,
                 (-154.0, -238.0): 1,
                 (-150.0, -238.0): 1,
-                (-146.0, -234.0): 6,
+                (-146.0, -234.0): 2,
             },
             'side_states': {
-                (-158.0, -246.0): 6,
-                (-158.0, -238.0): 6,
+                (-158.0, -246.0): 2,
+                (-158.0, -238.0): 2,
                 (-154.0, -242.0): 1,
                 (-154.0, -234.0): 1,
                 (-150.0, -242.0): 1,
                 (-150.0, -234.0): 1,
-                (-146.0, -238.0): 6,
-                (-146.0, -230.0): 6,
+                (-146.0, -238.0): 2,
+                (-146.0, -230.0): 2,
             },
             'maximum_water_depth': 1.25,
         },
@@ -2358,6 +2373,17 @@ def bake_map_graph(client_root, map_name, output=None, cell_size=4.0):
         original_maps, original_game_version = legacy.MAPS, legacy.GAME_VERSION
         original_format_name, original_format_version = legacy.FORMAT_NAME, legacy.FORMAT_VERSION
         original_expanded_bounds = legacy._expanded_bounds
+        original_shallow_threshold = legacy.SHALLOW_WATER_THRESHOLD
+        if SHALLOW_WATER_THRESHOLD != legacy.WATER_DEPTH_LIMIT:
+            # The two constants must name the same line.  A baseline that
+            # forbids water above one depth while this baker still penalises
+            # water above another reintroduces the split that made bots stall
+            # on a dry bank, so refuse to bake rather than emit a graph whose
+            # hazard class no longer matches the runtime probe.
+            raise UnsafeBakeInputError(
+                'shallow-water threshold %r does not match the baseline '
+                'navigable water limit %r' % (SHALLOW_WATER_THRESHOLD,
+                                              legacy.WATER_DEPTH_LIMIT))
         def target_expanded_bounds(map_config, requested_cell_size):
             return _target_sampling_bounds(
                 map_name, map_config, requested_cell_size)
@@ -2367,6 +2393,7 @@ def bake_map_graph(client_root, map_name, output=None, cell_size=4.0):
             legacy.FORMAT_NAME = 'offline-lan-0922-navgraph'
             legacy.FORMAT_VERSION = 2
             legacy._expanded_bounds = target_expanded_bounds
+            legacy.SHALLOW_WATER_THRESHOLD = SHALLOW_WATER_THRESHOLD
             original_terrain, original_obstacles = legacy.Terrain, legacy.ObstacleField
             original_validate = legacy.validate_graph
             original_bake_routes = legacy.bake_tactical_routes
@@ -2488,6 +2515,7 @@ def bake_map_graph(client_root, map_name, output=None, cell_size=4.0):
             legacy.MAPS, legacy.GAME_VERSION = original_maps, original_game_version
             legacy.FORMAT_NAME, legacy.FORMAT_VERSION = original_format_name, original_format_version
             legacy._expanded_bounds = original_expanded_bounds
+            legacy.SHALLOW_WATER_THRESHOLD = original_shallow_threshold
             legacy.Terrain, legacy.ObstacleField = original_terrain, original_obstacles
             legacy.validate_graph = original_validate
             legacy.bake_tactical_routes = original_bake_routes


### PR DESCRIPTION
## The report

Highway (`45_north_america`), the shallow creek east/south-east of the
south-west spawn: a crowd of vehicles jams on the bank instead of driving
across. Reported as "卡涉水了 不能识别浅水能顺利通过".

## What is actually wrong

Four layers answer "can a tank cross this water", and they disagree:

| layer | constant | value |
|---|---|---|
| baked graph | `SHALLOW_WATER_THRESHOLD` | **0.12 m** |
| runtime native probe | `bot_runtime.BOT_WATER_AVOID_DEPTH` | **0.90 m** |
| our own reviewed fords | `maximum_water_depth` | **0.99 / 1.25 m** |
| cover selection | inline | `server_bot_ai.py:356,1884` — 0.5 m |

The baked layer is the strictest and it wins, because `sample_clear()` takes
`_planner_corridor_clear`'s answer and returns immediately when it is not
`None` — the native water ray is never fired.

`BAKED_SHALLOW_WATER` is not a cost hint. It adds `4.0 * cell_size` (16 m on a
4 m grid, so a cell costs 20 m instead of 4 m), and it is a *hazard* for the
shortcut, smoothing, lookahead, `_pending_target`, `_route_lane_offset`
(`bot_runtime.py:6346`) and spawn route-join (`:6194`) checks. The driver fan
`(0, ±0.42, ±0.78, ±1.18, ±1.55)` is reduced to `CONTROLLED_SHALLOW_YAW_WINDOW`
= 0.45 rad, so the wide avoidance branches are vetoed. When nothing is left,
`driver.py:744` returns `throttle 0.0, turn 0.0, recovery_mode 'blocked'` and
forces the stuck timer into pivot/reverse.

The veto is an **entry** veto: `_planner_corridor_clear` returns `None` when
`wet_escape` is set, and `wet_escape` includes standing in a bit-4 cell. A hull
already in the water drives freely on the native probe; only the hull on the
dry bank looking in is frozen. That is exactly "堵在水边", not "堵在水里".

## Evidence

Per-cell water depth is derivable from a navgraph alone: for each connected
water component the surface is bounded below by
`max(bit-4 cell height) + 0.12` and above by
`min(adjacent dry cell height) + 0.12`. On 142 of 143 components in the
catalog the two agree to under a centimetre, and for Highway the result
(-12.60) matches the client value the baker recorded in
`bake.water_surface_heights` (**-12.604**).

The reported creek, `x -74…-42`, `z -378…-478`, 16–20 m wide
(`1` ≤0.30 m, `2` ≤0.50 m, `C` collar-rejected, `D` deep/fatal):

```
  -378 ..............23331.................
  -382 ..............22332.................
  -386 ..............12222.................
  -390 ...............21111................
  -430 ....................1221............
```

`south_town` crosses it at waypoint `(-62, -378)` — the first leg east out of
the south-west spawn. Highway has **zero** water cells with `x>0, z<0`, so this
is the ditch in the report.

Funnel reproduced with the real `TerrainNavigator` over the shipped graph, one
leg, penalty being the only variable:

| leg | shipped 4× | penalty 0 |
|---|---|---|
| `z=-390` → east | detours 36 m north, 194.3 m, **0 wet cells** | straight, 184.1 m |
| `z=-410` → east | 181.4 m, crosses at **(-50…-42, -422…-426)** | crosses at its own z |
| `z=-430` → east | 178.8 m, crosses at **the same cells** | 172.0 m ≈ straight line |

Two distinct approach lines collapse onto three shared cells. With lateral
spreading disabled by the same bit, a 20 m front behaves like a 4 m gate.

Class size: 26 of 41 maps carry the bit; 18 837 measurable cells; **87% are
shallower than 0.65 m** (Lakeville 2895, Hills 2145, Slough 1842, Tundra 1491,
Caucasus 1486, Airfield 1114, Highway 637).

## The change

Put the baked class and the runtime probe on one line.
`SHALLOW_WATER_THRESHOLD` becomes `WATER_DEPTH_LIMIT` (0.90 m), which the
baker asserts, so ordinary navigable water carries no hazard bit at all.
`HAZARD_SHALLOW_WATER` now marks only what needed it: a reviewed ford cell
whose scoped depth limit admits it *beyond* the navigable limit. Those are
hand-authored single-file corridors through ~1.2 m of water and they do want
the 4× cost, the narrow cone and the no-lane-offset discipline.

Highway's two ford contracts asserted `6` (`EDGE|SHALLOW`) on twelve rejected
cells. A rejected cell can now only be deep water and/or an edge, so those
become `2`; the eight states already recorded as `1` are unchanged.

Nothing in the runtime changed. An old graph still flags its shallow apron,
which only makes these consumers more conservative.

## Why "no bit at all" does not recreate the deeper-water rejection loop

`_has_safe_edge_clearance` already rejects any cell with water deeper than the
limit within 3 m or 6 m in eight directions — 10 470 cells across the catalog,
the `C` band in the render. Every navigable cell is therefore ~6 m from deep
water, deep water itself stays `HAZARD_WATER` and fatal, and the runtime
corridor probe reaches 8/15–20 m ahead. Roads stay preferred through the
reviewed tactical route polylines, not through a puddle penalty.

## Validation

- `tests.test_port_0922_navigation_baker` — 50 tests, OK (3 new)
- `tests.test_port_0922_navigation`, `_ai`, `_tactical_route_review` — 193, OK
- `tests.test_port_0922_bot_runtime`, `_server_bot_ai` — 538, OK
- CPython 2.7 source compile — 96 files, OK

## What this PR does not do, and the next step

**The tracked navgraphs are still the 0.12 m generation, so no player-visible
behaviour changes until the catalog is re-baked.** That needs `res/packages`
from the exact client, which this machine does not have.

For the Mac agent:

1. `export WOT_0922_CLIENT=...`, then re-bake all 41 maps with
   `tools/bake_navigation_0922.py` into a temporary directory and diff before
   replacing `navgraphs/`.
2. Expect `bake.shallow_water_threshold` to read `0.9` and
   `bake.shallow_water_nodes` to read `0` (the vendor counter runs before the
   ford adapters, which set the surviving bits afterwards). No code reads
   either field.
3. If a Highway ford contract raises `UnsafeBakeInputError`, the four
   `6`→`2` states I derived (depths 0.55, 0.69, 0.64, 0.47) or one of the eight
   side states whose depth is not derivable from the graph is off by one class
   — take the value from the fresh bake.
4. Consider tightening
   `test_shallow_water_class_shares_the_baseline_navigable_limit` with a
   catalog assertion once the re-baked graphs land.

## Not proved / out of scope

- Whether the pile-up actually ends needs a Windows playtest.
- The remaining exposure is sub-cell: the graph samples water at 4 m cell
  centres, so a plain cell at 0.88 m can have a corner past 0.90 m. The
  runtime probe and the 6 m collar bound it; it is not a new class of risk,
  only one the blanket veto used to mask.
- An alternative I did not take: threshold 0.65 m with a retained low-cost
  0.65–0.90 class, to keep a mild dry-ground preference. Say the word and I
  will switch — it needs per-cell depth at bake time, which the client has.
- Suspicious, unrelated, needs the same `scripts.pkg` read:
  `battle_runtime._drowning_sensor_thresholds` reads
  `chassis.topRightCarryingPoint[1]` as a height, but `vehicle_physics.py:15`
  and `track_damage.py:175` treat that `Vector2` as (half gauge, half length),
  which would put the drowning `caution` level at ~2–3 m. Fallback-only
  drowning UI, not navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)