### PR TITLE
Rest a hull on its chassis ends instead of one centre column

### DIFF
--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -18938,8 +18938,41 @@ class BattleRuntime(object):
             return bool(clearer(token))
         return False
 
+    def _support_column(self, x, z, hint_y, maximum_y=None):
+        """Return one layered support column below rejected upper faces."""
+        ray_end = self._vector((x, -1000.0, z))
+        ray_start = self._vector((x, float(hint_y) + 2.0, z))
+        ground_filter = self._ground_filter(x, z)
+        for unused_layer in range(4):
+            try:
+                hit = self._collide_down(
+                    ray_start, ray_end, ground_filter)
+            except Exception:
+                hit = None
+            if hit is None:
+                return None
+            candidate = float(hit[0].y)
+            above_limit = (maximum_y is not None and
+                           candidate > float(maximum_y))
+            ground_facing = True
+            try:
+                ground_facing = float(hit[1].y) > 0.5
+            except (AttributeError, IndexError, TypeError, ValueError):
+                # Engine-free compatibility probes historically supplied
+                # only the hit point. Production #1513 always supplies the
+                # normal, so this fallback cannot turn a live wall into
+                # support.
+                ground_facing = maximum_y is None
+            if not above_limit and ground_facing:
+                return candidate
+            next_y = candidate - 0.05
+            if next_y <= float(ray_end.y) + 0.01:
+                return None
+            ray_start = self._vector((x, next_y, z))
+        return None
+
     def _terrain_support(self, position, yaw, descriptor=None,
-                         maximum_y=None):
+                         maximum_y=None, follow_gap=None):
         """Copy 0.8.2 layered front/centre/back support probes.
 
         ``maximum_y`` asks the vertical ray to look below an upper hit which
@@ -18947,59 +18980,60 @@ class BattleRuntime(object):
         decks and low ruins: horizontal hull rays still own the real wall,
         while a harmless overhead/top face must not replace the floor and
         trap the vehicle in an endless support rollback.
+
+        ``follow_gap`` enables the chassis-end straddle law.  A tracked hull
+        rests on its chassis ends, so a trench, slot or crater narrower than
+        the tank must not lower the whole body into it merely because the
+        centre column found its floor.  The two extra lateral columns are
+        sampled only at that fall transition.
         """
         half_length = 2.5
+        half_width = 1.5
         try:
             hit_tester = _field(
                 _field(descriptor, 'hull', {}), 'hitTester', None)
             bbox = getattr(hit_tester, 'bbox', None)
             half_length = max(1.5, abs(float(bbox[1][2])))
+            half_width = max(0.3, max(abs(float(bbox[0][0])),
+                                      abs(float(bbox[1][0]))))
         except (TypeError, ValueError, IndexError, AttributeError):
             pass
         sine, cosine = math.sin(yaw), math.cos(yaw)
         highest = None
         centre = None
+        front = None
+        rear = None
         for distance in (half_length, 0.0, -half_length):
             x = position[0] + sine * distance
             z = position[2] + cosine * distance
-            ray_end = self._vector((x, -1000.0, z))
-            ray_start = self._vector((x, position[1] + 2.0, z))
-            ground_filter = self._ground_filter(x, z)
-            value = None
-            for unused_layer in range(4):
-                try:
-                    hit = self._collide_down(
-                        ray_start, ray_end, ground_filter)
-                except Exception:
-                    hit = None
-                if hit is None:
-                    break
-                candidate = float(hit[0].y)
-                above_limit = (maximum_y is not None and
-                               candidate > float(maximum_y))
-                ground_facing = True
-                try:
-                    ground_facing = float(hit[1].y) > 0.5
-                except (AttributeError, IndexError, TypeError, ValueError):
-                    # Engine-free compatibility probes historically supplied
-                    # only the hit point. Production #1513 always supplies the
-                    # normal, so this fallback cannot turn a live wall into
-                    # support.
-                    ground_facing = maximum_y is None
-                if not above_limit and ground_facing:
-                    value = candidate
-                    break
-                next_y = candidate - 0.05
-                if next_y <= float(ray_end.y) + 0.01:
-                    break
-                ray_start = self._vector((x, next_y, z))
+            value = self._support_column(
+                x, z, position[1], maximum_y)
             if value is None:
                 continue
             if highest is None or value > highest:
                 highest = value
             if distance == 0.0:
                 centre = value
