### PR TITLE
Stop broken destructibles from eating shells

### DIFF
--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -357,6 +357,22 @@ nearest vehicle cap the search, while ambiguity fails closed. Traversal resumes
 from the exact registered OBB exit plus a small epsilon, not a fixed jump that
 could skip a thick structure or its backing geometry.
 
+An item the round has already broken is not part of the collision scene. #1513
+`Vehicle._isDestructibleMayBeBroken` reports an item as broken as soon as its
+chunk controller does, whatever the delayed hide callback still draws, and a
+falling atom keeps its native skin in the world for the whole round. Vehicle
+movement and the HE blast rays already hide those skins through the exact
+`(chunk, item, material)` native keep-callback. The solid-shell ray now uses
+the same law: a proved-broken surface is filtered out and the ray is re-cast,
+so a felled pole or a broken wall panel no longer stops later shells while
+intact sibling modules and backing walls stay authoritative. A shell that has
+just destroyed an admitted item and cannot resolve that item's registered OBB
+exit resumes at the next surface proved by the same filtered re-cast rather
+than ending on debris. Every scenery stop now carries a `stop_reason`, so a
+Windows report can distinguish the legal `above_threshold_hp` and
+`shell_family` refusals from an identity failure such as `catalog_miss`,
+`catalog_ambiguous` or `native_reject`.
+
 The exact #1513 `destructibles.xml` supplies both numeric shooting-through
 contracts: `maxHpForShootingThrough` is `19`, and every listed material has
 `projectilePiercingPowerReduction` factor/minimum values `(0, 25)`. Version
@@ -370,7 +386,19 @@ needed. A sampled remainder below 1 mm makes
 the shell disappear at that
 obstacle. An above-threshold item may be destroyed but stops traversal. Under
 the pre-1.13 HE mechanics used by #1513, HE and HEAT stop at the first
-destructible, and HE explodes at that point.
+destructible, and HE explodes at that point. Stock
+`vehicle_items.Shell.isAmmoPercingType` names exactly the same
+ARMOR_PIERCING/ARMOR_PIERCING_HE/ARMOR_PIERCING_CR family, so the split is the
+client's own set rather than a guess.
+
+`DESTR_TYPE_TREE` is a documented deviation from that numeric law. The pinned
+tree table ranges from health `3` for bushes and shrubs to `70` for large
+firs, and 303 of its 498 entries exceed `maxHpForShootingThrough`. The port
+instead makes any validated, felled SpeedTree fully transparent with no
+penetration loss and no shell-family gate, which is more permissive than the
+threshold. Applying the 19 HP cap to trees would make most large trees stop
+AP shells; that is a gameplay-feel decision that still needs an exact-Windows
+comparison, so it is recorded here rather than changed.
 
 The threshold and material reduction are exact pinned-resource evidence.
 Official same-family mechanics descriptions support the shell-family split,

--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -391,14 +391,36 @@ destructible, and HE explodes at that point. Stock
 ARMOR_PIERCING/ARMOR_PIERCING_HE/ARMOR_PIERCING_CR family, so the split is the
 client's own set rather than a guess.
 
-`DESTR_TYPE_TREE` is a documented deviation from that numeric law. The pinned
-tree table ranges from health `3` for bushes and shrubs to `70` for large
-firs, and 303 of its 498 entries exceed `maxHpForShootingThrough`. The port
-instead makes any validated, felled SpeedTree fully transparent with no
-penetration loss and no shell-family gate, which is more permissive than the
-threshold. Applying the 19 HP cap to trees would make most large trees stop
-AP shells; that is a gameplay-feel decision that still needs an exact-Windows
-comparison, so it is recorded here rather than changed.
+`DESTR_TYPE_TREE` now follows the same numeric law. `destructibles.xml`
+publishes one `maxHpForShootingThrough` and one
+`projectilePiercingPowerReduction` table for every destructible type, and stock
+`Vehicle._isDestructibleMayBeBroken` runs a tree through the same
+non-structure branch it uses for fragiles and falling atoms, including
+`kineticDamageCorrection` -- which `DestructiblesCache.__readTree` does supply
+-- and the same `scaledDestructibleHealth(itemScale, refHealth)`. So a tree's
+reference health is scaled exactly like any other item's. The pinned tree table
+ranges from `3` for bushes and shrubs to `70` for large firs, and 303 of its
+498 entries exceed the cap, so most large trees now fell and then stop an AP
+shell while a small tree costs the flat 25 mm.
+
+Trees own no catalog OBB, so neither their item scale nor their exit distance
+can come from the baked catalog. Both come from the native item:
+`wg_getDestructibleMatrix` shares one native index space with
+`wg_getChunkDestrFilenames` and `wg_getDestructibleEffectCategory`, so a slot
+already proved resolved and named by the tree identity gate resolves there
+too, and `_matrix_item_scale_1513` reads the stock scale convention from it.
+The scale is frozen while the tree still stands, before the native fall can
+move its matrix, and the shell family is tested first so HE and HEAT never pay
+for the query. A tree the round has already felled keeps the broken-skin rule:
+it is not collision, costs no penetration and is never felled twice.
+
+Two boundaries remain unproved on this path. A native matrix query that fails
+for a resolved, named tree leaves no scale, which stops the shell and records
+`health_unavailable` rather than guessing a scale. And soft vegetation below
+health `10` -- 177 of the 498 entries, all bushes, shrubs and ferns -- is still
+excluded by the existing vegetation gate, so it is never felled and never
+tested against the cap; whether such an item can produce a mask-128 shell
+contact at all has not been observed on the exact client.
 
 The threshold and material reduction are exact pinned-resource evidence.
 Official same-family mechanics descriptions support the shell-family split,

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -1843,6 +1843,7 @@ class BattleRuntime(object):
         self._projectile_visual_meta = {}
         self._projectile_visual_terminals = _RecentIdSet()
         self._projectile_terminal_data = {}
+        self._projectile_scene_stop_reasons = {}
         self._projectile_target_positions = {}
         self._projectile_position_history = []
         self._projectile_historic_pose_cache = None
