### PR TITLE
Repair a destroyed module at the untrained crew's real speed

### DIFF
--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -7537,8 +7537,11 @@ class BattleRuntime(object):
             equipments = self._equipment_state
         else:
             snapshots = state.get('equipment_states') or ()
+            # Pass the whole ledger row, not just its contract: a spent kit
+            # no longer carries its passive, and the proposal has to agree
+            # with the owner about that.
             equipments = [
-                value.get('equipment') for value in snapshots
+                value for value in snapshots
                 if isinstance(value, dict) and
                 isinstance(value.get('equipment'), dict)]
         passives = equipment_mechanics.passive_effects(equipments)
@@ -10888,8 +10891,22 @@ class BattleRuntime(object):
             return False
         return True
 
+    def _local_repair_factor(self, descriptor):
+        """This vehicle's live repair factor, unused large kit included.
+
+        #1513 gives Repairkit no updateVehicleAttrFactors hook, so its
+        bonusValue never reaches a mounted factor: the passive comes from the
+        live consumable ledger and ends when the kit is spent.
+        """
+        loadout = self._local_loadout(descriptor)
+        passives = equipment_mechanics.passive_effects(
+            self._equipment_state or ())
+        return max(0.0, _number(loadout['repair_factor'], 1.0)) * (
+            1.0 + max(0.0, _number(
+                passives.get('repairkitBonusValue'), 0.0)))
+
     @staticmethod
-    def _tick_local_track_repair(entity, dt, loadout):
+    def _tick_local_track_repair(entity, dt, repair_factor):
         """Advance only the existing owner-CAS track repair checkpoint."""
         before = critical_damage._state(entity)
         devices = getattr(entity, 'devices_hp', None) or {}
@@ -10905,8 +10922,7 @@ class BattleRuntime(object):
                 continue
             repaired = critical_damage._device_damage.repair_step_hp(
                 devices[name], name, entity.typeDescriptor, dt,
-                has_big_repairkit=bool(loadout['has_big_kit']),
-                repair_factor=loadout['repair_factor'])
+                repair_factor=repair_factor)
             if repaired <= devices[name]:
                 continue
             devices[name] = repaired
@@ -10943,9 +10959,8 @@ class BattleRuntime(object):
         if not hasattr(entity, 'maxHealth'):
             entity.maxHealth = int(entity.typeDescriptor.maxHealth)
         now = self._clock()
-        loadout = self._local_loadout(entity.typeDescriptor)
         payload = self._tick_local_track_repair(
-            entity, dt, loadout)
+            entity, dt, self._local_repair_factor(entity.typeDescriptor))
         if payload is not None:
             record['critical_state'] = self._critical_state(payload)
             state = dict(record.get('state') or {})
@@ -10977,7 +10992,7 @@ class BattleRuntime(object):
         if cache is None:
             cache = {}
             entity._offline_lan_repair_progress = cache
-        loadout = self._local_loadout(entity.typeDescriptor)
+        repair_factor = self._local_repair_factor(entity.typeDescriptor)
         for name in tuple(destroyed):
             if name in critical_damage._device_damage.NO_REPAIR_PROGRESS_DEVICES:
                 continue
