### PR TITLE
Fix projectile catalog scan cost and repeated Bot combat rebases

### DIFF
--- a/server/lan_battle_server.py
+++ b/server/lan_battle_server.py
@@ -5979,6 +5979,13 @@ class BattleState:
         critical = state.get("critical")
         if critical:
             critical = _critical_state(_critical_payload(critical))
+            # Bot ledgers identify devices and crew by name. Descriptor crew
+            # order can differ from the compact row's mask order without any
+            # combat change. Normalize only this comparison, preserving the
+            # ordered descriptor/profile payloads used by other consumers.
+            critical["devices"].sort(key=lambda record: record["name"])
+            if "crew_roster" in critical:
+                critical["crew_roster"] = sorted(critical["crew_roster"])
             if _critical_discrete_state(critical) == (
                     (), (), (), False, False):
                 critical = None

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -843,8 +843,8 @@ def _critical_signature(payload):
                      (payload.get('destroyed') or ()))),
         tuple(sorted(str(name) for name in
                      (payload.get('crew_ko') or ()))),
-        tuple(str(name) for name in
-              (payload.get('crew_roster') or ())),
+        tuple(sorted(str(name) for name in
+                     (payload.get('crew_roster') or ()))),
         bool(payload.get('fire', False)),
         bool(payload.get('ammo_rack_death', False)))
     if signature == ((), (), (), (), False, False):

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/destructibles_sensor.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/destructibles_sensor.py
@@ -2182,6 +2182,7 @@ def _stream_baked_shot_instance_1513(spaceID, identity):
 	return instance
 
 
+@observed('destructible.shot_catalog')
 def _catalog_shot_intersection(spaceID, start, end, maximum_distance=None):
 	"""Resolve the nearest live-validated catalog OBB along a shell ray."""
 	segment = end - start
@@ -2194,17 +2195,26 @@ def _catalog_shot_intersection(spaceID, start, end, maximum_distance=None):
 	if not instances and not baked_instances:
 		return None
 	authority = _get_destr_authority()
-	identities = set(instances)
+	identities = set()
+	contact_bins = globals().get('g_offh_destr_contact_bins', {})
+	baked_bins = catalog.get('baked_shot_bins', {})
 	effective_end = end
 	if (maximum_distance is not None and
 			float(maximum_distance) < segment_length):
+		# The exact interval test below admits the native endpoint with this
+		# tolerance; its broad phase must include the same interval at bin edges.
 		effective_end = start + segment.scale(
-			max(0.0, float(maximum_distance)) / segment_length)
+			min(segment_length, max(0.0, float(maximum_distance) + 1.0e-6)) /
+			segment_length)
 	bounds = (min(start.x, effective_end.x), max(start.x, effective_end.x),
 		min(start.z, effective_end.z), max(start.z, effective_end.z))
 	for bin_key in _baked_bin_keys_for_bounds_1513(*bounds):
-		identities.update(
-			catalog.get('baked_shot_bins', {}).get(bin_key, ()))
+		# Registration and falling-transform updates already maintain this
+		# exact live footprint index. Seeding from every registered instance
+		# makes each projectile chord re-test props across the explored map.
+		identities.update(contact_bins.get(bin_key, ()))
+		identities.update(baked_bins.get(bin_key, ()))
+	combat_count('destructible_shot_candidates', len(identities))
 	hits = {}
 	for identity in sorted(identities):
 		if _destructible_isolated_1513(identity[0], identity[1]):

--- a/tests/test_port_0922_destructibles.py
+++ b/tests/test_port_0922_destructibles.py
@@ -4771,6 +4771,96 @@ class DestructiblesCompatibilityTests(unittest.TestCase):
         self.assertIn('native=-1 wire=live_validated', writes[0])
         self.assertIn('repeats=suppressed_for_battle', writes[0])
 
