### PR TITLE
Report the enemy shell type in the stock damage log

### DIFF
--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_feedback.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_feedback.py
@@ -9,6 +9,8 @@ That keeps a delayed notification from escaping into a later battle or the
 hangar while the #1513 lifecycle remains under BattleRuntime control.
 """
 
+import sys
+
 
 # Match the deterministic no-skill visibility hold.  A repeated authority
 # observation inside this window is one continuous spotting episode, not a
@@ -98,3 +100,103 @@ class SixthSenseController(object):
         holder[0] = callback
         self._pending_callback = callback
         return True
+
+
+# ``vehicles._VEHICLE_TYPE_XML_PATH + nationName + '/components/shells.xml'``:
+# the exact resource #1513 ``Cache.__readNation`` hands to ``_readShells``.
+SHELLS_XML_PATH = 'scripts/item_defs/vehicles/%s/components/shells.xml'
+
+# ``_readShells`` skips exactly these two top-level keys before it treats a
+# subsection as a shell definition.
+_NON_SHELL_SECTIONS = ('icons', 'xmlns:xmlref')
+
+# Resolved once per nation.  ``shells.xml`` is immutable client content, so
+# this never needs to follow a round, vehicle, or account change.
+_gold_shell_names = {}
+
+_reported_shell_price_failures = set()
+
+
+def reset_shell_price_cache():
+    """Drop resolved shell-price data (test isolation)."""
+    _gold_shell_names.clear()
+    _reported_shell_price_failures.clear()
+
+
+def _report_shell_price_failure(nation, reason):
+    """Write one bounded diagnostic per nation and failure reason."""
+    key = (str(nation), str(reason))
+    if key in _reported_shell_price_failures:
+        return False
+    _reported_shell_price_failures.add(key)
+    try:
+        sys.stdout.write(
+            '[Offline LAN 0.9.22] FEEDBACK shell prices unresolved: '
+            'nation=%s reason=%s\n' % (nation, reason))
+    except Exception:
+        return False
+    return True
+
+
+def _read_gold_shell_names(nation, res_mgr):
+    """Collect one nation's gold-priced shell names from its raw resource.
+
+    The exact client's own reader leaves ``Shell.isGold`` at its ``False``
+    default (``_readShell`` guards the assignment with ``IS_CELLAPP``), so the
+    value has to come from the raw item definitions.  ``_xml.readPrice``
+    decides the currency by probing ``<subsection>/gold``; this reproduces
+    that probe against the same sections ``_readShells`` iterates.
+    """
+    path = SHELLS_XML_PATH % (nation,)
+    if res_mgr is None:
+        import ResMgr
+        res_mgr = ResMgr
+    section = res_mgr.openSection(path)
+    if section is None:
+        return None
+    try:
+        names = set()
+        for name, subsection in section.items():
+            if name in _NON_SHELL_SECTIONS:
+                continue
+            if subsection['price/gold'] is not None:
+                names.add(name)
+    finally:
+        purge = getattr(res_mgr, 'purge', None)
+        if callable(purge):
+            # Match the stock readers, which release the shell XML tree as
+            # soon as they are done with it.
+            try:
+                purge(path, True)
+            except Exception:
+                pass
+    return names
+
+
+def gold_shell_names(nation, res_mgr=None):
+    """Return one nation's gold-priced shell names, or None when unresolved.
+
+    A failed or absent resource is contained here: the caller keeps the
+    ``False`` that the exact client itself reports on this seam.
+    """
+    nation = str(nation)
+    if nation in _gold_shell_names:
+        return _gold_shell_names[nation]
+    try:
+        names = _read_gold_shell_names(nation, res_mgr)
+        reason = None if names is not None else 'section_unavailable'
+    except Exception as error:
+        names = None
+        reason = '%s: %s' % (error.__class__.__name__, error)
+    _gold_shell_names[nation] = names
+    if names is None:
+        _report_shell_price_failure(nation, reason)
+    return names
+
+
+def is_gold_shell(nation, shell_name, res_mgr=None):
+    """True when ``<nation>/components/shells.xml`` prices the shell in gold."""
+    names = gold_shell_names(nation, res_mgr)
+    if names is None:
+        return False
+    return str(shell_name) in names

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -23,7 +23,7 @@ from gui.mods.offline_lan_0922.artillery_controller import \
 from gui.mods.offline_lan_0922.authority_worker_probe import \
     AuthorityWorkerProbe, write_probe_record
 from gui.mods.offline_lan_0922.battle_feedback import (
-    SixthSenseController, VehicleStatePresenter)
+    SixthSenseController, VehicleStatePresenter, is_gold_shell)
 from gui.mods.offline_lan_0922.bot_runtime import (
     BOT_WATER_AVOID_DEPTH, BotRuntime, PROBE_KINDS,
     WORKER_CONTROL_SECONDS)
@@ -1645,6 +1645,7 @@ class BattleRuntime(object):
         self._bot_yaw_rates = {}
         self._track_report_time = None
         self._hit_impulse_reports = 0
+        self._feedback_shell_failures = set()
         self._local_speed = 0.0
         self._local_turn_speed = 0.0
         self._local_drive_turn = 0.0
@@ -1962,6 +1963,7 @@ class BattleRuntime(object):
         self._bot_yaw_rates = {}
         self._track_report_time = None
         self._hit_impulse_reports = 0
+        self._feedback_shell_failures = set()
         self._local_speed = 0.0
         self._local_turn_speed = 0.0
         self._local_drive_turn = 0.0
@@ -9547,6 +9549,88 @@ class BattleRuntime(object):
             raise RuntimeError('combat attacker shell is unavailable')
         return shot, shell
 
+    def _feedback_shell_fields(self, event, attacker_record):
+        """Resolve the shell fields #1513 packs into a battle-event detail.
+
+        ``BATTLE_EVENT_TYPE.packDamage``/``packCrits`` carry a shell type index
+        and a gold flag beside the damage and attack reason.  The stock damage
+        log reads them back through ``_DamageExtra``/``_CritsExtra`` and draws
+        the shell abbreviation for received damage, received criticals and
+        blocked damage.  Only a shot has a shell: ``isShot`` is what selects
+        the log's shell column, so fire, ramming and world collision keep
+        ``NONE_SHELL_TYPE`` exactly as the retail cell does.
+        """
+        feedback_common = getattr(
+            self._runtime, 'battle_feedback_common', None)
+        none_shell = getattr(feedback_common, 'NONE_SHELL_TYPE', None)
+        if none_shell is None:
+            raise RuntimeError(
+                '#1513 shell-type feedback sentinel is unavailable')
+        none_shell = int(none_shell)
+        if (attacker_record is None or
+                self._combat_event_source(event) != 'shot' or
+                event.get('kind') not in (
+                    'hit', 'bot_hit', 'bot_human_hit', 'bot_bot_hit')):
+            return none_shell, False
+        indices = getattr(
+            self._runtime.constants, 'SHELL_TYPES_INDICES', None)
+        if not indices:
+            raise RuntimeError('#1513 shell type indices are unavailable')
+        try:
+            unused_shot, shell = self._event_shell(attacker_record, event)
+        except RuntimeError as error:
+            # ``_present_combat_hit`` owns the fatal shell-descriptor contract
+            # for a shot and runs first.  Losing the log's shell column must
+            # never also cost the canonical damage, ribbon and counter events.
+            self._report_feedback_shell_failure(str(error))
+            return none_shell, False
+        # #1513 ``Shell.kind`` is a property over ``Shell.type.name``; the
+        # copied law reads the same two shapes.
+        kind = _field(shell, 'kind', None)
+        if kind is None:
+            kind = _field(_field(shell, 'type', None), 'name', None)
+        if kind not in indices:
+            self._report_feedback_shell_failure(
+                'shell kind is not a #1513 shell type: %r' % (kind,))
+            return none_shell, False
+        return int(indices[kind]), self._shell_is_gold(shell)
+
+    def _report_feedback_shell_failure(self, reason):
+        """Write one bounded diagnostic per distinct unresolved shell."""
+        if reason in self._feedback_shell_failures:
+            return False
+        if len(self._feedback_shell_failures) >= 32:
+            return False
+        self._feedback_shell_failures.add(reason)
+        sys.stdout.write(
+            '[Offline LAN 0.9.22] FEEDBACK damage-log shell unresolved: %s\n'
+            % (reason,))
+        return True
+
+    def _shell_is_gold(self, shell):
+        """True when the raw item definitions price this shell in gold.
+
+        ``Shell.isGold`` stays at its ``False`` default on a client: only the
+        cell app's ``_readShell`` branch assigns it.  Resolving the flag from
+        ``shells.xml`` therefore reproduces the retail value instead of
+        reporting every premium round as standard.  A failed lookup keeps
+        ``False`` -- the same answer the exact client itself carries -- and is
+        contained to the gold background of one log row.
+        """
+        identity = _field(shell, 'id', None)
+        name = _field(shell, 'name', None)
+        if name is None or not isinstance(identity, (tuple, list)) or \
+                len(identity) < 1:
+            return False
+        names = getattr(getattr(self._runtime, 'nations', None), 'NAMES', None)
+        if not names:
+            return False
+        try:
+            nation = names[int(identity[0])]
+        except (IndexError, KeyError, TypeError, ValueError):
+            return False
+        return is_gold_shell(nation, name)
+
     @staticmethod
     def _critical_hit_mask(critical):
         """Pack #1513's device/destroyed/crew hit-direction bit fields."""
