### PR TITLE
Fix chassis support, Bot blocked-edge recovery, and destructible event retries

### DIFF
--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -620,6 +620,14 @@ Projectile timing and falling-body animation retain their stock lifecycle.
 Pinned-bytecode ABI checks and focused tests cover these contracts; exact
 Windows playtesting remains necessary for effect continuity and contact feel.
 
+Physical-contact destruction reports retain their original identity, position,
+yaw and speed until transport accepts them. A refused report does not repeat
+native destruction or turn an already accepted crush into a motion hold for
+that vehicle or unrelated vehicles. Space changes retire the old backlog
+before the scanner retries it. Shot destruction receipts remain inside their
+projectile transaction and never enter the standalone contact retry ledger.
+Focused tests prove publication and motion-result isolation, not native feel.
+
 The matrix boundary is contained at the scope of its evidence. A thrown chunk-
 matrix query isolates that chunk, while a successfully returned matrix whose
 translation is temporarily `None` remains solid and retries after streaming.

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/ai/navigation.py
@@ -1319,9 +1319,10 @@ class TerrainNavigator(object):
 		"""Keep moving without treating an unproved long segment as drivable.
 
 		A fully probed short waypoint is preferred after a conclusive A* failure.
-		If none exists (or the search is merely pending), return the strategic goal
-		as steering intent for LocalDriver. The caller still probes every candidate
-		vehicle-width corridor and can only throttle into one that is locally safe.
+		If none exists (or the search is merely pending), an unvetoed strategic goal
+		remains steering intent for LocalDriver. A Bot's own reported edge veto must
+		hold instead: LocalDriver can otherwise drive the long goal straight back
+		through the rejected edge before the next planner result arrives.
 		"""
 		# A fallback replaces the route decision, not the ford the planner already
 		# selected. Drop that ford only once it stops being a reachable safe edge.
@@ -1337,7 +1338,7 @@ class TerrainNavigator(object):
 			fallback = self.grid.safe_local_target(
 				current, goal, now, avoid_points,
 				1.0 if (int(bot_id) % 2) else -1.0,
-				self._active_macro_edge_penalties(bot_id, now))
+				self._active_planning_edge_penalties(bot_id, now))
 			if fallback is not None:
 				state['last_target'] = tuple(fallback)
 				state['navigation_status'] = 'safe'
@@ -1345,6 +1346,12 @@ class TerrainNavigator(object):
 					_distance_2d(fallback, goal) <= WAYPOINT_ARRIVAL_RADIUS)
 				self._set_fallback_mode(bot_id, 'safe_local')
 				return tuple(fallback)
+		if self._bot_edges_penalized(bot_id, current, goal, now):
+			state['last_target'] = tuple(current)
+			state['navigation_status'] = 'blocked'
+			state['target_is_terminal'] = False
+			self._set_fallback_mode(bot_id, 'reactive')
+			return tuple(current)
 		state['last_target'] = tuple(goal)
 		state['navigation_status'] = 'blocked'
 		state['target_is_terminal'] = False
@@ -1374,7 +1381,7 @@ class TerrainNavigator(object):
 				current, last_target, BAKED_SHALLOW_WATER)
 			controlled = state.get('controlled_shallow_target')
 			if (self.grid.segment_penalty(current, last_target, now) <= 0.0 and
-					not self._macro_edges_penalized(
+					not self._bot_edges_penalized(
 						bot_id, current, last_target, now) and
 					self.grid.segment_clear(current, last_target) and
 					(not shallow or controlled == last_target) and
@@ -1394,7 +1401,7 @@ class TerrainNavigator(object):
 			fallback = self.grid.safe_local_target(
 				current, goal, now, avoid_points,
 				1.0 if (int(bot_id) % 2) else -1.0,
-				self._active_macro_edge_penalties(bot_id, now))
+				self._active_planning_edge_penalties(bot_id, now))
 			if fallback is not None:
 				state['last_target'] = tuple(fallback)
 				state['navigation_status'] = 'pending'
@@ -1456,6 +1463,8 @@ class TerrainNavigator(object):
 			escape = tuple(escape)
 			if (float(now) < float(state.get('escape_until', now)) and
 					_distance_2d(current, escape) > WAYPOINT_ARRIVAL_RADIUS and
+					not self._bot_edges_penalized(
+						bot_id, current, escape, now) and
 					self.grid.dry_segment_clear(current, escape, now)):
 				return escape
 			state['target'] = tuple(goal)
@@ -1479,7 +1488,8 @@ class TerrainNavigator(object):
 		escape = self.grid.safe_local_target(
 			current, goal, now, None,
 			1.0 if (bot_id % 2) else -1.0,
-			None, FIRST_CANDIDATE_OFFSET)
+			self._active_planning_edge_penalties(bot_id, now),
+			FIRST_CANDIDATE_OFFSET)
 		state['target'] = tuple(goal)
 		state['position'] = tuple(current)
 		state['progress_at'] = float(now)
@@ -1496,7 +1506,8 @@ class TerrainNavigator(object):
 		escape = self.grid.safe_local_target(
 			current, target, now, None,
 			1.0 if (int(bot_id) % 2) else -1.0,
-			None, FIRST_CANDIDATE_OFFSET)
+			self._active_planning_edge_penalties(bot_id, now),
+			FIRST_CANDIDATE_OFFSET)
 		key = self.grid._edge_cells_for_segment(current, target)
 		if key is None and escape is None:
 			return False
@@ -1618,12 +1629,6 @@ class TerrainNavigator(object):
 		result = dict(self._active_bot_edge_penalties(bot_id, now) or {})
 		result.update(self._active_macro_edge_penalties(bot_id, now) or {})
 		return result or None
-
-	def _macro_edges_penalized(self, bot_id, start, end, now):
-		penalties = self._active_macro_edge_penalties(bot_id, now)
-		return bool(penalties and any(
-			edge in penalties
-			for edge in self.grid._edge_keys_for_segment(start, end)))
 
 	def _bot_edges_penalized(self, bot_id, start, end, now):
 		"""True when this bot's own escalation covers any edge of the segment."""
@@ -1877,7 +1882,7 @@ class TerrainNavigator(object):
 				owner, keep_key=key, kind=path_key[0])
 		if key in self.paths:
 			path = self.paths[key]
