### PR TITLE
Diagnose sniper aim drift during acceleration and braking

### DIFF
--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -2000,6 +2000,31 @@ across the window. Static inspection proves the property and owner contracts;
 only exact Windows acceptance can prove that the native HULL output is visible
 and that its magnitude feels correct.
 
+Sniper start/stop diagnosis distinguishes world aim from camera oscillation.
+The reviewed `SniperCamera.__cameraUpdate` updates its aiming system first,
+applies movement oscillation to the view transform, then projects the aiming
+matrix through `__calcAimOffset`. Movement oscillation is not included in the
+separate impulse transform passed to that projection. The available extracted
+scripts were inspected with CPython 2.7; a complete client installation was not
+available for `inspect_client.py`, so this inspection does not independently
+certify the installation or native stabilization behavior.
+
+The existing bounded `SWING_FRAME` observations now include companion
+`SNIPER_AIM` records when the active control is sniper. They record the aiming
+matrix, world-to-view rotation, copied stabilized rotation, last target sent
+by the gun rotator, current gun ray, dispersion and camera/gun update ages.
+They neither advance the stock camera/rotator nor issue a new targeting query.
+The existing limit is twelve movement edges per battle and nine sample times
+per edge; late frames produce one observation, not synthetic catch-up samples.
+For Windows reproduction, enter sniper before the first movement, keep the
+mouse still, and accelerate/brake against a fixed distant landmark. Preserve
+the vehicle, zoom and dynamic-camera setting with the report. Compare a time
+series, not a single frame: camera and gun callbacks have independent ages.
+On ordinary vehicles the port currently shares the physical body and
+stabilized matrix; suspension pitch reaching this provider is a hypothesis to
+test, not proof that the native camera loses world aim. These diagnostics do
+not constitute a stabilization fix or gameplay acceptance.
+
 Critical-hit calculation follows the same proposal/commit boundary. The
 firing client runs a device law derived from the retired predecessor against an
 explicit detached snapshot of the target descriptor, pose, collision

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -6451,6 +6451,67 @@ class BattleRuntime(object):
                           for index in range(3))
         return root_ypr, hull_ypr, delta_ypr
 
+    def _sample_sniper_swing_aim(self, entity, event, sample):
+        """Observe the stock aim/view split without casting a targeting ray.
+
+        #1513's camera applies movement oscillation to its view matrix, then
+        projects the independent aiming matrix back onto the screen. Reading
+        both, the last sent target and the current gun ray distinguishes view
+        motion from aim drift. Camera and gun timers are independent of this
+        presentation callback, so retain their ages rather than treating one
+        sample's disagreement as a stabilization failure.
+        """
+        if (self._worker_mode or self._server is None or
+                self._server_entity(self._server.vehicle_id) is not entity):
+            return False
+        handler = getattr(self._avatar, 'inputHandler', None)
+        if getattr(handler, '_AvatarInputHandler__ctrlModeName', None) != 'sniper':
+            return False
+        try:
+            control = handler._AvatarInputHandler__curCtrl
+            camera = control.camera
+            aim = self._runtime.math.Matrix(camera.aimingSystem.matrix)
+            view = self._runtime.math.Matrix(camera.camera.matrix)
+            stable = self._runtime.math.Matrix(self._local_stabilised_pose())
+            rotator = self._avatar.gunRotator
+            now = self._runtime.bigworld.time()
+            shot_origin, shot_direction = self._mutable_shot_ray()
+            target = rotator._VehicleGunRotator__prevSentShotPoint
+
+            def degrees(matrix):
+                return tuple(math.degrees(float(getattr(matrix, name)))
+                             for name in ('yaw', 'pitch', 'roll'))
+
+            observation = {
+                'event': event, 'sample': sample,
+                'round_id': (self._start_message or {}).get('round_id'),
+                'vehicle_id': self._server.vehicle_id,
+                'vehicle': entity.typeDescriptor.name,
+                'dynamic': bool(camera.isCameraDynamic()),
+                'speed': self._local_speed,
+                'aim_ypr_deg': degrees(aim),
+                # This is the world-to-view matrix, not world camera YPR.
+                'view_ypr_deg': degrees(view),
+                'stabilised_ypr_deg': degrees(stable),
+                'aim_origin': _xyz(aim.translation),
+                'last_sent_target': None if target is None else _xyz(target),
+                'shot_origin': _xyz(shot_origin),
+                'shot_direction': _xyz(shot_direction),
+                'dispersion': self._native_dispersion_angle(),
+                'camera_age': now - camera._SniperCamera__prevTime,
+                'gun_age': now - rotator._VehicleGunRotator__time,
+            }
+            sys.stdout.write('[Offline LAN 0.9.22] SNIPER_AIM %s\n' %
+                             json.dumps(observation, sort_keys=True))
+            return True
+        except Exception as error:
+            # An unavailable camera/gun must not retire the HULL probe or
+            # change aiming, firing, animator state or callback scheduling.
+            sys.stdout.write(
+                '[Offline LAN 0.9.22] SNIPER_AIM event=%d sample=%d '
+                'error=%r\n' % (event, sample, str(error)))
+            return False
+
     def _sample_local_acceleration_swinging(self, entity, elapsed):
         """Log sparse cross-frame HULL output for one movement transition."""
         probe = self._local_swinging_probe