@@ -10172,6 +10256,8 @@ class BattleRuntime(object):
         damage = max(0, int(event.get('damage', 0) or 0))
         if reason_id is None:
             reason_id = self._combat_attack_reason(event)
+        shell_type, shell_is_gold = self._feedback_shell_fields(
+            event, attacker_record)
         critical = event.get('critical')
         critical_count = len((critical or {}).get('events') or ())
         if attacker_record.get('local'):
@@ -10196,13 +10282,15 @@ class BattleRuntime(object):
                     'eventType': int(event_types.DAMAGE),
                     'targetID': target_id, 'count': 1,
                     'details': int(event_types.packDamage(
-                        damage, reason_id))})
+                        damage, reason_id, False, shell_type,
+                        shell_is_gold))})
             if critical_count > 0:
                 output.append({
                     'eventType': int(event_types.CRIT),
                     'targetID': target_id, 'count': 1,
                     'details': int(event_types.packCrits(
-                        critical_count, reason_id))})
+                        critical_count, reason_id, shell_type,
+                        shell_is_gold))})
             if bool(event.get('dead')):
                 output.append({
                     'eventType': int(event_types.KILL),
@@ -10285,19 +10373,22 @@ class BattleRuntime(object):
                     'eventType': int(event_types.TANKING),
                     'targetID': attacker_id, 'count': 1,
                     'details': int(event_types.packDamage(
-                        blocked_damage, reason_id))})
+                        blocked_damage, reason_id, False, shell_type,
+                        shell_is_gold))})
             if damage > 0:
                 output.append({
                     'eventType': int(event_types.RECEIVED_DAMAGE),
                     'targetID': attacker_id, 'count': 1,
                     'details': int(event_types.packDamage(
-                        damage, reason_id))})
+                        damage, reason_id, False, shell_type,
+                        shell_is_gold))})
             if critical_count > 0:
                 output.append({
                     'eventType': int(event_types.RECEIVED_CRIT),
                     'targetID': attacker_id, 'count': 1,
                     'details': int(event_types.packCrits(
-                        critical_count, reason_id))})
+                        critical_count, reason_id, shell_type,
+                        shell_is_gold))})
         if output:
             callback = getattr(self._avatar, 'onBattleEvents', None)
             if not callable(callback):
