### PR TITLE
Reuse immutable baked navigation edges across Bot searches

### DIFF
--- a/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
@@ -33,6 +33,8 @@ BAKED_FATAL_HAZARDS = 1 | 2
 BAKED_SHALLOW_WATER = 4
 # Cache compact answers, not crossed-cell lists, in the 32-bit worker.
 MAX_BAKED_CORRIDOR_CACHE = 2048
+# Share only visited cells, never expand the complete graph in the x86 worker.
+MAX_BAKED_SEARCH_EDGE_CACHE = 2048
 BAKED_SHALLOW_WATER_PENALTY = 4.0
 BAKED_EDGE_CLEARANCE_WEIGHT = 0.20
 BAKED_FORMAT_NAME = 'offline-lan-0922-navgraph'
@@ -184,6 +186,8 @@ class TerrainGrid(object):
 		self.prebaked = True
 		self._baked_corridor_cache = {}
 		self._baked_corridor_order = deque()
+		self._baked_search_edge_cache = {}
+		self._baked_search_edge_order = deque()
 
 	def cell_for(self, point):
 		origin_x, origin_z = self._baked_origin if self.prebaked else (0.0, 0.0)
@@ -815,6 +819,44 @@ class TerrainGrid(object):
 		mask = int(self._baked_links[index]) & 0xff
 		return self._LINK_COUNTS[mask]
 