-			hard_edge_penalties = self._active_macro_edge_penalties(
+			hard_edge_penalties = self._active_planning_edge_penalties(
 				owner, now)
 			# A probe can fail while distant chunks are still streaming. Successful
 			# paths are permanent for the battle; failed ones get another chance.
@@ -1916,8 +1921,11 @@ class TerrainNavigator(object):
 		search = self.searches.get(key)
 		if search is None:
 			edge_penalties = self._active_planning_edge_penalties(owner, now)
-			hard_edge_penalties = self._active_macro_edge_penalties(
-				owner, now)
+			# A repeated local contact vetoes the edge for this Bot for its lease.
+			# Keep it out of the graph as well as direct, cached and local targets:
+			# otherwise A* can admit the expensive edge, smooth it back into a
+			# shortcut, then restart the same rejected search on the next frame.
+			hard_edge_penalties = edge_penalties
 			penalized_direct = bool(
 				edge_penalties and any(
 					edge in edge_penalties
@@ -1958,7 +1966,8 @@ class TerrainNavigator(object):
 		self._finish_search(key, search, now)
 		return key, self.paths[key]
 
-	def _planned_next_segment_clear(self, current, path, index, now):
+	def _planned_next_segment_clear(self, current, path, index, now,
+			bot_id=None):
 		"""Keep an adjacent A* ford without inventing a shallow shortcut."""
 		if index + 1 >= len(path):
 			return False
@@ -1971,6 +1980,8 @@ class TerrainNavigator(object):
 		if ((not reached and
 				 not self.grid.live_shortcut_preserves_climb_approach(
 					 current, path, index, index + 1)) or
+			(bot_id is not None and self._bot_edges_penalized(
+				 bot_id, current, target, now)) or
 				self.grid.segment_penalty(current, target, now) > 0.0 or
 				not self.grid.segment_clear(current, target)):
 			return False
@@ -2007,7 +2018,7 @@ class TerrainNavigator(object):
 
 	@observed('nav.lookahead')
 	def _lookahead_index(self, current, path, index, path_key, now,
-			lookahead_distance):
+			lookahead_distance, bot_id=None):
 		"""Select a proved corridor point far enough ahead for current speed."""
 		lookahead = int(index)
 		if lookahead_distance is None:
@@ -2018,8 +2029,8 @@ class TerrainNavigator(object):
 			horizon = max(
 				self.grid.cell_size * 2.0, float(lookahead_distance))
 		prefer_clearance = self._prefers_baked_clearance(path_key)
-		edge_penalties = self._active_macro_edge_penalties(
-			self._path_owner(path_key), now)
+		edge_penalties = self._active_planning_edge_penalties(
+			bot_id if bot_id is not None else self._path_owner(path_key), now)
 		for candidate in range(index + 1, limit):
 			if (horizon is not None and candidate > index + 1 and
 					_distance_2d(current, path[candidate]) > horizon):
@@ -2135,6 +2146,8 @@ class TerrainNavigator(object):
 			escape = tuple(escape)
 			if (float(now) < float(state.get('macro_escape_until', now)) and
 					_distance_2d(current, escape) > WAYPOINT_ARRIVAL_RADIUS and
+					not self._bot_edges_penalized(
+						bot_id, current, escape, now) and
 					self.grid.dry_segment_clear(current, escape, now)):
 				state.pop('controlled_shallow_target', None)
 				state['last_target'] = escape
@@ -2179,7 +2192,7 @@ class TerrainNavigator(object):
 		                       None)
 		if path is None:
 			if (self.grid.dry_segment_clear(current, goal, now) and
-					not self._macro_edges_penalized(
+					not self._bot_edges_penalized(
 						bot_id, current, goal, now)):
 				state.pop('controlled_shallow_target', None)
 				state['last_target'] = tuple(goal)
@@ -2192,7 +2205,7 @@ class TerrainNavigator(object):
 				allow_pending_last_target, request_transition)
 		if not path:
 			if (self.grid.dry_segment_clear(current, goal, now) and
-					not self._macro_edges_penalized(
+					not self._bot_edges_penalized(
 						bot_id, current, goal, now)):
 				state.pop('controlled_shallow_target', None)
 				state['last_target'] = tuple(goal)
@@ -2233,7 +2246,7 @@ class TerrainNavigator(object):
 		current_segment_shallow = self.grid.segment_has_baked_hazard(
 			current, path[index], BAKED_SHALLOW_WATER)
 		if (self.grid.segment_penalty(current, path[index], now) > 0.0 or
-				self._macro_edges_penalized(
+				self._bot_edges_penalized(
 					bot_id, current, path[index], now) or
 				(current_segment_shallow and
 				 not self._planned_current_segment_clear(
@@ -2262,11 +2275,12 @@ class TerrainNavigator(object):
 		while (index + 1 < len(path) and
 		       _distance_2d(current, path[index]) < reach_radius and
 		       self._planned_next_segment_clear(
-			       current, path, index, now)):
+			       current, path, index, now, bot_id)):
 			index += 1
 		# Look ahead only while every skipped piece is continuously supported.
 		lookahead = self._lookahead_index(
-			current, path, index, effective_key, now, lookahead_distance)
+			current, path, index, effective_key, now, lookahead_distance,
+			bot_id)
 		if (lookahead == len(path) - 1 and
 				_distance_2d(current, path[lookahead]) < reach_radius and
 				_distance_2d(path[lookahead], goal) > reach_radius):
@@ -2283,11 +2297,11 @@ class TerrainNavigator(object):
 				next_index = 0
 				if (len(path) > 1 and
 						self._planned_next_segment_clear(
-							current, path, 0, now)):
+						 current, path, 0, now, bot_id)):
 					next_index = 1
 				next_index = self._lookahead_index(
 					current, path, next_index, continue_key, now,
-					lookahead_distance)
+					lookahead_distance, bot_id)
 				state['index'] = next_index
 				selected = tuple(path[next_index])
 				state['last_target'] = selected

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -18990,13 +18990,17 @@ class BattleRuntime(object):
         half_length = 2.5
         half_width = 1.5
         try:
-            hit_tester = _field(
-                _field(descriptor, 'hull', {}), 'hitTester', None)
-            bbox = getattr(hit_tester, 'bbox', None)
-            half_length = max(1.5, abs(float(bbox[1][2])))
-            half_width = max(0.3, max(abs(float(bbox[0][0])),
-                                      abs(float(bbox[1][0]))))
-        except (TypeError, ValueError, IndexError, AttributeError):
+            # Support belongs to the tracks/chassis.  The mounted hull can be
+            # narrower, so using its armour bbox leaves real track ends
+            # unprobed and lets a narrow slot swallow the vehicle.  Reuse the
+            # descriptor-derived chassis shape which the Bot and ram paths
+            # already use; its x/z footprint is deliberately independent from
+            # the mounted hull's vertical extension.
+            support_shape = tank_collision.chassis_shape(descriptor)
+            half_width = max(0.3, float(support_shape[0]))
+            half_length = max(1.5, float(support_shape[1]))
+        except (RuntimeError, TypeError, ValueError, IndexError,
+                AttributeError):
             pass
         sine, cosine = math.sin(yaw), math.cos(yaw)
         highest = None

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -11653,6 +11653,7 @@ class BotRuntime(object):
                 resolved_motion = False
                 contact_speed = state.get('destructible_contact_speed', speed)
                 contact_v0 = speed
+                realised_contact_yaw = None
                 if (path_clear and not pose_frozen and
                         abs(speed) > 0.0001 and
                         callable(self.motion_resolver)):
@@ -11698,8 +11699,11 @@ class BotRuntime(object):
                             speed = previous_speed
                             state.pop('destructible_contact_speed', None)
                         elif motion_status == 'hard':
+                            realised_contact_yaw = state['yaw']
+                            if contact_v0 < 0.0:
+                                realised_contact_yaw += math.pi
                             self._invalidate_realised_motion(
-                                state['id'], travel_yaw)
+                                state['id'], realised_contact_yaw)
                             hard_contact = True
                             state.pop('destructible_contact_speed', None)
                     else:
