### PR TITLE
Report a stopped shell's published damage, not the removed hit points

### DIFF
--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -2177,21 +2177,41 @@ remain rejected rather than extending the protocol.
 
 `PlayerAvatar.showOwnVehicleHitDirection(hitDirYaw, attackerID, damage, crits,
 isBlocked, isShellHE, damagedID)` is the only producer of the damage
-indicator. `gui/battle_control/hit_data.pyc` keeps `damage` and an
-`IS_BLOCKED` flag, and
-`gui/Scaleform/daapi/view/battle/shared/indicators.pyc` prints
-`str(HitData.getDamage())` as the extended marker's label while selecting
+indicator, and `gui/battle_control/hit_data.pyc` keeps `damage`, `IS_BLOCKED`
+and `IS_HIGH_EXPLOSIVE` as independent fields. In
+`gui/Scaleform/daapi/view/battle/shared/indicators.pyc`,
+`_MarkerData.__getMarkerType` reads `HitData.isBlocked()` before anything
+else. Its blocked branch is numeric: `_ExtendedMarkerVOBuilder` prints
+`str(HitData.getDamage())` as the label and selects
 `DAMAGEINDICATOR.BLOCKED_SMALL`/`BLOCKED_MEDIUM`/`BLOCKED_BIG` from
-`damage / playerVehMaxHP`. Those three blocked art frames are unreachable
-unless a blocked hit carries a real value, so a stopped shell reports what
-its armour absorbed rather than the hit points it removed. The damage log
-panel's blocked rows and its running total come from the same number: the
-`TANKING` battle event, whose totals `PersonalEfficiencyController`
-accumulates client-side from `Avatar.onBattleEvents`. The value itself is a
-product choice, not a recovered contract -- the cell app that packs retail's
-`damage` and blocked ledger is not in the reviewed package. This port reports
-the shell's published `shell.damage[0]`, because a shell that never pierced
-never drew a damage roll; a penetration keeps the roll it actually spent.
+`damage / playerVehMaxHP`. Every other zero-damage hit falls through to
+`CRITICAL_DAMAGE`, whose three sizes all map to the single `CRIT` frame and
+whose `_getDamageLabel` is the empty string below two criticals. The exact
+client therefore draws either a blocked marker carrying a real value or an
+unlabelled critical marker; a blocked marker worth `0` is unreachable, so
+`isBlocked` must mean a shell this vehicle's armour stopped rather than
+merely a hit that removed no hit points. `HitData.__buildFlags` sets
+`HP_DAMAGE` from `damage > 0` alone, so once a blocked marker carries a value
+`HitDirectionController.__findHit` matches an earlier marker from the same
+attacker and `HitData.extend` sums the two -- retail's own aggregation, and
+also what makes a blocked hit visible under the `WITHOUT_CRITS` preset that
+`_isValidHit` uses to drop zero-damage criticals. `isShellHE` reaches
+`HitData` but no #1513 view reads it.
+
+The damage log panel's blocked rows and its running total come from one
+number, the `TANKING` battle event, whose totals
+`PersonalEfficiencyController._onPlayerFeedbackReceived` accumulates
+client-side from `Avatar.onBattleEvents`; `_BET.ARMOR` maps the same event to
+the `BATTLE_EVENTS.BLOCKED_DAMAGE` ribbon. The value itself is a product
+choice, not a recovered contract -- the cell app that packs retail's `damage`
+argument and blocked ledger is not in the reviewed package, and neither is
+`res/text/LC_MESSAGES/battle_results.mo`, which carries the client's own
+`ArmorItemPacker` wording. This port reports the shell's published
+`shell.damage[0]`, because a shell that never pierced never drew a damage
+roll; a penetration keeps the roll it actually spent. Splash is excluded on
+both surfaces: its damage falls off with distance before armour absorbs the
+rest, so an absorbed near miss stays an unlabelled critical marker and
+credits no blocked damage.
 
 ## AI, room and round boundaries
 

--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -2175,6 +2175,24 @@ the next intent can proceed. Messages that cannot establish the current
 identity, round, type or exact sequence still consume nothing. Extra fields
 remain rejected rather than extending the protocol.
 
+`PlayerAvatar.showOwnVehicleHitDirection(hitDirYaw, attackerID, damage, crits,
+isBlocked, isShellHE, damagedID)` is the only producer of the damage
+indicator. `gui/battle_control/hit_data.pyc` keeps `damage` and an
+`IS_BLOCKED` flag, and
+`gui/Scaleform/daapi/view/battle/shared/indicators.pyc` prints
+`str(HitData.getDamage())` as the extended marker's label while selecting
+`DAMAGEINDICATOR.BLOCKED_SMALL`/`BLOCKED_MEDIUM`/`BLOCKED_BIG` from
+`damage / playerVehMaxHP`. Those three blocked art frames are unreachable
+unless a blocked hit carries a real value, so a stopped shell reports what
+its armour absorbed rather than the hit points it removed. The damage log
+panel's blocked rows and its running total come from the same number: the
+`TANKING` battle event, whose totals `PersonalEfficiencyController`
+accumulates client-side from `Avatar.onBattleEvents`. The value itself is a
+product choice, not a recovered contract -- the cell app that packs retail's
+`damage` and blocked ledger is not in the reviewed package. This port reports
+the shell's published `shell.damage[0]`, because a shell that never pierced
+never drew a damage roll; a penetration keeps the roll it actually spent.
+
 ## AI, room and round boundaries
 
 Humans take real team slots first. The first waiting 0.9.22 player owns map

--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -2202,16 +2202,34 @@ The damage log panel's blocked rows and its running total come from one
 number, the `TANKING` battle event, whose totals
 `PersonalEfficiencyController._onPlayerFeedbackReceived` accumulates
 client-side from `Avatar.onBattleEvents`; `_BET.ARMOR` maps the same event to
