### PR TITLE
Estimate player camera motion on the exact client sample interval

### DIFF
--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -1707,6 +1707,7 @@ class BattleRuntime(object):
         self._local_native_matrix = None
         self._local_native_stabilised_matrix = None
         self._local_camera_velocity = None
+        self._reset_local_camera_motion()
         self._local_engine_mode = None
         self._spectated_engine_id = None
         self._local_grind = 0
@@ -2017,6 +2018,7 @@ class BattleRuntime(object):
         self._local_native_matrix = None
         self._local_native_stabilised_matrix = None
         self._local_camera_velocity = None
+        self._reset_local_camera_motion()
         self._local_engine_mode = None
         self._spectated_engine_id = None
         self._local_grind = 0
@@ -6086,6 +6088,11 @@ class BattleRuntime(object):
             steady_rotation_matrix=self._local_steady_rotation(),
             stabilised_matrix=self._local_stabilised_pose())
         self._local_camera_velocity = zero_motion
+        self._reset_local_camera_motion()
+        # Seed the motion history with the spawn pose so the very first
+        # copied-physics frame already has one earlier sample to difference.
+        self._local_motion_history.append(
+            (0.0, tuple(float(value) for value in self._local_position)))
         self._local_physics = vehicle_physics.derive_params(
             entity.typeDescriptor,
             self._local_factors(entity.typeDescriptor))
@@ -6438,23 +6445,107 @@ class BattleRuntime(object):
             self._local_swinging_probe = None
         return True
 
+    def _reset_local_camera_motion(self):
+        """Drop the pose history behind the copied camera-motion estimate."""
+        self._local_motion_history = []
+        self._local_motion_clock = 0.0
+        self._local_motion_window = None
+        return True
+
+    def _camera_motion_window(self):
+        """Return the exact #1513 pose-sample interval for camera motion."""
+        window = self._local_motion_window
+        if window is not None:
+            return window
+        value = getattr(
+            self._runtime.constants, 'SERVER_TICK_LENGTH', None)
+        try:
+            window = float(value)
+        except (TypeError, ValueError):
+            raise RuntimeError('#1513 server tick length is unavailable')
+        if not window > 0.0:
+            raise RuntimeError('#1513 server tick length is invalid')
+        self._local_motion_window = window
+        return window
+
+    def _local_motion_pose_at(self, moment):
+        """Read the recorded copied pose at one exact earlier moment."""
+        history = self._local_motion_history
+        if not history or moment < history[0][0]:
+            return None
+        index = len(history) - 1
+        while index > 0 and history[index][0] > moment:
+            index -= 1
+        if index + 1 >= len(history):
+            return history[index][1]
+        earlier_moment, earlier = history[index]
+        later_moment, later = history[index + 1]
+        span = later_moment - earlier_moment
+        if span <= 0.0:
+            return later
+        ratio = (moment - earlier_moment) / span
+        return tuple(
+            earlier[axis] + (later[axis] - earlier[axis]) * ratio
+            for axis in range(3))
+
+    def _local_camera_motion(self, position, dt, previous_velocity):
+        """Estimate the pose motion #1513's dynamic cameras consume.
+
+        Retail fills ``WGVehicleFilter.velocity`` and ``acceleration`` from
+        the native filter, which observes the vehicle pose on the exact
+        ``constants.SERVER_TICK_LENGTH`` grid.  ``AccelerationSmoother`` and
+        ``SniperCamera.__calcCurOscillatorAcceleration`` turn that value into
+        camera rotation, so at sniper zoom it is an aiming input.
+
+        Differentiating this port's copied pose twice per rendered frame
+        measures the ground-follow snap instead of vehicle motion, and scales
+        the result with the frame rate: the same 112 m Prokhorovka drive
+        peaks at 18.5 m/s^2 at 60 FPS and 10.3 m/s^2 at 30 FPS.
+        Read the recorded pose at that exact interval instead.  Publication
+        cadence is unchanged; every rendered frame still carries a value.
+        """
+        window = self._camera_motion_window()
+        history = self._local_motion_history
+        moment = self._local_motion_clock + dt
+        self._local_motion_clock = moment
+        history.append((moment, position))
+        # Two intervals answer both differences.  Keep the newest sample
+        # already older than that span so the oldest lookup stays bracketed.
+        limit = moment - 2.0 * window
+        drop = 0
+        while drop + 1 < len(history) and history[drop + 1][0] <= limit:
+            drop += 1
+        if drop:
+            del history[:drop]
+
+        recent = self._local_motion_pose_at(moment - window)
+        if recent is None:
+            # A spawn, respawn or teardown leaves less than one interval of
+            # history.  Publish the last known velocity rather than invent
+            # one, exactly as a zero-length frame does.
+            return previous_velocity, (0.0, 0.0, 0.0)
+        velocity = tuple(
+            (position[axis] - recent[axis]) / window for axis in range(3))
+        earlier = self._local_motion_pose_at(moment - 2.0 * window)
+        if earlier is None:
+            return velocity, (0.0, 0.0, 0.0)
+        previous = tuple(
+            (recent[axis] - earlier[axis]) / window for axis in range(3))
+        acceleration = tuple(
+            (velocity[axis] - previous[axis]) / window for axis in range(3))
+        return velocity, acceleration
+
     def _update_local_presentation(self, entity, dt=0.0):
         if self._local_matrix is None or self._local_model is None:
             raise RuntimeError('player presentation is not attached')
         previous_yaw = float(getattr(
             self._local_matrix, 'yaw', self._local_yaw))
