### PR TITLE
Fix crew transfer hangs and cross-vehicle placement

### DIFF
--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -2709,6 +2709,18 @@ operation is forbidden, not unlimited.
 - Incremental Account updates publish current balances, changed inventory,
   crew and XP before command completion; growing unlock/elite sets carry only
   additions, matching `Stats.synchronize` and avoiding repeated notifications.
+- Crew placement checks nation and primary role, while preserving the original
+  training specialization across vehicle transfers and save restoration.
+  Moving a seated crew member records the source seat in `lastCrew` so the
+  stock return-crew action can find them again.
+- In #1513, `ItemsCache.__invalidateData.cbWrapper` invokes `onSyncCompleted`
+  before the adisp completion callback. An exception in that event can strand
+  a waiting generator. Account publication exceptions now return command
+  failure; the cache-refresh fallback also has a ten-second failure deadline.
+  Late callbacks and callbacks from a replaced account cannot report success
+  or refresh the new account's views. Accepted inventory mutations remain
+  saved when presentation fails; the failure does not claim a successful
+  refresh or roll back a potentially published change.
 
 This is a functional offline progression loop, not the proprietary retail
 server economy. Reward coefficients and premium-vehicle credit bonuses remain

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/garage.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/garage.py
@@ -1955,11 +1955,15 @@ class GarageState(object):
         if source is None:
             del barracks[tankman_inventory_id]
         elif source is record:
-            crew[crew.index(tankman_inventory_id)] = None
+            source_slot = crew.index(tankman_inventory_id)
+            self._remember_last_crew(record, [source_slot])
+            crew[source_slot] = None
             rows.pop(tankman_inventory_id, None)
         else:
             source_crew = list(source.get('crew') or ())
-            source_crew[source_crew.index(tankman_inventory_id)] = None
+            source_slot = source_crew.index(tankman_inventory_id)
+            self._remember_last_crew(source, [source_slot])
+            source_crew[source_slot] = None
             source['crew'] = source_crew
             source['tankmen'].pop(tankman_inventory_id, None)
             self._touched.add(_int(source.get('id', 0)))
@@ -2115,15 +2119,6 @@ class GarageState(object):
                 'vehicle type %d is not researched' % compact_descr)
         nation_id, vehicle_type_id, unused_roles = self._vehicle_type_crew(
             compact_descr)
-        seat = self._seated_record(tankman_id)
-        if seat is not None:
-            seated_type = _int(seat.get('vehicleTypeCompactDescr', 0))
-            if seated_type != compact_descr:
-                # A seated crew member has to match their vehicle's nation,
-                # type and role or the next restore rejects the whole garage.
-                raise GarageError(
-                    'unload this crew member before retraining them for '
-                    'another vehicle')
         tankmen = self._tankmen_module()
         try:
             descriptor = tankmen.TankmanDescr(rows[tankman_id])
@@ -2441,12 +2436,11 @@ class GarageState(object):
             raise GarageError('the client refused the vehicle crew: %s' % error)
 
     def _check_tankman_fits(self, record, roles, slot, compact_descr):
-        """Refuse a seat this crew member cannot hold without retraining.
+        """Refuse a seat with a different nation or primary role.
 