-the `BATTLE_EVENTS.BLOCKED_DAMAGE` ribbon. The value itself is a product
-choice, not a recovered contract -- the cell app that packs retail's `damage`
-argument and blocked ledger is not in the reviewed package, and neither is
-`res/text/LC_MESSAGES/battle_results.mo`, which carries the client's own
-`ArmorItemPacker` wording. This port reports the shell's published
+the `BATTLE_EVENTS.BLOCKED_DAMAGE` ribbon.
+
+`res/text/LC_MESSAGES/battle_results.mo` states the ledger rule the client
+itself shows. `EfficiencyTooltipData` binds `BATTLE_EFFICIENCY_TYPES.ARMOR` to
+`ArmorItemPacker` (`gui/shared/tooltips/efficiency.pyc`), whose header is
+`common/tooltip/armor/header` (装甲抵挡) and whose description is
+`common/tooltip/armor/description`: "计数: / • 跳弹 / • 未击穿 / HE与HESH炮弹不
+包含在内。" -- the counter takes ricochets and non-penetrations, and HE and
+HESH shells are not included. #1513 has a single `HIGH_EXPLOSIVE` kind for
+both, and `combat_rules.is_he` already reads exactly that kind, so `HEAT`
+(`HOLLOW_CHARGE`) and `APHE` (`ARMOR_PIERCING_HE`) keep their blocked credit
+even though `ingame_gui.mo` abbreviates `ARMOR_PIERCING_HE` and
+`HIGH_EXPLOSIVE` to the same `damageLog/shellType` label, `HE`. The battle
+server owns the ledger but holds no descriptors, so the worker publishes the
+shell fact beside `structural_armor_hit` and the server applies the rule.
+`IS_HIGH_EXPLOSIVE` does reach `HitData`, but no #1513 view reads it, so
+`isBlocked` is the only place the same rule can be expressed on the indicator.
+
+The remaining choice is the blocked value itself, which no reviewed file
+fixes: the cell app that packs retail's `damage` argument and blocked ledger
+is not in the package. This port reports the shell's published
 `shell.damage[0]`, because a shell that never pierced never drew a damage
-roll; a penetration keeps the roll it actually spent. Splash is excluded on
-both surfaces: its damage falls off with distance before armour absorbs the
-rest, so an absorbed near miss stays an unlabelled critical marker and
-credits no blocked damage.
+roll; a penetration keeps the roll it actually spent. Splash is excluded from
+both surfaces -- its damage falls off with distance before armour absorbs the
+rest -- so an absorbed near miss stays an unlabelled critical marker and
+credits nothing. The separate `potentialDamageReceived` column carries no such
+exclusion in any reviewed text, so it still accumulates every direct hit; that
+asymmetry is the client's rule, not a derived identity.
 
 ## AI, room and round boundaries
 

--- a/server/lan_battle_server.py
+++ b/server/lan_battle_server.py
@@ -8126,6 +8126,7 @@ class BattleState:
             "target_x", "target_y", "target_z",
             "damage_sticker",
             "structural_armor_hit",
+            "high_explosive",
         }
         required = {
             "target_kind", "target_id", "damage", "shot_result",
@@ -8147,6 +8148,13 @@ class BattleState:
         # Optional achievement metadata never owns projectile admission.
         # Unknown/malformed values are conservative external-module hits.
         structural_armor_hit = raw.get("structural_armor_hit") is True
+        # #1513 states its own armour-ledger rule in
+        # #battle_results:common/tooltip/armor/description: the counter takes
+        # ricochets and non-penetrations, and "HE and HESH shells are not
+        # included". Both are the one HIGH_EXPLOSIVE kind. The worker owns
+        # descriptors and reports the shell fact; an absent or malformed
+        # value stays a non-HE shell rather than discarding the terminal.
+        high_explosive = raw.get("high_explosive") is True
         shot_result = _exact_int(raw.get("shot_result"), 0, 2)
         pose = _bounded_vector(
             [raw.get("x"), raw.get("y"), raw.get("z")],
@@ -8247,6 +8255,7 @@ class BattleState:
             "target_alive": target_alive, "damage": damage,
             "potential_damage": potential_damage,
             "structural_armor_hit": structural_armor_hit,
+            "high_explosive": high_explosive,
             "shot_result": shot_result, "pose": pose,
             "critical": critical,
             "critical_delta": critical_delta,
@@ -8365,12 +8374,12 @@ class BattleState:
                     "target_kind", "target_id", "damage", "shot_result",
                     "x", "y", "z"}
                 # A bounce is the archetypal blocked-damage contact, so the
-                # harmless direct effect keeps the worker's potential-damage
-                # roll, decal identity and armour layer. Critical, stun and
-                # splash tokens stay forbidden on a continuing shell.
+                # harmless direct effect keeps the worker's potential damage,
+                # decal identity, armour layer and shell kind. Critical, stun
+                # and splash tokens stay forbidden on a continuing shell.
                 direct_optional = {
                     "damage_sticker", "potential_damage",
-                    "structural_armor_hit"}
+                    "structural_armor_hit", "high_explosive"}
                 if (not isinstance(raw_direct, dict) or
                         not direct_fields.issubset(raw_direct) or
                         set(raw_direct) - (direct_fields | direct_optional)):
