### PR TITLE
Contain Bot checkpoint failures and improve worker startup diagnostics

### DIFF
--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -126,6 +126,17 @@ simulation to the server: `BattleRuntime` continues to consume the original
 complete update locally. The optional shot yaw/pitch pair remains atomic at the
 projection boundary.
 
+A Bot checkpoint that cannot be encoded now publishes an identity-only
+`[bot_id]` row. The complete manifest roster and unique identities remain
+mandatory. The server retains that actor's last admitted pose and combat ACK;
+other rows advance normally. Frozen launches and ram reports involving that
+actor stay in the worker outbox until its checkpoint becomes encodable. The
+worker logs the round, actor and codec reason at a bounded cadence. Integration
+tests cover failure, retained ACK/state, frozen launch retention and recovery.
+This contains the `223753` field report's whole-round failure; its discarded
+original codec reason cannot be reconstructed from the report. Windows #1513
+acceptance of the recovery path remains outstanding.
+
 The short 0.0975-second generic planning cache remains a steering and slope
 refresh. A typed exact 3x3 receipt has an independent containment contract and
 may cross that refresh only under its exact origin, yaw, travel sign and

--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -131,8 +131,16 @@ A Bot checkpoint that cannot be encoded now publishes an identity-only
 mandatory. The server retains that actor's last admitted pose and combat ACK;
 other rows advance normally. Frozen launches and ram reports involving that
 actor stay in the worker outbox until its checkpoint becomes encodable. The
-worker logs the round, actor and codec reason at a bounded cadence. Integration
-tests cover failure, retained ACK/state, frozen launch retention and recovery.
+Bot/Bot ram report carries both frozen contact positions so recovery movement
+cannot invalidate an already observed collision. The server checks bounded
+finite coordinates, contact proximity, and immutable retry identity. An actor
+with an unavailable checkpoint holds new fire triggers until recovery, while
+its accepted burst continues; this preserves the burst identity needed to
+admit its frozen launches. If recovery spans the completed reload, the server
+validates the shot debit and reload completion as two ordinary ammunition
+transactions. The worker logs the round, actor and codec reason at a bounded
+cadence. Integration tests cover failure, retained ACK/state, frozen launch
+and contact recovery, and duplicate delivery.
 This contains the `223753` field report's whole-round failure; its discarded
 original codec reason cannot be reconstructed from the report. Windows #1513
 acceptance of the recovery path remains outstanding.

--- a/launcher/core.py
+++ b/launcher/core.py
@@ -86,7 +86,9 @@ PLAYER_ARGUMENT_0922 = "--player"
 WORKER_ONLY_ARGUMENT_0922 = "--worker-only"
 PAIRED_PLAYER_ARGUMENT_0922 = "--paired-player"
 STOP_STARTER_ARGUMENT_0922 = "--stop-starter"
-WORKER_READY_TIMEOUT_SECONDS_0922 = 60.0
+# The starter can spend 10 seconds attaching ProcDump before its own
+# 60-second ready wait. Let it record failure before launcher cancellation.
+WORKER_READY_TIMEOUT_SECONDS_0922 = 90.0
 WORKER_FAILURE_DRAIN_SECONDS_0922 = 0.5
 STARTER_CONTROL_TIMEOUT_SECONDS_0922 = 5.0
 STARTER_SHUTDOWN_TIMEOUT_SECONDS_0922 = 45.0
@@ -1985,6 +1987,16 @@ def wait_for_server(port_version, host, port, timeout=20.0, interval=0.25,
         if clock() >= deadline:
             return False
         sleep(interval)
+
+
+def worker_startup_exit_hint(exit_code):
+    """Explain loader failures that happen before the client can write a log."""
+    if exit_code is not None and (int(exit_code) & 0xffffffff) == 0xc0000135:
+        return ("0xC0000135: a required DLL could not be loaded. "
+                "Verify the game files and install the DirectX 9 June 2010 "
+                "runtime and Visual C++ x86 runtime. The exit code alone "
+                "does not identify the missing DLL.")
+    return ""
 
 
 def wait_for_worker_ready(process, game_root,

--- a/launcher/tests/test_launcher_core.py
+++ b/launcher/tests/test_launcher_core.py
@@ -2102,6 +2102,30 @@ class GameProcessTest(unittest.TestCase):
             is_running=lambda: True, timeout=1.0, poll=0.1,
             clock=lambda: next(ticks), sleep=lambda unused: None))
 
