### PR TITLE
Fix the 0.7.0 career loss at its root, and make a refused save recoverable

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -101,6 +101,16 @@ save is the one the game starts with. Saves live in
 made in an older build keeps working: its files move into the default save the
 first time this build starts.
 
+"Open save folder" opens that folder, "Back up save..." writes the whole save
+to one ZIP file, and "Restore save..." puts a backup back into the selected
+save. Close the game before restoring one. The files being replaced are kept in
+a pre-restore folder inside the save, so restoring the wrong backup is
+recoverable. The game also keeps its own copies beside each state file: a
+.backup1 to .backup3 copy of the file as an earlier session found it, and a
+.rejected- or .shrunk- copy of any file it refused to load or was about to
+shrink. Those copies are plain JSON files you can copy back over the live one
+while the game is closed.
+
 When you create a save the Launcher asks which account it starts from, and the
 answer cannot be changed later. "Fully unlocked" is the garage this mod always
 had: every vehicle, module and consumable already owned. "New account" starts

--- a/launcher/core.py
+++ b/launcher/core.py
@@ -1480,6 +1480,14 @@ def _reset_state_name(name):
         prefix = base_name + ".invalid."
         if name.startswith(prefix) and name[len(prefix):].isdigit():
             return True
+        # The client keeps rotated and quarantined copies of a state file
+        # beside it (``garage_state.backup1.json``,
+        # ``garage_state.rejected-...json``).  A confirmed reset promises to
+        # remove what the player earned, and a copy of it is still that.
+        stem, extension = os.path.splitext(base_name)
+        if (name.startswith(stem + ".") and name.endswith(extension) and
+                name != base_name):
+            return True
     return False
 
 

--- a/launcher/save_slots.py
+++ b/launcher/save_slots.py
@@ -55,6 +55,9 @@ STATE_FILE_NAMES = (
     "postbattle_state.json",
     "account_state.json",
 )
+# The client deletes what it has delivered from this one, so a restore that
+# left it behind would hand the player vehicles a different save paid for.
+LAUNCHER_INBOX_NAME = "launcher_inbox.json"
 APPDATA_PARTS = ("Wargaming.net", "WorldOfTanks", "offline_lan_0922")
 LEGACY_RELATIVE = "mods/configs/offline_lan_0922"
 
@@ -379,3 +382,263 @@ def delete_slot(slot_id, game_root=None, environment=None, root=None):
     except (IOError, OSError) as error:
         raise SaveSlotError("The save could not be deleted: %s" % error)
     return record
+
+
+# What a backup archive holds: exactly the files that describe one save, plus
+# the launcher's own record of it.  The rotated and quarantined copies the
+# client keeps are deliberately included: a player restoring a broken save
+# wants the evidence back too, and they are small.
+BACKUP_SCHEMA = 1
+BACKUP_MANIFEST_NAME = "wot-offline-save.json"
+# A save is a handful of JSON files.  Anything far larger is not one, and
+# unpacking it would be the archive deciding how much disk to use.
+MAX_BACKUP_MEMBER_BYTES = 64 * 1024 * 1024
+MAX_BACKUP_MEMBERS = 256
+
+
+def _state_file_names(directory):
+    """Return the save's own files, live copies and kept evidence alike."""
+    try:
+        names = sorted(os.listdir(directory))
+    except (IOError, OSError) as error:
+        raise SaveSlotError("The save could not be read: %s" % error)
+    kept = []
+    for name in names:
+        if not os.path.isfile(os.path.join(directory, name)):
+            continue
+        if name == METADATA_NAME or _belongs_to_state(name):
+            kept.append(name)
+    return kept
+
+
+def _belongs_to_state(name):
+    """Say whether one file name is part of a save's own state.
+
+    The client writes ``garage_state.json`` and keeps ``.backup1``,
+    ``.rejected-...`` and ``.shrunk-...`` copies of it beside the live file,
+    all with the same stem.  Matching on the stem keeps this launcher from
+    having to know each suffix the client may add.
+    """
+    if name.endswith(".tmp"):
+        # A half-written replacement is not state; it is what the atomic
+        # write left behind when it was interrupted.
+        return False
+    for state_name in STATE_FILE_NAMES + (LAUNCHER_INBOX_NAME,):
+        stem = os.path.splitext(state_name)[0]
+        if name == state_name or name.startswith(stem + "."):
+            return True
+    return False
+
+
+def backup_slot(slot_id, archive_path, game_root=None, environment=None,
+                root=None):
+    """Write one save to a ZIP archive the player owns and can keep anywhere.
+
+    Copying the folder by hand works and is documented, but a single file a
+    player can put on another disk is what actually gets kept.  The archive
+    records which save it came from so a restore can say when it is being
+    put back into a different one.
+    """
+    import zipfile
+
+    record = read_slot(slot_id, game_root, environment, root)
+    directory = record["path"]
+    if not os.path.isdir(directory):
+        raise SaveSlotError("This save has nothing to back up yet.")
+    names = _state_file_names(directory)
+    if not names:
+        raise SaveSlotError("This save has nothing to back up yet.")
+    archive_path = os.path.abspath(archive_path)
+    manifest = {
+        "schema": BACKUP_SCHEMA,
+        "id": record["id"],
+        "name": record["name"],
+        "mode": record["mode"],
+        "files": names,
+        "created": int(time.time()),
+    }
+    temporary = archive_path + ".tmp"
+    try:
+        with zipfile.ZipFile(temporary, "w", zipfile.ZIP_DEFLATED) as archive:
+            archive.writestr(
+                BACKUP_MANIFEST_NAME,
+                json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+            for name in names:
+                archive.write(os.path.join(directory, name), name)
+        os.replace(temporary, archive_path)
+    except (IOError, OSError, zipfile.BadZipFile) as error:
+        try:
+            if os.path.isfile(temporary):
+                os.unlink(temporary)
+        except (IOError, OSError):
+            pass
+        raise SaveSlotError("The backup could not be written: %s" % error)
+    return {"path": archive_path, "files": names, "id": record["id"],
+            "name": record["name"]}
+
+
+def read_backup(archive_path):
+    """Describe one archive without unpacking it."""
+    import zipfile
+
+    try:
+        with zipfile.ZipFile(archive_path) as archive:
+            names = [info.filename for info in archive.infolist()
+                     if not info.is_dir()]
+            if len(names) > MAX_BACKUP_MEMBERS:
+                raise SaveSlotError("This file holds too many members.")
+            for info in archive.infolist():
+                if info.file_size > MAX_BACKUP_MEMBER_BYTES:
+                    raise SaveSlotError(
+                        "This file holds a member that is too large.")
+            if BACKUP_MANIFEST_NAME in names:
+                manifest = json.loads(
+                    archive.read(BACKUP_MANIFEST_NAME).decode("utf-8"))
+            else:
+                manifest = {}
+    except SaveSlotError:
+        raise
+    except (IOError, OSError, ValueError, zipfile.BadZipFile) as error:
+        raise SaveSlotError("This is not a readable save backup: %s" % error)
+    if not isinstance(manifest, dict):
+        manifest = {}
+    state_names = [name for name in names
+                   if name != BACKUP_MANIFEST_NAME and _restorable_name(name)]
+    if not state_names:
+        raise SaveSlotError(
+            "This file holds no save data. Pick a backup this Launcher "
+            "wrote, or a folder copy of a save.")
+    return {
+        "path": os.path.abspath(archive_path),
+        "id": (manifest.get("id") if isinstance(manifest.get("id"), str)
+               else None),
+        "name": (manifest.get("name")
+                 if isinstance(manifest.get("name"), str) else None),
+        "files": sorted(state_names),
+    }
+
+
+def _restorable_name(name):
+    """Accept only a plain file name that belongs to a save.
+
+    A member with a path, a drive or a parent reference is refused rather
+    than sanitised: this Launcher wrote the archives it restores, and a
+    hand-made one that disagrees is not worth guessing about.
+    """
+    if not name or name != os.path.basename(name):
+        return False
+    if name in (os.curdir, os.pardir) or os.path.isabs(name):
+        return False
+    if "\\" in name or "/" in name or ":" in name:
+        return False
+    return name == METADATA_NAME or _belongs_to_state(name)
+
+
+def restore_slot(slot_id, archive_path, game_root=None, environment=None,
+                 root=None, is_running=None, keep_name=True):
+    """Replace one save's files with a backup's, keeping what it replaces.
+
+    The client owns these files while it runs, so a restore refuses to touch
+    a save the game may be writing.  The files being replaced are moved into
+    the same slot under a ``pre-restore`` stamp rather than deleted, because a
+    player who restores the wrong archive has then lost the save twice.
+    """
+    import zipfile
+
+    if is_running is None:
+        try:
+            from . import core
+        except ImportError:
+            import core
+
+        is_running = core.game_is_running
+    if callable(is_running) and is_running():
+        raise SaveSlotError(
+            "Close World of Tanks before restoring a save.")
+    backup = read_backup(archive_path)
+    record = read_slot(slot_id, game_root, environment, root)
+    directory = record["path"]
+    if not os.path.isdir(directory):
+        try:
+            os.makedirs(directory)
+        except (IOError, OSError) as error:
+            raise SaveSlotError("The save could not be restored: %s" % error)
+    stamp = time.strftime("pre-restore-%Y%m%d-%H%M%S", time.gmtime())
+    replaced = os.path.join(directory, stamp)
+    moved = []
+    written = []
+    try:
+        existing = _state_file_names(directory)
+        if existing:
+            os.makedirs(replaced)
+            for name in existing:
+                os.replace(os.path.join(directory, name),
+                           os.path.join(replaced, name))
+                moved.append(name)
+        with zipfile.ZipFile(archive_path) as archive:
+            for name in backup["files"]:
+                if keep_name and name == METADATA_NAME:
+                    # The archive's own name would rename the save it is put
+                    # into, which is not what restoring one file of it means.
+                    continue
+                target = _contained(
+                    directory, os.path.join(directory, name),
+                    "The restored file")
+                with archive.open(name) as source:
+                    payload = source.read(MAX_BACKUP_MEMBER_BYTES + 1)
+                if len(payload) > MAX_BACKUP_MEMBER_BYTES:
+                    raise SaveSlotError(
+                        "This file holds a member that is too large.")
+                with open(target, "wb") as destination:
+                    destination.write(payload)
+                written.append(name)
+    except Exception as error:
+        for name in written:
+            try:
+                os.unlink(os.path.join(directory, name))
+            except (IOError, OSError):
+                pass
+        for name in moved:
+            try:
+                os.replace(os.path.join(replaced, name),
+                           os.path.join(directory, name))
+            except (IOError, OSError):
+                pass
+        shutil.rmtree(replaced, ignore_errors=True)
+        if isinstance(error, SaveSlotError):
+            raise
+        raise SaveSlotError("The save could not be restored: %s" % error)
+    return {
+        "id": record["id"],
+        "name": record["name"],
+        "files": sorted(written),
+        "replaced": replaced if moved else None,
+        "from_id": backup["id"],
+        "from_name": backup["name"],
+    }
+
+
+def open_slot_folder(slot_id, game_root=None, environment=None, root=None,
+                     runner=None):
+    """Open one save's folder in Windows Explorer.
+
+    Copying a file out and putting it back is the recovery every player
+    already knows how to do, so the folder itself is the feature.  The
+    directory is created when it is missing: a save that has never been
+    started still has a folder the player can drop a backup into.
+    """
+    import subprocess
+
+    directory = slot_dir(slot_id, game_root, environment, root)
+    if not os.path.isdir(directory):
+        try:
+            os.makedirs(directory)
+        except (IOError, OSError) as error:
+            raise SaveSlotError("The save folder is unavailable: %s" % error)
+    runner = subprocess.Popen if runner is None else runner
+    try:
+        runner(["explorer.exe", os.path.normpath(directory)],
+               creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0))
+    except (IOError, OSError) as error:
+        raise SaveSlotError("The save folder could not be opened: %s" % error)
+    return directory

