### PR TITLE
Prepare one broken-skin filter per pose instead of per ground column

### DIFF
--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -416,6 +416,7 @@ def _is_port_object(value):
     return isinstance(origin, str) and origin.startswith(_PORT_PACKAGE)
 
 
+_EMPTY_GROUND_FILTER = object()
 _FRAME_STAGE_NAMES = (
     'house', 'sync', 'critical', 'drown', 'prewarm', 'transition', 'local',
     'outline', 'bots_update', 'bot_present', 'bot_events', 'spot', 'lock',
@@ -4794,6 +4795,28 @@ class BattleRuntime(object):
         ground_filter = probe(x, z)
         return ground_filter if callable(ground_filter) else None
 
+    def _prepared_ground_filter(self, points):
+        """Build one broken-skin filter covering several ground columns.
+
+        A pass that samples many columns of one pose does not need a rebuilt
+        candidate set per column.  The prepared sweep filter covers the whole
+        envelope and still resolves each hit by its exact native identity
+        against the live accepted ledger, so it decides exactly what the
+        per-column filter decides for every column inside that envelope.
+        Returns ``None`` when this runtime cannot prepare one, which keeps the
+        per-column path in ``_suspension_ground_y``.
+        """
+        probe = getattr(
+            self._destructibles, 'prepare_horizontal_collision_filter', None)
+        if not callable(probe) or not points:
+            return None
+        xs = [float(point[0]) for point in points]
+        zs = [float(point[1]) for point in points]
+        prepared = probe(
+            self._vector((min(xs), 0.0, min(zs))),
+            self._vector((max(xs), 0.0, max(zs))))
+        return prepared if callable(prepared) else _EMPTY_GROUND_FILTER
+
     def _collide_down(self, start, end, ground_filter):
         """Vertical probe that skips the skin of an already broken item."""
         if ground_filter is None:
@@ -4850,7 +4873,8 @@ class BattleRuntime(object):
         return height
 
     def _suspension_ground_y(
-            self, x, z, minimum_y, maximum_y, flat_maximum_y=None):
+            self, x, z, minimum_y, maximum_y, flat_maximum_y=None,
+            prepared_filter=None):
         """Return ground inside one suspension contact's legal travel.
 
         Unlike the navigation column, this probe must never acquire a roof or
@@ -4862,7 +4886,10 @@ class BattleRuntime(object):
         maximum_y = float(maximum_y)
         if maximum_y < minimum_y:
             minimum_y, maximum_y = maximum_y, minimum_y
-        ground_filter = self._ground_filter(x, z)
+        ground_filter = (
+            self._ground_filter(x, z) if prepared_filter is None else
+            None if prepared_filter is _EMPTY_GROUND_FILTER else
+            prepared_filter)
         start_y = maximum_y
         for unused_layer in range(3):
             try:
@@ -18930,6 +18957,7 @@ class BattleRuntime(object):
         probe_height = float(probe_height)
         points = vehicle_physics.suspension_world_points(
             params, position, yaw)
+        prepared_filter = self._prepared_ground_filter(points)
         memory = self._local_spring_ground_memory
         if not isinstance(memory, list) or len(memory) != len(points):
             memory = [None] * len(points)
@@ -18952,7 +18980,8 @@ class BattleRuntime(object):
                 vehicle_physics.CONTACT_PENETRATION)
             value = self._suspension_ground_y(
                 x, z, minimum_y, maximum_y,
-                flat_maximum_y=spring_maximum_y)
+                flat_maximum_y=spring_maximum_y,
+                prepared_filter=prepared_filter)
             value, memory[index] = vehicle_physics.retained_ground_contact(
                 point, value, memory[index],
                 params['contact_memory_distance'], support_gradient)
@@ -18972,6 +19001,7 @@ class BattleRuntime(object):
         probe_height = float(probe_height)
         points = vehicle_physics.suspension_pseudo_world_points(
             params, position, yaw)
+        prepared_filter = self._prepared_ground_filter(points)
         memory = self._local_pseudo_ground_memory
         if not isinstance(memory, list) or len(memory) != len(points):
             memory = [None] * len(points)
@@ -18996,7 +19026,8 @@ class BattleRuntime(object):
                 if contact.get('kind') == 'track' else None)
             value = self._suspension_ground_y(
                 x, z, minimum_y, maximum_y,
-                flat_maximum_y=flat_maximum_y)
+                flat_maximum_y=flat_maximum_y,
+                prepared_filter=prepared_filter)
             value, memory[index] = vehicle_physics.retained_ground_contact(
                 point, value, memory[index],
                 params['contact_memory_distance'], support_gradient)
@@ -19032,6 +19063,10 @@ class BattleRuntime(object):
             previous_plane, motion_pose[0], motion_pose[2])
         end_ground = vehicle_physics.suspension_plane_height(
             current_plane, position[0], position[2])
+        prepared_filter = self._prepared_ground_filter(tuple(
+            (float(motion_pose[0]) + dx * fraction,
+             float(motion_pose[2]) + dz * fraction)
+            for fraction in fractions))
         for fraction in fractions:
             x = float(motion_pose[0]) + dx * fraction
             z = float(motion_pose[2]) + dz * fraction
@@ -19039,7 +19074,8 @@ class BattleRuntime(object):
             ground = self._suspension_ground_y(
                 x, z, expected - GROUND_PLANE_EPSILON,
                 expected + GROUND_PLANE_EPSILON,
-                flat_maximum_y=expected + GROUND_PLANE_EPSILON)
+                flat_maximum_y=expected + GROUND_PLANE_EPSILON,
+                prepared_filter=prepared_filter)
             if (ground is None or
                     abs(float(ground) - expected) > GROUND_PLANE_EPSILON):
                 return False

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/world_collision.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/world_collision.py
@@ -86,7 +86,8 @@ def _drivable_surface(collision, maximum_gradient=_MAX_DRIVABLE_GRADIENT):
 
 @observed('motion.ground_profile')
 def _ground_profile(spaceID, Math, pos, sx, sz, sin_y, cos_y, direction,
-		look, segment_count=6, ground_plane=None):
+		look, segment_count=6, ground_plane=None,
+		collision_filter=_UNPREPARED_COLLISION_FILTER):
 	"""Sample the lane that produced a lower-hull hit."""
 	segment = look / float(segment_count)
 	heights = []
@@ -95,7 +96,8 @@ def _ground_profile(spaceID, Math, pos, sx, sz, sin_y, cos_y, direction,
 		x = sx + sin_y * distance * direction
 		z = sz + cos_y * distance * direction
 		ground = _ground_top(
-			spaceID, Math, pos, x, z, look, ground_plane)
+			spaceID, Math, pos, x, z, look, ground_plane,
+			collision_filter)
 		if ground is None:
 			return (), segment
 		heights.append(ground)
@@ -128,12 +130,14 @@ def _hit_matches_ground_profile(collision, heights, segment_length,
 
 
 def _hit_matches_exact_ground_top(spaceID, Math, pos, collision, look,
-		ground_plane=None):
+		ground_plane=None,
+		collision_filter=_UNPREPARED_COLLISION_FILTER):
 	"""Confirm that a coarse-profile candidate is the native top at its XZ."""
 	try:
 		point = collision[0]
 		top = _ground_top(
-			spaceID, Math, pos, point.x, point.z, look, ground_plane)
+			spaceID, Math, pos, point.x, point.z, look, ground_plane,
+			collision_filter)
 		return (top is not None and
 			abs(float(top) - float(point.y)) <=
 			_GROUND_HIT_EPSILON)
@@ -178,13 +182,21 @@ def _hull_pose_endpoint(local_start, local_end, half_width,
 
 
 @observed('motion.ground_top')
-def _ground_top(spaceID, Math, pos, x, z, look, ground_plane=None):
+def _ground_top(spaceID, Math, pos, x, z, look, ground_plane=None,
+		collision_filter=_UNPREPARED_COLLISION_FILTER):
 	"""Return support below the occupied lane, not an overhead deck.
 
 	The ceiling follows the posed upper hull ray, or the tangent plane of an
 	already witnessed drivable hit. A sky-origin ray can select a gatehouse
 	roof in one column and its road in the next, inventing a cliff. Horizontal
 	lower and upper rays still own walls and beams inside the occupied lanes.