@@ -24156,6 +24247,7 @@ class BattleRuntime(object):
         self._bot_yaw_rates = {}
         self._track_report_time = None
         self._hit_impulse_reports = 0
+        self._feedback_shell_failures = set()
         self._local_speed = 0.0
         self._local_turn_speed = 0.0
         self._local_drive_turn = 0.0

--- a/tests/test_port_0922_battle_feedback.py
+++ b/tests/test_port_0922_battle_feedback.py
@@ -8,9 +8,11 @@ ROOT = Path(__file__).resolve().parents[1]
 CLIENT_SCRIPTS = ROOT / 'src' / 'res' / 'scripts' / 'client'
 sys.path.insert(0, str(CLIENT_SCRIPTS))
 
+from gui.mods.offline_lan_0922 import battle_feedback
 from gui.mods.offline_lan_0922.battle_feedback import (
-    OBSERVATION_SECONDS, SIXTH_SENSE_DELAY_SECONDS, SixthSenseController,
-    VehicleStatePresenter)
+    OBSERVATION_SECONDS, SHELLS_XML_PATH, SIXTH_SENSE_DELAY_SECONDS,
+    SixthSenseController, VehicleStatePresenter, gold_shell_names,
+    is_gold_shell, reset_shell_price_cache)
 
 
 class _Scheduler(object):
@@ -126,6 +128,101 @@ class VehicleStatePresenterTests(unittest.TestCase):
         presenter.notify_observed_by_enemy(1)
 
         self.assertEqual([(observed, True)], calls)