@@ -8553,6 +8562,7 @@ class BattleState:
             attacker_key = "attacker_bot"
         blocked_damage = 0
         if (not proposal["splash"] and was_alive and
+                not proposal["high_explosive"] and
                 int(record["team"]) != int(proposal["target_team"]) and
                 proposal["shot_result"] != 2):
             blocked_damage = max(

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -9966,15 +9966,21 @@ class BattleRuntime(object):
         published for every hit that removed no hit points.
 
         A direct shell stopped by armour is the blocked case, and it never
-        drew a damage roll, so it carries the shell's published damage.  A
-        splash is not a stopped shell: its damage falls off with distance
-        before armour absorbs the rest, and the armour ledger excludes
-        splash for the same reason, so an absorbed near miss keeps retail's
-        unlabelled critical marker instead of claiming a blocked value.
+        drew a damage roll, so it carries the shell's published damage.
+        Three hits are not that case and keep retail's unlabelled critical
+        marker.  A splash is not a stopped shell: its damage falls off with
+        distance before armour absorbs the rest.  An ``HIGH_EXPLOSIVE``
+        shell is excluded by the client's own armour-ledger rule in
+        ``#battle_results:common/tooltip/armor/description`` -- "HE and HESH
+        shells are not included" -- and ``IS_HIGH_EXPLOSIVE`` reaches
+        ``HitData`` but no #1513 view reads it, so ``isBlocked`` is the only
+        place that rule can be expressed.  A penetration that removed no hit
+        points broke modules; armour stopped nothing.
         """
         blocked = bool(
             damage <= 0 and not bool(event.get('splash', False)) and
-            max(0, min(int(event.get('shot_result', 2)), 2)) != 2)
+            max(0, min(int(event.get('shot_result', 2)), 2)) != 2 and
+            not combat_rules.is_he(shot))
         if not blocked:
             return damage, False
         return max(0, int(combat_rules.shell_nominal_damage(shot))), True
@@ -14022,7 +14028,8 @@ class BattleRuntime(object):
                            critical, hull_damage, critical_delta,
                            target_position=None, damage_sticker=None,
                            potential_damage=None,
-                           structural_armor_hit=None):
+                           structural_armor_hit=None,
+                           high_explosive=None):
         target_kind = record.get('kind')
         if target_kind == 'human':
             target_kind = 'player'
@@ -14052,6 +14059,15 @@ class BattleRuntime(object):
             # Preserve the exact armour contact layer already chosen by the
             # worker instead of trying to reconstruct it on the server.
             effect['structural_armor_hit'] = bool(structural_armor_hit)
+        if high_explosive is not None:
+            # The exact client states its own armour-ledger rule in
+            # ``#battle_results:common/tooltip/armor/description``: the
+            # counter takes ricochets and non-penetrations, and "HE and
+            # HESH shells are not included".  #1513 has one shell kind for
+            # both, ``HIGH_EXPLOSIVE``, and the server owns the ledger but
+            # holds no descriptors, so the worker publishes the shell fact
+            # and the server applies the rule.
+            effect['high_explosive'] = bool(high_explosive)
         if target_position is not None:
             effect.update({
                 'target_x': float(target_position[0]),
@@ -14359,7 +14375,8 @@ class BattleRuntime(object):
             potential_damage=potential_damage,
             structural_armor_hit=(
                 contact is not None and
-                contact.get('layer') == 'structural'))
+                contact.get('layer') == 'structural'),
+            high_explosive=is_he)
 
     def _projectile_ricochet_contact(
             self, meta, state, terminal_data, collisions, contact):

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -9950,23 +9950,34 @@ class BattleRuntime(object):
         return True
 
     @staticmethod
-    def _hit_indicator_damage(event, shot, damage):
-        """Report the damage a stopped shell carried, not the HP it removed.
+    def _hit_indicator_marker(event, shot, damage):
+        """Return the (damage, isBlocked) pair #1513 can actually draw.
 
-        #1513's damage indicator prints ``str(HitData.getDamage())`` as the
-        marker label and picks ``DAMAGEINDICATOR.BLOCKED_SMALL/MEDIUM/BIG``
-        from ``damage / playerVehMaxHP``, so a blocked marker is built to
-        carry a real value; passing the removed hit points labels every
-        bounce ``0`` and pins it to the smallest blocked art.  A direct hit
-        that did not pierce never drew a damage roll, so the shell's
-        published damage is what its armour stopped.  A splash keeps the
-        applied value: its damage falls off with distance and absorption,
-        and the armour ledger excludes splash for the same reason.
+        The exact client has no marker for zero blocked damage.
+        ``_MarkerData.__getMarkerType`` routes on ``HitData.isBlocked()``
+        first, and the blocked branch is numeric:
+        ``_ExtendedMarkerVOBuilder`` prints ``str(HitData.getDamage())`` as
+        the label and selects ``DAMAGEINDICATOR.BLOCKED_SMALL/MEDIUM/BIG``
+        from ``damage / playerVehMaxHP``.  Every other zero-damage hit falls
+        to ``CRITICAL_DAMAGE``, whose three sizes all map to the single
+        ``CRIT`` frame and whose label is the empty string below two
+        criticals.  So retail draws either a blocked marker carrying a real
+        value or an unlabelled critical marker -- never the ``0`` this port
+        published for every hit that removed no hit points.
+
+        A direct shell stopped by armour is the blocked case, and it never
+        drew a damage roll, so it carries the shell's published damage.  A
+        splash is not a stopped shell: its damage falls off with distance
+        before armour absorbs the rest, and the armour ledger excludes
+        splash for the same reason, so an absorbed near miss keeps retail's
+        unlabelled critical marker instead of claiming a blocked value.
         """
-        if (damage > 0 or bool(event.get('splash', False)) or
-                max(0, min(int(event.get('shot_result', 2)), 2)) == 2):
-            return damage
-        return max(0, int(combat_rules.shell_nominal_damage(shot)))
+        blocked = bool(
+            damage <= 0 and not bool(event.get('splash', False)) and
+            max(0, min(int(event.get('shot_result', 2)), 2)) != 2)
+        if not blocked:
+            return damage, False
+        return max(0, int(combat_rules.shell_nominal_damage(shot))), True
 
     def _present_combat_hit(self, event, target_record, attacker_record,
                             attacker_id):
@@ -10012,11 +10023,12 @@ class BattleRuntime(object):
             hit_yaw = math.atan2(
                 -(attacker_position[0] - target_position[0]),
                 -(attacker_position[2] - target_position[2]))
+            indicator_damage, indicator_blocked = (
+                self._hit_indicator_marker(event, shot, damage))
             self._avatar.showOwnVehicleHitDirection(
-                hit_yaw, int(attacker_id or 0),
-                self._hit_indicator_damage(event, shot, damage),
+                hit_yaw, int(attacker_id or 0), indicator_damage,
                 self._critical_hit_mask(event.get('critical')),
-                damage <= 0, combat_rules.is_he(shot),
+                indicator_blocked, combat_rules.is_he(shot),
                 int(target_record['engine_id']))
 
         # An armour effect belongs to the visible world model.  Team/radio

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -9949,6 +9949,25 @@ class BattleRuntime(object):
             return False
         return True
 
+    @staticmethod
+    def _hit_indicator_damage(event, shot, damage):
+        """Report the damage a stopped shell carried, not the HP it removed.
+
+        #1513's damage indicator prints ``str(HitData.getDamage())`` as the
+        marker label and picks ``DAMAGEINDICATOR.BLOCKED_SMALL/MEDIUM/BIG``
+        from ``damage / playerVehMaxHP``, so a blocked marker is built to
+        carry a real value; passing the removed hit points labels every
+        bounce ``0`` and pins it to the smallest blocked art.  A direct hit
+        that did not pierce never drew a damage roll, so the shell's
+        published damage is what its armour stopped.  A splash keeps the
+        applied value: its damage falls off with distance and absorption,
+        and the armour ledger excludes splash for the same reason.
+        """
+        if (damage > 0 or bool(event.get('splash', False)) or
+                max(0, min(int(event.get('shot_result', 2)), 2)) == 2):
+            return damage
+        return max(0, int(combat_rules.shell_nominal_damage(shot)))
+
     def _present_combat_hit(self, event, target_record, attacker_record,
                             attacker_id):
         """Port the mature 0.8.2 hit feedback through exact #1513 APIs."""
@@ -9994,7 +10013,8 @@ class BattleRuntime(object):
                 -(attacker_position[0] - target_position[0]),
                 -(attacker_position[2] - target_position[2]))
             self._avatar.showOwnVehicleHitDirection(
-                hit_yaw, int(attacker_id or 0), damage,
+                hit_yaw, int(attacker_id or 0),
+                self._hit_indicator_damage(event, shot, damage),
                 self._critical_hit_mask(event.get('critical')),
                 damage <= 0, combat_rules.is_he(shot),
                 int(target_record['engine_id']))