@@ -10995,9 +11010,7 @@ class BattleRuntime(object):
             if extra_index <= 0:
                 continue
             seconds = critical_damage._device_damage.repair_seconds(
-                name, entity.typeDescriptor,
-                has_big_repairkit=bool(loadout['has_big_kit']),
-                repair_factor=loadout['repair_factor'])
+                name, entity.typeDescriptor, repair_factor=repair_factor)
             seconds_left = max(0.0, seconds * (1.0 - hp / cap))
             callback(entity.id, int(status),
                      int(extra_index) | (progress << 8),

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -2853,9 +2853,22 @@ class BotRuntime(object):
         states = self._equipment_states.get(bot_id, ())
         self._equipment_wire_cache.pop(bot_id, None)
         self._equipment_wire_exposed_in_update.discard(bot_id)
-        self._equipment_passives[bot_id] = \
-            equipment_mechanics.passive_effects(states)
+        self._refresh_equipment_passives(bot_id)
         return states
+
+    def _refresh_equipment_passives(self, bot_id):
+        """Re-read one Bot's passives from its live consumable ledger.
+
+        An unused large repair kit lends its bonusValue to the repair factor
+        and a spent one does not, so the cached factor cannot outlive a
+        consumed charge or a restored ledger.
+        """
+        bot_id = int(bot_id)
+        self._equipment_passives[bot_id] = \
+            equipment_mechanics.passive_effects(
+                self._equipment_states.get(bot_id, ()))
+        self._repair_factors.pop(bot_id, None)
+        return self._equipment_passives[bot_id]
 
     def _advance_equipment_clock(self, step):
         """Advance cooldowns on simulation time, never wall-clock time."""
@@ -3998,6 +4011,8 @@ class BotRuntime(object):
             self._apply_bot_equipment_effect(
                 state, descriptor, effect, strict=True)
             effects.append(dict(effect))
+        if effects:
+            self._refresh_equipment_passives(state['id'])
         self._publish_equipment_state(state)
         return effects
 

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/critical_damage.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/critical_damage.py
@@ -1607,8 +1607,7 @@ def apply_payload(vehicle, payload):
     return tuple(normalized)
 
 
-def tick_repair(vehicle, dt, repair_skill=100.0, has_big_kit=False,
-                repair_factor=None):
+def tick_repair(vehicle, dt, repair_skill=100.0, repair_factor=None):
     """Advance copied 0.8.2 repair law; transport/presentation stay outside."""
     if vehicle is None or dt is None or dt <= 0.0:
         return None
@@ -1632,7 +1631,7 @@ def tick_repair(vehicle, dt, repair_skill=100.0, has_big_kit=False,
                 bool(getattr(vehicle, 'is_on_fire', False))):
             continue
         devices[name] = _device_damage.repair_step_hp(
-            devices[name], name, descriptor, dt, repair_skill, has_big_kit,
+            devices[name], name, descriptor, dt, repair_skill,
             repair_factor)
         was_destroyed = name in destroyed
         if was_destroyed and devices[name] >= cap:

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/device_damage.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/device_damage.py
@@ -42,19 +42,36 @@ DEFAULT_FIRE_BURN_FRACTION = 0.0875  # engine default healthBurnPerSec fraction
 # 'critical' (orange).  This is a damage-state threshold; maxRegenHealth is a
 # separate auto-repair destination and must not decide the first yellow state.
 CRITICAL_HP_FRACTION = 0.5
-# Seconds to auto-repair a destroyed module back to functional with a nominal
-# crew at 0% Repair *secondary* skill (major qualification 100%), no toolbox, no
-# large kit. Tracks are quicker. The Repair skill / toolbox / kit multiply this.
-BASE_TRACK_REPAIR_SECONDS = 10.0
-BASE_MODULE_REPAIR_SECONDS = 18.0
-# Repair-speed gain at 100% crew Repair skill: 1.0 => ~2x faster than 0% skill.
-REPAIR_SKILL_SPEEDUP = 1.0
+# Seconds to auto-repair a destroyed module back to functional with the default
+# crew this port gives every vehicle: 100% major qualification, no Repair
+# *secondary* skill, no toolbox, no large kit, i.e. the number a player reads on
+# the damage panel of a stock crew.  Tracks are quicker.  The Repair skill,
+# toolbox and large repair kit divide it (see repair_seconds).
+#
+# #1513 cannot prove these: `readDeviceHealthParams` reads `healthRegenPerSec`
+# and `hysteresisHealth` only under `not IS_CLIENT and not IS_BOT`, so the
+# shipped descriptors carry no repair rate at all, and Avatar only *receives*
+# the remaining seconds with VEHICLE_MISC_STATUS.DESTROYED_DEVICE_IS_REPAIRING.
+# Wargaming never published the base times either, so the track value is the
+# retail number this project settled on (2026-09-08) and the module value keeps
+# this port's own 1.8x module/track ratio, no retail figure being retrievable.
+#
+# Retail derives the time from per-device `healthRegenPerSec`, so real repair
+# times differ per vehicle.  This port keeps one time per device class; a
+# per-vehicle law would need the stripped rates, not a guessed coefficient.
+#
+# The crew part of the law is EXACT: repair_seconds divides by the client's own
+# 'repairSpeed' factor (CREW_FACTOR_BASE + CREW_FACTOR_SLOPE * efficiency below)
+# normalized to the untrained crew these constants describe.
+BASE_TRACK_REPAIR_SECONDS = 12.0
+BASE_MODULE_REPAIR_SECONDS = 21.6
 # Fraction of max HP lost per second while on fire (bots + player DoT).
 FIRE_DAMAGE_FRACTION_PER_SEC = 0.05
 # How long a fire burns before the crew smothers it, when no extinguisher is
-# used. Nothing in the client can supply this: vehicles.py reads healthBurnPerSec,
-# healthRegenPerSec and hysteresisHealth only under `not IS_CLIENT or
-# IS_DEVELOPMENT`, so the shipped descriptors carry no burn parameters at all.
+# used. Nothing in the client can supply this: shared_readers.py reads
+# healthBurnPerSec, healthRegenPerSec and hysteresisHealth only under
+# `not IS_CLIENT and not IS_BOT`, so the shipped descriptors carry no burn
+# parameters at all.
 FIRE_DURATION_SECONDS = 10.0
 # The fuel tank is the one device with no repair bar: it is not patched up over
 # time, it simply stops being the thing that is burning. When the fire ends it
@@ -545,15 +562,24 @@ def is_crit_only(name):
     return name in CRIT_ONLY_DEVICES
 
 
-def crew_repair_factor(repair_skill_pct):
-    """Repair-speed multiplier from the crew's average Repair *secondary* skill.
-    0% Repair -> 1.0 (base time); 100% Repair -> 1 + REPAIR_SKILL_SPEEDUP (~2x)."""
+def crew_repair_speed(repair_skill_pct):
+    """#1513's factors['repairSpeed'] for an average Repair *secondary* skill.
+
+    VehicleDescrCrew._processSkills builds it as 0.57 + 0.43 * efficiency, so a
+    crew that has not trained Repair is 0.57 and a fully trained one is 1.0.
+    """
     s = repair_skill_pct
     if s < 0.0:
         s = 0.0
     elif s > 100.0:
         s = 100.0
-    return 1.0 + REPAIR_SKILL_SPEEDUP * (s / 100.0)
+    return CREW_FACTOR_BASE + CREW_FACTOR_SLOPE * (s / 100.0)
+
+
+def crew_repair_factor(repair_skill_pct):
+    """Repair-speed multiplier from the crew's average Repair *secondary* skill.
+    0% Repair -> 1.0 (base time); 100% Repair -> 1/0.57 (~1.75x)."""
+    return crew_repair_speed(repair_skill_pct) / CREW_FACTOR_BASE
 
 
 def repair_seconds(name, td, repair_skill_pct=0.0, has_big_repairkit=False,
@@ -564,13 +590,14 @@ def repair_seconds(name, td, repair_skill_pct=0.0, has_big_repairkit=False,
       toolbox            (td.miscAttrs['repairSpeedFactor'], 1.25 when mounted)
       large repair kit   (passive +10% while carried, bonusValue 0.1).
     A ``repair_factor`` from the client's own factor dictionary replaces the
-    percentage, and stays normalized so a fully trained crew keeps the speed
-    this port has always used."""
+    percentage.  Both forms are normalized by CREW_FACTOR_BASE, so the base
+    above is exactly the time a crew without the Repair skill takes and a fully
+    trained one divides it by 1/0.57."""
     base = BASE_TRACK_REPAIR_SECONDS if 'track' in name.lower() else BASE_MODULE_REPAIR_SECONDS
     if repair_factor is None:
         factor = crew_repair_factor(repair_skill_pct)
     else:
-        factor = (1.0 + REPAIR_SKILL_SPEEDUP) * max(0.0, float(repair_factor))
+        factor = max(0.0, float(repair_factor)) / CREW_FACTOR_BASE
     factor *= _misc_factor(td, 'repairSpeedFactor')
     if has_big_repairkit:
         factor *= 1.10
@@ -682,17 +709,23 @@ if __name__ == '__main__':
 
     # Repair: base is at 0% Repair skill; skill/toolbox/kit only speed it up.
     check('crew factor 0%% == 1.0', abs(crew_repair_factor(0.0) - 1.0) < 1e-9)
-    check('crew factor 100%% == 2.0', abs(crew_repair_factor(100.0) - 2.0) < 1e-9)
-    check('track base repair == 10s', abs(repair_seconds('leftTrackHealth', td) - 10.0) < 1e-6)
-    check('module base repair == 18s', abs(repair_seconds('engineHealth', td) - 18.0) < 1e-6)
-    check('100%% repair halves time', abs(repair_seconds('leftTrackHealth', td, repair_skill_pct=100.0) - 5.0) < 1e-6)
+    check('crew factor 100%% == 1/0.57', abs(crew_repair_factor(100.0) - 1.0 / 0.57) < 1e-9)
+    check('untrained client factor == base time',
+          abs(repair_seconds('leftTrackHealth', td, repair_factor=0.57) - 12.0) < 1e-6)
+    check('track base repair == 12s', abs(repair_seconds('leftTrackHealth', td) - 12.0) < 1e-6)
+    check('module base repair == 21.6s', abs(repair_seconds('engineHealth', td) - 21.6) < 1e-6)
+    check('100%% repair divides by 1/0.57',
+          abs(repair_seconds('leftTrackHealth', td, repair_skill_pct=100.0) - 12.0 * 0.57) < 1e-6)
+    check('both repair inputs agree at 100%%',
+          abs(repair_seconds('leftTrackHealth', td, repair_skill_pct=100.0) -
+              repair_seconds('leftTrackHealth', td, repair_factor=1.0)) < 1e-9)
     td.miscAttrs['repairSpeedFactor'] = 1.25
-    check('toolbox speeds repair', abs(repair_seconds('leftTrackHealth', td) - 8.0) < 1e-6)
+    check('toolbox speeds repair', abs(repair_seconds('leftTrackHealth', td) - 9.6) < 1e-6)
     td.miscAttrs['repairSpeedFactor'] = 1.0
-    check('big kit speeds repair', repair_seconds('engineHealth', td, has_big_repairkit=True) < 18.0)
-    check('trained crew speeds repair', repair_seconds('engineHealth', td, repair_skill_pct=50.0) < 18.0)
+    check('big kit speeds repair', repair_seconds('engineHealth', td, has_big_repairkit=True) < 21.6)
+    check('trained crew speeds repair', repair_seconds('engineHealth', td, repair_skill_pct=50.0) < 21.6)
 
-    # Repair step reaches the regen cap (destroyed track -> ~130 over ~10s at 100% crew)
+    # Repair step reaches the regen cap (destroyed track -> ~130 over ~12s at 100% crew)
     hp = 0.0
     for _ in range(600):
         hp = repair_step_hp(hp, 'leftTrackHealth', td, 0.02)

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/device_damage.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/device_damage.py
@@ -582,40 +582,40 @@ def crew_repair_factor(repair_skill_pct):
     return crew_repair_speed(repair_skill_pct) / CREW_FACTOR_BASE
 
 
-def repair_seconds(name, td, repair_skill_pct=0.0, has_big_repairkit=False,
-                   repair_factor=None):
+def repair_seconds(name, td, repair_skill_pct=0.0, repair_factor=None):
     """Seconds to auto-repair the named device from destroyed to functional,
     combining the reconstructed base (at 0% Repair skill) with the multipliers:
       crew Repair skill  (factors['repairSpeed'] = 0.57 + 0.43*efficiency)
       toolbox            (td.miscAttrs['repairSpeedFactor'], 1.25 when mounted)
-      large repair kit   (passive +10% while carried, bonusValue 0.1).
     A ``repair_factor`` from the client's own factor dictionary replaces the
     percentage.  Both forms are normalized by CREW_FACTOR_BASE, so the base
     above is exactly the time a crew without the Repair skill takes and a fully
-    trained one divides it by 1/0.57."""
+    trained one divides it by 1/0.57.
+
+    An unused large repair kit belongs in ``repair_factor``: #1513 gives
+    Repairkit no updateVehicleAttrFactors hook, so its bonusValue never reaches
+    a mounted factor and the caller folds it in from the live consumable
+    ledger, which is also what makes the bonus stop once the kit is spent."""
     base = BASE_TRACK_REPAIR_SECONDS if 'track' in name.lower() else BASE_MODULE_REPAIR_SECONDS
     if repair_factor is None:
         factor = crew_repair_factor(repair_skill_pct)
     else:
         factor = max(0.0, float(repair_factor)) / CREW_FACTOR_BASE
     factor *= _misc_factor(td, 'repairSpeedFactor')
-    if has_big_repairkit:
-        factor *= 1.10
     if factor <= 0.0:
         factor = 1.0
     return base / factor
 
 
 def repair_step_hp(current_hp, name, td, dt, repair_skill_pct=0.0,
-                   has_big_repairkit=False, repair_factor=None):
+                   repair_factor=None):
     """Advance a device's HP one tick toward its regen cap (~50%). Returns the new
     HP (unchanged if already at/above the cap). Repair kits set HP directly and
     should not go through here."""
     cap = device_regen_hp(td, name)
     if cap is None or current_hp >= cap:
         return current_hp
-    secs = repair_seconds(name, td, repair_skill_pct, has_big_repairkit,
-                          repair_factor)
+    secs = repair_seconds(name, td, repair_skill_pct, repair_factor)
     rate = cap / max(0.1, secs)          # HP per second
     new_hp = current_hp + rate * dt
     if new_hp > cap:
@@ -722,7 +722,10 @@ if __name__ == '__main__':
     td.miscAttrs['repairSpeedFactor'] = 1.25
     check('toolbox speeds repair', abs(repair_seconds('leftTrackHealth', td) - 9.6) < 1e-6)
     td.miscAttrs['repairSpeedFactor'] = 1.0
-    check('big kit speeds repair', repair_seconds('engineHealth', td, has_big_repairkit=True) < 21.6)
+    check('unused big kit speeds repair',
+          abs(repair_seconds('engineHealth', td,
+                             repair_factor=CREW_FACTOR_BASE * 1.10) -
+              21.6 / 1.10) < 1e-6)
     check('trained crew speeds repair', repair_seconds('engineHealth', td, repair_skill_pct=50.0) < 21.6)
 
     # Repair step reaches the regen cap (destroyed track -> ~130 over ~12s at 100% crew)

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/equipment_mechanics.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/equipment_mechanics.py
@@ -14,6 +14,14 @@ import math
 DEFAULT_BOT_CONSUMABLE_NAMES = (
     'autoExtinguishers', 'largeMedkit', 'largeRepairkit')
 
+# A Bot has one repair-kit charge, so a functional but damaged module only
+# earns it when losing that module costs the Bot the fight: its gun, its engine
+# and its ammo bay.  A yellow track, radio or observation device does not, and
+# waiting keeps the charge for the destroyed module that follows.  Any
+# destroyed module always earns it.
+BOT_YELLOW_REPAIR_DEVICES = frozenset(
+    ('ammoBayHealth', 'engineHealth', 'gunHealth'))
+
 EQUIPMENT_CONTRACT_FIELDS = (
     'name', 'kind', 'id', 'compactDescr', 'tags', 'reuseCount',
     'cooldownSeconds', 'autoactivate', 'fireStartingChanceFactor',
@@ -317,9 +325,38 @@ def restore_equipment_states(snapshots, contracts=None, now=0.0):
 
 
 def _projection(value):
+    """Return the immutable contract behind a state, a wire row or a contract."""
     if isinstance(value, EquipmentState):
         return value.contract
+    if isinstance(value, dict) and isinstance(value.get('equipment'), dict):
+        return value['equipment']
     return value
+
+
+def _remaining_uses(value):
+    """Charges left on one equipment, or None when the input cannot say."""
+    if isinstance(value, EquipmentState):
+        return value.uses_left
+    if isinstance(value, dict) and 'usesLeft' in value:
+        return _integer(value.get('usesLeft'), -1)
+    return None
+
+
+def _bot_repair_is_worthwhile(critical):
+    """True when this damage is worth one of a Bot's repair-kit charges."""
+    critical = critical if isinstance(critical, dict) else {}
+    if critical.get('destroyed'):
+        return True
+    for record in (critical.get('devices') or ()):
+        if not isinstance(record, dict):
+            continue
+        state = str(record.get('state') or '')
+        if state == 'destroyed':
+            return True
+        if (state == 'critical' and
+                str(record.get('name') or '') in BOT_YELLOW_REPAIR_DEVICES):
+            return True
+    return False
 
 
 def passive_effects(equipments):
@@ -337,16 +374,23 @@ def passive_effects(equipments):
         state = raw if isinstance(raw, EquipmentState) else None
         value = _projection(raw)
         kind = str(_value(value, 'kind', '') or '')
+        # An extinguisher's factor is a mounted one: #1513's
+        # Extinguisher.updateVehicleAttrFactors writes engine/fireStartingChance
+        # from the descriptor, so carrying it is enough.  A kit has no such
+        # hook, and its published passive holds only while the kit is unused.
+        spent = _remaining_uses(raw) == 0
         if kind == 'extinguisher':
             result['fireStartingChanceFactor'] *= max(
                 0.0, _number(_value(
                     value, 'fireStartingChanceFactor'), 1.0))
         elif kind == 'repairkit':
-            result['repairkitBonusValue'] += _number(
-                _value(value, 'bonusValue'), 0.0)
+            if not spent:
+                result['repairkitBonusValue'] += _number(
+                    _value(value, 'bonusValue'), 0.0)
         elif kind == 'medkit':
-            result['medkitBonusValue'] += _number(
-                _value(value, 'bonusValue'), 0.0)
+            if not spent:
+                result['medkitBonusValue'] += _number(
+                    _value(value, 'bonusValue'), 0.0)
         result['crewLevelIncrease'] += _number(
             _value(value, 'crewLevelIncrease'), 0.0)
         if kind == 'fuel' or (
@@ -561,7 +605,9 @@ class EquipmentState(object):
             return None
         now = _number(now, 0.0)
         candidate = effect_policy(self, critical, stunned=stunned)
-        if candidate is None or not self.ready(now):
+        if (candidate is None or not self.ready(now) or
+                (kind == 'repairkit' and
+                 not _bot_repair_is_worthwhile(critical))):
             self._ai_pending_since = None
             return None
         if self._ai_pending_since is None:

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/player_critical_mechanics.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/player_critical_mechanics.py
@@ -235,6 +235,13 @@ def advance_critical(player, dt, now):
     for name in list(devices):
         if name in TRACK_DEVICE_NAMES:
             continue
+        # Same law as critical_damage.tick_repair and the local track
+        # checkpoint: automatic repair starts only once a module is destroyed.
+        # A functional yellow module keeps its hidden HP loss until a repair
+        # kit clears it, and only a destroyed device is published to the stock
+        # DESTROYED_DEVICE_IS_REPAIRING panel.
+        if name not in destroyed:
+            continue
         cap = device_damage.device_regen_hp(descriptor, name)
         if cap is None or devices[name] >= cap:
             continue

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/player_critical_mechanics.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/player_critical_mechanics.py
@@ -220,9 +220,13 @@ def advance_critical(player, dt, now):
     params = getattr(player, 'effective_params', None) or {}
     loadout = params.get('loadout') or {}
     repair_factor = max(0.0, float(loadout.get('repair_factor', 1.0)))
-    has_big_kit = bool(loadout.get('has_big_kit', False))
     passives = equipment_mechanics.passive_effects(
         getattr(player, 'equipment_states', ()) or ())
+    # #1513 keeps Repairkit.bonusValue out of every mounted factor, so the
+    # live ledger is the only place the passive can come from, and it stops
+    # the moment the kit is spent.
+    repair_factor *= 1.0 + max(
+        0.0, float(passives.get('repairkitBonusValue', 0.0)))
     rpm_loss = max(
         0.0, float(passives.get('engineHpLossPerSecond', 0.0))) * float(dt)
     rpm_payload = (critical_damage.damage_device_over_time(
@@ -250,7 +254,6 @@ def advance_critical(player, dt, now):
             continue
         devices[name] = device_damage.repair_step_hp(
             devices[name], name, descriptor, float(dt),
-            has_big_repairkit=has_big_kit,
             repair_factor=repair_factor)
         if name in destroyed and devices[name] >= cap:
             destroyed.discard(name)

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -12341,12 +12341,18 @@ class BattleRuntimeContractTests(unittest.TestCase):
         entity._critical_devices = set()
         entity.appearance.addCrashedTrack = mock.Mock()
         entity.appearance.delCrashedTrack = mock.Mock()
-        loadout = {'has_big_kit': False, 'repair_factor': 0.5}
+        # The generated default crew has no Repair skill, so its client
+        # factor is CREW_FACTOR_BASE and the track takes exactly the untrained
+        # base time: half of it leaves the track destroyed.
+        device_damage = critical_damage._device_damage
+        loadout = {'has_big_kit': False,
+                   'repair_factor': device_damage.CREW_FACTOR_BASE}
+        half = device_damage.BASE_TRACK_REPAIR_SECONDS / 2.0
 
         partial = BattleRuntime._tick_local_track_repair(
-            entity, 5.0, loadout)
+            entity, half, loadout)
         repaired = BattleRuntime._tick_local_track_repair(
-            entity, 5.0, loadout)
+            entity, half, loadout)
 
         self.assertEqual('destroyed', partial['devices'][0]['state'])
         self.assertEqual('critical', repaired['devices'][0]['state'])

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -12345,14 +12345,12 @@ class BattleRuntimeContractTests(unittest.TestCase):
         # factor is CREW_FACTOR_BASE and the track takes exactly the untrained
         # base time: half of it leaves the track destroyed.
         device_damage = critical_damage._device_damage
-        loadout = {'has_big_kit': False,
-                   'repair_factor': device_damage.CREW_FACTOR_BASE}
         half = device_damage.BASE_TRACK_REPAIR_SECONDS / 2.0
 
         partial = BattleRuntime._tick_local_track_repair(
-            entity, half, loadout)
+            entity, half, device_damage.CREW_FACTOR_BASE)
         repaired = BattleRuntime._tick_local_track_repair(
-            entity, half, loadout)
+            entity, half, device_damage.CREW_FACTOR_BASE)
 
         self.assertEqual('destroyed', partial['devices'][0]['state'])
         self.assertEqual('critical', repaired['devices'][0]['state'])

--- a/tests/test_port_0922_bot_runtime.py
+++ b/tests/test_port_0922_bot_runtime.py
@@ -12107,13 +12107,16 @@ class BotRuntimeTests(unittest.TestCase):
                 critical=broken, revision=1, base_revision=1)]})
 
         # A bot carries #1513's default crew, which has no repair skill, so
