### PR TITLE
Fix elite vehicle popup replay after account sync and queued research

### DIFF
--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -901,7 +901,7 @@ not inferred from another 0.9.22 build:
 
 | Producer | Exact consumer contract covered |
 | --- | --- |
-| `CMD_SYNC_DATA` / `AccountSyncData` | `rev` and `prevRev`; every initial `Account._update` subscriber receives an explicit cache value instead of depending on a missing-key fallback. |
+| `CMD_SYNC_DATA` / `AccountSyncData` | Complete snapshots carry `rev` and omit `prevRev`; every initial `Account._update` subscriber receives an explicit cache value instead of depending on a missing-key fallback. The exact `AccountSyncData.__onSyncResponse` enables events after first sync, and `Account._update` treats any non-`None` `prevRev` as incremental, replaying all supplied `eliteVehicles`. Only actual pushed deltas carry `prevRev`; research captures its post-command stats before deferred publication so queued commands cannot repeat later unlock/elite events. |
 | `Stats` / `StatsRequester` / lobby controllers | Zeroed money and account scalars; mapping-shaped restrictions, referral data and clan locks; a non-empty `dailyPlayHours`; and full daily/weekly `playLimits`. Zero periods mean exhausted parental-control time in this build. `mayConsumeWalletResources` starts true because false is the native wallet's `SYNCING` state, and `tutorialsCompleted` carries the completed offline bitmask. |
 | `Inventory` / `InventoryRequester` | All item-type indices exist; vehicle `compDescr` and crew maps exist; `repair` is a two-item tuple and `shellsLayout` is a mapping. |
 | `QuestProgress` / personal-mission requesters | `quests`, `tokens`, and `potapovQuests`; both `regular` and `training` contain `slots`, `selected`, and `lastIDs`, while `compDescr` is always present. |

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/data.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/data.py
@@ -792,9 +792,12 @@ def sync_data(revision=0, selected_vehicle=None, int_user_settings=None,
     # helpers only create a requester cache entry when the corresponding key
     # exists in the sync diff; several lobby requesters then index that entry
     # directly instead of applying a missing-value default.
+    # This response contains the complete account, not a revision delta.
+    # #1513 identifies full sync by the absence of prevRev. Marking this as
+    # incremental replays every elite notification after first sync and
+    # keeps stale entries in the inventory and stats caches.
     result = {
         'rev': int(revision) + 1,
-        'prevRev': int(revision),
         'quests': {},
         'tokens': {},
         'potapovQuests': personal_missions(),

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/requests.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/requests.py
@@ -75,6 +75,10 @@ def _fitting(context, mutate, extension=None):
     # rather than re-reading the inventory, so the mutation can name one.
     ext = None if extension is None else extension(outcome)
     context['selected_vehicle'] = state.snapshot()
+    # Capture this command's result before deferred publication. Another
+    # command may mutate the garage before publish runs; its new unlocks and
+    # elite vehicles must belong only to its own notification delta.
+    current_stats = data.stats(state.snapshot())['stats']
     mutated = _clock()
     store = context.get('garage_store')
     if store is not None:
@@ -100,7 +104,6 @@ def _fitting(context, mutate, extension=None):
             only_items=touched_items, touched_tankmen=moved_tankmen)
         # StatsRequester merges these fields before the command callback.
         # Publish the ledger with the inventory for every paid garage action.
-        current_stats = data.stats(state.snapshot())['stats']
         changed_stats = dict((name, current_stats[name]) for name in (
             'credits', 'gold', 'freeXP', 'slots', 'berths', 'vehicleSellsLeft',
             'vehTypeXP', 'unlocks', 'eliteVehicles')

--- a/tests/test_port_0922_account_rpc.py
+++ b/tests/test_port_0922_account_rpc.py
@@ -853,6 +853,20 @@ class AccountRpcTests(unittest.TestCase):
         self.assertEqual(set(range(1, 13)), set(data['inventory']))
         self.assertEqual({}, data['inventory'][1]['compDescr'])
 
+    def test_repeated_sync_keeps_existing_elite_vehicles_out_of_notifications(self):
+        snapshot = _full_garage_snapshot()
+        self.server.update_context({'selected_vehicle': snapshot})
+        for revision in (0, 7, 8):
+            self.server.doCmdInt3(37, commands.CMD_SYNC_DATA, revision, 0, 0)
+            self._run()
+            value = pickle.loads(self.player.ext_responses[-1][3])
+            self.assertEqual(revision + 1, value['rev'])
+            self.assertEqual({50001, 50002}, value['stats']['eliteVehicles'])
+            # AccountSyncData.__onSyncResponse enables events after the
+            # first sync. Account._update suppresses elite events only when
+            # prevRev is absent, marking this complete snapshot as full.
+            self.assertNotIn('prevRev', value)
+
     def test_sync_data_populates_all_exact_lobby_consumer_caches(self):
         self.server.doCmdInt3(37, commands.CMD_SYNC_DATA, 0, 0, 0)
         self._run()
@@ -1509,6 +1523,45 @@ class DepotTests(unittest.TestCase):
             lambda garage: garage.snapshot()['unlockItemCompactDescrs'].add(4444))
         result.before_response()
         self.assertEqual({4444}, pushed[0]['stats']['unlocks'])
+
+    def test_queued_research_notifies_each_new_elite_vehicle_once(self):
+        snapshot = _full_garage_snapshot()
+        snapshot['wallet'] = {'credits': 0, 'gold': 0, 'freeXP': 100}
+        snapshot['shopItemPrices'].update({
+            4444: {'credits': 10}, 5555: {'credits': 20}})
+        vehicle_types = {
+            50001: types.SimpleNamespace(unlocksDescrs=((10, 4444),)),
+            50002: types.SimpleNamespace(unlocksDescrs=((20, 5555),)),
+        }
+        vehicles = types.SimpleNamespace(
+            getVehicleType=vehicle_types.__getitem__,
+            getTypeOfCompactDescr=lambda value: 4)
+        state = account_requests.garage.GarageState(
+            snapshot, vehicles_module=vehicles)
+        pushed = []
+        context = {'garage': state, 'push_update': pushed.append}
+        # Commands mutate immediately; FakeServer schedules their publication.
+        # The first response must not also notify the second research result.
+        with mock.patch.dict(sys.modules, {
+                'items': types.SimpleNamespace(vehicles=vehicles)}):
+            results = [account_requests.dispatch(
+                commands.CMD_UNLOCK, context, (vehicle, 0))
+                for vehicle in (50001, 50002)]
+            for result in results:
+                self.assertEqual(commands.RES_SUCCESS, result.result_id)
+                result.before_response()
+            self.assertEqual([{50001}, {50002}], [
+                diff['stats']['eliteVehicles'] for diff in pushed])
+            self.assertEqual([{4444}, {5555}], [
+                diff['stats']['unlocks'] for diff in pushed])
+            self.assertEqual(70, state.snapshot()['wallet']['freeXP'])
+            # Researching an already unlocked item spends nothing and emits
+            # no additional unlock or elite notification.
+            result = account_requests.dispatch(
+                commands.CMD_UNLOCK, context, (50002, 0))
+            result.before_response()
+            self.assertNotIn('stats', pushed[-1])
+            self.assertEqual(70, state.snapshot()['wallet']['freeXP'])
 
     def test_special_mode_item_cannot_be_bought_or_supplied(self):
         state = self._garage(item_type=11)

--- a/tools/account_lobby_consumer_contract.json
+++ b/tools/account_lobby_consumer_contract.json
@@ -3,7 +3,6 @@
   "syncData": {
     "directKeys": [
       "rev",
-      "prevRev",
       "inventory",
       "account",
       "stats",


### PR DESCRIPTION
Complete account sync responses were marked as incremental with `prevRev`. After the first sync, #1513 enables account events and interprets every supplied elite vehicle as newly elite, replaying the entire collection of modal notifications. Omit `prevRev` on complete snapshots while preserving revisioned deltas for actual changes.

Queued research had a second replay path: the first command calculated its post-command stats only when its deferred publisher ran, after later commands could already have researched more items. Capture stats immediately after each mutation so every new unlock and elite event belongs to one command. Update the reviewed sync contract and add regressions for repeat sync, queued free-XP research, and already-unlocked research.

Validation:
- Account RPC: 71 tests passed; both new regressions failed before the fix.
- Economy: 126 tests passed; garage: 248 tests passed.
- Exact #1513 lobby consumer audit passed; all client sources compile with CPython 2.7.18.
- Executed the shipped `AccountSyncData.__onSyncResponse` and `PlayerAccount._update` code objects under CPython 2.7.18 with stubbed external services: a synthetic account with 60 elite entries emitted 60 events on each repeat sync before the fix and zero after it. A genuine incremental elite update still emitted one event.

These are confirmed notification defects in current code. They explain a mechanism for the reported popup flood, but the reporter's exact research-to-resync trigger and Windows UI acceptance remain unverified.
