### PR TITLE
Correct available gold and reward vehicles in save customization

### DIFF
--- a/launcher/tests/test_gold_shop.py
+++ b/launcher/tests/test_gold_shop.py
@@ -76,6 +76,20 @@ class GoldShopTest(unittest.TestCase):
 
         self.assertEqual(["china:Ch01_Type59"], self._inbox()["vehicles"])
 
+    def test_zero_price_white_tiger_is_queued_without_charging_the_save(self):
+        self._write_state(gold=0)
+        reward = dict(nation="germany", vehicle="G04_PzVI_Tiger_IA",
+                      name="germany:G04_PzVI_Tiger_IA", label="White Tiger",
+                      level=7, gold=0, notInShop=True)
+        with mock.patch.object(gold_shop.vehicle_overlays, "list_gold_vehicles",
+                               return_value=[reward]):
+            self.assertTrue(gold_shop.list_offers(
+                self.slot, self.game, root=self.root)[0]["available"])
+            self._buy(reward["name"])
+        self.assertEqual([reward["name"]], self._inbox()["vehicles"])
+        self.assertEqual(0, save_ledger.read_balances(
+            self.slot, root=self.root)["gold"])
+
     def test_a_save_that_cannot_afford_the_vehicle_keeps_its_gold(self):
         path = self._write_state(gold=100)
 

--- a/launcher/tests/test_vehicle_overlays.py
+++ b/launcher/tests/test_vehicle_overlays.py
@@ -759,6 +759,26 @@ class VehicleOverlayTest(unittest.TestCase):
         self.assertEqual(8, rows[0]["level"])
         self.assertTrue(rows[0]["notInShop"])
 
+    def test_the_gold_shop_includes_zero_price_rewards_but_not_starter_tanks(self):
+        def record(vehicle, credits, gold, not_in_shop, level):
+            return dict(nation="germany", vehicle=vehicle,
+                        tags=("heavyTank", "secret", "unrecoverable"),
+                        credits=credits, gold=gold, notInShop=not_in_shop,
+                        level=level)
+
+        records = [
+            record("G04_PzVI_Tiger_IA", 0, 0, True, 7),
+            record("Starter", 0, 0, False, 1),
+            record("CreditTank", 1000, 0, False, 3),
+            record("HiddenCreditTank", 1000, 0, True, 3),
+        ]
+        with mock.patch.object(vehicle_overlays, "_vehicle_roster_from_archive",
+                               return_value=records):
+            rows = vehicle_overlays.list_gold_vehicles(self.game)
+        self.assertEqual(["germany:G04_PzVI_Tiger_IA"],
+                         [row["name"] for row in rows])
+        self.assertEqual(0, rows[0]["gold"])
+
     def test_the_gold_shop_excludes_unavailable_save_vehicles(self):
         unavailable = [
             ("germany", "G138_VK168_02_Mauerbrecher", ("heavyTank",)),
@@ -772,7 +792,8 @@ class VehicleOverlayTest(unittest.TestCase):
             ("ussr", "Fallout", ("heavyTank", "fallout")),
             ("ussr", "Tank_bootcamp", ("lightTank", "secret")),
         ]
