### PR TITLE
Keep a streamed but unidentified model solid

### DIFF
--- a/src/res/scripts/client/gui/mods/offline_lan_0922/destructibles_sensor.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/destructibles_sensor.py
@@ -1105,6 +1105,8 @@ def _clear_runtime_registry(preserve_spatial_batch=False):
 			'g_offh_destr_catalog_published',
 			'g_offh_destr_catalog_publish_pending',
 			'g_offh_destr_falling_active', 'g_offh_destr_ground_skips',
+			'g_offh_destr_unresolved_obstacles',
+			'g_offh_destr_unresolved_logs',
 			'g_offh_destr_broken_cache',
 			'g_offh_destr_item_names',
 			'g_offh_destr_native_name_lists',
@@ -2291,24 +2293,123 @@ def _catalog_shot_intersection(spaceID, start, end, maximum_distance=None):
 	}
 
 
+def _confirmed_unresolved_obstacle_1513(spaceID, identity):
+	"""Return exact baked OBBs for a streamed but unidentified model.
+
+	Registration proves *identity*: which descriptor the item uses, whether it
+	may be destroyed and which native event names it.  Blocking a hull needs
+	only *placement*, and the pinned catalog already owns that.  When the chunk
+	is streamed and the live item matrix still reproduces the pinned locator
+	signature, the model is standing exactly where the catalog says, so it must
+	keep stopping a hull even while its identity stays unresolved.  Anything
+	else - a chunk that is not streamed, a live matrix that contradicts the
+	catalog, or a falling body that has left its authored pose - returns no box
+	rather than inventing a wall.
+	"""
+	chunk_id, item_index = identity
+	catalog = _destructible_catalog
+	if catalog is None:
+		return ()
+	baked = catalog.get('baked_instances', {}).get(identity)
+	if baked is None or baked['kind'] == 'falling' or not baked['boxes']:
+		return ()
+	cache = globals().setdefault('g_offh_destr_unresolved_obstacles', {})
+	import AreaDestructibles
+	import BigWorld
+	import Math
+	mgr = getattr(AreaDestructibles, 'g_destructiblesManager', None)
+	try:
+		manager_space = None if mgr is None else mgr.getSpaceID()
+	except Exception:
+		return ()
+	if mgr is None or manager_space != spaceID:
+		return ()
+	native_count = _native_chunk_destructible_count_1513(mgr, chunk_id)
+	if native_count is None or item_index >= native_count:
+		# The chunk is no longer streamed, so neither is its geometry.
+		cache.pop(identity, None)
+		return ()
+	entry = cache.get(identity)
+	if entry is not None and entry[0] == native_count:
+		return entry[1]
+	try:
+		chunk_matrix = observed_call(
+			'native.destructible.chunk_matrix', BigWorld.wg_getChunkMatrix,
+			spaceID, chunk_id)
+		chunk_translation = getattr(chunk_matrix, 'translation', None)
+		if chunk_translation is None:
+			return ()
+		matrix = Math.Matrix(observed_call(
+			'native.destructible.item_matrix',
+			BigWorld.wg_getDestructibleMatrix, spaceID, chunk_id, item_index))
+		signature, unused_located = _catalog_instance_for_matrix_1513(
+			matrix, chunk_translation, Math)
+	except Exception:
+		# A placement query that cannot answer is not evidence of a wall.
+		return ()
+	boxes = baked['boxes'] if signature == baked['signature'] else ()
+	cache[identity] = (native_count, boxes)
+	if boxes:
+		_log_unresolved_obstacle_1513(chunk_id, item_index, baked)
+	return boxes
+
+
+def _log_unresolved_obstacle_1513(chunk_id, item_index, baked):
+	"""Name the first unidentified blocking model of each map resource."""
+	logged = globals().setdefault('g_offh_destr_unresolved_logs', set())
+	key = baked['descriptor_filename']
+	if key in logged or len(logged) >= _ISOLATION_LOG_TYPE_LIMIT:
+		return
+	logged.add(key)
+	try:
+		import sys
+		sys.stdout.write(
+			'[Offline LAN 0.9.22] DESTR blocking unidentified model '
+			'chunk=%s item=%s kind=%s name=%s map=%s '
+			'repeats=suppressed_for_battle\n' % (
+				chunk_id, item_index, baked['kind'], key,
+				(_destructible_catalog or {}).get('map') or 'unknown'))
+	except Exception:
+		# Runtime handling is authoritative; the log stream is observational.
+		pass
+
+
 @_batched_spatial_mutations_1513
 @observed('destructible.stream_motion')
 def _stream_baked_motion_instances_1513(spaceID, vehicle_box):