+    def test_worker_loader_failure_explains_unsigned_and_signed_status(self):
+        for code in (0xc0000135, -1073741515):
+            hint = core.worker_startup_exit_hint(code)
+            self.assertIn("0xC0000135", hint)
+            self.assertIn("x86", hint)
+            self.assertIn("does not identify", hint)
+        for code in (None, 0, 3, 1):
+            self.assertEqual("", core.worker_startup_exit_hint(code))
+
+    def test_launcher_ready_deadline_allows_starter_to_record_timeout(self):
+        native = os.path.join(os.path.dirname(__file__), "..", "..",
+                              "native", "offline_worker_starter.c")
+        with open(native) as stream:
+            definitions = dict(
+                (parts[1], int(parts[2]))
+                for line in stream
+                for parts in [line.split()]
+                if len(parts) == 3 and parts[0] == "#define"
+                and parts[2].isdigit())
+        starter_seconds = (definitions["WORKER_READY_TIMEOUT_MS"] +
+                           definitions["PROCDUMP_ATTACH_TIMEOUT_MS"]) / 1000.0
+        self.assertGreater(core.WORKER_READY_TIMEOUT_SECONDS_0922,
+                           starter_seconds + 5.0)
+
     def test_worker_ready_requires_a_live_process_and_marker(self):
         game_root = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, game_root, True)

--- a/launcher/wot_launcher.py
+++ b/launcher/wot_launcher.py
@@ -47,6 +47,10 @@ LAUNCHER_VERSION = "0.7.4"
 WINDOW_TITLE = "World of Tanks Offline Battles %s" % LAUNCHER_VERSION
 
 _CHINESE = {
+    core.worker_startup_exit_hint(0xc0000135):
+        "0xC0000135：无法加载必需的 DLL。请检查游戏文件完整性，并安装 "
+        "DirectX 9 June 2010 运行库和 Visual C++ x86 运行库。"
+        "仅凭退出码无法确定具体缺失哪个 DLL。",
     "Language": "语言",
     "Game client": "游戏客户端",
     "Game folder": "游戏目录",
@@ -3073,6 +3077,9 @@ class LauncherWindow(object):
                 self._log(
                     "The hidden simulation worker stopped with exit code %s." %
                     exit_code)
+                hint = core.worker_startup_exit_hint(exit_code)
+                if hint:
+                    self._log(hint)
             self._log_worker_failure(game_root)
         self._stop_worker(room_owned=room_owned)
         return False

--- a/server/lan_battle_server.py
+++ b/server/lan_battle_server.py
@@ -6394,7 +6394,17 @@ class BattleState:
                 if identity is None:
                     return self._set_protocol_reject(
                         "bot_state", "bot_identity", "bot=%s" % bot_id)
+                if bot_id in next_states:
+                    return self._set_protocol_reject(
+                        "bot_state", "batch_members",
+                        "duplicate bot=%s" % bot_id)
                 previous = self.bot_states.get(bot_id)
+                if len(row) == 1 and previous is not None:
+                    # The worker could not project this actor's checkpoint.
+                    # Retain all admitted ledgers without advancing its ACK;
+                    # the next valid row can reconcile the pending changes.
+                    next_states[bot_id] = previous
+                    continue
                 try:
                     raw = bot_state_codec.decode_row(row, identity)
                 except (bot_state_codec.BotStateCodecError, TypeError,

--- a/server/lan_battle_server.py
+++ b/server/lan_battle_server.py
@@ -2128,6 +2128,7 @@ class BattleState:
         self.bot_manifest = []
         self.bot_manifest_revision = 0
         self.bot_states = {}
+        self.bot_unavailable_checkpoints = set()
         self.bot_terminal_criticals = {}
         self.bot_state_revision = 0
         self.bot_planner = BotPlanner()
@@ -3301,6 +3302,7 @@ class BattleState:
         self.bot_manifest = []
         self.bot_manifest_revision = 0
         self.bot_states = {}
+        self.bot_unavailable_checkpoints = set()
         self.bot_terminal_criticals = {}
         self.bot_state_revision = 0
         self.bot_state_time_us = 0
@@ -5890,7 +5892,8 @@ class BattleState:
         return result
 
     @staticmethod
-    def _validate_bot_ammo_transition(previous, current):
+    def _validate_bot_ammo_transition(previous, current,
+                                      unavailable_checkpoint=False):
         """Require conserved inventory and exact magazine boundaries."""
         if previous is None:
             return True
@@ -5925,8 +5928,6 @@ class BattleState:
             raise ValueError("bot clip checkpoint is invalid")
         expected = list(before)
         if fire_delta:
-            if not pending:
-                raise ValueError("bot shot did not enter reload state")
             previous_active = bool((previous or {}).get(
                 "burst_active", False))
             if previous_active:
@@ -5948,6 +5949,25 @@ class BattleState:
                     previous_pending and previous_clip == 0):
                 raise ValueError("bot fired from an empty clip")
             burst_shell = int(current.get("burst_shell_index", loaded))
+            if not pending:
+                if (not unavailable_checkpoint or reload_time != 0.0 or
+                        current.get("burst_active", False) or
+                        not 0 <= burst_shell < len(after)):
+                    raise ValueError("bot shot did not enter reload state")
+                # The missing checkpoint may span the shot and its completed
+                # reload. Validate those two ordinary transactions in order;
+                # neither ammunition conservation nor shell/clip identity is
+                # waived by the unavailable marker.
+                exhausted = after[burst_shell] == 0 and sum(after) > 0
+                post_shot_clip = 0 if exhausted else expected_clip
+                full_reload = post_shot_clip == 0 or clip_size == 1
+                shot = dict(
+                    current, shell_index=burst_shell,
+                    next_shell_index=loaded if full_reload else next_shell,
+                    clip=post_shot_clip, ammo_reload_pending=True,
+                    reload_time=float(current.get("reload_duration", 0.0)))
+                BattleState._validate_bot_ammo_transition(previous, shot)
+                return BattleState._validate_bot_ammo_transition(shot, current)
             if loaded != burst_shell or loaded != expected_loaded:
                 raise ValueError("bot loaded shell changed while firing")
             if (expected_clip < 0 or loaded >= len(expected) or
@@ -6372,6 +6392,7 @@ class BattleState:
                             incoming, (list, tuple)) else None,
                         len(identities)))
             next_states = {}