+	def _baked_search_edges(self, cell):
+		"""Share immutable directed-edge inputs across this map's Bot searches.
+
+		Keep run and slope cost separate so A* retains its exact floating-point
+		addition order. Wrecks, expiring failures, per-Bot vetoes and avoid points
+		are live search inputs and never enter this cache.
+		"""
+		cached = self._baked_search_edge_cache.get(cell)
+		if cached is not None:
+			combat_count('nav_baked_edges_reused')
+			return cached
+		combat_count('nav_baked_edges_built')
+		current_y = self._baked_cell_height(cell)
+		grade_divisor = max(0.05, self._baked_max_grade)
+		edges = []
+		for unused_dx, unused_dz, length_scale, next_cell, next_y in \
+				self._baked_neighbours(cell):
+			run = self.cell_size * length_scale
+			delta_y = next_y - current_y
+			slope = abs(delta_y) / max(run, 0.1)
+			slope_ratio = slope / grade_divisor
+			slope_cost = run * slope_ratio * slope_ratio * 6.0
+			if delta_y < 0.0:
+				slope_cost *= 1.25
+			edge_key = ((cell, next_cell) if cell < next_cell else
+			            (next_cell, cell))
+			edges.append((
+				next_cell, next_y, run, slope_cost,
+				self._penalty(next_cell, None, False),
+				self._penalty(next_cell, None, True), edge_key))
+		cached = tuple(edges)
+		self._baked_search_edge_cache[cell] = cached
+		self._baked_search_edge_order.append(cell)
+		while len(self._baked_search_edge_order) > MAX_BAKED_SEARCH_EDGE_CACHE:
+			self._baked_search_edge_cache.pop(
+				self._baked_search_edge_order.popleft(), None)
+		return cached
+
 	def _baked_clearance_penalty(self, cell):
 		"""Prefer the middle of a proved corridor without inventing new links.
 
@@ -1006,52 +1048,60 @@ class TerrainGrid(object):
 				reached = current
 				break
 			current_y = heights[current]
-			grade_limit = (self._baked_max_grade if self.prebaked else
-			               min(self.max_grade_up, self.max_grade_down))
-			grade_divisor = max(0.05, grade_limit)
 			if self.prebaked:
-				neighbours = self._baked_neighbours(current)
+				neighbours = self._baked_search_edges(current)
 			else:
-				neighbours = ((dx, dz, length,
-					(current[0] + dx, current[1] + dz),
-					self._edge(current, current_y,
-					           (current[0] + dx, current[1] + dz)))
-					for dx, dz, length in self._NEIGHBOURS)
-			for offset_x, offset_z, length_scale, next_cell, next_y in neighbours:
-				if next_y is None:
-					continue
-				edge_key = (tuple(sorted((current, next_cell)))
-				            if hard_edge_penalties or edge_penalties else None)
+				grade_divisor = max(
+					0.05, min(self.max_grade_up, self.max_grade_down))
+				neighbours = self._NEIGHBOURS
+			for edge in neighbours:
+				if self.prebaked:
+					(next_cell, next_y, run, slope_cost,
+					 plain_penalty, clearance_penalty, edge_key) = edge
+					terrain_penalty = (clearance_penalty if prefer_clearance else
+					                   plain_penalty)
+				else:
+					offset_x, offset_z, length_scale = edge
+					next_cell = (current[0] + offset_x, current[1] + offset_z)
+					next_y = self._edge(current, current_y, next_cell)
+					if next_y is None:
+						continue
+					edge_key = tuple(sorted((current, next_cell)))
+					if (hard_edge_penalties and
+							edge_key in hard_edge_penalties):
+						continue
+					if offset_x and offset_z:
+						# Do not squeeze diagonally across a blocked corner.
+						if (self._edge(current, current_y,
+						               (current[0] + offset_x, current[1])) is None or
+						        self._edge(current, current_y,
+						               (current[0], current[1] + offset_z)) is None):
+							continue
+					run = self.cell_size * length_scale
+					delta_y = next_y - current_y
+					slope = abs(delta_y) / max(run, 0.1)
+					slope_ratio = slope / grade_divisor
+					# Descending retains the greater cost of the copied planner.
+					slope_cost = run * slope_ratio * slope_ratio * 6.0
+					if delta_y < 0.0:
+						slope_cost *= 1.25
+					terrain_penalty = 0.0
 				if (hard_edge_penalties and
 						edge_key in hard_edge_penalties):
 					continue
-				if offset_x and offset_z and not self.prebaked:
-					# Do not squeeze diagonally across a blocked corner.
-					if (self._edge(current, current_y,
-					               (current[0] + offset_x, current[1])) is None or
-					        self._edge(current, current_y,
-					               (current[0], current[1] + offset_z)) is None):
-						continue
-				run = self.cell_size * length_scale
-				delta_y = next_y - current_y
-				slope = abs(delta_y) / max(run, 0.1)
-				slope_ratio = slope / grade_divisor
-				# Risk rises non-linearly near the controllable-grade limit.  A
-				# downhill edge costs a little more because braking and lateral
-				# slide leave less recovery room than climbing the same surface.
-				slope_cost = run * slope_ratio * slope_ratio * 6.0
-				if delta_y < 0.0:
-					slope_cost *= 1.25
+				if avoid_points or not self.prebaked:
+					terrain_penalty = self._penalty(
+						next_cell, avoid_points, prefer_clearance)
 				local_penalty = 0.0
 				if edge_penalties:
 					local_penalty = float(edge_penalties.get(edge_key, 0.0))
+				failed_penalty = 0.0
+				if self._failed_edges or self._static_hull_edges:
+					failed_penalty = max(
+						self._static_hull_edges.get(edge_key, 0.0),
+						self._failed_edge_timed_penalty(edge_key, now))
 				new_cost = (cost_so_far[current] + run + slope_cost +
-				            self._penalty(
-				                next_cell, avoid_points, prefer_clearance) +
-				            (self._failed_edge_penalty(current, next_cell, now)
-				             if (self._failed_edges or
-				                 self._static_hull_edges) else 0.0) +
-				            local_penalty)
+				            terrain_penalty + failed_penalty + local_penalty)
 				if next_cell not in cost_so_far or new_cost < cost_so_far[next_cell]:
 					cost_so_far[next_cell] = new_cost
 					came_from[next_cell] = current

--- a/tests/test_port_0922_navigation_clearance.py
+++ b/tests/test_port_0922_navigation_clearance.py
@@ -8,7 +8,7 @@ CLIENT_SCRIPTS = PORT_ROOT / 'src' / 'res' / 'scripts' / 'client'
 sys.path.insert(0, str(CLIENT_SCRIPTS))
 
 from gui.mods.offline_lan_0922.ai.navigation import (
-    BAKED_SHALLOW_WATER, MAX_BAKED_CORRIDOR_CACHE,
+    BAKED_SHALLOW_WATER, MAX_BAKED_CORRIDOR_CACHE, MAX_BAKED_SEARCH_EDGE_CACHE,
     TerrainGrid, TerrainNavigator,
 )
 
@@ -56,6 +56,82 @@ def _graph(width, height, open_cells):
 
 
 class BakedClearanceNavigationTests(unittest.TestCase):
+    def test_repeated_search_reuses_baked_edges_with_identical_path(self):
+        graph = _graph(17, 7, (
+            (x, z) for z in range(7) for x in range(17)))
+        graph['heights_mm'] = tuple(
+            x * 300 + z * 100 for z in range(7) for x in range(17))
+        graph['hazards'] = tuple(
+            BAKED_SHALLOW_WATER if x == 8 and z < 5 else 0
+            for z in range(7) for x in range(17))
+        grid = TerrainGrid(lambda *unused: None, baked_graph=graph)
+        calls = []
+        original = grid._baked_neighbours
+
+        def neighbours(cell):
+            calls.append(cell)
+            return original(cell)
+
+        grid._baked_neighbours = neighbours
+        start, goal = (0.0, 0.3, 12.0), (64.0, 5.1, 12.0)
+        first = grid.plan(start, goal, prefer_clearance=True)
+        self.assertTrue(first)
+        self.assertTrue(calls)
+        calls[:] = []
+        self.assertEqual(first, grid.plan(start, goal, prefer_clearance=True))
+        self.assertEqual([], calls)
+
+    def test_shared_baked_edges_keep_live_wrecks_failures_and_bot_vetoes(self):
+        graph = _graph(9, 5, (
+            (x, z) for z in range(5) for x in range(9)))
+        grid = TerrainGrid(lambda *unused: None, baked_graph=graph)
+        # Inspect the actual A* edges before independent path smoothing.
+        grid._smooth = lambda path, *unused: tuple(path)
+        start, goal = (0.0, 0.0, 8.0), (32.0, 0.0, 8.0)
+        edge = ((3, 2), (4, 2))
+
+        def plan(**kwargs):
+            return grid.plan(start, goal, prefer_clearance=False, **kwargs)
+
+        def crosses(path):
+            cells = [grid.cell_for(point) for point in path]
+            return edge in [tuple(sorted(pair))
+                            for pair in zip(cells, cells[1:])]
+
+        original = plan()
+        self.assertTrue(crosses(original))
+        self.assertEqual(original, plan())
+        self.assertFalse(crosses(plan(hard_edge_penalties={edge})))
+        self.assertFalse(crosses(plan(edge_penalties={edge: 240.0})))
+        self.assertFalse(crosses(plan(avoid_points=[(16.0, 0.0, 8.0)])))
+        self.assertEqual(original, plan())
+        grid._failed_edges[edge] = (3.0, 240.0)
+        self.assertFalse(crosses(plan(now=2.0)))
+        self.assertEqual(original, plan(now=3.0))
+        grid.set_static_hulls([(71, 16.0, 8.0, 0.0, 1.6, 1.6)])
+        self.assertFalse(crosses(plan(now=4.0)))
+        grid.set_static_hulls([])
+        self.assertEqual(original, plan(now=5.0))
+
+    def test_baked_search_edge_cache_is_bounded_and_resets_with_map(self):
+        graph = _graph(48, 48, (
+            (x, z) for z in range(48) for x in range(48)))
+        grid = TerrainGrid(lambda *unused: None, baked_graph=graph)
+        for z in range(48):
+            for x in range(48):
+                grid._baked_search_edges((x, z))
+        self.assertEqual(MAX_BAKED_SEARCH_EDGE_CACHE,
+                         len(grid._baked_search_edge_cache))
+        self.assertEqual(MAX_BAKED_SEARCH_EDGE_CACHE,
+                         len(grid._baked_search_edge_order))
+        self.assertTrue(grid._baked_search_edges((0, 0)))
+        self.assertEqual(MAX_BAKED_SEARCH_EDGE_CACHE,
+                         len(grid._baked_search_edge_cache))
+        replacement = _graph(2, 1, ((0, 0),))
+        grid._install_baked_graph(replacement)
+        self.assertEqual({}, grid._baked_search_edge_cache)
+        self.assertEqual((), grid._baked_search_edges((0, 0)))
+
     def test_baked_corridor_reuse_keeps_world_bounds_and_live_penalties(self):
         graph = _graph(4, 1, ((x, 0) for x in range(4)))
         grid = TerrainGrid(lambda *unused: 0.0, baked_graph=graph)


### PR DESCRIPTION
Bot A* searches repeatedly derive the same baked cell links, heights, slope costs, and terrain preferences across the room's vehicles. Share those immutable directed-edge inputs in a map-owned cache capped at 2,048 visited cells, cleared when a graph is installed. Keep wrecks, expiring failures, per-Bot edge penalties/vetoes, and avoid points live. Preserve the existing cost addition order, search budget, fairness, path smoothing, and driving cadence.

In the deterministic 29-Bot Great Wall combat workload (`30 s`, `15 FPS`, three unprofiled runs), total Python CPU median changed from 7.126 s to 6.920 s (2.9% lower). Separate cProfile runs measured A* search time at 1.607 s versus 0.877 s (45% lower). These are Linux Python measurements with simulated native queries, not Windows FPS or gameplay acceptance. This is an incremental Bot optimization; it does not claim a 30% reduction in total Bot work.

Validation:

- Regression tests cover repeat-search reuse, live wreck insertion/removal, failure expiry, per-Bot vetoes and penalties, avoid points, cache bounds, and map replacement.
- An independent baseline comparison under CPython 2.7.18 covered all 41 shipped maps: 168 searches and 173,468 ordered expansions matched exactly.
- `tools/benchmark_bot_workload.py --map 59_asia_great_wall --scenario combat --seconds 30 --fps 15 --repeats 3`: full state messages, decisions, probe counts, 1,174 launches, and 90,326 simulated native queries matched the baseline exactly. A separate 5 FPS run also matched completely (1,145 launches; 64,664 native queries).
- All 97 client Python sources compile under CPython 2.7.18 without writing bytecode.
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=tests python3 -m unittest test_port_0922_ai test_port_0922_navigation test_port_0922_navigation_clearance test_port_0922_bot_runtime test_port_0922_worker_diagnostics`: 613 tests passed on the final pushed commit after rebasing onto #92. The final commit's 15 FPS workload snapshot also matched the original baseline exactly.

Based on main after #92. Exact-client Windows frame pacing remains to be measured.
