### PR TITLE
Correct critical-hit ribbon counts and stock voice inputs

### DIFF
--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -1310,6 +1310,27 @@ This is static and pure-data coverage. It proves which fields reach the native
 packers with which values; only acceptance on the exact Windows client can show
 the results window rendering those ribbons, counters and tooltips.
 
+### Critical-hit ribbons and shot-result voices
+
+The pinned `Avatar.PlayerAvatar.showShotResults` selects voices independently
+of `onBattleEvents` ribbons. Its `IS_ANY_PIERCING_MASK` includes
+`DEVICE_PIERCED_BY_PROJECTILE` and `DEVICE_PIERCED_BY_EXPLOSION`, but not
+`DEVICE_DAMAGED_*`. Confirmed device/crew damage supplies the piercing bit;
+otherwise a module hit followed by a ricochet selects the ricochet voice.
+External explosions set the positive-damage-factor material bit only when
+they damage vehicle HP, so a module-only explosion selects the no-HP-damage
+voice instead. The exact extracted method was executed under CPython 2.7
+with old/new flags to verify both selections, empty splash and killing shots.
+
+`BATTLE_EVENT_TYPE.packCrits` packs a critical count. The adapter counts device
+damage transitions and crew knockouts, excluding repair, fire-state and
+ammo-rack-death effects. Both outgoing and received critical ribbons use this
+count. Stock `ribbons_aggregator` excludes `CRITS` when the same target has a
+destruction ribbon; the adapter leaves that filtering and voice priority to
+the client. These checks prove RPC input and Python voice selection, not
+audible Chinese voice playback or the original server's hidden module-HP
+notification thresholds.
+
 ### Mastery badges and Marks of Excellence
 
 Both awards rank one player against every other player who drove the same

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -10330,7 +10330,18 @@ class BattleRuntime(object):
         shell_type, shell_is_gold = self._feedback_shell_fields(
             event, attacker_record)
         critical = event.get('critical')
-        critical_count = len((critical or {}).get('events') or ())
+        # CRIT counts newly damaged devices/crew, not fire, ammo-rack death
+        # effects or repairs carried alongside them in the state payload.
+        critical_events = []
+        for item in (critical or {}).get('events') or ():
+            kind, state = item.get('kind'), item.get('state')
+            if kind == 'crew' and state == 'destroyed':
+                critical_events.append(item)
+            elif kind == 'device' and state in ('critical', 'destroyed'):
+                old_state = item.get('old_state', 'normal')
+                if (old_state != state and old_state != 'destroyed'):
+                    critical_events.append(item)
+        critical_count = len(critical_events)
         if attacker_record.get('local'):
             self._assert_player_identity(attacker_record['engine_id'])
         target_team = self._combat_record_team(target_record)
@@ -10380,10 +10391,12 @@ class BattleRuntime(object):
                 explosion = bool(event.get('splash'))
                 if explosion:
                     flags = int(flags_type.ATTACK_IS_EXTERNAL_EXPLOSION)
-                    flags |= int(
-                        flags_type.
-                        MATERIAL_WITH_POSITIVE_DF_PIERCED_BY_EXPLOSION)
+                    if damage > 0:
+                        flags |= int(
+                            flags_type.
+                            MATERIAL_WITH_POSITIVE_DF_PIERCED_BY_EXPLOSION)
                     critical_cause = 'explosion'