+
+
+class _Section(object):
+    """One ``shells.xml`` shell subsection.
+
+    #1513 ``_xml.readPrice`` probes ``<subsection>/gold`` and reads ``None``
+    as "priced in credits", so only that access has to be reproduced.
+    """
+
+    def __init__(self, currency):
+        self.currency = currency
+
+    def __getitem__(self, path):
+        if path == 'price/gold' and self.currency == 'gold':
+            return 12
+        return None
+
+
+class _ResMgr(object):
+    def __init__(self, sections, available=True):
+        self.sections = sections
+        self.available = available
+        self.opened = []
+        self.purged = []
+
+    def openSection(self, path):
+        self.opened.append(path)
+        if not self.available:
+            return None
+        rows = [('icons', _Section(None)), ('xmlns:xmlref', _Section('gold'))]
+        rows.extend((name, _Section(currency))
+                    for name, currency in sorted(self.sections.items()))
+        return types.SimpleNamespace(items=lambda: list(rows))
+
+    def purge(self, path, recursive):
+        self.purged.append((path, recursive))
+
+
+class ShellPriceTests(unittest.TestCase):
+    """``Shell.isGold`` is cell-app only, so the flag comes from item defs."""
+
+    def setUp(self):
+        reset_shell_price_cache()
+        self.addCleanup(reset_shell_price_cache)
+
+    def test_gold_priced_shells_come_from_the_exact_resource(self):
+        res_mgr = _ResMgr({'_37mm_UBR-160P': 'gold', '_37mm_UBR-167': None})
+
+        names = gold_shell_names('ussr', res_mgr)
+
+        self.assertEqual(set(('_37mm_UBR-160P',)), names)
+        self.assertEqual([SHELLS_XML_PATH % ('ussr',)], res_mgr.opened)
+        self.assertEqual([(SHELLS_XML_PATH % ('ussr',), True)],
+                         res_mgr.purged)
+
+    def test_non_shell_sections_are_skipped_like_the_stock_reader(self):
+        res_mgr = _ResMgr({'_85mm_UBR-365K': None})
+
+        self.assertEqual(set(), gold_shell_names('ussr', res_mgr))
+
+    def test_one_nation_is_resolved_once(self):
+        res_mgr = _ResMgr({'_37mm_UBR-160P': 'gold'})
+
+        self.assertTrue(is_gold_shell('ussr', '_37mm_UBR-160P', res_mgr))
+        self.assertFalse(is_gold_shell('ussr', '_37mm_UBR-167', res_mgr))
+
+        self.assertEqual(1, len(res_mgr.opened))
+
+    def test_an_unavailable_resource_is_contained(self):
+        res_mgr = _ResMgr({}, available=False)
+
+        self.assertIsNone(gold_shell_names('ussr', res_mgr))
+        self.assertFalse(is_gold_shell('ussr', '_37mm_UBR-160P', res_mgr))
+        self.assertEqual(1, len(res_mgr.opened))
+
+    def test_a_failing_resource_is_contained(self):
+        class _Broken(object):
+            def openSection(self, unused_path):
+                raise RuntimeError('resource subsystem is down')
+
+        self.assertIsNone(gold_shell_names('ussr', _Broken()))
+        self.assertFalse(is_gold_shell('ussr', '_37mm_UBR-160P', _Broken()))
+
+    def test_the_cache_survives_without_a_purge_hook(self):
+        class _NoPurge(object):
+            def openSection(self, unused_path):
+                return types.SimpleNamespace(
+                    items=lambda: [('_37mm_UBR-160P', _Section('gold'))])
+
+        self.assertTrue(is_gold_shell('ussr', '_37mm_UBR-160P', _NoPurge()))
+
+    def test_the_resource_path_matches_the_stock_component_layout(self):
+        self.assertEqual(
+            'scripts/item_defs/vehicles/ussr/components/shells.xml',
+            battle_feedback.SHELLS_XML_PATH % ('ussr',))
 
 
 if __name__ == '__main__':

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -26,9 +26,9 @@ from gui.mods.offline_lan_0922.battle_runtime import (
     _MOVEMENT_ROTATE_RIGHT, _engine_rotation)
 from gui.mods.offline_lan_0922 import battle_runtime as \
     battle_runtime_module
-from gui.mods.offline_lan_0922 import bot_runtime, combat_rules, \
-    critical_damage, equipment_mechanics, gun_mechanics, loadout, \
-    tank_collision, vehicle_physics
+from gui.mods.offline_lan_0922 import battle_feedback, bot_runtime, \
+    combat_rules, critical_damage, equipment_mechanics, gun_mechanics, \
+    loadout, tank_collision, vehicle_physics
 from gui.mods.offline_lan_0922.entities.remote_vehicle import \
     RemoteVehicle, RemoteVehicleFactory, _RemoteFilter, \
     collide_vehicle_at_matrix
@@ -2116,6 +2116,86 @@ def _plain_bot_factors(unused_descriptor, crew_level=None):
     }
 
 