--- a/launcher/save_slots.py
+++ b/launcher/save_slots.py
@@ -563,7 +563,12 @@ def restore_slot(slot_id, archive_path, game_root=None, environment=None,
             os.makedirs(directory)
         except (IOError, OSError) as error:
             raise SaveSlotError("The save could not be restored: %s" % error)
-    stamp = time.strftime("pre-restore-%Y%m%d-%H%M%S", time.gmtime())
+    # Fixed width, milliseconds included, so two restores in one second do
+    # not collide on the folder that holds what they replaced.
+    now = time.time()
+    stamp = "pre-restore-%s-%03d" % (
+        time.strftime("%Y%m%d-%H%M%S", time.gmtime(now)),
+        int((now % 1) * 1000))
     replaced = os.path.join(directory, stamp)
     moved = []
     written = []

--- a/launcher/tests/test_launcher_core.py
+++ b/launcher/tests/test_launcher_core.py
@@ -2435,3 +2435,20 @@ class VehicleOverlayFetchTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ResetStateNameTests(unittest.TestCase):
+    """A confirmed reset removes copies of earned progress too."""
+
+    def test_the_clients_rotated_and_quarantined_copies_are_reset(self):
+        for name in ("garage_state.json", "garage_state.json.tmp",
+                     "garage_state.backup1.json",
+                     "garage_state.rejected-20260908-000000-000.json",
+                     "garage_state.shrunk-20260908-000000-000.json",
+                     "postbattle_state.backup2.json"):
+            self.assertTrue(core._reset_state_name(name), name)
+
+    def test_files_that_are_not_this_mods_state_are_left_alone(self):
+        for name in ("garage_state", "vehicle_profiles.json", "python.log",
+                     "garage_state.json.zip", "other_state.backup1.json"):
+            self.assertFalse(core._reset_state_name(name), name)

--- a/launcher/tests/test_save_slots.py
+++ b/launcher/tests/test_save_slots.py
@@ -245,3 +245,154 @@ class SaveSlotsTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class SaveBackupTests(unittest.TestCase):
+    """A player-owned copy of one save, and a restore that keeps evidence."""
+
+    def setUp(self):
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        self.base = directory.name
+        self.root = os.path.join(directory.name, "saves")
+
+    def _slot_with_state(self, name="Career", **files):
+        record = save_slots.create_slot(
+            name, save_slots.MODE_NEW_ACCOUNT, root=self.root)
+        payload = {
+            "garage_state.json": {"schema": 7, "vehicles": {"50001": {}}},
+            "postbattle_state.json": {"schema": 1, "progress": {"battles": 9}},
+        }
+        payload.update(files)
+        for file_name, value in payload.items():
+            with open(os.path.join(record["path"], file_name), "w",
+                      encoding="utf-8") as stream:
+                json.dump(value, stream)
+        return record
+
+    def _archive(self, name="backup.zip"):
+        return os.path.join(self.base, name)
+
+    def test_a_backup_holds_the_saves_own_files_and_names_its_origin(self):
+        record = self._slot_with_state()
+
+        result = save_slots.backup_slot(
+            record["id"], self._archive(), root=self.root)
+
+        self.assertEqual(
+            ["garage_state.json", "postbattle_state.json", "save.json"],
+            sorted(result["files"]))
+        described = save_slots.read_backup(result["path"])
+        self.assertEqual(record["id"], described["id"])
+        self.assertEqual("Career", described["name"])
+
+    def test_a_backup_keeps_the_copies_the_client_left_behind(self):
+        """The evidence is part of the save a player wants back.
+
+        The client keeps ``.backup1`` and ``.rejected-`` copies of a state
+        file beside the live one, and those are exactly what a player
+        recovering a broken career needs.
+        """
+        record = self._slot_with_state(**{
+            "garage_state.backup1.json": {"schema": 7, "vehicles": {}},
+            "garage_state.rejected-20260908-000000-000.json": {"schema": 7},
+        })
+
+        result = save_slots.backup_slot(
+            record["id"], self._archive(), root=self.root)
+
+        self.assertIn("garage_state.backup1.json", result["files"])
+        self.assertIn(
+            "garage_state.rejected-20260908-000000-000.json",
+            result["files"])
+
+    def test_an_empty_save_has_nothing_to_back_up(self):
+        record = save_slots.create_slot(
+            "Fresh", save_slots.MODE_NEW_ACCOUNT, root=self.root)
+        os.unlink(os.path.join(record["path"], save_slots.METADATA_NAME))
+
+        with self.assertRaises(save_slots.SaveSlotError):
+            save_slots.backup_slot(
+                record["id"], self._archive(), root=self.root)
+
+    def test_a_restore_replaces_the_state_and_keeps_what_it_replaced(self):
+        source = self._slot_with_state("Career")
+        save_slots.backup_slot(
+            source["id"], self._archive(), root=self.root)
+        target = self._slot_with_state("Other", **{
+            "garage_state.json": {"schema": 7, "vehicles": {"50009": {}}},
+        })
+
+        result = save_slots.restore_slot(
+            target["id"], self._archive(), root=self.root,
+            is_running=lambda: False)
+
+        with open(os.path.join(target["path"], "garage_state.json"),
+                  encoding="utf-8") as stream:
+            self.assertEqual(["50001"], list(json.load(stream)["vehicles"]))
+        # The save keeps its own name and the replaced files stay recoverable.
+        self.assertEqual(
+            "Other",
+            save_slots.read_slot(target["id"], root=self.root)["name"])
+        self.assertEqual("Career", result["from_name"])
+        with open(os.path.join(result["replaced"], "garage_state.json"),
+                  encoding="utf-8") as stream:
+            self.assertEqual(["50009"], list(json.load(stream)["vehicles"]))
+
+    def test_a_restore_refuses_while_the_game_may_be_writing_the_save(self):
+        record = self._slot_with_state()
+        save_slots.backup_slot(
+            record["id"], self._archive(), root=self.root)
+
+        with self.assertRaises(save_slots.SaveSlotError):
+            save_slots.restore_slot(
+                record["id"], self._archive(), root=self.root,
+                is_running=lambda: True)
+
+    def test_a_file_that_is_not_a_save_backup_is_refused_unchanged(self):
+        record = self._slot_with_state()
+        stranger = self._archive("stranger.zip")
+        import zipfile
+
+        with zipfile.ZipFile(stranger, "w") as archive:
+            archive.writestr("notes.txt", "hello")
+
+        with self.assertRaises(save_slots.SaveSlotError):
+            save_slots.restore_slot(
+                record["id"], stranger, root=self.root,
+                is_running=lambda: False)
+        with open(os.path.join(record["path"], "garage_state.json"),
+                  encoding="utf-8") as stream:
+            self.assertEqual(["50001"], list(json.load(stream)["vehicles"]))
+
+    def test_a_member_with_a_path_never_leaves_the_save_folder(self):
+        record = self._slot_with_state()
+        hostile = self._archive("hostile.zip")
+        import zipfile
+
+        with zipfile.ZipFile(hostile, "w") as archive:
+            archive.writestr(
+                "../garage_state.json", '{"schema": 7, "vehicles": {}}')
+            archive.writestr("garage_state.json", '{"schema": 7}')
+
+        result = save_slots.restore_slot(
+            record["id"], hostile, root=self.root, is_running=lambda: False)
+
+        self.assertEqual(["garage_state.json"], result["files"])
+        self.assertFalse(os.path.isfile(
+            os.path.join(os.path.dirname(record["path"]),
+                         "garage_state.json")))
+
+    def test_opening_a_save_folder_creates_it_and_asks_explorer_for_it(self):
+        record = save_slots.create_slot(
+            "Career", save_slots.MODE_NEW_ACCOUNT, root=self.root)
+        asked = []
+
+        directory = save_slots.open_slot_folder(
+            record["id"], root=self.root,
+            runner=lambda command, **unused: asked.append(command))
+
+        self.assertEqual(record["path"], directory)
+        self.assertEqual(1, len(asked))
+        self.assertEqual("explorer.exe", asked[0][0])
+        self.assertTrue(os.path.isdir(directory))

--- a/launcher/wot_launcher.py
+++ b/launcher/wot_launcher.py
@@ -126,6 +126,28 @@ _CHINESE = {
     "New save...": "新建存档…",
     "Rename save...": "重命名存档…",
     "Delete save...": "删除存档…",
+    "Open save folder": "打开存档文件夹",
+    "Back up save...": "备份存档…",
+    "Restore save...": "恢复存档…",
+    "Back up save": "备份存档",
+    "Restore save": "恢复存档",
+    "Save backup": "存档备份",
+    "Restore save?": "恢复存档？",
+    "Replace the contents of save '%s' with the backup of '%s'? The files "
+    "being replaced are kept in a pre-restore folder inside the save.":
+        "确定把存档“%s”的内容替换成“%s”的备份吗？被替换的文件会保留在存档内的 "
+        "pre-restore 文件夹里。",
+    "another save": "其他存档",
+    "The save folder could not be opened: %s": "无法打开存档文件夹：%s",
+    "Opened the save folder: %s": "已打开存档文件夹：%s",
+    "The save could not be backed up: %s": "存档备份失败：%s",
+    "Backed up save '%s' to %s (%d file(s)).":
+        "已把存档“%s”备份到 %s（%d 个文件）。",
+    "The backup could not be read: %s": "无法读取备份文件：%s",
+    "The save could not be restored: %s": "存档恢复失败：%s",
+    "Restored %d file(s) into save '%s'.": "已恢复 %d 个文件到存档“%s”。",
+    "The files that were replaced were kept in %s.":
+        "被覆盖的文件已保留在 %s。",
     "New save": "新建存档",
     "Rename save": "重命名存档",
     "Save name:": "存档名称：",
@@ -206,8 +228,10 @@ _CHINESE = {
     "results are removed permanently.":
         "确定删除存档“%s”吗？它的车库、乘员、账号设置和战斗记录将被永久删除。",
     "Each save keeps its own garage, crew, account settings and battle "
-    "results. The selected save is the one the game starts with.":
-        "每个存档有独立的车库、乘员、账号设置和战斗记录。启动游戏时使用当前选中的存档。",
+    "results. The selected save is the one the game starts with. Back up a "
+    "save to a ZIP file, or open its folder and copy the files out yourself.":
+        "每个存档有独立的车库、乘员、账号设置和战斗记录。启动游戏时使用当前选中的"
+        "存档。可以把存档备份成 ZIP 文件，也可以打开存档文件夹自行复制文件。",
     "Repair": "修复",
     "Repair startup (keep saved data)": "修复启动问题（保留存档）",
     "Normal client stuck loading? Clean preferences...":
@@ -695,11 +719,27 @@ class LauncherWindow(object):
             save_actions, text="", command=self._delete_save_slot)
         self.delete_save_slot_button.pack(
             side="left", fill="x", expand=True, padx=(6, 0))
+        # A save is a few small JSON files, so the recovery a player can
+        # always perform is copying them out and putting them back.
+        save_backup_actions = tk.Frame(self.save_panel)
+        save_backup_actions.grid(
+            row=2, column=0, columnspan=2, sticky="we", pady=(6, 0))
+        self.open_save_folder_button = tk.Button(
+            save_backup_actions, text="", command=self._open_save_folder)
+        self.open_save_folder_button.pack(side="left", fill="x", expand=True)
+        self.backup_save_button = tk.Button(
+            save_backup_actions, text="", command=self._backup_save_slot)
+        self.backup_save_button.pack(
+            side="left", fill="x", expand=True, padx=(6, 0))
+        self.restore_save_button = tk.Button(
+            save_backup_actions, text="", command=self._restore_save_slot)
+        self.restore_save_button.pack(
+            side="left", fill="x", expand=True, padx=(6, 0))
         self.save_help_label = tk.Label(
             self.save_panel, text="", anchor="w", justify="left",
             wraplength=620)
         self.save_help_label.grid(
-            row=2, column=0, columnspan=2, sticky="we", pady=(8, 0))
+            row=3, column=0, columnspan=2, sticky="we", pady=(8, 0))
         self.save_panel.grid_columnconfigure(1, weight=1)
 
         # Gold is the one currency an offline account can never earn, so the
@@ -930,10 +970,15 @@ class LauncherWindow(object):
         self.new_save_slot_button.config(text=self._t("New save..."))
         self.rename_save_slot_button.config(text=self._t("Rename save..."))
         self.delete_save_slot_button.config(text=self._t("Delete save..."))
+        self.open_save_folder_button.config(
+            text=self._t("Open save folder"))
+        self.backup_save_button.config(text=self._t("Back up save..."))
+        self.restore_save_button.config(text=self._t("Restore save..."))
         self.save_help_label.config(text=self._t(
             "Each save keeps its own garage, crew, account settings and "
             "battle results. The selected save is the one the game starts "
-            "with."))
+            "with. Back up a save to a ZIP file, or open its folder and copy "
+            "the files out yourself."))
         self.account_panel.config(text=self._t("Account"))
         for name, label in self.balance_labels.items():
             label.config(text=self._t(_BALANCE_LABELS[name]))
@@ -1569,6 +1614,96 @@ class LauncherWindow(object):
         self._save_settings()
         self._log("Deleted save '%s'." % record["name"])
         return True