-        The restore boundary requires every seated crew member to match their
-        vehicle's nation, type and role, so a mismatch would make the whole
-        save unrestorable.  Retraining is how a crew member changes vehicle;
-        a seat is not.
+        Nation and primary role must match. Training specialization is kept
+        unchanged when moving between vehicles; the client computes its
+        proficiency effects from the original descriptor.
         """
         tankmen = self._tankmen_module()
         vehicles = self._vehicles_module()
@@ -2458,10 +2452,6 @@ class GarageState(object):
             raise GarageError('the client refused the crew member: %s' % error)
         if _int(descriptor.nationID) != _int(nation_id):
             raise GarageError('this crew member serves another nation')
-        if _int(descriptor.vehicleTypeID) != _int(vehicle_type_id):
-            raise GarageError(
-                'this crew member is trained for another vehicle: retrain '
-                'them first')
         if descriptor.role != roles[slot][0]:
             raise GarageError(
                 'this crew member is a %s and seat %d is for a %s'

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/requests.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/requests.py
@@ -134,17 +134,26 @@ def _fitting(context, mutate, extension=None):
             completed[0] = True
             on_complete()
 
+        def failed(error):
+            if completed[0]:
+                return
+            result.result_id = commands.RES_FAILURE
+            result.error = 'GARAGE_REFRESH_FAILED: %s' % error
+            complete()
+
         if callable(on_complete) and callable(push_and_wait):
-            if not push_and_wait(diff, after_publish=complete):
-                complete()
+            if not push_and_wait(diff, after_publish=complete,
+                                 after_failure=failed):
+                failed('account is unavailable')
         else:
             push(diff)
             complete()
         _report_fitting_cost(started, mutated, saved, built, diff)
 
-    return Result(
+    result = Result(
         commands.RES_SUCCESS, ext=ext, before_response=publish,
         wait_for_before_response=True)
+    return result
 
 
 def _report_fitting_cost(started, mutated, saved, built, diff):

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/server.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/server.py
@@ -5,11 +5,13 @@ try:
 except ImportError:
     import pickle as _pickle
 import zlib
+import traceback
 
 from gui.mods.offline_lan_0922.account_rpc import commands, data, requests
 
 
-def _refresh_garage_views(diff, after_refresh=None):
+def _refresh_garage_views(diff, after_refresh=None, after_failure=None,
+                          is_current=None):
     """Complete the stock refresh chain for a locally applied inventory diff.
 
     ``gui/shared/personality.onClientUpdate`` runs
@@ -21,18 +23,26 @@ def _refresh_garage_views(diff, after_refresh=None):
     ``Hangar.__updateParams``.  Running the second alone would recompute the
     parameters panel from the pre-mount descriptor.
 
-    This is a fallback: when the stock listener already completes the chain,
-    both calls are idempotent.  Any failure here is presentation only.
-    ``after_refresh`` is called exactly once after the chain finishes or can
-    no longer be started.
+    This is a fallback for the stock listener. Complete through exactly one
+    of ``after_refresh`` and ``after_failure``. A failure must end the command
+    wait without reporting that CurrentVehicle is ready.
     """
     completed = [False]
+    timer = [None]
+    import BigWorld
 
-    def complete():
+    def complete(error=None):
         if completed[0]:
             return
         completed[0] = True
-        if callable(after_refresh):
+        if timer[0] is not None:
+            BigWorld.cancelCallback(timer[0])
+            timer[0] = None
+        if error is not None:
+            print('[Offline LAN 0.9.22] garage refresh failed: %s' % error)
+            if callable(after_failure):
+                after_failure(error)
+        elif callable(after_refresh):
             after_refresh()
 
     try:
@@ -40,28 +50,41 @@ def _refresh_garage_views(diff, after_refresh=None):
         from gui.ClientUpdateManager import g_clientUpdateManager
         from gui.shared.items_cache import CACHE_SYNC_REASON
         from gui.shared.personality import ServicesLocator
-    except ImportError:
-        complete()
+    except ImportError as error:
+        complete(error)
         return False
+
+    def expired():
+        timer[0] = None
+        complete('inventory refresh callback timed out')
+
+    # #1513 invokes onSyncCompleted before its adisp callback. An exception
+    # in that later event dispatch never resumes the waiting generator.
+    # Bound the wait and report failure, without pretending the cache is ready.
+    timer[0] = BigWorld.callback(10.0, expired)
 
     @adisp.process
     def refresh():
         try:
             yield ServicesLocator.itemsCache.update(
                 CACHE_SYNC_REASON.CLIENT_UPDATE, diff)
+            if completed[0]:
+                return
+            if callable(is_current) and not is_current():
+                complete('account changed during inventory refresh')
+                return
             g_clientUpdateManager.update(diff)
         except Exception as error:
-            print('[Offline LAN 0.9.22] the garage views did not refresh: '
-                  '%s' % error)
-        finally:
+            traceback.print_exc()
+            complete(error)
+        else:
             complete()
 
     try:
         refresh()
     except Exception as error:
-        print('[Offline LAN 0.9.22] the garage refresh could not start: %s'
-              % error)
-        complete()
+        traceback.print_exc()
+        complete(error)
         return False
     return True
 
@@ -102,7 +125,7 @@ class FakeServer(object):
     def inventory_refresh_pending(self):
         return self._pending_inventory_updates > 0
 
-    def _push_update(self, diff, after_publish=None):
+    def _push_update(self, diff, after_publish=None, after_failure=None):
         """Publish one account diff through the exact #1513 entity method.
 
         ``PlayerAccount.update`` unpickles its argument and forwards it to