-        return highest, centre
+            elif distance > 0.0:
+                front = value
+            else:
+                rear = value
+        if (centre is None or follow_gap is None or
+                position[1] - centre <= float(follow_gap)):
+            return highest, centre
+        lateral = tuple(
+            self._support_column(
+                position[0] + offset[0], position[2] + offset[1],
+                position[1], maximum_y)
+            for offset in tank_collision.chassis_span_offsets(
+                yaw, half_width, half_length)[1])
+        bridged = tank_collision.straddled_support(
+            position[1], follow_gap, ((front, rear), lateral))
+        if bridged is None or bridged <= centre:
+            return highest, centre
+        if highest is None or bridged > highest:
+            highest = bridged
+        return highest, bridged
 
     def _report_local_suspension_trial(self, outcome):
         """Publish each distinct player suspension activation outcome once.
@@ -19353,15 +19387,15 @@ class BattleRuntime(object):
     def _update_vertical_motion_legacy(self, entity, position, yaw, dt):
         """Copy vertical motion while rejecting false raised support."""
         self._local_support_rise_blocked = False
+        snap_gap = vehicle_physics.ground_follow_gap(
+            self._local_speed, self._local_last_pitch, dt)
         highest, centre = self._terrain_support(
-            position, yaw, entity.typeDescriptor)
+            position, yaw, entity.typeDescriptor, follow_gap=snap_gap)
         # Front/rear hits keep a hull supported across a narrow ditch, but the
         # real distance to that support decides whether it can still be
         # followed.
         ground = centre if centre is not None else highest
         if ground is not None:
-            snap_gap = vehicle_physics.ground_follow_gap(
-                self._local_speed, self._local_last_pitch, dt)
             max_climb = max(0.6, abs(self._local_speed) * dt * 2.5)
             com_gap = position[1] - ground
             land_y = ground if centre is None else centre

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -6039,21 +6039,54 @@ class BotRuntime(object):
         return self._suspension_rise_exceeds_base(
             position[1], support)
 
-    def _terrain_support(self, state):
+    def _ground_probe_at(self, x, z, hint):
+        """Run one accounted physics ground column."""
+        self._probe_totals[3] += 1
+        probe_started = self._probe_started()
+        try:
+            return self._physics_ground_probe(x, z, hint)
+        finally:
+            self._probe_finished(3, probe_started)
+
+    def _straddled_terrain_support(self, state, position, follow_gap):
+        """Return chassis-end support when the centre column drops away.
+
+        A tracked hull rests on its chassis ends. Stalingrad's trenches and
+        shell craters are narrower than a tank, so a centre-only support law
+        lowers the whole body into them and the horizontal hull rays then fire
+        from inside the walls. Probe the four chassis ends only at this fall
+        transition and keep the single-ray fast path everywhere else.
+        """
+        yaw = _number(state.get('yaw'))
+        half_length = max(1.5, _number(state.get('half_length'), 3.5))
+        half_width = max(0.3, _number(state.get('half_width'), 1.7))
+        axis_samples = []
+        for pair in tank_collision.chassis_span_offsets(
+                yaw, half_width, half_length):
+            axis_samples.append(tuple(
+                self._ground_probe_at(
+                    position[0] + offset[0], position[2] + offset[1],
+                    position[1])
+                for offset in pair))
+        return tank_collision.straddled_support(
+            position[1], follow_gap, axis_samples)
+
+    def _terrain_support(self, state, follow_gap=None):
         """Probe centre first, then the 0.8.2 edge fallback when unsupported."""
         position = _position(state)
         yaw = _number(state.get('yaw'))
         half_length = max(1.5, _number(state.get('half_length'), 3.5))
         sine, cosine = math.sin(yaw), math.cos(yaw)
-        self._probe_totals[3] += 1
-        probe_started = self._probe_started()
-        try:
-            centre = self._physics_ground_probe(
-                position[0], position[2], position[1])
-        finally:
-            self._probe_finished(3, probe_started)
+        centre = self._ground_probe_at(
+            position[0], position[2], position[1])
         if centre is not None:
             centre = float(centre)
+            if (follow_gap is not None and
+                    position[1] - centre > float(follow_gap)):
+                bridged = self._straddled_terrain_support(
+                    state, position, follow_gap)
+                if bridged is not None and bridged > centre:
+                    return bridged, bridged
             # The vertical law below always selects centre while it exists;
             # front/back could not affect the realised pose on this branch.
             return centre, centre
@@ -6061,12 +6094,7 @@ class BotRuntime(object):
         for distance in (half_length, -half_length):
             x = position[0] + sine * distance
             z = position[2] + cosine * distance
-            self._probe_totals[3] += 1
-            probe_started = self._probe_started()
-            try:
-                value = self._physics_ground_probe(x, z, position[1])
-            finally:
-                self._probe_finished(3, probe_started)
+            value = self._ground_probe_at(x, z, position[1])
             if value is None:
                 continue
             value = float(value)
@@ -6782,7 +6810,9 @@ class BotRuntime(object):
                 state['push_z'] = 0.0
                 self._turn_speeds[int(state['id'])] = 0.0
                 return True
-        highest, centre = self._terrain_support(state)
+        snap_gap = vehicle_physics.ground_follow_gap(
+            state['speed'], state.get('last_drive_pitch', 0.0), step)
+        highest, centre = self._terrain_support(state, snap_gap)
         # Front/rear hits keep a bot supported across a narrow ditch, but use
         # their real CoM distance below so a remote valley floor cannot pull
         # the bot down in one tick.
@@ -6792,8 +6822,6 @@ class BotRuntime(object):
                           'grounded_before': state.get('grounded_once', False)})
         if ground is not None:
             speed = abs(state['speed'])
-            snap_gap = vehicle_physics.ground_follow_gap(
-                state['speed'], state.get('last_drive_pitch', 0.0), step)
             max_climb = max(0.6, speed * step * 2.5)
             support_rise_obstacle = bool(
                 state.get('grounded_once', False) and

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/tank_collision.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/tank_collision.py
@@ -34,6 +34,8 @@ POSITION_SLOP = 0.01
 RAM_CONTACT_POINT_SLOP = 0.75
 POSITION_PERCENT = 0.95
 CONTACT_BROADPHASE_PADDING = 0.25
+# A chassis-end straddle may only stop a descent, never lift the hull.
+SUPPORT_STRADDLE_RISE = 0.12
 _SHAPE_CACHE = {}
 SPATIAL_CELL_SIZE = 24.0
 
@@ -252,6 +254,70 @@ def support_rise_is_obstacle(body_y, support_y, maximum_climb, slop=0.02,
         return rise > limit
     except (TypeError, ValueError):
         return False
+
+
+def chassis_span_offsets(yaw, half_width, half_length):
+    """Return the four chassis-end XZ offsets that can straddle a gap.
+
+    The pairs are ordered ``(front, rear)`` then ``(right, left)`` so a caller
+    can test each chassis axis independently.
+    """
+    sine = math.sin(float(yaw))
+    cosine = math.cos(float(yaw))
+    length = max(0.0, float(half_length))
+    width = max(0.0, float(half_width))
+    return (
+        ((sine * length, cosine * length),
+         (-sine * length, -cosine * length)),
+        ((cosine * width, -sine * width),
+         (-cosine * width, sine * width)),
+    )
+
+
+def straddled_support(body_y, follow_gap, axis_samples,
+                      maximum_rise=SUPPORT_STRADDLE_RISE):
+    """Return the support of a hull spanning a gap under its centre column.
+
+    A tracked hull rests on its chassis ends, not on one ray at its centre.
+    When the centre column drops out of the follow envelope but both ends of a
+    chassis axis are still inside it, the hull is bridging a trench, crater or
+    slot narrower than itself and must not descend into it.  One supported end
+    is a cliff edge, not a bridge, so it keeps the existing fall.
+
+    ``axis_samples`` is the sequence returned for
+    :func:`chassis_span_offsets`, each entry a ``(first, second)`` pair of
+    sampled ground heights or ``None``.  This law may only stop a descent, so
+    an end higher than ``maximum_rise`` above the body is not straddle
+    evidence: climbing a step stays the centre column's own gated decision and
+    must not become an unreviewable lift from a side ray on a wall top.
+    """
+    if body_y is None:
+        return None
+    try:
+        body_y = float(body_y)
+        gap = max(0.0, float(follow_gap))
+        rise = max(0.0, float(maximum_rise))
+    except (TypeError, ValueError):
+        return None
+    support = None
+    for pair in axis_samples:
+        heights = []
+        for value in pair:
+            if value is None:
+                break
+            try:
+                height = float(value)
+            except (TypeError, ValueError):
+                break
+            if not -gap <= height - body_y <= rise:
+                break
+            heights.append(height)
+        if len(heights) != 2:
+            continue
+        candidate = max(heights)
+        if support is None or candidate > support:
+            support = candidate
+    return support
 
 
 def _axes(yaw):

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -19793,6 +19793,69 @@ class BattleRuntimeContractTests(unittest.TestCase):
                 RuntimeError, 'native suspension ground hit is malformed'):
             battle._suspension_ground_y(0.0, 0.0, -0.5, 0.8)
 
+    def _legacy_support_battle(self, columns, floor):
+        """Return a legacy-vertical player over one sampled ground field."""
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        battle._local_fall_armed = True
+        battle._local_suspension_disabled = True
+        entity = _Vehicle(
+            10, _Descriptor(), _Vector(), (0, 0, 0), {'health': 500})
+        calls = []
+
+        def collide(space_id, start, end, flags, *rest):
+            calls.append((round(start.x, 1), round(start.z, 1)))
+            height = columns.get(
+                (round(start.x, 1), round(start.z, 1)), floor)
+            return (_Vector(start.x, height, start.z),
+                    _Vector(0.0, 1.0, 0.0), 2)
+
+        runtime.bigworld.wg_collideSegment = collide
+        return battle, entity, calls
+
+    def test_player_bridges_a_trench_narrower_than_its_chassis(self):
+        """The human hull must straddle a slot its centre column falls into."""
+        battle, entity, unused_calls = self._legacy_support_battle(
+            {(0.0, 3.5): 10.0, (0.0, -3.5): 10.0}, 7.0)
+
+        position = battle._update_vertical_motion(
+            entity, (0.0, 10.0, 0.0), 0.0, 0.1)
+
+        self.assertAlmostEqual(10.0, position[1], places=6)
+        self.assertFalse(battle._local_airborne)
+        self.assertEqual(0.0, battle._local_vertical_speed)
+
+    def test_player_bridges_a_slot_running_along_its_hull(self):
+        battle, entity, unused_calls = self._legacy_support_battle(
+            {(1.7, 0.0): 9.95, (-1.7, 0.0): 10.0}, 7.0)
+
+        position = battle._update_vertical_motion(
+            entity, (0.0, 10.0, 0.0), 0.0, 0.1)
+
+        self.assertAlmostEqual(10.0, position[1], places=6)
+        self.assertFalse(battle._local_airborne)
+
+    def test_player_still_falls_where_only_one_chassis_end_is_supported(self):
+        battle, entity, unused_calls = self._legacy_support_battle(
+            {(0.0, -3.5): 10.0}, 0.0)
+
+        position = battle._update_vertical_motion(
+            entity, (0.0, 10.0, 0.0), 0.0, 0.1)
+
+        self.assertTrue(battle._local_airborne)
+        self.assertLess(position[1], 10.0)
+
+    def test_player_flat_ground_keeps_the_three_column_support_probe(self):
+        battle, entity, calls = self._legacy_support_battle({}, 10.0)
+
+        position = battle._update_vertical_motion(
+            entity, (0.0, 10.0, 0.0), 0.0, 0.1)
+
+        self.assertAlmostEqual(10.0, position[1], places=6)
+        self.assertEqual(
+            [(0.0, 3.5), (0.0, 0.0), (0.0, -3.5)], calls)
+
     def test_local_suspension_samples_twenty_two_columns_once_per_tick(self):
         runtime = _runtime()
         battle = BattleRuntime(runtime)

--- a/tests/test_port_0922_bot_runtime.py
+++ b/tests/test_port_0922_bot_runtime.py
@@ -4158,6 +4158,85 @@ class BotRuntimeTests(unittest.TestCase):
                 self.assertAlmostEqual(gradient,
                     state['_suspension_ground_plane']['gradient_z'], places=4)
 
+    def _trench_probe(self, floor, rims):
+        """Return a probe whose centre column drops into a narrow trench.
+
+        ``rims`` maps a chassis-end offset key to its ground height, so one
+        fixture can describe a bridged trench, a longitudinal slot and a plain
+        cliff edge with the same geometry the runtime samples.
+        """
+        calls = []
+
+        def probe(x, z, unused_hint):
+            calls.append((round(x, 3), round(z, 3)))
+            key = (round(x, 1), round(z, 1))
+            return rims.get(key, floor)
+
+        return probe, calls
+
+    def test_bot_bridges_a_trench_narrower_than_its_chassis(self):
+        """Stalingrad's trenches must not swallow a straddling hull."""
+        self.runtime.battle_start(self.start)
+        state = self.runtime.states[11]
+        state.update(x=0.0, y=10.0, z=0.0, yaw=0.0, speed=4.0,
+                     grounded_once=True, airborne=False,
+                     vertical_speed=0.0)
+        probe, calls = self._trench_probe(
+            7.0, {(0.0, 3.5): 10.0, (0.0, -3.5): 10.0})
+        self.runtime._physics_ground_probe = probe
+
+        self.assertFalse(self.runtime._update_vertical_motion(state, 0.04))
+
+        self.assertAlmostEqual(10.0, state['y'], places=6)
+        self.assertFalse(state['airborne'])
+        self.assertAlmostEqual(0.0, state['vertical_speed'], places=6)
+        # One centre column on flat ground, five only at the fall transition.
+        self.assertEqual(5, len(calls))
+
+    def test_bot_bridges_a_slot_running_along_its_hull(self):
+        self.runtime.battle_start(self.start)
+        state = self.runtime.states[11]
+        state.update(x=0.0, y=10.0, z=0.0, yaw=0.0, speed=4.0,
+                     grounded_once=True, airborne=False,
+                     vertical_speed=0.0)
+        probe, unused_calls = self._trench_probe(
+            7.0, {(1.5, 0.0): 9.95, (-1.5, 0.0): 10.0})
+        self.runtime._physics_ground_probe = probe
+
+        self.assertFalse(self.runtime._update_vertical_motion(state, 0.04))
+
+        self.assertAlmostEqual(10.0, state['y'], places=6)
+        self.assertFalse(state['airborne'])
+
+    def test_bot_still_falls_off_a_cliff_edge_with_one_supported_end(self):
+        self.runtime.battle_start(self.start)
+        state = self.runtime.states[11]
+        state.update(x=0.0, y=10.0, z=0.0, yaw=0.0, speed=4.0,
+                     grounded_once=True, airborne=False,
+                     vertical_speed=0.0)
+        probe, unused_calls = self._trench_probe(
+            0.0, {(0.0, -3.5): 10.0})
+        self.runtime._physics_ground_probe = probe
+
+        self.assertFalse(self.runtime._update_vertical_motion(state, 0.04))
+
+        self.assertTrue(state['airborne'])
+        self.assertLess(state['y'], 10.0)
+
+    def test_bot_keeps_the_single_column_fast_path_on_flat_ground(self):
+        self.runtime.battle_start(self.start)
+        state = self.runtime.states[11]
+        state.update(x=0.0, y=10.0, z=0.0, yaw=0.0, speed=4.0,
+                     grounded_once=True, airborne=False,
+                     vertical_speed=0.0)
+        probe, calls = self._trench_probe(10.0, {})
+        self.runtime._physics_ground_probe = probe
+
+        self.assertFalse(self.runtime._update_vertical_motion(state, 0.04))
+
+        self.assertEqual(1, len(calls))
+        self.assertAlmostEqual(10.0, state['y'], places=6)
+
     def test_bot_steep_hull_keeps_falling_without_support(self):
         for axis in ('pitch', 'roll'):
             with self.subTest(axis=axis):