@@ -6473,6 +6534,7 @@ class BattleRuntime(object):
                             'swingingAnimator', None) is not animator):
                 self._local_swinging_probe = None
                 return False
+            self._sample_sniper_swing_aim(entity, probe['event'], index)
             root_ypr, hull_ypr, delta_ypr = \
                 self._local_hull_swing_snapshot(entity)
             period = _number(animator.accelSwingingPeriod)

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -29402,6 +29402,102 @@ class LocalBodySwingingTests(unittest.TestCase):
         self.assertIn('sample=1 elapsed=0.050 period=1.950', output)
         self.assertIn('delta_ypr_deg=(0.000, 0.500, 0.000)', output)
 
+    def _sniper_probe(self):
+        battle, entity = self._battle()
+        battle._attach_local_presentation()
+        entity.typeDescriptor.name = 'test:vehicle'
+        aim, view = _Matrix(), _Matrix()
+        aim.pitch = -0.1
+        view.pitch = 0.2
+        camera = types.SimpleNamespace(
+            aimingSystem=types.SimpleNamespace(matrix=aim),
+            camera=types.SimpleNamespace(matrix=view),
+            isCameraDynamic=lambda: True,
+            _SniperCamera__prevTime=9.98)
+        handler = battle._avatar.inputHandler
+        handler._AvatarInputHandler__ctrlModeName = 'sniper'
+        handler._AvatarInputHandler__curCtrl = types.SimpleNamespace(
+            camera=camera)
+        battle._runtime.bigworld.time = lambda: 10.0
+        rotator = battle._avatar.gunRotator
+        rotator._VehicleGunRotator__time = 9.96
+        rotator._VehicleGunRotator__prevSentShotPoint = _Vector(1, 2, 300)
+        rotator.getCurShotPosition = mock.Mock(return_value=(
+            _Vector(1, 2, 3), _Vector(0, 0, 900)))
+        rotator.dispersionAngle = 0.02
+        entity.appearance.compoundModel = types.SimpleNamespace(
+            node=lambda name: _Matrix())
+        return battle, entity, camera
+
+    def test_sniper_probe_separates_view_motion_from_aim_and_gun(self):
+        battle, entity, camera = self._sniper_probe()
+        stream = io.StringIO()
+        rotator = battle._avatar.gunRotator
+        native_ray = rotator.getCurShotPosition.return_value
+        with mock.patch('sys.stdout', stream):
+            battle._update_local_acceleration_swinging(
+                entity, _MOVEMENT_FORWARD)
+            camera.camera.matrix.pitch += 0.1
+            battle._local_matrix.pitch += 0.05
+            battle._sample_local_acceleration_swinging(entity, 0.05)
+        records = [json.loads(line.split('SNIPER_AIM ', 1)[1])
+                   for line in stream.getvalue().splitlines()
+                   if 'SNIPER_AIM ' in line]
+        self.assertEqual(2, len(records))
+        first, second = records
+        self.assertNotEqual(first['view_ypr_deg'], second['view_ypr_deg'])
+        self.assertNotEqual(first['stabilised_ypr_deg'],
+                            second['stabilised_ypr_deg'])
+        self.assertEqual(first['aim_ypr_deg'], second['aim_ypr_deg'])
+        self.assertEqual([1, 2, 300], second['last_sent_target'])
+        self.assertEqual([0, 0, 1], second['shot_direction'])
+        self.assertAlmostEqual(0.02, second['camera_age'])
+        self.assertAlmostEqual(0.04, second['gun_age'])
+        self.assertEqual(0.02, second['dispersion'])
+        self.assertEqual((0, 0, 900), tuple(native_ray[1]))
+        self.assertEqual(-0.1, camera.aimingSystem.matrix.pitch)
+
+    def test_sniper_probe_is_bounded_and_does_not_sample_other_modes(self):
+        battle, entity, camera = self._sniper_probe()
+        rotator = battle._avatar.gunRotator
+        with mock.patch('sys.stdout', io.StringIO()):
+            for unused in range(battle_runtime_module.
+                                LOCAL_ACCEL_SWING_REPORT_LIMIT + 2):
+                battle._local_swinging_move_flags = 0
+                battle._update_local_acceleration_swinging(
+                    entity, _MOVEMENT_FORWARD)
+                battle._sample_local_acceleration_swinging(entity, 3.0)
+                battle._sample_local_acceleration_swinging(entity, 3.0)
+        # An overdue callback observes once; it cannot fabricate missed frames.
+        self.assertEqual(2 * battle_runtime_module.LOCAL_ACCEL_SWING_REPORT_LIMIT,
+                         rotator.getCurShotPosition.call_count)
+        rotator.getCurShotPosition.reset_mock()
+        handler = battle._avatar.inputHandler
+        handler._AvatarInputHandler__ctrlModeName = 'arcade'
+        self.assertFalse(battle._sample_sniper_swing_aim(entity, 1, 0))
+        handler._AvatarInputHandler__ctrlModeName = 'sniper'
+        battle._worker_mode = True
+        self.assertFalse(battle._sample_sniper_swing_aim(entity, 1, 0))
+        battle._worker_mode = False
+        battle._runtime.bigworld.entities.pop(entity.id)
+        self.assertFalse(battle._sample_sniper_swing_aim(entity, 1, 0))
+        rotator.getCurShotPosition.assert_not_called()
+
+    def test_failed_sniper_read_does_not_retire_the_animator_or_hull_probe(self):
+        battle, entity, camera = self._sniper_probe()
+        camera.aimingSystem = None
+        stream = io.StringIO()
+        with mock.patch('sys.stdout', stream):
+            self.assertTrue(battle._update_local_acceleration_swinging(
+                entity, _MOVEMENT_FORWARD))
+            self.assertTrue(battle._sample_local_acceleration_swinging(
+                entity, 0.05))
+        self.assertEqual(2, stream.getvalue().count('SWING_FRAME'))
+        self.assertEqual(2, stream.getvalue().count('SNIPER_AIM'))
+        self.assertIsNotNone(battle._local_swinging_probe)
+        self.assertEqual(2.0,
+                         entity.appearance.swingingAnimator.accelSwingingPeriod)
+
     def test_second_bind_setter_failure_rolls_back_and_disables_feature(self):
         battle, entity = self._battle()
         native_compensation = _Matrix()