-        # factors['repairSpeed'] is 0.57 and the track takes 10 / (2 * 0.57)
-        # seconds rather than the five a fully trained crew would need.
+        # factors['repairSpeed'] is 0.57 and the track takes exactly the
+        # untrained BASE_TRACK_REPAIR_SECONDS, not the 0.57x of it a fully
+        # trained crew would need.
+        from gui.mods.offline_lan_0922 import device_damage
+        ticks = int(round(device_damage.BASE_TRACK_REPAIR_SECONDS / .20))
         outgoing = None
-        for index in range(25):
+        for index in range(ticks // 2):
             outgoing = bot_state_rows.bots(runtime.update(.20, 1.0 + index * .20)[0])[0]
         self.assertLess(outgoing['critical']['devices'][0]['hp'], 130.0)
-        for index in range(25, 45):
+        for index in range(ticks // 2, ticks):
             outgoing = bot_state_rows.bots(runtime.update(.20, 1.0 + index * .20)[0])[0]
 
         device = outgoing['critical']['devices'][0]

--- a/tests/test_port_0922_bot_runtime.py
+++ b/tests/test_port_0922_bot_runtime.py
@@ -12088,6 +12088,31 @@ class BotRuntimeTests(unittest.TestCase):
             restored.states[11]['equipment_states'][2][
                 'cooldownTimeLeft'])
 
+    def test_bot_repair_speed_takes_the_large_kit_bonus_once(self):
+        from gui.mods.offline_lan_0922 import device_damage
+        descriptor = _critical_descriptor()
+        contracts = _bot_equipment_contracts(self.module)
+        runtime = self.module.BotRuntime(
+            1, descriptor_resolver=lambda unused: descriptor,
+            adapter_factory=lambda *args, **kwargs: _Adapter(*args),
+            direction_probe=lambda *unused: {'clear': True, 'slope': 0.0},
+            ground_probe=lambda *unused: 0.0,
+            physics_ground_probe=lambda *unused: 0.0,
+            spawn_resolver=_spawn_resolver, baked_graph=_graph(),
+            bot_equipment_resolver=lambda: contracts)
+        runtime.battle_start(self.start)
+
+        factor = runtime._bot_repair_factor(11, descriptor)
+
+        # #1513 keeps the large repair kit's bonusValue out of every crew
+        # factor, so the Bot folds that 10% in itself, exactly once, on top of
+        # the default crew's untrained 0.57.
+        self.assertAlmostEqual(device_damage.CREW_FACTOR_BASE * 1.10, factor)
+        self.assertAlmostEqual(
+            device_damage.BASE_TRACK_REPAIR_SECONDS / 1.10,
+            device_damage.repair_seconds(
+                'leftTrackHealth', descriptor, repair_factor=factor))
+
     def test_destroyed_bot_track_repairs_to_regen_cap(self):
         descriptor = _critical_descriptor()
         runtime = self.module.BotRuntime(

--- a/tests/test_port_0922_critical_damage.py
+++ b/tests/test_port_0922_critical_damage.py
@@ -13,6 +13,7 @@ from gui.mods.offline_lan_0922 import critical_damage
 from gui.mods.offline_lan_0922 import device_damage
 from gui.mods.offline_lan_0922 import internal_hit_layouts
 from gui.mods.offline_lan_0922 import internal_layout_profiles
+from gui.mods.offline_lan_0922 import player_critical_mechanics
 from gui.mods.offline_lan_0922 import track_damage
 
 
@@ -1323,7 +1324,8 @@ class CriticalDamageTests(unittest.TestCase):
             _crew_ko=set(), is_on_fire=False)
 
         payload = critical_damage.tick_repair(
-            vehicle, 10.0, repair_skill=0.0)
+            vehicle, device_damage.BASE_TRACK_REPAIR_SECONDS,
+            repair_skill=0.0)
 
         self.assertEqual(50.0, vehicle.devices_hp['leftTrackHealth'])
         self.assertNotIn('leftTrackHealth', vehicle._destroyed_devices)