-	"""Live-validate catalog wires covering one exact vehicle sweep."""
+	"""Live-validate catalog wires covering one exact vehicle sweep.
+
+	Returns the world boxes of every streamed model the sweep reaches that
+	registration could not identify.  Those models are solid in the engine but
+	invisible to the registered-candidate path, and three hull lanes at three
+	fixed heights can pass straight through an open frame such as #1513's
+	girder flatcar, so the caller must still stop the hull on them.
+	"""
 	catalog = _destructible_catalog or {}
 	if not catalog.get('has_instance_index'):
-		return
+		return ()
 	identities = set()
 	for bin_key in _baked_bin_keys_for_bounds_1513(
 			*_box_xz_bounds(vehicle_box)):
 		identities.update(
 			catalog.get('baked_shot_bins', {}).get(bin_key, ()))
 	instances = globals().get('g_offh_destr_instances', {})
+	unresolved = []
+	cache = globals().get('g_offh_destr_unresolved_obstacles')
 	for identity in sorted(identities):
 		combat_count('destructible_stream_candidates')
-		if identity not in instances:
-			combat_count('destructible_stream_missing')
-			_stream_baked_shot_instance_1513(spaceID, identity)
+		if identity in instances:
+			continue
+		combat_count('destructible_stream_missing')
+		if _stream_baked_shot_instance_1513(spaceID, identity) is not None:
+			if cache is not None:
+				cache.pop(identity, None)
+			continue
+		boxes = _confirmed_unresolved_obstacle_1513(spaceID, identity)
+		if boxes:
+			combat_count('destructible_stream_unidentified')
+			unresolved.append((identity, boxes))
+	return tuple(unresolved)
 
 
 def _vehicle_swept_box(pos, yaw, vel, bbox, travel_reach=None,
@@ -3243,6 +3344,17 @@ def _catalog_pending_at_hull(pos, yaw, vel, td, now, dt=0.04,
 	return False
 
 
+def _unidentified_hull_contact_1513(unresolved, vehicle_box, authority):
+	"""Return whether an unidentified streamed model still fills the sweep."""
+	for identity, boxes in unresolved:
+		chunk_id, item_index = identity
+		for world_box in _catalog_intersections(boxes, vehicle_box):
+			if authority.is_destroyed(chunk_id, item_index, world_box[2]):
+				continue
+			return True
+	return False
+
+
 @observed('destructible.hull_guard')
 def _catalog_hull_contact(pos, yaw, vel, td, dt=0.04,
 		motion_yaw=None):
@@ -3250,10 +3362,20 @@ def _catalog_hull_contact(pos, yaw, vel, td, dt=0.04,
 	bbox = _vehicle_hull_bbox(td)
 	if _destructible_catalog is None or bbox is None:
 		return False
-	return bool(_catalog_contact_candidates(
-		_vehicle_swept_box(
-			pos, yaw, vel, bbox, _motion_travel_reach(vel, dt),
-			motion_yaw=motion_yaw)))
+	vehicle_box = _vehicle_swept_box(
+		pos, yaw, vel, bbox, _motion_travel_reach(vel, dt),
+		motion_yaw=motion_yaw)
+	if _catalog_contact_candidates(vehicle_box):
+		return True
+	# A receipt-reuse caller must not step past a model the full sweep already
+	# proved solid but unidentified.  Read only the confirmed placements that
+	# sweep cached; this guard adds no native query of its own.
+	cache = globals().get('g_offh_destr_unresolved_obstacles')
+	if not cache:
+		return False
+	return _unidentified_hull_contact_1513(
+		[(identity, entry[1]) for identity, entry in cache.items()],
+		vehicle_box, _get_destr_authority())
 
 
 def _catalog_motion_result(status, token=None, accepted_now=False,
@@ -3318,9 +3440,14 @@ def _catalog_motion_blocked(spaceID, pos, yaw, vel, td, now,
 	# The visible player does not run the authority Bot scan that normally
 	# populates the live item registry.  Admit only checksum-pinned wires in the
 	# current hull bins through the same read-only native validation as shells.
-	_stream_baked_motion_instances_1513(spaceID, vehicle_box)
+	unresolved = _stream_baked_motion_instances_1513(spaceID, vehicle_box)
 	candidates = _catalog_contact_candidates(vehicle_box)
-	if not candidates:
+	# An unidentified model is real geometry this sweep cannot name, destroy or
+	# publish.  #1513 keeps it solid, so the hull stops on it until a later tick
+	# resolves its identity and the ordinary crush law can decide.
+	unidentified = bool(unresolved) and _unidentified_hull_contact_1513(
+		unresolved, vehicle_box, auth)
+	if not candidates and not unidentified:
 		return _catalog_motion_result(
 			'pending' if publish_failures else 'clear', publish_failures,
 			return_status=return_status, return_detail=return_detail,
@@ -3335,13 +3462,15 @@ def _catalog_motion_blocked(spaceID, pos, yaw, vel, td, now,
 		pos, yaw, bbox, travel=float(vel) * max(0.0, float(dt)),
 		motion_yaw=motion_yaw)
 		if kinetic_speed is not None else None)
-	blocked = False
+	blocked = bool(unidentified)
 	crushed = False
 	kinetic = False
 	approach = False
 	publication_pending = bool(publish_failures)
 	exact_token = set(publish_failures)
 	contact_kinds = set(publish_kinds)
+	if unidentified:
+		contact_kinds.add('unidentified')
 	commit_candidates = []
 
 	for identity in sorted(grouped):

--- a/tests/test_port_0922_destructibles.py
+++ b/tests/test_port_0922_destructibles.py
@@ -202,6 +202,8 @@ class DestructiblesCompatibilityTests(unittest.TestCase):
                      'g_offh_destr_catalog_published',
                      'g_offh_destr_catalog_publish_pending',
                      'g_offh_destr_falling_active',
+                     'g_offh_destr_unresolved_obstacles',
+                     'g_offh_destr_unresolved_logs',
                      'g_offh_destr_item_names',
                      'g_offh_destr_native_name_lists',
                      'g_offh_destr_item_name_budget',
@@ -8172,6 +8174,246 @@ class DestructiblesCompatibilityTests(unittest.TestCase):
               for material in (0, 1, 2)]),
             bigworld.wg_getDestructibleEffectCategory.call_args_list)
 
+    def _prohorovka_wagon_environment(self, descriptor_available=False):
+        """Build the exact #1513 girder flatcar the player drove through."""
+        catalog_path = ROOT / 'destructibles' / '05_prohorovka.json'
+        catalog = json.loads(catalog_path.read_text())
+        row = next(
+            value for value in catalog['instances']
+            if value[14:16] == [32637, 56])
+        filename = row[12]
+        self.assertTrue(filename.endswith('rw004_Carriage1.model'))
+        self.assertEqual('fragile', catalog['resources'][filename]['kind'])
+
+        class CatalogMatrix(object):
+            def __init__(self, source_row, offset=0.0):
+                self.row = source_row
+                self.translation = _Vector(*(
+                    value / 1000.0 + offset for value in source_row[:3]))
+
+            def applyVector(self, point):
+                basis = self.row[3:12]
+                return _Vector(
+                    (basis[0] * point.x + basis[3] * point.y +
+                     basis[6] * point.z) / 1000.0,
+                    (basis[1] * point.x + basis[4] * point.y +
+                     basis[7] * point.z) / 1000.0,
+                    (basis[2] * point.x + basis[5] * point.y +
+                     basis[8] * point.z) / 1000.0)
+
+            def applyPoint(self, point):
+                return self.translation + self.applyVector(point)
+
+        manager = _Manager()
+        manager.space_id = 1
+        manager.set_chunk_count(32637, 61)
+        area = types.ModuleType('AreaDestructibles')
+        area.g_destructiblesManager = manager
+        area.DESTR_TYPE_TREE = 1
+        area.DESTR_TYPE_FALLING_ATOM = 2
+        area.DESTR_TYPE_FRAGILE = 3
+        area.DESTR_TYPE_STRUCTURE = 4
+        area.DESTRUCTIBLE_MATKIND = types.SimpleNamespace(
+            NORMAL_MIN=73, NORMAL_MAX=86)
+        area.g_cache = types.SimpleNamespace(
+            unitVehicleMass=10000.0,
+            getDescByFilename=lambda value: (
+                {'type': 3, 'health': 15, 'kineticDamageCorrection': 0.0}
+                if descriptor_available and value == filename else None))
+        bigworld = types.ModuleType('BigWorld')
+        # #1513 reports no resolvable name for this chunk, so the streamed
+        # wire never reaches an identity of its own.
+        bigworld.wg_getChunkDestrFilenames = (
+            lambda unused_space, unused_chunk: ())
+        bigworld.wg_getChunkMatrix = (
+            lambda unused_space, unused_chunk:
+            types.SimpleNamespace(translation=_Vector()))
+        bigworld.wg_getDestructibleEffectCategory = mock.Mock(return_value=3)
+        # Chunk 32637 holds 61 destructibles and the shared per-tick native
+        # name budget is 16, so alignment needs several rendered frames.
+        clock = [10.0]
+        bigworld.time = lambda: clock[0]
+        rows_by_wire = dict(
+            (tuple(value[14:16]), value) for value in catalog['instances'])
+        elsewhere = [9000000, 0, 9000000, 1000, 0, 0, 0, 1000, 0, 0, 0, 1000]
+        matrix_calls = []
+        offset = [0.0]
+
+        def destructible_matrix(unused_space, chunk, item):
+            matrix_calls.append((chunk, item))
+            source = rows_by_wire.get((chunk, item))
+            if source is None:
+                return CatalogMatrix(elsewhere)
+            return CatalogMatrix(
+                source,
+                offset[0] if (chunk, item) == (32637, 56) else 0.0)
+
+        bigworld.wg_getDestructibleMatrix = destructible_matrix
+        math_module = types.ModuleType('Math')
+        math_module.Vector3 = _Vector
+        math_module.Matrix = lambda value: value
+        cache = types.ModuleType('DestructiblesCache')
+        cache.scaledDestructibleHealth = lambda scale, health: scale * health
+        # An AMX M4 mle. 49 sized hull, standing where the screenshot puts it.
+        hull = _Strict1513Component(
+            hitTester=types.SimpleNamespace(bbox=(
+                (-1.7, -1.0, -3.7), (1.7, 1.5, 3.7), None)))
+        descriptor = _Strict1513Component(
+            physics={'weight': 57000.0}, hull=hull)
+        centre = _Vector(*(value / 1000.0 for value in row[:3]))
+        destructibles_sensor.xrange = range
+        destructibles_sensor.set_catalog(catalog)
+        return {
+            'row': row, 'filename': filename, 'matrix': CatalogMatrix,
+            'manager': manager, 'area': area, 'bigworld': bigworld,
+            'math': math_module, 'cache': cache,
+            'descriptor': descriptor, 'centre': centre, 'clock': clock,
+            'offset': offset, 'matrix_calls': matrix_calls,
+        }
+
+    def _wagon_sweep(self, environment, authority, offset=0.0,
+                     position=None, commit_enabled=False):
+        environment['offset'][0] = offset
+        with mock.patch.dict(
+                sys.modules, {'AreaDestructibles': environment['area'],
+                              'BigWorld': environment['bigworld'],
+                              'DestructiblesCache': environment['cache'],
+                              'Math': environment['math']}), \
+                mock.patch.object(
+                    destructibles_sensor, '_get_destr_authority',
+                    return_value=authority):
+            return destructibles_sensor._catalog_motion_blocked(
+                1, environment['centre'] if position is None else position,
+                0.0, 3.3, environment['descriptor'], 10.0, dt=0.05,
+                return_detail=True, commit_enabled=commit_enabled)
+
+    def test_unidentified_prohorovka_wagon_still_stops_the_hull(self):
+        """A streamed model our rays can thread through must stay solid."""
+        environment = self._prohorovka_wagon_environment()
+        authority = types.SimpleNamespace(
+            is_destroyed=lambda *unused: False,
+            destroy_fragile=lambda *unused: self.fail(
+                'an unidentified model must never be destroyed'))
+        writes = []
+
+        with mock.patch.object(
+                sys, 'stdout', types.SimpleNamespace(write=writes.append)):
+            detail = self._wagon_sweep(environment, authority)
+
+        self.assertEqual('hard', detail['status'])
+        self.assertIn('unidentified', detail['kinds'])
+        self.assertIsNone(detail['token'])
+        self.assertNotIn(
+            (32637, 56),
+            getattr(destructibles_sensor, 'g_offh_destr_instances', {}))
+        self.assertTrue(any(
+            'DESTR blocking unidentified model' in line and
+            'chunk=32637 item=56' in line and
+            'rw004_Carriage1.model' in line
+            for line in writes))
+
+    def test_pending_name_alignment_blocks_before_the_crush_law_owns_it(self):
+        """The wagon is solid while pending and crushable once identified."""
+        environment = self._prohorovka_wagon_environment(
+            descriptor_available=True)
+        authority = types.SimpleNamespace(
+            is_destroyed=lambda *unused: False,
+            destroy_fragile=mock.Mock(return_value=True))
+        destructibles_sensor.set_event_sink(lambda unused_event: True)
+        details = []
+
+        for tick in range(8):
+            environment['clock'][0] = 10.0 + tick
+            details.append(self._wagon_sweep(
+                environment, authority, commit_enabled=True))
+            if details[-1]['status'] == 'crushed':
+                break
+
+        self.assertEqual('hard', details[0]['status'])
+        self.assertIn('unidentified', details[0]['kinds'])
+        self.assertEqual('crushed', details[-1]['status'])
+        self.assertNotIn('unidentified', details[-1]['kinds'])
+        self.assertEqual(((32637, 56, None),), details[-1]['token'])
+        authority.destroy_fragile.assert_called_once()
+        self.assertIn(
+            (32637, 56), destructibles_sensor.g_offh_destr_instances)
+
+    def test_identified_wagon_blocks_the_visible_player_without_crushing(self):
+        environment = self._prohorovka_wagon_environment(
+            descriptor_available=True)
+        authority = types.SimpleNamespace(
+            is_destroyed=lambda *unused: False,
+            destroy_fragile=lambda *unused: self.fail(
+                'a visible-client sweep must not mutate native state'))
+        detail = None
+
+        for tick in range(8):
+            environment['clock'][0] = 10.0 + tick
+            detail = self._wagon_sweep(environment, authority)
+            if (32637, 56) in getattr(
+                    destructibles_sensor, 'g_offh_destr_instances', {}):
+                break
+
+        self.assertEqual('hard', detail['status'])
+        self.assertNotIn('unidentified', detail['kinds'])
+        self.assertEqual(((32637, 56, None),), detail['token'])
+
+    def test_unstreamed_chunk_never_invents_a_wall(self):
+        environment = self._prohorovka_wagon_environment()
+        environment['manager']._DestructiblesManager__loadedChunkIDs.clear()
+        authority = types.SimpleNamespace(is_destroyed=lambda *unused: False)
+
+        detail = self._wagon_sweep(environment, authority)
+
+        self.assertEqual('clear', detail['status'])
+
+    def test_a_model_away_from_its_authored_pose_is_not_a_wall(self):
+        """A live matrix that contradicts the catalog proves nothing."""
+        environment = self._prohorovka_wagon_environment()
+        authority = types.SimpleNamespace(is_destroyed=lambda *unused: False)
+
+        detail = self._wagon_sweep(environment, authority, offset=4.0)
+
+        self.assertEqual('clear', detail['status'])
+
+    def test_a_destroyed_unidentified_model_stops_blocking(self):
+        environment = self._prohorovka_wagon_environment()
+        authority = types.SimpleNamespace(is_destroyed=lambda *unused: True)
+
+        detail = self._wagon_sweep(environment, authority)
+
+        self.assertEqual('clear', detail['status'])
+
+    def test_an_unloaded_chunk_releases_its_unidentified_wall(self):
+        """A cached placement dies with the streamed chunk that proved it."""
+        environment = self._prohorovka_wagon_environment()
+        authority = types.SimpleNamespace(is_destroyed=lambda *unused: False)
+
+        blocked = self._wagon_sweep(environment, authority)
+        environment['manager']._DestructiblesManager__loadedChunkIDs.clear()
+        released = self._wagon_sweep(environment, authority)
+
+        self.assertEqual('hard', blocked['status'])
+        self.assertEqual('clear', released['status'])
+        self.assertEqual(
+            {}, destructibles_sensor.g_offh_destr_unresolved_obstacles)
+
+    def test_the_unidentified_placement_proof_is_queried_once(self):
+        environment = self._prohorovka_wagon_environment()
+        authority = types.SimpleNamespace(is_destroyed=lambda *unused: False)
+
+        wire = (32637, 56)
+        first = self._wagon_sweep(environment, authority)
+        first_queries = environment['matrix_calls'].count(wire)
+        second = self._wagon_sweep(environment, authority)
+
+        self.assertEqual('hard', first['status'])
+        self.assertEqual('hard', second['status'])
+        # The confirmed placement is cached, so a later sweep over the same
+        # unidentified model costs no further native query.
+        self.assertEqual(
+            first_queries, environment['matrix_calls'].count(wire))
+
     def test_malinovka_log_fence_streams_with_native_module_indices(self):
         catalog_path = ROOT / 'destructibles' / '02_malinovka.json'
         catalog = json.loads(catalog_path.read_text())
@@ -8278,7 +8520,11 @@ class DestructiblesCompatibilityTests(unittest.TestCase):
                 1, _Vector(29.5, 8.0, -267.5), 0.0, 1.0,
                 descriptor, 10.0, dt=0.02, kinetic_speed=16.667)
 
-        self.assertEqual('clear', pending_detail['status'])
+        # A streamed model whose identity is still pending is real geometry.
+        # It keeps stopping the hull until the next tick can name it, and only
+        # then does the exact retail crush law get to decide.
+        self.assertEqual('hard', pending_detail['status'])
+        self.assertIn('unidentified', pending_detail['kinds'])
         self.assertEqual('crushed', detail['status'])
         self.assertTrue(detail['requires_commit'])
         self.assertEqual(((32636, 25, 74),), detail['token'])


### PR DESCRIPTION
## Report

Prokhorovka, from Peng's screenshot: the player's AMX M4 mle. 49 is driven
clean through an **intact** railway flatcar, hull inside the wagon frame.

## Cause

The model is `content/Railway/rw004_Carriage1.model` — a `fragile` whose baked
collider is a single 3.14 × 2.51 × 16.2 m box, drawn as an open girder frame.

A *registered* catalog item can only produce one of two outcomes here:

* the visible client runs `_catalog_motion_blocked` with `commit_enabled=False`,
  so a physically crushable item falls into `blocked = True` → the wagon stops
  the tank; or
* `_catalog_motion_proposal` → `commit_local_prediction` → native destroy → the
  wagon breaks and hides.

Neither happened, so the wire was **not live-registered** at that moment, and
the only remaining guard — three hull lanes at 0.6/1.1/1.6 m — threaded the open
frame. Offline the baked data is provably fine: catalog `version=7`, 72 railway
instances on Prokhorovka, every carriage box bottom within 1.5 m of the baked
navgraph terrain.

The transient is reproducible against the shipped catalog and is covered by a
test here: chunk 32637 holds **61** destructibles and
`_ITEM_NAME_QUERY_BUDGET` is **16** shared queries per rendered frame, so name
alignment needs several frames. A hull at speed reaches the wagon inside that
window, and `_catalog_contact_candidates` saw nothing at all.

An existing test even encoded the old behaviour —
`test_malinovka_log_fence_streams_with_native_module_indices` asserted that the
first, still-pending proposal was `'clear'`. That assertion is the defect, and
it is updated here.

## Change

Registration proves *identity*: which descriptor an item uses, whether it may
be destroyed, which native event names it. Stopping a hull needs only
*placement*, and the pinned catalog already owns that.

`_stream_baked_motion_instances_1513` now returns the models a sweep could not
identify, and `_catalog_motion_blocked` keeps the hull on them
(`status='hard'`, `kinds` names `unidentified`). A box is admitted only when:

* the chunk is streamed and the item index is inside its native slot count;
* the live `wg_getDestructibleMatrix` still reproduces the pinned locator
  signature, so the model stands exactly where the catalog says;
* the identity is not already destroyed (per module, for structures);
* it is not a `falling` body, which may have left its authored pose.

Anything else yields no box rather than inventing a wall. The confirmed
placement is cached against the chunk's streamed slot count, so it costs one
native query per model and is released when the chunk unloads. The
receipt-reuse guard `_catalog_hull_contact` reads that cache so a Bot cannot
step past a model the full sweep already proved solid, and it issues no native
query of its own.

Nothing is destroyed or published for an unidentified model, and no mutation is
added. Once identity resolves on a later tick the exact retail kinetic law owns
the wagon again and a heavy tank crushes it as before.

## Checks

* `CPython 2.7 source compile passed: 97 files`
* `test_port_0922_destructibles`, `test_port_0922_solid_hit_pipeline`,
  `test_port_0922_world_collision`, `test_port_0922_battle_projectiles`,
  `test_port_0922_he_blast_runtime`, `test_port_0922_battle_runtime`,
  `test_port_0922_tank_collision` — 1364 tests, OK
* `test_port_0922_bot_runtime` — 458 tests, OK

New tests use the real shipped `destructibles/05_prohorovka.json` row for wire
`(32637, 56)`: the pending wagon blocks, the identified wagon crushes, an
unstreamed chunk and a contradicting live matrix never invent a wall, a
destroyed identity stops blocking, the placement proof is queried once, and an
unloading chunk releases it.

## Not proved here

Whether that exact Prokhorovka wagon was unregistered for this reason in Peng's
battle is still an inference — the `[Offline LAN 0.9.22] DESTR …` lines from
that session's `python.log` would confirm it. The fix does not depend on which
identity failure occurred: any unidentified streamed model now blocks. Windows
acceptance is the boundary for whether the wagon now stops a tank and still
breaks under a heavy ram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)