@@ -164,25 +187,36 @@ class FakeServer(object):
                         print('[Offline LAN 0.9.22] refreshed garage could '
                               'not be published to the room: %s' % error)
 
+        def fail(error):
+            if not release() or self._player() is not player:
+                return
+            print('[Offline LAN 0.9.22] account update failed: %s' % error)
+            if callable(after_failure):
+                after_failure(error)
+
         def publish():
             if self._player() is not player:
                 release()
                 return
             try:
                 player.update(payload)
+                if self._player() is not player:
+                    release()
+                    return
                 if inventory:
-                    _refresh_garage_views(diff, after_refresh=finish)
+                    _refresh_garage_views(
+                        diff, after_refresh=finish, after_failure=fail,
+                        is_current=lambda: self._player() is player)
                 else:
                     finish()
-            except Exception:
-                release()
-                raise
+            except Exception as error:
+                traceback.print_exc()
+                fail(error)
 
         try:
             self._callback(0.0, publish)
-        except Exception:
-            release()
-            raise
+        except Exception as error:
+            fail(error)
         return True
 
     def _player(self):
@@ -241,12 +275,26 @@ class FakeServer(object):
         result = requests.dispatch(command, self._context, args)
 
         def before_response(on_complete):
-            if callable(result.before_response):
-                if result.wait_for_before_response:
-                    result.before_response(on_complete)
-                    return
-                result.before_response()
-            on_complete()
+            completed = [False]
+
+            def complete():
+                if not completed[0]:
+                    completed[0] = True
+                    on_complete()
+
+            try:
+                if callable(result.before_response):
+                    if result.wait_for_before_response:
+                        result.before_response(complete)
+                        return
+                    result.before_response()
+            except Exception as error:
+                if completed[0]:
+                    raise
+                result.result_id = commands.RES_FAILURE
+                result.error = 'GARAGE_UPDATE_FAILED: %s' % error
+                print('[Offline LAN 0.9.22] %s' % result.error)
+            complete()
 
         if result.result_id == commands.RES_STREAM:
             desc, payload = pack_stream(result.stream)

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bootstrap.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bootstrap.py
@@ -311,7 +311,6 @@ def _validate_restored_vehicle(record, vehicles, tankmen, customizations):
             continue
         tankman = tankmen.TankmanDescr(crew[tankman_id])
         if (int(tankman.nationID) != int(nation_id) or
-                int(tankman.vehicleTypeID) != int(vehicle_type_id) or
                 tankman.role != roles[slot][0]):
             raise ValueError(
                 'saved crew member does not match the vehicle slot')

--- a/tests/test_port_0922_account_rpc.py
+++ b/tests/test_port_0922_account_rpc.py
@@ -142,6 +142,12 @@ class _NativeLong(int):
 
 class AccountRpcTests(unittest.TestCase):
     def setUp(self):