@@ -11715,19 +11719,22 @@ class BotRuntime(object):
                     contact_target = command.get('move_position')
                     if (contact_target is not None and
                             navigation_grid is not None):
-                        # The exact hull sweep used committed_travel_yaw, not
-                        # the strategic waypoint.  A tank may hit a wall while
-                        # turning toward that waypoint, so reporting the latter
-                        # can veto an unrelated route edge for this Bot.
+                        # A generic contact came from the pre-turn direction
+                        # probe.  A resolved one came from this exact hull yaw
+                        # and signed speed; a reversing command can still be
+                        # braking a forward-moving hull (or vice versa).
+                        contact_yaw = travel_yaw
+                        if realised_contact_yaw is not None:
+                            contact_yaw = realised_contact_yaw
                         edge_length = _number(
                             getattr(navigation_grid, 'cell_size', 0.0), 0.0)
                         if edge_length > 0.0:
                             contact_target = (
                                 position[0] + math.sin(
-                                    committed_travel_yaw) * edge_length,
+                                    contact_yaw) * edge_length,
                                 position[1],
                                 position[2] + math.cos(
-                                    committed_travel_yaw) * edge_length)
+                                    contact_yaw) * edge_length)
                     if (callable(report_contact) and
                             contact_target is not None):
                         report_contact(

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -11510,8 +11510,21 @@ class BotRuntime(object):
                         not (isinstance(motion_probe, dict) and
                              motion_probe.get('collision', False)) and
                         command.get('move_position') is not None):
-                    report_blocked(state['id'], position,
-                                   command.get('move_position'), now)
+                    blocked_target = command.get('move_position')
+                    if navigation_grid is not None:
+                        # The generic probe just rejected travel_yaw before
+                        # this slice turns the hull.  Mark that local edge,
+                        # rather than the strategic waypoint it was pursuing.
+                        edge_length = _number(
+                            getattr(navigation_grid, 'cell_size', 0.0), 0.0)
+                        if edge_length > 0.0:
+                            blocked_target = (
+                                position[0] + math.sin(travel_yaw) *
+                                edge_length,
+                                position[1],
+                                position[2] + math.cos(travel_yaw) *
+                                edge_length)
+                    report_blocked(state['id'], position, blocked_target, now)
             steer_dir = 0
             if abs(turn) > 0.01:
                 # LocalDriver already inverts reverse recovery steering for the
@@ -11699,11 +11712,27 @@ class BotRuntime(object):
                             descriptor, step, now)
                     report_contact = getattr(
                         self.navigator, 'report_blocked_step', None)
