### PR TITLE
Complete turret detachment for late ammo-bay death causes

### DIFF
--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -2354,6 +2354,20 @@ target detaches nothing: retail has no `DetachedTurret` in AOI for a vehicle
 never spotted. A missing exploded model, a full turret budget or a failed
 `createEntity` leaves exactly the -5 burn-off wreck the port produced before.
 
+A late ammo-bay cause can arrive after the ordinary death edge. It now admits
+one detachment from the existing wreck's turret pose, even though the health
+signature is already terminal. A per-record launch attempt fence and the
+native detached-health flag suppress repeated snapshot launches. Successful
+creation updates `appearance.damageState` with the special health, crew state
+and water state, then calls `Vehicle.confirmTurretDetachment` for its single
+model refresh. Exact #1513 `CompoundAppearance.onVehicleHealthChanged` also
+calls the input-handler death hook and `processVehicleDeath`; the late path
+must not call it or replay `Vehicle.onHealthChanged`, kill credit or death
+feedback. Failed creation keeps the burn-off wreck and does not retry on every
+snapshot. The original reported match did not log terminal-cause ordering,
+so this repairs a reproduced ordering gap without claiming that match's root
+cause is established.
+
 The ABI audit pins all of it against `scripts.pkg`: the 22 `DetachedTurret`
 signatures, `Vehicle.confirmTurretDetachment`, both special health constants,
 the three `AMMOBAY_DESTRUCTION_MODE` values and the effect's energy window.

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -23575,6 +23575,50 @@ class BattleRuntime(object):
             return int(special.TURRET_DETACHED)
         return int(special.AMMO_BAY_DESTROYED)
 
+    def _detach_late_ammo_turret(self, record, entity):
+        """Complete a late terminal cause without repeating vehicle death."""
+        if (self._detached_turrets is None or
+                record.get('_ammo_turret_attempted') or
+                bool(getattr(entity, 'isTurretMarkedForDetachment', False)) or
+                not self._turret_detachment_drawn(record)):
+            return False
+        appearance = getattr(entity, 'appearance', None)
+        damage_state = getattr(appearance, 'damageState', None)
+        update_damage = getattr(damage_state, 'update', None)
+        confirm = getattr(entity, 'confirmTurretDetachment', None)
+        water = getattr(appearance, 'waterSensor', None)
+        if not callable(update_damage) or not callable(confirm) or water is None:
+            return False
+        plan = self._run_optional_feature(
+            'ammo-bay turret detachment', self._detached_turrets.prepare,
+            (entity,), disable=False)
+        if not plan:
+            return False
+        # Creation can synchronously enter stock SynchronousDetachment.
+        # Install the terminal identity before that call and admit one launch.
+        record['_ammo_turret_attempted'] = True
+        previous_health = entity.health
+        entity.health = int(
+            self._runtime.constants.SPECIAL_VEHICLE_HEALTH.TURRET_DETACHED)
+        entity._Vehicle__turretDetachmentConfirmed = True
+        launched = self._run_optional_feature(
+            'ammo-bay turret detachment', self._detached_turrets.launch,
+            (plan, self._turret_detachment_seed(record['engine_id']),
+             self._clock()), disable=False)
+        if not launched:
+            entity._Vehicle__turretDetachmentConfirmed = False
+            entity.health = previous_health
+            return False
+        # Exact #1513 onVehicleHealthChanged also invokes inputHandler death
+        # and processVehicleDeath. Update only its damage-state data, then use
+        # confirmTurretDetachment's single turretless model refresh instead.
+        def refresh():
+            update_damage(entity.health, entity.isCrewActive, water.isUnderWater)
+            confirm()
+        self._run_optional_feature(
+            'late ammo-bay wreck refresh', refresh, (), disable=False)
+        return True
+
     def _turret_detachment_drawn(self, record):
         """Whether this target is drawn, so retail would have a turret at all.
 
@@ -23656,8 +23700,10 @@ class BattleRuntime(object):
                 entity = self._server_entity(engine_id)
                 if entity is None:
                     return
+                previous_native_health = entity.health
+                self._detach_late_ammo_turret(record, entity)
                 native_health = self._ammo_bay_special_health(entity)
-                if entity.health != native_health:
+                if previous_native_health != native_health:
                     entity.health = native_health
                     # A terminal snapshot may arrive before the critical
                     # cause. Correct the bar without replaying native death,
@@ -23770,6 +23816,7 @@ class BattleRuntime(object):
             # without seeding the turret's filter from the vehicle's own,
             # never-fed ``WGVehicleFilter``.
             entity._Vehicle__turretDetachmentConfirmed = True
+            record['_ammo_turret_attempted'] = True
             launched = self._run_optional_feature(
                 'ammo-bay turret detachment',
                 self._detached_turrets.launch,

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -5619,6 +5619,63 @@ class RemoteVehicleFactoryTests(unittest.TestCase):
         return {'health': 0, 'alive': False,
                 'critical': {'ammo_rack_death': True}}
 
+    def test_late_ammo_bay_cause_detaches_once_without_repeating_death(self):
+        for local in (False, True):
+            with self.subTest(local=local):
+                battle, record, vehicle = self._ammo_bay_death_battle()
+                record['local'] = local
+                turrets = mock.Mock()
+                turrets.prepare.return_value = {'plan': True}
+                turrets.launch.return_value = True
+                battle._detached_turrets = turrets
+                vehicle.onHealthChanged = mock.Mock(wraps=vehicle.onHealthChanged)
+                battle._apply_health(record, {'health': 0, 'alive': False})
+                health_calls = vehicle.onHealthChanged.call_count
+                kill_calls = battle._binding.arena_vehicle_killed.call_count
+                order = []
+                appearance = vehicle.appearance
+                appearance.onVehicleHealthChanged = mock.Mock()
+                appearance.damageState = mock.Mock()
+                appearance.waterSensor = mock.Mock(isUnderWater=False)
+                appearance.damageState.update.side_effect = lambda *args: order.append(
+                    ('damage', args))
+                vehicle.confirmTurretDetachment = mock.Mock(side_effect=lambda:
+                    order.append(('refresh', vehicle.health,
+                                  vehicle._Vehicle__turretDetachmentConfirmed)))
+                turrets.launch.side_effect = lambda *args: order.append(
+                    ('launch', vehicle.health,
+                     vehicle._Vehicle__turretDetachmentConfirmed)) or True
+                state = self._ammo_bay_death_state()
+                battle._apply_health(record, state)
+                battle._apply_health(record, state, force_cause=True)
+                self.assertEqual(_TURRET_DETACHED, vehicle.health)
+                self.assertEqual([
+                    ('launch', _TURRET_DETACHED, True),
+                    ('damage', (_TURRET_DETACHED, False, False)),
+                    ('refresh', _TURRET_DETACHED, True)], order)
+                turrets.launch.assert_called_once()
+                vehicle.confirmTurretDetachment.assert_called_once()
+                appearance.onVehicleHealthChanged.assert_not_called()
+                self.assertEqual(health_calls, vehicle.onHealthChanged.call_count)
+                self.assertEqual(kill_calls, battle._binding.arena_vehicle_killed.call_count)
+
+    def test_late_ammo_bay_failed_launch_is_not_retried_by_snapshots(self):
+        battle, record, vehicle = self._ammo_bay_death_battle()
+        battle._apply_health(record, {'health': 0, 'alive': False})
+        vehicle.appearance.damageState = mock.Mock()
+        vehicle.appearance.waterSensor = mock.Mock(isUnderWater=False)
+        vehicle.confirmTurretDetachment = mock.Mock()
+        turrets = mock.Mock()
+        turrets.prepare.return_value = {'plan': True}
+        turrets.launch.return_value = False
+        battle._detached_turrets = turrets
+        battle._apply_health(record, self._ammo_bay_death_state())
+        battle._apply_health(record, self._ammo_bay_death_state())
+        self.assertEqual(_AMMO_BAY_DESTROYED, vehicle.health)
+        self.assertFalse(vehicle._Vehicle__turretDetachmentConfirmed)
+        turrets.launch.assert_called_once()
+        vehicle.confirmTurretDetachment.assert_not_called()
+
     def test_ammo_bay_death_detaches_the_turret_in_the_stock_order(self):
         """Create the flying entity, then one refresh, already turretless.
 