+        refresh = mock.patch(
+            'gui.mods.offline_lan_0922.account_rpc.server._refresh_garage_views',
+            side_effect=lambda diff, after_refresh, after_failure=None, is_current=None:
+                after_refresh())
+        refresh.start()
+        self.addCleanup(refresh.stop)
         self.pending = []
         self.player = _Player()
         self.server = FakeServer(lambda: self.player,
@@ -290,7 +296,7 @@ class AccountRpcTests(unittest.TestCase):
         with mock.patch(
                 'gui.mods.offline_lan_0922.account_rpc.server.'
                 '_refresh_garage_views',
-                side_effect=lambda diff, after_refresh: completed.append(
+                side_effect=lambda diff, after_refresh, after_failure=None, is_current=None: completed.append(
                     after_refresh)):
             self.server._push_update(diff)
             self.server._push_update(diff)
@@ -326,7 +332,7 @@ class AccountRpcTests(unittest.TestCase):
         with mock.patch(
                 'gui.mods.offline_lan_0922.account_rpc.server.'
                 '_refresh_garage_views',
-                side_effect=lambda diff, after_refresh: completed.append(
+                side_effect=lambda diff, after_refresh, after_failure=None, is_current=None: completed.append(
                     after_refresh)):
             self.server._push_update(
                 {'inventory': {}}, after_publish=queue_another)
@@ -344,10 +350,43 @@ class AccountRpcTests(unittest.TestCase):
         self.server._context['on_inventory_refreshed'] = refreshed
         self.player.update = mock.Mock(side_effect=RuntimeError('retired update'))
         self.server._push_update({'inventory': {}})
-        with self.assertRaises(RuntimeError):
-            self._run()
+        self._run()
         self.assertFalse(self.server.inventory_refresh_pending)
         refreshed.assert_not_called()
+
+    def test_failed_crew_refresh_answers_failure_once(self):
+        self.player.update = mock.Mock(side_effect=ValueError('crew listener'))
+        result = account_requests.Result(commands.RES_SUCCESS)
+
+        def publish(complete):
+            def failed(error):
+                result.result_id = commands.RES_FAILURE
+                result.error = str(error)
+                complete()
+            self.server._push_update(
+                {'inventory': {}}, after_publish=lambda player: complete(),
+                after_failure=failed)
+        result.before_response = publish
+        result.wait_for_before_response = True
+        with mock.patch.object(account_requests, 'dispatch', return_value=result):
+            self.server.doCmdInt3(41, commands.CMD_EQUIP_TMAN, 9, 0, -1)
+        while self.pending:
+            self._run()
+        self.assertEqual(
+            [(41, commands.RES_FAILURE, 'crew listener')], self.player.responses)
+        self.assertFalse(self.server.inventory_refresh_pending)
+
+    def test_inventory_builder_failure_answers_instead_of_stranding_request(self):
+        result = account_requests.Result(
+            commands.RES_SUCCESS,
+            before_response=mock.Mock(side_effect=ValueError('bad crew diff')),
+            wait_for_before_response=True)
+        with mock.patch.object(account_requests, 'dispatch', return_value=result):
+            self.server.doCmdInt3(42, commands.CMD_EQUIP_TMAN, 9, 0, -1)
+        self._run()
+        self.assertEqual(1, len(self.player.responses))
+        self.assertEqual((42, commands.RES_FAILURE), self.player.responses[0][:2])
+        self.assertIn('bad crew diff', self.player.responses[0][2])
 
     def test_stats_update_does_not_run_the_inventory_refresh_fallback(self):
         with mock.patch(
@@ -446,7 +485,8 @@ class AccountRpcTests(unittest.TestCase):
         self.player.onCmdResponse = (
             lambda *args: trace.append('response'))
 
-        def delayed_refresh(unused_diff, after_refresh=None):
+        def delayed_refresh(unused_diff, after_refresh=None, after_failure=None,
+                            is_current=None):
             trace.append('refresh-start')
 
             def complete():
@@ -1487,7 +1527,7 @@ class DepotTests(unittest.TestCase):
     def test_purchase_publishes_balance_before_acknowledgement(self):
         state = self._garage(item_type=11)
         events = []
-        def publish(diff, after_publish):
+        def publish(diff, after_publish, after_failure=None):
             self.assertEqual({'credits': 60000}, diff['stats'])
             self.assertEqual(2, diff['inventory'][11][4444])
             events.append('update')
@@ -1646,3 +1686,101 @@ class DepotTests(unittest.TestCase):
             snapshot, validate=False)['inventory']
 
         self.assertEqual(370, published[10][11010])
+
+
+class GarageRefreshCompletionTests(unittest.TestCase):
+    """Model #1513's callback dispatch outside the waiting generator."""
+
+    def setUp(self):
+        self.timers = {}
+        self.waiting = []
+        self.success = mock.Mock()
+        self.failure = mock.Mock()
+        self.manager = mock.Mock()
+        self.current = True
+        self.cache = types.SimpleNamespace(
+            update=lambda *args: lambda callback: self.waiting.append(callback))
+
+        def schedule(delay, callback):
+            self.assertGreater(delay, 0.0)
+            self.timers[1] = callback
+            return 1
+
+        def process(fn):
+            def start():
+                generator = fn()
+                def step(value=None):
+                    try:
+                        operation = generator.send(value)
+                    except StopIteration:
+                        return
+                    operation(step)
+                step()
+            return start
+
+        modules = {
+            'BigWorld': types.SimpleNamespace(
+                callback=schedule,
+                cancelCallback=lambda key: self.timers.pop(key)),
+            'adisp': types.SimpleNamespace(process=process),
+            'gui.ClientUpdateManager': types.SimpleNamespace(
+                g_clientUpdateManager=self.manager),
+            'gui.shared.items_cache': types.SimpleNamespace(
+                CACHE_SYNC_REASON=types.SimpleNamespace(CLIENT_UPDATE=1)),
+            'gui.shared.personality': types.SimpleNamespace(
+                ServicesLocator=types.SimpleNamespace(itemsCache=self.cache)),
+        }
+        patcher = mock.patch.dict(sys.modules, modules)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def start(self):
+        from gui.mods.offline_lan_0922.account_rpc.server import _refresh_garage_views
+        return _refresh_garage_views(
+            {'inventory': {}}, after_refresh=self.success,
+            after_failure=self.failure, is_current=lambda: self.current)
+
+    def test_account_replaced_during_refresh_does_not_update_new_views(self):
+        self.start()
+        self.current = False
+        self.waiting[0]()
+        self.failure.assert_called_once()
+        self.success.assert_not_called()
+        self.manager.update.assert_not_called()
+        self.assertEqual({}, self.timers)
+
+    def test_delayed_refresh_completes_once_and_cancels_deadline(self):
+        self.start()
+        self.success.assert_not_called()
+        self.waiting[0]()
+        self.success.assert_called_once_with()
+        self.failure.assert_not_called()
+        self.assertEqual({}, self.timers)
+        self.manager.update.assert_called_once()
+
+    def test_lost_callback_times_out_and_late_completion_cannot_succeed(self):
+        self.start()
+        # An onSyncCompleted listener can raise before the stock dispatcher
+        # reaches the stored callback. No exception enters the generator.
+        self.timers.pop(1)()
+        self.failure.assert_called_once()
+        self.success.assert_not_called()
+        self.waiting[0]()
+        self.failure.assert_called_once()
+        self.success.assert_not_called()
+        self.manager.update.assert_not_called()
+
+    def test_synchronous_cache_failure_ends_wait_and_cancels_deadline(self):
+        self.cache.update = mock.Mock(side_effect=ValueError('bad inventory'))
+        self.start()
+        self.failure.assert_called_once()
+        self.success.assert_not_called()
+        self.assertEqual({}, self.timers)
+
+    def test_view_listener_failure_is_reported_as_failure(self):
+        self.manager.update.side_effect = ValueError('crew view failed')
+        self.start()
+        self.waiting[0]()
+        self.failure.assert_called_once()
+        self.success.assert_not_called()
+        self.assertEqual({}, self.timers)

--- a/tests/test_port_0922_bootstrap_lifecycle.py
+++ b/tests/test_port_0922_bootstrap_lifecycle.py
@@ -1181,6 +1181,23 @@ class BootstrapLifecycleTests(unittest.TestCase):
         with mock.patch.dict(sys.modules, modules):
             self.assertTrue(bootstrap._validate_restored_garage(snapshot))
 
+    def test_transferred_crew_restores_with_original_training(self):
+        bootstrap, snapshot, modules = self._restorable(
+            save_mode='new_account', starters=self.STARTER_NAMES)
+        record = snapshot['vehicles'][0]
+        tankman_id = record['crew'][0]
+        original = record['tankmen'][tankman_id]
+        nation, trained_type, remainder = original.split(b':', 2)
+        self.assertNotEqual(b'12', trained_type)
+        record['tankmen'][tankman_id] = b':'.join((nation, b'12', remainder))
+        with mock.patch.dict(sys.modules, modules):
+            self.assertTrue(bootstrap._validate_restored_garage(snapshot))
+            for invalid in (b'9:12:' + remainder,
+                            nation + b':12:wrong_role'):
+                record['tankmen'][tankman_id] = invalid
+                with self.assertRaises(ValueError):
+                    bootstrap._validate_restored_garage(snapshot)
+
     def test_a_restored_device_is_removed_from_the_published_depot(self):
         bootstrap, snapshot, modules = self._restorable(
             save_mode='new_account', starters=self.STARTER_NAMES)

--- a/tests/test_port_0922_garage.py
+++ b/tests/test_port_0922_garage.py
@@ -1065,6 +1065,20 @@ class GarageStateTests(unittest.TestCase):
         self.assertEqual(
             {101: b'tman:101'}, state.snapshot()['barracksTankmen'])
 
+    def test_direct_transfer_remembers_the_source_seat(self):
+        state = self._two_vehicle_state()
+        state.equip_tankman(9, 0, 201)
+        self.assertEqual([201, None],
+                         state.snapshot()['vehicles'][1]['lastCrew'])
+        self.assertEqual([201], state.return_crew(10))
+        self.assertEqual([201, 202], state.snapshot()['vehicles'][1]['crew'])
+
+    def test_transfer_preserves_another_vehicle_training(self):
+        state = self._two_seat_state(barracks={201: b'tman:201@2'})
+        state.equip_tankman(9, 0, 201)
+        self.assertEqual(b'tman:201@2',
+                         state.snapshot()['vehicles'][0]['tankmen'][201])
+
     def test_a_full_barracks_refuses_the_move_rather_than_lose_the_occupant(
             self):
         state = self._two_vehicle_state(berths=0)
@@ -1522,16 +1536,12 @@ class GarageStateTests(unittest.TestCase):
         self.assertEqual(
             100000 - 20000, state.snapshot()['wallet']['credits'])
 
-    def test_a_seated_crew_member_is_not_retrained_out_of_their_seat(self):
-        """The restore boundary needs every seated crew member to match."""
+    def test_seated_training_can_differ_from_the_current_vehicle(self):
         state = self._recruiting_state(unlocks=(50001, 50002))
-
-        with self.assertRaises(self.garage.GarageError):
-            state.retrain_tankman(101, 1, 50002)
-
+        state.retrain_tankman(101, 1, 50002)
         self.assertEqual(
-            b'tman:101', state.snapshot()['vehicles'][0]['tankmen'][101])
-        self.assertEqual(100000, state.snapshot()['wallet']['credits'])
+            b'tman:101@2|', state.snapshot()['vehicles'][0]['tankmen'][101])
+        self.assertEqual(80000, state.snapshot()['wallet']['credits'])
 
     def test_retraining_for_the_vehicle_they_are_already_in_is_allowed(self):
         state = self._recruiting_state()
@@ -1778,6 +1788,30 @@ class FittingRequestTests(unittest.TestCase):
             customizations_module=_Customizations)
         self.context['garage'] = self.state
         return self.state
+
+    def test_failed_refresh_finishes_accepted_crew_change_without_rollback(self):
+        snapshot = copy.deepcopy(SNAPSHOT)
+        snapshot['accountBerths'] = 4
+        vehicles, tankmen = _modules()
+        self.state = self.garage.GarageState(
+            snapshot, vehicles_module=vehicles, tankmen_module=tankmen)
+        self.context['garage'] = self.state
+        completions = []
+        callbacks = []
+        def push(diff, after_publish, after_failure):
+            self.pushed.append(diff)
+            callbacks.extend((after_publish, after_failure))
+            return True
+        self.context['push_update_and_wait'] = push
+        result = self._dispatch(self.commands.CMD_EQUIP_TMAN, (9, 0, -1))
+        result.before_response(lambda: completions.append(result.result_id))
+        self.assertEqual([], completions)
+        callbacks[1]('listener failed')
+        callbacks[0]()
+        self.assertEqual([self.commands.RES_FAILURE], completions)
+        self.assertIn('GARAGE_REFRESH_FAILED', result.error)
+        self.assertEqual([None, 102], self.state.snapshot()['vehicles'][0]['crew'])
+        self.assertEqual(b'tman:101', self.state.snapshot()['barracksTankmen'][101])
 
     def test_equip_eqs_decodes_the_exact_1513_payload(self):
         result = self._dispatch(


### PR DESCRIPTION
Crew transfers could apply their inventory changes and then wait forever when account publication or a later ItemsCache listener failed. The command now returns failure on publication errors or a lost refresh callback (10-second deadline), preserves the accepted inventory mutation, and ignores late completions and replaced accounts.

Crew can move between vehicles of the same nation and primary role without rewriting their training specialization. Save restoration accepts that state, the obsolete seated-retraining restriction is removed, and direct transfers record the source seat for Return Crew.

Validation: the full local suite and the final Account RPC, garage and bootstrap regression suites passed. CPython 2.7 source compilation passed. Exercised the modified refresh adapter with the exact #1513 adisp and ItemsCache bytecode: a lost callback terminates once, and late completion cannot report success. Added regressions for publication/build failures, timeout, account replacement, preserved training and source crew history.

The screenshot's specific failing listener remains unidentified without its session log. Exact Windows UI acceptance has not been performed; the timeout provides a terminal failure rather than claiming that the underlying listener succeeded.
