### PR TITLE
Fix consumables disappearing during battle startup and resupply

### DIFF
--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -2761,6 +2761,14 @@ The source audit deliberately keeps the following differences visible:
   layout mapped onto the gun's shot order, and the consumables come from the
   mounted slots, so an empty slot carries nothing. Bots keep a synthetic
   loadout by design;
+- `PlayerAvatar.__startVehicleVisual` calls `EquipmentsController.clear(False)`
+  for the own vehicle. Loading snapshots must retain their equipment state
+  without publishing or caching HUD echoes until native client readiness,
+  after that clear. The normal item-transition deduplication then remains
+  necessary to preserve the expanded repair/medical selector. Garage inventory
+  updates publish the room loadout after the asynchronous stock cache refresh;
+  starting a round checks that refresh has finished and queues the current
+  loadout before the start request;
 - the spotting law now applies the situational devices and the vision and
   concealment crew skills for the player and for authority bots. Coated optics
   stay implicit through `miscAttrs['circularVisionRadiusFactor']`, which

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/server.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/server.py
@@ -81,6 +81,7 @@ class FakeServer(object):
     def __init__(self, player_getter, callback=None, context=None):
         self._player_getter = player_getter
         self._context = dict(context or {})
+        self._pending_inventory_updates = 0
         if self._context.get('account_state') is None:
             from gui.mods.offline_lan_0922.account_rpc.state import AccountState
             self._context['account_state'] = AccountState(path=None)
@@ -96,6 +97,10 @@ class FakeServer(object):
         self._context.setdefault('push_update', self._push_update)
         self._context.setdefault(
             'push_update_and_wait', self._push_update)