+class _ShellPriceSection(object):
+    """One ``shells.xml`` shell subsection: only the price probe is used.
+
+    #1513 ``_xml.readPrice`` decides the currency by asking the section for
+    ``<subsection>/gold`` and taking ``None`` as "priced in credits".
+    """
+
+    def __init__(self, currency):
+        self._currency = currency
+
+    def __getitem__(self, path):
+        if path == 'price/gold' and self._currency == 'gold':
+            return object()
+        return None
+
+
+class _ShellPriceResMgr(object):
+    """ResMgr stub over per-nation ``components/shells.xml`` sections."""
+
+    def __init__(self, nations, missing=()):
+        self._nations = nations
+        self._missing = set(missing)
+        self.purged = []
+
+    def openSection(self, path):
+        for nation, shells in self._nations.items():
+            if path == battle_feedback.SHELLS_XML_PATH % (nation,):
+                if nation in self._missing:
+                    return None
+                rows = [('icons', _ShellPriceSection(None))]
+                rows.extend(
+                    (name, _ShellPriceSection(currency))
+                    for name, currency in sorted(shells.items()))
+                return types.SimpleNamespace(items=lambda: list(rows))
+        return None
+
+    def purge(self, path, recursive):
+        self.purged.append((path, recursive))
+
+
+# Exact #1513 ``BattleFeedbackCommon`` constants and bit layouts.  A fake that
+# drops the shell fields cannot show that the damage log receives them.
+_NONE_SHELL_TYPE = 127
+_SHELL_TYPES_LIST = (
+    'HOLLOW_CHARGE', 'HIGH_EXPLOSIVE', 'ARMOR_PIERCING',
+    'ARMOR_PIERCING_HE', 'ARMOR_PIERCING_CR')
+_SHELL_TYPES_INDICES = dict(
+    (value, index) for index, value in enumerate(_SHELL_TYPES_LIST))
+
+
+def _pack_damage(damage, attackReasonID, isBurst=False,
+                 shellTypeID=_NONE_SHELL_TYPE, shellIsGold=False):
+    """[ 32-17 damage | 16-10 reason | 9 burst | 8-2 shell | 1 gold ]"""
+    return ((int(damage) & 65535) << 16 |
+            (int(attackReasonID) & 127) << 9 |
+            (1 if isBurst else 0) << 8 |
+            (int(shellTypeID) & 127) << 1 |
+            (1 if shellIsGold else 0))
+
+
+def _unpack_damage(packedDamage):
+    return (packedDamage >> 16 & 65535, packedDamage >> 9 & 127,
+            packedDamage >> 8 & 1, packedDamage >> 1 & 127,
+            packedDamage & 1)
+
+
+def _pack_crits(critsCount, attackReasonID,
+                shellTypeID=_NONE_SHELL_TYPE, shellIsGold=False):
+    """[ 32-17 count | 16-9 reason | 8-2 shell | 1 gold ]"""
+    return ((int(critsCount) & 65535) << 16 |
+            (int(attackReasonID) & 255) << 8 |
+            (int(shellTypeID) & 127) << 1 |
+            (1 if shellIsGold else 0))
+
+
+def _unpack_crits(packedCrits):
+    return (packedCrits >> 16 & 65535, packedCrits >> 8 & 255,
+            packedCrits >> 1 & 127, packedCrits & 1)
+
+
 def _runtime():
     avatar = _Avatar()
     compatibility = _Compatibility()
@@ -2198,6 +2278,8 @@ def _runtime():
             GUN_DAMAGED_BY_EXPLOSION=262144,
             ATTACK_IS_DIRECT_PROJECTILE=1048576,
             ATTACK_IS_EXTERNAL_EXPLOSION=2097152),
+        SHELL_TYPES_LIST=_SHELL_TYPES_LIST,
+        SHELL_TYPES_INDICES=dict(_SHELL_TYPES_INDICES),
         FINISH_REASON=types.SimpleNamespace(
             EXTERMINATION=1, BASE=2, TIMEOUT=3, FAILURE=4, TECHNICAL=5))
     arena = types.SimpleNamespace(
@@ -2280,14 +2362,13 @@ def _runtime():
             CLIENT_MASK=0xfff00000, SERVER_MASK=0x000fffff),
         compatibility=compatibility, constants=constants,
         battle_feedback_common=types.SimpleNamespace(
+            NONE_SHELL_TYPE=_NONE_SHELL_TYPE,
             BATTLE_EVENT_TYPE=types.SimpleNamespace(
                 SPOTTED=0, RADIO_ASSIST=1, TRACK_ASSIST=2, CRIT=6,
                 TANKING=5, DAMAGE=7, KILL=8, RECEIVED_CRIT=9,
                 RECEIVED_DAMAGE=10, STUN_ASSIST=11, TARGET_VISIBILITY=12,
-                packDamage=lambda damage, reason: (
-                    (int(damage) << 16) | (int(reason) << 9)),
-                packCrits=lambda count, reason: (
-                    (int(count) << 16) | (int(reason) << 8)),
+                packDamage=_pack_damage, unpackDamage=_unpack_damage,
+                packCrits=_pack_crits, unpackCrits=_unpack_crits,
                 packVisibility=lambda visible, direct: (
                     int(bool(visible)) | (int(bool(direct)) << 1)))),
         encode_gun_angles=lambda *unused: 0,
@@ -14067,7 +14148,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertEqual([7], [
             value['eventType']
             for value in battle._avatar.battle_events[0]])