+
+    def _open_save_folder(self):
+        record = self._selected_save_slot_record()
+        if record is None:
+            self._log("Select a save before opening its folder.")
+            return False
+        game_root = self.game_root.get().strip()
+        try:
+            directory = save_slots.open_slot_folder(
+                record["id"], game_root or None)
+        except save_slots.SaveSlotError as error:
+            self._log(self._t("The save folder could not be opened: %s")
+                      % error)
+            return False
+        self._log(self._t("Opened the save folder: %s") % directory)
+        return True
+
+    def _backup_save_slot(self):
+        record = self._selected_save_slot_record()
+        if record is None:
+            self._log("Select a save before backing it up.")
+            return False
+        game_root = self.game_root.get().strip()
+        suggested = "wot-offline-save-%s-%s.zip" % (
+            record["id"], time.strftime("%Y%m%d-%H%M%S"))
+        chosen = self._filedialog.asksaveasfilename(
+            title=self._t("Back up save"), initialfile=suggested,
+            defaultextension=".zip",
+            filetypes=((self._t("Save backup"), "*.zip"),))
+        if not chosen:
+            self._log("Save backup was cancelled.")
+            return False
+        try:
+            result = save_slots.backup_slot(
+                record["id"], chosen, game_root or None)
+        except save_slots.SaveSlotError as error:
+            self._log(self._t("The save could not be backed up: %s") % error)
+            return False
+        self._log(self._t("Backed up save '%s' to %s (%d file(s)).") % (
+            record["name"], result["path"], len(result["files"])))
+        return True
+
+    def _restore_save_slot(self):
+        if self._busy or self._maintenance_busy:
+            self._log("Wait for the current launcher operation to finish.")
+            return False
+        record = self._selected_save_slot_record()
+        if record is None:
+            self._log("Select the save to restore into.")
+            return False
+        chosen = self._filedialog.askopenfilename(
+            title=self._t("Restore save"),
+            filetypes=((self._t("Save backup"), "*.zip"),))
+        if not chosen:
+            self._log("Save restore was cancelled.")
+            return False
+        game_root = self.game_root.get().strip()
+        try:
+            backup = save_slots.read_backup(chosen)
+        except save_slots.SaveSlotError as error:
+            self._log(self._t("The backup could not be read: %s") % error)
+            return False
+        if not self._confirm_restore_save_slot(record, backup):
+            self._log("Save restore was cancelled.")
+            return False
+        try:
+            result = save_slots.restore_slot(
+                record["id"], chosen, game_root or None)
+        except save_slots.SaveSlotError as error:
+            self._log(self._t("The save could not be restored: %s") % error)
+            return False
+        self._log(self._t("Restored %d file(s) into save '%s'.") % (
+            len(result["files"]), record["name"]))
+        if result["replaced"]:
+            self._log(self._t("The files that were replaced were kept in %s.")
+                      % result["replaced"])
+        self._refresh_save_slots()
+        return True
+
+    def _confirm_restore_save_slot(self, record, backup):
+        from tkinter import messagebox
+
+        origin = backup["name"] or backup["id"] or self._t("another save")
+        return messagebox.askyesno(
+            self._t("Restore save?"),
+            self._t("Replace the contents of save '%s' with the backup of "
+                    "'%s'? The files being replaced are kept in a "
+                    "pre-restore folder inside the save.")
+            % (record["name"], origin),
+            icon="warning")
 
     def _refresh_bot_lineup_profiles(self):
         self._bot_lineup_store = bot_lineup_profiles.normalize_store(

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/data.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/data.py
@@ -302,7 +302,14 @@ def _validate_selected_vehicle(vehicle):
             required_prices = set()
             for item_type in REQUIRED_VEHICLE_COMPONENT_TYPES + (10,):
                 required_prices.update(inventory_items[item_type])
-            installed_item_compact_descrs.update(required_prices)
+            # Only the researchable module types belong in the unlock
+            # requirement below.  #1513 researches item types 2-7; rounds are
+            # bought, never researched, so nothing ever unlocks them and a
+            # gun's own ammunition arrives with the gun.  Requiring them
+            # refused every career that installed a researched gun.
+            for item_type in REQUIRED_VEHICLE_COMPONENT_TYPES:
+                installed_item_compact_descrs.update(
+                    inventory_items[item_type])
             if not required_prices.issubset(set(item_prices)):
                 raise ValueError(
                     'selected vehicle modules and shells must have shop prices')

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/data.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/data.py
@@ -204,6 +204,20 @@ def _vehicle_records(vehicle):
     return list(records)
 
 
+class VehicleRestoreError(ValueError):
+    """One vehicle record this client refused, named so the rest can survive.
+
+    Restoring a saved garage used to be all or nothing, so a single stale
+    fitting cost the player every vehicle, their crew, their research and
+    their balances.  Naming the record lets ``GarageStore`` leave that one
+    vehicle at its stock build and publish the rest of the account.
+    """
+
+    def __init__(self, message, vehicle_key=None):
+        ValueError.__init__(self, message)
+        self.vehicle_key = None if vehicle_key is None else str(vehicle_key)
+
+
 def _validate_selected_vehicle(vehicle):
     """Reject incomplete garage snapshots before native requesters consume them."""
     records = _vehicle_records(vehicle)
@@ -217,84 +231,92 @@ def _validate_selected_vehicle(vehicle):
     vehicle_type_compact_descrs = []
     installed_item_compact_descrs = set()
     for record in records:
-        if not record.get('compDescr'):
-            raise ValueError('vehicle compact descriptor must be non-empty')
-        vehicle_id = int(record.get('id', 0))
-        if vehicle_id <= 0:
-            raise ValueError('vehicle inventory ids must be positive')
-        vehicle_ids.append(vehicle_id)
-        comp_descrs.append(record['compDescr'])
-        crew = list(record.get('crew', ()))
-        tankmen = dict(record.get('tankmen', {}))
-        # #1513's ``Vehicle._buildCrew`` walks the crew list slot by slot and
-        # reads ``None`` as an empty seat, so an unloaded crew member leaves a
-        # hole rather than shortening the list.
-        manned = [tankman_id for tankman_id in crew if tankman_id is not None]
-        tankman_ids.extend(manned)
-        vehicle_type_compact_descr = record.get(
-            'vehicleTypeCompactDescr')
-        if vehicle_type_compact_descr is not None:
-            vehicle_type_compact_descrs.append(vehicle_type_compact_descr)
-
-        if not crew:
-            raise ValueError('selected vehicle crew must have one seat per role')
+        # A record this client cannot publish is named, so a restore can
+        # drop that one vehicle instead of the whole garage.
         try:
-            crew_ids_are_positive = all(
-                int(tankman_id) > 0 for tankman_id in manned)
-        except (TypeError, ValueError):
-            crew_ids_are_positive = False
-        if not crew_ids_are_positive:
-            raise ValueError('selected vehicle crew ids must be positive')
-        if len(manned) != len(tankmen) or set(manned) != set(tankmen):
-            raise ValueError(
-                'selected vehicle crew ids must resolve to tankmen')
+            if not record.get('compDescr'):
+                raise ValueError('vehicle compact descriptor must be non-empty')
+            vehicle_id = int(record.get('id', 0))
+            if vehicle_id <= 0:
+                raise ValueError('vehicle inventory ids must be positive')
+            vehicle_ids.append(vehicle_id)
+            comp_descrs.append(record['compDescr'])
+            crew = list(record.get('crew', ()))
+            tankmen = dict(record.get('tankmen', {}))
+            # #1513's ``Vehicle._buildCrew`` walks the crew list slot by slot and
+            # reads ``None`` as an empty seat, so an unloaded crew member leaves a
+            # hole rather than shortening the list.
+            manned = [tankman_id for tankman_id in crew if tankman_id is not None]
+            tankman_ids.extend(manned)
+            vehicle_type_compact_descr = record.get(
+                'vehicleTypeCompactDescr')
+            if vehicle_type_compact_descr is not None:
+                vehicle_type_compact_descrs.append(vehicle_type_compact_descr)
 
-        for key in ('repair', 'lock'):
-            value = record.get(key)
-            if not isinstance(value, (tuple, list)) or len(value) != 2:
+            if not crew:
+                raise ValueError('selected vehicle crew must have one seat per role')
+            try:
+                crew_ids_are_positive = all(
+                    int(tankman_id) > 0 for tankman_id in manned)
+            except (TypeError, ValueError):
+                crew_ids_are_positive = False
+            if not crew_ids_are_positive:
+                raise ValueError('selected vehicle crew ids must be positive')
+            if len(manned) != len(tankmen) or set(manned) != set(tankmen):
                 raise ValueError(
-                    'selected vehicle %s must contain two values' % key)
-        # ``repair`` is (outstanding cost, remaining health).  #1513's own
-        # ``Vehicle.modelState`` reads a health of 0 beside a bill as
-        # DESTROYED and a negative one as EXPLODED, so neither is a damaged
-        # snapshot -- both are a vehicle waiting to be repaired.
-        if int(record['repair'][0]) < 0:
-            raise ValueError('selected vehicle repair cost cannot be negative')
-        for key in ('eqs', 'eqsLayout'):
-            value = record.get(key)
-            if not isinstance(value, (tuple, list)) or len(value) != 3:
+                    'selected vehicle crew ids must resolve to tankmen')
+
+            for key in ('repair', 'lock'):
+                value = record.get(key)
+                if not isinstance(value, (tuple, list)) or len(value) != 2:
+                    raise ValueError(
+                        'selected vehicle %s must contain two values' % key)
+            # ``repair`` is (outstanding cost, remaining health).  #1513's own
+            # ``Vehicle.modelState`` reads a health of 0 beside a bill as
+            # DESTROYED and a negative one as EXPLODED, so neither is a damaged
+            # snapshot -- both are a vehicle waiting to be repaired.
+            if int(record['repair'][0]) < 0:
+                raise ValueError('selected vehicle repair cost cannot be negative')
+            for key in ('eqs', 'eqsLayout'):
+                value = record.get(key)
+                if not isinstance(value, (tuple, list)) or len(value) != 3:
+                    raise ValueError(
+                        'selected vehicle %s must contain three slots' % key)
+
+            shells = record.get('shells')
+            if (not isinstance(shells, (tuple, list)) or not shells or
+                    len(shells) % 2):
                 raise ValueError(
-                    'selected vehicle %s must contain three slots' % key)
+                    'selected vehicle shells must contain descriptor/count pairs')
+            if not isinstance(record.get('shellsLayout'), dict):
+                raise ValueError('selected vehicle shellsLayout must be a mapping')
 
-        shells = record.get('shells')
-        if (not isinstance(shells, (tuple, list)) or not shells or
-                len(shells) % 2):
-            raise ValueError(
-                'selected vehicle shells must contain descriptor/count pairs')
-        if not isinstance(record.get('shellsLayout'), dict):
-            raise ValueError('selected vehicle shellsLayout must be a mapping')
+            inventory_items = dict(record.get('inventoryItems', {}))
+            for item_type in REQUIRED_VEHICLE_COMPONENT_TYPES + (10,):
+                items = inventory_items.get(item_type)
+                if not isinstance(items, dict) or not items:
+                    raise ValueError(
+                        'selected vehicle item type %d must be non-empty' %
+                        item_type)
 
-        inventory_items = dict(record.get('inventoryItems', {}))
-        for item_type in REQUIRED_VEHICLE_COMPONENT_TYPES + (10,):
-            items = inventory_items.get(item_type)
-            if not isinstance(items, dict) or not items:
+            required_prices = set()
+            for item_type in REQUIRED_VEHICLE_COMPONENT_TYPES + (10,):
+                required_prices.update(inventory_items[item_type])
+            installed_item_compact_descrs.update(required_prices)
+            if not required_prices.issubset(set(item_prices)):
                 raise ValueError(
-                    'selected vehicle item type %d must be non-empty' %
-                    item_type)
-
-        required_prices = set()
-        for item_type in REQUIRED_VEHICLE_COMPONENT_TYPES + (10,):
-            required_prices.update(inventory_items[item_type])
-        installed_item_compact_descrs.update(required_prices)
-        if not required_prices.issubset(set(item_prices)):
-            raise ValueError(
-                'selected vehicle modules and shells must have shop prices')
-        shell_pairs = dict(
-            (shells[index], shells[index + 1])
-            for index in range(0, len(shells), 2))
-        if shell_pairs != inventory_items[10]:
-            raise ValueError(
-                'selected vehicle shell layout and inventory must match')
+                    'selected vehicle modules and shells must have shop prices')
+            shell_pairs = dict(
+                (shells[index], shells[index + 1])
+                for index in range(0, len(shells), 2))
+            if shell_pairs != inventory_items[10]:
+                raise ValueError(
+                    'selected vehicle shell layout and inventory must match')
+        except VehicleRestoreError:
+            raise
+        except Exception as error:
+            raise VehicleRestoreError(
+                str(error), record.get('vehicleTypeCompactDescr'))
 
     if len(set(vehicle_ids)) != len(vehicle_ids):
         raise ValueError('vehicle inventory ids must be unique')

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/garage.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/garage.py
@@ -308,6 +308,14 @@ class GarageState(object):
                                 if value < 0)
         if len(values) % 2:
             raise GarageError('shells must be descriptor/count pairs')
+        if not values:
+            # A rack with no rows at all is a garage this port cannot
+            # publish: data._validate_selected_vehicle requires the flat pair
+            # list and the shell inventory to name what the vehicle carries,
+            # even when every count is zero.  Refusing the command keeps the
+            # live garage writable instead of producing a save the next start
+            # cannot read.
+            raise GarageError('a shell layout must name at least one round')
         record = self._record(vehicle_inventory_id, touch=False)
         # data._validate_selected_vehicle requires the shell inventory and the
         # flat pair list to agree, so both move together.
@@ -696,7 +704,10 @@ class GarageState(object):
                 for compact_descr, count in _layout_pairs(
                         shells_layout, preserve_currency=True):
                     flat.extend((compact_descr, count))