--- a/tools/audit_client_abi.py
+++ b/tools/audit_client_abi.py
@@ -300,6 +300,9 @@ EXPECTED_ABI = {
     'scripts/client/AvatarInputHandler/DynamicCameras/SniperCamera.pyc': {
         'SniperCamera.__calcCurOscillatorAcceleration': (
             'self', 'deltaTime'),
+        'SniperCamera.__cameraUpdate': ('self', 'allowModeChange'),
+        'SniperCamera.__calcAimOffset': ('self', 'aimLocalTransform'),
+        'SniperCamera.__updateOscillators': ('self', 'deltaTime'),
     },
     'scripts/client/AvatarInputHandler/AimingSystems/'
     'ArcadeAimingSystem.pyc': {
@@ -1628,6 +1631,18 @@ EXPECTED_CODE_NAMES = {
         'SniperCamera.__calcCurOscillatorAcceleration': (
             'BigWorld', 'player', 'vehicle', 'isAlive', 'filter', 'velocity',
             '_SniperCamera__accelerationSmoother', 'update'),
+        'SniperCamera.__cameraUpdate': (
+            '_SniperCamera__prevTime', '_SniperCamera__aimingSystem',
+            '_SniperCamera__updateOscillators', '_SniperCamera__cam',
+            '_SniperCamera__calcAimOffset', '_SniperCamera__aimOffset'),
+        'SniperCamera.__calcAimOffset': (
+            '_SniperCamera__aimingSystem', 'matrix', 'postMultiply',
+            'projectPoint', 'translation'),
+        'SniperCamera.__updateOscillators': (
+            'isCameraDynamic', '_SniperCamera__movementOscillator',
+            '_SniperCamera__impulseOscillator',
+            '_SniperCamera__noiseOscillator', 'deviation',
+            'createRotationMatrix'),
     },
     'scripts/client/AvatarInputHandler/AimingSystems/'
     'ArcadeAimingSystem.pyc': {
@@ -1849,7 +1864,10 @@ EXPECTED_CODE_NAMES = {
             'getServerGunAngles', 'LatencyInfo'),
         'VehicleGunRotator.__trackPointOnServer': (
             '_VehicleGunRotator__avatar', 'playerVehicleID',
-            'trackRelativePointWithGun'),
+            'trackRelativePointWithGun',
+            '_VehicleGunRotator__prevSentShotPoint'),
+        'VehicleGunRotator.__getTimeDiff': (
+            'BigWorld', 'time', '_VehicleGunRotator__time'),
         'VehicleGunRotator.getAvatarOwnVehicleStabilisedMatrix': (
             '_VehicleGunRotator__avatar',
             'getOwnVehicleStabilisedMatrix',


### PR DESCRIPTION
Starting or braking in sniper mode reportedly moves the aiming point along with the view. Stock camera code keeps movement oscillation in the view transform and projects a separate aiming matrix. The current port shares the physical body and stabilized pose for ordinary vehicles, but static inspection does not establish whether that is the cause of the reported drift.

This draft adds bounded `SNIPER_AIM` observations alongside existing `SWING_FRAME` samples: aim and view rotations, stabilized pose, last sent target, current gun ray, dispersion, and independent camera/gun update ages. It pins the inspected script contracts and tests that diagnosis is bounded, observational, and isolated from read failures. No stabilization behavior is changed.

Validation:
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=tests python3 -m unittest -q test_port_0922_battle_runtime` — 829 passed.
- Focused `LocalBodySwingingTests` and `test_port_0922_client_abi_audit` — 29 passed.
- `PYTHONDONTWRITEBYTECODE=1 python2.7 tools/audit_client_abi.py /tmp/wot-client-audit.qPhlqH` — passed against the available extracted scripts archive.
- CPython 2.7 in-memory source compilation — 99 files passed; `git diff --check` passed.

The complete #1513 installation is unavailable and `inspect_client.py` could not pass. No native Windows gameplay claim is validated. Before treating this as a fix, reproduce with the diagnostic build on the exact client: enter sniper before the first movement, keep the mouse still on a distant fixed landmark, accelerate and brake, then preserve the report with vehicle, zoom, and dynamic-camera setting. The existing probe budget covers the first twelve movement edges in the battle, up to nine samples each.