+
+    @property
+    def inventory_refresh_pending(self):
+        return self._pending_inventory_updates > 0
 
     def _push_update(self, diff, after_publish=None):
         """Publish one account diff through the exact #1513 entity method.
@@ -127,29 +132,57 @@ class FakeServer(object):
         diff.setdefault('prevRev', revision)
         diff.setdefault('rev', revision + 1)
         payload = _pickle.dumps(diff, _pickle.HIGHEST_PROTOCOL)
+        inventory = 'inventory' in diff
+        completed = [False]
+        if inventory:
+            self._pending_inventory_updates += 1
+
+        def release():
+            if completed[0]:
+                return False
+            completed[0] = True
+            if inventory:
+                self._pending_inventory_updates -= 1
+            return True
+
+        def finish():
+            if not release() or self._player() is not player:
+                return
+            try:
+                if callable(after_publish):
+                    after_publish(player)
+            finally:
+                # Account.update is queued and ItemsCache refresh can yield.
+                # The room may read CurrentVehicle only after both complete,
+                # including any inventory update queued by the response.
+                notify = self._context.get('on_inventory_refreshed')
+                if (inventory and not self.inventory_refresh_pending and
+                        self._player() is player and callable(notify)):
+                    try:
+                        notify()
+                    except Exception as error:
+                        print('[Offline LAN 0.9.22] refreshed garage could '
+                              'not be published to the room: %s' % error)
 
         def publish():
             if self._player() is not player:
+                release()
                 return
-            player.update(payload)
+            try:
+                player.update(payload)
+                if inventory:
+                    _refresh_garage_views(diff, after_refresh=finish)
+                else:
+                    finish()
+            except Exception:
+                release()
+                raise
 
-            def finish():
-                if (self._player() is player and
-                        callable(after_publish)):
-                    after_publish(player)
-
-            # The fallback exists for fitting changes whose inventory payload
-            # must be re-read by the current-vehicle cache.  Reapplying a
-            # stats-only update needlessly runs that expensive inventory path
-            # a second time.  An accepted fitting command chains its success
-            # response through ``after_publish``, so finish only after the
-            # CurrentVehicle listener can read the new descriptor.
-            if 'inventory' in diff:
-                _refresh_garage_views(diff, after_refresh=finish)
-            else:
-                finish()
-
-        self._callback(0.0, publish)
+        try:
+            self._callback(0.0, publish)
+        except Exception:
+            release()
+            raise
         return True
 
     def _player(self):

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -7469,7 +7469,10 @@ class BattleRuntime(object):
         return 1, int(stages.READY), 0
 
     def _present_equipments(self, now=None):
-        if self._equipment_state is None:
+        # Loading snapshots can precede stock __startVehicleVisual, which
+        # clears the equipment controller. Do not cache a presentation until
+        # the native enter/ready boundary has passed that last clear.
+        if not self._client_ready_received or self._equipment_state is None:
             return False
         if now is None:
             now = self._clock()

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bootstrap.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bootstrap.py
@@ -796,6 +796,12 @@ def _selected_vehicle(config, restore_saved=True):
         raise
 
 
+def _on_inventory_refreshed():
+    notify = getattr(_session, 'on_inventory_refreshed', None)
+    if callable(notify):
+        notify()
+
+
 def _on_lobby_view_loaded(event):
     global _lobby_view_loaded
     _lobby_view_loaded = True
@@ -1254,6 +1260,7 @@ def _run_once():
             _account_context = {
                 'selected_vehicle': _selected_vehicle(_config),
                 'garage_store': _garage_store(),
+                'on_inventory_refreshed': _on_inventory_refreshed,
                 # Account settings are server-owned in #1513. Keep their
                 # local offline substitute beside config across restarts.
                 'account_state': account_state,

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
@@ -1784,7 +1784,7 @@ class LANClient(object):
 
     def select_vehicle(self, vehicle, max_health, outfits=None,
                        vehicle_compact_descr=None, effective_params=None):
-        """Publish one waiting-room garage change for the next round."""
+        """Accept the current loadout, sending only a changed selection."""
         if not self.ready or self.phase != 'waiting':
             return False
         vehicle = _safe_text(vehicle, '', 64)
@@ -1806,7 +1806,7 @@ class LANClient(object):
                 outfits == self.outfits and
                 compact == self.vehicle_compact_descr and
                 params == self.effective_params):
-            return False
+            return True
         message = {'type': 'select_vehicle', 'vehicle': vehicle,
                    'max_health': max_health,
                    'vehicle_compact_descr': compact,

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/lan_session.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/lan_session.py
@@ -51,6 +51,15 @@ def _load_client():
     return LANClient
 
 
+def _garage_inventory_refresh_pending():
+    try:
+        import BigWorld
+    except ImportError:
+        return False
+    server = getattr(BigWorld.player(), 'fakeServer', None)
+    return bool(getattr(server, 'inventory_refresh_pending', False))
+
+
 def _start_adisp_request(request_results, context, completed):
     """Advance one stock ``@async @process`` request to completion."""
     from adisp import process
@@ -815,6 +824,8 @@ class LANSession(object):
 
     def _publish_selected_vehicle(self):
         """Send the current garage tank so the next round uses it."""
+        if _garage_inventory_refresh_pending():
+            return False
         client = self.client
         select = getattr(client, 'select_vehicle', None)
         if client is None or not callable(select):
@@ -839,10 +850,19 @@ class LANSession(object):
             return bool(select(
                 vehicle, max_health, outfits, vehicle_compact_descr,
                 effective_params))
-        except TypeError:
-            # Test doubles and the first protocol-v5 client accepted only the
-            # original vehicle and max-health arguments.
-            return bool(select(vehicle, max_health))
+        except Exception as error:
+            # A failed modern projection/send must never fall back to a
+            # vehicle-only request that reuses the previous loadout.
+            sys.stdout.write(
+                '[Offline LAN 0.9.22] vehicle selection could not be '
+                'published: %s\n' % error)
+            return False
+
+    def on_inventory_refreshed(self):
+        """Publish a completed fitting/resupply without another room click."""
+        if self._stopped or self.state != 'waiting' or self._start_requested:
+            return False
+        return self._publish_selected_vehicle()
 
     def _return_to_join_after_vehicle_selection_error(self):
         self.client = None
@@ -1977,14 +1997,25 @@ class LANSession(object):
                 self._endpoint_value())
             self._close_picker_after_event()
             return True
-        accepted = bool(self.client.request_start(
-            map_name, self._round_seconds))
+        accepted = self._send_start_request(map_name)
         if accepted:
             self._start_requested = True
             self._pending_map = None
             self.state = 'awaiting_battle_start'
             self._close_picker_after_event()
         return accepted
+
+    def _send_start_request(self, map_name):
+        if _garage_inventory_refresh_pending():
+            self._status_notifier(tr(
+                'Vehicle supplies are updating. Try starting again in a moment.'))
+            return False
+        # select_vehicle and start share the transport's ordered send queue.
+        # Never start with an older loadout after a failed garage projection.
+        if not self._publish_selected_vehicle():
+            self._status_notifier(tr(VEHICLE_SELECTION_WARNING))
+            return False
+        return bool(self.client.request_start(map_name, self._round_seconds))
 
     def _stop_active_round(self):
         try:
@@ -2082,8 +2113,7 @@ class LANSession(object):
                         tr('The LAN server does not offer the selected map.'))
                     self._sync_waiting_surface(previous_host_player_id)
                     return
-                if self.client.request_start(pending_map,
-                                             self._round_seconds):
+                if self._send_start_request(pending_map):
                     self._start_requested = True
                     self.state = 'awaiting_battle_start'
                     self._close_picker()

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/ui_i18n.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/ui_i18n.py
@@ -90,6 +90,7 @@ _ZH = {
     'Starting %s...': u'正在开始 %s...',
     'The server did not accept that map.': u'服务器未接受该地图。',
     'Select a valid vehicle in the garage, then click Battle! again.': u'请在车库选择有效车辆，然后再次点击战斗按钮。',
+    'Vehicle supplies are updating. Try starting again in a moment.': u'车辆补给正在更新，请稍后再点击开始战斗。',
     'You left the LAN room. Click Battle! to join again.': u'已离开局域网房间。点击战斗按钮可重新加入。',
     'waiting for roster': u'等待玩家列表',
     'Requesting Bot tier preset...': u'正在申请电脑等级设置...',

--- a/tests/test_port_0922.py
+++ b/tests/test_port_0922.py
@@ -6635,6 +6635,7 @@ class BootstrapContractTests(unittest.TestCase):
                         account_context={'selected_vehicle': {
                             'id': 1, 'compDescr': 12345},
                             'garage_store': None,
+                            'on_inventory_refreshed': module._on_inventory_refreshed,
                             'account_state': account_state})],
                     lobby_entry.mock_calls)
                 bigworld.run_next()
@@ -6760,6 +6761,7 @@ class BootstrapContractTests(unittest.TestCase):
             account_context={'selected_vehicle': {
                 'id': 1, 'compDescr': 12345},
                 'garage_store': None,
+                'on_inventory_refreshed': module._on_inventory_refreshed,
                 'account_state': account_state})
         self.assertEqual([expected_connect, expected_connect],
                          compatibility.connect.call_args_list)

--- a/tests/test_port_0922_account_rpc.py
+++ b/tests/test_port_0922_account_rpc.py
@@ -281,6 +281,74 @@ class AccountRpcTests(unittest.TestCase):
         self.assertEqual(set(), touched_items[10])
         self.assertEqual(set(), touched_items[11])
 
+    def test_inventory_ready_notification_waits_for_all_cache_refreshes(self):
+        refreshed = []
+        completed = []
+        self.server._context['on_inventory_refreshed'] = lambda: refreshed.append(
+            self.server.inventory_refresh_pending)
+        diff = {'inventory': {1: {'eqs': {9: [11001, 0, 0]}}}}
+        with mock.patch(
+                'gui.mods.offline_lan_0922.account_rpc.server.'
+                '_refresh_garage_views',
+                side_effect=lambda diff, after_refresh: completed.append(
+                    after_refresh)):
+            self.server._push_update(diff)
+            self.server._push_update(diff)
+            self.assertTrue(self.server.inventory_refresh_pending)
+            self._run()
+            self._run()
+        self.assertEqual([], refreshed)
+        completed[0]()
+        completed[0]()
+        self.assertTrue(self.server.inventory_refresh_pending)
+        self.assertEqual([], refreshed)
+        completed[1]()
+        self.assertFalse(self.server.inventory_refresh_pending)
+        self.assertEqual([False], refreshed)
+
+    def test_retired_inventory_update_does_not_notify_replacement_account(self):
+        refreshed = mock.Mock()
+        self.server._context['on_inventory_refreshed'] = refreshed
+        self.server._push_update({'inventory': {}})
+        self.player = _Player()
+        self._run()
+        self.assertFalse(self.server.inventory_refresh_pending)
+        refreshed.assert_not_called()
+
+    def test_inventory_notification_waits_for_response_queued_update(self):
+        refreshed = mock.Mock()
+        self.server._context['on_inventory_refreshed'] = refreshed
+        completed = []
+
+        def queue_another(unused_player):
+            self.server._push_update({'inventory': {}})
+
+        with mock.patch(
+                'gui.mods.offline_lan_0922.account_rpc.server.'
+                '_refresh_garage_views',
+                side_effect=lambda diff, after_refresh: completed.append(
+                    after_refresh)):
+            self.server._push_update(
+                {'inventory': {}}, after_publish=queue_another)
+            self._run()
+            completed[0]()
+            self.assertTrue(self.server.inventory_refresh_pending)
+            refreshed.assert_not_called()
+            self._run()
+            completed[1]()
+        refreshed.assert_called_once_with()
+        self.assertFalse(self.server.inventory_refresh_pending)
+
+    def test_failed_inventory_publication_releases_pending_state(self):
+        refreshed = mock.Mock()
+        self.server._context['on_inventory_refreshed'] = refreshed
+        self.player.update = mock.Mock(side_effect=RuntimeError('retired update'))
+        self.server._push_update({'inventory': {}})
+        with self.assertRaises(RuntimeError):
+            self._run()
+        self.assertFalse(self.server.inventory_refresh_pending)
+        refreshed.assert_not_called()
+
     def test_stats_update_does_not_run_the_inventory_refresh_fallback(self):
         with mock.patch(
                 'gui.mods.offline_lan_0922.account_rpc.server.'

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -7967,6 +7967,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
             crewLevelIncrease=10.0)
         runtime.vehicles.g_cache.equipments = lambda: {401: descriptor}
         battle = BattleRuntime(runtime)
+        battle._client_ready_received = True
         battle.client = _Client()
         battle._avatar = runtime.bigworld.avatar
         battle._server = types.SimpleNamespace(vehicle_id=10)
@@ -8086,9 +8087,54 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertEqual(snapshot, restored.snapshot(500.0))
         self.assertEqual(4, battle._equipment_revision)
 
+    def test_loading_equipment_survives_stock_vehicle_visual_clear(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle.client = types.SimpleNamespace(player_id=7)
+        battle._avatar = runtime.bigworld.avatar
+        battle._server = types.SimpleNamespace(vehicle_id=10)
+        battle.state = 'loading_entities'
+        controller = {}
+        updates = []
+
+        def update(vehicle_id, compact, quantity, stage, remaining):
+            controller[compact] = (quantity, stage)
+            updates.append(compact)
+
+        battle._avatar.updateVehicleAmmo = update
+        snapshots = []
+        for index, (name, tag) in enumerate((
+                ('largeRepairkit', 'repairkit'),
+                ('largeMedkit', 'medkit'), ('chocolate', 'food'))):
+            descriptor = types.SimpleNamespace(
+                id=(11, 41 + index), compactDescr=441 + index,
+                name=name, tags=(tag,), reuseCount=-1,
+                cooldownSeconds=90.0, repairAll=True)
+            snapshots.append(equipment_mechanics.EquipmentState(
+                equipment_mechanics.project_equipment(descriptor)).snapshot())
+        message = {'players': [{
+            'id': 7, 'equipment_revision': 1,
+            'equipment_states': snapshots}]}
+
+        battle._restore_local_equipment_snapshot(message, present=True)
+        self.assertEqual(3, len(battle._equipment_state))
+        self.assertEqual([], updates)
+        self.assertIsNone(battle._equipment_signature)
+        # Exact #1513 __startVehicleVisual clears the controller before the
+        # bridge can publish native client readiness. A loading snapshot must
+        # not populate the deduplication cache on the earlier side.
+        controller.clear()
+        battle._client_ready_received = True
+        battle._restore_local_equipment_snapshot(message, present=True)
+        self.assertEqual({441, 442, 443}, set(controller))
+        for unused in range(100):
+            battle._restore_local_equipment_snapshot(message, present=True)
+        self.assertEqual([441, 442, 443], updates)
+
     def test_equipment_snapshots_preserve_expanded_selection_keys(self):
         runtime = _runtime()
         battle = BattleRuntime(runtime)
+        battle._client_ready_received = True
         battle.client = types.SimpleNamespace(player_id=7)
         battle._avatar = runtime.bigworld.avatar
         battle._server = types.SimpleNamespace(vehicle_id=10)
@@ -27387,6 +27433,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
     def test_equipment_activation_decodes_extra_and_enters_cooldown(self):
         runtime = _runtime()
         battle = BattleRuntime(runtime)
+        battle._client_ready_received = True
         battle.state = 'running'
         battle._avatar = runtime.bigworld.avatar
         send_intent = mock.Mock(side_effect=(1, 2, 3, 4))

--- a/tests/test_port_0922_bootstrap_lifecycle.py
+++ b/tests/test_port_0922_bootstrap_lifecycle.py
@@ -1551,6 +1551,21 @@ class BootstrapLifecycleTests(unittest.TestCase):
             self.assertIsNone(bootstrap._cleanup_runtime())
         self.assertEqual('uninstall_announcement_router', events[-1])
 
+    def test_inventory_refresh_notifies_only_the_current_lan_session(self):
+        (bootstrap, unused_callbacks, unused_compatibility,
+         unused_app_loader, unused_spaces, unused_events,
+         unused_modules) = self._load()
+        first = types.SimpleNamespace(on_inventory_refreshed=mock.Mock())
+        second = types.SimpleNamespace(on_inventory_refreshed=mock.Mock())
+        bootstrap._session = first
+        bootstrap._on_inventory_refreshed()
+        bootstrap._session = second
+        bootstrap._on_inventory_refreshed()
+        bootstrap._session = None
+        bootstrap._on_inventory_refreshed()
+        first.on_inventory_refreshed.assert_called_once_with()
+        second.on_inventory_refreshed.assert_called_once_with()
+
     def test_lobby_view_load_immediately_notifies_the_lan_session(self):
         (bootstrap, unused_callbacks, unused_compatibility,
          unused_app_loader, unused_spaces, unused_events,

--- a/tests/test_port_0922_lan_protocol.py
+++ b/tests/test_port_0922_lan_protocol.py
@@ -255,7 +255,8 @@ class LanProtocolTests(unittest.TestCase):
         self.client.vehicle = 'ussr:R11_MS-1'
         self.client.max_health = 90
 
-        self.assertFalse(self.client.select_vehicle('ussr:R11_MS-1', 90))
+        self.assertTrue(self.client.select_vehicle('ussr:R11_MS-1', 90))
+        self.assertEqual([], self.sent)
         self.assertTrue(self.client.select_vehicle(
             'germany:G01_PzI', 150,
             vehicle_compact_descr='cHpp'))
@@ -284,7 +285,7 @@ class LanProtocolTests(unittest.TestCase):
 
         self.assertEqual('germany:G01_PzI', self.client.vehicle)
         self.assertEqual(150, self.client.max_health)
-        self.assertFalse(self.client.select_vehicle('germany:G01_PzI', 150))
+        self.assertTrue(self.client.select_vehicle('germany:G01_PzI', 150))
 
     def test_modern_vehicle_change_rejects_non_exact_health_atomically(self):
         invalid_values = (

--- a/tests/test_port_0922_lan_session.py
+++ b/tests/test_port_0922_lan_session.py
@@ -98,11 +98,12 @@ class _Client(object):
         self.leave_calls += 1
         return True
 
-    def select_vehicle(self, vehicle, max_health):
+    def select_vehicle(self, vehicle, max_health, outfits=None,
+                       vehicle_compact_descr=None, effective_params=None):
         if not self.ready or self.phase != 'waiting':
             return False
         if vehicle == self.vehicle and max_health == self.max_health:
-            return False
+            return True
         self.selections.append((vehicle, max_health))
         self.vehicle = vehicle
         self.max_health = max_health
@@ -329,6 +330,75 @@ class LANSessionTests(unittest.TestCase):
         if 'players' in message:
             self.client.roster = list(message['players'])
         self.client.on_event(kind, message)
+
+    def test_start_publishes_current_loadout_before_start_message(self):
+        self.emit('welcome', {'phase': 'waiting', 'map_pool': ['01_karelia']})
+        calls = []
+        self.session._effective_params_provider = lambda: {'equipment': [441]}
+        self.client.select_vehicle = lambda *args: calls.append(
+            ('select', args[-1])) or True
+        self.client.request_start = lambda *args: calls.append(('start', args)) or True
+        self.assertTrue(self.session.request_start('01_karelia'))
+        self.assertEqual(['select', 'start'], [call[0] for call in calls])
+        self.assertEqual({'equipment': [441]}, calls[0][1])
+
+    def test_inventory_refresh_blocks_start_then_publishes_completed_loadout(self):
+        self.emit('welcome', {'phase': 'waiting', 'map_pool': ['01_karelia']})
+        provider = mock.Mock(return_value={'equipment': [441, 442, 443]})
+        self.session._effective_params_provider = provider
+        self.client.select_vehicle = mock.Mock(return_value=True)
+        with mock.patch.object(self.module, '_garage_inventory_refresh_pending',
+                               return_value=True, create=True):
+            self.assertFalse(self.session.request_start('01_karelia'))
+            self.assertFalse(self.session._publish_selected_vehicle())
+        provider.assert_not_called()
+        self.assertEqual([], self.client.requests)
+        self.assertEqual('waiting', self.session.state)
+        self.session.on_inventory_refreshed()
+        self.assertEqual({'equipment': [441, 442, 443]},
+                         self.client.select_vehicle.call_args[0][-1])
+        self.assertTrue(self.session.request_start('01_karelia'))
+
+    def test_start_does_not_use_old_loadout_after_projection_failure(self):
+        self.emit('welcome', {'phase': 'waiting', 'map_pool': ['01_karelia']})
+        self.session._effective_params_provider = mock.Mock(
+            side_effect=ValueError('garage item is unavailable'))
+        self.assertFalse(self.session.request_start('01_karelia'))
+        self.assertEqual([], self.client.requests)
+        self.assertFalse(self.session._start_requested)
+
+    def test_start_requires_loadout_send_to_be_accepted(self):
+        self.emit('welcome', {'phase': 'waiting', 'map_pool': ['01_karelia']})
+        self.client.select_vehicle = mock.Mock(return_value=False)
+        self.assertFalse(self.session.request_start('01_karelia'))
+        self.assertEqual([], self.client.requests)
+
+    def test_selection_type_error_never_retries_with_the_old_loadout(self):
+        self.emit('welcome', {'phase': 'waiting', 'map_pool': ['01_karelia']})
+        self.session._effective_params_provider = lambda: {'equipment': [441]}
+        self.client.select_vehicle = mock.Mock(
+            side_effect=[TypeError('invalid loadout'), True])
+        self.assertFalse(self.session.request_start('01_karelia'))
+        self.assertEqual(1, self.client.select_vehicle.call_count)
+        self.assertEqual([], self.client.requests)
+
+    def test_pending_map_start_also_waits_for_inventory_refresh(self):
+        self.assertTrue(self.session.request_start('01_karelia'))
+        with mock.patch.object(self.module, '_garage_inventory_refresh_pending',
+                               return_value=True):
+            self.emit('welcome', {'phase': 'waiting', 'map_pool': ['01_karelia']})
+        self.assertEqual([], self.client.requests)
+        self.assertFalse(self.session._start_requested)
+
+    def test_inventory_notification_cannot_publish_during_or_after_battle(self):
+        self.client.select_vehicle = mock.Mock(return_value=True)
+        for state in ('battle', 'awaiting_battle_start', 'awaiting_round_end'):
+            self.session.state = state
+            self.assertFalse(self.session.on_inventory_refreshed())
+        self.session.state = 'waiting'
+        self.session._stopped = True
+        self.assertFalse(self.session.on_inventory_refreshed())
+        self.client.select_vehicle.assert_not_called()
 
     def test_waiting_room_team_selection_reaches_the_client(self):
         self.client.ready = True
@@ -2831,6 +2901,7 @@ class LANSessionRoomTests(unittest.TestCase):
             picker_opener=lambda: self.opens.append(True) or True,
             battle_runtime=_BattleRuntime(),
             vehicle_provider=lambda: ('ussr:R11_MS-1', 90),
+            vehicle_compact_provider=lambda: 'YQ==',
             status_notifier=self.statuses.append)
         self.assertTrue(self.session.start())
         # Production only reaches start() from the Battle click, and only that
@@ -3005,6 +3076,7 @@ class LANSessionMapWindowTests(unittest.TestCase):
             cancel_callback=lambda handle: self.scheduled.pop(handle, None),
             battle_runtime=_BattleRuntime(),
             vehicle_provider=lambda: ('ussr:R11_MS-1', 90),
+            vehicle_compact_provider=lambda: 'YQ==',
             status_notifier=lambda unused_message: None)
         self.assertTrue(self.session.start())
         self.session._picker_requested = True

--- a/tools/audit_client_abi.py
+++ b/tools/audit_client_abi.py
@@ -813,6 +813,7 @@ EXPECTED_ABI = {
             'self', 'entityName', 'avatar'),
         'EquipmentsController.setEquipment': (
             'self', 'intCD', 'quantity', 'stage', 'timeRemaining'),
+        'EquipmentsController.clear': ('self', 'leave'),
     },
     'scripts/client/OfflineMapCreator.pyc': {
         'OfflineMapCreator.create': ('self', 'mapName'),
@@ -1217,7 +1218,8 @@ EXPECTED_CODE_NAMES = {
             '_PlayerAvatar__onInitStepCompleted'),
         'PlayerAvatar.__startVehicleVisual': (
             '_PlayerAvatar__ownVehicleStabMProv', 'target',
-            'stabilisedMatrix', 'matrix'),
+            'stabilisedMatrix', 'matrix', 'guiSessionProvider', 'shared',
+            'equipments', 'clear', 'setPlayerVehicle'),
         'PlayerAvatar.getOwnVehicleMatrix': (
             'getObservedVehicleMatrix', '_PlayerAvatar__ownVehicleMProv'),
         'PlayerAvatar.getOwnVehicleStabilisedMatrix': (
@@ -1712,6 +1714,7 @@ EXPECTED_CODE_NAMES = {
         '_ExpandedItem.getActivationCode': (
             'isEntityRequired', 'makeExtraName', 'index'),
         '_ExtinguisherItem.getActivationCode': ('id',),
+        'EquipmentsController.clear': ('_order', '_equipments', 'popitem', 'clear'),
     },
     'scripts/client/AreaDestructibles.pyc': {
         '_printErrDescNotAvailable': (
@@ -2427,6 +2430,12 @@ EXPECTED_ORDERED_INSTRUCTION_PATTERNS = {
             )),
     },
     'scripts/client/Avatar.pyc': {
+        'PlayerAvatar.__startVehicleVisual': (
+            'own vehicle visuals clear consumables without leaving battle', 0, (
+                ('LOAD_ATTR', 'value', 'clear'),
+                ('LOAD_GLOBAL', 'value', 'False'),
+                ('CALL_FUNCTION', 'argument', 1),
+            )),
         'PlayerAvatar.updateVehicleHealth': (
             'local death restores raw special health into Vehicle', 0, (
                 ('STORE_FAST', 'value', 'prevHealth'),


### PR DESCRIPTION
Consumables could disappear for the whole battle when a loading snapshot reached the HUD before stock #1513 own-vehicle initialization cleared the equipment controller. The presenter had already cached the item state, so identical snapshots could not restore the missing items. Publish equipment only after native client readiness, while preserving transition-only updates that keep repair and medical selection menus usable.

Garage fitting and automatic resupply now publish the room loadout after queued inventory updates and the stock cache refresh finish. Both start paths refuse an unfinished refresh or failed loadout publication, and queue the current loadout before starting. A failed selection no longer falls back to a vehicle-only request using old equipment.

Validation:
- Regression tests cover early snapshots and native controller clearing, unchanged equipment selection, overlapping inventory refreshes, retired accounts, failed projection/send, and both start paths.
- Full client test suite, CPython 2.7 source compilation, and the exact #1513 ABI audit.
- An isolated test executing stock Avatar/equipment-controller bytecode reproduces the missing three items before this fix and preserves all three after it for both initialization orders.

Exact Windows gameplay acceptance has not been performed; this change fixes deterministic Python lifecycle and synchronization defects without claiming to reproduce every reported client session.