+    def test_shot_query_work_does_not_grow_with_distant_registered_props(self):
+        destructibles_sensor.xrange = range
+        axes = ((1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0))
+        authority = types.SimpleNamespace(is_destroyed=lambda *unused: False)
+        for distant_count in (0, 64, 1079):
+            with self.subTest(distant_count=distant_count):
+                centers = [(0.0, 0.0, 5.0)] + [
+                    (1000.0 + index * 8.0, 0.0, 1000.0)
+                    for index in range(distant_count)]
+                instances = {
+                    (22, index): {
+                        'filename': 'test.model', 'kind': 'fragile',
+                        'item_scale': 1.0, 'boxes': ((center, axes, None),),
+                    } for index, center in enumerate(centers)}
+                destructibles_sensor.g_offh_destr_instances = instances
+                bins = destructibles_sensor.g_offh_destr_contact_bins = {}
+                for identity, instance in instances.items():
+                    destructibles_sensor._index_catalog_instance_1513(
+                        bins, identity, instance)
+                with mock.patch.object(
+                        destructibles_sensor, '_get_destr_authority',
+                        return_value=authority), mock.patch.object(
+                        destructibles_sensor, '_segment_world_box_interval',
+                        wraps=destructibles_sensor._segment_world_box_interval
+                        ) as intersections:
+                    hit = destructibles_sensor._catalog_shot_intersection(
+                        1, _Vector(), _Vector(0.0, 0.0, 20.0))
+                self.assertEqual((22, 0), hit['candidate'][:2])
+                self.assertAlmostEqual(4.0, hit['distance'])
+                self.assertEqual(1, intersections.call_count)
+
+    def test_shot_query_keeps_live_modules_at_bin_edges_and_native_cap(self):
+        destructibles_sensor.xrange = range
+        axes = ((1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0))
+        instance = {
+            'filename': 'test.model', 'kind': 'structure', 'item_scale': 1.0,
+            'boxes': (((8.0, 0.0, 40.0), axes, 73),
+                      ((8.0, 0.0, 20.0), axes, 74)),
+        }
+        destructibles_sensor.g_offh_destr_instances = {(22, 1): instance}
+        bins = destructibles_sensor.g_offh_destr_contact_bins = {}
+        destructibles_sensor._index_catalog_instance_1513(
+            bins, (22, 1), instance)
+        destroyed = set()
+        authority = types.SimpleNamespace(is_destroyed=lambda *key: (
+            key in destroyed))
+        with mock.patch.object(
+                destructibles_sensor, '_get_destr_authority',
+                return_value=authority):
+            # Reverse travel on an exact cell edge must include the module
+            # touching the native endpoint, but nothing behind that endpoint.
+            start, end = _Vector(8.0, 0.0, 60.0), _Vector(8.0, 0.0, 0.0)
+            self.assertIsNone(destructibles_sensor._catalog_shot_intersection(
+                1, start, end, 18.0))
+            hit = destructibles_sensor._catalog_shot_intersection(
+                1, start, end, 19.0)
+            self.assertEqual((22, 1, 73), hit['candidate'][:3])
+            self.assertAlmostEqual(19.0, hit['distance'])
+            destroyed.add((22, 1, 73))
+            self.assertIsNone(destructibles_sensor._catalog_shot_intersection(
+                1, start, end, 19.0))
+            hit = destructibles_sensor._catalog_shot_intersection(
+                1, start, end)
+            self.assertEqual((22, 1, 74), hit['candidate'][:3])
+            self.assertAlmostEqual(39.0, hit['distance'])
+            destructibles_sensor._drop_isolated_destructible_1513(22, 1)
+            self.assertIsNone(destructibles_sensor._catalog_shot_intersection(
+                1, start, end))
+
+    def test_shot_query_native_cap_tolerance_crosses_a_spatial_bin_edge(self):
+        destructibles_sensor.xrange = range
+        instance = {
+            'filename': 'test.model', 'kind': 'fragile', 'item_scale': 1.0,
+            'boxes': (((0.0, 0.0, 9.0),
+                       ((1.0, 0.0, 0.0), (0.0, 1.0, 0.0),
+                        (0.0, 0.0, 1.0)), None),),
+        }
+        destructibles_sensor.g_offh_destr_instances = {(22, 1): instance}
+        bins = destructibles_sensor.g_offh_destr_contact_bins = {}
+        destructibles_sensor._index_catalog_instance_1513(
+            bins, (22, 1), instance)
+        authority = types.SimpleNamespace(is_destroyed=lambda *unused: False)
+        with mock.patch.object(
+                destructibles_sensor, '_get_destr_authority',
+                return_value=authority):
+            hit = destructibles_sensor._catalog_shot_intersection(
+                1, _Vector(), _Vector(0.0, 0.0, 20.0), 8.0 - 0.5e-6)
+        self.assertEqual((22, 1), hit['candidate'][:2])
+        self.assertAlmostEqual(8.0, hit['distance'])
+
     def test_handlerless_effect_category_reaches_shot_intersection(self):
         unused_filename, area, bigworld, math_module = (
             self._streamed_fragile_fixture())