+
+	``collision_filter`` is the sweep-wide broken-skin callback already prepared
+	for the horizontal lanes.  Every ground column sampled by this sweep lies
+	inside that envelope, and the callback still resolves each hit by its exact
+	native identity against the live accepted ledger, so sharing it decides
+	exactly what a per-column filter decides without rebuilding the candidate
+	set for each of the sweep's ground rays.
 	"""
 	import BigWorld
 	try:
@@ -200,7 +212,9 @@ def _ground_top(spaceID, Math, pos, x, z, look, ground_plane=None):
 			return None
 		start = Math.Vector3(x, start_y, z)
 		end = Math.Vector3(x, pos.y - probe_down, z)
-		broken_filter = ground_collision_filter(x, z)
+		broken_filter = collision_filter
+		if broken_filter is _UNPREPARED_COLLISION_FILTER:
+			broken_filter = ground_collision_filter(x, z)
 		ground = (observed_ray(
 			'native.motion.ground', BigWorld.wg_collideSegment,
 			spaceID, start, end, 128)
@@ -215,7 +229,8 @@ def _ground_top(spaceID, Math, pos, x, z, look, ground_plane=None):
 
 @observed('motion.ground_ahead')
 def _lane_ground_ahead(spaceID, Math, pos, start_x, start_z,
-		footprint_x, footprint_z, end_x, end_z, look, ground_plane=None):
+		footprint_x, footprint_z, end_x, end_z, look, ground_plane=None,
+		collision_filter=_UNPREPARED_COLLISION_FILTER):
 	"""Conservatively extend the ground observed inside the hull footprint.
 
 	A downward ``wg_collideSegment`` returns the first surface, which can be a
