### PR TITLE
Fix ammo-rack death markers and audit module-hit coverage

### DIFF
--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -2001,7 +2001,7 @@ only exact Windows acceptance can prove that the native HULL output is visible
 and that its magnitude feels correct.
 
 Critical-hit calculation follows the same proposal/commit boundary. The
-firing client runs a device law derived from the retired predecessor against an
+hidden worker runs a device law derived from the retired predecessor against an
 explicit detached snapshot of the target descriptor, pose, collision
 components and critical state. That calculation cannot change the live target
 or invoke native kill
@@ -2016,6 +2016,73 @@ accepted revision exactly once.
 Repair reports remain pending until the server acknowledges their proposal
 revision, so a successful socket write or an older snapshot cannot rewind the
 HUD state.
+
+The internal-module model is a reconstruction, not the recovered #1513
+server collision model. Native component collision queries supply the armour
+and exposed-device contacts; `internal_layout_profiles.py` supplies interior
+boxes fitted to the selected component bounds and transformed by the current
+vehicle/turret/gun pose. `BattleRuntime._vehicle_trace` limits solid-shell
+travel to ten calibres from the first vehicle material. HE uses the separate
+finite interior cone. The active critical loop scores each reached device
+once, using the shell's independent `damage[1]` channel. The current device
+roll is uniform within +/-25%; the available client contracts do not establish
+that server-side distribution. The common ammo-bay material specifies device
+damage and 0.27 for both projectile and explosion hit chances. Deadeye adds
+three percentage points for AP/APCR/HEAT. A successful hit that reduces the
+rack to zero destroys the vehicle without a second detonation roll.
+
+The launcher editor writes `damage/devices`, and the mounted-shell snapshot
+and projectile launch preserve a value of 2000. Tests cover AP, APCR, HEAT,
+APHE and HE, player and Bot victims, the 27% saving-throw boundary and duplicate
+contacts with one rack. Even the low 1500 damage roll destroys a reached
+ordinary rack after its saving throw. This proves the numerical path once a
+module contact exists; it does not prove that a retail aiming point intersects
+the reconstructed box. A missing/invalid profile supplies no internal contact,
+so raising damage cannot fix missing geometry. Run the read-only inventory:
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 python3 tools/audit_internal_layouts.py \
+  "$WOT_0922_CLIENT/res/packages/scripts.pkg"
+```
+
+The reviewed resource catalog has 680 listed vehicle definitions: 248 match
+the retained profiles and their #1513 crew-role bindings, and 432 lack a
+profile. These totals include special/training variants and the one vehicle
+already excluded for missing client art. A profile match does not validate
+its geometry against the retail server. Filling the missing entries with
+generic boxes or enlarging existing boxes would change gameplay without
+establishing correctness; this audit does neither.
+
+Ammo-rack death also has a separate presentation contract. LAN health remains
+zero, but the stock Vehicle, marker feedback and local
+`PlayerAvatar.updateVehicleHealth` receive
+`SPECIAL_VEHICLE_HEALTH.AMMO_BAY_DESTROYED` (-5). The marker consumer preserves
+that special negative value, while it normalizes ordinary negative health to
+zero. The Avatar writes its raw argument back into the Vehicle at local death,
+so passing zero there would erase an earlier correction. A late critical cause
+corrects the marker without repeating the death/kill/postmortem callbacks.
+The ABI audit pins the negative constants and marker consumer; regression
+tests fail against the old zero-only presentation for local, remote and late
+ammo-rack deaths.
+
+Turret flight remains unimplemented. `Vehicle.showAmmoBayEffect` only forwards
+mode and fireball volume to `CompoundAppearance`; its projected-speed argument
+is unused. The separate `DetachedTurret` entity, `WGTurretFilter`, vehicle
+confirmation and motion inputs own detachment. The port creates no such entity
+and supplies no authoritative detached-turret motion. It therefore must not
+publish `TURRET_DETACHED` (-13) or claim flight was fixed by an explosion call.
+WG's [Update 9.0 notes](https://worldoftanks.com/en/content/docs/release_notes/90-update-notes/)
+establish the intended turret-detachment feature. Its later
+[Object 277 explanation](https://worldoftanks.com/en/news/general-news/3-soviet-tanks-get-adjustments/)
+also confirms that changing internal module geometry changes ammo-rack
+exposure; those later vehicle values are not imported into #1513.
+
+The resource inventory and CPython 2.7 bytecode audit can run on an isolated
+`scripts.pkg`. That is only resource/contract evidence. The investigation did
+not have a complete Chinese HD installation passing `inspect_client.py`, all
+vehicle collision assets, a retail server model, or Windows gameplay evidence.
+The repaired marker still needs exact #1513 rendering acceptance; the missing
+layouts and detached-turret implementation remain explicit product gaps.
 
 Track damage follows the detailed model Update 6.4 introduced. A track
 material's live `damageKind` selects the shell damage channel:

--- a/launcher/tests/test_vehicle_overlays.py
+++ b/launcher/tests/test_vehicle_overlays.py
@@ -1037,15 +1037,15 @@ class VehicleOverlayTest(unittest.TestCase):
         field_path = "Shell-A/damage/devices"
 
         result = vehicle_overlays.apply_vehicle_edit(
-            self.game, self.SHELLS, field_path, "30",
+            self.game, self.SHELLS, field_path, "2000",
             is_running=lambda: False)
 
         value = vehicle_overlays._find_value(
             self._root(self.SHELLS), field_path)
         self.assertEqual(packed.TYPE_INTEGER, value.value_type)
-        self.assertEqual(30, value.value)
+        self.assertEqual(2000, value.value)
         self.assertEqual("27", result["originalValue"])
-        self.assertEqual("30", result["currentValue"])
+        self.assertEqual("2000", result["currentValue"])
 
     def test_ids_resources_compressed_strings_and_missing_children_are_refused(self):
         refused = (

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -23409,6 +23409,16 @@ class BattleRuntime(object):
         crew_active = bool(state.get('alive', health > 0)) and health > 0
         dead = health <= 0 or not crew_active
         crew_knockout = health > 0 and not crew_active
+        critical = state.get('critical') or {}
+        ammo_rack_death = bool(
+            health <= 0 and critical.get('ammo_rack_death', False))
+        native_health = display_health if dead and display_health > 0 else health
+        if ammo_rack_death and not self._worker_mode:
+            # #1513's marker and damage-state consumers require raw special
+            # health. LAN HP stays nonnegative. Do not mark TURRET_DETACHED:
+            # that requires a real DetachedTurret entity and its handshake.
+            native_health = int(
+                self._runtime.constants.SPECIAL_VEHICLE_HEALTH.AMMO_BAY_DESTROYED)
         # Blind non-lethal hits stay private, but death is public authority:
         # native shutdown, the wreck, the kill and statistics form one edge.
         suppress_combat_presentation = bool(
@@ -23428,6 +23438,18 @@ class BattleRuntime(object):
             # Replayed combat events and late snapshots may repeat a terminal
             # state. Keep the durable signature current without replaying
             # native death callbacks, effects, markers or kill notifications.
+            if ammo_rack_death and not self._worker_mode:
+                entity = self._server_entity(engine_id)
+                if entity is None:
+                    return
+                if entity.health != native_health:
+                    entity.health = native_health
+                    # A terminal snapshot may arrive before the critical
+                    # cause. Correct the bar without replaying native death,
+                    # kill credit, postmortem activation or the explosion.
+                    self._avatar.guiSessionProvider.setVehicleHealth(
+                        bool(record.get('local')), engine_id, native_health,
+                        int(attacker_id), int(attack_reason_id))
             self._last_health[engine_id] = signature
             return
         if not durable_changed and not force_cause:
@@ -23488,8 +23510,6 @@ class BattleRuntime(object):
                         critical=death_payload,
                         attribute_attacker=death_cause not in (
                             'drowning', 'world_collision', 'overturn'))
-        preserve_inactive_hull = dead and display_health > 0
-        native_health = display_health if preserve_inactive_hull else health
         if self._worker_mode:
             entity.health = native_health
             notifier = getattr(entity, 'set_health', None)
@@ -23572,7 +23592,8 @@ class BattleRuntime(object):
                     self._sender.forward = 0.0
                     self._sender.turn = 0.0
             self._avatar.updateVehicleHealth(
-                engine_id, display_health, int(reason_id),
+                engine_id, native_health if ammo_rack_death else display_health,
+                int(reason_id),
                 crew_active, False)
         if not previous_dead and dead:
             if not suppress_combat_presentation:

--- a/tests/test_audit_internal_layouts.py
+++ b/tests/test_audit_internal_layouts.py
@@ -1,0 +1,57 @@
+import importlib.util
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+import zipfile
+
+
+TOOLS = Path(__file__).resolve().parents[1] / 'tools'
+sys.path.insert(0, str(TOOLS))
+import packed_xml
+
+spec = importlib.util.spec_from_file_location(
+    'audit_internal_layouts', TOOLS / 'audit_internal_layouts.py')
+audit = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(audit)
+
+
+def _string(value):
+    return packed_xml.PackedValue(packed_xml.TYPE_STRING, value.encode('ascii'))
+
+
+class InternalLayoutAuditTests(unittest.TestCase):
+    def test_catalog_inventory_distinguishes_missing_and_mismatched_profiles(self):
+        names = ('Ch02_Type62', 'Ch04_T34_1')
+        listing = packed_xml.PackedElement(children=[
+            (name.encode('ascii'), _string('')) for name in names])
+        # Compressed Packed XML strings are base64 byte storage, not UTF-8.
+        roles = [(b'commander', _string('')), (b'gunner', _string('')),
+                 (b'driver', _string('')), (b'loader', packed_xml.PackedValue(
+                     packed_xml.TYPE_COMPRESSED_STRING, b'\xad\xa7b\xa2f\xa7'))]
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / 'scripts.pkg'
+            for mismatch in (False, True):
+                crew = list(roles)
+                if mismatch:
+                    crew[0] = (b'commander', _string('radioman'))
+                    crew[-1] = (b'loader', _string(''))
+                definition = packed_xml.PackedElement(children=[
+                    (b'crew', packed_xml.PackedValue(packed_xml.TYPE_ELEMENT,
+                        packed_xml.PackedElement(children=crew)))])
+                with zipfile.ZipFile(path, 'w') as archive:
+                    prefix = 'scripts/item_defs/vehicles/china/'
+                    archive.writestr(prefix + 'list.xml',
+                                     packed_xml.write_packed_xml(listing))
+                    for name in names:
+                        archive.writestr(prefix + name + '.xml',
+                                         packed_xml.write_packed_xml(definition))
+                result = audit.scan(path)
+                self.assertFalse(result['collision_geometry_verified'])
+                self.assertEqual({
+                    'crew_mismatch' if mismatch else 'profile_matched': 1,
+                    'missing_profile': 1}, result['summary'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -2254,6 +2254,8 @@ def _runtime():
             'overturn': 7},
         AMMOBAY_DESTRUCTION_MODE=types.SimpleNamespace(
             POWDER_BURN_OFF=0, POWDER_EXPLOSION=1, HE_DETONATION=2),
+        SPECIAL_VEHICLE_HEALTH=types.SimpleNamespace(
+            AMMO_BAY_DESTROYED=-5, TURRET_DETACHED=-13),
         DAMAGE_INFO_INDICES={
             'DEVICE_DESTROYED_AT_FIRE': 10,
             'DEVICE_CRITICAL_AT_WORLD_COLLISION': 11,
@@ -27093,6 +27095,91 @@ class BattleRuntimeContractTests(unittest.TestCase):
         battle._apply_health(record, {'health': 0})
 
         self.assertEqual((0, 0, 0), entity.health_change)
+
+    def test_ammo_rack_death_preserves_special_health_at_all_consumers(self):
+        for local in (False, True):
+            with self.subTest(local=local):
+                runtime = _runtime()
+                battle = BattleRuntime(runtime)
+                battle._avatar = runtime.bigworld.avatar
+                battle._binding = mock.Mock()
+                entity = _Vehicle(10, _Descriptor(), _Vector(), (0, 0, 0),
+                                  {'health': 500})
+                runtime.bigworld.entities[10] = entity
+                record = {'engine_id': 10, 'local': local,
+                          'presentation': not local, 'native_remote': True}
+                state = {'health': 0, 'display_health': 0, 'alive': False,
+                         'critical': {'ammo_rack_death': True}}
+
+                def exact_avatar_update(vehicle_id, raw_health, *unused):
+                    # PlayerAvatar.updateVehicleHealth writes rawHealth back
+                    # into Vehicle after the first local death notification.
+                    entity.health = raw_health
+
+                battle._avatar.updateVehicleHealth = mock.Mock(
+                    side_effect=exact_avatar_update)
+                entity.onHealthChanged = mock.Mock(wraps=entity.onHealthChanged)
+                with mock.patch.object(critical_damage, 'apply_death',
+                                       return_value=None):
+                    battle._apply_health(record, state, attacker_id=11)
+                    battle._apply_health(record, state, attacker_id=11,
+                                         force_cause=True)
+
+                self.assertEqual(-5, entity.health)
+                entity.onHealthChanged.assert_called_once_with(-5, 11, 0)
+                self.assertEqual(0, state['health'])
+                self.assertEqual(0, state['display_health'])
+                battle._binding.arena_vehicle_killed.assert_called_once()
+                if local:
+                    battle._avatar.updateVehicleHealth.assert_called_once_with(
+                        10, -5, 0, False, False)
+                else:
+                    battle._avatar.guiSessionProvider.setVehicleHealth.\
+                        assert_called_once_with(False, 10, -5, 11, 0)
+
+    def test_late_ammo_rack_cause_corrects_marker_without_replaying_death(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        battle._binding = mock.Mock()
+        entity = _Vehicle(10, _Descriptor(), _Vector(), (0, 0, 0),
+                          {'health': 500})
+        runtime.bigworld.entities[10] = entity
+        record = {'engine_id': 10, 'local': False,
+                  'presentation': True, 'native_remote': True}
+        state = {'health': 0, 'alive': False}
+        entity.onHealthChanged = mock.Mock(wraps=entity.onHealthChanged)
+        with mock.patch.object(critical_damage, 'apply_death',
+                               return_value=None):
+            battle._apply_health(record, state, attacker_id=11)
+            state['critical'] = {'ammo_rack_death': True}
+            battle._apply_health(record, state, attacker_id=11)
+            battle._apply_health(record, state, attacker_id=11)
+        self.assertEqual(-5, entity.health)
+        entity.onHealthChanged.assert_called_once_with(0, 11, 0)
+        battle._binding.arena_vehicle_killed.assert_called_once()
+        self.assertEqual([
+            mock.call(False, 10, 0, 11, 0),
+            mock.call(False, 10, -5, 11, 0)],
+            battle._avatar.guiSessionProvider.setVehicleHealth.call_args_list)
+
+    def test_worker_keeps_numeric_health_when_ammo_rack_detonates(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._worker_mode = True
+        battle._avatar = runtime.bigworld.avatar
+        entity = _Vehicle(10, _Descriptor(), _Vector(), (0, 0, 0),
+                          {'health': 500})
+        runtime.bigworld.entities[10] = entity
+        record = {'engine_id': 10, 'local': False}
+        state = {'health': 0, 'alive': False,
+                 'critical': {'ammo_rack_death': True}}
+        with mock.patch.object(critical_damage, 'apply_death', return_value=None):
+            battle._apply_health(record, state)
+            battle._apply_health(record, state)
+        self.assertEqual(0, entity.health)
+        self.assertFalse(entity.isCrewActive)
+        battle._avatar.guiSessionProvider.setVehicleHealth.assert_not_called()
 
     def test_local_death_crosses_stock_postmortem_activation_boundary(self):
         runtime = _runtime()

--- a/tests/test_port_0922_critical_damage.py
+++ b/tests/test_port_0922_critical_damage.py
@@ -1049,6 +1049,50 @@ class CriticalDamageTests(unittest.TestCase):
         self.assertTrue(payload['ammo_rack_death'])
         self.assertEqual('ammo_rack', payload['events'][-1]['kind'])
 
+    def test_2000_module_damage_detonates_a_reached_rack_after_one_saving_throw(self):
+        kinds = ('ARMOR_PIERCING', 'ARMOR_PIERCING_CR', 'HOLLOW_CHARGE',
+                 'ARMOR_PIERCING_HE', 'HIGH_EXPLOSIVE')
+        for kind in kinds:
+            for target_id in (1, 999):
+                for chance_roll in (0.269, 0.270):
+                    with self.subTest(kind=kind, target=target_id,
+                                      chance_roll=chance_roll):
+                        vehicle = types.SimpleNamespace(
+                            id=target_id, health=500,
+                            typeDescriptor=_descriptor(),
+                            position=object(), matrix=object(),
+                            getComponents=lambda: ())
+                        shell = {'kind': kind, 'damage': (100.0, 2000.0)}
+                        # These are reached module contacts. Native and
+                        # reconstructed multi-box contacts must not add rolls.
+                        mat = _Material('ammoBayHealth', chance=0.27)
+                        hits = ((1.0, 1.0, mat, None), (1.2, 1.0, mat, None))
+                        with mock.patch.dict(sys.modules, {
+                                'BigWorld': self.bigworld, 'Math': self.math}), \
+                                mock.patch('random.uniform',
+                                           side_effect=lambda low, high: low), \
+                                mock.patch('random.random',
+                                           return_value=chance_roll) as roll, \
+                                mock.patch.object(critical_damage,
+                                    '_offh_internal_cone_hits', return_value=()):
+                            if kind == 'HIGH_EXPLOSIVE':
+                                damage, payload, delta = critical_damage.propose_explosion(
+                                    vehicle, hits, object(), object(), 100, shell,
+                                    attacker_id=2, with_delta=True)
+                            else:
+                                damage, payload, delta = critical_damage.propose_direct(
+                                    vehicle, hits, object(), object(), 100, shell,
+                                    attacker_id=2, penetrated=True, with_delta=True)
+                        roll.assert_called_once()
+                        if chance_roll < 0.27:
+                            self.assertEqual(510, damage)
+                            self.assertTrue(payload['ammo_rack_death'])
+                            self.assertEqual(100.0, delta['devices'][0]['hp_loss'])
+                        else:
+                            self.assertEqual(100, damage)
+                            self.assertFalse((payload or {}).get('ammo_rack_death'))
+                            self.assertEqual([], delta['devices'])
+
     def test_proposal_records_module_operation_before_stale_hp_clamp(self):
         vehicle = types.SimpleNamespace(
             id=1, health=500, typeDescriptor=_descriptor(),

--- a/tests/test_port_0922_effective_params.py
+++ b/tests/test_port_0922_effective_params.py
@@ -406,6 +406,26 @@ class EffectiveParamsContractTests(unittest.TestCase):
             contract.MAX_CRITICAL_DEVICE_HP + 1.0
         self.assertIsNone(contract.canonical(over_limit))
 
+    def test_2000_module_damage_survives_snapshot_and_launch_for_every_shell_kind(self):
+        from gui.mods.offline_lan_0922.lan_client import _strict_projectile_source_shot
+        for kind in ('ARMOR_PIERCING', 'ARMOR_PIERCING_CR', 'HOLLOW_CHARGE',
+                     'ARMOR_PIERCING_HE', 'HIGH_EXPLOSIVE'):
+            with self.subTest(kind=kind):
+                source = effective_params()
+                shell = source['gun']['shots'][0]['source_shot']['shell']
+                shell['kind'] = kind
+                shell['damage'][1] = 2000.0
+                canonical = contract.canonical(source)
+                self.assertIsNotNone(canonical)
+                frozen = _strict_projectile_source_shot(
+                    canonical['gun']['shots'][0]['source_shot'])
+                self.assertIsNotNone(frozen)
+                self.assertEqual(2000.0, frozen['shell']['damage'][1])
+                # A subsequent editor/shell selection change cannot rebind
+                # the law already admitted for this projectile.
+                shell['damage'][1] = 1.0
+                self.assertEqual(2000.0, frozen['shell']['damage'][1])
+
     def test_snapshot_preserves_complete_he_shell_factors(self):
         source = effective_params()
         shell = source['gun']['shots'][0]['source_shot']['shell']

--- a/tests/test_port_0922_server_projectiles.py
+++ b/tests/test_port_0922_server_projectiles.py
@@ -1119,6 +1119,47 @@ class ServerProjectileLedgerTests(unittest.TestCase):
         self.assertTrue(hit['critical']['ammo_rack_death'])
         self.assertEqual([ammo_rack_event], hit['critical']['events'])
 
+    def test_fatal_player_ammo_rack_delta_drains_hull_and_publishes_cause(self):
+        state = _state()
+        target = state.players[2]
+        target.health = target.display_health = 900
+        target.effective_params['critical']['devices'] = [{
+            'name': 'ammoBayHealth', 'max_hp': 100.0, 'regen_hp': 50.0}]
+        critical = {
+            'devices': [{'name': 'ammoBayHealth', 'hp': 0.0,
+                         'max_hp': 100.0, 'state': 'destroyed'}],
+            'destroyed': ['ammoBayHealth'], 'crew_ko': [],
+            'crew_roster': ['commander'], 'fire': False,
+            'ammo_rack_death': True, 'events': [],
+        }
+        proposal = {
+            'target_kind': 'player', 'target_id': 2, 'target': target,
+            'target_team': 2, 'target_alive': True,
+            'retired_target': False, 'damage': 910,
+            'potential_damage': 100, 'shot_result': 2,
+            'pose': (10.0, 1.0, 0.0), 'critical': critical,
+            # The worker records HP actually lost, capped to the rack pool,
+            # even when the source shell's module damage was 2000.
+            'critical_delta': {'devices': [
+                {'name': 'ammoBayHealth', 'hp_loss': 100.0}],
+                'crew_ko': [], 'ignite': False},
+            'critical_accepted': True, 'hull_damage': 100,
+            'splash': False, 'stun_end_server_time_ms': 0,
+        }
+
+        state._apply_projectile_effect(self._critical_record(), proposal)
+
+        self.assertFalse(target.alive)
+        self.assertEqual(0, target.health)
+        self.assertEqual(0, target.display_health)
+        self.assertTrue(target.critical['ammo_rack_death'])
+        hit = [event for event in state.pending_events
+               if event.get('target') == 2][-1]
+        self.assertEqual(900, hit['damage'])
+        self.assertTrue(hit['critical']['ammo_rack_death'])
+        self.assertIn({'kind': 'ammo_rack', 'state': 'destroyed',
+                       'cause': 'shot'}, hit['critical']['events'])
+
     def test_bot_ram_commits_terminal_critical_for_both_wrecks(self):
         state = _state()
         state.bot_manifest_authority_id = SIMULATION_WORKER_AUTHORITY_ID

--- a/tools/audit_client_abi.py
+++ b/tools/audit_client_abi.py
@@ -1565,7 +1565,8 @@ EXPECTED_CODE_NAMES = {
             '_VehicleMarkerPlugin__updateVehicleHealth'),
         'VehicleMarkerPlugin.__updateVehicleHealth': (
             '_invokeMarker', '_VehicleMarkerPlugin__getVehicleDamageType',
-            'ATTACK_REASONS'),
+            'ATTACK_REASONS', 'SPECIAL_VEHICLE_HEALTH',
+            'IS_AMMO_BAY_DESTROYED'),
         'VehicleMarkerPlugin.__getVehicleDamageType': (
             'vehicleID', '_VehicleMarkerPlugin__playerVehicleID',
             'DAMAGE_TYPE', 'FROM_PLAYER', 'FROM_ALLY'),
@@ -2028,6 +2029,12 @@ EXPECTED_RESOURCE_STRINGS = {
 
 
 EXPECTED_PACKED_XML_PATH_VALUES = {
+    'scripts/item_defs/vehicles/common/vehicle.xml': {
+        ('materials', 'ammoBay', 'extra'): ((1, 'ammoBayHealth'),),
+        ('materials', 'ammoBay', 'damageKind'): ((1, 'device'),),
+        ('materials', 'ammoBay', 'chanceToHitByProjectile'): ((1, '0.27'),),
+        ('materials', 'ammoBay', 'chanceToHitByExplosion'): ((1, '0.27'),),
+    },
     'scripts/entity_defs/Avatar.def': {
         ('BaseMethods', 'vehicle_changeSetting', 'Exposed'): (
             (1, ''),),
@@ -2257,6 +2264,10 @@ EXPECTED_CLASS_CONSTANTS = {
             'POWDER_EXPLOSION': 1,
             'HE_DETONATION': 2,
         },
+        'SPECIAL_VEHICLE_HEALTH': {
+            'AMMO_BAY_DESTROYED': -5,
+            'TURRET_DETACHED': -13,
+        },
         'ARENA_UPDATE': {
             'VEHICLE_ADDED': 2,
             'PERIOD': 3,
@@ -2361,6 +2372,17 @@ EXPECTED_ORDERED_INSTRUCTION_PATTERNS = {
             )),
     },
     'scripts/client/Avatar.pyc': {
+        'PlayerAvatar.updateVehicleHealth': (
+            'local death restores raw special health into Vehicle', 0, (
+                ('STORE_FAST', 'value', 'prevHealth'),
+                ('LOAD_FAST', 'value', 'rawHealth'),
+                ('LOAD_FAST', 'value', 'vehicle'),
+                ('STORE_ATTR', 'value', 'health'),
+                ('LOAD_FAST', 'value', 'vehicle'),
+                ('LOAD_ATTR', 'value', 'set_health'),
+                ('LOAD_FAST', 'value', 'prevHealth'),
+                ('CALL_FUNCTION', 'argument', 1),
+            )),
         'PlayerAvatar.showTracer': (
             'visible non-ricochet uses the current on-screen muzzle', 10, (
                 ('LOAD_FAST', 'value', 'refStartPoint'),

--- a/tools/audit_internal_layouts.py
+++ b/tools/audit_internal_layouts.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Inventory reconstructed internal-module coverage against a scripts.pkg.
+
+This is a read-only resource audit, not client identity verification or a
+collision-mesh audit. Run inspect_client.py on a complete client first when
+one is available. No inferred layout is generated for an uncovered vehicle.
+"""
+
+import argparse
+import base64
+from collections import Counter
+import json
+from pathlib import Path
+import sys
+import zipfile
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / 'src' / 'res' / 'scripts' / 'client'))
+from gui.mods.offline_lan_0922 import internal_hit_layouts
+from gui.mods.offline_lan_0922 import vehicle_blacklist
+from packed_xml import read_packed_xml, TYPE_COMPRESSED_STRING, TYPE_ELEMENT
+
+
+def _text(value):
+    if value.value_type == TYPE_COMPRESSED_STRING:
+        return base64.b64encode(value.value).decode('ascii')
+    return value.value.decode('ascii')
+
+
+def scan(package_path):
+    rows = []
+    with zipfile.ZipFile(package_path) as archive:
+        listings = sorted(name for name in archive.namelist()
+                          if name.startswith('scripts/item_defs/vehicles/')
+                          and name.endswith('/list.xml')
+                          and name.count('/') == 4)
+        for listing in listings:
+            nation = listing.split('/')[-2]
+            directory = listing.rsplit('/', 1)[0]
+            catalog = read_packed_xml(archive.read(listing))
+            for raw_name, unused in catalog.children:
+                name = raw_name.decode('ascii')
+                if ':' in name:
+                    continue
+                vehicle = nation + ':' + name
+                definition = read_packed_xml(archive.read(
+                    directory + '/' + name + '.xml'))
+                crew = next(value for key, value in definition.children
+                            if key == b'crew')
+                if crew.value_type != TYPE_ELEMENT:
+                    raise ValueError('invalid crew section: ' + vehicle)
+                roles = tuple((key.decode('ascii'),) + tuple(_text(value).split())
+                              for key, value in crew.value.children)
+                profile_key, compiled = internal_hit_layouts._compiled_profile(vehicle)
+                profile = internal_hit_layouts._profile_record(compiled)
+                if profile is None:
+                    status = 'missing_profile'
+                elif profile['crew_roles'] != roles:
+                    status = 'crew_mismatch'
+                else:
+                    status = 'profile_matched'
+                rows.append({
+                    'vehicle': vehicle,
+                    'status': status,
+                    'profile_key': profile_key,
+                    'crew_roles': roles,
+                    'blacklisted_resources': vehicle_blacklist.is_unusable(vehicle),
+                })
+    return {
+        'scope': 'listed vehicle descriptors and reconstructed profile bindings only',
+        'collision_geometry_verified': False,
+        'summary': dict(Counter(row['status'] for row in rows)),
+        'vehicles': rows,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('scripts_package', help='Path to the client scripts.pkg')
+    args = parser.parse_args()
+    print(json.dumps(scan(args.scripts_package), indent=2, sort_keys=True))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Ammo-rack deaths reached the stock client as health 0, so the marker lost the special ammo-rack death state. Preserve the audited -5 presentation value through Vehicle, marker feedback and PlayerAvatar's final raw-health write. Correct late causes without replaying death, kill credit or postmortem activation; worker and LAN health stay nonnegative.

The accompanying investigation checks the reported 2000 module-damage setting across the editor, immutable shot contract, AP/APCR/HEAT/APHE/HE critical calculations, player/Bot victims and server settlement. Reached ammo racks use one 27% saving throw and independent module HP; the successful damage roll does not have a second detonation probability. The numerical regression cases pass without changing the damage formula.

The collision model cannot be described as retail-equivalent: the retained interior profiles are reconstructed. A reproducible scripts.pkg inventory finds 248 matched profiles among 680 listed vehicle definitions, with 432 missing (including special/training variants and one already blacklisted vehicle). Missing profiles provide no reconstructed internal contact, regardless of damage. Profile matching alone does not prove geometry accuracy.

Turret flight remains unimplemented. The existing showAmmoBayEffect call only selects an effect; it does not create the separate DetachedTurret entity, motion inputs or detachment handshake. This PR deliberately does not publish the -13 detached-turret state without that implementation. COMPATIBILITY_REVIEW.md records these gaps and the evidence limits.

Validation:

- Original runtime fails all three new local/remote/late marker regression cases; the corrected runtime passes.
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=tests python3 -m unittest test_port_0922_battle_runtime test_port_0922_critical_damage test_port_0922_effective_params test_port_0922_server_projectiles test_port_0922_client_abi_audit test_audit_internal_layouts`: 1071 tests passed.
- From launcher: `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -p test_vehicle_overlays.py`: 125 tests passed, 2 existing environment-dependent skips.
- CPython 2.7.18 compiled all 99 client source files without adjacent bytecode.
- `python2.7 tools/audit_client_abi.py` passed against the available scripts.pkg, including the ammo material, special-health constants, marker consumer and Avatar raw-health write.
- `python3 tools/audit_internal_layouts.py` produced the catalog-wide coverage inventory; staged diff passed whitespace checks.

Only standalone resource/bytecode evidence was available: the complete Chinese HD installation could not pass inspect_client.py because required installation files were absent. Exact #1513 Windows marker rendering is not accepted yet. This PR does not claim to fix missing layouts or turret flight, and no release is being published.

Public cross-checks: [WG Update 9.0 turret-detachment notes](https://worldoftanks.com/en/content/docs/release_notes/90-update-notes/) and [WG's explanation of internal geometry affecting ammo-rack exposure](https://worldoftanks.com/en/news/general-news/3-soviet-tanks-get-adjustments/). Later vehicle values are not imported into #1513.