@@ -14005,12 +14025,14 @@ class BattleRuntime(object):
             'z': float(impact[2]),
         }
         if potential_damage is not None:
-            # The armour ledger needs the roll the damage law already made,
-            # before armour and modules reduced it.  Splash carries no roll:
-            # the server excludes splash from blocked damage. An overlay-edited
-            # shell can roll past 5000, the ceiling the wire validator and battle
-            # server enforce, so saturate the statistic instead of letting
-            # the validator drop the whole terminal.
+            # The armour ledger needs the damage this shell could have
+            # delivered before armour and modules reduced it: the roll a
+            # penetration spent, and the shell's published damage when
+            # armour stopped it before any roll could apply.  Splash never
+            # carries one: the server excludes splash from blocked damage.
+            # An overlay-edited shell can exceed 5000, the ceiling the wire
+            # validator and battle server enforce, so saturate the statistic
+            # instead of letting the validator drop the whole terminal.
             effect['potential_damage'] = max(
                 0, min(5000, int(potential_damage)))
         if structural_armor_hit is not None:
@@ -14308,9 +14330,16 @@ class BattleRuntime(object):
                     collision_evidence))
         critical = self._critical_with_crew_roster(
             critical_target, critical)
-        potential_damage = None
-        if contact is not None:
-            potential_damage = int(damage_roll)
+        # A penetration spent the roll it drew, so that roll is the damage
+        # the target could have taken.  Every other verdict -- a ricochet, a
+        # non-penetration, and a traversal that only ever found external
+        # plates -- stopped the shell before any roll could apply, so the
+        # armour ledger owes the shell's published damage instead of a
+        # sample nobody took.  This is the value the damage log's blocked
+        # rows and the #1513 damage indicator both report.
+        potential_damage = int(
+            damage_roll if int(result) == 2
+            else combat_rules.shell_nominal_damage(shot))
         return self._projectile_effect(
             record, damage, result, terminal_data['impact'],
             critical, hull_damage, critical_delta,

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/combat_rules.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/combat_rules.py
@@ -717,6 +717,19 @@ def shell_damage_roll(shot, random_gauss=None):
     return sample_shell_value(average, random_gauss)
 
 
+def shell_nominal_damage(shot):
+    """Return the listed vehicle damage of a shell without the +/-25% roll.
+
+    A shell that never pierced armour never had its damage drawn, so the
+    armour ledger and the damage indicator report the shell's published
+    value rather than a sample nobody took.  Reuse ``shell_damage_roll``
+    with the identity sampler so the nominal and the roll cannot drift on
+    field lookup, missing-descriptor fallback or rounding.
+    """
+    return shell_damage_roll(
+        shot, random_gauss=lambda mean, unused_sigma: mean)
+
+
 def damage(shot, result, nominal_armor, random_gauss=None,
            spall_coefficient=1.0, rolled_damage=None):
     """Apply direct damage, optionally reusing the caller's exact frozen roll."""

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
@@ -1042,7 +1042,7 @@ def _strict_projectile_effect(value):
             return None
         result['damage_sticker'] = damage_sticker
     if has_potential_damage:
-        # The armour ledger's un-reduced roll shares the damage bound the
+        # The armour ledger's un-reduced value shares the damage bound the
         # server enforces; a splash proposal never carries one.
         potential_damage = _projectile_int_range(
             value.get('potential_damage'), 0, 5000)
@@ -2956,7 +2956,7 @@ class LANClient(object):
             'target_kind', 'target_id', 'damage', 'shot_result',
             'x', 'y', 'z'}
         # A bounce is the archetypal blocked-damage contact, so a continuing
-        # shell still publishes its potential-damage roll, decal identity and
+        # shell still publishes its potential damage, decal identity and
         # armour layer. Critical, stun and splash tokens stay forbidden here.
         direct_optional = {
             'damage_sticker', 'potential_damage', 'structural_armor_hit'}

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
@@ -961,10 +961,12 @@ def _strict_projectile_effect(value):
     damage_sticker_fields = frozenset(('damage_sticker',))
     potential_fields = frozenset(('potential_damage',))
     structural_fields = frozenset(('structural_armor_hit',))