+                    pierced_flag = int(flags_type.DEVICE_PIERCED_BY_EXPLOSION)
                     device_flag = int(
                         flags_type.DEVICE_DAMAGED_BY_EXPLOSION)
                     chassis_flag = int(
@@ -10405,6 +10418,7 @@ class BattleRuntime(object):
                     else:
                         flags |= int(flags_type.RICOCHET)
                     critical_cause = 'shot'
+                    pierced_flag = int(flags_type.DEVICE_PIERCED_BY_PROJECTILE)
                     device_flag = int(
                         flags_type.DEVICE_DAMAGED_BY_PROJECTILE)
                     chassis_flag = int(
@@ -10420,8 +10434,12 @@ class BattleRuntime(object):
                     state = critical_event.get('state')
                     if kind == 'fire' and bool(state):
                         flags |= int(flags_type.FIRE_STARTED)
-                    elif (kind == 'device' and
-                          state in ('critical', 'destroyed')):
+                    elif critical_event in critical_events:
+                        # #1513's voice selector tests DEVICE_PIERCED, not
+                        # DEVICE_DAMAGED, for module-only hits and ricochets.
+                        flags |= pierced_flag
+                        if kind != 'device':
+                            continue
                         name = str(critical_event.get('name', ''))
                         flags |= device_flag
                         if name in ('leftTrackHealth', 'rightTrackHealth'):

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -2284,10 +2284,12 @@ def _runtime():
             VEHICLE_KILLED=1, FIRE_STARTED=4, RICOCHET=8,
             MATERIAL_WITH_POSITIVE_DF_PIERCED_BY_PROJECTILE=16,
             MATERIAL_WITH_POSITIVE_DF_NOT_PIERCED_BY_PROJECTILE=32,
+            DEVICE_PIERCED_BY_PROJECTILE=256,
             DEVICE_DAMAGED_BY_PROJECTILE=1024,
             CHASSIS_DAMAGED_BY_PROJECTILE=2048,
             GUN_DAMAGED_BY_PROJECTILE=4096,
             MATERIAL_WITH_POSITIVE_DF_PIERCED_BY_EXPLOSION=8192,
+            DEVICE_PIERCED_BY_EXPLOSION=32768,
             DEVICE_DAMAGED_BY_EXPLOSION=65536,
             CHASSIS_DAMAGED_BY_EXPLOSION=131072,
             GUN_DAMAGED_BY_EXPLOSION=262144,
@@ -13571,11 +13573,86 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertEqual(
             flags.ATTACK_IS_DIRECT_PROJECTILE |
             flags.MATERIAL_WITH_POSITIVE_DF_PIERCED_BY_PROJECTILE |
+            flags.DEVICE_PIERCED_BY_PROJECTILE |
             flags.DEVICE_DAMAGED_BY_PROJECTILE,
             packed >> 32)
         self.assertEqual([7, 6], [
             value['eventType']
             for value in battle._avatar.battle_events[0]])
+
+    def test_critical_ribbons_count_damage_not_effects_or_repairs(self):
+        damage_events = [
+            {'kind': 'device', 'name': 'fuelTankHealth',
+             'old_state': 'normal', 'state': 'destroyed'},
+            {'kind': 'device', 'name': 'ammoBayHealth',
+             'old_state': 'critical', 'state': 'destroyed'},
+            {'kind': 'crew', 'name': 'commander', 'state': 'destroyed'},
+        ]
+        other_events = [
+            {'kind': 'fire', 'state': True},
+            {'kind': 'fire', 'state': False},
+            {'kind': 'ammo_rack', 'state': 'destroyed'},
+            {'kind': 'device', 'name': 'gunHealth',
+             'old_state': 'destroyed', 'state': 'critical'},
+            {'kind': 'device', 'name': 'engineHealth', 'state': 'normal'},
+            {'kind': 'crew', 'name': 'driver', 'state': 'normal'},
+        ]
+        for outgoing in (True, False):
+            for events, expected in ((damage_events + other_events, 3),
+                                     (other_events, 0)):
+                with self.subTest(outgoing=outgoing, expected=expected):
+                    runtime = _runtime()
+                    battle = BattleRuntime(runtime)
+                    battle._avatar = runtime.bigworld.avatar
+                    battle._avatar.playerVehicleID = 10
+                    battle._synchronise_player_identity(10)
+                    attacker = {'engine_id': 10, 'local': outgoing,
+                                'kind': 'player', 'state': {'team': 1}}
+                    target = {'engine_id': 11, 'local': not outgoing,
+                              'kind': 'bot', 'state': {'team': 2}}
+                    battle._present_combat_feedback({
+                        'kind': 'bot_hit', 'damage': 0, 'shot_result': 1,
+                        'source': 'shot', 'attack_reason': 0,
+                        'critical': {'events': events}}, target, attacker)
+                    ribbons = [item for batch in battle._avatar.battle_events
+                               for item in batch]
+                    self.assertEqual(1 if expected else 0, len(ribbons))
+                    if expected:
+                        self.assertEqual(6 if outgoing else 9,
+                                         ribbons[0]['eventType'])
+                        self.assertEqual(expected, ribbons[0]['details'] >> 16)
+
+    def test_module_only_shots_supply_stock_voice_piercing_flags(self):
+        for splash in (False, True):
+            for kind in ('device', 'crew', None):
+                with self.subTest(splash=splash, kind=kind):
+                    runtime = _runtime()
+                    battle = BattleRuntime(runtime)
+                    battle._avatar = runtime.bigworld.avatar
+                    battle._avatar.playerVehicleID = 10
+                    battle._synchronise_player_identity(10)
+                    attacker = {'engine_id': 10, 'local': True,
+                                'kind': 'player', 'state': {'team': 1}}
+                    target = {'engine_id': 11, 'local': False,
+                              'kind': 'bot', 'state': {'team': 2}}
+                    events = [] if kind is None else [{
+                        'kind': kind, 'name': 'engineHealth' if kind ==
+                        'device' else 'commander', 'state': 'destroyed',
+                        'cause': 'explosion' if splash else 'shot'}]
+                    battle._present_combat_feedback({
+                        'kind': 'bot_hit', 'damage': 0, 'shot_result': 0,
+                        'source': 'shot', 'attack_reason': 0, 'splash': splash,
+                        'critical': {'events': events}}, target, attacker)
+                    flags = battle._avatar.shot_results[0][0] >> 32
+                    vhf = runtime.constants.VEHICLE_HIT_FLAGS
+                    piercing = (vhf.DEVICE_PIERCED_BY_EXPLOSION if splash
+                                else vhf.DEVICE_PIERCED_BY_PROJECTILE)
+                    self.assertEqual(bool(kind), bool(flags & piercing))
+                    self.assertFalse(flags & (
+                        vhf.MATERIAL_WITH_POSITIVE_DF_PIERCED_BY_EXPLOSION |
+                        vhf.MATERIAL_WITH_POSITIVE_DF_PIERCED_BY_PROJECTILE))
+                    if not splash:
+                        self.assertTrue(flags & vhf.RICOCHET)
 
     def test_hidden_worker_never_invokes_stock_combat_feedback(self):
         runtime = _runtime()
@@ -13621,6 +13698,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertEqual(
             flags.ATTACK_IS_DIRECT_PROJECTILE |
             flags.MATERIAL_WITH_POSITIVE_DF_NOT_PIERCED_BY_PROJECTILE |
+            flags.DEVICE_PIERCED_BY_PROJECTILE |
             flags.DEVICE_DAMAGED_BY_PROJECTILE |
             flags.CHASSIS_DAMAGED_BY_PROJECTILE |
             flags.GUN_DAMAGED_BY_PROJECTILE |
@@ -13660,6 +13738,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertEqual(
             flags.ATTACK_IS_EXTERNAL_EXPLOSION |
             flags.MATERIAL_WITH_POSITIVE_DF_PIERCED_BY_EXPLOSION |
+            flags.DEVICE_PIERCED_BY_EXPLOSION |
             flags.DEVICE_DAMAGED_BY_EXPLOSION |
             flags.CHASSIS_DAMAGED_BY_EXPLOSION |
             flags.GUN_DAMAGED_BY_EXPLOSION |


### PR DESCRIPTION
Critical-hit feedback counted fire and ammo-rack effects as extra criticals, omitted piercing flags used by the stock voice selector, and marked every splash as vehicle-HP damage. Count only device damage transitions and crew knockouts, provide the confirmed piercing flags, and distinguish module-only splash damage. Keep stock ribbon filtering and voice priority.

Validation: 927 battle-runtime and critical-damage tests passed; all 105 client Python files compiled under CPython 2.7.18. Executed the extracted #1513 `showShotResults` method with old/new flags to confirm corrected ricochet and module-only explosion voice selection, plus empty splash and kill handling. Exact Windows audio playback and original server notification thresholds remain unverified.