-        previous_position = _xyz(self._local_matrix.translation)
         position = self._vector(self._local_position)
         dt = max(0.0, float(dt))
         previous_velocity = _xyz(self._local_camera_velocity)
         if dt > 0.0:
-            current_position = _xyz(position)
-            velocity_tuple = tuple(
-                (current_position[index] - previous_position[index]) / dt
-                for index in range(3))
-            acceleration_tuple = tuple(
-                (velocity_tuple[index] - previous_velocity[index]) / dt
-                for index in range(3))
+            velocity_tuple, acceleration_tuple = self._local_camera_motion(
+                _xyz(position), dt, previous_velocity)
         else:
             velocity_tuple = previous_velocity
             acceleration_tuple = (0.0, 0.0, 0.0)
@@ -6626,6 +6717,7 @@ class BattleRuntime(object):
         self._local_native_matrix = None
         self._local_native_stabilised_matrix = None
         self._local_camera_velocity = None
+        self._reset_local_camera_motion()
         self._local_engine_mode = None
         return True
 
@@ -23831,6 +23923,7 @@ class BattleRuntime(object):
         self._local_native_matrix = None
         self._local_native_stabilised_matrix = None
         self._local_camera_velocity = None
+        self._reset_local_camera_motion()
         self._local_engine_mode = None
         self._spectated_engine_id = None
         self._local_grind = 0

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -2025,6 +2025,7 @@ def _runtime():
             VEHICLE_KILLED=6, AVATAR_READY=7, TEAM_KILLER=10),
         ARENA_PERIOD=types.SimpleNamespace(PREBATTLE=2, BATTLE=3),
         VEHICLE_PHYSICS_MODE=types.SimpleNamespace(STANDARD=0),