--- a/tests/test_port_0922_server_combat_lineage.py
+++ b/tests/test_port_0922_server_combat_lineage.py
@@ -1,3 +1,4 @@
+import copy
 import importlib.util
 import math
 from pathlib import Path
@@ -291,6 +292,71 @@ class ServerCombatLineageIntegrationTests(unittest.TestCase):
                 server.bot_state_time_us - first_mapped_time_us),
         })
 
+    def test_combat_wire_roundtrip_keeps_lineage_and_real_change_guards(self):
+        server = BattleState.__new__(BattleState)
+        for roster in (['gunner1', 'driver'],
+                       ['commander', 'gunner1', 'driver', 'loader1'],
+                       ['loader2', 'loader1', 'commander', 'driver']):
+            with self.subTest(roster=roster):
+                previous = {
+                    'id': 11, 'health': 900, 'alive': True,
+                    'combat_revision': 3, 'combat_base_revision': 3,
+                    'combat_seq': 0, 'combat_ack_seq': 0,
+                    'combat_fire_elapsed': 0.0, 'combat_fire_timer': 0.0,
+                    'stun_end_server_time_ms': 0,
+                    'critical': {
+                        'devices': [
+                            {'name': 'leftTrackHealth', 'hp': 170.0,
+                             'max_hp': 170.0, 'state': 'normal'},
+                            {'name': 'gunHealth', 'hp': 54.0,
+                             'max_hp': 54.0, 'state': 'normal'},
+                        ],
+                        'destroyed': [], 'crew_ko': [], 'crew_roster': roster,
+                        'fire': False, 'ammo_rack_death': False, 'events': [],
+                    },
+                }
+                frozen = copy.deepcopy(previous)
+                raw = bot_state_rows.bot_state_codec.decode_row(
+                    bot_state_rows.row(previous), {})
+                for signature in (server._bot_combat_signature,
+                                  self.bot_runtime._combat_signature):
+                    self.assertEqual(signature(previous), signature(raw))
+                current = copy.deepcopy(raw)
+                server._reconcile_modern_bot_combat(raw, previous, current)
+                self.assertEqual(3, current['combat_base_revision'])
+                self.assertEqual(0, current['combat_ack_seq'])
+                self.assertEqual(frozen, previous)
+
+                for changed_field in ('health', 'device_hp', 'crew_ko',
+                                      'crew_roster'):
+                    with self.subTest(changed_field=changed_field):
+                        changed = copy.deepcopy(raw)
+                        critical = changed['critical']
+                        if changed_field == 'health':
+                            changed['health'] -= 1
+                        elif changed_field == 'device_hp':
+                            critical['devices'][0]['hp'] -= 1.0
+                        elif changed_field == 'crew_ko':
+                            critical['crew_ko'] = [roster[0]]
+                        else:
+                            critical['crew_roster'].remove(roster[0])
+                        for signature in (server._bot_combat_signature,
+                                          self.bot_runtime._combat_signature):
+                            self.assertNotEqual(signature(previous),
+                                                signature(changed))
+                        with self.assertRaisesRegex(
+                                ValueError, 'repeated bot combat publication'):
+                            server._reconcile_modern_bot_combat(
+                                changed, previous, copy.deepcopy(changed))
+                        # The same real change is admitted when its owner
+                        # advances the publication sequence exactly once.
+                        changed['combat_seq'] = 1
+                        current = copy.deepcopy(changed)
+                        server._reconcile_modern_bot_combat(
+                            changed, previous, current)
+                        self.assertEqual(1, current['combat_ack_seq'])
+                        self.assertEqual(3, current['combat_base_revision'])
+
     def test_external_hit_crew_roster_survives_repeated_publication(self):
         runtime, server, unused_roster = self._runtime_and_server()
         human = _human()