+            next_unavailable_checkpoints = set()
             human_ram_armors = self._validated_human_ram_armors(
                 message.get("human_ram_armors"))
             if human_ram_armors is None:
@@ -6404,6 +6425,7 @@ class BattleState:
                     # Retain all admitted ledgers without advancing its ACK;
                     # the next valid row can reconcile the pending changes.
                     next_states[bot_id] = previous
+                    next_unavailable_checkpoints.add(bot_id)
                     continue
                 try:
                     raw = bot_state_codec.decode_row(row, identity)
@@ -6485,7 +6507,9 @@ class BattleState:
                     try:
                         burst_edges = self._bot_burst_transition(
                             previous, current)
-                        self._validate_bot_ammo_transition(previous, current)
+                        self._validate_bot_ammo_transition(
+                            previous, current,
+                            bot_id in self.bot_unavailable_checkpoints)
                     except ValueError as error:
                         # The published magazine and burst clock do not follow
                         # from the last ones the server admitted, which a
@@ -6577,6 +6601,7 @@ class BattleState:
                     "missing=%s" % sorted(set(identities) - set(next_states)))
             self._commit_human_ram_armors(human_ram_armors)
             self.bot_states = next_states
+            self.bot_unavailable_checkpoints = next_unavailable_checkpoints
             for bot_id in stun_clears:
                 self.pending_events.append({
                     "kind": "stun", "active": False,
@@ -9111,9 +9136,23 @@ class BattleState:
             key = (("contact", contact_player_id, contact_seq)
                    if has_contact_player else
                    ("authority", self.authority_epoch, player_id, ram_seq))
+            contact_positions = None
+            if "contact_positions" in message:
+                positions = message["contact_positions"]
+                if (target_kind != "bot" or
+                        not isinstance(positions, (list, tuple)) or
+                        len(positions) != 4):
+                    return False
+                try:
+                    contact_positions = tuple(
+                        _bounded_float(value, -5000.0, 5000.0)
+                        for value in positions)
+                except (TypeError, ValueError, OverflowError):
+                    return False
             fingerprint = (
                 bot_id, target_kind, target_id, damage_to_bot,
-                damage_to_target, contact_player_id, contact_seq)
+                damage_to_target, contact_player_id, contact_seq,
+                contact_positions)
             previous_fingerprint = (
                 self.bot_reported_ram_fingerprints.get(key))
             if previous_fingerprint is not None:
@@ -9154,8 +9193,14 @@ class BattleState:
                             else target.x)
                 target_z = (target.get("z") if target_kind == "bot"
                             else target.z)
-                if math.hypot(float(bot["x"]) - float(target_x),
-                              float(bot["z"]) - float(target_z)) > 12.5:
+                # A projection failure can defer this immutable contact past
+                # later movement. Validate its frozen geometry, not the pose
+                # of the recovery checkpoint that happened to carry it.
+                positions = contact_positions or (
+                    float(bot["x"]), float(bot["z"]),
+                    float(target_x), float(target_z))
+                if math.hypot(positions[0] - positions[2],
+                              positions[1] - positions[3]) > 12.5:
                     return False
             if ram_contact is not None and (
                     not bot.get("alive") or not target.alive):

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -21339,13 +21339,17 @@ class BattleRuntime(object):
             return self.client.send_bot_observation(
                 message.get('contacts'), message.get('affordances'))
         if kind == 'bot_ram':
+            contact_kwargs = {}
+            if 'contact_positions' in message:
+                contact_kwargs['contact_positions'] = message[
+                    'contact_positions']
             return self.client.send_bot_ram(
                 message.get('bot_id'), message.get('target_kind'),
                 message.get('target_id'), message.get('ram_seq'),
                 message.get('damage_to_bot'),
                 message.get('damage_to_target'),
                 message.get('ram_contact_player_id'),
-                message.get('ram_contact_seq'))
+                message.get('ram_contact_seq'), **contact_kwargs)
         if kind == 'rules_state':
             rules = message.get('rules') or {}
             return self.client.send_rules_state(rules.get('bases'))

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -12143,7 +12143,8 @@ class BotRuntime(object):
             self._sample_time_us = step_end_time_us
             return []
         wire_rows = []