-        self.assertEqual((50 << 16) | (2 << 9),
+        self.assertEqual(_pack_damage(50, 2),
                          battle._avatar.battle_events[0][0]['details'])
 
     def test_local_projectile_at_ally_keeps_stock_ally_hit_only(self):
@@ -14116,6 +14197,11 @@ class BattleRuntimeContractTests(unittest.TestCase):
         runtime = _runtime()
         battle = BattleRuntime(runtime)
         battle._avatar = runtime.bigworld.avatar
+        runtime.bigworld.entities.update({
+            10: _Vehicle(10, _Descriptor(), _Vector(), (0, 0, 0),
+                         {'health': 500}),
+            11: _Vehicle(11, _Descriptor(), _Vector(10, 0, 0), (0, 0, 0),
+                         {'health': 500})})
         attacker = {
             'engine_id': 11, 'local': False, 'kind': 'bot',
             'network_id': 2, 'state': {'team': 2}}
@@ -14124,7 +14210,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
             'network_id': 1, 'state': {'team': 1}}
 
         self.assertTrue(battle._present_combat_feedback({
-            'kind': 'bot_human_hit', 'damage': 0,
+            'kind': 'bot_human_hit', 'damage': 0, 'shell_index': 0,
             'blocked_damage': 320, 'shot_result': 0,
             'dead': False, 'attack_reason': 0, 'death_reason': 0,
             'source': 'shot'}, target, attacker))
@@ -14133,8 +14219,120 @@ class BattleRuntimeContractTests(unittest.TestCase):
             value['eventType']
             for value in battle._avatar.battle_events[0]])
         self.assertEqual(11, battle._avatar.battle_events[0][0]['targetID'])
-        self.assertEqual(320 << 16,
-                         battle._avatar.battle_events[0][0]['details'])
+        # Blocked damage always draws the shell column in the stock log.
+        self.assertEqual(
+            _pack_damage(320, 0, False,
+                         _SHELL_TYPES_INDICES['ARMOR_PIERCING'], False),
+            battle._avatar.battle_events[0][0]['details'])
+
+    def test_received_hit_reports_the_enemy_shell_type_and_gold_flag(self):
+        """The stock damage log draws its shell column from these fields."""
+        battle_feedback.reset_shell_price_cache()
+        self.addCleanup(battle_feedback.reset_shell_price_cache)
+        runtime = _runtime()
+        runtime.nations = types.SimpleNamespace(NAMES=('ussr',))
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        attacker_descriptor = _Descriptor()
+        shell = attacker_descriptor.gun.shots[0].shell
+        shell.kind = 'ARMOR_PIERCING_CR'
+        shell.id = (0, 12)
+        shell.name = '_37mm_UBR-160P'
+        runtime.bigworld.entities.update({
+            10: _Vehicle(10, _Descriptor(), _Vector(), (0, 0, 0),
+                         {'health': 500}),
+            11: _Vehicle(11, attacker_descriptor, _Vector(10, 0, 0),
+                         (0, 0, 0), {'health': 500})})
+        # Resolve the nation's gold-priced shells from a fake raw resource so
+        # the packed flag comes from item definitions, not from Shell.isGold.
+        self.assertEqual(
+            set(('_37mm_UBR-160P',)),
+            battle_feedback.gold_shell_names(
+                'ussr', _ShellPriceResMgr({'ussr': {
+                    '_37mm_UBR-160P': 'gold',
+                    '_37mm_UBR-167': 'credits'}})))
+        attacker = {
+            'engine_id': 11, 'local': False, 'kind': 'bot',
+            'network_id': 2, 'state': {'team': 2}}
+        target = {
+            'engine_id': 10, 'local': True, 'kind': 'player',
+            'network_id': 1, 'state': {'team': 1}}
+
+        self.assertTrue(battle._present_combat_feedback({
+            'kind': 'bot_human_hit', 'damage': 144, 'shell_index': 0,
+            'shot_result': 2, 'dead': False, 'attack_reason': 0,
+            'death_reason': 0, 'source': 'shot',
+            'critical': {'events': [{
+                'kind': 'device', 'name': 'engineHealth',
+                'state': 'critical', 'cause': 'shot'}]}}, target, attacker))
+
+        events = battle._avatar.battle_events[0]
+        self.assertEqual([10, 9], [value['eventType'] for value in events])
+        self.assertEqual(
+            (144, 0, 0, _SHELL_TYPES_INDICES['ARMOR_PIERCING_CR'], 1),
+            _unpack_damage(events[0]['details']))
+        self.assertEqual(
+            (1, 0, _SHELL_TYPES_INDICES['ARMOR_PIERCING_CR'], 1),
+            _unpack_crits(events[1]['details']))
+
+    def test_standard_shell_reports_no_gold_background(self):
+        battle_feedback.reset_shell_price_cache()
+        self.addCleanup(battle_feedback.reset_shell_price_cache)
+        runtime = _runtime()
+        runtime.nations = types.SimpleNamespace(NAMES=('ussr',))
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        attacker_descriptor = _Descriptor()
+        shell = attacker_descriptor.gun.shots[0].shell
+        shell.kind = 'HIGH_EXPLOSIVE'
+        shell.id = (0, 13)
+        shell.name = '_37mm_UBR-167'
+        runtime.bigworld.entities.update({
+            10: _Vehicle(10, _Descriptor(), _Vector(), (0, 0, 0),
+                         {'health': 500}),
+            11: _Vehicle(11, attacker_descriptor, _Vector(10, 0, 0),
+                         (0, 0, 0), {'health': 500})})
+        battle_feedback.gold_shell_names(
+            'ussr', _ShellPriceResMgr({'ussr': {
+                '_37mm_UBR-160P': 'gold', '_37mm_UBR-167': 'credits'}}))
+        attacker = {
+            'engine_id': 11, 'local': False, 'kind': 'bot',
+            'network_id': 2, 'state': {'team': 2}}
+        target = {
+            'engine_id': 10, 'local': True, 'kind': 'player',
+            'network_id': 1, 'state': {'team': 1}}
+
+        self.assertTrue(battle._present_combat_feedback({
+            'kind': 'bot_human_hit', 'damage': 90, 'shell_index': 0,
+            'shot_result': 2, 'dead': False, 'attack_reason': 0,
+            'death_reason': 0, 'source': 'shot'}, target, attacker))
+
+        events = battle._avatar.battle_events[0]
+        self.assertEqual(
+            (90, 0, 0, _SHELL_TYPES_INDICES['HIGH_EXPLOSIVE'], 0),
+            _unpack_damage(events[0]['details']))
+
+    def test_unresolvable_attacker_shell_keeps_the_damage_row(self):
+        """A missing descriptor costs the shell column, never the event."""
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        attacker = {
+            'engine_id': 11, 'local': False, 'kind': 'bot',
+            'network_id': 2, 'state': {'team': 2}}
+        target = {
+            'engine_id': 10, 'local': True, 'kind': 'player',
+            'network_id': 1, 'state': {'team': 1}}
+
+        self.assertTrue(battle._present_combat_feedback({
+            'kind': 'bot_human_hit', 'damage': 144, 'shell_index': 0,
+            'shot_result': 2, 'dead': False, 'attack_reason': 0,
+            'death_reason': 0, 'source': 'shot'}, target, attacker))
+
+        events = battle._avatar.battle_events[0]
+        self.assertEqual([10], [value['eventType'] for value in events])
+        self.assertEqual((144, 0, 0, _NONE_SHELL_TYPE, 0),
+                         _unpack_damage(events[0]['details']))
 
     def test_blocked_efficiency_event_is_not_replayed(self):
         runtime = _runtime()
