### PR TITLE
Fix trench support and false collision caps

### DIFF
--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -16615,6 +16615,10 @@ class BattleRuntime(object):
                 path or 'still', self._local_motion_status,
                 self._local_motion_kinds, self._local_support_rise_blocked,
                 self._local_airborne))
+        trace = getattr(self, '_local_world_collision_trace', None)
+        if self._local_motion_status == 'hard' and trace and trace.get('reason'):
+            sys.stdout.write('[Offline LAN 0.9.22] LOCAL HARD CONTACT %s\n' %
+                             json.dumps(trace, sort_keys=True))
         return True
 
     def _report_local_contact_tick(self, path, before, pitch, rise):
@@ -17614,6 +17618,7 @@ class BattleRuntime(object):
         self._local_motion_cap_crushed = False
         self._local_motion_kinds = '-'
         self._local_motion_status = 'clear'
+        self._local_world_collision_trace = {}
         if not self._arena_motion_is_clear(
                 entity, position, yaw, speed, dt, hull_yaw=hull_yaw):
             self._local_motion_kinds = 'arena'
@@ -17718,7 +17723,8 @@ class BattleRuntime(object):
                     entity.typeDescriptor, self._local_airborne, dt, True,
                     True, kinetic_speed, commit_enabled=False,
                     pitch=self._local_pitch, roll=self._local_roll,
-                    motion_yaw=world_motion_yaw)
+                    motion_yaw=world_motion_yaw,
+                    trace=self._local_world_collision_trace)
                 if isinstance(world_status, bool):
                     world_status = 'hard' if world_status else 'clear'
                 if world_status not in ('clear', 'kinetic'):
@@ -17736,7 +17742,8 @@ class BattleRuntime(object):
             bool(kinetic_speed is not None), kinetic_speed,
             commit_enabled=False,
             pitch=self._local_pitch, roll=self._local_roll,
-            motion_yaw=world_motion_yaw)
+            motion_yaw=world_motion_yaw,
+            trace=self._local_world_collision_trace)
         if isinstance(world_status, bool):
             world_status = 'hard' if world_status else 'clear'
         if world_status == 'hard':

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -17068,12 +17068,18 @@ class BattleRuntime(object):
         return self._commit_ground_plane(plane, force_raw=force_raw)
 
     def _drive_pitch(self, position, yaw):
-        """Copy the 0.8.2 close-range drive slope probe exactly.
+        """Use contacted terrain for drive gravity, then the legacy probe.
 