+    high_explosive_fields = frozenset(('high_explosive',))
     keys = set(value)
     if not required.issubset(keys) or not keys.issubset(
             required | critical_fields | stun_fields | target_pose_fields |
-            damage_sticker_fields | potential_fields | structural_fields):
+            damage_sticker_fields | potential_fields | structural_fields |
+            high_explosive_fields):
         return None
     kind = value.get('target_kind')
     target_id = _projectile_int_range(
@@ -983,6 +985,7 @@ def _strict_projectile_effect(value):
     has_damage_sticker = 'damage_sticker' in value
     has_potential_damage = 'potential_damage' in value
     has_structural_armor_hit = 'structural_armor_hit' in value
+    has_high_explosive = 'high_explosive' in value
     expected = (required |
                 (critical_fields if has_critical else frozenset()) |
                 (stun_fields if has_stun else frozenset()) |
@@ -992,6 +995,7 @@ def _strict_projectile_effect(value):
                 (potential_fields if has_potential_damage else frozenset()))
     expected |= (structural_fields if has_structural_armor_hit else
                  frozenset())
+    expected |= (high_explosive_fields if has_high_explosive else frozenset())
     if (kind not in ('player', 'bot') or target_id is None or
             damage is None or shot_result is None or
             any(component is None for component in position) or
@@ -1054,6 +1058,11 @@ def _strict_projectile_effect(value):
         # or malformed value must not discard an otherwise valid terminal.
         result['structural_armor_hit'] = (
             value.get('structural_armor_hit') is True)
+    if has_high_explosive:
+        # #1513 keeps HE and HESH out of the armour ledger. This field only
+        # selects that rule, so a malformed value must not discard the
+        # terminal along with its reload and ammunition bookkeeping.
+        result['high_explosive'] = value.get('high_explosive') is True
     if has_target_pose:
         target_position = []
         for axis in ('x', 'y', 'z'):
@@ -2956,10 +2965,12 @@ class LANClient(object):
             'target_kind', 'target_id', 'damage', 'shot_result',
             'x', 'y', 'z'}
         # A bounce is the archetypal blocked-damage contact, so a continuing
-        # shell still publishes its potential damage, decal identity and
-        # armour layer. Critical, stun and splash tokens stay forbidden here.
+        # shell still publishes its potential damage, decal identity, armour
+        # layer and shell kind. Critical, stun and splash tokens stay
+        # forbidden here.
         direct_optional = {
-            'damage_sticker', 'potential_damage', 'structural_armor_hit'}
+            'damage_sticker', 'potential_damage', 'structural_armor_hit',
+            'high_explosive'}
         if (parsed_epoch is None or parsed_epoch != _exact_int(
                 self.authority_epoch) or parsed_projectile_id is None or
                 parsed_base is None or parsed_time is None or

--- a/tests/test_port_0922_battle_projectiles.py
+++ b/tests/test_port_0922_battle_projectiles.py
@@ -5541,7 +5541,7 @@ class BattleProjectileTests(unittest.TestCase):
         self.assertGreater(cone.call_args.args[3].length, 0.0)
         self.assertTrue(cone.call_args.kwargs['deadeye'])
 
-    def test_direct_effect_publishes_the_exact_damage_roll(self):
+    def test_direct_effect_publishes_the_armour_ledger_potential(self):
         battle, unused_bigworld = _battle()
         source = battle._server_entity(41)
         target = types.SimpleNamespace(
@@ -5564,17 +5564,19 @@ class BattleProjectileTests(unittest.TestCase):
             'piercing_loss': 0.0, 'penetration_factor': 1.0,
         }
 
-        # The armour ledger needs the one roll the damage law consumed,
-        # truncated exactly as the law truncates it, for every verdict. A
-        # ricochet forces damage to zero afterwards and still owes the full
-        # roll, because that is the damage the armour actually stopped. A
-        # broad vehicle hit with no resolved armour contact remains terminal,
-        # but cannot claim that armour stopped its roll.
+        # A penetration spent the roll the damage law consumed, truncated
+        # exactly as the law truncates it, so that roll is its potential.
+        # Every verdict that stopped the shell -- a ricochet, a
+        # non-penetration, and a traversal that only found external plates
+        # and so resolved no armour contact -- never drew a roll at all, so
+        # the ledger owes the shell's published 390 instead of a sample
+        # nobody took.  This is the number the damage log's blocked rows and
+        # the #1513 damage indicator both report.
         for contact, result, damage, potential in (
-                ({'result': 0}, 0, 0, 312),
-                ({'result': 1}, 1, 0, 312),
+                ({'result': 0}, 0, 0, 390),
+                ({'result': 1}, 1, 0, 390),
                 ({'result': 2}, 2, 312, 312),
-                (None, 1, 0, None)):
+                (None, 1, 0, 390)):
             with self.subTest(contact=contact):
                 with mock.patch.object(
                         combat_rules, 'resolve_armor_contact',
@@ -5597,10 +5599,7 @@ class BattleProjectileTests(unittest.TestCase):
 
                 self.assertEqual(result, effect['shot_result'])
                 self.assertEqual(damage, effect['damage'])
-                if potential is None:
-                    self.assertNotIn('potential_damage', effect)
-                else:
-                    self.assertEqual(potential, effect['potential_damage'])
+                self.assertEqual(potential, effect['potential_damage'])
                 self.assertEqual(
                     (390.0, 32.5), gaussian.call_args.args)
 

--- a/tests/test_port_0922_battle_projectiles.py
+++ b/tests/test_port_0922_battle_projectiles.py
@@ -5600,6 +5600,7 @@ class BattleProjectileTests(unittest.TestCase):
                 self.assertEqual(result, effect['shot_result'])
                 self.assertEqual(damage, effect['damage'])
                 self.assertEqual(potential, effect['potential_damage'])
+                self.assertIs(False, effect['high_explosive'])
                 self.assertEqual(
                     (390.0, 32.5), gaussian.call_args.args)
 

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -12757,6 +12757,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
                 self.assertEqual(100, direction[2])
                 self.assertIs(True, direction[4])
                 self.assertEqual(0, direction[3])
+                self.assertIs(False, direction[5])
                 events = battle._avatar.battle_events[-1]
                 self.assertEqual(
                     [5], [value['eventType'] for value in events])
@@ -12765,18 +12766,32 @@ class BattleRuntimeContractTests(unittest.TestCase):
                     direction[2],
                     _unpack_damage(events[0]['details'])[0])
 
-    def test_absorbed_splash_and_penetration_keep_the_applied_damage(self):
-        """Only a stopped direct shell owes its published damage.
+    def test_indicator_never_labels_a_marker_zero(self):
+        """Retail cannot draw a blocked marker worth zero damage.
 
-        A splash falls off with distance and absorption, and the armour
-        ledger excludes it, so a fully absorbed near miss stays at zero.  A
-        penetration already spent its roll, so it reports what it removed.
+        ``_MarkerData.__getMarkerType`` reads ``HitData.isBlocked()``
+        first and the blocked branch is numeric, while every other
+        zero-damage hit falls to ``CRITICAL_DAMAGE``, whose label is empty
+        below two criticals.  So a stopped shell claims blocked with the
+        shell's published damage, and a hit that removed no hit points
+        without being stopped -- an absorbed splash, or a penetration that
+        only broke modules -- keeps retail's unlabelled critical marker
+        rather than a blocked ``0``.
         """
         for label, event, expected in (
+                ('ricochet', {
+                    'shot_result': 0, 'damage': 0}, (100, True)),
+                ('non-penetration', {
+                    'shot_result': 1, 'damage': 0}, (100, True)),
                 ('absorbed splash', {
-                    'shot_result': 1, 'damage': 0, 'splash': True}, 0),
+                    'shot_result': 1, 'damage': 0, 'splash': True},
+                 (0, False)),
+                ('module-only penetration', {
+                    'shot_result': 2, 'damage': 0}, (0, False)),
                 ('penetration', {
-                    'shot_result': 2, 'damage': 144}, 144)):
+                    'shot_result': 2, 'damage': 144}, (144, False)),
+                ('leaking non-penetration', {
+                    'shot_result': 1, 'damage': 40}, (40, False))):
             with self.subTest(label):
                 battle, target_record, attacker_record = (
                     self._blocked_hit_fixture())
@@ -12789,8 +12804,9 @@ class BattleRuntimeContractTests(unittest.TestCase):
                 battle._present_combat_hit(
                     event, target_record, attacker_record, 11)
 
-                self.assertEqual(
-                    expected, battle._avatar.hit_directions[-1][2])
+                direction = battle._avatar.hit_directions[-1]
+                self.assertEqual(expected, (direction[2], direction[4]))
+                self.assertFalse(direction[2] == 0 and direction[4])
 
     def test_native_impact_effect_exception_keeps_nonvisual_feedback(self):
         runtime = _runtime()

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -12706,13 +12706,15 @@ class BattleRuntimeContractTests(unittest.TestCase):
             value['eventType']
             for value in battle._avatar.battle_events[0]])
 
-    def _blocked_hit_fixture(self):
+    def _blocked_hit_fixture(self, shell_kind='ARMOR_PIERCING'):
         runtime = _runtime()
         battle = BattleRuntime(runtime)
         battle._avatar = runtime.bigworld.avatar
         target = _Vehicle(10, _Descriptor(), _Vector(), (0, 0, 0),
                           {'health': 500})
-        attacker = _Vehicle(11, _Descriptor(), _Vector(10, 0, 0),
+        attacker_descriptor = _Descriptor()
+        attacker_descriptor.gun.shots[0].shell.kind = shell_kind
+        attacker = _Vehicle(11, attacker_descriptor, _Vector(10, 0, 0),
                             (0, 0, 0), {'health': 500})
         runtime.bigworld.entities.update({10: target, 11: attacker})
         battle._local_position = (0.0, 0.0, 0.0)
@@ -12777,24 +12779,37 @@ class BattleRuntimeContractTests(unittest.TestCase):
         without being stopped -- an absorbed splash, or a penetration that
         only broke modules -- keeps retail's unlabelled critical marker
         rather than a blocked ``0``.
+
+        ``HIGH_EXPLOSIVE`` never claims the blocked marker either:
+        ``#battle_results:common/tooltip/armor/description`` excludes HE and
+        HESH from the armour ledger, and #1513 has one shell kind for both.
+        HEAT and APHE are not excluded.
         """