@@ -1357,7 +1359,8 @@ class CriticalDamageTests(unittest.TestCase):
             position=object(), matrix=object(), getComponents=lambda: ())
 
         payload = critical_damage.tick_repair(
-            vehicle, 10.0, repair_skill=0.0)
+            vehicle, device_damage.BASE_TRACK_REPAIR_SECONDS,
+            repair_skill=0.0)
         shadow = critical_damage._CriticalProposalVehicle(vehicle)
 
         self.assertEqual(80.0, vehicle.devices_hp['leftTrackHealth'])
@@ -1429,7 +1432,8 @@ class CriticalDamageTests(unittest.TestCase):
         shell = {'damage': (100.0, 120.0)}
 
         repaired = critical_damage.tick_repair(
-            vehicle, 10.0, repair_skill=0.0)
+            vehicle, device_damage.BASE_TRACK_REPAIR_SECONDS,
+            repair_skill=0.0)
         with mock.patch.dict(
                 sys.modules, {'BigWorld': self.bigworld, 'Math': self.math}), \
                 mock.patch('random.uniform', return_value=120.0), \
@@ -1938,6 +1942,129 @@ class CrewInjuryLawTests(unittest.TestCase):
         for stat in ('reload', 'aim_time', 'dispersion', 'turret_speed',
                      'mobility', 'vision', 'signal'):
             self.assertEqual(1.0, device_damage.crew_stat_factor((), stat))