-                self.equip_shells(vehicle_inventory_id, flat)
+                # An empty layout in a combined request names no round to
+                # set, which is not the same as emptying the rack.
+                if flat:
+                    self.equip_shells(vehicle_inventory_id, flat)
             if (equipments_layout is not None and
                     _int(equipment_type) == EQUIPMENT_TYPE_REGULAR):
                 pairs = _layout_pairs(

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/garage_store.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/garage_store.py
@@ -54,6 +54,19 @@ _VEHICLE_INT_KEYS = (
     'eqs', 'eqsLayout', 'shells', 'shellsLayoutIdx', 'repair')
 _CUSTOMIZATION_SEASONS = (1, 2, 4, 8, 15)
 MAX_BATTLE_RECEIPTS = 512
+# How many individual vehicles a restore may drop before it stops trying.  A
+# handful of refused records is a stale save against a changed catalogue; a
+# long run of them means the file itself is wrong, and the ledger-only restore
+# below is the honest answer.
+MAX_CONTAINED_VEHICLES = 8
+
+
+# The relational validator owns this type. It is raised from both the native
+# descriptor checks in ``bootstrap`` and the snapshot checks in ``data``, and
+# what a restore acts on is the ``vehicle_key`` it carries rather than the
+# class: a validator loaded through a second module instance is a different
+# class object with the same contract.
+VehicleRestoreError = data.VehicleRestoreError
 
 
 def _log(message):
@@ -329,6 +342,16 @@ class GarageStore(object):
         # Inventory ids are rebuilt on startup. Preserve actual crew awards
         # for a same-session results retry, never as durable crew identity.
         self._session_crew_xp = {}
+        # What the file on disk holds, so a write that would destroy far more
+        # than the command behind it can be recognised before it replaces it.
+        self._saved_vehicle_keys = None
+        self._saved_unlock_count = 0
+        self._rotated = False
+        self._shrink_kept = False
+        # Set when a restore could not publish the save whole: this session
+        # plays a garage the file does not describe, so nothing but a real
+        # player change may rewrite it.
+        self._restore_degraded = False
 
     # ---- writing --------------------------------------------------------
 
@@ -343,14 +366,129 @@ class GarageStore(object):
         """
         if not self._dirty or self._path is None:
             return False
-        payload = self._payload(snapshot)
+        if not self._write_state(self._payload(snapshot), snapshot):
+            return False
+        self._dirty = False
+        return True
+
+    def _write_state(self, payload, snapshot=None):
+        """Replace the saved garage, keeping a copy of what it overwrites.
+
+        Every write here is the whole file, so a payload built from the wrong
+        snapshot replaces a career rather than editing it.  Three things stand
+        between that and a lost career: one rotated copy per session, a
+        quarantined copy the first time a write shrinks the save, and a
+        refusal for the shapes no accepted command can produce.
+        """
+        if self._path is None:
+            return False
+        removed, lost_unlocks = self._destroyed_by(payload)
+        if removed or lost_unlocks:
+            reason = self._refusal(payload, removed, lost_unlocks, snapshot)
+            if reason is not None:
+                _log('the garage state was NOT saved: %s. The save on disk is '
+                     'kept as it is, so nothing earned before this session is '
+                     'lost; restart the client to load it again' % reason)
+                return False
+            if not self._shrink_kept:
+                kept = port_config.quarantine_state_file(
+                    self._path, port_config.QUARANTINE_SHRUNK)
+                self._shrink_kept = True
+                dropped = []
+                if removed:
+                    dropped.append('%d vehicle(s)' % len(removed))
+                if lost_unlocks:
+                    dropped.append(
+                        '%d researched item(s) this client no longer offers'
+                        % lost_unlocks)
+                _log('this save write drops %s; the previous file was kept '
+                     'as %s' % (
+                         ' and '.join(dropped),
+                         kept if kept is not None else '(no copy)'))
+        if not self._rotated:
+            port_config.rotate_state_backup(self._path)
+            self._rotated = True
         try:
             port_config.write_json(self._path, payload)
         except (IOError, OSError) as error:
             _log('the garage state could not be saved: %s' % error)
             return False
-        self._dirty = False
+        self._remember_saved(payload)
         return True
+
+    def _destroyed_by(self, payload):
+        """Return what one payload would remove from the file on disk.
+
+        Both counts come from what the last read or write left in memory, so
+        an ordinary write costs no file access and no second copy of the
+        unlock set.
+        """
+        if self._saved_vehicle_keys is None:
+            return (frozenset(), 0)
+        removed = frozenset(self._saved_vehicle_keys) - frozenset(
+            payload.get('vehicles') or ())
+        ledger = payload.get('ledger')
+        unlocks = (ledger.get('unlocks') if isinstance(ledger, dict) else ())
+        lost = max(0, self._saved_unlock_count - len(unlocks or ()))
+        return (removed, lost)
+
+    def _refusal(self, payload, removed, lost_unlocks, snapshot):
+        """Return why a write must not happen, or None to let it through.
+
+        Selling a vehicle and spending credits legitimately shrink a save, and
+        so does playing against a vehicle catalogue that no longer offers
+        something the save named, so a shrinking write is kept rather than
+        refused.  Two shapes have no accepted command behind them:
+
+        - a garage that lost every vehicle at once, which is what an empty or
+          not-yet-populated snapshot writes; and
+        - research this client still sells that the payload no longer holds.
+          Nothing in this economy ever revokes research, so a payload missing
+          an item the current catalogue still offers was not built from the
+          saved account at all.  That is the write that turns a career into a
+          new account, and it is the one worth refusing.
+        """
+        if removed and not payload.get('vehicles'):
+            return ('a payload with no vehicles would replace %d saved '
+                    'vehicle(s)' % len(removed))
+        if not lost_unlocks:
+            return None
+        missing = self._missing_unlocks(payload)
+        if not missing:
+            return None
+        offered = set(int(compact_descr)
+                      for compact_descr in ((snapshot or {}).get(
+                          'shopItemPrices') or ()))
+        still_offered = missing & offered if offered else missing
+        if still_offered:
+            return ('%d researched item(s) this client still offers are '
+                    'missing from the payload, including %d' % (
+                        len(still_offered), min(still_offered)))
+        return None
+
+    def _missing_unlocks(self, payload):
+        """Return the saved research a payload does not carry.
+
+        The saved set is re-read here rather than held: it is the whole
+        catalogue in a fully unlocked save, and this only runs on the write
+        that already looks wrong.
+        """
+        stored = self._read_file(self._path)
+        ledger = (stored or {}).get('ledger')
+        saved = (ledger.get('unlocks') if isinstance(ledger, dict) else None)
+        if not isinstance(saved, (list, tuple)):
+            return set()
+        payload_ledger = payload.get('ledger')
+        published = (payload_ledger.get('unlocks')
+                     if isinstance(payload_ledger, dict) else ())
+        return set(_int_value(value) for value in saved) - set(
+            _int_value(value) for value in (published or ()))
+
+    def _remember_saved(self, payload):
+        self._saved_vehicle_keys = frozenset(payload.get('vehicles') or ())
+        ledger = payload.get('ledger')
+        unlocks = (ledger.get('unlocks') if isinstance(ledger, dict) else None)
+        self._saved_unlock_count = len(unlocks or ())
 
     def _payload(self, snapshot, battle_receipts=None):
         vehicles = {}
@@ -578,9 +716,15 @@ class GarageStore(object):
         marker['service_costs'] = dict(result['service_costs'])
         next_receipts = (list(self._battle_receipts) + [marker])[
             -MAX_BATTLE_RECEIPTS:]
-        if self._path is not None:
-            port_config.write_json(
-                self._path, self._payload(staged, next_receipts))
+        if self._path is not None and not self._write_state(
+                self._payload(staged, next_receipts), staged):
+            # The award is not banked unless its marker reaches disk with it,
+            # or a retried receipt would award it twice.  The server keeps an
+            # unacknowledged receipt, so leaving it pending is recoverable and
+            # claiming it silently is not.
+            raise RuntimeError(
+                'the garage state could not be saved, so this battle receipt '
+                'is left pending')
         snapshot.clear()
         snapshot.update(staged)
         self._battle_receipts = next_receipts
@@ -605,22 +749,118 @@ class GarageStore(object):
         happen on a detached copy; any problem leaves the bootstrap snapshot
         byte-for-byte untouched.  ``validator`` may additionally exercise the
         exact client's native compact-descriptor parsers before commit.
+
+        A refusal is contained as narrowly as the validator can attribute it.
+        One vehicle this client cannot publish costs that vehicle's fittings
+        and crew, not the account's research, balances and every other tank:
+        the whole save used to be discarded over any single bad field, and the
+        first accepted change afterwards overwrote it with the stock garage.
         """
         stored = self._read()
         self._session_crew_xp = {}
         if stored is None:
             self._receipts_loaded = True
             return False
+        skipped = set()
+        while True:
+            staged, applied = self._staged(snapshot, stored, skipped)
+            try:
+                self._validate_staged(staged, validator)
+            except Exception as error:
+                key = getattr(error, 'vehicle_key', None)
+                if (key is None or key in skipped or
+                        len(skipped) >= MAX_CONTAINED_VEHICLES):
+                    _log('the saved garage state is inconsistent (%s)'
+                         % error)
+                    break
+                skipped.add(key)
+                _log('the saved garage for vehicle %s is inconsistent; that '
+                     'one vehicle is restored as stock (%s)' % (key, error))
+                continue
+            return self._commit(snapshot, stored, staged, applied, skipped)
+
+        # Nothing about the vehicles could be published.  The ledger is plain
+        # integers and crew the barracks owns, so it is restored on its own
+        # rather than lost with them: research and balances are what a career
+        # cannot rebuild by playing.
+        staged, applied = self._staged(
+            snapshot, stored, skipped=None, ledger_only=True)
+        try:
+            self._validate_staged(staged, validator)
+        except Exception as error:
+            kept = port_config.quarantine_state_file(
+                self._path, port_config.QUARANTINE_REJECTED)
+            _log('the saved garage state could not be published at all; using '
+                 'the stock garage (%s). The refused file was kept as %s'
+                 % (error, kept if kept is not None else '(no copy)'))
+            # Do not trust receipt markers whose matching crew descriptors
+            # could not be restored.  A pending server receipt may now safely
+            # rebuild the award on the fresh bootstrap garage.
+            self._battle_receipts = []
+            self._receipts_loaded = True
+            self._restore_degraded = True
+            return False
+        return self._commit(
+            snapshot, stored, staged, applied, skipped, ledger_only=True)
+
+    def _commit(self, snapshot, stored, staged, applied, skipped,
+                ledger_only=False):
+        """Publish one restored garage and report how complete it is."""
+        snapshot.clear()
+        snapshot.update(staged)
+        self._battle_receipts = self._validated_battle_receipts(
+            stored.get('battleCrewReceipts'))
+        self._receipts_loaded = True
+        if ledger_only or skipped:
+            self._restore_degraded = True
+            kept = port_config.quarantine_state_file(
+                self._path, port_config.QUARANTINE_REJECTED)
+            _log('the saved garage was restored without %s; the file as it '
+                 'was saved was kept as %s' % (
+                     'any vehicle fitting or crew' if ledger_only else
+                     '%d vehicle(s)' % len(skipped),
+                     kept if kept is not None else '(no copy)'))
+        if applied:
+            _log('restored the saved garage for %d vehicle(s)' % applied)
+        return True
+
+    def restore_degraded(self):
+        """Report whether this session plays a garage the save does not hold.
+
+        A caller that writes the save for its own convenience rather than for
+        something the player did must not do it while this is true: the file
+        still holds fittings and crew this client could not publish, and a
+        later build may well be able to.
+        """
+        return self._restore_degraded
+
+    def _validate_staged(self, staged, validator):
+        if validator is not None:
+            validator(staged)
+        _floor_account_stock(staged)
+        data._validate_selected_vehicle(staged)
+
+    def _staged(self, snapshot, stored, skipped, ledger_only=False):
+        """Build one candidate restore on a detached copy of the snapshot.
+
+        ``skipped`` names the saved vehicles to leave at their stock build;
+        ``ledger_only`` leaves every vehicle stock and restores just the
+        account.  Each attempt starts from the bootstrap snapshot again so a
+        refused overlay cannot leave half of itself behind.
+        """
         staged = copy.deepcopy(snapshot)
         vehicles = stored.get('vehicles')
-        if not isinstance(vehicles, dict):
+        if not isinstance(vehicles, dict) or ledger_only:
             vehicles = {}
         applied = 0
         for record in _records(staged):
             key = record.get('vehicleTypeCompactDescr')
             if key is None:
                 continue
-            saved = vehicles.get(str(int(key)))
+            key = str(int(key))
+            if skipped and key in skipped:
+                continue
+            saved = vehicles.get(key)
             if isinstance(saved, dict) and self._apply_vehicle(record, saved):
                 applied += 1
 
@@ -649,30 +889,7 @@ class GarageStore(object):
                         target[compact_descr] = int(count)
                 published[item_type] = target
         _apply_ledger(staged, stored)
-
-        try:
-            if validator is not None:
-                validator(staged)
-            _floor_account_stock(staged)
-            data._validate_selected_vehicle(staged)
-        except Exception as error:
-            _log('the saved garage state is inconsistent; using the stock '
-                 'garage (%s)' % error)
-            # Do not trust receipt markers whose matching crew descriptors
-            # could not be restored.  A pending server receipt may now safely
-            # rebuild the award on the fresh bootstrap garage.
-            self._battle_receipts = []
-            self._receipts_loaded = True
-            return False
-
-        snapshot.clear()
-        snapshot.update(staged)
-        self._battle_receipts = self._validated_battle_receipts(
-            stored.get('battleCrewReceipts'))
-        self._receipts_loaded = True
-        if applied:
-            _log('restored the saved garage for %d vehicle(s)' % applied)
-        return True
+        return (staged, applied)
 
     def _ensure_receipts_loaded(self):
         if self._receipts_loaded:
@@ -803,31 +1020,50 @@ class GarageStore(object):
         record.setdefault('inventoryItems', {})[11] = consumables
         return changed
 
+    @staticmethod
+    def _read_file(path):
+        """Parse one state file, or return None with the reason logged."""
+        if path is None or not os.path.isfile(path):
+            return None
+        try:
+            import json
+            with open(path, 'rb') as stream:
+                value = json.load(stream)
+        except (IOError, OSError, ValueError) as error:
+            _log('the saved garage state in %s is unreadable (%s)'
+                 % (path, error))
+            return None
+        if not isinstance(value, dict):
+            _log('the saved garage state in %s has an unexpected shape'
+                 % path)
+            return None
+        return value
+
     def _read(self):
         if self._path is None:
             return None
         for path in (self._path, self._path + '.bak'):
-            if not os.path.isfile(path):
-                continue
-            try:
-                import json
-                with open(path, 'rb') as stream:
-                    value = json.load(stream)
-            except (IOError, OSError, ValueError):
-                _log('the saved garage state is unreadable; using the '
-                     'stock garage')
-                continue
-            if not isinstance(value, dict):
-                _log('the saved garage state has an unexpected shape; using '
-                     'the stock garage')
+            value = self._read_file(path)
+            if value is None:
                 continue
             if value.get('schema') not in READABLE_SCHEMAS:
                 _log('the saved garage state uses schema %r, not one of %r; '
                      'using the stock garage' % (
                          value.get('schema'), READABLE_SCHEMAS))
                 return None
+            self._remember_read(value)
             return value
         return None
+
+    def _remember_read(self, stored):
+        """Record what the file holds, before this session can replace it."""
+        vehicles = stored.get('vehicles')
+        self._saved_vehicle_keys = frozenset(
+            vehicles if isinstance(vehicles, dict) else ())
+        ledger = stored.get('ledger')
+        unlocks = (ledger.get('unlocks') if isinstance(ledger, dict) else None)
+        self._saved_unlock_count = len(
+            unlocks if isinstance(unlocks, (list, tuple)) else ())
 
 
 def _records(snapshot):

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/garage_store.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/garage_store.py
@@ -352,6 +352,11 @@ class GarageStore(object):
         # plays a garage the file does not describe, so nothing but a real
         # player change may rewrite it.
         self._restore_degraded = False
+        # Set when no saved vehicle reached the garage at all.  Then every
+        # fitting and crew member in the file is one this session never had,
+        # so this session may not write the file back at any price.
+        self._vehicles_unrestored = False
+        self._refusals_logged = set()
 
     # ---- writing --------------------------------------------------------
 
@@ -382,13 +387,19 @@ class GarageStore(object):
         """
         if self._path is None:
             return False
+        if self._vehicles_unrestored and os.path.isfile(self._path):
+            # Not a judgement about this payload: no saved vehicle reached
+            # this session at all, so any payload it builds describes a
+            # garage this file never held.  Whether the vehicle count or the
+            # research happens to look smaller is beside the point.
+            self._refuse('no saved vehicle could be published this session, '
+                         'so this garage is not what the save holds')
+            return False
         removed, lost_unlocks = self._destroyed_by(payload)
         if removed or lost_unlocks:
             reason = self._refusal(payload, removed, lost_unlocks, snapshot)
             if reason is not None:
-                _log('the garage state was NOT saved: %s. The save on disk is '
-                     'kept as it is, so nothing earned before this session is '
-                     'lost; restart the client to load it again' % reason)
+                self._refuse(reason)
                 return False
             if not self._shrink_kept:
                 kept = port_config.quarantine_state_file(
@@ -415,6 +426,20 @@ class GarageStore(object):
             return False
         self._remember_saved(payload)
         return True
+
+    def _refuse(self, reason):
+        """Report one refused write, once per reason per session.
+
+        Fittings happen at click speed and a refused save stays refused, so
+        repeating the same line for every click would bury it.
+        """
+        if reason in self._refusals_logged:
+            return
+        self._refusals_logged.add(reason)
+        _log('the garage state was NOT saved: %s. The save on disk is kept as '
+             'it is, so nothing earned before this session is lost. Restart '
+             'the client to load it again, or restore a backup from the '
+             'Launcher' % reason)
 
     def _destroyed_by(self, payload):
         """Return what one payload would remove from the file on disk.
@@ -799,6 +824,7 @@ class GarageStore(object):
             self._battle_receipts = []
             self._receipts_loaded = True
             self._restore_degraded = True
+            self._vehicles_unrestored = True
             return False
         return self._commit(
             snapshot, stored, staged, applied, skipped, ledger_only=True)
@@ -813,6 +839,7 @@ class GarageStore(object):
         self._receipts_loaded = True
         if ledger_only or skipped:
             self._restore_degraded = True
+            self._vehicles_unrestored = bool(ledger_only)
             kept = port_config.quarantine_state_file(
                 self._path, port_config.QUARANTINE_REJECTED)
             _log('the saved garage was restored without %s; the file as it '

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/postbattle_store.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/postbattle_store.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 import copy
 import json
 import os
+import sys
 import time
 import uuid
 import zlib
@@ -817,6 +818,10 @@ def pack_battle_result(receipt, packers=None, replay_types=None,
     )
 
 
+def _log(message):
+    sys.stdout.write('[Offline LAN 0.9.22] %s\n' % message)
+
+
 class PostBattleStore(object):
     """Apply each LAN receipt once and retain it until the native 1501 ack."""
 
@@ -835,6 +840,7 @@ class PostBattleStore(object):
         # Native progress cards use current tankman inventory ids. Old results
         # remain readable after restart without pointing at a different crew.
         self._session_crew_xp = {}
+        self._rotated = False
         self._load()
 
     def set_progress_applier(self, callback):
@@ -1203,21 +1209,55 @@ class PostBattleStore(object):
         self._session_crew_xp = value['session_crew_xp']
 
     def _load(self):
-        if self._path is None or not os.path.isfile(self._path):
+        """Read the saved results, or say why the totals start from zero.
+
+        This file carries the account's lifetime record: battles, wins,
+        damage, medals and every per-vehicle mastery mark.  Discarding it used
+        to be silent and total, and the next terminal barrier then wrote the
+        empty totals back over it, so a file this build could not read cost
+        the player their record with nothing in the log to say so.
+        """
+        if self._path is None:
             return
-        try:
-            with open(self._path, 'rb') as stream:
-                value = json.load(stream)
-            if not isinstance(value, dict) or value.get('schema') != SCHEMA:
+        for path in (self._path, self._path + '.bak'):
+            if not os.path.isfile(path):
+                continue
+            reason = self._load_from(path)
+            if reason is None:
                 return
+            _log('the saved battle results in %s were not read (%s)'
+                 % (path, reason))
+            self._reset_saved()
+            if path == self._path:
+                kept = port_config.quarantine_state_file(
+                    path, port_config.QUARANTINE_REJECTED)
+                _log('the account record starts from empty totals; the '
+                     'refused file was kept as %s'
+                     % (kept if kept is not None else '(no copy)'))
+
+    def _reset_saved(self):
+        self._pending = {}
+        self._history = []
+        self._awards = {}
+        self._progress = self._empty_progress()
+
+    def _load_from(self, path):
+        """Adopt one saved file, or return why it was refused."""
+        try:
+            with open(path, 'rb') as stream:
+                value = json.load(stream)
+            if not isinstance(value, dict):
+                return 'the file does not hold a JSON object'
+            if value.get('schema') != SCHEMA:
+                return 'schema %r is not %r' % (value.get('schema'), SCHEMA)
             account_key = _bounded_text(value.get('accountKey'), 64)
             if not account_key:
-                return
+                return 'the account key is missing'
             pending = {}
             for raw in value.get('pending', ()):
                 receipt = _receipt(raw)
                 if receipt['account_key'] != account_key:
-                    return
+                    return 'a pending receipt belongs to another account'
                 pending[str(receipt['arena_unique_id'])] = receipt
             history = []
             for raw in value.get('history', ()):
@@ -1232,11 +1272,11 @@ class PostBattleStore(object):
                     if 'account_key' in raw:
                         raw = _receipt(raw)
                         if raw['account_key'] != account_key:
-                            return
+                            return 'an archived receipt belongs to another account'
                     history.append(raw)
             progress = value.get('progress')
             if not isinstance(history, list) or not isinstance(progress, dict):
-                return
+                return 'the stored totals are not in the expected shape'
             self._account_key = account_key
             self._pending = pending
             self._history = history
@@ -1289,12 +1329,10 @@ class PostBattleStore(object):
                     if isinstance(row, dict):
                         self._update_record_extrema(row, receipt)
             self._trim_history_bodies()
-        except (IOError, OSError, TypeError, ValueError):
+        except (IOError, OSError, TypeError, ValueError) as error:
             # Keep a corrupt optional cache from preventing an offline login.
-            self._pending = {}
-            self._history = []
-            self._awards = {}
-            self._progress = self._empty_progress()
+            return 'unreadable: %s' % error
+        return None
 
     def _archived_identities(self):
         """Project the archive down to what a restart actually needs.
@@ -1320,6 +1358,11 @@ class PostBattleStore(object):
             'history': self._archived_identities(),
             'progress': self._progress,
         }
+        if not self._rotated:
+            # The lifetime record is not reconstructible by playing, so keep
+            # the previous file once per session before replacing it.
+            port_config.rotate_state_backup(self._path)
+            self._rotated = True
         # This file is a machine-owned cache rewritten on the terminal round
         # barrier.  Only ``_load`` reads it, so sorted and indented output
         # buys nothing and costs the embedded 2.7 runtime its C JSON encoder.

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bootstrap.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bootstrap.py
@@ -181,7 +181,8 @@ def _restore_garage(snapshot):
         1 for record in (snapshot.get('vehicles') or ())
         if isinstance(record, dict) and
         str(record.get('vehicleTypeName') or '') not in named)
-    if unnamed:
+    degraded = getattr(store, 'restore_degraded', None)
+    if unnamed and not (callable(degraded) and degraded()):
         store.mark_dirty()
         if store.flush(snapshot):
             sys.stdout.write(
@@ -224,80 +225,100 @@ def _validate_restored_garage(snapshot):
     validates the relational snapshot. A saved fitting can differ from the
     initial stock descriptor without invalidating the player's whole garage.
     """
+    from gui.mods.offline_lan_0922.account_rpc import data
     from items import customizations, tankmen, vehicles
     records = snapshot.get('vehicles')
     if not isinstance(records, (list, tuple)):
         records = [snapshot]
     for record in records:
-        descriptor = vehicles.VehicleDescr(
-            compactDescr=record['compDescr'])
-        record.setdefault('inventoryItems', {}).update(
-            vehicle_records.mounted_module_items(descriptor))
-        devices = {}
-        for device in descriptor.optionalDevices:
-            if device is not None:
-                compact_descr = int(device.compactDescr)
-                devices[compact_descr] = devices.get(compact_descr, 0) + 1
-        record['inventoryItems'][9] = devices
-        nation_id, vehicle_type_id = descriptor.type.id
-        vehicle_type = vehicles.makeIntCompactDescrByID(
-            'vehicle', nation_id, vehicle_type_id)
-        if int(record.get('vehicleTypeCompactDescr', 0)) != int(vehicle_type):
-            raise ValueError(
-                'saved vehicle descriptor does not match its garage type')
-
-        layout_key = (int(descriptor.turret.compactDescr),
-                      int(descriptor.gun.compactDescr))
-        if tuple(record.get('shellsLayoutIdx') or ()) != layout_key:
-            raise ValueError(
-                'saved ammunition layout does not match the mounted gun')
-        compatible_shells = set()
-        for shot in (getattr(descriptor.gun, 'shots', ()) or ()):
-            shell = getattr(shot, 'shell', None)
-            compact_descr = getattr(shell, 'compactDescr', 0)
-            if compact_descr:
-                compatible_shells.add(int(compact_descr))
-        shells = list(record.get('shells') or ())
-        loaded = 0
-        for index in range(0, len(shells), 2):
-            compact_descr = int(shells[index])
-            count = int(shells[index + 1])
-            if compact_descr not in compatible_shells or count < 0:
-                raise ValueError(
-                    'saved ammunition does not fit the mounted gun')
-            loaded += count
-        # An empty rack is a real save: a battle that fired every round leaves
-        # one, and the layout still names what to buy back.  Refusing it here
-        # would throw the whole career away over an ordinary last shot.
-        maximum = int(getattr(descriptor.gun, 'maxAmmo', 0) or 0)
-        if maximum > 0 and loaded > maximum:
-            raise ValueError('saved ammunition exceeds the gun capacity')
-
-        crew_ids = list(record.get('crew') or ())
-        crew = dict(record.get('tankmen') or {})
-        roles = tuple(descriptor.type.crewRoles)
-        if len(crew_ids) != len(roles):
-            raise ValueError('saved crew does not match the vehicle')
-        for slot, tankman_id in enumerate(crew_ids):
-            if tankman_id is None:
-                # An unloaded seat is empty, not damaged: #1513 reads it back
-                # as a vehicle whose crew is not full.
-                continue
-            tankman = tankmen.TankmanDescr(crew[tankman_id])
-            if (int(tankman.nationID) != int(nation_id) or
-                    int(tankman.vehicleTypeID) != int(vehicle_type_id) or
-                    tankman.role != roles[slot][0]):
-                raise ValueError(
-                    'saved crew member does not match the vehicle slot')
-
-        for outfit_data in dict(record.get('outfits') or {}).values():
-            outfit_descr, unused_enabled = outfit_data
-            customizations.parseOutfitDescr(outfit_descr)
+        try:
+            _validate_restored_vehicle(
+                record, vehicles, tankmen, customizations)
+        except data.VehicleRestoreError:
+            raise
+        except Exception as error:
+            # Name the vehicle so the store can contain one refused record
+            # instead of discarding the whole save.
+            raise data.VehicleRestoreError(
+                str(error), record.get('vehicleTypeCompactDescr'))
 
     # A crew member in the barracks is published too, so a descriptor this
     # client cannot parse has to be caught at the same boundary.
     for compact_descr in (snapshot.get('barracksTankmen') or {}).values():
         tankmen.TankmanDescr(compact_descr)
+    return True
+
+
+def _validate_restored_vehicle(record, vehicles, tankmen, customizations):
+    """Exercise one saved vehicle's native descriptors.
+
+    Extracted so a refusal can name the vehicle it refused: the store
+    drops that one record and keeps the rest of the career.
+    """
+    descriptor = vehicles.VehicleDescr(
+        compactDescr=record['compDescr'])
+    record.setdefault('inventoryItems', {}).update(
+        vehicle_records.mounted_module_items(descriptor))
+    devices = {}
+    for device in descriptor.optionalDevices:
+        if device is not None:
+            compact_descr = int(device.compactDescr)
+            devices[compact_descr] = devices.get(compact_descr, 0) + 1
+    record['inventoryItems'][9] = devices
+    nation_id, vehicle_type_id = descriptor.type.id
+    vehicle_type = vehicles.makeIntCompactDescrByID(
+        'vehicle', nation_id, vehicle_type_id)
+    if int(record.get('vehicleTypeCompactDescr', 0)) != int(vehicle_type):
+        raise ValueError(
+            'saved vehicle descriptor does not match its garage type')
+
+    layout_key = (int(descriptor.turret.compactDescr),
+                  int(descriptor.gun.compactDescr))
+    if tuple(record.get('shellsLayoutIdx') or ()) != layout_key:
+        raise ValueError(
+            'saved ammunition layout does not match the mounted gun')
+    compatible_shells = set()
+    for shot in (getattr(descriptor.gun, 'shots', ()) or ()):
+        shell = getattr(shot, 'shell', None)
+        compact_descr = getattr(shell, 'compactDescr', 0)
+        if compact_descr:
+            compatible_shells.add(int(compact_descr))
+    shells = list(record.get('shells') or ())
+    loaded = 0
+    for index in range(0, len(shells), 2):
+        compact_descr = int(shells[index])
+        count = int(shells[index + 1])
+        if compact_descr not in compatible_shells or count < 0:
+            raise ValueError(
+                'saved ammunition does not fit the mounted gun')
+        loaded += count
+    # An empty rack is a real save: a battle that fired every round leaves
+    # one, and the layout still names what to buy back.  Refusing it here
+    # would throw the whole career away over an ordinary last shot.
+    maximum = int(getattr(descriptor.gun, 'maxAmmo', 0) or 0)
+    if maximum > 0 and loaded > maximum:
+        raise ValueError('saved ammunition exceeds the gun capacity')
+
+    crew_ids = list(record.get('crew') or ())
+    crew = dict(record.get('tankmen') or {})
+    roles = tuple(descriptor.type.crewRoles)
+    if len(crew_ids) != len(roles):
+        raise ValueError('saved crew does not match the vehicle')
+    for slot, tankman_id in enumerate(crew_ids):
+        if tankman_id is None:
+            # An unloaded seat is empty, not damaged: #1513 reads it back
+            # as a vehicle whose crew is not full.
+            continue
+        tankman = tankmen.TankmanDescr(crew[tankman_id])
+        if (int(tankman.nationID) != int(nation_id) or
+                int(tankman.vehicleTypeID) != int(vehicle_type_id) or
+                tankman.role != roles[slot][0]):
+            raise ValueError(
+                'saved crew member does not match the vehicle slot')
+
+    for outfit_data in dict(record.get('outfits') or {}).values():
+        outfit_descr, unused_enabled = outfit_data
+        customizations.parseOutfitDescr(outfit_descr)
     return True
 
 

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/config.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/config.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import json
 import os
 import re
+import time
 
 
 try:
@@ -168,6 +169,128 @@ def _copy_defaults():
     return dict((key, (value[:] if isinstance(value, list) else
                        dict(value) if isinstance(value, dict) else value))
                 for key, value in DEFAULT_CONFIG.items())
+
+
+# How many rotated copies of one state file are kept beside it.  A save is a
+# few hundred kilobytes, so keeping a short history costs almost nothing and
+# is the only thing that makes an overwritten career recoverable at all.
+STATE_BACKUP_GENERATIONS = 3
+# How many quarantined copies of one state file are kept.  Each is evidence of
+# a save this client refused or shrank, so the oldest is dropped rather than
+# the newest.
+STATE_QUARANTINE_COPIES = 5
+BACKUP_SUFFIX = '.backup'
+QUARANTINE_REJECTED = 'rejected'
+QUARANTINE_SHRUNK = 'shrunk'
+
+
+def _state_variant_path(path, marker):
+    """Return ``<name>.<marker>.json`` beside one state file.
+
+    Keeping the ``.json`` extension means a player can open a backup in any
+    text editor and copy it back over the live file by hand, which is the
+    recovery path that needs no tooling at all.
+    """
+    base, extension = os.path.splitext(path)
+    return '%s.%s%s' % (base, marker, extension or '.json')
+
+
+def state_backup_path(path, generation):
+    return _state_variant_path(path, 'backup%d' % int(generation))
+
+
+def rotate_state_backup(path, generations=STATE_BACKUP_GENERATIONS):
+    """Keep the last few copies of one state file beside it.
+
+    Called once per store per session, before the first write, so a session
+    that destroys a save leaves the previous one intact.  A failure here is
+    never fatal: a missing backup is worse than no backup only if it stops the
+    player from playing, which it must not.
+    """
+    if not os.path.isfile(path):
+        return False
+    generations = max(1, int(generations))
+    try:
+        for generation in range(generations, 1, -1):
+            older = state_backup_path(path, generation)
+            newer = state_backup_path(path, generation - 1)
+            if not os.path.isfile(newer):
+                continue
+            if os.path.exists(older):
+                os.unlink(older)
+            os.rename(newer, older)
+        _copy_file(path, state_backup_path(path, 1))
+    except (IOError, OSError):
+        return False
+    return True
+
+
+def quarantine_state_file(path, tag, copies=STATE_QUARANTINE_COPIES):
+    """Copy one state file aside under a timestamped name.
+
+    The live file is copied rather than moved: this client has already decided
+    to carry on without it, and moving it would turn a refused save into a
+    missing one.  Returns the copy's path, or None when there was nothing to
+    keep.
+    """
+    if not os.path.isfile(path):
+        return None
+    # Every stamp has the same fixed width, so the names sort chronologically
+    # and trimming the oldest cannot delete the copy just written.  Two calls
+    # inside one millisecond would collide, so the millisecond field is walked
+    # forward rather than a shorter-sorting suffix appended.
+    now = time.time()
+    second = time.strftime('%Y%m%d-%H%M%S', time.gmtime(now))
+    candidate = None
+    for millisecond in range(int((now % 1) * 1000), 1000):
+        candidate = _state_variant_path(
+            path, '%s-%s-%03d' % (tag, second, millisecond))
+        if not os.path.exists(candidate):
+            break
+    else:
+        return None
+    try:
+        _copy_file(path, candidate)
+    except (IOError, OSError):
+        return None
+    _trim_quarantine(path, tag, copies)
+    return candidate
+
+
+def _trim_quarantine(path, tag, copies):
+    """Drop the oldest quarantined copies of one file beyond ``copies``."""
+    directory = os.path.dirname(path) or '.'
+    base, extension = os.path.splitext(os.path.basename(path))
+    prefix = '%s.%s-' % (base, tag)
+    try:
+        names = sorted(
+            name for name in os.listdir(directory)
+            if name.startswith(prefix) and name.endswith(extension or '.json'))
+    except (IOError, OSError):
+        return
+    for name in names[:max(0, len(names) - max(1, int(copies)))]:
+        try:
+            os.unlink(os.path.join(directory, name))
+        except (IOError, OSError):
+            pass
+
+
+def _copy_file(source_path, destination_path):
+    """Replace one file with a copy of another, contents first.
+
+    ``shutil`` is avoided on purpose: this runs inside the game's embedded
+    interpreter during startup and settlement, and a plain streamed copy has
+    no import cost and no metadata behaviour to reason about.
+    """
+    temporary_path = destination_path + '.tmp'
+    with open(source_path, 'rb') as source:
+        with open(temporary_path, 'wb') as destination:
+            while True:
+                block = source.read(262144)
+                if not block:
+                    break
+                destination.write(block)
+    _replace(temporary_path, destination_path, write_through=False)
 
 
 def _quarantine_invalid_config(path):

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/config.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/config.py
@@ -249,28 +249,44 @@ def quarantine_state_file(path, tag, copies=STATE_QUARANTINE_COPIES):
             break
     else:
         return None
+    # Make room first: a copy that is trimmed the moment it is written would
+    # leave the player with older evidence than the file just refused.
+    _trim_quarantine(path, tag, max(1, int(copies)) - 1)
     try:
         _copy_file(path, candidate)
     except (IOError, OSError):
         return None
-    _trim_quarantine(path, tag, copies)
     return candidate
 
 
 def _trim_quarantine(path, tag, copies):
-    """Drop the oldest quarantined copies of one file beyond ``copies``."""
+    """Drop the oldest quarantined copies of one file beyond ``copies``.
+
+    Ordered by write time rather than by name: a trimmed name becomes free
+    again, so the next copy can take it back and name order stops matching
+    the order the copies were made in.
+    """
     directory = os.path.dirname(path) or '.'
     base, extension = os.path.splitext(os.path.basename(path))
     prefix = '%s.%s-' % (base, tag)
+    rows = []
     try:
-        names = sorted(
-            name for name in os.listdir(directory)
-            if name.startswith(prefix) and name.endswith(extension or '.json'))
+        names = [name for name in os.listdir(directory)
+                 if name.startswith(prefix) and
+                 name.endswith(extension or '.json')]
     except (IOError, OSError):
         return
-    for name in names[:max(0, len(names) - max(1, int(copies)))]:
+    for name in names:
+        full_path = os.path.join(directory, name)
         try:
-            os.unlink(os.path.join(directory, name))
+            rows.append((os.path.getmtime(full_path), name, full_path))
+        except (IOError, OSError):
+            continue
+    rows.sort()
+    for unused_stamp, unused_name, full_path in rows[
+            :max(0, len(rows) - max(0, int(copies)))]:
+        try:
+            os.unlink(full_path)
         except (IOError, OSError):
             pass
 

--- a/tests/test_port_0922.py
+++ b/tests/test_port_0922.py
@@ -709,6 +709,81 @@ class PortConfigTests(unittest.TestCase):
             self.assertEqual(value, json.loads(compact_text))
             self.assertEqual(value, json.loads(readable_text))
 
+    def test_a_state_file_keeps_the_last_few_copies_of_itself(self):
+        """The only thing that makes an overwritten save recoverable.
+
+        One rotation per session is enough to survive the write that
+        destroyed a career, and the copies keep the ``.json`` extension so a
+        player can copy one back by hand with no tooling at all.
+        """
+        config_module = _load_port_source('config')
+        with tempfile.TemporaryDirectory() as directory:
+            path = str(Path(directory) / 'garage_state.json')
+            for generation in range(1, 5):
+                config_module.write_json(path, {'generation': generation})
+                config_module.rotate_state_backup(path)
+
+            first = str(Path(directory) / 'garage_state.backup1.json')
+            second = str(Path(directory) / 'garage_state.backup2.json')
+            third = str(Path(directory) / 'garage_state.backup3.json')
+            self.assertEqual(
+                {'generation': 4}, json.loads(Path(first).read_text()))
+            self.assertEqual(
+                {'generation': 3}, json.loads(Path(second).read_text()))
+            self.assertEqual(
+                {'generation': 2}, json.loads(Path(third).read_text()))
+            self.assertFalse(
+                (Path(directory) / 'garage_state.backup4.json').exists())
+
+    def test_rotating_a_state_file_that_does_not_exist_is_not_an_error(self):
+        config_module = _load_port_source('config')
+        with tempfile.TemporaryDirectory() as directory:
+            path = str(Path(directory) / 'garage_state.json')
+
+            self.assertFalse(config_module.rotate_state_backup(path))
+            self.assertEqual([], sorted(os.listdir(directory)))
+
+    def test_a_refused_state_file_is_copied_aside_rather_than_moved(self):
+        """This client carries on without the file, so it must stay put.
+
+        Moving it would turn a save this build refused into a save the next
+        build cannot find either.
+        """
+        config_module = _load_port_source('config')
+        with tempfile.TemporaryDirectory() as directory:
+            path = str(Path(directory) / 'garage_state.json')
+            config_module.write_json(path, {'career': True})
+
+            kept = config_module.quarantine_state_file(
+                path, config_module.QUARANTINE_REJECTED)
+
+            self.assertTrue(os.path.isfile(path))
+            self.assertEqual(
+                {'career': True}, json.loads(Path(kept).read_text()))
+            self.assertTrue(
+                os.path.basename(kept).startswith('garage_state.rejected-'))
+            self.assertTrue(kept.endswith('.json'))
+
+    def test_quarantined_copies_are_capped_and_drop_the_oldest(self):
+        config_module = _load_port_source('config')
+        with tempfile.TemporaryDirectory() as directory:
+            path = str(Path(directory) / 'garage_state.json')
+            config_module.write_json(path, {'career': True})
+
+            for unused in range(4):
+                kept = config_module.quarantine_state_file(
+                    path, config_module.QUARANTINE_REJECTED, copies=2)
+
+            surviving = sorted(
+                name for name in os.listdir(directory)
+                if '.rejected-' in name)
+            self.assertEqual(2, len(surviving))
+            self.assertIn(os.path.basename(kept), surviving)
+            self.assertEqual(
+                {'career': True},
+                json.loads(
+                    (Path(directory) / surviving[0]).read_text()))
+
     def test_waiting_room_choices_round_trip_in_player_owned_state(self):
         config_module = _load_port_source('config')
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_port_0922_garage.py
+++ b/tests/test_port_0922_garage.py
@@ -2718,6 +2718,50 @@ class GarageSaveDurabilityTests(unittest.TestCase):
         self.assertEqual(
             [11001, 0, 0], self._saved()['vehicles']['50002']['eqs'])
 
+    def test_a_session_that_restored_no_vehicle_may_not_write_the_save(self):
+        """The reported loss, refused on the fact rather than on arithmetic.
+
+        A save this client refuses outright leaves the player in the garage
+        the bootstrap built from the file's own vehicle list: the same tanks,
+        stock, with the seeded research.  Whether that payload happens to look
+        smaller than the file decides nothing -- no saved vehicle reached this
+        session, so this session cannot describe the save.
+        """
+        store, snapshot = self._save_career(equipped=True)
+        fresh = self._career_snapshot()
+
+        def reject(unused_staged):
+            raise ValueError('native descriptor rejected')
+
+        reloaded = self._store()
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.assertFalse(reloaded.apply(fresh, validator=reject))
+
+        # The same research the save holds, so no shrink rule can fire.
+        reloaded.mark_dirty()
+        with contextlib.redirect_stdout(io.StringIO()) as log:
+            self.assertFalse(reloaded.flush(snapshot))
+            reloaded.mark_dirty()
+            self.assertFalse(reloaded.flush(snapshot))
+
+        self.assertIn('no saved vehicle could be published', log.getvalue())
+        # One line per reason, not one per click.
+        self.assertEqual(1, log.getvalue().count('was NOT saved'))
+        self.assertEqual(
+            [11001, 0, 0], self._saved()['vehicles']['50002']['eqs'])
+
+    def test_a_first_save_is_written_even_though_nothing_was_restored(self):
+        """A save that does not exist yet has nothing to protect."""
+        store = self._store()
+        fresh = self._career_snapshot()
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.assertFalse(store.apply(fresh))
+            store.mark_dirty()
+            self.assertTrue(store.flush(fresh))
+
+        self.assertEqual(
+            ['50001', '50002'], sorted(self._saved()['vehicles']))
+
     def test_a_save_nothing_can_publish_is_kept_beside_the_stock_garage(self):
         store, snapshot = self._save_career()
         fresh = copy.deepcopy(SNAPSHOT)

--- a/tests/test_port_0922_garage.py
+++ b/tests/test_port_0922_garage.py
@@ -2438,6 +2438,302 @@ class StockRuleTests(unittest.TestCase):
             set(records.STOCKED_ITEM_TYPES))
 
 
+class GarageSaveDurabilityTests(unittest.TestCase):
+    """A career is never destroyed silently: contain it, keep it, or refuse.
+
+    Every write here replaces the whole file, so a payload built from the
+    wrong snapshot replaces a career rather than editing it.  These are the
+    boundaries that make such a write recoverable, or stop it happening.
+    """
+
+    def setUp(self):
+        unused_requests, unused_commands, self.garage = _request_modules()
+        self.store_module = _load('garage_store')
+        self.directory = tempfile.mkdtemp()
+        self.path = os.path.join(self.directory, 'garage_state.json')
+
+    def tearDown(self):
+        shutil.rmtree(self.directory, ignore_errors=True)
+
+    def _state(self, snapshot=None):
+        vehicles, tankmen = _modules()
+        return self.garage.GarageState(
+            snapshot if snapshot is not None else SNAPSHOT,
+            vehicles_module=vehicles, tankmen_module=tankmen)
+
+    def _store(self):
+        return self.store_module.GarageStore(path=self.path)
+
+    def _saved(self):
+        with open(self.path, 'rb') as stream:
+            return json.load(stream)
+
+    def _variants(self, marker):
+        return sorted(
+            name for name in os.listdir(self.directory)
+            if name.startswith('garage_state.%s' % marker))
+
+    @staticmethod
+    def _career_snapshot():
+        """A save worth losing: two vehicles, money and researched items."""
+        snapshot = copy.deepcopy(SNAPSHOT)
+        snapshot['wallet'] = {'credits': 250000, 'gold': 700, 'freeXP': 4200}
+        # Everything installed has to be researched, exactly as bootstrap
+        # publishes it, or the relational validator refuses the snapshot for
+        # a reason that has nothing to do with what these tests exercise.
+        snapshot['unlockItemCompactDescrs'] = set(
+            (50001, 50002, 2002, 2003, 2004, 2005, 2006, 2007,
+             10010, 10011, 11001))
+        snapshot['shopItemPrices'][50002] = {'credits': 0, 'gold': 0}
+        second = copy.deepcopy(snapshot['vehicles'][0])
+        second['id'] = 10
+        second['compDescr'] = b'veh:10'
+        second['vehicleTypeCompactDescr'] = 50002
+        second['crew'] = [201, 202]
+        second['tankmen'] = {201: b'tman:201', 202: b'tman:202'}
+        snapshot['vehicles'].append(second)
+        snapshot['vehicleTypeCompactDescrs'] = set((50001, 50002))
+        return snapshot
+
+    def _save_career(self, equipped=False):
+        snapshot = self._career_snapshot()
+        if equipped:
+            # A real fitting on the second vehicle, so a restored record is
+            # distinguishable from the stock build the next start hands over.
+            # ``GarageState`` works on its own copy, so the mutated snapshot
+            # is the one it publishes back.
+            state = self._state(snapshot)
+            state.equip_equipments(10, [11001, 0, 0])
+            snapshot = state.snapshot()
+        store = self._store()
+        store.mark_dirty()
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.assertTrue(store.flush(snapshot))
+        return store, snapshot
+
+    def test_a_payload_with_no_vehicles_never_replaces_a_saved_garage(self):
+        """The shape a fresh or empty snapshot writes, and the reported bug.
+
+        No accepted command empties a garage: selling removes one vehicle at
+        a time.  A payload with none of them is a snapshot that never held
+        them, so the file it would replace is kept as it is.
+        """
+        store, unused_snapshot = self._save_career()
+
+        store.mark_dirty()
+        with contextlib.redirect_stdout(io.StringIO()) as log:
+            self.assertFalse(store.flush({}))
+
+        self.assertIn('was NOT saved', log.getvalue())
+        self.assertEqual(
+            ['50001', '50002'], sorted(self._saved()['vehicles']))
+        self.assertEqual(250000, self._saved()['ledger']['wallet']['credits'])
+
+    def test_a_stock_snapshot_never_replaces_a_researched_career(self):
+        """The reported loss: research, crew and fittings gone, tanks kept.
+
+        A save this client refuses to restore leaves the player in the garage
+        the bootstrap built -- the same vehicles, at their stock build, with
+        the seeded research.  Writing that over the file is what turned a
+        career into a new account, and nothing in this economy ever revokes
+        research, so the write is refused instead.
+        """
+        store, snapshot = self._save_career()
+        bootstrapped = self._career_snapshot()
+        bootstrapped['unlockItemCompactDescrs'] = set((50001, 50002))
+
+        store.mark_dirty()
+        with contextlib.redirect_stdout(io.StringIO()) as log:
+            self.assertFalse(store.flush(bootstrapped))
+
+        self.assertIn('was NOT saved', log.getvalue())
+        self.assertIn('this client still offers', log.getvalue())
+        self.assertEqual(
+            sorted(self._career_snapshot()['unlockItemCompactDescrs']),
+            self._saved()['ledger']['unlocks'])
+
+    def test_research_this_client_no_longer_offers_is_saved_without_it(self):
+        """A changed vehicle catalogue is not a broken save.
+
+        Only research the current catalogue still sells is evidence that the
+        payload was not built from the saved account, so a save that names an
+        item this client no longer offers still saves -- with a copy of the
+        file it replaced beside it.
+        """
+        store, snapshot = self._save_career()
+        retired = self._career_snapshot()
+        retired['unlockItemCompactDescrs'].remove(11001)
+        del retired['shopItemPrices'][11001]
+        del retired['inventoryItems'][11]
+
+        store.mark_dirty()
+        with contextlib.redirect_stdout(io.StringIO()) as log:
+            self.assertTrue(store.flush(retired))
+
+        self.assertIn('no longer offers', log.getvalue())
+        self.assertNotIn(11001, self._saved()['ledger']['unlocks'])
+        self.assertEqual(1, len(self._variants('shrunk-')))
+
+    def test_a_payload_with_no_research_never_replaces_researched_items(self):
+        """Research is only ever added, so losing all of it has no producer."""
+        store, snapshot = self._save_career()
+        snapshot['unlockItemCompactDescrs'] = set()
+
+        store.mark_dirty()
+        with contextlib.redirect_stdout(io.StringIO()) as log:
+            self.assertFalse(store.flush(snapshot))
+
+        self.assertIn('researched item(s) this client still offers',
+                      log.getvalue())
+        self.assertEqual(
+            sorted(self._career_snapshot()['unlockItemCompactDescrs']),
+            self._saved()['ledger']['unlocks'])
+
+    def test_one_sold_vehicle_is_saved_and_the_previous_file_kept(self):
+        """A real sale must still save; the shrink is only worth a copy.
+
+        Spending credits, selling a tank and playing against a changed
+        vehicle catalogue all legitimately shrink a save, so this write is
+        kept rather than refused -- with the file it replaced beside it.
+        """
+        store, snapshot = self._save_career()
+        snapshot['vehicles'].pop()
+
+        store.mark_dirty()
+        with contextlib.redirect_stdout(io.StringIO()) as log:
+            self.assertTrue(store.flush(snapshot))
+
+        self.assertIn('drops 1 vehicle', log.getvalue())
+        self.assertEqual(['50001'], sorted(self._saved()['vehicles']))
+        kept = self._variants('shrunk-')
+        self.assertEqual(1, len(kept))
+        with open(os.path.join(self.directory, kept[0]), 'rb') as stream:
+            self.assertEqual(
+                ['50001', '50002'], sorted(json.load(stream)['vehicles']))
+
+    def test_the_file_one_session_found_is_kept_for_the_next(self):
+        """One rotation per session, taken before the first write.
+
+        The write that destroys a save is the one right after the session
+        that broke it started, so the copy worth keeping is the file as this
+        session found it.
+        """
+        unused_store, snapshot = self._save_career()
+
+        second_session = self._store()
+        second_session.mark_dirty()
+        snapshot['wallet']['credits'] = 1
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.assertTrue(second_session.flush(snapshot))
+            second_session.mark_dirty()
+            self.assertTrue(second_session.flush(snapshot))
+
+        self.assertEqual(1, self._saved()['ledger']['wallet']['credits'])
+        self.assertEqual(
+            ['garage_state.backup1.json'], self._variants('backup'))
+        with open(os.path.join(
+                self.directory, 'garage_state.backup1.json'), 'rb') as stream:
+            self.assertEqual(
+                250000, json.load(stream)['ledger']['wallet']['credits'])
+
+    def test_one_refused_vehicle_leaves_the_rest_of_the_career(self):
+        store, snapshot = self._save_career(equipped=True)
+        fresh = self._career_snapshot()
+
+        def reject_second(staged):
+            for record in staged['vehicles']:
+                # Only the restored fitting is refused, which is what a
+                # native descriptor check actually rejects.
+                if (int(record['vehicleTypeCompactDescr']) == 50002 and
+                        list(record.get('eqs') or ()) != [0, 0, 0]):
+                    raise self.store_module.VehicleRestoreError(
+                        'saved crew member does not match the vehicle slot',
+                        50002)
+            return True
+
+        with contextlib.redirect_stdout(io.StringIO()) as log:
+            self.assertTrue(
+                self._store().apply(fresh, validator=reject_second))
+
+        self.assertIn('vehicle 50002', log.getvalue())
+        self.assertIn('without 1 vehicle', log.getvalue())
+        # The account survives the one vehicle it could not publish.
+        self.assertEqual(
+            {'credits': 250000, 'gold': 700, 'freeXP': 4200}, fresh['wallet'])
+        self.assertIn(50002, fresh['unlockItemCompactDescrs'])
+        self.assertEqual(1, len(self._variants('rejected-')))
+
+    def test_a_garage_no_vehicle_can_publish_still_restores_the_account(self):
+        """Research and balances are what playing cannot rebuild.
+
+        They are plain integers and cannot be the reason a native descriptor
+        was refused, so they are restored on their own rather than lost with
+        the fittings.
+        """
+        store, snapshot = self._save_career(equipped=True)
+        fresh = self._career_snapshot()
+        fresh['wallet'] = {'credits': 100000, 'gold': 0, 'freeXP': 0}
+        fresh['unlockItemCompactDescrs'] = set((50001,))
+
+        def reject_every_restored_vehicle(staged):
+            for record in staged['vehicles']:
+                if list(record.get('eqs') or ()) != [0, 0, 0]:
+                    raise ValueError('every saved fitting is unpublishable')
+            return True
+
+        with contextlib.redirect_stdout(io.StringIO()) as log:
+            self.assertTrue(self._store().apply(
+                fresh, validator=reject_every_restored_vehicle))
+
+        self.assertIn('without any vehicle fitting or crew', log.getvalue())
+        self.assertEqual(
+            {'credits': 250000, 'gold': 700, 'freeXP': 4200}, fresh['wallet'])
+        self.assertIn(50002, fresh['unlockItemCompactDescrs'])
+
+    def test_a_degraded_restore_is_not_rewritten_for_convenience(self):
+        """Only a real player change may replace a save this client refused.
+
+        The startup path that fills in vehicle names for the Launcher is a
+        convenience, and running it after a contained refusal would write the
+        stock build over fittings and crew a later build may still be able to
+        read.
+        """
+        store, snapshot = self._save_career(equipped=True)
+        fresh = self._career_snapshot()
+
+        def reject_second(staged):
+            for record in staged['vehicles']:
+                if (int(record['vehicleTypeCompactDescr']) == 50002 and
+                        list(record.get('eqs') or ()) != [0, 0, 0]):
+                    raise self.store_module.VehicleRestoreError(
+                        'unpublishable fitting', 50002)
+            return True
+
+        reloaded = self._store()
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.assertTrue(reloaded.apply(fresh, validator=reject_second))
+
+        self.assertTrue(reloaded.restore_degraded())
+        # The refused vehicle's saved fitting is still on disk.
+        self.assertEqual(
+            [11001, 0, 0], self._saved()['vehicles']['50002']['eqs'])
+
+    def test_a_save_nothing_can_publish_is_kept_beside_the_stock_garage(self):
+        store, snapshot = self._save_career()
+        fresh = copy.deepcopy(SNAPSHOT)
+        before = copy.deepcopy(fresh)
+
+        def reject(unused_staged):
+            raise ValueError('native descriptor rejected')
+
+        with contextlib.redirect_stdout(io.StringIO()) as log:
+            self.assertFalse(self._store().apply(fresh, validator=reject))
+
+        self.assertIn('could not be published at all', log.getvalue())
+        self.assertEqual(before, fresh)
+        self.assertEqual(1, len(self._variants('rejected-')))
+
+
 class GaragePersistenceTests(unittest.TestCase):
     """Persist -> reload -> same state, across a simulated client restart."""
 
@@ -2827,7 +3123,13 @@ class GaragePersistenceTests(unittest.TestCase):
             restored['shellsLayout'][(7001, 4444)])
         _load('data')._validate_selected_vehicle(fresh)
 