-        for label, event, expected in (
-                ('ricochet', {
+        for label, kind, event, expected in (
+                ('ricochet', 'ARMOR_PIERCING', {
                     'shot_result': 0, 'damage': 0}, (100, True)),
-                ('non-penetration', {
+                ('non-penetration', 'ARMOR_PIERCING', {
                     'shot_result': 1, 'damage': 0}, (100, True)),
-                ('absorbed splash', {
+                ('HEAT non-penetration', 'HOLLOW_CHARGE', {
+                    'shot_result': 1, 'damage': 0}, (100, True)),
+                ('APHE non-penetration', 'ARMOR_PIERCING_HE', {
+                    'shot_result': 1, 'damage': 0}, (100, True)),
+                ('HE non-penetration', 'HIGH_EXPLOSIVE', {
+                    'shot_result': 1, 'damage': 0}, (0, False)),
+                ('HE ricochet', 'HIGH_EXPLOSIVE', {
+                    'shot_result': 0, 'damage': 0}, (0, False)),
+                ('absorbed splash', 'HIGH_EXPLOSIVE', {
                     'shot_result': 1, 'damage': 0, 'splash': True},
                  (0, False)),
-                ('module-only penetration', {
+                ('module-only penetration', 'ARMOR_PIERCING', {
                     'shot_result': 2, 'damage': 0}, (0, False)),
-                ('penetration', {
+                ('penetration', 'ARMOR_PIERCING', {
                     'shot_result': 2, 'damage': 144}, (144, False)),
-                ('leaking non-penetration', {
+                ('leaking HE non-penetration', 'HIGH_EXPLOSIVE', {
                     'shot_result': 1, 'damage': 40}, (40, False))):
             with self.subTest(label):
                 battle, target_record, attacker_record = (
-                    self._blocked_hit_fixture())
+                    self._blocked_hit_fixture(shell_kind=kind))
                 event = dict({
                     'kind': 'bot_human_hit', 'world_pose': True,
                     'x': 0.5, 'y': 1.0, 'z': 0.0, 'shell_index': 0,

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -12706,6 +12706,92 @@ class BattleRuntimeContractTests(unittest.TestCase):
             value['eventType']
             for value in battle._avatar.battle_events[0]])
 
+    def _blocked_hit_fixture(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        target = _Vehicle(10, _Descriptor(), _Vector(), (0, 0, 0),
+                          {'health': 500})
+        attacker = _Vehicle(11, _Descriptor(), _Vector(10, 0, 0),
+                            (0, 0, 0), {'health': 500})
+        runtime.bigworld.entities.update({10: target, 11: attacker})
+        battle._local_position = (0.0, 0.0, 0.0)
+        target_record = {
+            'engine_id': 10, 'state': {'team': 1, 'health': 500},
+            'kind': 'player', 'network_id': 1, 'local': True}
+        attacker_record = {
+            'engine_id': 11,
+            'spot_visible': False, 'spot_marker_visible': False,
+            'state': {'team': 2, 'health': 500,
+                      'x': 10.0, 'y': 0.0, 'z': 0.0},
+            'kind': 'bot', 'network_id': 2, 'local': False}
+        return battle, target_record, attacker_record
+
+    def test_blocked_hit_indicator_reports_the_published_shell_damage(self):
+        """A bounce labels the marker with the shell, not the lost HP.
+
+        #1513's extended indicator prints ``str(HitData.getDamage())`` and
+        selects ``DAMAGEINDICATOR.BLOCKED_SMALL/MEDIUM/BIG`` from
+        ``damage / playerVehMaxHP``, so the removed hit points label every
+        blocked marker ``0`` and pin it to the smallest blocked art.  The
+        damage log's blocked row must read the same number.
+        """
+        for shot_result in (0, 1):
+            with self.subTest(shot_result=shot_result):
+                battle, target_record, attacker_record = (
+                    self._blocked_hit_fixture())
+                event = {
+                    'kind': 'bot_human_hit', 'world_pose': True,
+                    'x': 0.5, 'y': 1.0, 'z': 0.0, 'shell_index': 0,
+                    'shot_result': shot_result, 'damage': 0,
+                    'blocked_damage': 100, 'source': 'shot',
+                    'dead': False, 'attack_reason': 0, 'death_reason': 0}
+
+                self.assertTrue(battle._present_combat_hit(
+                    event, target_record, attacker_record, 11))
+                self.assertTrue(battle._present_combat_feedback(
+                    event, target_record, attacker_record))
+
+                direction = battle._avatar.hit_directions[-1]
+                # _Descriptor's shell is published at 100 armour damage.
+                self.assertEqual(100, direction[2])
+                self.assertIs(True, direction[4])
+                self.assertEqual(0, direction[3])
+                events = battle._avatar.battle_events[-1]
+                self.assertEqual(
+                    [5], [value['eventType'] for value in events])
+                # Indicator and blocked log row report one number.
+                self.assertEqual(
+                    direction[2],
+                    _unpack_damage(events[0]['details'])[0])
+
+    def test_absorbed_splash_and_penetration_keep_the_applied_damage(self):
+        """Only a stopped direct shell owes its published damage.
+
+        A splash falls off with distance and absorption, and the armour
+        ledger excludes it, so a fully absorbed near miss stays at zero.  A
+        penetration already spent its roll, so it reports what it removed.
+        """
+        for label, event, expected in (
+                ('absorbed splash', {
+                    'shot_result': 1, 'damage': 0, 'splash': True}, 0),
+                ('penetration', {
+                    'shot_result': 2, 'damage': 144}, 144)):
+            with self.subTest(label):
+                battle, target_record, attacker_record = (
+                    self._blocked_hit_fixture())
+                event = dict({
+                    'kind': 'bot_human_hit', 'world_pose': True,
+                    'x': 0.5, 'y': 1.0, 'z': 0.0, 'shell_index': 0,
+                    'source': 'shot', 'dead': False,
+                    'attack_reason': 0, 'death_reason': 0}, **event)
+
+                battle._present_combat_hit(
+                    event, target_record, attacker_record, 11)
+
+                self.assertEqual(
+                    expected, battle._avatar.hit_directions[-1][2])
+
     def test_native_impact_effect_exception_keeps_nonvisual_feedback(self):
         runtime = _runtime()
         battle = BattleRuntime(runtime)

--- a/tests/test_port_0922_he_blast_runtime.py
+++ b/tests/test_port_0922_he_blast_runtime.py
@@ -444,6 +444,47 @@ class HEBlastEffectRuntimeTests(unittest.TestCase):
                          _xyz(critical.call_args.args[3]))
         self.assertIs(True, critical.call_args.kwargs['allow_interior'])
 
+    def test_nonpenetrating_he_owes_the_published_damage_not_the_roll(self):
+        """A stopped HE shell owes its listed damage, never a live roll.
+
+        The blast that leaks through armour is derived from a roll, but the
+        shell never pierced, so the armour ledger reports the published 400
+        even when the roll came in high.  The blocked value the damage log
+        and the damage indicator show is ``potential - damage``, so this
+        also proves that a leaking HE hit cannot report zero or negative
+        blocked damage.
+        """
+        (battle, meta, unused_target, unused_collision,
+         terminal, state) = self._direct_fixture()
+        weak_hull = _collision(1.5, 25.0)
+        blast = {
+            'damage': 240, 'nominal_armor': 25.0, 'distance': 1.5,
+            'point': (6.5, 1.0, 0.0), 'direction': (1.0, 0.0, 0.0),
+            'collision': weak_hull, 'collisions': (weak_hull,),
+        }
+        contact = {
+            'result': 1, 'layer': 'structural', 'distance': 5.0,
+            'component': 'vehicleHull',
+        }
+
+        with mock.patch.object(
+                combat_rules, 'resolve_armor_contact', return_value=contact), \
+                mock.patch.object(random, 'gauss', return_value=480.0), \
+                mock.patch.object(
+                    battle, '_projectile_he_blast_contact',
+                    return_value=blast) as blast_contact, \
+                mock.patch.object(
+                    critical_damage, 'propose_explosion',
+                    return_value=(240, None, {})):
+            effect = battle._projectile_direct_effect(meta, state, terminal)
+
+        # The blast still consumed the +20 percent roll it drew.
+        self.assertEqual(480.0, blast_contact.call_args.args[5])
+        self.assertEqual(240, effect['damage'])
+        self.assertEqual(400, effect['potential_damage'])
+        self.assertGreater(
+            effect['potential_damage'] - effect['damage'], 0)
+
     def test_penetrating_he_keeps_full_direct_damage_without_surface_search(self):
         battle, meta, unused_target, unused_collision, terminal, state = \
             self._direct_fixture()

--- a/tests/test_port_0922_he_blast_runtime.py
+++ b/tests/test_port_0922_he_blast_runtime.py
@@ -484,6 +484,9 @@ class HEBlastEffectRuntimeTests(unittest.TestCase):
         self.assertEqual(400, effect['potential_damage'])
         self.assertGreater(
             effect['potential_damage'] - effect['damage'], 0)
+        # The server holds no descriptors, so the shell kind travels with
+        # the terminal and keeps HE out of the armour ledger there.
+        self.assertIs(True, effect['high_explosive'])
 
     def test_penetrating_he_keeps_full_direct_damage_without_surface_search(self):
         battle, meta, unused_target, unused_collision, terminal, state = \

--- a/tests/test_port_0922_lan_client_projectiles.py
+++ b/tests/test_port_0922_lan_client_projectiles.py
@@ -801,7 +801,7 @@ class ProjectileWireTests(unittest.TestCase):
                 self.assertIs(
                     False, message['direct']['structural_armor_hit'])
 
-    def test_first_ricochet_wire_keeps_the_blocked_damage_roll(self):
+    def test_first_ricochet_wire_keeps_the_blocked_damage_potential(self):
         client = self.active_worker_client()
         direct = self.effect('bot', 17, 11.0)
         direct['damage'] = 0

--- a/tests/test_port_0922_server_projectiles.py
+++ b/tests/test_port_0922_server_projectiles.py
@@ -3040,7 +3040,7 @@ class ServerProjectileLedgerTests(unittest.TestCase):
             SIMULATION_WORKER_AUTHORITY_ID, second))
         self.assertEqual(1, record['ricochet_count'])
 
-    def test_worker_roll_becomes_the_victim_blocked_damage_ledger(self):
+    def test_worker_potential_becomes_the_victim_blocked_damage_ledger(self):
         for shot_result, damage, blocked in (
                 (1, 0, 390), (1, 200, 190), (2, 300, 0)):
             with self.subTest(shot_result=shot_result, damage=damage):
@@ -3080,8 +3080,9 @@ class ServerProjectileLedgerTests(unittest.TestCase):
             _ricochet('1:p:1:1', direct=_effect(
                 damage=0, shot_result=0, potential_damage=420))))
 
-        # A bounce is the archetypal blocked hit: the whole roll counts for
-        # the vehicle whose armour stopped it, and the shell keeps flying.
+        # A bounce is the archetypal blocked hit: the shell's whole
+        # potential counts for the vehicle whose armour stopped it, and the
+        # shell keeps flying.
         bounce = [event for event in state.pending_events
                   if event.get('kind') == 'hit'][-1]
         self.assertEqual(0, bounce['shot_result'])

--- a/tests/test_port_0922_server_projectiles.py
+++ b/tests/test_port_0922_server_projectiles.py
@@ -1051,6 +1051,7 @@ class ServerProjectileLedgerTests(unittest.TestCase):
             'pose': (10.0, 1.0, 0.0), 'critical': admitted,
             'critical_delta': None, 'critical_accepted': True,
             'hull_damage': 100, 'splash': False,
+            'structural_armor_hit': True, 'high_explosive': False,
             'stun_end_server_time_ms': 0,
         }
         record = {
@@ -1100,6 +1101,7 @@ class ServerProjectileLedgerTests(unittest.TestCase):
             'pose': (10.0, 1.0, 0.0), 'critical': admitted,
             'critical_delta': None, 'critical_accepted': True,
             'hull_damage': 100, 'splash': False,
+            'structural_armor_hit': True, 'high_explosive': False,
             'stun_end_server_time_ms': 0,
         }
         record = {
@@ -3069,6 +3071,38 @@ class ServerProjectileLedgerTests(unittest.TestCase):
                 self.assertEqual(
                     blocked, state.vehicle_interactions[
                         ('player', 2)]['player:1']['damage_blocked'])
+
+    def test_high_explosive_never_credits_blocked_damage(self):
+        """#1513 keeps HE and HESH out of its own armour ledger.
+
+        ``#battle_results:common/tooltip/armor/description`` states the rule
+        the ``ArmorItemPacker`` tooltip shows over the blocked total: the
+        counter takes ricochets and non-penetrations, and "HE and HESH
+        shells are not included".  #1513 has one shell kind for both.  The
+        potential damage the results screen reports is a separate column
+        with no such exclusion, so it still accumulates.
+        """
+        for shot_result, damage in ((0, 0), (1, 0), (1, 200)):
+            with self.subTest(shot_result=shot_result, damage=damage):
+                state = _state()
+                self.assertTrue(_launch_authority(state, _launch()))
+
+                self.assertTrue(state.resolve_projectile(
+                    SIMULATION_WORKER_AUTHORITY_ID,
+                    _resolve('1:p:1:1', direct=_effect(
+                        damage=damage, shot_result=shot_result,
+                        potential_damage=390, high_explosive=True))))
+
+                hit = [event for event in state.pending_events
+                       if event.get('kind') == 'hit'][-1]
+                self.assertEqual(0, hit['blocked_damage'])
+                victim_row = state._statistics_row('player', 2)
+                self.assertEqual(0, victim_row['damage_blocked'])
+                self.assertEqual(0, state.vehicle_interactions[
+                    ('player', 2)]['player:1']['damage_blocked'])
+                # The separate potential-damage column is untouched.
+                self.assertEqual(
+                    390, victim_row['potential_damage_received'])
 
     def test_first_ricochet_credits_one_bounce_and_no_penetration(self):
         state = _state()


### PR DESCRIPTION
## What was wrong

A shell that did not pierce reported nothing useful on any surface that shows it:

| Surface | Before | After |
| --- | --- | --- |
| Damage indicator (`showOwnVehicleHitDirection`) | applied hit points, so every bounce read `0` | the shell's published damage |
| Damage log blocked row + running blocked total (`TANKING`) | `roll - applied`, so the same bounce read a different number each time | `published - applied` |
| Blocked-damage ribbon (`_BET.ARMOR` → `BATTLE_EVENTS.BLOCKED_DAMAGE`) | same roll | same published value |
| Battle results `damageBlockedByArmor` / `potentialDamageReceived` | same roll | same published value |
| Non-penetration that resolved no armour contact (external plates only) | published no ledger value at all, so the log showed nothing | published like every other non-penetration |

## Client evidence

`gui/Scaleform/daapi/view/battle/shared/indicators.pyc` prints
`str(HitData.getDamage())` as the extended marker's label, and
`_ExtendedMarkerVOBuilder._getBackground` selects
`DAMAGEINDICATOR.BLOCKED_SMALL` / `BLOCKED_MEDIUM` / `BLOCKED_BIG` from
`damage / playerVehMaxHP`. `_MarkerData.__getMarkerType` routes on
`HitData.isBlocked()` first, so a blocked marker has its own art family *and*
three size frames — two of which are unreachable while the port passes the hit
points a bounce did not remove. `gui/battle_control/hit_data.pyc` keeps
`damage` and `IS_BLOCKED` as independent fields, so a nonzero value on a
blocked marker is the shape the client was built for.

The in-battle log totals need no separate wiring:
`PersonalEfficiencyController._onPlayerFeedbackReceived` accumulates them
client-side from the same `Avatar.onBattleEvents` `TANKING` details.

## The rule

- **Penetration** — keeps the roll it actually spent, so
  `potential == received + blocked` still holds.
- **Everything that stopped the shell** — ricochet, non-penetration, and a
  traversal that only ever found external plates — never drew a roll, so the
  ledger owes `shell.damage[0]`.

The worker owns that for the log, the ribbon and the results; the visible
client labels the indicator from the same shell descriptor it already resolved
for the impact effect, so no wire field was added.

## Boundaries

- **The value is a product choice, not a recovered contract.** The pyc proves
  retail expects *a* nonzero blocked value; the cell app that packs retail's
  `damage` argument and blocked ledger is not in the reviewed package.
  "Published damage, because no roll happens without a penetration" is Peng's
  call. This supersedes a534375e / da19b329, which chose the roll for every
  verdict.
- **A fully absorbed splash still reads `0`.** HE splash falls off with
  distance and absorption, and the armour ledger already excludes splash, so a
  near miss keeps the applied value. Say so if it should read the published
  damage too.
- **Consecutive bounces from one attacker now merge and sum on the
  indicator.** `HitData.__buildFlags` sets `HP_DAMAGE` once the value is
  nonzero, so `HitDirectionController.__findHit` matches the earlier marker and
  `HitData.extend` adds the damage. That is retail's aggregation path — a
  growing number on one marker is expected, not a defect.
- **A friendly bounce shows on the indicator but not in the blocked log.** The
  server excludes same-team hits from the armour ledger, which matches retail
  keeping friendly hits on their own `HP_ALLAY_DAMAGE` marker.

## Validation

- `python3 -m unittest discover -s tests -p "test_*.py"` (from `tests/`) — full
  client suite green.
- CPython 2.7.18 source compile over `src/res/scripts/client` — 103 files.
- New/updated coverage: the worker's potential-damage law for all four
  verdicts; an HE non-penetration that leaks damage (roll 480, published 400,
  blocked stays positive); the indicator's blocked label for both ricochet and
  non-penetration, asserted equal to the number unpacked from the `TANKING`
  event; and absorbed-splash / penetration keeping the applied value.

Not proved here: how the marker, its art frame and the log row actually look on
the exact Windows client. That needs a battle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