+
+
+class _RepairDescriptor(object):
+    """Only the descriptor surface the repair law reads."""
+
+    def __init__(self, repair_speed_factor=1.0):
+        self.engine = {'maxHealth': 170, 'maxRegenHealth': 130}
+        self.chassis = {'maxHealth': 260, 'maxRegenHealth': 130}
+        self.miscAttrs = {'repairSpeedFactor': repair_speed_factor}
+
+
+def _repair_player(hp, state, destroyed=()):
+    """One server-owned participant with a single damaged engine."""
+    return types.SimpleNamespace(
+        player_id=7, health=500, max_health=500, x=0.0, y=0.0, z=0.0,
+        alive=True, combat_fire_timer=0.0, equipment_states=(),
+        critical={
+            'devices': [{'name': 'engineHealth', 'hp': float(hp),
+                         'max_hp': 170.0, 'state': state}],
+            'destroyed': list(destroyed), 'crew_ko': [], 'fire': False},
+        effective_params={
+            'critical': {'devices': [
+                {'name': 'engineHealth', 'max_hp': 170.0,
+                 'regen_hp': 130.0}]},
+            'loadout': {'repair_factor': device_damage.CREW_FACTOR_BASE,
+                        'has_big_kit': False}})
+
+
+class ModuleRepairSpeedTests(unittest.TestCase):
+    """The one repair law shared by the player, the local track CAS and bots."""
+
+    def test_untrained_default_crew_takes_the_documented_base_time(self):
+        descriptor = _RepairDescriptor()
+        # #1513 gives a crew with no Repair skill factors['repairSpeed'] 0.57,
+        # and that crew is exactly what the base constants describe.
+        self.assertEqual(12.0, device_damage.BASE_TRACK_REPAIR_SECONDS)
+        self.assertAlmostEqual(
+            device_damage.BASE_TRACK_REPAIR_SECONDS,
+            device_damage.repair_seconds(
+                'leftTrackHealth', descriptor,
+                repair_factor=device_damage.CREW_FACTOR_BASE))
+        self.assertAlmostEqual(
+            device_damage.BASE_MODULE_REPAIR_SECONDS,
+            device_damage.repair_seconds(
+                'engineHealth', descriptor,
+                repair_factor=device_damage.CREW_FACTOR_BASE))
+
+    def test_full_repair_skill_divides_by_the_client_curve(self):
+        descriptor = _RepairDescriptor()
+        # 0.57 + 0.43 * 1.0 = 1.0, so a fully trained crew is 1/0.57 faster,
+        # not the flat 2x this port used before.
+        self.assertAlmostEqual(
+            device_damage.BASE_TRACK_REPAIR_SECONDS *
+            device_damage.CREW_FACTOR_BASE,
+            device_damage.repair_seconds(
+                'leftTrackHealth', descriptor, repair_factor=1.0))
+        self.assertAlmostEqual(
+            1.0 / device_damage.CREW_FACTOR_BASE,
+            device_damage.crew_repair_factor(100.0))
+
+    def test_percentage_and_client_factor_paths_agree(self):
+        descriptor = _RepairDescriptor()
+        for percentage in (0.0, 50.0, 100.0):
+            factor = device_damage.crew_repair_speed(percentage)
+            self.assertAlmostEqual(
+                device_damage.repair_seconds(
+                    'engineHealth', descriptor,
+                    repair_skill_pct=percentage),
+                device_damage.repair_seconds(
+                    'engineHealth', descriptor, repair_factor=factor))
+
+    def test_large_repair_kit_bonus_is_applied_once_on_either_route(self):
+        descriptor = _RepairDescriptor()
+        # The player folds the mounted kit in as a flag; a bot folds the same
+        # descriptor bonusValue into its client factor.  Both must land on one
+        # 10% gain, never two.
+        flag = device_damage.repair_seconds(
+            'engineHealth', descriptor,
+            repair_factor=device_damage.CREW_FACTOR_BASE,
+            has_big_repairkit=True)
+        bonus = device_damage.repair_seconds(
+            'engineHealth', descriptor,
+            repair_factor=device_damage.CREW_FACTOR_BASE * 1.10)
+        self.assertAlmostEqual(flag, bonus)
+        self.assertAlmostEqual(
+            device_damage.BASE_MODULE_REPAIR_SECONDS / 1.10, flag)
+
+    def test_toolbox_uses_the_exact_descriptor_factor(self):
+        # A StaticFactorDevice writes miscAttrs/repairSpeedFactor; the law only
+        # divides by whatever the descriptor carries.
+        self.assertAlmostEqual(
+            device_damage.BASE_TRACK_REPAIR_SECONDS / 1.25,
+            device_damage.repair_seconds(
+                'leftTrackHealth', _RepairDescriptor(1.25),
+                repair_factor=device_damage.CREW_FACTOR_BASE))
+
+    def test_player_repairs_a_destroyed_engine_at_the_bot_rate(self):
+        player = _repair_player(0.0, 'destroyed', destroyed=('engineHealth',))
+        bot = types.SimpleNamespace(
+            typeDescriptor=_RepairDescriptor(), health=500,
+            devices_hp={'engineHealth': 0.0},
+            _destroyed_devices=set(['engineHealth']),
+            _critical_devices=set(), _crew_ko=set(), is_on_fire=False)
+
+        player_payload = player_critical_mechanics.advance_critical(
+            player, 5.0, 5.0)
+        critical_damage.tick_repair(
+            bot, 5.0, repair_factor=device_damage.CREW_FACTOR_BASE)
+
+        self.assertAlmostEqual(
+            bot.devices_hp['engineHealth'],
+            player_payload['devices'][0]['hp'])
+        self.assertAlmostEqual(
+            130.0 * 5.0 / device_damage.BASE_MODULE_REPAIR_SECONDS,
+            bot.devices_hp['engineHealth'])
+
+    def test_player_yellow_module_does_not_auto_repair(self):
+        player = _repair_player(40.0, 'critical')
+
+        payload = player_critical_mechanics.advance_critical(
+            player, 100.0, 100.0)
+
+        self.assertIsNone(payload)
 
 
 if __name__ == '__main__':