@@ -308,7 +374,8 @@ class ServerCombatLineageIntegrationTests(unittest.TestCase):
                 'max_hp': 170.0, 'state': 'normal',
             }],
             'destroyed': [], 'crew_ko': [],
-            'crew_roster': ['driver', 'gunner1'],
+            # Descriptor crew order differs from the compact wire mask order.
+            'crew_roster': ['gunner1', 'driver'],
             'fire': False, 'ammo_rack_death': False, 'events': [],
         }
         canonical = server.bot_states[11]
@@ -317,6 +384,7 @@ class ServerCombatLineageIntegrationTests(unittest.TestCase):
                          critical=dict(critical))
         self.assertTrue(server._commit_external_bot_combat(
             canonical, before))
+        external_revision = canonical['combat_base_revision']
 
         runtime.apply_snapshot({
             'server_tick': 2,
@@ -335,7 +403,14 @@ class ServerCombatLineageIntegrationTests(unittest.TestCase):
             'source_batch_horizon_us':
                 repeated['source_batch_horizon_us'],
         })), server.last_bot_state_reject)
+        self.assertEqual(external_revision,
+                         server.bot_states[11]['combat_base_revision'])
         for frame in range(1, 25):
+            runtime.apply_snapshot({
+                'server_tick': 2 + frame,
+                'bots': [dict(server.bot_states[bot_id])
+                         for bot_id in sorted(server.bot_states)],
+            })
             publication = runtime.update(
                 1.0 / 24.0, 1.1 + frame / 24.0,
                 players=[human])[0]
@@ -346,6 +421,8 @@ class ServerCombatLineageIntegrationTests(unittest.TestCase):
                 'source_batch_horizon_us':
                     publication['source_batch_horizon_us'],
             })), server.last_bot_state_reject)
+            self.assertEqual(external_revision,
+                             server.bot_states[11]['combat_base_revision'])
             if server.bot_pending_projectile_launches:
                 break
         self.assertTrue(any(


### PR DESCRIPTION
Each projectile chord scanned every registered destructible, so exploring a map made later shots increasingly expensive. Query the existing live and baked footprint bins before the unchanged exact intersection and nearest-hit traversal. Keep native endpoint tolerance across bin edges, and expose the catalog stage/candidate count in the existing sampled diagnostics. The regression scene now checks one local OBB even with 1,079 unrelated registered props; previously it checked 1,080.

Compact Bot rows reconstruct crew rosters in mask order, while projectile damage carries descriptor order. Order-sensitive combat signatures mistook this harmless round trip for an unsequenced state change and repeatedly opened new server bases. Normalize named device/crew order only for Bot combat comparisons on both peers. Preserve the original descriptor/profile ordering and the guards for actual HP, crew, and sequence changes.

Validation on the final source:
- Reproduced the full-scan and unsolicited-rebase failures before the fix.
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -p test_port_0922_destructibles.py` — 254 passed.
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=tests python3 -m unittest test_port_0922_bot_runtime test_port_0922_bot_state_codec test_port_0922_server_combat_lineage` — 474 passed.
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=tests python3 -m unittest test_port_0922_battle_projectiles test_port_0922_projectile_runtime test_port_0922_worker_diagnostics` — 182 passed.
- CPython 2.7.18 source compilation — all 97 client modules passed; `git diff --cached --check` passed.

Windows frame pacing and gameplay acceptance on Chinese HD 0.9.22.0.1 #1513 remain untested for this change. The candidate-count regression proves bounded local work, not an FPS gain.