--- a/tests/test_port_0922_tank_collision.py
+++ b/tests/test_port_0922_tank_collision.py
@@ -649,5 +649,53 @@ class TankCollisionTests(unittest.TestCase):
             against_wreck['correction'][0], against_live['correction'][0])
 
 
+class StraddledSupportTests(unittest.TestCase):
+    def test_opposing_ends_bridge_a_slot_narrower_than_the_hull(self):
+        """A trench under the centre column must not lower the hull."""
+        support = tank_collision.straddled_support(
+            10.0, 1.0, ((10.0, 9.6), (None, None)))
+
+        self.assertAlmostEqual(10.0, support)
+
+    def test_one_supported_end_is_a_cliff_edge_and_not_a_bridge(self):
+        self.assertIsNone(tank_collision.straddled_support(
+            10.0, 1.0, ((10.0, None), (None, 9.9))))
+        self.assertIsNone(tank_collision.straddled_support(
+            10.0, 1.0, ((10.0, 2.0), (3.0, 9.9))))
+
+    def test_a_raised_end_is_never_straddle_evidence(self):
+        """A side ray on a wall top must not lift the hull."""
+        self.assertIsNone(tank_collision.straddled_support(
+            10.0, 2.5, ((11.0, 10.0), (None, None))))
+
+    def test_the_lateral_axis_bridges_a_longitudinal_trench(self):
+        support = tank_collision.straddled_support(
+            4.0, 0.9, ((1.0, 1.0), (4.05, 3.9)))
+
+        self.assertAlmostEqual(4.05, support)
+
+    def test_span_offsets_follow_the_chassis_axes(self):
+        (front, rear), (right, left) = tank_collision.chassis_span_offsets(
+            0.0, 1.7, 3.5)
+
+        self.assertAlmostEqual(0.0, front[0])
+        self.assertAlmostEqual(3.5, front[1])
+        self.assertAlmostEqual(0.0, rear[0])
+        self.assertAlmostEqual(-3.5, rear[1])
+        self.assertAlmostEqual(1.7, right[0])
+        self.assertAlmostEqual(0.0, right[1])
+        self.assertAlmostEqual(-1.7, left[0])
+        self.assertAlmostEqual(0.0, left[1])
+
+    def test_span_offsets_rotate_with_yaw(self):
+        (front, unused_rear), (right, unused_left) = (
+            tank_collision.chassis_span_offsets(math.pi / 2.0, 1.7, 3.5))
+
+        self.assertAlmostEqual(3.5, front[0])
+        self.assertAlmostEqual(0.0, front[1], places=6)
+        self.assertAlmostEqual(0.0, right[0], places=6)
+        self.assertAlmostEqual(-1.7, right[1])
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Report