--- a/tests/test_port_0922_critical_damage.py
+++ b/tests/test_port_0922_critical_damage.py
@@ -11,6 +11,7 @@ sys.path.insert(0, str(CLIENT_SCRIPTS))
 
 from gui.mods.offline_lan_0922 import critical_damage
 from gui.mods.offline_lan_0922 import device_damage
+from gui.mods.offline_lan_0922 import equipment_mechanics
 from gui.mods.offline_lan_0922 import internal_hit_layouts
 from gui.mods.offline_lan_0922 import internal_layout_profiles
 from gui.mods.offline_lan_0922 import player_critical_mechanics
@@ -1953,6 +1954,14 @@ class _RepairDescriptor(object):
         self.miscAttrs = {'repairSpeedFactor': repair_speed_factor}
 
 
+def _kit_contract(name, tags, repair_all=True, bonus=0.10):
+    """One projected #1513 kit contract, as the item cache would give it."""
+    return equipment_mechanics.project_equipment(types.SimpleNamespace(
+        name=name, id=(11, 23), compactDescr=423, tags=tags,
+        reuseCount=0, cooldownSeconds=90.0, repairAll=repair_all,
+        bonusValue=bonus))
+
+
 def _repair_player(hp, state, destroyed=()):
     """One server-owned participant with a single damaged engine."""
     return types.SimpleNamespace(
@@ -2013,21 +2022,34 @@ class ModuleRepairSpeedTests(unittest.TestCase):
                 device_damage.repair_seconds(
                     'engineHealth', descriptor, repair_factor=factor))
 