+                    contact_target = command.get('move_position')
+                    if (contact_target is not None and
+                            navigation_grid is not None):
+                        # The exact hull sweep used committed_travel_yaw, not
+                        # the strategic waypoint.  A tank may hit a wall while
+                        # turning toward that waypoint, so reporting the latter
+                        # can veto an unrelated route edge for this Bot.
+                        edge_length = _number(
+                            getattr(navigation_grid, 'cell_size', 0.0), 0.0)
+                        if edge_length > 0.0:
+                            contact_target = (
+                                position[0] + math.sin(
+                                    committed_travel_yaw) * edge_length,
+                                position[1],
+                                position[2] + math.cos(
+                                    committed_travel_yaw) * edge_length)
                     if (callable(report_contact) and
-                            command.get('move_position') is not None):
+                            contact_target is not None):
                         report_contact(
                             state['id'], position,
-                            command.get('move_position'), now)
+                            contact_target, now)
                 elif motion_status in ('soft', 'cap_crushed'):
                     self._hard_contact_grinds[state['id']] = 1
                 if resolved_motion and callable(self.motion_report):

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/destructibles_sensor.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/destructibles_sensor.py
@@ -3496,27 +3496,19 @@ def _catalog_motion_blocked(spaceID, pos, yaw, vel, td, now,
 		raise ValueError(
 			'catalog motion proposals require detail and kinetic classification')
 	_diagnostic_flush_1513(now)
-	publish_failures, publish_kinds = _retry_catalog_publications_1513()
-	if publish_failures:
-		# Backpressure is an operation-local pending result.  Do not admit more
-		# irreversible native mutations until the already committed event is
-		# observable, and retain its exact identity for the worker retry.
-		return _catalog_motion_result(
-			'pending', publish_failures, return_status=return_status,
-			return_detail=return_detail, kinds=publish_kinds,
-			requires_commit=False if proposal_only else None)
+	# Native acceptance already decided collision. Keep transport retries in
+	# their frozen ledger; a delayed event must not hold this or another hull.
+	_retry_catalog_publications_1513(spaceID)
 	if _destructible_catalog is None:
 		return _catalog_motion_result(
-			'pending' if publish_failures else 'clear', publish_failures,
+			'clear',
 			return_status=return_status, return_detail=return_detail,
-			kinds=publish_kinds,
 			requires_commit=False if proposal_only else None)
 	bbox = _vehicle_hull_bbox(td)
 	if bbox is None:
 		return _catalog_motion_result(
-			'pending' if publish_failures else 'clear', publish_failures,
+			'clear',
 			return_status=return_status, return_detail=return_detail,
-			kinds=publish_kinds,
 			requires_commit=False if proposal_only else None)
 	import Math
 	auth = _get_destr_authority()
@@ -3536,9 +3528,8 @@ def _catalog_motion_blocked(spaceID, pos, yaw, vel, td, now,
 		unresolved, vehicle_box, auth)
 	if not candidates and not unidentified:
 		return _catalog_motion_result(
-			'pending' if publish_failures else 'clear', publish_failures,
+			'clear',
 			return_status=return_status, return_detail=return_detail,
-			kinds=publish_kinds,
 			requires_commit=False if proposal_only else None)
 
 	grouped = {}
@@ -3553,9 +3544,8 @@ def _catalog_motion_blocked(spaceID, pos, yaw, vel, td, now,
 	crushed = False
 	kinetic = False
 	approach = False
-	publication_pending = bool(publish_failures)
-	exact_token = set(publish_failures)
-	contact_kinds = set(publish_kinds)
+	exact_token = set()
+	contact_kinds = set()
 	if unidentified:
 		contact_kinds.add('unidentified')
 	commit_candidates = []
@@ -3696,10 +3686,9 @@ def _catalog_motion_blocked(spaceID, pos, yaw, vel, td, now,
 		exact_token.add((chunk_id, item_index, mat_kind))
 		note_destroyed(
 			event_kind, chunk_id, item_index, mat_kind, now)
-		if not _publish_catalog_once_1513(
+		_publish_catalog_once_1513(
 				event_kind, chunk_id, item_index, point, yaw, vel,
-				mat_kind if event_kind == 'module' else None):
-			publication_pending = True
+				mat_kind if event_kind == 'module' else None)
 		accepted_now = True
 		used_kinetic_speed = used_kinetic_speed or used_cap
 		_diagnostic_contact_1513(
@@ -3708,8 +3697,7 @@ def _catalog_motion_blocked(spaceID, pos, yaw, vel, td, now,
 				('speed', '%.3f' % float(gate_speed))), now=now)
 		crushed = True
 
-	status = ('pending' if publication_pending else
-		'hard' if blocked else
+	status = ('hard' if blocked else
 		'kinetic' if kinetic else
 		'crushed' if crushed else
 		'approach' if approach else 'clear')
@@ -4204,8 +4192,13 @@ def _publish_catalog_once_1513(
 	return True
 
 
-def _retry_catalog_publications_1513():
-	"""Retry native-committed catalog events before geometry can move away."""
+def _retry_catalog_publications_1513(spaceID):
+	"""Retry native-committed events independently of their current geometry."""
+	owner = globals().get('g_offh_destr_runtime_space')
+	if owner is not None and int(owner) != int(spaceID):
+		# Motion may run before the new space's scanner clears old state, or a
+		# stale caller may arrive after teardown. Neither may replay this ledger.
+		return set(), set()
 	pending = globals().get('g_offh_destr_catalog_publish_pending', {})
 	failed = set()
 	kinds = set()
@@ -4429,11 +4422,18 @@ def _try_destroy_destructible(spaceID, matInfo, yaw, vel,
 			_event_kind, chunkID, itemIndex,
 			matKind if _event_kind == 'module' else None,
 			_now)
-	_publish_destroyed(
-		_event_kind,
-		chunkID, itemIndex, hitPt, yaw, vel,
-		matKind if typ == AreaDestructibles.DESTR_TYPE_STRUCTURE else None,
-		isShotDamage)
+	_event_mat = matKind if typ == AreaDestructibles.DESTR_TYPE_STRUCTURE else None
+	if isShotDamage:
+		# Shot receipts belong to the current projectile transaction. They must
+		# never be retried later as independent physical-contact LAN events.
+		_publish_destroyed(
+			_event_kind, chunkID, itemIndex, hitPt, yaw, vel, _event_mat, True)
+	else:
+		# Native destruction cannot be rolled back if transport rejects this
+		# report. Freeze it for the existing per-space retry owner before
+		# returning the accepted physical result.
+		_publish_catalog_once_1513(
+			_event_kind, chunkID, itemIndex, hitPt, yaw, vel, _event_mat)
 	return True
 
 
@@ -5024,10 +5024,6 @@ def _fell_trees_near(
 	import AreaDestructibles
 	import BigWorld
 	import Math
-	# An event whose LAN admission was refused stays frozen and pending. Drain
-	# that backlog before proving more native destruction, so a publication the
-	# transport could not take is retried instead of lost.
-	_retry_catalog_publications_1513()
 	try:
 		mgr = getattr(AreaDestructibles, 'g_destructiblesManager', None)
 		if not mgr:
@@ -5044,6 +5040,9 @@ def _fell_trees_near(
 			# empty/deferred transaction shell while clearing every prior battle.
 			_clear_runtime_registry(preserve_spatial_batch=True)
 			globals()['g_offh_destr_runtime_space'] = int(spaceID)
+		# Retire prior-space events before retrying this battle's frozen
+		# publications. Native item IDs can name different objects in a new map.
+		_retry_catalog_publications_1513(spaceID)
 		_st = globals().setdefault('g_offh_tree_state', {'chunks': {}, 'felled': set(), 'spaceID': None})
 		if _st.get('spaceID') != spaceID:
 			# New battle/space: chunk IDs collide between maps and the

--- a/tests/test_port_0922_ai.py
+++ b/tests/test_port_0922_ai.py
@@ -1204,6 +1204,178 @@ class BotAiPortTests(unittest.TestCase):
         self.assertEqual(ford, peer['controlled_shallow_target'])
         self.assertFalse(navigator.grid._failed_edges)
 
+    def test_pending_search_does_not_reuse_this_bots_vetoed_target(self):
+        """A blocked-step replan must not drive the old edge while queued."""
+        navigator = TerrainNavigator(
+            lambda *unused: None, baked_graph=self._baked_graph(5, 1))
+        current = (10.0, 0.0, 20.0)
+        vetoed = (26.0, 0.0, 20.0)
+        state = {'last_target': vetoed}
+        navigator.bot_states[7] = state
+        edge = navigator.grid._edge_cells_for_segment(current, vetoed)
+        navigator.bot_failed_edges[7] = {edge: (60.0, 240.0)}
+        navigator.grid.safe_local_target = lambda *unused: None
+
+        selected = navigator._pending_target(
+            7, current, vetoed, 1.0, state)
+
+        self.assertEqual(current, selected)
+        self.assertEqual('pending', state['navigation_status'])
+        # The failed edge remains private: an unaffected peer may still use it.
+        peer = {'last_target': vetoed}
+        navigator.bot_states[8] = peer
+        self.assertEqual(vetoed, navigator._pending_target(
+            8, current, vetoed, 1.0, peer))
+
+    def test_blocked_step_veto_covers_pending_and_failed_search_fallbacks(self):
+        """A real blocked-step veto fences every direct progress fallback."""
+        current = (10.0, 0.0, 20.0)
+        goal = (26.0, 0.0, 20.0)
+        route_key = ('route', 1, 'vetoed-corridor')
+
+        def escalate(navigator, bot_id):
+            target = navigator.next_target(
+                bot_id, current, goal, route_key, 1.0)
+            verdicts = [navigator.report_blocked_step(
+                bot_id, current, target, now)
+                for now in (1.0, 1.34, 1.68, 2.02)]
+            self.assertEqual([False, False, False, True], verdicts)
+
+        # Keep the actual replan queued past its normal local-progress grace.
+        # This exercises both the direct shortcut while pending and the bounded
+        # safe-local candidate selected after that grace.
+        pending = TerrainNavigator(
+            lambda *unused: None, baked_graph=self._baked_graph(5, 1))
+        escalate(pending, 11)
+        pending._path = lambda key, *unused: (key, None)
+        self.assertEqual(current, pending.next_target(
+            11, current, goal, route_key, 2.03))
+        now = 2.03 + navigation.PENDING_PROGRESS_SECONDS + 0.01
+        selected = pending.next_target(11, current, goal, route_key, now)
+        self.assertNotEqual(goal, selected)
+        self.assertFalse(pending.bot_segment_penalized(
+            11, current, selected, now))
+
+        # A conclusively failed search uses the same safe-local admission.
+        failed = TerrainNavigator(
+            lambda *unused: None, baked_graph=self._baked_graph(5, 1))
+        escalate(failed, 12)
+        failed._path = lambda key, *unused: (key, ())
+        selected = failed.next_target(12, current, goal, route_key, 2.03)
+        self.assertNotEqual(goal, selected)
+        self.assertFalse(failed.bot_segment_penalized(
+            12, current, selected, 2.03))
+
+        # A long reactive goal would otherwise reach LocalDriver unchanged.
+        # With no fully probed local candidate, the vetoed Bot must hold.
+        no_local = TerrainNavigator(
+            lambda *unused: None, baked_graph=self._baked_graph(5, 1))
+        escalate(no_local, 13)
+        no_local._path = lambda key, *unused: (key, ())
+        no_local.grid.safe_local_target = lambda *unused: None
+        selected = no_local.next_target(13, current, goal, route_key, 2.03)
+        self.assertEqual(current, selected)
+        self.assertEqual(
+            'blocked', no_local.bot_states[13]['navigation_status'])
+
+    def test_blocked_step_replan_detours_then_expires_per_bot(self):
+        """A real replan avoids its reported edge without changing a peer."""
+        current = (10.0, 0.0, 24.0)
+        goal = (26.0, 0.0, 24.0)
+        route_key = ('route', 1, 'replan-detour')
+        navigator = TerrainNavigator(
+            lambda *unused: None, baked_graph=self._baked_graph(5, 3))
+        target = navigator.next_target(11, current, goal, route_key, 1.0)
+        peer = navigator.next_target(12, current, goal, route_key, 1.0)
+        self.assertEqual(goal, target)
+        self.assertEqual(goal, peer)
+        self.assertEqual(
+            [False, False, False, True],
+            [navigator.report_blocked_step(11, current, target, now)
+             for now in (1.0, 1.34, 1.68, 2.02)])
+
+        selected = None
+        now = 2.02
+        for unused_step in range(32):
+            now += 0.05
+            candidate = navigator.next_target(
+                11, current, goal, route_key, now)
+            if (navigator.bot_states[11].get('path_key') is not None and
+                    candidate != current):
+                selected = candidate
+                break
+        self.assertIsNotNone(selected)
+        self.assertNotEqual(goal, selected)
+        self.assertFalse(navigator.bot_segment_penalized(
+            11, current, selected, now))
+        self.assertEqual(goal, navigator.next_target(
+            12, current, goal, route_key, now))
+
+        restored_at = 2.02 + navigation.BLOCKED_STEP_EDGE_TTL + 0.10
+        self.assertEqual(goal, navigator.next_target(
+            11, current, goal, route_key, restored_at))
+        self.assertFalse(navigator.bot_segment_penalized(
+            11, current, goal, restored_at))
+
+    def test_blocked_step_replan_holds_the_only_vetoed_corridor(self):
+        """No detour never permits the rejected edge as a soft-cost route."""
+        current = (10.0, 0.0, 20.0)
+        goal = (26.0, 0.0, 20.0)
+        route_key = ('route', 1, 'only-corridor')
+        navigator = TerrainNavigator(
+            lambda *unused: None, baked_graph=self._baked_graph(5, 1))
+        target = navigator.next_target(11, current, goal, route_key, 1.0)
+        self.assertEqual(
+            [False, False, False, True],
+            [navigator.report_blocked_step(11, current, target, now)
+             for now in (1.0, 1.34, 1.68, 2.02)])
+
+        selected = None
+        now = 2.02
+        for unused_step in range(32):
+            now += 0.05
+            candidate = navigator.next_target(
+                11, current, goal, route_key, now)
+            if candidate != current:
+                selected = candidate
+                break
+        self.assertIsNotNone(selected)
+        self.assertNotEqual(goal, selected)
+        self.assertFalse(navigator.bot_segment_penalized(
+            11, current, selected, now))
+
+    def test_macro_escape_rechecks_a_live_blocked_step_veto(self):
+        """A macro escape cannot bypass a later per-Bot edge rejection."""
+        current = (10.0, 0.0, 20.0)
+        goal = (26.0, 0.0, 20.0)
+        route_key = ('route', 1, 'macro-veto')
+        navigator = TerrainNavigator(
+            lambda *unused: None, baked_graph=self._baked_graph(5, 1))
+        target = navigator.next_target(11, current, goal, route_key, 1.0)
+        self.assertEqual(
+            [False, False, False, True],
+            [navigator.report_blocked_step(11, current, target, now)
+             for now in (1.0, 1.34, 1.68, 2.02)])
+
+        penalties = []
+
+        def unsafe_escape(*args):
+            penalties.append(args[5])
+            return goal
+
+        navigator.grid.safe_local_target = unsafe_escape
+        state = navigator.bot_states[11]
+        self.assertTrue(navigator._start_macro_replan(
+            11, state, current, goal, 2.03))
+        self.assertTrue(penalties[0])
+        self.assertTrue(navigator.bot_segment_penalized(
+            11, current, goal, 2.03))
+        navigator._path = lambda key, *unused: (key, None)
+        navigator.grid.safe_local_target = lambda *unused: None
+        self.assertEqual(current, navigator.next_target(
+            11, current, goal, route_key, 2.04))
+        self.assertNotIn('macro_escape_target', state)
+
     def test_blocked_step_escalation_reroutes_only_the_reporting_bot(self):
         graph = self._baked_graph(5, 3, blocked=((2, 1),))
         navigator = TerrainNavigator(lambda *unused: None, baked_graph=graph)

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -557,6 +557,19 @@ class _Descriptor(object):
                 self.turret.hitTester, self.gun.hitTester)
 
 
+def _wide_track_descriptor():
+    """Return the exact #1513 Ch24_Type64 bounds used by world-collision tests."""
+    descriptor = _Descriptor()
+    descriptor.chassis.hitTester = _HitTester1513(
+        _Vector(-1.565461, 0.002, -2.648121),
+        _Vector(1.565461, 1.175350, 2.648682))
+    descriptor.hull.hitTester = _HitTester1513(
+        _Vector(-1.15, -0.540596, -2.79015),
+        _Vector(1.15, 0.729932, 2.70431))
+    descriptor.chassis.hullPosition = _Vector(0.0, 0.999047, 0.0)
+    return descriptor
+
+
 def _suspension_descriptor():
     """Return one fixture with every client-owned trial suspension field."""
     descriptor = _Descriptor()
@@ -19793,7 +19806,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
                 RuntimeError, 'native suspension ground hit is malformed'):
             battle._suspension_ground_y(0.0, 0.0, -0.5, 0.8)
 
-    def _legacy_support_battle(self, columns, floor):
+    def _legacy_support_battle(self, columns, floor, descriptor=None):
         """Return a legacy-vertical player over one sampled ground field."""
         runtime = _runtime()
         battle = BattleRuntime(runtime)
@@ -19801,7 +19814,8 @@ class BattleRuntimeContractTests(unittest.TestCase):
         battle._local_fall_armed = True
         battle._local_suspension_disabled = True
         entity = _Vehicle(
-            10, _Descriptor(), _Vector(), (0, 0, 0), {'health': 500})
+            10, descriptor or _Descriptor(), _Vector(), (0, 0, 0),
+            {'health': 500})
         calls = []
 
         def collide(space_id, start, end, flags, *rest):
@@ -19826,15 +19840,30 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertFalse(battle._local_airborne)
         self.assertEqual(0.0, battle._local_vertical_speed)
 
-    def test_player_bridges_a_slot_running_along_its_hull(self):
+    def test_player_bridges_a_slot_running_along_its_chassis(self):
         battle, entity, unused_calls = self._legacy_support_battle(
-            {(1.7, 0.0): 9.95, (-1.7, 0.0): 10.0}, 7.0)
+            {(1.5, 0.0): 9.95, (-1.5, 0.0): 10.0}, 7.0)
 
         position = battle._update_vertical_motion(
             entity, (0.0, 10.0, 0.0), 0.0, 0.1)
 
         self.assertAlmostEqual(10.0, position[1], places=6)
         self.assertFalse(battle._local_airborne)
+
+    def test_player_support_uses_wide_chassis_not_narrower_hull(self):
+        """A Type 64-style track footprint still bridges its narrow hull slot."""
+        descriptor = _wide_track_descriptor()
+        battle, entity, calls = self._legacy_support_battle(
+            {(1.6, 0.0): 10.0, (-1.6, 0.0): 10.0}, 7.0,
+            descriptor)
+
+        position = battle._update_vertical_motion(
+            entity, (0.0, 10.0, 0.0), 0.0, 0.1)
+
+        self.assertAlmostEqual(10.0, position[1], places=6)
+        self.assertFalse(battle._local_airborne)
+        self.assertIn((1.6, 0.0), calls)
+        self.assertIn((-1.6, 0.0), calls)
 
     def test_player_still_falls_where_only_one_chassis_end_is_supported(self):
         battle, entity, unused_calls = self._legacy_support_battle(

--- a/tests/test_port_0922_bot_runtime.py
+++ b/tests/test_port_0922_bot_runtime.py
@@ -3774,6 +3774,103 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertIn(11, runtime._decision_cache)
         self.assertIn(11, runtime._motion_probe_cache)
 
+    def test_realised_hard_contact_reports_resolver_direction_while_braking(self):
+        yaw = 0.25
+        aim = (math.sin(yaw + 0.75) * 200.0, 0.0,
+               math.cos(yaw + 0.75) * 200.0)
+        for throttle, initial_speed in ((-1.0, 6.0), (1.0, -6.0)):
+            with self.subTest(throttle=throttle, initial_speed=initial_speed):
+                command = {
+                    'target_yaw': yaw, 'throttle': throttle, 'turn': 0.0,
+                    'shell_index': 0, 'fire_allowed': False,
+                    'target_id': None, 'fire_range': 0.0,
+                    'combat_mode': 'route', 'aim_position': aim,
+                    'face_position': aim, 'move_position': aim,
+                    'recovery_mode': 'drive', 'movement_intent': True,
+                }
+                resolver_calls = []
+
+                class FailureDriver(object):
+                    def __init__(self):
+                        self.calls = []
+
+                    def remember_failure(self, *args):
+                        self.calls.append(args)
+
+                def resolver(*args, **unused_kwargs):
+                    resolver_calls.append(args)
+                    return 'hard'
+
+                adapter = _FixedAdapter(command)
+                adapter.driver = FailureDriver()
+                runtime = self.module.BotRuntime(
+                    1, descriptor_resolver=lambda unused: _combat_descriptor(),
+                    adapter_factory=lambda *unused, **kwargs: adapter,
+                    direction_probe=lambda *unused: {
+                        'clear': False, 'collision': True, 'water': False,
+                        'slope': 0.0},
+                    motion_resolver=resolver,
+                    ground_probe=lambda *unused: 0.0,
+                    physics_ground_probe=lambda *unused: 0.0,
+                    spawn_resolver=_spawn_resolver, baked_graph=_graph())
+                runtime.battle_start(self.start)
+                reports = []
+                runtime.navigator.report_blocked_step = (
+                    lambda *args: reports.append(args))
+                state = runtime.states[11]
+                state.update(x=0.0, y=0.0, z=0.0, yaw=yaw,
+                             speed=initial_speed, grounded_once=True)
+
+                runtime.update(.04, 1.0)
+
+                self.assertGreaterEqual(len(resolver_calls), 1)
+                resolver_yaw = resolver_calls[0][2]
+                resolver_speed = resolver_calls[0][3]
+                self.assertEqual(1 if initial_speed > 0.0 else -1,
+                                 1 if resolver_speed > 0.0 else -1)
+                report_yaw = (resolver_yaw if resolver_speed > 0.0 else
+                              resolver_yaw + math.pi)
+                expected = (math.sin(report_yaw) * 4.0, 0.0,
+                            math.cos(report_yaw) * 4.0)
+                self.assertEqual(expected, reports[0][2])
+                self.assertEqual([(11, report_yaw, 5.0)],
+                                 adapter.driver.calls)
+
+    def test_unresolved_hard_contact_reports_the_queried_travel_edge(self):
+        yaw = 0.25
+        aim = (math.sin(yaw + 0.75) * 200.0, 0.0,
+               math.cos(yaw + 0.75) * 200.0)
+        command = {
+            'target_yaw': yaw, 'throttle': -1.0, 'turn': 0.0,
+            'shell_index': 0, 'fire_allowed': False, 'target_id': None,
+            'fire_range': 0.0, 'combat_mode': 'route',
+            'aim_position': aim, 'face_position': aim,
+            'move_position': aim, 'recovery_mode': 'drive',
+            'movement_intent': True,
+        }
+        runtime = self.module.BotRuntime(
+            1, descriptor_resolver=lambda unused: _combat_descriptor(),
+            adapter_factory=lambda *unused, **kwargs: _FixedAdapter(command),
+            direction_probe=lambda *unused: {
+                'clear': False, 'collision': True, 'water': False,
+                'slope': 0.0},
+            ground_probe=lambda *unused: 0.0,
+            physics_ground_probe=lambda *unused: 0.0,
+            spawn_resolver=_spawn_resolver, baked_graph=_graph())
+        runtime.battle_start(self.start)
+        reports = []
+        runtime.navigator.report_blocked_step = (
+            lambda *args: reports.append(args))
+        state = runtime.states[11]
+        state.update(x=0.0, y=0.0, z=0.0, yaw=yaw, speed=6.0,
+                     grounded_once=True)
+
+        runtime.update(.04, 1.0)
+
+        expected = (math.sin(yaw + math.pi) * 4.0, 0.0,
+                    math.cos(yaw + math.pi) * 4.0)
+        self.assertEqual(expected, reports[0][2])
+
     def test_nonhard_realised_contacts_keep_cached_command_and_probe(self):
         command = {
             'target_yaw': 0.0, 'throttle': 1.0, 'turn': 0.0,

--- a/tests/test_port_0922_bot_runtime.py
+++ b/tests/test_port_0922_bot_runtime.py
@@ -173,6 +173,19 @@ def _combat_descriptor(reload_time=0.5, clip=(2, 0.2),
         hull=hull, maxHealth=1000)
 
 
+def _wide_track_descriptor():
+    """Return the exact #1513 Ch24_Type64 bounds used by world-collision tests."""
+    descriptor = _combat_descriptor()
+    descriptor.chassis.hitTester = _HitTester1513(
+        (-1.565461, 0.002, -2.648121),
+        (1.565461, 1.175350, 2.648682))
+    descriptor.hull.hitTester = _HitTester1513(
+        (-1.15, -0.540596, -2.79015),
+        (1.15, 0.729932, 2.70431))
+    descriptor.chassis.hullPosition = (0.0, 0.999047, 0.0)
+    return descriptor
+
+
 def _suspension_descriptor():
     descriptor = _combat_descriptor()
     descriptor.physics.update({
@@ -4207,6 +4220,26 @@ class BotRuntimeTests(unittest.TestCase):
 
         self.assertAlmostEqual(10.0, state['y'], places=6)
         self.assertFalse(state['airborne'])
+
+    def test_bot_support_uses_wide_chassis_not_narrower_hull(self):
+        descriptor = _wide_track_descriptor()
+        half_length, half_width = self.module._hull_dimensions(descriptor)
+        self.assertAlmostEqual(2.648682, half_length)
+        self.assertAlmostEqual(1.565461, half_width)
+        state = {
+            'x': 0.0, 'y': 10.0, 'z': 0.0, 'yaw': 0.0,
+            'half_length': half_length, 'half_width': half_width,
+        }
+        probe, calls = self._trench_probe(
+            7.0, {(1.6, 0.0): 10.0, (-1.6, 0.0): 10.0})
+        runtime = self.module.BotRuntime(1, physics_ground_probe=probe)
+
+        highest, centre = runtime._terrain_support(state, follow_gap=1.0)
+
+        self.assertAlmostEqual(10.0, highest)
+        self.assertAlmostEqual(10.0, centre)
+        self.assertIn((1.565, 0.0), calls)
+        self.assertIn((-1.565, 0.0), calls)
 
     def test_bot_still_falls_off_a_cliff_edge_with_one_supported_end(self):
         self.runtime.battle_start(self.start)

--- a/tests/test_port_0922_bot_runtime.py
+++ b/tests/test_port_0922_bot_runtime.py
@@ -1934,7 +1934,8 @@ class BotRuntimeTests(unittest.TestCase):
             (0.0, 0.0, 0.0), 0.0, 0.0, allow_shallow=True))
 
     def test_repeated_water_veto_reports_a_blocked_step_for_that_bot(self):
-        aim = (0.0, 0.0, 200.0)
+        aim = (math.sin(0.75) * 200.0, 0.0,
+               math.cos(0.75) * 200.0)
         command = self._stationary_command()
         command.update({
             'throttle': 1.0, 'combat_mode': 'route',
@@ -1960,7 +1961,8 @@ class BotRuntimeTests(unittest.TestCase):
 
         runtime.update(.04, 1.0)
 
-        self.assertEqual([(11, (0.0, 0.0, 0.0), aim, 1.0)], reports)
+        self.assertEqual(
+            [(11, (0.0, 0.0, 0.0), (0.0, 0.0, 4.0), 1.0)], reports)
         self.assertEqual((0.0, 0.0), (state['x'], state['z']))
 
     def test_post_turn_travel_yaw_cannot_enter_unplanned_shallow(self):
@@ -3708,8 +3710,8 @@ class BotRuntimeTests(unittest.TestCase):
 
     def test_realised_hard_contact_invalidates_cached_command_and_probe(self):
         attempted_yaw = 0.25
-        aim = (math.sin(attempted_yaw) * 200.0, 0.0,
-               math.cos(attempted_yaw) * 200.0)
+        aim = (math.sin(attempted_yaw + 0.75) * 200.0, 0.0,
+               math.cos(attempted_yaw + 0.75) * 200.0)
         command = {
             'target_yaw': attempted_yaw, 'throttle': 1.0, 'turn': 0.0,
             'shell_index': 0, 'fire_allowed': False, 'target_id': None,
@@ -3757,7 +3759,9 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertEqual([(11, attempted_yaw, 5.0)],
                          adapter.driver.calls)
         self.assertEqual(1, len(contact_reports))
-        self.assertEqual((11, before_position, aim, 1.0),
+        realised_edge = (math.sin(attempted_yaw) * 4.0, 0.0,
+                         math.cos(attempted_yaw) * 4.0)
+        self.assertEqual((11, before_position, realised_edge, 1.0),
                          contact_reports[0])
         self.assertEqual(1, len(adapter.calls))
 

--- a/tests/test_port_0922_destructibles.py
+++ b/tests/test_port_0922_destructibles.py
@@ -2243,6 +2243,130 @@ class DestructiblesCompatibilityTests(unittest.TestCase):
         self.assertIs(hit_point, calls[0][3])
         self.assertTrue(calls[0][4])
 
+    def test_material_contact_retries_frozen_event_after_native_acceptance(self):
+        for kind, method_name, event_kind, mat_kind in (
+                (1, 'destroy_tree', 'tree', None),
+                (2, 'destroy_column', 'column', None),
+                (3, 'destroy_fragile', 'fragile', None),
+                (4, 'destroy_module', 'module', 75)):
+            with self.subTest(kind=kind):
+                destructibles_sensor._clear_runtime_registry()
+                area = types.ModuleType('AreaDestructibles')
+                area.g_destructiblesManager = types.SimpleNamespace(
+                    isChunkLoaded=lambda unused: False)
+                area.DESTR_TYPE_TREE = 1
+                area.DESTR_TYPE_FALLING_ATOM = 2
+                area.DESTR_TYPE_FRAGILE = 3
+                area.DESTR_TYPE_STRUCTURE = 4
+                area.g_cache = types.SimpleNamespace(
+                    getDescByFilename=lambda unused: {
+                        'type': kind, 'health': 10,
+                        'modules': {75: {'health': 1}}})
+                destroyed = set()
+                native = mock.Mock(side_effect=lambda *unused:
+                                   destroyed.add((22, 37)) or True)
+                authority = types.SimpleNamespace(
+                    is_destroyed=lambda chunk, item, mat=None:
+                    (chunk, item) in destroyed)
+                setattr(authority, method_name, native)
+                sink = mock.Mock(side_effect=(
+                    False, RuntimeError('transport unavailable'), True))
+                destructibles_sensor.set_event_sink(sink)
+                hit = _mat_info_1513(
+                    True, _Vector(10, 2, 20), _Vector(0, 1, 0),
+                    75, 'fence', 22, 37)
+                with mock.patch.dict(sys.modules, {'AreaDestructibles': area}), \
+                        mock.patch.object(destructibles_sensor,
+                                          '_get_destr_authority',
+                                          return_value=authority), \
+                        mock.patch.object(destructibles_sensor,
+                                          'validate_tree_identity_1513',
+                                          return_value=True):
+                    self.assertTrue(destructibles_sensor._try_destroy_destructible(
+                        1, hit, 0.25, 6.0, False))
+                    self.assertFalse(destructibles_sensor._try_destroy_destructible(
+                        1, hit, 0.75, 8.0, True))
+                    destructibles_sensor._retry_catalog_publications_1513(1)
+                    self.assertIn((22, 37, mat_kind),
+                        destructibles_sensor.g_offh_destr_catalog_publish_pending)
+                    destructibles_sensor._retry_catalog_publications_1513(1)
+                native.assert_called_once()
+                self.assertEqual(3, sink.call_count)
+                events = [call.args[0] for call in sink.call_args_list]
+                self.assertTrue(all(event == events[0] for event in events))
+                self.assertEqual({
+                    'destructible_kind': event_kind, 'chunk_id': 22,
+                    'item_index': 37, 'x': 10.0, 'y': 2.0, 'z': 20.0,
+                    'fall_yaw': 0.25, 'speed': 6.0, 'is_shot': False,
+                    **({'mat_kind': mat_kind} if mat_kind is not None else {}),
+                }, events[0])
+                self.assertEqual({},
+                    destructibles_sensor.g_offh_destr_catalog_publish_pending)
+
+    def test_failed_destruction_publication_does_not_block_unrelated_hull(self):
+        (bigworld, math_module, area, cache, authority,
+         descriptor) = self._direction_catalog_fixture()
+        sink = mock.Mock(return_value=False)
+        destructibles_sensor.set_event_sink(sink)
+        self.assertFalse(destructibles_sensor._publish_catalog_once_1513(
+            'fragile', 22, 37, _Vector(), 0.25, 6.0))
+        with mock.patch.dict(sys.modules, {
+                'BigWorld': bigworld, 'Math': math_module,
+                'AreaDestructibles': area, 'DestructiblesCache': cache,
+                }), mock.patch.object(destructibles_sensor,
+                    '_get_destr_authority', return_value=authority):
+            result = destructibles_sensor._catalog_motion_proposal(
+                1, _Vector(100, 0, 100), 0.0, 20.0, descriptor, 10.0,
+                dt=0.04, kinetic_speed=20.0)
+        self.assertEqual('clear', result['status'])
+        self.assertIsNone(result['token'])
+        self.assertFalse(result['requires_commit'])
+        self.assertIn((22, 37, None),
+            destructibles_sensor.g_offh_destr_catalog_publish_pending)
+        self.assertEqual(2, sink.call_count)
+        authority.destroy_fragile.assert_not_called()
+
+    def test_new_space_discards_pending_publication_before_scanner_retry(self):
+        area, bigworld, math_module, descriptor = self._scanner_tree_fixture()
+        destructibles_sensor.g_offh_destr_runtime_space = 2
+        sink = mock.Mock(return_value=False)
+        destructibles_sensor.set_event_sink(sink)
+        self.assertFalse(destructibles_sensor._publish_catalog_once_1513(
+            'fragile', 12, 3, _Vector(10, 2, 20), 0.25, 6.0))
+        sink.reset_mock()
+        sink.return_value = True
+        with mock.patch.dict(sys.modules, {
+                'AreaDestructibles': area, 'BigWorld': bigworld,
+                'Math': math_module}):
+            destructibles_sensor._fell_trees_near(
+                1, _Vector(), 0.0, 6.0, descriptor)
+        sink.assert_not_called()
+        self.assertEqual(1, destructibles_sensor.g_offh_destr_runtime_space)
+        self.assertFalse(getattr(destructibles_sensor,
+                                'g_offh_destr_catalog_publish_pending', {}))
+
+    def test_foreign_space_motion_does_not_replay_contact_backlog(self):
+        (bigworld, math_module, area, cache, authority,
+         descriptor) = self._direction_catalog_fixture()
+        destructibles_sensor.g_offh_destr_runtime_space = 2
+        sink = mock.Mock(return_value=False)
+        destructibles_sensor.set_event_sink(sink)
+        self.assertFalse(destructibles_sensor._publish_catalog_once_1513(
+            'fragile', 12, 3, _Vector(), 0.25, 6.0))
+        sink.reset_mock()
+        sink.return_value = True
+        with mock.patch.dict(sys.modules, {
+                'BigWorld': bigworld, 'Math': math_module,
+                'AreaDestructibles': area, 'DestructiblesCache': cache,
+                }), mock.patch.object(destructibles_sensor,
+                    '_get_destr_authority', return_value=authority):
+            destructibles_sensor._catalog_motion_proposal(
+                1, _Vector(100, 0, 100), 0.0, 20.0, descriptor, 10.0,
+                dt=0.04, kinetic_speed=20.0)
+        sink.assert_not_called()
+        self.assertIn((12, 3, None),
+            destructibles_sensor.g_offh_destr_catalog_publish_pending)
+
     def test_named_material_without_descriptor_isolates_exact_wire(self):
         filename = 'content/test/missing-destructible.model'
         area = types.ModuleType('AreaDestructibles')
@@ -7610,11 +7734,14 @@ class DestructiblesCompatibilityTests(unittest.TestCase):
                         1, _Vector(), 0.2, 20.0, descriptor, 10.0,
                         dt=0.04, kinetic_speed=20.0)
 
-                self.assertEqual('pending', committed['status'])
+                self.assertEqual('crushed', committed['status'])
                 self.assertEqual((key,), committed['token'])
                 self.assertTrue(committed['accepted_now'])
-                self.assertEqual('pending', retry['status'])
-                self.assertEqual((key,), retry['token'])
+                self.assertEqual(
+                    'clear' if kind == 'falling' else 'crushed',
+                    retry['status'])
+                self.assertEqual(
+                    None if kind == 'falling' else (key,), retry['token'])
                 self.assertFalse(retry['requires_commit'])
                 self.assertEqual(
                     'clear' if kind == 'falling' else 'crushed',


### PR DESCRIPTION
This fixes three gameplay paths that can leave a vehicle stuck or make an accepted map-object destruction inconsistent between clients.

- Player fallback ground support now samples the descriptor's chassis footprint. Using the narrower hull bounds could miss the tracks resting on both sides of a narrow slot. The existing Ch24_Type64 geometry fixture covers the player and Bot paths; the armed suspension solver is unchanged.
- A Bot's repeated blocked-step reports now fence the same edge throughout A*, cached paths, smoothing, direct shortcuts, pending targets, local recovery, and escape-target reuse. Failure reports identify the direction proved by their source: the queried heading for a generic probe and the exact hull yaw plus signed speed passed to the collision resolver. Navigation and local-driver failure memory agree even when opposite throttle is braking a still-moving hull. This prevents a turn toward a waypoint from vetoing an unrelated route. The existing 12-second lease stays private to that Bot; an available detour remains usable and the original route becomes eligible after expiry.
- Physical-contact destruction reports retain their original payload for retry after transport refusal. Publication backpressure no longer holds the contacting vehicle or unrelated vehicles, and foreign-space calls cannot replay an old backlog. Shot receipts retain their projectile transaction owner.

Validation for `50ff47b1de03eb43d35cdfaae8fa24ab3a75983e`:

- Six focused Bot/contact/departure tests pass, including Airfield/Fjord and Himmelsdorf at 15/24 FPS, opposite-throttle braking in both directions, and generic collision attribution.
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -p 'test_*.py' -v`: 4,343 tests pass (296.534 seconds).
- The same unittest discovery command from `launcher/`: 508 tests pass (2 skipped).
- CPython 2.7.18 in-memory compilation of all 99 client source files and `git diff --check` pass.
- [Exact-head Tests workflow](https://github.com/pengw0048/wot-offline-battles/actions/runs/34173832176): all three jobs pass, including the Windows server, Python 2.7 client packaging/validation, and Windows launcher bundle smoke test.

Exact Windows Chinese HD 0.9.22.0.1 #1513 ground contact, crush resistance, animation, and frame timing still require native playtesting. The parallel projectile audit found no additional defect demonstrated with legitimate launch inputs; disappearing shells were not reproduced in this audit. No resistance coefficient or projectile formula is changed.