-        launches = [dict(launch) for launch in self._pending_launches]
+        failed_ids = set()
+        published_states = []
         for state in self._ordered_states():
             if diagnostic is not None:
                 diagnostic.actor(state['id'])
@@ -12154,16 +12155,45 @@ class BotRuntime(object):
             try:
                 row = observed_call(
                     'bot.wire_projection', bot_state_codec.encode_row, state)
-            except bot_state_codec.BotStateCodecError:
-                raise RuntimeError('bot publication projection failed')
+            except (bot_state_codec.BotStateCodecError, ValueError,
+                    TypeError, OverflowError) as error:
+                # An identity-only row explicitly retains the server's last
+                # checkpoint. Do not acknowledge combat or fabricate a pose.
+                bot_id = int(state['id'])
+                failed_ids.add(bot_id)
+                row = [bot_id]
+                previous = state.get('_wire_projection_failure')
+                reason = str(error)
+                if (previous is None or previous[0] != reason or
+                        now - previous[1] >= 5.0):
+                    print('[BOT STATE] projection unavailable round=%s '
+                          'bot=%s reason=%s' % (
+                              self.round_id, bot_id, reason))
+                    state['_wire_projection_failure'] = (reason, now)
+                wire_rows.append(row)
+                continue
+            state.pop('_wire_projection_failure', None)
+            published_states.append(state)
             if 'equipment_states' in state:
                 self._equipment_wire_exposed_in_update.add(int(state['id']))
             wire_rows.append(row)
         if diagnostic is not None:
             diagnostic.actor(None)
         self._sample_time_us = step_end_time_us
+        # Keep frozen launches and contact barriers pending until their
+        # participants can publish again; unrelated actors continue normally.
+        launches = [dict(launch) for launch in self._pending_launches
+                    if not failed_ids or int(launch['id']) not in failed_ids]
+        ram_reports = []
+        deferred_ram = []
+        for report in self._pending_ram_reports:
+            blocked = bool(failed_ids) and (
+                int(report['bot_id']) in failed_ids or
+                (report.get('target_kind') == 'bot' and
+                 int(report['target_id']) in failed_ids))
+            (deferred_ram if blocked else ram_reports).append(report)
         edge_sample_time_us, edge_revision = self._mark_publication_edge(
-            ordered_states, launches, self._pending_ram_reports,
+            published_states, launches, ram_reports,
             self._sample_time_us)
         publication = {
             'type': 'bot_state', 'rows': wire_rows,
@@ -12178,8 +12208,8 @@ class BotRuntime(object):
         outgoing = [publication]
         # The server validates ram proximity against its latest authority pose.
         # Publish state first, then the cooldown-gated damage reports.
-        outgoing.extend(self._pending_ram_reports)
-        self._pending_ram_reports = []
+        outgoing.extend(ram_reports)
+        self._pending_ram_reports = deferred_ram
         if collect_observation:
             self._next_observation = now + OBSERVATION_SECONDS
             outgoing.append({

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -7882,6 +7882,8 @@ class BotRuntime(object):
                 'damage_to_bot': event['damage_to_self'],
                 'damage_to_target': event['damage_to_other'],
             }
+            if target_kind == 'bot':
+                report['contact_positions'] = list(event['contact_positions'])
             if (target_kind == 'human' and
                     isinstance(human_ram_receipt, dict)):
                 report['ram_contact_player_id'] = int(
@@ -10400,7 +10402,11 @@ class BotRuntime(object):
               launch_receipt=None, ammo_state=None, launch_preview=None,
               launch_time_us=None):
         if (state.get('_drowning', False) or
-                state.get('_overturned', False)):
+                state.get('_overturned', False) or
+                state.get('_wire_projection_failure') is not None):
+            # A later trigger would replace the unavailable checkpoint's
+            # burst identity before the server can admit its frozen launches.
+            # An already accepted burst still advances through its own path.
             return False
         if ammo_state is None:
             ammo_state = self._ammo_states.get(int(state.get('id', 0)))

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bot_state_codec.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bot_state_codec.py
@@ -16,6 +16,8 @@ them.
 Both peers import this module: the worker through the client script root inside
 the game, the server through the same path on ``sys.path``.  It is the single
 source of truth for the layout, and it must parse and run on CPython 2.7.
+An identity-only row ``[bot_id]`` is an explicit unavailable checkpoint, handled
+by the server before decoding: it retains the last admitted state and ACK.
 
 The immutable consumable contracts ride ``bot_manifest`` once per round instead
 of every row, because they were the largest part of the old encoding and never
@@ -235,7 +237,8 @@ def encode_row(state):
         if all(present):
             flags |= bit
         elif any(present):
-            raise BotStateCodecError('bot state group is incomplete')
+            raise BotStateCodecError('bot state group is incomplete: %s' %
+                                     ','.join(names))
     if movement > 0.01:
         flags |= F_MOVING_FORWARD
     elif movement < -0.01:
@@ -255,15 +258,21 @@ def encode_row(state):
                 row.append(0)
                 continue
             raw = state[name]
-            if name == 'shot_yaw':
-                raw = _wrapped_angle(raw)
-            row.append(_fixed(raw, scale, CLAMPS.get(name)))
+            try:
+                if name == 'shot_yaw':
+                    raw = _wrapped_angle(raw)
+                row.append(_fixed(raw, scale, CLAMPS.get(name)))
+            except (ValueError, TypeError, OverflowError) as error:
+                raise BotStateCodecError('%s: %s' % (name, error))
             continue
         value = state.get(name, 0)
-        if scale is None:
-            row.append(_exact(value))
-        else:
-            row.append(_fixed(value, scale, CLAMPS.get(name)))
+        try:
+            if scale is None:
+                row.append(_exact(value))
+            else:
+                row.append(_fixed(value, scale, CLAMPS.get(name)))
+        except (ValueError, TypeError, OverflowError) as error:
+            raise BotStateCodecError('%s: %s' % (name, error))
 
     if flags & F_HAS_AMMO:
         shells = list(ammo)

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
@@ -3257,7 +3257,8 @@ class LANClient(object):
 
     def send_bot_ram(self, bot_id, target_kind, target_id, ram_seq,
                      damage_to_bot, damage_to_target,
-                     ram_contact_player_id=None, ram_contact_seq=None):
+                     ram_contact_player_id=None, ram_contact_seq=None,
+                     contact_positions=None):
         """Report one receipt-owned tank collision as authority."""
         if not self.is_bot_authority():
             return False