Stalingrad, from Peng's screenshot: many tanks fall into a ditch and sink into
the ground, staying there alive with only their hull roof above the surface.

## Cause

`BattleRuntime` constructs `BotRuntime` without a `suspension_ground_probe`
(an existing test pins this), so `_suspension_params_for` returns `None` for
every Bot and all Bots run the legacy vertical law; only the local player gets
the ten-spring suspension trial.

That legacy law returned `(centre, centre)` from `_terrain_support` as soon as
the centre column hit, so the entire hull was carried by one ground ray at the
hull centre. A trench, slot or shell crater narrower than the chassis therefore
lowers the whole tank into it, and the 0.6/1.1/1.6 m horizontal hull rays then
fire from inside the pit walls, so the vehicle can no longer drive out.
`battle_runtime._update_vertical_motion_legacy` had the identical shape, so the
player hits it too whenever the suspension trial is excluded or retires.

## Change

`tank_collision.chassis_span_offsets` + `straddled_support` are the shared law,
used by both vertical paths:

* it runs only at the fall transition, when the centre column has dropped out
  of the ground-follow envelope;
* it then probes the four chassis ends, and when **both** ends of one chassis
  axis are still inside that envelope the hull is bridging and keeps their
  support;
* one supported end is a cliff edge, not a bridge, so a real drop still falls
  exactly as before;
* the law may never lift the hull (`SUPPORT_STRADDLE_RISE` 0.12), so climbing a
  step stays the centre column's own gated decision and a side ray on a wall
  top cannot start a support rollback;
* flat ground keeps its single-ray fast path — the extra columns cost nothing
  until a tank is about to fall.

## Checks

* `CPython 2.7 source compile passed: 97 files`
* `test_port_0922_tank_collision`, `test_port_0922_battle_runtime` — 872 tests, OK
* `test_port_0922_bot_runtime` — 462 tests, OK
* `test_port_0922_world_collision`, `test_port_0922_vehicle_physics` (with
  bot_runtime and tank_collision) — 639 tests, OK

## Not proved here

This is a Python-level support law. Whether a Stalingrad trench now actually
holds a tank, and whether cliff and ledge behaviour still feels retail, needs
acceptance on the exact Windows client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)