-    def test_large_repair_kit_bonus_is_applied_once_on_either_route(self):
+    def test_only_an_unused_large_repair_kit_speeds_the_repair(self):
         descriptor = _RepairDescriptor()
-        # The player folds the mounted kit in as a flag; a bot folds the same
-        # descriptor bonusValue into its client factor.  Both must land on one
-        # 10% gain, never two.
-        flag = device_damage.repair_seconds(
-            'engineHealth', descriptor,
-            repair_factor=device_damage.CREW_FACTOR_BASE,
-            has_big_repairkit=True)
-        bonus = device_damage.repair_seconds(
-            'engineHealth', descriptor,
-            repair_factor=device_damage.CREW_FACTOR_BASE * 1.10)
-        self.assertAlmostEqual(flag, bonus)
+        contract = _kit_contract('largeRepairkit', ('repairkit',))
+        kit = equipment_mechanics.EquipmentState(contract)
+
+        unused = equipment_mechanics.passive_effects([kit])
+        kit.activate(0.0, {'destroyed': ['engineHealth'],
+                           'devices': [{'name': 'engineHealth',
+                                        'state': 'destroyed'}]})
+        spent = equipment_mechanics.passive_effects([kit])
+
+        self.assertEqual(0, kit.uses_left)
+        self.assertAlmostEqual(0.10, unused['repairkitBonusValue'])
+        self.assertEqual(0.0, spent['repairkitBonusValue'])
+        # Wargaming publishes the kit's 10% as an un-used bonus, and #1513
+        # gives Repairkit no factor hook, so it lives on the live ledger.
         self.assertAlmostEqual(
-            device_damage.BASE_MODULE_REPAIR_SECONDS / 1.10, flag)
+            device_damage.BASE_MODULE_REPAIR_SECONDS / 1.10,
+            device_damage.repair_seconds(
+                'engineHealth', descriptor,
+                repair_factor=device_damage.CREW_FACTOR_BASE *
+                (1.0 + unused['repairkitBonusValue'])))
+        self.assertAlmostEqual(
+            device_damage.BASE_MODULE_REPAIR_SECONDS,
+            device_damage.repair_seconds(
+                'engineHealth', descriptor,
+                repair_factor=device_damage.CREW_FACTOR_BASE *
+                (1.0 + spent['repairkitBonusValue'])))
 
     def test_toolbox_uses_the_exact_descriptor_factor(self):
         # A StaticFactorDevice writes miscAttrs/repairSpeedFactor; the law only

--- a/tests/test_port_0922_equipment_mechanics.py
+++ b/tests/test_port_0922_equipment_mechanics.py
@@ -219,6 +219,50 @@ class EquipmentStateTests(unittest.TestCase):
         self.assertEqual(
             'repair_devices', state.poll_bot(95.02, critical)['action'])
 
+    def test_bot_spends_a_repair_kit_only_on_damage_worth_the_charge(self):
+        contract = equipment_mechanics.project_equipment(_defaults()[2])
+
+        def yellow(name):
+            return {'devices': [{'name': name, 'state': 'critical',
+                                 'hp': 40.0, 'max_hp': 100.0}],
+                    'destroyed': []}
+
+        # A Bot holds one charge, so a functional but damaged gun, engine or
+        # ammo bay earns it and a track, radio or observation device does not.
+        for name in ('gunHealth', 'engineHealth', 'ammoBayHealth'):
+            state = equipment_mechanics.EquipmentState(contract)
+            self.assertIsNone(state.poll_bot(5.0, yellow(name)), name)
+            self.assertEqual(
+                'repair_devices',
+                state.poll_bot(5.01, yellow(name))['action'], name)
+        for name in ('leftTrackHealth', 'rightTrackHealth', 'radioHealth',
+                     'surveyingDeviceHealth', 'turretRotatorHealth',
+                     'fuelTankHealth'):
+            state = equipment_mechanics.EquipmentState(contract)
+            self.assertIsNone(state.poll_bot(5.0, yellow(name)), name)
+            self.assertIsNone(state.poll_bot(5.01, yellow(name)), name)
+            self.assertIsNone(state.poll_bot(9.0, yellow(name)), name)
+            self.assertEqual(
+                equipment_mechanics.EquipmentState(contract).uses_left,
+                state.uses_left, name)
+
+    def test_bot_keeps_the_kit_for_a_track_that_is_actually_destroyed(self):
+        contract = equipment_mechanics.project_equipment(_defaults()[2])
+        state = equipment_mechanics.EquipmentState(contract)
+        yellow = {'devices': [{'name': 'leftTrackHealth', 'state': 'critical',
+                               'hp': 40.0, 'max_hp': 100.0}],
+                  'destroyed': []}
+        broken = {'devices': [{'name': 'leftTrackHealth',
+                               'state': 'destroyed', 'hp': 0.0,
+                               'max_hp': 100.0}],
+                  'destroyed': ['leftTrackHealth']}
+
+        self.assertIsNone(state.poll_bot(5.0, yellow))
+        self.assertIsNone(state.poll_bot(5.01, yellow))
+        self.assertIsNone(state.poll_bot(6.0, broken))
+        self.assertEqual(
+            'repair_devices', state.poll_bot(6.01, broken)['action'])
+
     def test_bot_large_medkit_waits_then_clears_stun_without_crew_damage(self):
         contract = equipment_mechanics.project_equipment(_defaults()[1])
         state = equipment_mechanics.EquipmentState(contract)


