### PR TITLE
Default to a pull request instead of a direct push to main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,12 +27,14 @@ symlink target. Read this file before investigating or changing the repository.
   ambiguous; inspect the exact map, client data, logs, and lifecycle.
 - Fix an in-scope bug directly rather than handing it to an imaginary future
   owner. Preserve unrelated user changes in a dirty worktree.
-- Peng has explicitly permitted in-scope changes to be committed and pushed
-  directly to `main`. Never force-push. Create a tag or publish a release only
-  when Peng explicitly requests it. Keep validation proportional to his
-  instruction: report missing Windows evidence honestly, but do not invent an
-  extra review, full-CI, or native-acceptance gate after he explicitly asks to
-  commit, package, or release without it.
+- Land a change on a branch and open a pull request. That is the default even
+  for a fix Peng asked for directly, because he reads the change there before
+  it reaches `main`. Push `main` directly only when he asks for it in that
+  task; then say so in the handoff. Never force-push. Create a tag or publish
+  a release only when Peng explicitly requests it. Keep validation
+  proportional to his instruction: report missing Windows evidence honestly,
+  but do not invent an extra review, full-CI, or native-acceptance gate after
+  he explicitly asks to commit, package, or release without it.
 
 ## Start every task from the exact current state
 
@@ -309,9 +311,9 @@ source hash in this instruction file.
   not use a small fixed sleep as proof that a handler or worker consumed a
   message.
 - Unless Peng explicitly asks to skip them, inspect the staged diff, run the
-  proportional checks, commit one coherent change, push `main` when requested,
-  and verify the exact pushed commit's relevant CI for runtime, packaging, CI,
-  or release behavior.
+  proportional checks, commit one coherent change, open its pull request, and
+  verify the exact pushed commit's relevant CI for runtime, packaging, CI, or
+  release behavior.
 
 A useful final handoff records:
 
@@ -320,7 +322,8 @@ A useful final handoff records:
 - exact commands run and their results;
 - package or runtime identity when relevant;
 - what remains unproved, especially native Windows behavior;
-- whether work was committed, pushed, tagged, or released.
+- whether work was committed, opened as a pull request, merged, tagged,
+  or released.
 
 Never describe a task as complete merely because the static tree is green when
 the stated acceptance requires native Windows evidence.


### PR DESCRIPTION
The working agreement said Peng had permitted in-scope changes to be pushed
straight to `main`, and I read that as the default. On 2026-09-08 I landed
four commits that way (`1cf273d1`, `c1a27534`, `97b7c491`, `4b90f1a5`) and he
asked for a pull request instead: he reads a change there before it reaches
`main`. Direct pushes are the exception he names in a task, not the standing
rule.

Three places change, all documentation:

- the working-agreement bullet that granted the direct push;
- the validation bullet that ended "push `main` when requested";
- the handoff checklist, which now records whether a change was opened as a
  pull request and merged.

`AGENTS.md` is a symlink to this file and is untouched. No code or test
changes, so no CI behaviour changes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)