@@ -3275,6 +3276,8 @@ class LANClient(object):
                 ram_contact_seq is not None):
             message['ram_contact_player_id'] = int(ram_contact_player_id)
             message['ram_contact_seq'] = int(ram_contact_seq)
+        if contact_positions is not None:
+            message['contact_positions'] = list(contact_positions)
         return self._send(message)
 
     def send_rules_state(self, bases):

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/tank_collision.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/tank_collision.py
@@ -870,6 +870,7 @@ def resolve_tank(tank, others, now=None, ram_cooldowns=None,
             'pair': pair,
             'self_id': self_id,
             'other_id': other_id,
+            'contact_positions': (x, z, other_x, other_z),
             'self_vehicle': str(
                 _tank_value(tank, 'vehicle', '') or ''),
             'other_vehicle': str(

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -28865,6 +28865,16 @@ class BattleRuntimeContractTests(unittest.TestCase):
             11, 'human', 2, 5, 21, 41, 2, 9)
         battle._bots.ack_human_ram_receipt.assert_not_called()
 
+        battle.client.send_bot_ram.reset_mock()
+        self.assertTrue(battle._send_bot_message({
+            'type': 'bot_ram', 'bot_id': 11, 'target_kind': 'bot',
+            'target_id': 12, 'ram_seq': 6, 'damage_to_bot': 21,
+            'damage_to_target': 41,
+            'contact_positions': [0.0, 0.0, 0.8, 0.0]}))
+        battle.client.send_bot_ram.assert_called_once_with(
+            11, 'bot', 12, 6, 21, 41, None, None,
+            contact_positions=[0.0, 0.0, 0.8, 0.0])
+
     def test_bot_state_uses_the_already_projected_client_boundary(self):
         battle = BattleRuntime(_runtime())
         battle.client = types.SimpleNamespace(

--- a/tests/test_port_0922_server_combat_lineage.py
+++ b/tests/test_port_0922_server_combat_lineage.py
@@ -462,6 +462,168 @@ class ServerCombatLineageIntegrationTests(unittest.TestCase):
             server.last_bot_state_reject)
         self.assertIsNone(server.battle_result)
 
+    def test_deferred_ram_uses_frozen_contact_after_actors_move_apart(self):
+        from gui.mods.offline_lan_0922.lan_client import LANClient
+        from test_port_0922_tank_collision import _tank
+
+        runtime, server, unused_roster = self._runtime_and_server()
+        runtime._resolve_tank_contacts = lambda *unused: []
+        first = runtime.update(1.0 / 24.0, 1.0)[0]
+        self.assertTrue(server.update_bot_states(1, dict(
+            first, round_id=server.round_id)))
+        contact = self.bot_runtime.tank_collision.resolve_tank(
+            _tank(11, 0.0, 0.0, mass=25000.0, vx=10.0, team=1),
+            (_tank(25, 0.8, 0.0, mass=30000.0, team=2),), now=1.0)
+        report = runtime._ram_reports(
+            runtime.states[11], contact['ram_events'])[0]
+        self.assertEqual([0.0, 0.0, 0.8, 0.0],
+                         report['contact_positions'])
+        runtime._pending_ram_reports.append(report)
+        codec = self.bot_runtime.bot_state_codec
+        original = codec.encode_row
+
+        def invalid_pose(state):
+            if state['id'] == 11:
+                raise codec.BotStateCodecError('shot_yaw: not finite')
+            return original(state)
+
+        codec.encode_row = invalid_pose
+        try:
+            failed = runtime.update(1.0 / 24.0, 1.1)[0]
+        finally:
+            codec.encode_row = original
+        self.assertTrue(server.update_bot_states(1, dict(
+            failed, round_id=server.round_id)))
+        runtime.states[11]['x'] = 100.0
+        recovered = runtime.update(1.0 / 24.0, 1.2)
+        self.assertTrue(server.update_bot_states(1, dict(
+            recovered[0], round_id=server.round_id)))
+        recovered_report = next(message for message in recovered
+                                if message['type'] == 'bot_ram')
+        wire = []
+        client = types.SimpleNamespace(
+            is_bot_authority=lambda: True, round_id=server.round_id,
+            _send=lambda message: wire.append(message) or True)
+        LANClient.send_bot_ram(
+            client, recovered_report['bot_id'],
+            recovered_report['target_kind'], recovered_report['target_id'],
+            recovered_report['ram_seq'], recovered_report['damage_to_bot'],
+            recovered_report['damage_to_target'],
+            contact_positions=recovered_report['contact_positions'])
+        self.assertEqual('bot_ram_report', wire[0]['type'])
+        before = server.bot_states[25]['health']
+        self.assertTrue(server.report_bot_ram(1, wire[0]))
+        self.assertEqual(before - report['damage_to_target'],
+                         server.bot_states[25]['health'])
+        self.assertTrue(server.report_bot_ram(1, wire[0]))
+        self.assertEqual(before - report['damage_to_target'],
+                         server.bot_states[25]['health'])
+        self.assertEqual([], runtime._pending_ram_reports)
+        for positions in ([0.0, 0.0, 100.0, 0.0], [0.0],
+                          [True, 0.0, 0.0, 0.0],
+                          [float('nan'), 0.0, 0.0, 0.0],
+                          [5001.0, 0.0, 5001.0, 0.0]):
+            self.assertFalse(server.report_bot_ram(1, dict(
+                wire[0], ram_seq=2, contact_positions=positions)))
+        self.assertFalse(server.report_bot_ram(1, dict(
+            wire[0], contact_positions=[0.0, 0.0, 1.0, 0.0])))
+
+    def test_unavailable_shot_recovers_after_reload_before_next_trigger(self):
+        from test_port_0922_server_projectiles import _launch
+
+        runtime, server, unused_roster = self._runtime_and_server()
+        runtime._resolve_tank_contacts = lambda *unused: []
+        for index in range(12):
+            first = runtime.update(0.1, 1.0 + index * 0.1)[0]
+            self.assertTrue(server.update_bot_states(1, dict(
+                first, round_id=server.round_id)))
+        state = runtime.states[11]
+        gun = runtime._gun_states[11]
+        descriptor = runtime._descriptors[11]
+        previous = copy.deepcopy(server.bot_states[11])
+        preview = {'fire_seq': 1, 'shot_yaw': 0.0, 'shot_pitch': 0.0,
+                   'origin': (0.0, 1.0, 0.0)}
+        self.assertTrue(runtime._fire(
+            state, gun, 1.0, descriptor, launch_preview=preview))
+        frozen = dict(runtime._pending_launches[0])
+        codec = self.bot_runtime.bot_state_codec
+        original = codec.encode_row
+
+        def invalid_pose(actor):
+            if actor['id'] == 11:
+                raise codec.BotStateCodecError('shot_yaw: not finite')
+            return original(actor)
+
+        codec.encode_row = invalid_pose
+        try:
+            for index in range(12):
+                failed = runtime.update(0.1, 2.2 + index * 0.1)[0]
+                self.assertTrue(server.update_bot_states(1, dict(
+                    failed, round_id=server.round_id)))
+        finally:
+            codec.encode_row = original
+        self.assertTrue(gun.ready())
+        self.assertFalse(runtime._fire(
+            state, gun, 1.0, descriptor,
+            launch_preview=dict(preview, fire_seq=2)))
+        self.assertEqual(1, state['fire_seq'])
+        recovered = runtime.update(0.1, 3.4)[0]
+        self.assertEqual([frozen], recovered['launches'])
+        self.assertTrue(server.update_bot_states(1, dict(
+            recovered, round_id=server.round_id)))
+        self.assertIn((11, 1), server.bot_pending_projectile_launches)
+        current = copy.deepcopy(server.bot_states[11])
+        bad_ammo = dict(current, ammo_remaining=[45])
+        with self.assertRaises(ValueError):
+            server._validate_bot_ammo_transition(
+                previous, bad_ammo, unavailable_checkpoint=True)
+        with self.assertRaises(ValueError):
+            server._bot_burst_transition(
+                previous, dict(current, burst_group_seq=2))
+        launch = _launch(
+            11, 1, 'bot', launch_time_us=frozen['launch_time_us'],
+            launch_pose=list(frozen['launch_pose']),
+            origin=list(frozen['shot_origin']))
+        launch['authority_epoch'] = server.authority_epoch
+        self.assertTrue(server.launch_projectile(1, launch))
+        self.assertEqual(1, len(server.projectiles))
+        self.assertTrue(server.launch_projectile(1, launch))
+        self.assertEqual(1, len(server.projectiles))
+        self.assertTrue(runtime.ack_projectile_launch(11, 1))
+        self.assertTrue(runtime._fire(
+            state, gun, 1.0, descriptor,
+            launch_preview=dict(preview, fire_seq=2)))
+        second = runtime.update(0.1, 3.5)[0]
+        self.assertTrue(server.update_bot_states(1, dict(
+            second, round_id=server.round_id)))
+        self.assertIn((11, 2), server.bot_pending_projectile_launches)
+
+    def test_recovery_reload_keeps_magazine_and_shell_conservation(self):
+        for fired, after, loaded, clip in (
+                (1, [2, 5], 0, 2),
+                (3, [0, 5], 1, 3)):
+            previous = {
+                'ammo_remaining': [3, 5], 'shell_index': 0,
+                'next_shell_index': 0, 'fire_seq': 0,
+                'clip_size': 3, 'clip': 3, 'ammo_reload_pending': False,
+                'reload_time': 0.0, 'burst_active': False,
+            }
+            current = dict(
+                previous, ammo_remaining=after, fire_seq=fired,
+                shell_index=loaded, next_shell_index=loaded, clip=clip,
+                burst_shell_index=0, reload_duration=0.5)
+            self.assertTrue(BattleState._validate_bot_ammo_transition(
+                previous, current, unavailable_checkpoint=True))
+            with self.assertRaises(ValueError):
+                BattleState._validate_bot_ammo_transition(previous, current)
+            for broken in (
+                    dict(current, ammo_remaining=[3, 5]),
+                    dict(current, burst_shell_index=1),
+                    dict(current, clip=4)):
+                with self.assertRaises(ValueError):
+                    BattleState._validate_bot_ammo_transition(
+                        previous, broken, unavailable_checkpoint=True)
+
     def test_external_hit_crew_roster_survives_repeated_publication(self):
         runtime, server, unused_roster = self._runtime_and_server()
         human = _human()

--- a/tests/test_port_0922_server_combat_lineage.py
+++ b/tests/test_port_0922_server_combat_lineage.py
@@ -357,6 +357,111 @@ class ServerCombatLineageIntegrationTests(unittest.TestCase):
                         self.assertEqual(1, current['combat_ack_seq'])
                         self.assertEqual(3, current['combat_base_revision'])
 
+    def test_unavailable_projection_preserves_actor_and_recovers(self):
+        runtime, server, unused_roster = self._runtime_and_server()
+        first = runtime.update(1.0 / 24.0, 1.0)[0]
+        self.assertTrue(server.update_bot_states(1, dict(
+            first, round_id=server.round_id)), server.last_bot_state_reject)
+        previous = copy.deepcopy(server.bot_states[11])
+        other_x = server.bot_states[12]['x']
+        codec = self.bot_runtime.bot_state_codec
+        original = codec.encode_row
+
+        def invalid_pose(state):
+            if state['id'] == 11:
+                return original(dict(state, shot_yaw=float('nan'),
+                                     shot_pitch=0.0))
+            if state['id'] == 12:
+                return original(dict(state, x=other_x + 3.0))
+            return original(state)
+
+        codec.encode_row = invalid_pose
+        try:
+            failed = runtime.update(1.0 / 24.0, 1.1)[0]
+        finally:
+            codec.encode_row = original
+        self.assertIn([11], failed['rows'])
+        self.assertEqual(29, len(failed['rows']))
+        self.assertTrue(server.update_bot_states(1, dict(
+            failed, round_id=server.round_id)), server.last_bot_state_reject)
+        self.assertEqual(previous, server.bot_states[11])
+        self.assertEqual(other_x + 3.0, server.bot_states[12]['x'])
+        self.assertIsNone(server.battle_result)
+        self.assertFalse(runtime.finished)
+        recovered = runtime.update(1.0 / 24.0, 1.2)[0]
+        self.assertTrue(all(len(row) > 1 for row in recovered['rows']))
+        self.assertTrue(server.update_bot_states(1, dict(
+            recovered, round_id=server.round_id)), server.last_bot_state_reject)
+        self.assertNotIn('_wire_projection_failure', runtime.states[11])
+
+    def test_unavailable_projection_does_not_ack_or_discard_frozen_launch(self):
+        runtime, server, unused_roster = self._runtime_and_server()
+        frozen = {'id': 11, 'fire_seq': 1, 'shot_yaw': 0.2}
+        runtime._pending_launches.append(frozen)
+        codec = self.bot_runtime.bot_state_codec
+        original = codec.encode_row
+
+        def invalid_pose(state):
+            if state['id'] == 11:
+                raise codec.BotStateCodecError('shot_yaw: not finite')
+            return original(state)
+
+        codec.encode_row = invalid_pose
+        try:
+            failed = runtime.update(1.0 / 24.0, 1.0)[0]
+        finally:
+            codec.encode_row = original
+        self.assertNotIn('launches', failed)
+        self.assertEqual([frozen], runtime._pending_launches)
+        recovered = runtime.update(1.0 / 24.0, 1.1)[0]
+        self.assertEqual([frozen], recovered['launches'])
+        self.assertEqual([frozen], runtime._pending_launches)
+
+    def test_unavailable_projection_retains_contact_barriers_for_both_actors(self):
+        runtime, server, unused_roster = self._runtime_and_server()
+        reports = [
+            {'type': 'bot_ram', 'bot_id': 11, 'target_kind': 'bot',
+             'target_id': 12, 'ram_seq': 1},
+            {'type': 'bot_ram', 'bot_id': 12, 'target_kind': 'bot',
+             'target_id': 11, 'ram_seq': 2},
+            {'type': 'bot_ram', 'bot_id': 12, 'target_kind': 'human',
+             'target_id': 1, 'ram_seq': 3},
+        ]
+        runtime._pending_ram_reports.extend(reports)
+        runtime._resolve_tank_contacts = lambda *unused: []
+        codec = self.bot_runtime.bot_state_codec
+        original = codec.encode_row
+
+        def invalid_pose(state):
+            if state['id'] == 11:
+                raise codec.BotStateCodecError('shot_yaw: not finite')
+            return original(state)
+
+        codec.encode_row = invalid_pose
+        try:
+            outgoing = runtime.update(1.0 / 24.0, 1.0)
+        finally:
+            codec.encode_row = original
+        self.assertEqual([reports[2]], [message for message in outgoing
+                                       if message['type'] == 'bot_ram'])
+        self.assertEqual(reports[:2], runtime._pending_ram_reports)
+        recovered = runtime.update(1.0 / 24.0, 1.1)
+        self.assertEqual(reports[:2], [message for message in recovered
+                                      if message['type'] == 'bot_ram'])
+        self.assertEqual([], runtime._pending_ram_reports)
+
+    def test_unavailable_rows_still_require_unique_manifest_identities(self):
+        runtime, server, unused_roster = self._runtime_and_server()
+        rows = [[bot_id] for bot_id in sorted(server.bot_states)]
+        for invalid in (rows[:-1], rows[:-1] + [rows[0]],
+                        rows[:-1] + [[99999]]):
+            self.assertFalse(server.update_bot_states(1, {
+                'round_id': server.round_id, 'rows': invalid}))
+        self.assertTrue(server.update_bot_states(1, {
+            'round_id': server.round_id, 'rows': rows}),
+            server.last_bot_state_reject)
+        self.assertIsNone(server.battle_result)
+
     def test_external_hit_crew_roster_survives_repeated_publication(self):
         runtime, server, unused_roster = self._runtime_and_server()
         human = _human()


### PR DESCRIPTION
A Bot checkpoint projection failure previously escaped the worker update and could end a live round. The worker now publishes an identity-only row for the affected Bot, preserving its last admitted server checkpoint while other Bots continue. Frozen launches and collision events wait for their participants to publish again.

Recovery preserves combat outcomes even when the missing checkpoint spans a completed reload or the vehicles have moved apart. The affected Bot pauses new triggers until its checkpoint is publishable; already accepted burst tails retain their own path. The server validates shooting and reload completion as two ordinary ammunition transactions, without bypassing burst identity or ammunition conservation. Bot/Bot collision reports carry their frozen contact coordinates through the existing wire message, with bounded geometry and duplicate-event validation.

Startup diagnostics also explain signed and unsigned missing-DLL exit statuses and leave the native starter time to write its own readiness failure.

Validation: 10 server combat-lineage tests, 469 Bot runtime tests, 180 collision/projectile/ram-sender tests, 175 launcher-core tests and 144 launcher-window tests passed. Codec and LAN transport suites passed. All 107 client Python files compiled with CPython 2.7.18. Recovery tests exercise real shot creation, delayed launch admission, repeated events, resumed triggers, and rejection of invalid ammunition or burst identity.

Exact Windows gameplay behavior remains unverified by these local tests. Combined integration with PR #125 retains this identity-only recovery path instead of replaying stale full rows.