-    def test_a_saved_shell_outside_the_current_catalogue_falls_back_atomically(self):
+    def test_a_saved_shell_outside_the_current_catalogue_costs_one_vehicle(self):
+        """One stale fitting is contained to the vehicle that carries it.
+
+        The whole save used to be refused here, and the next accepted change
+        then wrote the stock garage over it: a single unpriced round cost the
+        player their research, their balances and every other tank.
+        """
         state = self._state()
         state.install_component(9, 4444)
         store = self._store()
@@ -2835,12 +3137,15 @@ class GaragePersistenceTests(unittest.TestCase):
         self.assertTrue(store.flush(state.snapshot()))
 
         fresh = copy.deepcopy(SNAPSHOT)
-        before = copy.deepcopy(fresh)
+        stock = copy.deepcopy(fresh['vehicles'][0])
         with contextlib.redirect_stdout(io.StringIO()) as log:
-            self.assertFalse(self._store().apply(fresh))
+            self.assertTrue(self._store().apply(fresh))
 
-        self.assertIn('inconsistent', log.getvalue())
-        self.assertEqual(before, fresh)
+        self.assertIn('vehicle 50001', log.getvalue())
+        self.assertEqual(stock, fresh['vehicles'][0])
+        self.assertTrue(any(
+            name.startswith('garage_state.rejected-')
+            for name in os.listdir(self.directory)))
 
     def test_a_native_validation_failure_falls_back_atomically(self):
         state = self._state()