@@ -2139,6 +2140,7 @@ class BattleRuntime(object):
         self._projectile_visual_meta = {}
         self._projectile_visual_terminals = _RecentIdSet()
         self._projectile_terminal_data = {}
+        self._projectile_scene_stop_reasons = {}
         self._projectile_target_positions = {}
         self._projectile_position_history = []
         self._projectile_historic_pose_cache = None
@@ -11335,6 +11337,7 @@ class BattleRuntime(object):
         self._projectile_epoch = epoch
         self._projectile_meta = {}
         self._projectile_terminal_data = {}
+        self._projectile_scene_stop_reasons = {}
         # An epoch change elects a new simulator inside the same battle. Keep
         # observational target history across that handoff: restored shells
         # resume from their last checked cursor, which can predate election.
@@ -13642,14 +13645,17 @@ class BattleRuntime(object):
         if world_blocks:
             fraction = max(
                 0.0, min(1.0, world_distance / chord_length))
+            impact = lerp3(start, end, fraction)
             self._projectile_terminal_data[projectile_id] = {
-                'impact': lerp3(start, end, fraction),
+                'impact': impact,
                 'target_key': None,
                 'collisions': None,
                 'query': None,
                 'piercing_loss': meta['piercing_loss'],
                 'penetration_factor': meta.get('penetration_factor'),
+                'stop_reason': scene.get('stop_reason'),
             }
+            self._report_shot_scene_stop(scene.get('stop_reason'), impact)
             return {'reason': 'impact', 'fraction': fraction}
         if nearest_key is not None:
             self._projectile_terminal_data[projectile_id] = {
@@ -13665,6 +13671,30 @@ class BattleRuntime(object):
             }
             return {'reason': 'impact', 'fraction': nearest_fraction}
         return None
+
+    def _report_shot_scene_stop(self, reason, impact):
+        """Name the scenery contract that ended a shot, once per round.
+
+        A player only reports that "an object ate the shell".  The branch that
+        stopped it is the whole diagnosis: a legal ``above_threshold_hp`` or
+        ``shell_family`` refusal, a penetration budget spent on destructibles,
+        or an identity failure such as ``catalog_miss``.  One line per distinct
+        reason keeps a full battle log readable.
+        """
+        if reason is None or not bool(
+                (self._config or {}).get('debug_logging', False)):
+            return False
+        reasons = self._projectile_scene_stop_reasons
+        seen = reasons.get(reason, 0)
+        reasons[reason] = seen + 1
+        if seen:
+            return False
+        sys.stdout.write(
+            '[Offline LAN 0.9.22] SHOT scenery stop reason=%s at '
+            '(%.1f %.1f %.1f)\n' % (
+                reason, float(impact[0]), float(impact[1]),
+                float(impact[2])))
+        return True
 
     def _projectile_shot(self, meta):
         frozen = meta.get('source_shot')
@@ -23574,6 +23604,7 @@ class BattleRuntime(object):
                 'piercing_loss': initial_piercing_loss,
                 'stopped_by_destructible': False,
                 'penetration_factor': penetration_factor,
+                'stop_reason': None,
             }
         travelled = 0.0
         piercing_loss = initial_piercing_loss
@@ -23618,6 +23649,7 @@ class BattleRuntime(object):
                     'piercing_loss': piercing_loss,
                     'stopped_by_destructible': True,
                     'penetration_factor': penetration_factor,
+                    'stop_reason': 'penetration_exhausted',
                 }
             stop_distance = result.get('stop_distance')
             if stop_distance is not None:
@@ -23628,6 +23660,7 @@ class BattleRuntime(object):
                     'stopped_by_destructible': bool(
                         result.get('stopped_by_destructible')),
                     'penetration_factor': penetration_factor,
+                    'stop_reason': result.get('stop_reason'),
                 }
             advance = result.get('continue_from')
             if advance is None:
@@ -23640,6 +23673,7 @@ class BattleRuntime(object):
                     'piercing_loss': piercing_loss,
                     'stopped_by_destructible': False,
                     'penetration_factor': penetration_factor,
+                    'stop_reason': result.get('stop_reason'),
                 }
             advance = _number(advance)
             if advance <= 0.0:
@@ -23650,7 +23684,8 @@ class BattleRuntime(object):
                 return {'world_distance': 999999.0,
                         'piercing_loss': piercing_loss,
                         'stopped_by_destructible': False,
-                        'penetration_factor': penetration_factor}
+                        'penetration_factor': penetration_factor,
+                        'stop_reason': None}
         raise RuntimeError('#1513 destructible shot traversal exceeded 64 hits')
 
     @staticmethod
@@ -23986,6 +24021,7 @@ class BattleRuntime(object):
         self._projectile_visual_meta = {}
         self._projectile_visual_terminals = _RecentIdSet()
         self._projectile_terminal_data = {}
+        self._projectile_scene_stop_reasons = {}
         self._projectile_target_positions = {}
         self._projectile_position_history = []
         self._projectile_historic_pose_cache = None

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/destructibles_sensor.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/destructibles_sensor.py
@@ -6017,6 +6017,53 @@ def _broken_shot_surface_key_1513(chunk_id, item_index, mat_kind):
 	return None
 
 