-        This is deliberately separate from the four-point visual hull pose.
-        The drive law skips bridge decks above the hull and clamps walls and
-        cliff faces before their gradient reaches longitudinal physics.
+        A centre-line probe may fall into a trench while the tracks still
+        bridge its banks. That floor is not the grade carrying this vehicle.
+        The suspension plane excludes unsupported samples and body rocking.
         """
+        if (self._local_suspension_params is not None and
+                not self._local_suspension_disabled):
+            supported_pitch = vehicle_physics.suspension_drive_pitch(
+                self._local_ground_plane, yaw)
+            if supported_pitch is not None:
+                return supported_pitch
         sine, cosine = math.sin(yaw), math.cos(yaw)
         distance = 2.0
         wall_rise = distance * 1.43

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -16593,30 +16593,45 @@ class BattleRuntime(object):
                 str(commit_status or '-')))
         return True
 
-    def _report_local_motion_stall(self, start, end, dt, throttle, path):
+    def _report_local_motion_stall(self, start, end, dt, throttle, path,
+                                   before=None, drive=None, pitch=None,
+                                   contact=None):
         """Record bounded pose evidence when powered travel cannot advance."""
         if dt <= 0.0 or abs(throttle) <= 0.01:
             return False
         dx, dz = end[0] - start[0], end[2] - start[2]
-        if dx * dx + dz * dz > (0.2 * dt) ** 2:
+        stalled = dx * dx + dz * dz <= (0.2 * dt) ** 2
+        contact_limited = path not in (None, 'still', 'advance')
+        losing_speed = (before is not None and throttle * before > 0.0 and
+                        abs(self._local_speed) + 0.1 < abs(before))
+        if not (stalled or contact_limited or losing_speed):
             return False
         now = self._clock()
         if now < getattr(self, '_next_local_stall_report', 0.0):
             return False
         self._next_local_stall_report = now + 2.0
         sys.stdout.write(
-            '[Offline LAN 0.9.22] LOCAL STALL '
+            '[Offline LAN 0.9.22] LOCAL %s '
             'pos=(%.3f,%.3f,%.3f) yaw=%.3f pitch=%.3f roll=%.3f '
             'throttle=%.2f speed=%.3f vertical=%.3f '
             'path=%s world=%s kinds=%s support_blocked=%s airborne=%s\n' % (
+                'STALL' if stalled else 'SLOWDOWN',
                 end[0], end[1], end[2], self._local_yaw,
                 self._local_pitch, self._local_roll, throttle,
                 self._local_speed, self._local_vertical_speed,
                 path or 'still', self._local_motion_status,
                 self._local_motion_kinds, self._local_support_rise_blocked,
                 self._local_airborne))
-        trace = getattr(self, '_local_world_collision_trace', None)
-        if self._local_motion_status == 'hard' and trace and trace.get('reason'):
+        if before is not None:
+            sys.stdout.write(
+                '[Offline LAN 0.9.22] LOCAL DRIVE '
+                'before=%.4f drive=%.4f final=%.4f pitch=%.4f '
+                'travel=%.4f dt=%.4f plane=%s\n' % (
+                    before, drive, self._local_speed, pitch,
+                    math.sqrt(dx * dx + dz * dz), dt,
+                    json.dumps(self._local_ground_plane, sort_keys=True)))
+        trace = contact or getattr(self, '_local_world_collision_trace', None)
+        if trace and trace.get('reason'):
             sys.stdout.write('[Offline LAN 0.9.22] LOCAL HARD CONTACT %s\n' %
                              json.dumps(trace, sort_keys=True))
         return True
@@ -20206,6 +20221,8 @@ class BattleRuntime(object):
                 slope_pitch, dt, self._local_airborne, 0,
                 handbrake)
 
+        drive_speed = self._local_speed
+        primary_contact = None
         if abs(self._local_speed) > 0.0001 and dt > 0.0:
             if self._motion_is_clear(
                     entity, position, yaw, self._local_speed, dt,
@@ -20218,6 +20235,10 @@ class BattleRuntime(object):
                 self._local_grind = max(0, self._local_grind - 1)
                 contact_path = 'advance'
             elif not self._local_airborne:
+                # Keep the first blocking witness: a later clear deflection
+                # probe must not erase the reason this drive slice slowed.
+                primary_contact = dict(getattr(
+                    self, '_local_world_collision_trace', None) or {})
                 if self._local_motion_cap_crushed:
                     # The speed cap only proves that this vehicle may crush the
                     # exact item.  It is never copied vehicle momentum.  Keep
@@ -20378,7 +20399,8 @@ class BattleRuntime(object):
             position[1] - tick_pose[1])
         self._local_position, self._local_yaw = position, yaw
         self._report_local_motion_stall(
-            tick_pose, position, dt, throttle, contact_path)
+            tick_pose, position, dt, throttle, contact_path,
+            previous_speed, drive_speed, slope_pitch, primary_contact)
         presentation_position = self._update_local_presentation(entity, dt)
         self._avatar.updateOwnVehiclePosition(
             presentation_position,

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -11628,6 +11628,14 @@ class BotRuntime(object):
                     path_clear = False
                     throttle = 0.0
                     state['movement_dir'] = 0
+                # The corridor grade ranks future navigation, but a trench
+                # below that probe need not support the tracks now. Reuse the
+                # accepted suspension plane for drive gravity, projected onto
+                # the post-turn hull heading used by this integration slice.
+                supported_pitch = vehicle_physics.suspension_drive_pitch(
+                    state.get('_suspension_ground_plane'), candidate_hull_yaw)
+                if supported_pitch is not None:
+                    slope_pitch = supported_pitch
                 previous_speed = state['speed']
                 speed = (0.0 if siege_motion_locked else
                     vehicle_physics.longitudinal_step(

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -6096,10 +6096,15 @@ class BotRuntime(object):
             position[0], position[2], position[1])
         if centre is not None:
             centre = float(centre)
-            if (follow_gap is not None and
-                    position[1] - centre > float(follow_gap)):
+            # Speed and a forward corridor grade can enlarge follow_gap
+            # beyond an entire trench. Check the tracks before accepting that
+            # drop; the dynamic envelope alone proves no surface continuity.
+            support_gap = (None if follow_gap is None else min(
+                float(follow_gap), vehicle_physics.GROUND_FOLLOW_MIN))
+            if (support_gap is not None and
+                    position[1] - centre > support_gap):
                 bridged = self._straddled_terrain_support(
-                    state, position, follow_gap)
+                    state, position, support_gap)
                 if bridged is not None and bridged > centre:
                     return bridged, bridged
             # The vertical law below always selects centre while it exists;

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/vehicle_physics.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/vehicle_physics.py
@@ -1143,6 +1143,19 @@ def suspension_support_vertical_velocity(plane, velocity_x, velocity_z):
 	return gradient_x * velocity_x + gradient_z * velocity_z
 
 
+def suspension_drive_pitch(plane, yaw):
+	"""Project contacted terrain onto the hull-forward drive axis."""
+	try:
+		yaw = float(yaw)
+		if math.isnan(yaw) or math.isinf(yaw):
+			return None
+	except (TypeError, ValueError, OverflowError):
+		return None
+	tangent = suspension_support_vertical_velocity(
+		plane, math.sin(yaw), math.cos(yaw))
+	return None if tangent is None else -math.atan(tangent)
+
+
 def landing_impact_speed(world_velocity, support_normal):
 	'''Return closing speed along one trustworthy upward support normal.
 

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/world_collision.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/world_collision.py
@@ -280,12 +280,14 @@ def _lane_ground_ahead(spaceID, Math, pos, start_x, start_z,
 	footprint_ground = _ground_top(
 		spaceID, Math, pos, footprint_x, footprint_z, look, ground_plane,
 		collision_filter)
+	if (start_ground is not None and support_start_y is not None and
+			float(start_ground) < float(support_start_y) - _GROUND_HIT_EPSILON):
+		# A floor below the posed chassis is not its support. This also applies
+		# to outward corner lanes, whose clamped local endpoints coincide: they
+		# have no descending pose trend even when a trench lies below them.
+		# Pulling their end down to that floor invents a collision with the lip.
+		return None
 	if descending and start_ground is not None and footprint_ground is not None:
-		if (support_start_y is not None and
-				float(start_ground) < float(support_start_y) - _GROUND_HIT_EPSILON):
-			# The witness starts above its old support while leaving the crest.
-			# A floor below it cannot lower the occupied hull's collision ray.
-			return None
 		# A crest can already lie beneath the front of the footprint while
 		# the body is still supported behind it. A chord through that lower
 		# floor is outside the occupied hull. Confirm the middle of the

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/world_collision.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/world_collision.py
@@ -19,6 +19,21 @@ _WORLD_SOFT_RECAST_BUDGET = 4
 _UNPREPARED_COLLISION_FILTER = object()
 
 
+def _record_hard_contact(trace, reason, start, end, collision,
+        ground_ahead=None, heights=()):
+    """Copy existing query evidence; diagnostics must never change the verdict."""
+    if trace is None:
+        return
+    try:
+        def vector(value):
+            return tuple(float(getattr(value, axis)) for axis in ('x', 'y', 'z'))
+        trace.update(reason=reason, ray_start=vector(start), ray_end=vector(end),
+                     hit=vector(collision[0]), normal=vector(collision[1]),
+                     ground_ahead=ground_ahead, profile=list(heights))
+    except Exception:
+        trace['reason'] = reason
+
+
 def _collide_horizontal(spaceID, start, end,
 		collision_filter=_UNPREPARED_COLLISION_FILTER):
 	"""Raycast while hiding only exact destructibles already marked broken."""
@@ -340,7 +355,7 @@ def _raised_ray_has_wall(spaceID, Math, pos, x1, z1, x2, z2,
 		local_start, local_end, pose_y, target_length,
 		maximum_gradient=_MAX_DRIVABLE_GRADIENT, ground_profile=None,
 		collision_filter=_UNPREPARED_COLLISION_FILTER,
-		ground_ahead=None):
+		ground_ahead=None, trace=None):
 	"""A drivable lower slope must not hide an independent wall above it."""
 	for height in (1.1, 1.6):
 		start, end = _posed_ray(
@@ -364,6 +379,8 @@ def _raised_ray_has_wall(spaceID, Math, pos, x1, z1, x2, z2,
 					spaceID, Math, pos, collision, ground_profile[7],
 					ground_profile[8], collision_filter):
 				continue
+		_record_hard_contact(trace, 'raised_wall', start, end, collision,
+			ground_ahead)
 		return True
 	return False
 
@@ -479,7 +496,7 @@ def check_horizontal_collision(bigworld, math_module, *args, **kwargs):
 def _check_horizontal_collision(spaceID, pos, yaw, vel, td=None,
 		airborne=False, dt=0.04, return_status=False,
 		allow_kinetic=False, kinetic_speed=None, commit_enabled=True,
-		motion_yaw=None, pitch=0.0, roll=0.0):
+		motion_yaw=None, pitch=0.0, roll=0.0, trace=None):
 	import math, BigWorld, Math
 	try:
 		hw = 1.5
@@ -489,6 +506,12 @@ def _check_horizontal_collision(spaceID, pos, yaw, vel, td=None,
 		extents = _vehicle_motion_extents(td)
 		if extents is not None:
 			hw, hl_back, hl_front = extents
+
+		if trace is not None:
+			trace.clear()
+			trace.update(position=(pos.x, pos.y, pos.z), yaw=yaw, speed=vel,
+				dt=dt, motion_yaw=motion_yaw, pitch=pitch, roll=roll,
+				airborne=airborne, extents=(hw, hl_back, hl_front))
 
 		# Look-ahead beyond the hull. The old flat +2.0 m made an invisible
 		# wall 2 m before every obstacle, and DURING A FALL it saw the cliff
@@ -684,6 +707,8 @@ def _check_horizontal_collision(spaceID, pos, yaw, vel, td=None,
 							# This is a proved continuous-direction terrain profile, not
 							# a small prop. An ascent/descent outside its directional
 							# bound remains solid instead of falling into prop handling.
+							_record_hard_contact(trace, 'ground_profile', start_bot,
+								end_bot, col_bot, _ground_ahead, _heights)
 							return 'hard' if return_status else True
 					_surface_is_ground = _drivable_surface(
 						col_bot, _gradient_limit)
@@ -707,7 +732,7 @@ def _check_horizontal_collision(spaceID, pos, yaw, vel, td=None,
 								 profile_x, profile_z,
 								 profile_sin, profile_cos,
 								 profile_direction, profile_look, _profile_plane),
-								_sweep_filter, _ground_ahead):
+								_sweep_filter, _ground_ahead, trace=trace):
 							return 'hard' if return_status else True
 						continue
 					# Treat every occupied hull height as independent evidence.  The
@@ -742,6 +767,8 @@ def _check_horizontal_collision(spaceID, pos, yaw, vel, td=None,
 						if _resolved == 'kinetic':
 							_kinetic_contact = True
 						elif _resolved is not True:
+							_record_hard_contact(trace, 'solid_lane', _ray_start,
+								_ray_end, _ray_hit, _ground_ahead, _heights)
 							return 'hard' if return_status else True
 			if col_bot is None or d_bot >= target_len:
 				# A suspended beam or upper wall may miss the 0.6 m ray entirely.
@@ -773,6 +800,8 @@ def _check_horizontal_collision(spaceID, pos, yaw, vel, td=None,
 					if _resolved == 'kinetic':
 						_kinetic_contact = True
 					elif _resolved is not True:
+						_record_hard_contact(trace, 'upper_lane', _ray_start,
+							_ray_end, _ray_hit, _ground_ahead)
 						return 'hard' if return_status else True
 	except Exception:
 		raise

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/world_collision.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/world_collision.py
@@ -287,18 +287,19 @@ def _lane_ground_ahead(spaceID, Math, pos, start_x, start_z,
 		# have no descending pose trend even when a trench lies below them.
 		# Pulling their end down to that floor invents a collision with the lip.
 		return None
-	if descending and start_ground is not None and footprint_ground is not None:
-		# A crest can already lie beneath the front of the footprint while
-		# the body is still supported behind it. A chord through that lower
-		# floor is outside the occupied hull. Confirm the middle of the
-		# support chord before allowing it to pull a descending ray down.
+	if (start_ground is not None and footprint_ground is not None and
+			(descending or float(footprint_ground) < float(start_ground))):
+		# The ground may descend even while the hull lane rises. Before
+		# extrapolating that descent, require the middle to agree with the
+		# same support chord. Either a high crest or a low trench sample
+		# breaks continuity; neither may bend the occupied ray into a lip.
 		middle_ground = _ground_top(
 			spaceID, Math, pos, (start_x + footprint_x) * 0.5,
 			(start_z + footprint_z) * 0.5, look, ground_plane,
 			collision_filter)
 		if (middle_ground is None or
-				float(middle_ground) >
-				(float(start_ground) + float(footprint_ground)) * 0.5 +
+				abs(float(middle_ground) -
+					(float(start_ground) + float(footprint_ground)) * 0.5) >
 				_GROUND_HIT_EPSILON):
 			return None
 	try:

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -21642,6 +21642,50 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertEqual((0.0, 0.0, 0.0), position)
         self.assertGreater(battle._local_slide_speed, 0.0)
 
+    def test_supported_tracks_do_not_use_trench_floor_as_drive_grade(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        # Both tracks bridge a short depression around the centre-line probe
+        # at z=2.0. Every contacting road wheel is still on the level banks.
+        params = {'springs': [{'x': x, 'y': 0.0, 'z': z}
+                             for x in (-1.0, 1.0)
+                             for z in (-2.4, -1.2, 0.0, 1.2, 2.4)]}
+        battle._local_suspension_params = params
+        battle._local_ground_plane = vehicle_physics.suspension_world_ground_plane(
+            params, (0.0,) * 10, (0.0, 0.0, 0.0), 0.0, 0.15)
+        # Deliberately rock the rendered body; its attitude is not the grade.
+        battle._local_pitch = -0.2
+        runtime.bigworld.wg_collideSegment = mock.Mock(side_effect=(
+            lambda space, start, end, mask: (
+                _Vector(start.x, -1.5 if start.z > 0 else 0.0, start.z),)))
+
+        self.assertEqual(0.0, battle._drive_pitch((0.0, 0.0, 0.0), 0.0))
+        runtime.bigworld.wg_collideSegment.assert_not_called()
+
+    def test_suspension_drive_grade_follows_current_heading_not_body_rock(self):
+        battle = BattleRuntime(_runtime())
+        battle._local_suspension_params = {'springs': ()}
+        battle._local_ground_plane = {'gradient_x': 0.2, 'gradient_z': -0.3}
+        battle._local_pitch, battle._local_roll = 0.5, -0.4
+        battle._collide_down = mock.Mock(side_effect=AssertionError('extra query'))
+        for yaw, tangent in ((0.0, -0.3), (math.pi, 0.3),
+                             (math.pi / 2.0, 0.2)):
+            self.assertAlmostEqual(-math.atan(tangent),
+                battle._drive_pitch((0.0, 0.0, 0.0), yaw))
+
+    def test_retired_suspension_does_not_supply_cached_drive_grade(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        battle._local_suspension_params = {'springs': ()}
+        battle._local_suspension_disabled = True
+        battle._local_ground_plane = {'gradient_x': 0.0, 'gradient_z': 0.0}
+        runtime.bigworld.wg_collideSegment = lambda space, start, end, mask: (
+            _Vector(start.x, 0.2 * start.z, start.z),)
+        self.assertAlmostEqual(-math.atan(0.2),
+            battle._drive_pitch((0.0, 0.0, 0.0), 0.0))
+
     def test_drive_pitch_skips_bridge_deck_above_the_hull(self):
         runtime = _runtime()
         battle = BattleRuntime(runtime)

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -21642,6 +21642,26 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertEqual((0.0, 0.0, 0.0), position)
         self.assertGreater(battle._local_slide_speed, 0.0)
 
+    def test_local_slowdown_retains_first_contact_above_stall_speed(self):
+        battle = BattleRuntime(_runtime())
+        battle._local_speed = 4.0
+        battle._local_support_rise_blocked = False
+        battle._local_world_collision_trace = {}
+        first = {'reason': 'ground_profile', 'hit': [1.0, 2.0, 3.0]}
+        with mock.patch('sys.stdout') as output:
+            self.assertTrue(battle._report_local_motion_stall(
+                (0.0, 0.0, 0.0), (0.0, 0.0, 0.08), 0.02, 1.0,
+                'deflect', 10.0, 10.1, 0.0, first))
+        text = ''.join(call.args[0] for call in output.write.call_args_list)
+        self.assertIn('before=10.0000 drive=10.1000 final=4.0000', text)
+        self.assertIn('"reason": "ground_profile"', text)
+        battle._next_local_stall_report = 0.0
+        with mock.patch('sys.stdout') as output:
+            self.assertFalse(battle._report_local_motion_stall(
+                (0.0, 0.0, 0.0), (0.0, 0.0, 0.08), 0.02, 1.0,
+                'advance', 4.0, 4.0, 0.0))
+        output.write.assert_not_called()
+
     def test_supported_tracks_do_not_use_trench_floor_as_drive_grade(self):
         runtime = _runtime()
         battle = BattleRuntime(runtime)

--- a/tests/test_port_0922_bot_runtime.py
+++ b/tests/test_port_0922_bot_runtime.py
@@ -4307,6 +4307,47 @@ class BotRuntimeTests(unittest.TestCase):
         # One centre column on flat ground, five only at the fall transition.
         self.assertEqual(5, len(calls))
 
+    def test_fast_bot_checks_track_support_before_following_a_trench_floor(self):
+        self.runtime.battle_start(self.start)
+        state = self.runtime.states[11]
+        state.update(x=0.0, y=10.0, z=0.0, yaw=0.0, speed=12.0,
+                     last_drive_pitch=0.5, grounded_once=True,
+                     airborne=False, vertical_speed=0.0)
+        probe, calls = self._trench_probe(
+            8.46, {(1.5, 0.0): 10.0, (-1.5, 0.0): 10.0})
+        self.runtime._physics_ground_probe = probe
+        # The forward corridor's downhill grade expands the follow envelope
+        # beyond this 1.54 m trench; it is not proof of a continuous surface.
+        self.assertGreater(self.module.vehicle_physics.ground_follow_gap(
+            state['speed'], state['last_drive_pitch'], 0.15), 1.54)
+
+        self.assertFalse(self.runtime._update_vertical_motion(state, 0.15))
+
+        self.assertAlmostEqual(10.0, state['y'])
+        self.assertFalse(state['airborne'])
+        self.assertEqual(5, len(calls))
+
+    def test_fast_bot_follow_gap_still_accepts_an_unbridged_drop(self):
+        for single_rim in (False, True):
+            with self.subTest(single_rim=single_rim):
+                self.runtime.battle_start(self.start)
+                state = self.runtime.states[11]
+                state.update(x=0.0, y=10.0, z=0.0, yaw=0.0, speed=12.0,
+                             last_drive_pitch=0.5, grounded_once=True,
+                             airborne=False, vertical_speed=0.0)
+                calls = []
+                def probe(x, z, hint):
+                    calls.append((x, z))
+                    if single_rim and z < -3.0:
+                        return 10.0
+                    return 8.46 - z * 0.2
+                self.runtime._physics_ground_probe = probe
+
+                self.assertFalse(self.runtime._update_vertical_motion(state, 0.15))
+
+                self.assertAlmostEqual(8.46, state['y'])
+                self.assertEqual(5, len(calls))
+
     def test_bot_bridges_a_slot_running_along_its_hull(self):
         self.runtime.battle_start(self.start)
         state = self.runtime.states[11]

--- a/tests/test_port_0922_bot_runtime.py
+++ b/tests/test_port_0922_bot_runtime.py
@@ -4442,6 +4442,25 @@ class BotRuntimeTests(unittest.TestCase):
         })
         return runtime, state, calls
 
+    def test_bot_drive_uses_contacted_plane_instead_of_corridor_grade(self):
+        runtime, state, unused_calls = self._full_suspension_case(
+            lambda x, z: 0.0)
+        self.assertFalse(runtime._update_vertical_motion(state, 0.04))
+        self.assertIn('_suspension_ground_plane', state)
+        command = self._stationary_command()
+        command.update(throttle=1.0, movement_intent=True,
+                       move_position=(0.0, 0.0, 10.0),
+                       combat_mode='advance', recovery_mode='drive')
+        runtime.adapter.decide = lambda *unused: dict(command)
+        runtime.direction_probe = lambda *unused: {
+            'clear': True, 'collision': False, 'slope': 0.375}
+        state['speed'] = 4.0
+
+        runtime.update(0.1, 1.1)
+
+        self.assertAlmostEqual(0.0, state['last_drive_pitch'])
+        self.assertGreater(state['speed'], 4.0)
+
     def test_ten_spring_bot_samples_22_contacts_once_per_outer_tick(self):
         runtime, state, calls = self._suspension_case(
             lambda unused_x, unused_z: 0.0)

--- a/tests/test_port_0922_vehicle_physics.py
+++ b/tests/test_port_0922_vehicle_physics.py
@@ -100,6 +100,16 @@ class VehiclePhysicsDescriptorTests(unittest.TestCase):
 
 class VehiclePhysicsSuspensionTrialTests(unittest.TestCase):
 
+    def test_drive_pitch_projects_terrain_and_rejects_missing_support(self):
+        plane = {'gradient_x': 0.2, 'gradient_z': -0.3}
+        for yaw, tangent in ((0.0, -0.3), (math.pi, 0.3),
+                             (math.pi / 2.0, 0.2)):
+            self.assertAlmostEqual(-math.atan(tangent),
+                vehicle_physics.suspension_drive_pitch(plane, yaw))
+        for invalid in (None, {}, {'gradient_x': float('nan'), 'gradient_z': 0}):
+            self.assertIsNone(vehicle_physics.suspension_drive_pitch(invalid, 0.0))
+        self.assertIsNone(vehicle_physics.suspension_drive_pitch(plane, float('inf')))
+
     def test_suspension_contacts_share_the_collision_ypr_transform(self):
         from gui.mods.offline_lan_0922 import tank_collision
         point = {'x': 1.2, 'y': 0.4, 'z': -2.0}

--- a/tests/test_port_0922_world_collision.py
+++ b/tests/test_port_0922_world_collision.py
@@ -1311,6 +1311,42 @@ class WorldCollisionTests(unittest.TestCase):
                 None, False, 0.20, True, commit_enabled=False))
         self.assertEqual(0, ground_queries[0])
 
+    def test_hard_trace_preserves_queries_and_clears_previous_hit(self):
+        queries = []
+        blocked = [True]
+
+        def collide(space, start, end, mask, *filters):
+            queries.append((start.x, start.y, start.z, end.x, end.y, end.z))
+            if not blocked[0] or _vertical_ray(start, end):
+                return None
+            return (start + (end - start).scale(0.5),
+                    _Vector(0, 0, -1), 0)
+
+        scene = types.SimpleNamespace(wg_collideSegment=collide,
+            wg_getMatInfoNearPoint=_miss_mat_info_1513)
+        args = (scene, types.SimpleNamespace(Vector3=_Vector),
+                1, _Vector(), 0.0, 1.0, None, False, 0.04, True)
+        with mock.patch.object(world_collision, '_destroy_and_recast',
+                               return_value=False):
+            self.assertEqual('hard', world_collision.check_horizontal_collision(
+                *args, commit_enabled=False))
+            baseline = list(queries)
+            queries[:] = []
+            trace = {}
+            self.assertEqual('hard', world_collision.check_horizontal_collision(
+                *args, commit_enabled=False, trace=trace))
+            self.assertEqual(baseline, queries)
+            self.assertEqual('solid_lane', trace['reason'])
+            self.assertEqual((0.0, 0.0, -1.0), trace['normal'])
+            self.assertEqual((1.5, 3.5, 3.5), trace['extents'])
+            for actual, expected in zip(trace['hit'], (-1.5, 0.6, 1.7)):
+                self.assertAlmostEqual(expected, actual)
+            blocked[0] = False
+            self.assertEqual('clear', world_collision.check_horizontal_collision(
+                *args, commit_enabled=False, trace=trace))
+            self.assertNotIn('reason', trace)
+            self.assertNotIn('hit', trace)
+
     def test_exact_ground_top_uses_one_millimetre_epsilon(self):
         point = _Vector(1.0, 2.0, 3.0)
         top_y = [point.y]

--- a/tests/test_port_0922_world_collision.py
+++ b/tests/test_port_0922_world_collision.py
@@ -1729,6 +1729,68 @@ class WorldCollisionTests(unittest.TestCase):
                             None, False, 0.04, True, commit_enabled=False,
                             pitch=direction * math.atan(0.2)))
 
+    def test_normandy_trench_corner_does_not_lower_occupied_hull_ray(self):
+        # #1513 Type 62 LOCAL HARD CONTACT at 2026-09-08 10:28:08.969.
+        # A 0.4 m outward corner lane was lowered from 71.824 to 70.248 m
+        # by the 69.648 m trench floor. It hit the flat lip at 71.185 m.
+        # Reconstruct that discontinuity; a real wall above the lip still
+        # occupies the physical hull lane and must remain blocking.
+        floor, lip = 69.64762115478516, 71.1848373413086
+        extents = (1.4029690027236938, 2.885922908782959, 2.7345070838928223)
+        for mirror in (-1.0, 1.0):
+            yaw = mirror * -2.3640474101574105
+            motion_yaw = mirror * -3.3640474101574105
+            sx, sz = math.sin(motion_yaw), math.cos(motion_yaw)
+            corner_u = (mirror * -17.4951171875 * sx +
+                        -386.9683532714844 * sz)
+            edge_u = corner_u + 0.1
+            wall_u = corner_u + 0.3
+            for wall in (False, True):
+                for velocity in (-1.3819551129510972, 1.3819551129510972):
+                    def collide(space, start, end, mask, *filters):
+                        u0 = start.x * sx + start.z * sz
+                        u1 = end.x * sx + end.z * sz
+                        du, dy = u1 - u0, end.y - start.y
+                        hits = []
+                        if abs(dy) > 1.0e-9:
+                            for level, lower_side in ((floor, True), (lip, False)):
+                                t = (level - start.y) / dy
+                                u = u0 + t * du
+                                on_surface = u <= edge_u if lower_side else u >= edge_u
+                                if 0.0 <= t <= 1.0 and on_surface:
+                                    hits.append((t, _Vector(0, 1, 0)))
+                        if abs(du) > 1.0e-9:
+                            faces = [(edge_u, floor, lip)]
+                            if wall:
+                                faces.append((wall_u, lip, lip + 1.2))
+                            for face_u, bottom, top in faces:
+                                t = (face_u - u0) / du
+                                y = start.y + t * dy
+                                if 0.0 <= t <= 1.0 and bottom <= y <= top:
+                                    hits.append((t, _Vector(-sx, 0, -sz)))
+                        if not hits:
+                            return None
+                        t, normal = min(hits, key=lambda hit: hit[0])
+                        return start + (end - start).scale(t), normal, 0
+
+                    scene = types.SimpleNamespace(wg_collideSegment=collide,
+                        wg_getMatInfoNearPoint=_miss_mat_info_1513)
+                    trace = {}
+                    with self.subTest(mirror=mirror, wall=wall, velocity=velocity), \
+                            mock.patch.object(world_collision, '_vehicle_motion_extents',
+                                              return_value=extents), \
+                            mock.patch.object(world_collision, '_destroy_and_recast',
+                                              return_value=False):
+                        status = world_collision.check_horizontal_collision(
+                            scene, types.SimpleNamespace(Vector3=_Vector),
+                            1, _Vector(mirror * -14.576963424682617,
+                                       71.03958892822266, -386.0038757324219),
+                            yaw, velocity, None, False, 0.0200042724609375, True,
+                            commit_enabled=False, motion_yaw=motion_yaw,
+                            pitch=-0.02338010148582502,
+                            roll=mirror * 0.08774969656052144, trace=trace)
+                        self.assertEqual('hard' if wall else 'clear', status, trace)
+
     def test_departed_hull_cannot_follow_a_floor_below_its_support_start(self):
         scene = types.SimpleNamespace(wg_collideSegment=self._pitched_hull_scene(-0.4),
             wg_getMatInfoNearPoint=_miss_mat_info_1513)

--- a/tests/test_port_0922_world_collision.py
+++ b/tests/test_port_0922_world_collision.py
@@ -1791,6 +1791,64 @@ class WorldCollisionTests(unittest.TestCase):
                             roll=mirror * 0.08774969656052144, trace=trace)
                         self.assertEqual('hard' if wall else 'clear', status, trace)
 
+    def test_rising_hull_lane_cannot_extrapolate_a_trench_floor(self):
+        # #1513 Type 62 at 20:28:54: the drive law retained 16.51 m/s,
+        # then an artificial downward chord hit a near-horizontal trench lip
+        # and deflection cut travel to 8.31 m/s. The occupied hull rises along
+        # this lane, so the old descending-only midpoint guard never ran.
+        extents = (1.4029690027236938, 2.885922908782959, 2.7345070838928223)
+        for mirror in (-1.0, 1.0):
+            yaw = mirror * 3.0657583005906637
+            pos = _Vector(mirror * 160.1546630859375,
+                          75.01629638671875, 182.86094665527344)
+            sx, sz = math.sin(yaw), math.cos(yaw)
+            for wall in (False, True):
+                def collide(space, start, end, mask, *filters):
+                    u0 = (start.x - pos.x) * sx + (start.z - pos.z) * sz
+                    u1 = (end.x - pos.x) * sx + (end.z - pos.z) * sz
+                    du, dy = u1 - u0, end.y - start.y
+                    slope, lip = 0.1, 75.07
+                    hits = []
+                    denominator = dy - slope * du
+                    if abs(denominator) > 1.0e-9:
+                        for base, low, high in ((lip, -100.0, 0.3),
+                                               (lip - 1.54, 0.3, 3.2),
+                                               (lip, 3.2, 100.0)):
+                            t = (base + slope * u0 - start.y) / denominator
+                            u = u0 + t * du
+                            if 0.0 <= t <= 1.0 and low <= u <= high:
+                                hits.append((t, _Vector(-slope * sx, 1.0, -slope * sz)))
+                    if abs(du) > 1.0e-9:
+                        faces = [(0.3, lip - 1.54, lip),
+                                 (3.2, lip - 1.54, lip)]
+                        if wall:
+                            faces.append((2.4, lip - 1.54, lip + 1.2))
+                        for face, bottom, top in faces:
+                            t = (face - u0) / du
+                            height = start.y + t * dy - slope * face
+                            if 0.0 <= t <= 1.0 and bottom <= height <= top:
+                                hits.append((t, _Vector(-sx, 0.0, -sz)))
+                    if not hits:
+                        return None
+                    t, normal = min(hits, key=lambda row: row[0])
+                    return start + (end - start).scale(t), normal, 0
+                scene = types.SimpleNamespace(wg_collideSegment=collide,
+                    wg_getMatInfoNearPoint=_miss_mat_info_1513)
+                trace = {}
+                with self.subTest(mirror=mirror, wall=wall), \
+                        mock.patch.object(world_collision, '_vehicle_motion_extents',
+                                          return_value=extents), \
+                        mock.patch.object(world_collision, '_destroy_and_recast',
+                                          return_value=False):
+                    self.assertEqual('hard' if wall else 'clear',
+                        world_collision.check_horizontal_collision(
+                            scene, types.SimpleNamespace(Vector3=_Vector),
+                            1, pos, yaw, 16.51405163142728, None, False,
+                            0.01800537109375, True, commit_enabled=False,
+                            pitch=-0.10736769659612626,
+                            roll=mirror * -0.010139458485721595, trace=trace),
+                        trace)
+
     def test_departed_hull_cannot_follow_a_floor_below_its_support_start(self):
         scene = types.SimpleNamespace(wg_collideSegment=self._pitched_hull_scene(-0.4),
             wg_getMatInfoNearPoint=_miss_mat_info_1513)


### PR DESCRIPTION
Normandy trench crossings could abruptly halve player speed, while a friendly Chi-Ri could settle into a trench and repeatedly hit its walls. Exact #1513 playtesting captured both failures. The latest player trace preserves 16.51 m/s through longitudinal integration, then drops to 8.31 m/s during collision deflection.

Repair two support assumptions:
- Collision lane caps must use supported, continuous ground. Reject a floor below the lane's current support and validate a descending ground chord even when the hull itself is rising. A low trench midpoint and a high crest both invalidate extrapolation; neither may pull the occupied ray down through the lip. Real walls retain their existing collision checks.
- Legacy Bot support must check whether the chassis spans a drop before accepting a speed/grade-expanded ground-follow envelope. Keep one support query on normal ground, using the existing four additional span probes only for drops beyond the existing minimum envelope. Full Bot suspension remains disabled.

Player drive gravity uses an available suspension contact plane instead of a raw centre-line trench-floor grade. The optional Bot suspension path shares that projection, with existing probe fallback when no plane is available. This does not enable the optional solver or alter engine power.

Retain bounded diagnostics for real-client follow-up: original hard-contact witnesses survive subsequent clear deflection queries, and moving slowdown reports include before/drive/final speed, contacted plane, and actual travel. Reporting retains its two-second bound and performs no extra native queries.

Validation:
- Recorded-pose regression fixtures reproduce the false corner and rising-lane trench contacts on the preceding code. Empty trenches pass after repair; wall variants remain blocking.
- A Bot regression reproduces an erroneous 1.54 m descent despite supported track sides when the dynamic follow envelope exceeds the trench depth. The fix retains bridge support while unbridged drops and normal downhill following keep their prior behavior. Tests assert one normal support query and five at the exceptional drop.
- Latest local checks: 79 world-collision and 838 battle-runtime tests pass; the preceding unchanged Bot support change passed all 469 bot-runtime tests. All 103 client files compile with CPython 2.7; the updated launcher payload validates 123 WOTMOD members.
- Query comparison on analytic scenes: ordinary level travel, transient pitch on level ground, and aligned ascent/descent are unchanged. A rising hull over descending ground uses three additional vertical queries across its three lanes.
- Exact latest commit 18b0ceeb passed the CI test job, including full client/launcher suites, Python 2.7 packaging, and WOTMOD validation. Windows server and native exception trail jobs also passed. The unchanged Windows launcher rebuild is not required for this locally deployed client-Python update.
- Local test payload is `local-18b0ceeb-trench-cap`, preserving the 0.7.2 launcher/server/native binaries. The latest exact-client replay was reported as restored to normal with the player trench hesitation resolved. The friendly Bot sinking case has not yet received a separate acceptance report. No claim of complete swept-volume collision or verified Windows frame pacing is made.