-        records = [dict(nation=nation, vehicle=vehicle, tags=tags, gold=1)
+        records = [dict(nation=nation, vehicle=vehicle, tags=tags, gold=1,
+                        credits=0, notInShop=False)
                    for nation, vehicle, tags in unavailable]
         with mock.patch.object(vehicle_overlays, "_vehicle_roster_from_archive",
                                return_value=records):

--- a/launcher/tests/test_vehicle_overlays.py
+++ b/launcher/tests/test_vehicle_overlays.py
@@ -752,33 +752,31 @@ class VehicleOverlayTest(unittest.TestCase):
         self.assertEqual(8, by_name["R12_Test"]["level"])
         self.assertTrue(by_name["R12_Test"]["notInShop"])
 
-    def test_the_gold_shop_lists_every_vehicle_priced_in_gold(self):
+    def test_the_gold_shop_keeps_hidden_rewards_and_excludes_observers(self):
         rows = vehicle_overlays.list_gold_vehicles(self.game)
-
-        # Highest tier first, which is the order a shop is read in.
-        self.assertEqual(
-            ["ussr:R12_Test", "ussr:Observer"],
-            [row["name"] for row in rows])
+        self.assertEqual(["ussr:R12_Test"], [row["name"] for row in rows])
         self.assertEqual(12500, rows[0]["gold"])
         self.assertEqual(8, rows[0]["level"])
         self.assertTrue(rows[0]["notInShop"])
-        self.assertFalse(rows[1]["notInShop"])
 
-    def test_the_gold_shop_offers_what_the_editor_refuses_to_touch(self):
-        """A vehicle the data editor will not rewrite is still ownable.
-
-        ``selectable`` keeps native construction hazards out of an editor that
-        changes a vehicle's data.  Buying one is a different question, and the
-        client answers it when it builds the record.
-        """
-        choices = vehicle_overlays.list_vehicle_choices(self.game)
-
-        self.assertNotIn(
-            "Observer", [choice["vehicle"] for choice in choices])
-        self.assertIn(
-            "Observer",
-            [row["vehicle"]
-             for row in vehicle_overlays.list_gold_vehicles(self.game)])
+    def test_the_gold_shop_excludes_unavailable_save_vehicles(self):
+        unavailable = [
+            ("germany", "G138_VK168_02_Mauerbrecher", ("heavyTank",)),
+            ("germany", "G65_JagdTiger_SdKfz_185_IGR", ("AT-SPG", "premiumIGR")),
+            ("usa", "A13_T34_hvy_IGR", ("heavyTank", "premiumIGR")),
+            ("ussr", "R54_KV-5_IGR", ("heavyTank", "premiumIGR")),
+            ("germany", "G48_E-25_IGR", ("AT-SPG", "premiumIGR")),
+            ("france", "F28_105_leFH18B2_IGR", ("SPG", "premiumIGR")),
+            ("ussr", "R31_Valentine_LL_IGR", ("lightTank", "premiumIGR")),
+            ("ussr", "Event", ("lightTank", "event_battles")),
+            ("ussr", "Fallout", ("heavyTank", "fallout")),
+            ("ussr", "Tank_bootcamp", ("lightTank", "secret")),
+        ]
+        records = [dict(nation=nation, vehicle=vehicle, tags=tags, gold=1)
+                   for nation, vehicle, tags in unavailable]
+        with mock.patch.object(vehicle_overlays, "_vehicle_roster_from_archive",
+                               return_value=records):
+            self.assertEqual([], vehicle_overlays.list_gold_vehicles(self.game))
 
     def test_vehicle_browser_resolves_shared_topology_and_impact(self):
         choices = vehicle_overlays.list_vehicle_choices(self.game)

--- a/launcher/vehicle_overlays.py
+++ b/launcher/vehicle_overlays.py
@@ -782,9 +782,10 @@ def list_vehicle_choices(game_root):
 
 
 def list_gold_vehicles(game_root):
-    """List gold-priced vehicles the client can add to a save.
+    """List gold and reward vehicles the client can add to a save.
 
-    Keep hidden reward vehicles, including ``notInShop`` entries, but apply
+    Include zero-credit ``notInShop`` rewards such as White Tiger without
+    adding the free starter tech-tree vehicles. Keep hidden rewards, but apply
     the same standard-battle and resource exclusions as vehicle_records.
     The launcher already mirrors those rules for Bot lineup choices.
     """
@@ -804,7 +805,8 @@ def list_gold_vehicles(game_root):
     translators = {}
     vehicles = []
     for record in roster:
-        if (record["gold"] <= 0 or
+        is_reward = record["credits"] == 0 and record["notInShop"]
+        if ((record["gold"] <= 0 and not is_reward) or
                 not bot_lineup_profiles.vehicle_choice_is_eligible(record)):
             continue
         nation = record["nation"]

--- a/launcher/vehicle_overlays.py
+++ b/launcher/vehicle_overlays.py
@@ -39,9 +39,10 @@ except ImportError:
     import vehicle_prices
 
 try:
-    from . import core
+    from . import core, bot_lineup_profiles
 except ImportError:
     import core
+    import bot_lineup_profiles
 
 
 TARGET_VERSION = "0.9.22.0.1"
@@ -781,17 +782,11 @@ def list_vehicle_choices(game_root):
 
 
 def list_gold_vehicles(game_root):
-    """List every vehicle the installed client prices in gold.
+    """List gold-priced vehicles the client can add to a save.
 
-    #1513 ships 196 of them and marks 145 ``notInShop``: reward and event
-    tanks the retail shop never sold and that no tech tree leads to. Offline
-    they are exactly as reachable as the rest, which is why this reads the
-    whole roster rather than the shop's own subset.
-
-    The ``selectable`` filter the vehicle editor uses is deliberately not
-    applied. It keeps native construction hazards out of an editor that
-    rewrites a vehicle's data; owning one is a different question, and the
-    client answers it when it builds the record.
+    Keep hidden reward vehicles, including ``notInShop`` entries, but apply
+    the same standard-battle and resource exclusions as vehicle_records.
+    The launcher already mirrors those rules for Bot lineup choices.
     """
     status, package_path = _require_target(game_root)
     try:
@@ -809,7 +804,8 @@ def list_gold_vehicles(game_root):
     translators = {}
     vehicles = []
     for record in roster:
-        if record["gold"] <= 0:
+        if (record["gold"] <= 0 or
+                not bot_lineup_profiles.vehicle_choice_is_eligible(record)):
             continue
         nation = record["nation"]
         if nation not in translators:


### PR DESCRIPTION
Save customization offered IGR vehicles and VK16801 WB that the client rejects, while hiding the usable zero-price White Tiger reward. List gold-priced vehicles and zero-credit notInShop rewards, then apply the existing launcher eligibility predicate mirroring client standard-battle rules and the pinned resource blacklist. Hidden rewards remain available; free starter and credit-priced tech-tree vehicles are excluded.

Validation:
- Launcher suite: 616 tests passed, 2 skipped.
- Client/launcher eligibility parity suite: 10 tests passed; bootstrap lifecycle suite: 64 tests passed.
- Regression coverage includes all seven reported unavailable vehicles, hidden rewards, zero-price White Tiger queueing, and starter/credit vehicle exclusions.
- Independent exact #1513 audit: 680 prices match the client price catalogue; all eight resource blacklist entries match a fresh scan. Final launcher output exactly matches all 190 expected vehicles (no missing or extra entries).

Windows UI/gameplay acceptance has not been run.