@@ -14151,12 +14349,13 @@ class BattleRuntimeContractTests(unittest.TestCase):
                 'local': False, 'ready': True,
                 'state': {'team': 2, 'health': 500, 'alive': True}},
         }
-        battle._server_entity = mock.Mock(return_value=object())
+        battle._server_entity = mock.Mock(
+            return_value=types.SimpleNamespace(typeDescriptor=_Descriptor()))
         battle._present_combat_hit = mock.Mock(return_value=False)
         battle._apply_health = mock.Mock(return_value=True)
         message = {'events': [{
             'event_id': '1:12:0', 'kind': 'bot_human_hit',
-            'attacker_bot': 2, 'target': 1,
+            'attacker_bot': 2, 'target': 1, 'shell_index': 0,
             'damage': 0, 'blocked_damage': 320, 'shot_result': 0,
             'health': 500, 'dead': False, 'attack_reason': 0,
             'death_reason': 0, 'source': 'shot'}]}
@@ -14168,8 +14367,10 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertEqual([5], [
             value['eventType']
             for value in battle._avatar.battle_events[0]])
-        self.assertEqual(320 << 16,
-                         battle._avatar.battle_events[0][0]['details'])
+        self.assertEqual(
+            _pack_damage(320, 0, False,
+                         _SHELL_TYPES_INDICES['ARMOR_PIERCING'], False),
+            battle._avatar.battle_events[0][0]['details'])
 
     def test_fire_feedback_never_uses_projectile_result_or_impact_effect(self):
         runtime = _runtime()
@@ -14194,7 +14395,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
 
         self.assertEqual([], battle._avatar.shot_results)
         battle._avatar.terrainEffects.addNew.assert_not_called()