--- a/tools/audit_client_abi.py
+++ b/tools/audit_client_abi.py
@@ -744,7 +744,12 @@ EXPECTED_ABI = {
         'DamageFromShotDecoder.decodeSegment': (
             'segment', 'vehicleDescr'),
     },
+    'scripts/client/vehicle_systems/vehicle_damage_state.pyc': {
+        'VehicleDamageState.update': (
+            'self', 'health', 'isCrewActive', 'isUnderWater'),
+    },
     'scripts/client/vehicle_systems/CompoundAppearance.pyc': {
+        'CompoundAppearance.updateTurretVisibility': ('self',),
         'CompoundAppearance.start': ('self', 'prereqs'),
         'CompoundAppearance.__linkCompound': ('self',),
         'CompoundAppearance.__onModelsRefresh': (
@@ -1763,7 +1768,14 @@ EXPECTED_CODE_NAMES = {
         'encodeFragile': ('int',),
         'decodeFragile': ('bool',),
     },
+    'scripts/client/vehicle_systems/vehicle_damage_state.pyc': {
+        'VehicleDamageState.update': (
+            'getState', 'getStateParams', '_VehicleDamageState__state',
+            '_VehicleDamageState__model', '_VehicleDamageState__effect'),
+    },
     'scripts/client/vehicle_systems/CompoundAppearance.pyc': {
+        'CompoundAppearance.updateTurretVisibility': (
+            '_CompoundAppearance__requestModelsRefresh',),
         'CompoundAppearance': (
             'waterSensor', 'isInWater', 'isUnderwater'),
         'CompoundAppearance.start': ('getHitTesters', 'loadBspModel'),


### PR DESCRIPTION
When a vehicle death is presented before its ammo-bay terminal cause arrives, the repeated-health path currently corrects only the special health value and never launches the turret. Complete that late cause with one stock detached-turret creation and one turretless wreck refresh, without replaying death callbacks, kill credit or postmortem behavior. Fence launch attempts before synchronous native creation; repeated snapshots do not relaunch successful or failed attempts.

The late refresh updates the reviewed #1513 damage-state data and uses `confirmTurretDetachment`, avoiding `CompoundAppearance.onVehicleHealthChanged`, which also invokes death processing. Pin the new stock seams in the ABI audit.

Validation: the two new regression tests fail on the original implementation and pass with the fix; all 852 battle-runtime and 30 turret-presentation tests pass, along with CPython 2.7 compilation and the exact-client ABI audit. Review found no blocking issues. CI wait is skipped per the user's earlier instruction. The original match did not record cause ordering, so its specific root cause and the updated Windows presentation remain unconfirmed.