### PR DESCRIPTION
## What Peng asked

Whether Bot repair is correct, whether Bots carry a repair kit / medkit at all,
and whether a track really takes ~12 s.

## What the review found

1. **Bots already carry consumables.** Every Bot mounts `autoExtinguishers`,
   `largeMedkit` and `largeRepairkit`, projected from this client's own item
   cache (`equipment_mechanics.DEFAULT_BOT_CONSUMABLE_NAMES`), which is the same
   trio `bootstrap` mounts on every player garage vehicle. `reuseCount` and
   `cooldownSeconds` come from the exact `_readReuseParams` fields and
   `EquipmentState` enforces both, so the cooldown limit Peng asked about is
   already real data. Peng's decision for this round: keep the large trio.
2. **The repair speed was wrong.** `repair_seconds` divided the base time by
   `2 * factors['repairSpeed']`. #1513 builds that factor as
   `0.57 + 0.43 * efficiency` (`VehicleDescrCrew._processSkills`), and the
   generated default crew a Bot and a stock player carry has no Repair skill, so
   it is 0.57: the port ran 14% faster than its own base constant claimed, and a
   fully trained crew got a flat 2.0x where the client's curve says 1/0.57.
3. **The player and Bots disagreed on which devices repair.** The server-side
   player tick repaired any device below its regen cap, silently healing a
   functional yellow module, while `tick_repair`, the local track checkpoint and
   every Bot start only once a module is destroyed.

## The change

* Normalize both repair inputs by `CREW_FACTOR_BASE`, so the base constant means
  exactly "seconds for a crew with no Repair skill" and the client factor,
  toolbox (`miscAttrs/repairSpeedFactor`, written by a `StaticFactorDevice`) and
  the large kit's +10% each apply once.
* Rebase the constants on that meaning: track 12 s, other modules 21.6 s
  (this port's own 1.8x ratio). Before: a Bot repaired a track in 7.97 s and a
  stock player in 8.77 s.
* Player auto-repair now starts only on a destroyed module, like every other
  path.

## Evidence

| | before | after |
| --- | --- | --- |
| Bot track (large kit +10%) | 7.97 s | 10.91 s |
| Player track, default crew | 8.77 s | 12.00 s |
| Player track, 100% Repairs | 5.00 s | 6.84 s |
| Default-crew engine | 15.79 s | 21.60 s |

The base seconds are **not** client-provable and Wargaming never published them:
`shared_readers.readDeviceHealthParams` reads `healthRegenPerSec` and
`hysteresisHealth` only under `not IS_CLIENT and not IS_BOT`, and
`Avatar.updateVehicleMiscStatus` only *receives* the remaining seconds with
`DESTROYED_DEVICE_IS_REPAIRING`. Retail derives the time from a per-device HP
rate, so real repair times differ per vehicle; this port keeps one time per
device class rather than inventing a rate. The crew, toolbox and kit parts of
the law are exact.

## Tests

* `python3 -m unittest discover -s tests -p "test_*.py"` - 4728 tests, OK
  (1 skipped)
* `python3 src/res/scripts/client/gui/mods/offline_lan_0922/device_damage.py` -
  79 checks, 0 failures
* CPython 2.7 source compile gate - 103 files
* New `ModuleRepairSpeedTests` and a Bot large-kit factor test pin the untrained/trained ends of the client
  curve, that the two inputs agree, that the large kit bonus lands once on
  either route, the toolbox factor, player/Bot rate parity, and that a yellow
  module does not auto-repair.

## Not proved here

Windows acceptance. Nothing in this change touches native code, but only the
exact client can show the damage-panel countdown and the felt repair pace.

## Bot kit policy and the un-used passive (second round, Peng's decision)

4. **A Bot spent its one repair kit ~0.2 s after the first module turned
   yellow**, radio and optics included, and had nothing left for the tracks or
   the ammo bay it lost later. It now keeps the charge unless a module is
   *destroyed* or the functional damage is on the **gun, engine or ammo bay**
   (`BOT_YELLOW_REPAIR_DEVICES`). The player's manual activation is unchanged -
   retail lets a player repair any yellow module.
5. **Both large-kit passives survived using the kit.** `artefacts.Repairkit`
   has no `updateVehicleAttrFactors` hook - unlike `Extinguisher`, `Fuel`,
   `Stimulator` and the toolbox's `StaticFactorDevice` - so the kit bonus never
   reaches a mounted factor, and Wargaming publishes it as an *un-used* bonus.
   `passive_effects` now drops a spent kit's `repairkitBonusValue` and
   `medkitBonusValue` and understands a wire ledger row, so a crit proposal
   against a remote target agrees with that target's owner about a spent
   medkit. `has_big_repairkit` is gone from `repair_seconds`, `repair_step_hp`
   and `tick_repair`: the hardcoded 1.10 duplicated a descriptor field and
   could not express a spent kit, so every path now folds the ledger's own
   `bonusValue` into `repair_factor`, which is what a Bot already did. A Bot
   refreshes its passives and drops its cached repair factor whenever the
   ledger changes.

## Known limitations (reported, not fixed)

* A Bot cannot use a non-`repairAll` kit: `poll_bot` never chooses a device or
  crewman, so a small repair kit or small medkit would sit unused all round.
  `bot_consumable_contracts` currently rejects that loadout outright, so it
  fails loudly rather than silently.
* `turretRotatorHealth` and `fuelTankHealth` were not named in the decision, so
  a *yellow* one of those does not spend a Bot's kit; a destroyed one does.
* The opening-frame damage-panel seed in `critical_damage` still reports the
  untrained base time and ignores a toolbox or a trained crew;
  `_present_repair_progress` corrects it on the next frame.
* `BASE_MODULE_REPAIR_SECONDS` has no retail source at all - only the track
  number does. It is the track number times this port's previous 10/18 ratio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