--- a/tests/test_port_0922_garage.py
+++ b/tests/test_port_0922_garage.py
@@ -2511,6 +2511,67 @@ class GarageSaveDurabilityTests(unittest.TestCase):
             self.assertTrue(store.flush(snapshot))
         return store, snapshot
 
+    def test_a_researched_guns_own_rounds_do_not_refuse_the_save(self):
+        """The v0.7.0 loss, from a real client log.
+
+        Installing a researched gun loads the rounds that gun fires.  Rounds
+        are never researched in #1513, so nothing ever put them in the
+        account's unlocked set, and the next start refused the whole career
+        with "every garage vehicle, module and shell must be unlocked".
+        """
+        snapshot = self._career_snapshot()
+        # The catalogue prices the researched gun's own rounds, as bootstrap
+        # publishes every mountable gun's ammunition.
+        snapshot['shopItemPrices'].update({
+            4444: {'credits': 0, 'gold': 0},
+            7001: {'credits': 0, 'gold': 0},
+            20010: {'credits': 0, 'gold': 0},
+            20011: {'credits': 0, 'gold': 0},
+        })
+        snapshot['inventoryItems'][10].update({20010: 30, 20011: 15})
+        # The researched gun is unlocked, as researching it is what made it
+        # installable; its rounds never are.
+        snapshot['unlockItemCompactDescrs'].update((4444, 7001))
+        state = self._state(snapshot)
+        state.install_component(9, 4444)
+        snapshot = state.snapshot()
+        store = self._store()
+        store.mark_dirty()
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.assertTrue(store.flush(snapshot))
+
+        fresh = copy.deepcopy(snapshot)
+        for record in fresh['vehicles']:
+            record['shells'] = [10010, 20, 10011, 10]
+            record['shellsLayout'] = {(7001, 7002): [10010, 20, 10011, 10]}
+            record['shellsLayoutIdx'] = (7001, 7002)
+            record['inventoryItems'][10] = {10010: 20, 10011: 10}
+        with contextlib.redirect_stdout(io.StringIO()) as log:
+            restored = self._store().apply(fresh)
+
+        self.assertNotIn('must be unlocked', log.getvalue())
+        self.assertTrue(restored)
+        self.assertEqual(
+            (7001, 4444), tuple(fresh['vehicles'][0]['shellsLayoutIdx']))
+
+    def test_a_rack_with_no_rows_is_refused_rather_than_saved(self):
+        """Every live garage state has to be one the next start can read.
+
+        A rack with no rows at all is not a garage this port can publish, so
+        the command that would produce one is refused while the garage is
+        still writable.  A combined layout request that names no round is
+        setting nothing, not emptying the rack.
+        """
+        snapshot = self._career_snapshot()
+        state = self._state(snapshot)
+
+        self.assertRaises(
+            self.garage.GarageError, state.equip_shells, 9, [])
+        state.set_layouts(9, shells_layout=[])
+
+        self.assertEqual(
+            [10010, 20, 10011, 10], state.snapshot()['vehicles'][0]['shells'])
+
     def test_a_payload_with_no_vehicles_never_replaces_a_saved_garage(self):
         """The shape a fresh or empty snapshot writes, and the reported bug.
 

--- a/tests/test_port_0922_postbattle.py
+++ b/tests/test_port_0922_postbattle.py
@@ -1,4 +1,5 @@
 import base64
+import io
 import json
 import os
 import pickle
@@ -367,6 +368,51 @@ class PostBattleContractTests(unittest.TestCase):
         self.assertEqual(3000, tier_three_loss['credits'])
         self.assertEqual(3000 * 185 // 100,
                          tier_three_win['credits'])
+
+    def test_an_unreadable_record_says_why_and_is_kept_beside_the_new_one(self):
+        """This file is the account's lifetime record, not a scratch cache.
+
+        Discarding it used to be silent and total, and the next terminal
+        barrier wrote the empty totals back over it.  A player whose medals
+        and battle count reset had nothing in the log to report.
+        """
+        import contextlib
+
+        with tempfile.TemporaryDirectory() as folder:
+            path = str(Path(folder) / 'postbattle_state.json')
+            store = postbattle_store.PostBattleStore(path=path)
+            self.assertTrue(store.accept(_receipt(store.account_key)))
+            Path(path).write_text(
+                '{"schema": 1, "accountKey": "abcd", "pending": [], '
+                '"history": [], "progress": []}')
+
+            with contextlib.redirect_stdout(io.StringIO()) as log:
+                restarted = postbattle_store.PostBattleStore(path=path)
+
+            self.assertIn('were not read', log.getvalue())
+            self.assertIn('expected shape', log.getvalue())
+            self.assertEqual(0, restarted.progress()['battles'])
+            kept = sorted(
+                name for name in os.listdir(folder)
+                if name.startswith('postbattle_state.rejected-'))
+            self.assertEqual(1, len(kept))
+            self.assertIn('progress', Path(folder, kept[0]).read_text())
+
+    def test_a_record_left_behind_by_an_interrupted_replace_is_read(self):
+        """Windows keeps a ``.bak`` only when the atomic replace fell back.
+
+        A process killed inside that window leaves the record as the backup
+        alone, which is a complete file rather than a reason to start over.
+        """
+        with tempfile.TemporaryDirectory() as folder:
+            path = str(Path(folder) / 'postbattle_state.json')
+            store = postbattle_store.PostBattleStore(path=path)
+            self.assertTrue(store.accept(_receipt(store.account_key)))
+            os.rename(path, path + '.bak')
+
+            recovered = postbattle_store.PostBattleStore(path=path)
+
+            self.assertEqual(1, recovered.progress()['battles'])
 
     def test_store_survives_restart_applies_once_and_clears_only_on_ack(self):
         with tempfile.TemporaryDirectory() as folder:


### PR DESCRIPTION
## The report

A player on v0.7.0 lost a career save: research, crew skills and equipment gone
at tier V. His sequence was "played a battle, was killed, returned to the
garage, got a server-disconnected prompt, clicked nothing, the client crashed,
and the save was broken on the next start." The Launcher's save panel still
showed normal data.

**The exact trigger cannot be proved**: the save has been deleted and there is
no `python.log`. What the code does prove is why that loss was final:

- `config.write_json` is tmp + fsync + `MoveFileExW(WRITE_THROUGH)`, so a
  process kill cannot truncate the live file — and the normal Windows path
  leaves no `.bak`, so an overwrite had nothing behind it.
- `GarageStore.apply` refused the whole file for any single bad field, and
  `bootstrap._owned_vehicle_types` still built the saved vehicles from the same
  file, which is exactly "the tanks are there, the research and fittings are
  not".
- The first accepted garage change or battle settlement afterwards wrote that
  stock garage over the save.
- `PostBattleStore._load` discarded the account's lifetime record — battles,
  medals, mastery marks — on any problem, with no log line at all, and wrote
  the empty totals back at the next terminal barrier.

Note for future reports: the Launcher looking healthy proves nothing.
`save_ledger.read_balances` falls back to `save.json`'s `initial_wallet`
whenever `garage_state.json` is missing or has no ledger.

## What this changes

**Containment.** `bootstrap._validate_restored_vehicle` and
`data._validate_selected_vehicle`'s per-record loop raise a failure that names
the vehicle (`vehicle_key`); the store drops that one vehicle's saved overlay
and publishes the rest. If no vehicle can be published, the account ledger —
research, balances, barracks, recycle bin, slots, berths — is restored on its
own, because that is what playing cannot rebuild. The store matches on the
attribute rather than the class, since a validator loaded through a second
module instance is a different class object with the same contract.

**Two refusals.** A payload with no vehicles at all, and one missing research
this client still prices, have no accepted command behind them: both are what
an empty or freshly bootstrapped snapshot writes. They are refused, the file is
kept, and the log says so. Selling a vehicle, spending credits and a changed
vehicle catalogue all still save normally.

**Copies.** Each session rotates the file as it found it into
`<name>.backup1..3.json`. A refused or contained restore keeps the file it
could not publish as `<name>.rejected-<stamp>.json`; the first shrinking write
of a session keeps `<name>.shrunk-<stamp>.json`. A degraded restore also stops
the startup vehicle-naming convenience from rewriting the save.

**Launcher.** The Saves tab gains "Open save folder", "Back up save..." (one
ZIP holding the save and the copies beside it) and "Restore save...", which
refuses while the game runs and keeps what it replaced in a `pre-restore-<stamp>`
folder inside the save. Both languages, and "Reset all offline data" now also
removes the new copies.

## Tradeoff worth stating

A contained restore is a partial success: a vehicle whose saved fitting this
client cannot publish appears at its stock build instead of the whole save
being refused. And a session whose save was refused outright cannot write to it
at all — that is deliberate, since the alternative is replacing a career with a
new account.

## Validation

- `python -m unittest discover -s tests`: 4733 tests, OK.
- `launcher`: 610 tests, OK. `launcher/tests/test_launcher_core.py`: 173, OK.
- CPython 2.7.18 source compile of `src/res/scripts/client`: 103 files.
- New coverage: per-vehicle containment, the ledger-only tier, both refusals,
  the catalogue-change shrink, backup rotation and quarantine capping, the
  post-battle reason/quarantine/`.bak` path, and the Launcher backup, restore,
  hostile-archive and game-running refusals.

**Unproved:** none of this has run on the exact Windows client. It needs one
real session to confirm that a normal start still restores a save unchanged and
that the Launcher's three buttons behave on a real installation.