+        SERVER_TICK_LENGTH=0.1,
         VEHICLE_SIEGE_STATE=types.SimpleNamespace(
             DISABLED=0, SWITCHING_ON=1, ENABLED=2, SWITCHING_OFF=3),
         VEHICLE_SETTING=types.SimpleNamespace(
@@ -15702,7 +15703,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertEqual(attach_reads, entity.model.reads)
         self.assertIs(battle._local_matrix, entity.model._matrix)
 
-    def test_local_camera_motion_is_derived_from_copied_pose_each_frame(self):
+    def _camera_motion_battle(self):
         runtime = _runtime()
         battle = BattleRuntime(runtime)
         battle.client = _Client()
@@ -15714,30 +15715,118 @@ class BattleRuntimeContractTests(unittest.TestCase):
         battle._local_position = (2.0, 3.0, 4.0)
         battle._local_descriptor = entity.typeDescriptor
         battle._attach_local_presentation()
+        return runtime, battle, entity
+
+    @staticmethod
+    def _camera_motion_overlay(runtime, entity):
+        overlay = runtime.compatibility.pose_overlays[id(entity)]
+        return (tuple(overlay['velocity']), tuple(overlay['acceleration']))
+
+    def test_local_camera_motion_uses_the_exact_client_sample_interval(self):
+        # Retail fills WGVehicleFilter.velocity/acceleration from the native
+        # filter on the constants.SERVER_TICK_LENGTH grid.  Differencing the
+        # copied pose once per rendered frame instead measures the ground
+        # snap and scales with the frame rate, and SniperCamera turns that
+        # straight into camera rotation.
+        runtime, battle, entity = self._camera_motion_battle()
 
         battle._local_position = (2.0, 3.0, 4.5)
         battle._update_local_presentation(entity, 0.1)
-        overlay = runtime.compatibility.pose_overlays[id(entity)]
-        self.assertEqual((0.0, 0.0, 5.0), tuple(overlay['velocity']))
-        self.assertEqual((0.0, 0.0, 50.0),
-                         tuple(overlay['acceleration']))
+        velocity, acceleration = self._camera_motion_overlay(runtime, entity)
+        self.assertEqual((0.0, 0.0, 5.0), velocity)
+        # One completed interval carries a velocity but no second difference.
+        self.assertEqual((0.0, 0.0, 0.0), acceleration)
 
         battle._local_position = (2.0, 3.0, 5.0)
         battle._update_local_presentation(entity, 0.1)
-        overlay = runtime.compatibility.pose_overlays[id(entity)]
-        self.assertEqual((0.0, 0.0, 5.0), tuple(overlay['velocity']))
-        self.assertEqual((0.0, 0.0, 0.0),
-                         tuple(overlay['acceleration']))
+        velocity, acceleration = self._camera_motion_overlay(runtime, entity)
+        self.assertEqual((0.0, 0.0, 5.0), velocity)
+        self.assertEqual((0.0, 0.0, 0.0), acceleration)
 
         battle._sender = types.SimpleNamespace(
             forward=1.0, turn=0.0, handbrake=False,
             send_current=mock.Mock(return_value=True))
         battle._battle_result = {'winner': 1}
         battle._drive_local(0.1)
-        overlay = runtime.compatibility.pose_overlays[id(entity)]
-        self.assertEqual((0.0, 0.0, 0.0), tuple(overlay['velocity']))
-        self.assertEqual((0.0, 0.0, -50.0),
-                         tuple(overlay['acceleration']))
+        velocity, acceleration = self._camera_motion_overlay(runtime, entity)
+        self.assertEqual((0.0, 0.0, 0.0), velocity)
+        for expected, actual in zip((0.0, 0.0, -50.0), acceleration):
+            self.assertAlmostEqual(expected, actual, places=6)
+
+    def test_camera_motion_estimate_does_not_scale_with_the_frame_rate(self):
+        # One slope discontinuity, exactly what a terrain triangle edge
+        # produces under the copied ground follow.  Its true second
+        # difference over the exact client interval is
+        # 6 m/s * 0.06 / 0.1 s = 3.6 m/s^2.  A per-frame second difference
+        # reports 0.36 / dt instead: 8.6 at 24 FPS and 43.2 at 120 FPS.
+        def peak(frame_rate):
+            runtime, battle, entity = self._camera_motion_battle()
+            dt = 1.0 / frame_rate
+            highest = 0.0
+            for frame in range(1, 2 * frame_rate + 1):
+                moment = frame * dt
+                z = 4.0 + 6.0 * moment
+                y = 3.0 if z < 10.0 else 3.0 + 0.06 * (z - 10.0)
+                battle._local_position = (2.0, y, z)
+                battle._update_local_presentation(entity, dt)
+                unused, acceleration = self._camera_motion_overlay(
+                    runtime, entity)
+                highest = max(highest, max(abs(v) for v in acceleration))
+            return highest
+
+        peaks = [peak(rate) for rate in (24, 30, 45, 60, 90, 120)]
+        for value in peaks:
+            self.assertLessEqual(value, 3.6 * 1.01)
+        self.assertGreater(min(peaks), 0.0)
+        self.assertLess(max(peaks) / min(peaks), 1.25)
+
+    def test_a_one_frame_ground_snap_is_not_a_camera_impulse(self):
+        # A five centimetre vertical step inside one rendered frame is a
+        # discretisation of the copied ground follow, not vehicle dynamics.
+        runtime, battle, entity = self._camera_motion_battle()
+        dt = 1.0 / 60.0
+        highest = 0.0
+        for frame in range(1, 61):
+            y = 3.0 if frame < 30 else 3.05
+            battle._local_position = (2.0, y, 4.0)
+            battle._update_local_presentation(entity, dt)
+            unused, acceleration = self._camera_motion_overlay(
+                runtime, entity)
+            highest = max(highest, abs(acceleration[1]))
+        # The rejected per-frame estimate reports 0.05 / dt ** 2 = 180 m/s^2.
+        self.assertLess(highest, 10.0)
+
+    def test_a_parked_player_publishes_no_camera_motion(self):
+        runtime, battle, entity = self._camera_motion_battle()
+        for unused_frame in range(60):
+            battle._update_local_presentation(entity, 1.0 / 60.0)
+        velocity, acceleration = self._camera_motion_overlay(runtime, entity)
+        self.assertEqual((0.0, 0.0, 0.0), velocity)
+        self.assertEqual((0.0, 0.0, 0.0), acceleration)
+
+    def test_camera_motion_history_is_dropped_with_the_presentation(self):
+        # A retained history would report hundreds of metres per second on
+        # the first frame after the next spawn.
+        runtime, battle, entity = self._camera_motion_battle()
+        battle._local_position = (2.0, 3.0, 4.5)
+        battle._update_local_presentation(entity, 0.1)
+        self.assertTrue(battle._local_motion_history)
+
+        battle._detach_local_presentation()
+
+        self.assertEqual([], battle._local_motion_history)
+        self.assertEqual(0.0, battle._local_motion_clock)
+
+    def test_camera_motion_history_stays_bounded_at_a_high_frame_rate(self):
+        runtime, battle, entity = self._camera_motion_battle()
+        for frame in range(1, 601):
+            battle._local_position = (2.0, 3.0, 4.0 + frame * 0.01)
+            battle._update_local_presentation(entity, 1.0 / 300.0)
+        window = runtime.constants.SERVER_TICK_LENGTH
+        self.assertLessEqual(len(battle._local_motion_history), 64)
+        oldest = battle._local_motion_history[0][0]
+        self.assertLessEqual(
+            battle._local_motion_clock - oldest, 2.0 * window + window)
 
     def test_visible_local_motion_never_commits_destructibles(self):
         runtime = _runtime()

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -15750,6 +15750,8 @@ class BattleRuntimeContractTests(unittest.TestCase):
         battle._drive_local(0.1)
         velocity, acceleration = self._camera_motion_overlay(runtime, entity)
         self.assertEqual((0.0, 0.0, 0.0), velocity)
+        # These steps are one interval long, so the estimate reduces to the
+        # cell-tick second difference and reports the whole stop.
         for expected, actual in zip((0.0, 0.0, -50.0), acceleration):
             self.assertAlmostEqual(expected, actual, places=6)
 


### PR DESCRIPTION
## Report

> 有没有觉得开了狙击模式瞄准有点奇怪，就是车停车和移动时候，瞄准界面会抖动

There is a real defect behind the *moving* half. The parked half is not reproduced; see **What this does not explain**.

## The only path that rotates the #1513 sniper view

Traced through `res/packages/scripts.pkg` with a Python 2.7 disassembler, not a decompiler:

- `SniperCamera.__cameraUpdate` post-multiplies the camera matrix by the impulse and movement oscillator rotations.
- `SniperCamera.__updateOscillators` does `movementOscillator.externalForce += __calcCurOscillatorAcceleration(dt)`.
- `__calcCurOscillatorAcceleration` is `AccelerationSmoother.update(vehicle, dt)`, which reads `vehicle.filter.velocity` and `vehicle.filter.acceleration`, then `mathUtils.RangeFilter(accelerationThreshold, accelerationMax, 100, SMAFilter(5))`.

Two properties of that consumer matter:

- once a direction change is older than `maxAccelerationDuration` (default 1.5 s) the smoother keeps **only the vehicle-local vertical component**; any near-stop (`curVelocity.dot(prevVelocity) <= 0.01`) reopens the full 3-D vector for another 1.5 s;
- `RangeFilter` clamps the magnitude to `maxAllowedAcceleration` but preserves the direction, and silently zeroes anything at or above 100 m/s². A noisy input therefore reaches the oscillator as a full-amplitude vector that flips direction, or as an intermittent dropout.

The sniper *aim direction* is not the problem: `SniperAimingSystem.__STABILIZED_CONSTRAINTS` is `Vector3(2.1*pi, pi/2*0.95, 0.0)` with unit multipliers, and the yaw/pitch axes of its `PyOscillator` have zero stiffness and zero drag, so the aim is world-locked and hull attitude only shifts the camera position by a few centimetres.

## The defect

`_update_local_presentation` published `filter.velocity` and `filter.acceleration` as a first and second difference of the copied pose taken once per **rendered frame**. Retail fills them from the native filter, which observes the pose on the `constants.SERVER_TICK_LENGTH` (= 0.1 s) grid. The per-frame form measures the discretisation of the ground follow, and its amplitude scales with the frame rate.

Measured with the engine-free harness driving the copied physics over the real baked heights in `navgraphs/05_prohorovka.json` at 14 m/s for 112 m — peak camera-motion input, and frames above 10 m/s²:

| start | FPS | before | after |
| --- | --- | --- | --- |
| `(0, -400)` | 60 | **18.5** m/s² (5 frames >10) | **4.1** m/s² (0) |
| `(0, -400)` | 30 | 10.3 m/s² (1) | 4.5 m/s² (0) |
| `(300, -400)` | 60 | **71.5** m/s² (22) | **13.5** m/s² (6) |
| `(300, -400)` | 30 | 23.9 m/s² (11) | 10.3 m/s² (2) |
| `(-300, -400)` | 60 | 14.7 m/s² (4) | 7.7 m/s² (0) |
| `(-300, -400)` | 30 | 15.4 m/s² (3) | 8.3 m/s² (0) |

The identical trajectory produced 1.8x and 3.0x more camera input at 60 FPS than at 30 FPS. After the change the two rates agree within 10-30%.

## The change

Record the copied pose each frame and read it back at the exact client interval, interpolating between the two bracketing samples so the interval is exact regardless of frame pacing. `constants.SERVER_TICK_LENGTH` is read from the exact client and cached per round.

- Publication cadence is unchanged: every rendered frame still carries a value.
- History is bounded by two intervals (at most 64 samples even at 300 FPS) and is dropped at every site that clears `_local_camera_velocity`, so the first frame after a respawn cannot report a teleport as velocity.
- A frame with `dt == 0` keeps the previous behaviour.
- The same overlay feeds `ArcadeCamera.__calcCurOscillatorAcceleration`, so arcade is covered by the same fix.

The legitimate longitudinal lurch is untouched. On flat ground with the real copied physics, a start and a brake-to-stop report 3.9 and 11.3 m/s² before and after, at both 30 and 60 FPS, and a parked vehicle publishes exactly zero on both trees.

## Tradeoff

The estimate now lags a real acceleration change by up to one 0.1 s interval. That is exactly how retail samples a remote vehicle; retail's own-vehicle value comes from the native physics solver, which this port cannot use (`WGVehiclePhysics.update` is fatal in #1513). The alternative — deriving the velocity from the integrator's own drive state — needs an invented vertical model, so it was rejected.

## What this does not explain

- **Parked.** The overlay is exactly zero at rest on flat, sloped and rough ground on both trees, and stock's `randomNoiseOscillatorSpherical` only fires on shot/hit impulses. Discriminator for a Windows session: turn 动态摄像机 off. If the parked wobble survives that, it is not this path. A Bot leaning on the hull would feed `_resolve_local_tank_contacts` into this same overlay and would fit a "parked next to a teammate" report.
- **Separate findings, deliberately out of scope.** The copied brake law decelerates at 11.3 m/s² (1.16 g) on flat ground, roughly twice a real tank; and `_update_vertical_motion` uses `min(1.0, dt * 15.0)`, so the ground-follow filter is itself frame-rate dependent (no filtering at all at 15 FPS). Both touch landing damage and ground-follow physics.

## Validation

- `python -m unittest discover -s tests` — 4143 tests, OK.
- `python -m unittest tests.test_port_0922_battle_runtime` — 796 tests, OK.
- CPython 2.7.18 source compile of `src/res/scripts/client` — 96 files, passed.

New contract tests: the exact-interval estimate, frame-rate independence across 24/30/45/60/90/120 FPS, a one-frame 5 cm ground snap staying under 10 m/s² (the rejected form reports 180), zero motion while parked, history cleared with the presentation, and a bounded history at 300 FPS.

Evidence ladder: this proves frame-rate independence and a retail-plausible magnitude from local logic and exact client data. Whether the shake is gone in sniper mode is Windows acceptance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)