+def _native_item_scale_1513(measured, spaceID, chunk_id, item_index):
+	"""Read one native destructible item scale without quarantining the slot.
+
+	``wg_getDestructibleMatrix`` shares the exact native item index space with
+	``wg_getChunkDestrFilenames`` and ``wg_getDestructibleEffectCategory``, so a
+	SpeedTree slot already proved resolved and named by the tree identity gate
+	resolves here too.  Trees own no catalog OBB, so this is the only scale
+	source for them.  A failed query is an anomaly for the caller to classify,
+	not evidence that the slot is unsafe.
+	"""
+	import BigWorld
+	import Math
+	try:
+		matrix = Math.Matrix(measured(
+			'native.destructible.item_matrix',
+			BigWorld.wg_getDestructibleMatrix,
+			spaceID, int(chunk_id), int(item_index)))
+		return _matrix_item_scale_1513(matrix, Math)
+	except Exception:
+		return None
+
+
+def _tree_shoot_through_1513(measured, spaceID, decoded, shot):
+	"""Return ``(allowed, health)`` for one standing SpeedTree on a shell ray.
+
+	#1513 keeps trees under the same numeric destructible contract as every
+	other type.  ``destructibles.xml`` publishes one ``maxHpForShootingThrough``
+	and one ``projectilePiercingPowerReduction`` table for all of them, and
+	stock ``Vehicle._isDestructibleMayBeBroken`` runs a tree through the same
+	``scaledDestructibleHealth(itemScale, refHealth)`` branch it uses for
+	fragiles and falling atoms, including ``kineticDamageCorrection``, which
+	``DestructiblesCache.__readTree`` does supply.  The shell family is checked
+	first so HE and HEAT never pay for a native matrix query.
+	"""
+	if _shot_kind_1513(shot) not in _SHOT_AP_KINDS_1513:
+		return False, None
+	import AreaDestructibles
+	desc = _runtime_material_descriptor_1513(
+		AreaDestructibles, decoded[5], decoded[2], decoded[3])
+	health = _scaled_shot_through_health_1513(
+		desc, decoded[4],
+		_native_item_scale_1513(
+			measured, spaceID, decoded[2], decoded[3]))
+	return (health is not None and
+		health <= _SHOT_THROUGH_MAX_HP_1513), health
+
+
 def _shot_broken_surface_advance_1513(measured, bigworld, spaceID,
 		start_pos, end_pos, identity, obstacle_distance, ignored_surfaces,
 		surface_filter):
@@ -6082,6 +6129,15 @@ def shot_world_distance(bigworld, spaceID, start_pos, end_pos, dir_vec,
 				spaceID, start_pos, end_pos, world_dist)
 			if catalog_hit is not None:
 				break
+		tree_shoot_through = None
+		if (tree_identity is not None and shot is not None and
+				not _get_destr_authority().is_destroyed(
+					tree_identity[0], tree_identity[1], decoded[4])):
+			# Freeze this standing tree's own scaled health before the
+			# native fall can move its item matrix.  The legacy float
+			# contract has no shell to test and keeps tree transparency.
+			tree_shoot_through = _tree_shoot_through_1513(
+				measured, spaceID, decoded, shot)
 		destruction_accepted = _try_destroy_destructible(
 			spaceID, mat_info, shot_yaw, 12.0, True)
 		if destruction_accepted:
@@ -6093,7 +6149,30 @@ def shot_world_distance(bigworld, spaceID, start_pos, end_pos, dir_vec,
 		if tree_identity is not None and (
 				destruction_accepted or _get_destr_authority().is_destroyed(
 					tree_identity[0], tree_identity[1], decoded[4])):
-			broken_surface = (tree_identity[0], tree_identity[1], None)
+			tree_key = (tree_identity[0], tree_identity[1], None)
+			if not (destruction_accepted and
+					tree_shoot_through is not None):
+				# A tree the round already felled is not collision at all.
+				broken_surface = tree_key
+			elif not tree_shoot_through[0]:
+				# Above the threshold, or HE/HEAT: felled, but the shell
+				# ends here exactly like any other destructible.
+				return _typed_shot_result_1513(
+					world_dist, stop_distance=world_dist,
+					stopped_by_destructible=True,
+					stop_reason=_shot_through_refusal_1513(
+						shot, tree_shoot_through[1]))
+			else:
+				# Trees own no catalog OBB, so the proved next surface is
+				# the only exit evidence available for one.
+				return _typed_shot_result_1513(
+					99999.0,
+					piercing_loss=_SHOT_THROUGH_MIN_REDUCTION_1513,
+					continue_from=_shot_broken_surface_advance_1513(
+						measured, bigworld, spaceID, start_pos, end_pos,
+						tree_key, world_dist, ignored_surfaces,
+						surface_filter),
+					loss_distance=world_dist)
 		elif not destruction_accepted:
 			# A fragile, module or falling atom that this round already broke
 			# keeps its native skin while the hide callback runs, and a felled

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/destructibles_sensor.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/destructibles_sensor.py
@@ -5877,9 +5877,24 @@ def _scaled_shot_through_health_1513(desc, mat_kind, item_scale):
 		return None
 
 
+def _shot_through_refusal_1513(shot, health):
+	"""Name why an item this shell destroyed still ended its flight.
+
+	The pinned #1513 ``destructibles.xml`` caps shooting through at
+	``maxHpForShootingThrough`` = 19, and stock ``Shell.isAmmoPercingType``
+	restricts the family to AP, APHE and APCR.  Both refusals are legal retail
+	behaviour, so a report needs to tell them apart from a failed lookup.
+	"""
+	if _shot_kind_1513(shot) not in _SHOT_AP_KINDS_1513:
+		return 'shell_family'
+	if health is None:
+		return 'health_unavailable'
+	return 'above_threshold_hp'
+
+
 def _typed_shot_result_1513(world_distance, stop_distance=None,
 		piercing_loss=0.0, continue_from=None, loss_distance=None,
-		stopped_by_destructible=False):
+		stopped_by_destructible=False, stop_reason=None):
 	return {
 		'world_distance': float(world_distance),
 		'stop_distance': (None if stop_distance is None
@@ -5890,6 +5905,9 @@ def _typed_shot_result_1513(world_distance, stop_distance=None,
 		'loss_distance': (None if loss_distance is None
 			else float(loss_distance)),
 		'stopped_by_destructible': bool(stopped_by_destructible),
+		# Names the exact branch that ended the ray.  A Windows report can then
+		# say which contract stopped a shell instead of only that one did.
+		'stop_reason': (None if stop_reason is None else str(stop_reason)),
 	}
 
 
@@ -5924,17 +5942,105 @@ def _validated_tree_shot_identity_1513(spaceID, decoded):
 	return int(chunk_id), int(item_index)
 
 
-def _transparent_tree_shot_filter_1513(ignored_trees):
-	"""Keep every native surface except an exact validated SpeedTree."""
+def _transparent_shot_surface_filter_1513(ignored_surfaces):
+	"""Keep every native surface except an exact proved-broken destructible.
+
+	``ignored_surfaces`` holds ``(chunkID, itemIndex, matKind)`` keys.  A ``None``
+	material covers the whole item, which is how SpeedTrees, fragiles and falling
+	atoms are addressed.  A structure names its exact broken module so its intact
+	sibling modules and any backing wall still stop the shell.
+	"""
 	def keep_surface(*hit):
 		# #1513 passes (matKind, collFlags, itemIndex, chunkID).  Malformed or
-		# ordinary surfaces stay authoritative; only exact tree wires are skipped.
+		# ordinary surfaces stay authoritative; only proved-broken destructible
+		# skins are skipped.
 		try:
 			identity = int(hit[3]), int(hit[2])
 		except (IndexError, TypeError, ValueError, OverflowError):
 			return True
-		return identity not in ignored_trees
+		if identity + (None,) in ignored_surfaces:
+			return False
+		try:
+			material = hit[0]
+		except IndexError:
+			return True
+		try:
+			return identity + (material,) not in ignored_surfaces
+		except TypeError:
+			return True
 	return keep_surface
+
+
+def _already_broken_shot_surface_1513(decoded):
+	"""Return the exact broken identity this native shell surface belongs to.
+
+	#1513 ``Vehicle._isDestructibleMayBeBroken`` treats an item as broken as soon
+	as the chunk controller reports it, whatever the delayed hide callback still
+	draws, and a falling atom keeps its native skin in the world for the whole
+	round.  The movement path already hides those skins through
+	``ground_collision_filter``/``horizontal_collision_filter``; the shell ray
+	must use the same law or a felled pole eats every later shell.  Only a
+	destructible material range plus an accepted authority key may skip a
+	surface, so an ordinary wall is never hidden by a coincidental index.
+	"""
+	if decoded is None:
+		return None
+	unused_hit, unused_normal, chunk_id, item_index, mat_kind, unused_name = \
+		decoded
+	try:
+		if (mat_kind < _DESTRUCTIBLE_MAT_KIND_MIN_1513 or
+				mat_kind > _DESTRUCTIBLE_MAT_KIND_MAX_1513):
+			return None
+		identity = int(chunk_id), int(item_index)
+	except (TypeError, ValueError, OverflowError):
+		return None
+	if _destructible_isolated_1513(identity[0], identity[1]):
+		return None
+	return _broken_shot_surface_key_1513(
+		identity[0], identity[1], mat_kind)
+
+
+def _broken_shot_surface_key_1513(chunk_id, item_index, mat_kind):
+	"""Return the accepted key that removes one broken surface from the ray.
+
+	A tree, fragile or falling atom is accepted whole and is addressed with a
+	``None`` material.  A structure is accepted per module, so only the exact
+	broken module may be hidden while its siblings keep stopping the shell.
+	"""
+	authority = _get_destr_authority()
+	identity = int(chunk_id), int(item_index)
+	if authority.is_destroyed(identity[0], identity[1], None):
+		return identity + (None,)
+	if (mat_kind is not None and
+			authority.is_destroyed(identity[0], identity[1], mat_kind)):
+		return identity + (mat_kind,)
+	return None
+
+
+def _shot_broken_surface_advance_1513(measured, bigworld, spaceID,
+		start_pos, end_pos, identity, obstacle_distance, ignored_surfaces,
+		surface_filter):
+	"""Return a proved resume distance past one exact just-broken skin.
+
+	The item this shell destroyed no longer belongs to the collision scene, but
+	its registered OBB exit was not available, so a fixed jump could skip real
+	geometry.  Hiding this exact identity and re-casting proves that nothing
+	else stands between the contact and the next unfiltered surface, which is
+	where the caller resumes.
+	"""
+	if identity is None:
+		# The destroy order was accepted but left no readable key.  Keep the
+		# historical conservative advance rather than hiding an unknown surface.
+		return float(obstacle_distance) + 0.6
+	ignored_surfaces.add(identity)
+	next_hit = measured('native.projectile.world',
+		bigworld.wg_collideSegment,
+		spaceID, start_pos, end_pos, 128, surface_filter)
+	floor = float(obstacle_distance) + _SHOT_RAY_EPSILON
+	if next_hit is None:
+		return max(floor, (end_pos - start_pos).length)
+	return max(floor,
+		(next_hit[0] - start_pos).length - _SHOT_RAY_EPSILON)
 
 
 def shot_world_distance(bigworld, spaceID, start_pos, end_pos, dir_vec,
@@ -5950,9 +6056,9 @@ def shot_world_distance(bigworld, spaceID, start_pos, end_pos, dir_vec,
 			return function(*args)
 		return diagnostic.call(stage, function, *args)
 
-	ignored_trees = set()
-	tree_filter = _transparent_tree_shot_filter_1513(ignored_trees)
-	tree_hits = 0
+	ignored_surfaces = set()
+	surface_filter = _transparent_shot_surface_filter_1513(ignored_surfaces)
+	skipped_hits = 0
 	world_dist = 99999.0
 	world_collision = measured('native.projectile.world',
 		bigworld.wg_collideSegment,
@@ -5983,20 +6089,33 @@ def shot_world_distance(bigworld, spaceID, start_pos, end_pos, dir_vec,
 				_diagnostic_contact_1513(
 					'shot_material_accept', decoded[2], decoded[3],
 					fields=(('mat', decoded[4]),))
+		broken_surface = None
 		if tree_identity is not None and (
 				destruction_accepted or _get_destr_authority().is_destroyed(
 					tree_identity[0], tree_identity[1], decoded[4])):
-			if tree_identity in ignored_trees:
+			broken_surface = (tree_identity[0], tree_identity[1], None)
+		elif not destruction_accepted:
+			# A fragile, module or falling atom that this round already broke
+			# keeps its native skin while the hide callback runs, and a felled
+			# column keeps it for the whole round.  Retail removes it from
+			# collision at once, so it must not stop a later shell either.
+			broken_surface = _already_broken_shot_surface_1513(decoded)
+			if broken_surface is not None:
+				_diagnostic_contact_1513(
+					'shot_broken_skin_skip', broken_surface[0],
+					broken_surface[1], fields=(('mat', broken_surface[2]),))
+		if broken_surface is not None:
+			if broken_surface in ignored_surfaces:
 				raise RuntimeError(
-					'#1513 transparent tree shot filter did not advance')
-			ignored_trees.add(tree_identity)
-			tree_hits += 1
-			if tree_hits > 64:
+					'#1513 transparent shot surface filter did not advance')
+			ignored_surfaces.add(broken_surface)
+			skipped_hits += 1
+			if skipped_hits > 64:
 				raise RuntimeError(
-					'#1513 transparent tree shot traversal exceeded 64 hits')
+					'#1513 transparent shot traversal exceeded 64 hits')
 			world_collision = measured('native.projectile.world',
 				bigworld.wg_collideSegment,
-				spaceID, start_pos, end_pos, 128, tree_filter)
+				spaceID, start_pos, end_pos, 128, surface_filter)
 			continue
 		if destruction_accepted:
 			if shot is not None:
@@ -6015,10 +6134,17 @@ def shot_world_distance(bigworld, spaceID, start_pos, end_pos, dir_vec,
 						start_pos, end_pos, decoded[0])
 					if registered_exit is None:
 						if _destructible_catalog is not None:
-							return _typed_shot_result_1513(
-								world_dist, stop_distance=world_dist,
-								stopped_by_destructible=True)
-						continue_from = world_dist + 0.6
+							# The item is gone; only its exact exit is unknown.
+							# Prove the next surface instead of ending an
+							# admitted shot on debris.
+							continue_from = _shot_broken_surface_advance_1513(
+								measured, bigworld, spaceID, start_pos,
+								end_pos,
+								_broken_shot_surface_key_1513(
+									decoded[2], decoded[3], decoded[4]),
+								world_dist, ignored_surfaces, surface_filter)
+						else:
+							continue_from = world_dist + 0.6
 					else:
 						continue_from = (registered_exit +
 							_SHOT_RAY_EPSILON)
@@ -6027,7 +6153,8 @@ def shot_world_distance(bigworld, spaceID, start_pos, end_pos, dir_vec,
 						continue_from=continue_from, loss_distance=world_dist)
 				return _typed_shot_result_1513(
 					world_dist, stop_distance=world_dist,
-					stopped_by_destructible=True)
+					stopped_by_destructible=True,
+					stop_reason=_shot_through_refusal_1513(shot, health))
 			# Destructible broken by the shell: re-cast past the debris.
 			second = measured('native.projectile.world',
 				bigworld.wg_collideSegment,
@@ -6084,6 +6211,8 @@ def shot_world_distance(bigworld, spaceID, start_pos, end_pos, dir_vec,
 				'shot_catalog_miss', point=world_collision[0])
 		return (_typed_shot_result_1513(
 			world_dist, stop_distance=(world_dist
+				if world_collision is not None else None),
+			stop_reason=('catalog_miss'
 				if world_collision is not None else None))
 			if shot is not None else world_dist)
 	if catalog_hit['ambiguous']:
@@ -6093,7 +6222,8 @@ def shot_world_distance(bigworld, spaceID, start_pos, end_pos, dir_vec,
 		ambiguous_distance = float(catalog_hit['distance'])
 		return (_typed_shot_result_1513(
 			ambiguous_distance, stop_distance=ambiguous_distance,
-			stopped_by_destructible=True)
+			stopped_by_destructible=True,
+			stop_reason='catalog_ambiguous')
 			if shot is not None else ambiguous_distance)
 
 	candidate = catalog_hit['candidate']
@@ -6111,6 +6241,8 @@ def shot_world_distance(bigworld, spaceID, start_pos, end_pos, dir_vec,
 			fields=(('kind', kind), ('mat', mat_kind)))
 		return (_typed_shot_result_1513(
 			world_dist, stop_distance=(world_dist
+				if world_collision is not None else None),
+			stop_reason=('native_reject'
 				if world_collision is not None else None))
 			if shot is not None else world_dist)
 	_diagnostic_contact_1513(
@@ -6124,15 +6256,27 @@ def shot_world_distance(bigworld, spaceID, start_pos, end_pos, dir_vec,
 			desc, mat_kind, candidate[5])
 		can_continue = (_shot_kind_1513(shot) in _SHOT_AP_KINDS_1513 and
 			health is not None and health <= _SHOT_THROUGH_MAX_HP_1513)
-		if can_continue and catalog_hit.get('exit_proved', True):
+		if can_continue:
+			if catalog_hit.get('exit_proved', True):
+				continue_from = (catalog_hit['exit_distance'] +
+					_SHOT_RAY_EPSILON)
+			else:
+				# Same law as the native material path: an item this shell
+				# just removed may not end the shot merely because its OBB
+				# exit was unavailable.
+				continue_from = _shot_broken_surface_advance_1513(
+					measured, bigworld, spaceID, start_pos, end_pos,
+					_broken_shot_surface_key_1513(
+						chunk_id, item_index, mat_kind),
+					catalog_hit['distance'], ignored_surfaces, surface_filter)
 			return _typed_shot_result_1513(
 				99999.0, piercing_loss=_SHOT_THROUGH_MIN_REDUCTION_1513,
-				continue_from=(catalog_hit['exit_distance'] +
-					_SHOT_RAY_EPSILON),
+				continue_from=continue_from,
 				loss_distance=catalog_hit['distance'])
 		return _typed_shot_result_1513(
 			catalog_hit['distance'], stop_distance=catalog_hit['distance'],
-			stopped_by_destructible=True)
+			stopped_by_destructible=True,
+			stop_reason=_shot_through_refusal_1513(shot, health))
 	# Re-cast beyond the proved OBB just like the legacy material path.  This
 	# lets a shell continue after a dynamic-only prop while a surviving static
 	# backing remains authoritative for structures during native replacement.

--- a/tests/test_port_0922_destructibles.py
+++ b/tests/test_port_0922_destructibles.py
@@ -3566,7 +3566,7 @@ class DestructiblesCompatibilityTests(unittest.TestCase):
         self.assertTrue(lookups)
         self.assertEqual({filename}, set(lookups))
 
-    def test_typed_native_trees_are_transparent_without_skipping_wall(self):
+    def test_typed_native_felled_trees_are_transparent_without_wall(self):
         filenames = (
             'speedtree/45_North_America/Maple.spt',
             'speedtree/45_North_America/Oak.spt')
@@ -3613,18 +3613,11 @@ class DestructiblesCompatibilityTests(unittest.TestCase):
         for shell_kind in (
                 'ARMOR_PIERCING', 'ARMOR_PIERCING_CR',
                 'ARMOR_PIERCING_HE', 'HOLLOW_CHARGE', 'HIGH_EXPLOSIVE'):
-            destroyed = set()
             calls = []
-
-            def destroy_tree(*args):
-                calls.append(args)
-                destroyed.add(args[2])
-                return True
-
             authority = types.SimpleNamespace(
-                is_destroyed=lambda unused_chunk, item, unused_mat=None: (
-                    item in destroyed),
-                destroy_tree=destroy_tree)
+                is_destroyed=lambda unused_chunk, unused_item,
+                unused_mat=None: True,
+                destroy_tree=lambda *args: calls.append(args) or True)
             shot = types.SimpleNamespace(shell=types.SimpleNamespace(
                 kind=shell_kind))
             with mock.patch.dict(
@@ -3640,15 +3633,126 @@ class DestructiblesCompatibilityTests(unittest.TestCase):
                     bigworld, 1, _Vector(), _Vector(0, 0, 20),
                     _Vector(0, 0, 1), shot)
 
+            # Both trees were already felled this round, so no shell family
+            # pays for their residual skin and the wall behind them still
+            # owns the stop.
             for result in (first, repeated):
                 self.assertAlmostEqual(5.1, result['stop_distance'])
                 self.assertIsNone(result['continue_from'])
                 self.assertEqual(0.0, result['piercing_loss'])
                 self.assertFalse(result['stopped_by_destructible'])
-            self.assertEqual(2, len(calls), shell_kind)
-            self.assertEqual(
-                {(1, 22, 1), (1, 22, 2)},
-                {call[:3] for call in calls})
+            self.assertEqual([], calls, shell_kind)
+
+    def _standing_tree_shot(self, tree_health, item_scale, shell_kind):
+        """Fire one shell at a single standing #1513 SpeedTree."""
+        filename = 'speedtree/45_North_America/Maple.spt'
+        tree_point = _Vector(0.0, 0.0, 5.0)
+        wall = _Vector(0.0, 0.0, 9.0)
+        matrix_queries = []
+        math_module = types.ModuleType('Math')
+        math_module.Vector3 = _Vector
+        math_module.Matrix = lambda value: value
+        bigworld = types.ModuleType('BigWorld')
+
+        def collide(unused_space, unused_start, unused_end, unused_mask,
+                    collision_filter=None):
+            if (collision_filter is None or
+                    collision_filter(71, 0, 1, 22)):
+                return tree_point, _Vector(0.0, 0.0, -1.0)
+            return wall, _Vector(0.0, 0.0, -1.0)
+
+        bigworld.wg_collideSegment = collide
+
+        def material(unused_space, unused_start, unused_stop, point,
+                     unused_callback):
+            if abs(float(point.z) - 5.0) <= 0.01:
+                return _mat_info_1513(
+                    True, point, _Vector(0, 1, 0), 71, filename, 22, 1)
+            return _mat_info_1513(
+                True, point, _Vector(0, 1, 0), 5, '', 0, 0)
+
+        bigworld.wg_getMatInfoNearPoint = material
+
+        def item_matrix(space_id, chunk_id, item_index):
+            matrix_queries.append((space_id, chunk_id, item_index))
+            return _ItemMatrix(scale=item_scale)
+
+        bigworld.wg_getDestructibleMatrix = item_matrix
+        area = types.ModuleType('AreaDestructibles')
+        area.g_destructiblesManager = _Manager()
+        area.DESTR_TYPE_TREE = 1
+        area.DESTR_TYPE_FALLING_ATOM = 2
+        area.DESTR_TYPE_FRAGILE = 3
+        area.DESTR_TYPE_STRUCTURE = 4
+        area.g_cache = types.SimpleNamespace(
+            getDescByFilename=lambda value: (
+                {'type': 1, 'health': tree_health}
+                if value == filename else None))
+        cache = types.ModuleType('DestructiblesCache')
+        cache.scaledDestructibleHealth = lambda scale, health: int(
+            math.ceil(scale * scale * health))
+        destructibles_sensor.set_event_sink(lambda unused: True)
+        felled = []
+        authority = types.SimpleNamespace(
+            is_destroyed=lambda *unused: False,
+            destroy_tree=lambda *args: felled.append(args) or True)
+        shot = types.SimpleNamespace(shell=types.SimpleNamespace(
+            kind=shell_kind))
+        with mock.patch.dict(
+                sys.modules, {'BigWorld': bigworld,
+                              'AreaDestructibles': area,
+                              'DestructiblesCache': cache,
+                              'Math': math_module}), \
+                mock.patch.object(
+                    destructibles_sensor, '_get_destr_authority',
+                    return_value=authority):
+            result = destructibles_sensor.shot_world_distance(
+                bigworld, 1, _Vector(), _Vector(0, 0, 20),
+                _Vector(0, 0, 1), shot)
+        return result, felled, matrix_queries
+
+    def test_standing_tree_below_the_threshold_costs_25mm_and_passes(self):
+        result, felled, queries = self._standing_tree_shot(
+            18, 1.0, 'ARMOR_PIERCING')
+        self.assertEqual(1, len(felled))
+        self.assertEqual((1, 22, 1), felled[0][:3])
+        self.assertEqual([(1, 22, 1)], queries)
+        self.assertIsNone(result['stop_distance'])
+        self.assertEqual(25.0, result['piercing_loss'])
+        self.assertAlmostEqual(5.0, result['loss_distance'])
+        # Trees have no catalog OBB, so the proved next surface is the exit.
+        self.assertLess(result['continue_from'], 9.0)
+        self.assertGreater(result['continue_from'], 8.99)
+
+    def test_standing_tree_above_the_threshold_falls_and_stops_the_shell(self):
+        result, felled, unused_queries = self._standing_tree_shot(
+            20, 1.0, 'ARMOR_PIERCING')
+        self.assertEqual(1, len(felled))
+        self.assertAlmostEqual(5.0, result['stop_distance'])
+        self.assertIsNone(result['continue_from'])
+        self.assertEqual(0.0, result['piercing_loss'])
+        self.assertTrue(result['stopped_by_destructible'])
+        self.assertEqual('above_threshold_hp', result['stop_reason'])
+
+    def test_tree_threshold_uses_the_native_scaled_health(self):
+        """ceil(1.2 * 1.2 * 18) = 26 exceeds maxHpForShootingThrough."""
+        result, felled, queries = self._standing_tree_shot(
+            18, 1.2, 'ARMOR_PIERCING')
+        self.assertEqual([(1, 22, 1)], queries)
+        self.assertEqual(1, len(felled))
+        self.assertAlmostEqual(5.0, result['stop_distance'])
+        self.assertEqual('above_threshold_hp', result['stop_reason'])
+
+    def test_he_and_heat_stop_at_a_tree_without_a_matrix_query(self):
+        for shell_kind in ('HIGH_EXPLOSIVE', 'HOLLOW_CHARGE'):
+            result, felled, queries = self._standing_tree_shot(
+                18, 1.0, shell_kind)
+            self.assertEqual(1, len(felled), shell_kind)
+            self.assertAlmostEqual(5.0, result['stop_distance'], msg=shell_kind)
+            self.assertTrue(result['stopped_by_destructible'], shell_kind)
+            self.assertEqual('shell_family', result['stop_reason'])
+            # The family gate is decided before any native scale is read.
+            self.assertEqual([], queries, shell_kind)
 
     def test_catalog_obstacle_stops_before_native_trees_are_destroyed(self):
         destructibles_sensor.xrange = range

--- a/tests/test_port_0922_destructibles.py
+++ b/tests/test_port_0922_destructibles.py
@@ -3833,6 +3833,171 @@ class DestructiblesCompatibilityTests(unittest.TestCase):
                 self.assertIsNone(result['continue_from'])
                 self.assertEqual(0.0, result['piercing_loss'])
                 self.assertTrue(result['stopped_by_destructible'])
+                self.assertEqual('shell_family', result['stop_reason'])
+
+    def _falling_pole_shot_fixture(self, boxes):
+        """Register one exact #1513 falling atom with a live catalog OBB."""
+        filename = (
+            'content/Environment/envAM_009_Poles/normal/lod0/'
+            'envAM_009_Poles_01.model')
+        destructibles_sensor.xrange = range
+        destructibles_sensor.set_catalog(_catalog({
+            filename: {'kind': 'falling', 'boxes': boxes},
+        }))
+        record = destructibles_sensor._destructible_catalog[
+            'resources'][filename.lower()]
+        math_module = types.ModuleType('Math')
+        math_module.Vector3 = _Vector
+        instance = {
+            'filename': filename.lower(),
+            'descriptor_filename': filename,
+            'kind': 'falling',
+            'item_scale': 1.0,
+            'boxes': destructibles_sensor._world_catalog_boxes(
+                record, _ItemMatrix(), _Vector(), math_module),
+        }
+        destructibles_sensor.g_offh_destr_instances = {(22, 1): instance}
+        destructibles_sensor.g_offh_destr_contact_bins = {}
+        destructibles_sensor._index_catalog_instance_1513(
+            destructibles_sensor.g_offh_destr_contact_bins,
+            (22, 1), instance)
+        area = types.ModuleType('AreaDestructibles')
+        area.g_destructiblesManager = object()
+        area.DESTR_TYPE_TREE = 1
+        area.DESTR_TYPE_FALLING_ATOM = 2
+        area.DESTR_TYPE_FRAGILE = 3
+        area.DESTR_TYPE_STRUCTURE = 4
+        area.g_cache = types.SimpleNamespace(
+            getDescByFilename=lambda value: (
+                {'type': 2, 'health': 18} if value == filename else None))
+        cache = types.ModuleType('DestructiblesCache')
+        cache.scaledDestructibleHealth = lambda scale, health: int(
+            math.ceil(scale * scale * health))
+        return filename, math_module, area, cache
+
+    @staticmethod
+    def _filtered_world_ray(surfaces):
+        """Reproduce the #1513 filtered ``wg_collideSegment`` contract.
+
+        ``surfaces`` are ``(distance, chunk, item, material)`` in ray order.
+        The optional fifth argument is the engine's keep-callback, which is
+        invoked with ``(matKind, collFlags, itemIndex, chunkID)``.
+        """
+        def collide(space_id, start, end, flags, keep=None):
+            for distance, chunk, item, material in surfaces:
+                if keep is not None and not keep(material, 0, item, chunk):
+                    continue
+                return (_Vector(0.0, 0.0, distance),
+                        _Vector(0.0, 0.0, -1.0))
+            return None
+        return collide
+
+    def test_broken_falling_atom_skin_no_longer_stops_a_later_shell(self):
+        """A felled pole keeps its native skin; retail stops colliding with it."""
+        filename, math_module, area, cache = self._falling_pole_shot_fixture(
+            [[-0.5, -1.0, 4.0, 0.5, 2.0, 6.0, None]])
+        surfaces = ((4.0, 22, 1, 72), (9.0, 0, 0, 5))
+        bigworld = types.ModuleType('BigWorld')
+        bigworld.wg_collideSegment = self._filtered_world_ray(surfaces)
+        bigworld.time = lambda: 10.0
+
+        def material(space_id, start, near, point, unused_filter):
+            if abs(float(point.z) - 4.0) <= 0.01:
+                return _mat_info_1513(
+                    True, point, _Vector(0, 1, 0), 72, filename, 22, 1)
+            return _mat_info_1513(
+                True, point, _Vector(0, 1, 0), 5, '', 0, 0)
+
+        bigworld.wg_getMatInfoNearPoint = material
+        destructibles_sensor.set_event_sink(lambda unused: True)
+        orders = []
+        authority = types.SimpleNamespace(
+            is_destroyed=lambda chunk, item, mat=None: (
+                (chunk, item) == (22, 1)),
+            destroy_column=lambda *args: orders.append(args) or True)
+        shot = types.SimpleNamespace(shell=types.SimpleNamespace(
+            kind='ARMOR_PIERCING'))
+        with mock.patch.dict(
+                sys.modules, {'BigWorld': bigworld,
+                              'AreaDestructibles': area,
+                              'DestructiblesCache': cache,
+                              'Math': math_module}), \
+                mock.patch.object(
+                    destructibles_sensor, '_get_destr_authority',
+                    return_value=authority):
+            result = destructibles_sensor.shot_world_distance(
+                bigworld, 1, _Vector(), _Vector(0, 0, 20),
+                _Vector(0, 0, 1), shot)
+
+        # The wall behind the debris owns the stop, and the removed pole
+        # neither charges penetration nor is destroyed a second time.
+        self.assertEqual([], orders)
+        self.assertAlmostEqual(9.0, result['stop_distance'])
+        self.assertEqual(0.0, result['piercing_loss'])
+        self.assertFalse(result['stopped_by_destructible'])
+
+    def test_destroyed_item_without_exact_exit_still_passes_the_shell(self):
+        """An admitted shot may not end on an item it has just removed."""
+        filename, math_module, area, cache = self._falling_pole_shot_fixture(
+            [[-0.5, -1.0, 12.0, 0.5, 2.0, 14.0, None]])
+        surfaces = ((4.0, 22, 1, 72), (9.0, 0, 0, 5))
+        bigworld = types.ModuleType('BigWorld')
+        bigworld.wg_collideSegment = self._filtered_world_ray(surfaces)
+        bigworld.time = lambda: 10.0
+
+        def material(space_id, start, near, point, unused_filter):
+            if abs(float(point.z) - 4.0) <= 0.01:
+                return _mat_info_1513(
+                    True, point, _Vector(0, 1, 0), 72, filename, 22, 1)
+            return _mat_info_1513(
+                True, point, _Vector(0, 1, 0), 5, '', 0, 0)
+
+        bigworld.wg_getMatInfoNearPoint = material
+        destructibles_sensor.set_event_sink(lambda unused: True)
+        destroyed = set()
+        authority = types.SimpleNamespace(
+            is_destroyed=lambda chunk, item, mat=None: (
+                (chunk, item) in destroyed),
+            destroy_column=lambda space, chunk, item, yaw, vel, hit: (
+                destroyed.add((chunk, item)) or True))
+        shot = types.SimpleNamespace(shell=types.SimpleNamespace(
+            kind='ARMOR_PIERCING'))
+        with mock.patch.dict(
+                sys.modules, {'BigWorld': bigworld,
+                              'AreaDestructibles': area,
+                              'DestructiblesCache': cache,
+                              'Math': math_module}), \
+                mock.patch.object(
+                    destructibles_sensor, '_get_destr_authority',
+                    return_value=authority):
+            result = destructibles_sensor.shot_world_distance(
+                bigworld, 1, _Vector(), _Vector(0, 0, 20),
+                _Vector(0, 0, 1), shot)
+
+        # The registered OBB does not cover this contact, so no exact exit
+        # exists.  The proved next surface owns the resume distance instead.
+        self.assertEqual({(22, 1)}, destroyed)
+        self.assertIsNone(result['stop_distance'])
+        self.assertEqual(25.0, result['piercing_loss'])
+        self.assertAlmostEqual(4.0, result['loss_distance'])
+        self.assertLess(result['continue_from'], 9.0)
+        self.assertGreater(result['continue_from'], 8.99)
+
+    def test_broken_surface_filter_hides_only_the_accepted_material(self):
+        """A broken module may not make its intact siblings transparent."""
+        item_wide = destructibles_sensor._transparent_shot_surface_filter_1513(
+            {(22, 1, None)})
+        self.assertFalse(item_wide(73, 0, 1, 22))
+        self.assertFalse(item_wide(74, 0, 1, 22))
+        self.assertTrue(item_wide(73, 0, 2, 22))
+        module_only = \
+            destructibles_sensor._transparent_shot_surface_filter_1513(
+                {(22, 1, 73)})
+        self.assertFalse(module_only(73, 0, 1, 22))
+        self.assertTrue(module_only(74, 0, 1, 22))
+        # A malformed native tuple never hides a surface.
+        self.assertTrue(module_only('x', 0, 1, 22))
+        self.assertTrue(module_only(73, 0))
 
     def test_unknown_shell_kind_and_missing_descriptor_stop_fail_closed(self):
         self.assertIsNone(destructibles_sensor._shot_kind_1513(


### PR DESCRIPTION
Fix solid shells stopping on the residual native skins of already destroyed destructibles. Recast through accepted item identities while keeping intact structure modules and backing geometry authoritative.

The final change also applies the pinned destructible shoot-through rules to standing trees: AP/APCR/APHE may continue through scaled health at or below 19 for a 25 mm penetration loss; HE/HEAT and above-threshold items stop the shell. Freeze tree scale before requesting the native fall. Already felled trees remain transparent without another penetration charge. This supersedes the original description's claim that tree rules were unchanged.

When an accepted item has no resolved OBB exit, resume before the nearest remaining native or catalog surface. The integration review reproduced and fixed a gap where a filtered mask-128 ray could otherwise skip a catalog-only prop between the broken item and the next wall (or ray endpoint). The regression covers both cases and preserves a nearer static wall.

Scenery stops carry a bounded debug diagnostic identifying the refusal or lookup branch.

Validation: all three PR heads (#89, #90, #91) were combined locally; the initial combined suite passed 4,243 tests with one skip. The additional catalog-resume regression failed before the repair in both skipping cases, and the repaired destructibles suite passed 251 tests. Exact #1513 client inspection and the Python 2.7 ABI audit passed; all 97 client Python files compiled under CPython 2.7.18. The final combined suite including the repair passed 4,244 tests with one skip. The repair is included in the main integration commit.

Exact Windows gameplay, tree matrix behavior, visual effects, and frame pacing were not exercised in this review. Existing soft-vegetation exclusion remains unchanged.