@@ -227,11 +242,14 @@ def _lane_ground_ahead(spaceID, Math, pos, start_x, start_z,
 	"""
 	import math
 	start_ground = _ground_top(
-		spaceID, Math, pos, start_x, start_z, look, ground_plane)
+		spaceID, Math, pos, start_x, start_z, look, ground_plane,
+		collision_filter)
 	footprint_ground = _ground_top(
-		spaceID, Math, pos, footprint_x, footprint_z, look, ground_plane)
+		spaceID, Math, pos, footprint_x, footprint_z, look, ground_plane,
+		collision_filter)
 	end_ground = _ground_top(
-		spaceID, Math, pos, end_x, end_z, look, ground_plane)
+		spaceID, Math, pos, end_x, end_z, look, ground_plane,
+		collision_filter)
 	try:
 		inside_length = math.sqrt(
 			(float(footprint_x) - float(start_x)) ** 2 +
@@ -312,7 +330,7 @@ def _raised_ray_has_wall(spaceID, Math, pos, x1, z1, x2, z2,
 					ground_profile[6])):
 			if _hit_matches_exact_ground_top(
 					spaceID, Math, pos, collision, ground_profile[7],
-					ground_profile[8]):
+					ground_profile[8], collision_filter):
 				continue
 		return True
 	return False
@@ -576,7 +594,7 @@ def _check_horizontal_collision(spaceID, pos, yaw, vel, td=None,
 			_ground_ahead = (
 				_lane_ground_ahead(spaceID, Math, pos,
 					x1, z1, footprint_x, footprint_z,
-					x2, z2, target_len, ground_plane)
+					x2, z2, target_len, ground_plane, _sweep_filter)
 				if pose_y[2] else None)
 			
 			# Spodní paprsek pro pevnou geometrii (0.6m nad zemí)
@@ -621,7 +639,8 @@ def _check_horizontal_collision(spaceID, pos, yaw, vel, td=None,
 						_heights, _segment = _ground_profile(
 							spaceID, Math, pos, profile_x, profile_z,
 							profile_sin, profile_cos, profile_direction,
-							profile_look, ground_plane=_profile_plane)
+							profile_look, ground_plane=_profile_plane,
+							collision_filter=_sweep_filter)
 						_gradient_limit = _profile_gradient_limit(_heights)
 						if (_heights and
 								abs(float(_heights[-1]) -
@@ -643,7 +662,7 @@ def _check_horizontal_collision(spaceID, pos, yaw, vel, td=None,
 								profile_direction)):
 						_surface_is_ground = _hit_matches_exact_ground_top(
 							spaceID, Math, pos, col_bot, profile_look,
-							_profile_plane)
+							_profile_plane, _sweep_filter)
 					if (_heights and
 							_drivable_ground_profile(_heights, _segment) and
 							_surface_is_ground):

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -19617,6 +19617,66 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertFalse(battle._local_left_flying)
         self.assertFalse(battle._local_right_flying)
 
+    def test_local_suspension_tick_prepares_one_broken_skin_filter(self):
+        """The 22 columns of one pose share the prepared envelope filter."""
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        battle._local_fall_armed = True
+        entity = _Vehicle(
+            10, _suspension_descriptor(), _Vector(), (0, 0, 0),
+            {'health': 500})
+        skin_filter = lambda *unused_hit: False
+        prepared = mock.Mock(return_value=skin_filter)
+        battle._destructibles = types.SimpleNamespace(
+            prepare_horizontal_collision_filter=prepared,
+            ground_collision_filter=mock.Mock(
+                side_effect=AssertionError(
+                    'a shared pose must not rebuild a per-column filter')))
+        filters = []
+
+        def collision(unused_space, start, unused_end, unused_mask,
+                      ground_filter=None):
+            filters.append(ground_filter)
+            return (_Vector(start.x, 0.0, start.z), _Vector(0.0, 1.0, 0.0))
+
+        runtime.bigworld.wg_collideSegment = collision
+
+        battle._update_vertical_motion(entity, (0.0, 0.0, 0.0), 0.0, 0.1)
+
+        # One prepared filter per sample pass, not one per sampled column.
+        self.assertEqual(2, prepared.call_count)
+        self.assertEqual(22, len(filters))
+        self.assertTrue(all(value is skin_filter for value in filters))
+
+    def test_local_suspension_tick_probes_unfiltered_with_nothing_broken(self):
+        """An envelope with nothing broken keeps the shipped bare query."""
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        battle._local_fall_armed = True
+        entity = _Vehicle(
+            10, _suspension_descriptor(), _Vector(), (0, 0, 0),
+            {'health': 500})
+        battle._destructibles = types.SimpleNamespace(
+            prepare_horizontal_collision_filter=lambda *unused: None,
+            ground_collision_filter=mock.Mock(
+                side_effect=AssertionError(
+                    'a prepared empty envelope must not be rebuilt')))
+        widths = []
+
+        def collision(unused_space, start, unused_end, unused_mask,
+                      *filters):
+            widths.append(len(filters))
+            return (_Vector(start.x, 0.0, start.z), _Vector(0.0, 1.0, 0.0))
+
+        runtime.bigworld.wg_collideSegment = collision
+
+        battle._update_vertical_motion(entity, (0.0, 0.0, 0.0), 0.0, 0.1)
+
+        self.assertEqual(22, len(widths))
+        self.assertEqual({0}, set(widths))
+
     def test_local_suspension_solves_slope_pitch_and_ground_metadata(self):
         runtime = _runtime()
         battle = BattleRuntime(runtime)

--- a/tests/test_port_0922_world_collision.py
+++ b/tests/test_port_0922_world_collision.py
@@ -841,7 +841,7 @@ class WorldCollisionTests(unittest.TestCase):
         def ground_profile(unused_space, unused_math, unused_pos,
                            unused_x, unused_z, unused_sin, unused_cos,
                            unused_direction, look, segment_count=6,
-                           ground_plane=None):
+                           ground_plane=None, collision_filter=None):
             segment = float(look) / float(segment_count)
             return ([index * segment * 0.5
                      for index in range(segment_count + 1)], segment)
@@ -1333,16 +1333,21 @@ class WorldCollisionTests(unittest.TestCase):
         math_module = types.SimpleNamespace(Vector3=_Vector)
 
         with mock.patch.object(
-                world_collision, 'ground_collision_filter',
-                return_value=reject_broken) as filter_factory:
+                world_collision, 'prepare_horizontal_collision_filter',
+                return_value=reject_broken) as filter_factory, \
+                mock.patch.object(
+                    world_collision, 'ground_collision_filter',
+                    side_effect=AssertionError(
+                        'the sweep must reuse its prepared filter')):
             self.assertFalse(world_collision.check_horizontal_collision(
                 bigworld, math_module, 1, _Vector(), 0.0, 20.0,
                 None, False, 0.20, pitch=-math.atan(gradient)))
 
         # Nine conservative lane-cap samples, three exact-top probes and three
         # seven-sample ground profiles all hide a destructible skin that has
-        # already been marked broken.
-        self.assertEqual(33, filter_factory.call_count)
+        # already been marked broken, and all of them carry the single filter
+        # this sweep prepared for its lane envelope.
+        self.assertEqual(1, filter_factory.call_count)
         self.assertEqual(9, len(filtered_queries))
         self.assertTrue(all(row[2] is reject_broken
                             for row in filtered_queries))
@@ -1387,7 +1392,7 @@ class WorldCollisionTests(unittest.TestCase):
         math_module = types.SimpleNamespace(Vector3=_Vector)
 
         with mock.patch.object(
-                world_collision, 'ground_collision_filter',
+                world_collision, 'prepare_horizontal_collision_filter',
                 return_value=reject_broken):
             self.assertFalse(world_collision.check_horizontal_collision(
                 bigworld, math_module, 1, _Vector(), 0.0, 20.0,
@@ -2007,7 +2012,7 @@ class WorldCollisionTests(unittest.TestCase):
 
         self.assertTrue(blocked)
 
-    def test_ground_profile_filter_skips_broken_skin_to_terrain(self):
+    def test_level_ground_profile_filter_skips_broken_skin(self):
         gradient = 0.20
         profile_look = 3.5 + 20.0 * 0.20 + 0.20
         broken_z = profile_look / 6.0 * 2.0
@@ -2047,7 +2052,7 @@ class WorldCollisionTests(unittest.TestCase):
         math_module = types.SimpleNamespace(Vector3=_Vector)
 
         with mock.patch.object(
-                world_collision, 'ground_collision_filter',
+                world_collision, 'prepare_horizontal_collision_filter',
                 return_value=reject_broken):
             self.assertFalse(world_collision.check_horizontal_collision(
                 bigworld, math_module, 1, _Vector(), 0.0, 20.0,


### PR DESCRIPTION
## The report

> 更新物理效果之后撞铁栏杆和地图上的零碎物件会严重掉帧，AI 互殴的时候乱压直接卡成 PPT

The direction of that report reproduces. The boundary the reporter names is real:
`d245105` "Pose hull collision rays with the authoritative hull attitude", shipped
in **v0.6.8**, is the only release that changed the per-frame world-collision
geometry, and it roughly doubled the ground querying that every vehicle does.

## What the physics update actually changed

`tools/benchmark_bot_workload.py --scenario combat --map 06_ensk --seconds 10
--fps 30`, 29 Bots, 300 frames, with `pitch`/`roll` forced to zero for the A side:

| | native `wg_collideSegment` | per frame | CPU |
|---|---|---|---|
| shipped posed lanes | 48,150 | 160.5 | 3.00 s |
| pose forced level | 25,497 | 85.0 | 2.78 s |

The 22,653 extra queries are all vertical, and attribution is exact: 25.17
`_lane_ground_ahead` calls per frame × 3 columns = 75.5 of them. A posed lane
samples three ground columns before its first horizontal ray; a level lane
samples none. One sweep therefore pays 9 ground columns clear, up to 17 on a
lane hit, and 15 on the five-lane cross-heading corridor that ram separation
uses. `_check_horizontal_collision` runs from seven call sites per local drive
step (drive, slope slide, suspension slide, tank contacts), so the visible
client pays that several times per frame.

**Those extra queries are load-bearing and this PR keeps every one of them.**
Gating them on whether the pose lifts the lane above its level baseline looks
correct and is not: it breaks
`test_wall_top_cannot_raise_the_ground_ahead_cap` and
`test_a_pitched_hull_sees_a_wall_standing_on_its_own_slope` on descending
ground, where the estimate *lowers* the lane onto a wall whose top is below the
level baseline. The suite is right; that experiment is abandoned.

## The defect this PR fixes

What is not load-bearing is that **each of those queries rebuilt its own
`#1513` fifth-argument broken-skin filter**. `ground_collision_filter(x, z)`
re-derives the bin's candidate set, indexes the chunk's accepted keys and
re-scans the speculative set, per column. It is cheap only while nothing near
the hull is broken — which is exactly the condition the report says makes
frames drop.

Measured on **CPython 2.7.18** (not CPython 3 — batching's sign is
interpreter-dependent here), eight fragile items in the probe's bin and one
felled tree anywhere in the space:

| | shipped | this PR |
|---|---|---|
| one `ground_collision_filter` build | 16.76 µs | — |
| one prepared envelope filter build | — | 14.15 µs |
| one complete posed world sweep | 285.4 µs | **199.0 µs** (−30.3%) |
| one local suspension tick's filter work (22 columns) | 368.6 µs | **14.1 µs** |

The 22 columns are the ten damper springs plus twelve pseudo contacts that
`initVehiclePhysicsClient`'s recipe gives the local player every physics tick —
the same defect class as the world sweep, so it is fixed in the same change.

## The fix

Hand both paths the sweep-wide filter that the horizontal lanes already
prepare, and prepare one per suspension pose pass.

This is exact, not an approximation:

- every ground column of a sweep lies inside that lane envelope, and
  `_destructible_bin_key` and `_bin_keys_for_bounds` use the same
  `floor(v / 8.0)` formula, so the prepared member set is a superset of every
  per-column set inside it;
- the callback still resolves each hit by its exact `(chunkID, itemIndex,
  matKind)` identity against the live accepted ledger, so a superset admits and
  hides exactly what the per-column filter did;
- `_live_broken_collision_filter_1513` reads that ledger at invocation rather
  than snapshotting it, which is what keeps a destructible admitted by an
  earlier lane hidden from a later lane. The earlier objection to a sweep-wide
  memo was that `_accepted_tree_collision_keys_1513()` gets snapshotted; the
  world sweep never fells a tree (`_try_destroy_solid_hit` handles only
  fragile/structure/falling), so the emptiness decision cannot change inside one
  sweep.

Both paths keep the per-column build as the fallback when a runtime cannot
prepare one, so injected seams are unaffected.

## Also fixed

`test_ground_profile_filter_skips_broken_skin_to_terrain` was defined **twice**
in `WorldCollisionTests`. The second definition shadowed the first, so the posed
variant had never run. Both now run under distinct names — the suite is 71
tests where it was 70.

## Validation

- `tests.test_port_0922_world_collision` — 71 tests, OK
- `tests.test_port_0922_battle_runtime` — 815 tests, OK (2 new)
- full `unittest discover -s tests` — **4226 tests, OK**
- CPython 2.7 source compile of `src/res/scripts/client` — 97 files, passed

New coverage pins the cost contract so it cannot silently regress: a posed
sweep must prepare its filter **once** and never call the per-column factory,
all nine ground columns must carry that one callback, and a suspension tick
must prepare twice (one per pass) for its 22 columns while an envelope with
nothing broken keeps the shipped bare four-argument query.

## What is still unproved

Windows. These are Python microseconds on Linux/x86-64 under CPython 2.7.18;
they are not frame time on the exact #1513 client, and they do not prove that
this accounts for all of the reporter's frame loss. The shipped build already
emits the discriminator — a `PERF summary` line in `python.log` carrying
`logical_native_probes` for `native.motion.ground` and `python_stages_ms`.
One contact-heavy round's PERF lines before and after would convert these counts
into milliseconds.

Two findings worth a separate scope decision, deliberately **not** touched here:

1. `_lane_ground_ahead` is triggered by `pose_y[2]` (pitch) alone, so a purely
   **rolled** hull's side lane can lift its endpoint by `hw · sin(roll)` — 0.26 m
   at 10° — with no ground guard at all. `test_hull_roll_poses_lanes_without_
   adding_native_rays` currently enshrines that as intended.
2. The doubled ground-query count itself. It is correct, but it is the largest
   single per-frame native cost the physics update introduced, and reducing it
   needs a behavioural decision rather than a refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)