-        self.assertEqual((10 << 16) | (1 << 9),
+        self.assertEqual(_pack_damage(10, 1),
                          battle._avatar.battle_events[0][0]['details'])
 
     def test_combat_attack_reason_is_mandatory_and_matches_source(self):
@@ -14287,7 +14488,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertEqual((380, 0, 3), entity.health_change)
         self.assertEqual([{
             'eventType': 10, 'targetID': 10, 'count': 1,
-            'details': (120 << 16) | (3 << 9),
+            'details': _pack_damage(120, 3),
         }], battle._avatar.battle_events[0])
         self.assertEqual([], battle._avatar.hit_directions)
         self.assertEqual([], battle._avatar.shot_results)

--- a/tools/audit_client_abi.py
+++ b/tools/audit_client_abi.py
@@ -283,6 +283,11 @@ EXPECTED_ABI = {
         'ArcadeCamera.setToVehicleDirection': ('self',),
     },
     'scripts/common/BattleFeedbackCommon.pyc': {
+        'BATTLE_EVENT_TYPE.packDamage': (
+            'damage', 'attackReasonID', 'isBurst', 'shellTypeID',
+            'shellIsGold'),
+        'BATTLE_EVENT_TYPE.packCrits': (
+            'critsCount', 'attackReasonID', 'shellTypeID', 'shellIsGold'),
         'BATTLE_EVENT_TYPE.packVisibility': ('isVisible', 'isDirect'),
     },
     'scripts/client/gui/battle_control/controllers/feedback_events.pyc': {


### PR DESCRIPTION
## Observed

In battle, the stock damage log shows the damage number, the attacker and the
action icon, but the shell column is always empty — you cannot see whether the
enemy hit you with AP, APCR, HE or HEAT.

## Root cause

`BattleFeedbackCommon.BATTLE_EVENT_TYPE` packs the shell into the same 32-bit
detail as the damage (verified against #1513 bytecode, now pinned in
`tools/audit_client_abi.py`):

```
packDamage(damage, attackReasonID, isBurst=False,
           shellTypeID=NONE_SHELL_TYPE, shellIsGold=False)
    [ 32-17 damage | 16-10 reason | 9 burst | 8-2 shell | 1 gold ]
packCrits(critsCount, attackReasonID,
          shellTypeID=NONE_SHELL_TYPE, shellIsGold=False)
```

`damage_log_panel` reads it back through `feedback_events._DamageExtra`
/`_CritsExtra` and draws `_SHELL_TYPES_TO_STR[info.getShellType()]` on a
`DAMAGE_LOG_SHELL_BG_TYPES` background — `_DamageShellVOBuilder` for
`RECEIVED_DAMAGE`, `_CritsShellVOBuilder` for `RECEIVED_CRITICAL_HITS`, and a
plain `_ShellVOBuilder` for `BLOCKED_DAMAGE`. This port called both packers
with two arguments everywhere, so `shellTypeID` was always `NONE_SHELL_TYPE`
(127) and `getShellType()` returned `None`, which the panel renders as an empty
column.

## Change

`_present_combat_feedback` resolves the shell once per event and packs it into
all five shot-sourced details (`DAMAGE`, `CRIT`, `TANKING`, `RECEIVED_DAMAGE`,
`RECEIVED_CRIT`). The shell comes from the attacker descriptor the event's
`shell_index` already selects — the same `_event_shell` lookup
`_present_combat_hit` performs one call earlier in `_apply_combat_event`.

Fire, ramming, world collision and assists keep `NONE_SHELL_TYPE`: `isShot()`
is what selects the panel's shell column, and the retail cell packs nothing for
them either. `isBurst` stays `False` — nothing in #1513 reads it back.

### The gold flag, and the tradeoff

`Shell.isGold` cannot be read on a client. `items/vehicles._readShell` assigns
it only under `IS_CELLAPP`, so `Shell.__init__`'s `False` survives for all 954
shipped shells — 325 of which are gold-priced. Two options:

1. **Always white** — no new resource read, but misrenders every premium round.
2. **Resolve from item definitions** (chosen) — one `ResMgr.openSection` per
   nation over `scripts/item_defs/vehicles/<nation>/components/shells.xml`,
   probing `<shell>/price/gold` exactly as `_xml.readPrice` does, cached for
   the process and purged like the stock readers. This is the same pattern
   `track_damage.bulk_health_factor` already uses for a cell-only descriptor
   slot.

## Containment

- An unavailable or failing `shells.xml` keeps `False` (the value the exact
  client itself carries) and writes one bounded diagnostic per nation.
- An unresolvable attacker descriptor costs the shell column only; the damage,
  critical and counter events still publish. `_present_combat_hit` still owns
  the fatal descriptor contract for a shot and runs first.

## Validation

- `tools/audit_client_abi.py` against real #1513 `scripts.pkg`: exit 0 with
  `BATTLE_EVENT_TYPE.packDamage` and `packCrits` signatures verified.
- CPython 2.7 source compile of `src/res/scripts/client`: 97 files.
- Full client suite: 4233 tests, OK. Test fakes now implement the exact
  `packDamage`/`packCrits`/`unpackDamage`/`unpackCrits` bit layouts instead of
  a two-argument stub, so the shell fields are actually asserted.

## Not proved here

Whether Scaleform renders the abbreviation and the gold background needs a
round on the exact Windows client. The Python side can only prove that
`onBattleEvents` receives correctly packed details.

## Follow-up (not in this PR)

`bot_runtime._bot_ammo_categories` classifies premium rounds by a penetration
heuristic, documented as "the pinned descriptor does not expose a stable
credits/gold price at this seam". There is now an exact resource-level answer.