### PR TITLE
Autorotate the hull on the same rule as the retail gun rotator

### DIFF
--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -1898,15 +1898,28 @@ this port answers. Leaving that mode restores the saved setting.
 once the vehicle has yaw hull aiming, `True` for a fully rotating turret on a
 centre-pivot chassis, `False` for one on a track-pivot chassis, and `None`
 when the player vehicle is not yet in `BigWorld.entities`. Entering sniper on
-a limited-traverse vehicle therefore forces autorotation off, and `enableSwitchAutorotationMode` — `preferred is not
-False` — makes both the `CMD_CM_VEHICLE_SWITCH_AUTOROTATION` key and
-`PlayerAvatar.moveVehicle`'s re-enable no-ops for exactly those vehicles while
-sniper is active. Outside sniper the key toggles the lock and any key-down
-movement command without `_MOVEMENT_FLAGS.BLOCK_TRACKS` turns it back on.
+a limited-traverse vehicle therefore forces autorotation off, and
+`enableSwitchAutorotationMode` — `preferred is not False` — makes both the
+`CMD_CM_VEHICLE_SWITCH_AUTOROTATION` key and `PlayerAvatar.moveVehicle`'s
+re-enable no-ops for every vehicle the mode prefers `False` for, which is both
+the limited-traverse case and a fully rotating turret on a track-pivot
+chassis. Only the first of those has an arc to notice it. Outside sniper the
+key toggles the lock and any key-down movement command without
+`_MOVEMENT_FLAGS.BLOCK_TRACKS` turns it back on.
 `SiegeModeControl.handleKeyEvent` consumes that same key first on a siege
-vehicle. #1513 carries no user setting for any of this; `options.py` exposes
-only the key binding. The ABI audit pins the signatures, the code names and the
-control flow of all five methods.
+vehicle. The whole package writes `__isAutorotation` in five places, all in
+`AvatarInputHandler`, so nothing else can release the lock while sniper is
+active. The ABI audit pins the signatures, the code names and the control flow
+of all five methods.
+
+Modern retail behaves differently, and the difference is a version boundary,
+not a defect here. Wargaming added both the in-battle `X` toggle for sniper
+hull lock and the game setting for its default state in Update 1.12.1 of April
+2021, describing the behaviour it replaced as "when you enter Sniper mode, the
+hull is automatically locked and you cannot aim outside of the aiming angles",
+which is exactly what this January 2018 build does. Reproducing the 1.12.1
+convenience would be a deliberate product deviation from #1513, not a parity
+fix.
 
 Only the cell behaviour is ours. The copied local physics reads the stock
 `getAutorotation()` and, when the unclamped mouse target leaves the installed

--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -1931,9 +1931,13 @@ executable computes the direction in `WGGunRotatorImpl` from elapsed time, the
 desired yaw, the current turret yaw, the yaw limits and the turret and vehicle
 rotation speeds, with no drive input reaching that routine, and the movement
 flags it publishes carry `_MOVEMENT_FLAGS.FORWARD` beside the rotation bit.
-Autorotation therefore composes with driving exactly like holding W and D. How
-the retail cell merges those flags is server Python that no client build ships,
-so only Windows play can confirm the resulting feel.
+The copied cell composes that desired hull direction with forward or reverse
+driving. Its traverse integrator reverses A/D steering under reverse drive, so
+the autorotation adapter converts the desired hull direction to that input
+convention first; otherwise reversing makes the hull turn away from the aim.
+How the retail cell merges those flags is server Python that no client build
+ships, so the exact composition remains an inference and the resulting feel
+still needs Windows play.
 
 LAN pose samples retain the fractional remainder of the nominal 30 Hz
 publication interval. Clearing the entire accumulator quantised a 40 FPS

--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -1878,6 +1878,50 @@ and copied bot integrator without feeding a second physics owner.
 `BigWorld.Entity.teleport` remains forbidden; #1513 rejects it for an in-world
 client Vehicle as `Operation is not allowed`.
 
+### Hull autorotation and the sniper hull lock
+
+Every part of retail's hull lock except the cell itself is stock #1513 code the
+port already runs. `AvatarInputHandler.start` seeds `__isAutorotation` from the
+arcade control mode, which prefers nothing, so a round starts autorotating.
+`onControlModeChanged` then asks the new control mode for
+`getPreferredAutorotationMode()`; a mode that returns a boolean saves the
+previous setting, forces its own, and publishes it through
+`PlayerAvatar.enableOwnVehicleAutorotation`, which both invalidates
+`VEHICLE_VIEW_STATE.AUTO_ROTATION` for the lower-left damage-panel indicator
+and sends `VEHICLE_SETTING.AUTOROTATION_ENABLED` down the vehicle mailbox that
+this port answers. Leaving that mode restores the saved setting.
+
+`SniperControlMode.getPreferredAutorotationMode` returns
+`isYawHullAimingAvailable or (chassis.rotationIsAroundCenter and gun
+.turretYawLimits is None)`. Running that exact code object against a stub
+`BigWorld` gives `False` for a limited-traverse gun on either chassis, `True`
+once the vehicle has yaw hull aiming, `True` for a fully rotating turret on a
+centre-pivot chassis, `False` for one on a track-pivot chassis, and `None`
+when the player vehicle is not yet in `BigWorld.entities`. Entering sniper on
+a limited-traverse vehicle therefore forces autorotation off, and `enableSwitchAutorotationMode` — `preferred is not
+False` — makes both the `CMD_CM_VEHICLE_SWITCH_AUTOROTATION` key and
+`PlayerAvatar.moveVehicle`'s re-enable no-ops for exactly those vehicles while
+sniper is active. Outside sniper the key toggles the lock and any key-down
+movement command without `_MOVEMENT_FLAGS.BLOCK_TRACKS` turns it back on.
+`SiegeModeControl.handleKeyEvent` consumes that same key first on a siege
+vehicle. #1513 carries no user setting for any of this; `options.py` exposes
+only the key binding. The ABI audit pins the signatures, the code names and the
+control flow of all five methods.
+
+Only the cell behaviour is ours. The copied local physics reads the stock
+`getAutorotation()` and, when the unclamped mouse target leaves the installed
+`gun.turretYawLimits`, feeds one binary rotation direction into the single pose
+integrator; the descriptor, native gun rotator and copied traverse physics keep
+owning the arc, gun speed and dispersion. A live A/D command and
+`CMD_BLOCK_TRACKS` both suppress it, but the throttle does not: the pinned
+executable computes the direction in `WGGunRotatorImpl` from elapsed time, the
+desired yaw, the current turret yaw, the yaw limits and the turret and vehicle
+rotation speeds, with no drive input reaching that routine, and the movement
+flags it publishes carry `_MOVEMENT_FLAGS.FORWARD` beside the rotation bit.
+Autorotation therefore composes with driving exactly like holding W and D. How
+the retail cell merges those flags is server Python that no client build ships,
+so only Windows play can confirm the resulting feel.
+
 LAN pose samples retain the fractional remainder of the nominal 30 Hz
 publication interval. Clearing the entire accumulator quantised a 40 FPS
 render loop to 20 Hz and 45/50/75 FPS to 22.5/25/25 Hz. At most one current

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -20085,7 +20085,8 @@ class BattleRuntime(object):
                 position[1] + self._local_vertical_speed * dt,
                 next_z)
 
-    def _local_autorotation_turn(self, entity, turn, tracks_blocked=False):
+    def _local_autorotation_turn(self, entity, turn, drive_intent=0.0,
+                                 tracks_blocked=False):
         """Apply #1513's limited-traverse autorotation to copied physics.
 
         The stock input handler owns whether autorotation is enabled in the
@@ -20101,8 +20102,8 @@ class BattleRuntime(object):
         yaw, the current turret yaw, the installed yaw limits and the turret
         and vehicle rotation speeds; no drive input reaches that routine, and
         the movement flags it publishes carry ``_MOVEMENT_FLAGS.FORWARD``
-        beside the rotation bit.  Autorotation therefore composes with a live
-        throttle exactly like the player holding W and D together.
+        beside the rotation bit.  The copied cell preserves that desired hull
+        direction when composing it with either forward or reverse driving.
         """
         turn = float(turn)
         if turn != 0.0:
@@ -20145,7 +20146,11 @@ class BattleRuntime(object):
         elif relative_yaw > maximum + GUN_TRAVERSE_LIMIT_EPSILON:
             autorotation_turn = 1.0
         if autorotation_turn:
-            return autorotation_turn
+            # traverse_step interprets steering as an A/D key and reverses it
+            # under reverse drive. Convert the desired hull yaw direction to
+            # that input convention so autorotation still approaches the aim.
+            return (-autorotation_turn if float(drive_intent) < 0.0 else
+                    autorotation_turn)
         return turn
 
     def _local_siege_drive_locked(self, entity):
@@ -20249,7 +20254,7 @@ class BattleRuntime(object):
                     self._sender.forward)
         turn = (0.0 if siege_drive_locked or overturned else
                 self._local_autorotation_turn(
-                    entity, self._sender.turn,
+                    entity, self._sender.turn, throttle,
                     tracks_blocked=self._sender.handbrake))
         is_tracked = bool(getattr(entity, 'is_tracked', False))
         is_engine_dead = bool(getattr(entity, 'is_engine_dead', False))

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -20085,8 +20085,7 @@ class BattleRuntime(object):
                 position[1] + self._local_vertical_speed * dt,
                 next_z)
 
-    def _local_autorotation_turn(self, entity, turn, drive_intent=0.0,
-                                 tracks_blocked=False):
+    def _local_autorotation_turn(self, entity, turn, tracks_blocked=False):
         """Apply #1513's limited-traverse autorotation to copied physics.
 
         The stock input handler owns whether autorotation is enabled in the
@@ -20096,16 +20095,19 @@ class BattleRuntime(object):
         local cell must feed that same binary direction into its sole pose
         integrator.  The descriptor, native gun rotator and copied traverse
         physics continue to own the arc, gun speed and resulting dispersion.
+
+        The direction is independent of the throttle.  The pinned executable
+        computes it in ``WGGunRotatorImpl`` from the elapsed time, the desired
+        yaw, the current turret yaw, the installed yaw limits and the turret
+        and vehicle rotation speeds; no drive input reaches that routine, and
+        the movement flags it publishes carry ``_MOVEMENT_FLAGS.FORWARD``
+        beside the rotation bit.  Autorotation therefore composes with a live
+        throttle exactly like the player holding W and D together.
         """
         turn = float(turn)
         if turn != 0.0:
-            return turn
-        # Retail autorotation is an idle arcade-mode convenience.  Any live
-        # drive command owns the hull even when the vehicle is physically
-        # blocked and its measured speed is zero.  ``forward`` also carries
-        # the native R/F cruise presets, so this covers both keyboard drive
-        # and cruise without inferring motion from speed.
-        if float(drive_intent) != 0.0:
+            # A live A/D command owns the hull.  Only the rotation half of the
+            # retail command is in question here; the throttle keeps driving.
             return turn
         # CMD_BLOCK_TRACKS is independent from the persistent autorotation
         # setting.  Holding Space does not clear that setting, but the retail
@@ -20247,7 +20249,7 @@ class BattleRuntime(object):
                     self._sender.forward)
         turn = (0.0 if siege_drive_locked or overturned else
                 self._local_autorotation_turn(
-                    entity, self._sender.turn, throttle,
+                    entity, self._sender.turn,
                     tracks_blocked=self._sender.handbrake))
         is_tracked = bool(getattr(entity, 'is_tracked', False))
         is_engine_dead = bool(getattr(entity, 'is_engine_dead', False))

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -15926,6 +15926,11 @@ class BattleRuntimeContractTests(unittest.TestCase):
         # #1513's WGGunRotatorImpl publishes the rotation direction without
         # reading any drive input, so driving does not suppress the hull turn.
         self.assertEqual(1.0, battle._local_autorotation_turn(entity, 0.0))
+        # Explicit A/D still owns steering, including its reverse convention.
+        for throttle in (-1.0, 1.0):
+            for turn in (-1.0, 1.0):
+                self.assertEqual(turn, battle._local_autorotation_turn(
+                    entity, turn, drive_intent=throttle))
 
     def test_limited_traverse_autorotation_respects_block_tracks(self):
         runtime = _runtime()
@@ -15975,6 +15980,37 @@ class BattleRuntimeContractTests(unittest.TestCase):
         # ``FORWARD | ROTATE_RIGHT`` command #1513's rotator publishes.
         self.assertEqual((2, 9), entity.engineMode)
         self.assertEqual(0.5, runtime.bigworld.avatar.positions[-1][3])
+
+    def test_autorotation_tracks_target_while_driving_in_either_direction(self):
+        for throttle in (-1.0, -0.25, 0.0, 0.25, 1.0):
+            for aim_yaw in (-0.75, 0.75):
+                with self.subTest(throttle=throttle, aim_yaw=aim_yaw):
+                    runtime = _runtime()
+                    battle = BattleRuntime(runtime)
+                    battle.client = _Client()
+                    battle._avatar = runtime.bigworld.avatar
+                    battle._avatar.inputHandler.getAutorotation = lambda: True
+                    descriptor = _Descriptor()
+                    descriptor.gun.turretYawLimits = (-0.10, 0.10)
+                    entity = _Vehicle(
+                        10, descriptor, _Vector(), (0, 0, 0), {'health': 500})
+                    runtime.bigworld.entities[10] = entity
+                    battle._server = types.SimpleNamespace(vehicle_id=10)
+                    battle._sender = types.SimpleNamespace(
+                        forward=throttle, turn=0.0, aim_yaw=aim_yaw,
+                        handbrake=False, send_current=lambda: None)
+                    battle._local_descriptor = descriptor
+                    battle._attach_local_presentation()
+
+                    # Exercise the real integrator: reverse steering changes
+                    # the input sign, but aiming must still close the yaw error.
+                    battle._drive_local(0.1)
+
+                    self.assertGreater(battle._local_yaw * aim_yaw, 0.0)
+                    self.assertLess(abs(aim_yaw - battle._local_yaw),
+                                    abs(aim_yaw))
+                    if throttle:
+                        self.assertGreater(battle._local_speed * throttle, 0.0)
 
     def test_drowning_countdown_keeps_movement_until_the_vehicle_drowns(self):
         runtime = _runtime()

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -511,7 +511,7 @@ class _Descriptor(object):
             shell=shell, piercingPower=(1000.0, 800.0),
             speed=800.0, gravity=9.81, maxDistance=500.0)
         self.gun = types.SimpleNamespace(
-            itemTypeName='vehicleGun',
+            itemTypeName='vehicleGun', turretYawLimits=None,
             pitchLimits={'absolute': (-0.2, 0.4)}, shots=[shot],
             maxAmmo=40, clip=(1,), reloadTime=1.5, rotationSpeed=1.0,
             aimingTime=1.0, burst=(1, 0.1),
@@ -538,6 +538,7 @@ class _Descriptor(object):
                 _Vector(1.5, 0.8, 3.5), loaded),
             hullPosition=_Vector(0.0, 0.6, 0.0),
             rotationSpeed=0.75,
+            rotationIsAroundCenter=False,
             shotDispersionFactors=(0.14, 0.14))
         self.hull = _Strict1513Component(
             itemTypeName='vehicleHull',
@@ -546,6 +547,7 @@ class _Descriptor(object):
                 _Vector(1.7, 1.4, 3.5), loaded),
             turretPositions=(_Vector(),))
         self.maxHealth = 500
+        self.isYawHullAimingAvailable = False
         self.activeGunShotIndex = 0
         self.activeTurretPosition = 0
 
@@ -1039,6 +1041,81 @@ class _InputHandler(object):
 
     def showGunMarker2(self, flag):
         self.server_markers.append(bool(flag))
+
+
+class _StockAutorotationHandler(object):
+    """Mirror #1513's AvatarInputHandler autorotation state machine.
+
+    ``AvatarInputHandler.start`` seeds the flag from the arcade control mode
+    (``__init__.pyc`` lines 607-614), ``onControlModeChanged`` saves, forces
+    and restores it around a control mode that prefers one (lines 767-792),
+    ``setAutorotation`` is gated by ``enableSwitchAutorotationMode`` and
+    ``isOnArena`` (lines 489-503), and ``switchAutorotation`` is the CMD_CM_
+    VEHICLE_SWITCH_AUTOROTATION key.  ``SniperControlMode`` prefers
+    ``isYawHullAimingAvailable or (rotationIsAroundCenter and not
+    turretHasYawLimits)`` and only allows switching while that is not False
+    (``control_modes.pyc`` lines 1427-1442).
+
+    This mirror reproduces the evaluated truth table of those exact code
+    objects, which cannot run here because the suite is Python 3.  The audit
+    pins their signatures, code names and control flow against the package.
+    """
+
+    def __init__(self, descriptor, on_arena=True):
+        self._descriptor = descriptor
+        self.isOnArena = on_arena
+        self.mode = 'arcade'
+        self.published = []
+        self._isAutorotation = True
+        self._prevModeAutorotation = None
+
+    def _preferred(self, mode):
+        if mode != 'sniper':
+            return None
+        descriptor = self._descriptor
+        return (descriptor.isYawHullAimingAvailable or
+                (descriptor.chassis.rotationIsAroundCenter and
+                 descriptor.gun.turretYawLimits is None))
+
+    def _enable_switch(self, mode):
+        return self._preferred(mode) is not False
+
+    def _publish(self, enable):
+        self.published.append(bool(enable))
+
+    def getAutorotation(self):
+        return self._isAutorotation
+
+    def setAutorotation(self, value):
+        if not self._enable_switch(self.mode):
+            return
+        if not self.isOnArena:
+            return
+        if self._isAutorotation != value:
+            self._isAutorotation = value
+            self._publish(self._isAutorotation)
+        self._prevModeAutorotation = None
+
+    def switchAutorotation(self):
+        self.setAutorotation(not self._isAutorotation)
+
+    def onControlModeChanged(self, mode):
+        previous_mode = self.mode
+        self.mode = mode
+        preferred = self._preferred(mode)
+        if preferred is not None:
+            if self._preferred(previous_mode) is None:
+                self._prevModeAutorotation = self._isAutorotation
+            if self._isAutorotation != preferred:
+                self._isAutorotation = preferred
+                self._publish(self._isAutorotation)
+        elif self._preferred(previous_mode) is not None:
+            if self._prevModeAutorotation is None:
+                self._prevModeAutorotation = True
+            if self._isAutorotation != self._prevModeAutorotation:
+                self._isAutorotation = self._prevModeAutorotation
+                self._publish(self._isAutorotation)
+            self._prevModeAutorotation = None
 
 
 class _ArcadeCamera(object):
@@ -15776,7 +15853,65 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertEqual(
             0.0, battle._local_autorotation_turn(entity, 0.0))
 
-    def test_limited_traverse_autorotation_requires_no_drive_or_cruise(self):
+    def test_limited_traverse_autorotation_follows_the_stock_control_mode(self):
+        """Mirror #1513's arcade/sniper autorotation state machine."""
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        descriptor = _Descriptor()
+        descriptor.gun.turretYawLimits = (-0.10, 0.10)
+        entity = _Vehicle(
+            10, descriptor, _Vector(), (0, 0, 0), {'health': 500})
+        battle._sender = types.SimpleNamespace(aim_yaw=0.75)
+        battle._local_yaw = 0.0
+        handler = _StockAutorotationHandler(descriptor)
+        battle._avatar.inputHandler = handler
+
+        # Arcade starts autorotating, so the aim beyond the arc turns the hull.
+        self.assertTrue(handler.getAutorotation())
+        self.assertEqual(1.0, battle._local_autorotation_turn(entity, 0.0))
+
+        # Entering sniper locks the hull of a limited-traverse vehicle, and X
+        # cannot release it while that control mode is preferred.
+        handler.onControlModeChanged('sniper')
+        self.assertFalse(handler.getAutorotation())
+        self.assertEqual(0.0, battle._local_autorotation_turn(entity, 0.0))
+        handler.switchAutorotation()
+        self.assertFalse(handler.getAutorotation())
+        self.assertEqual(0.0, battle._local_autorotation_turn(entity, 0.0))
+
+        # Neither does a movement key, because the same gate rejects it.
+        handler.setAutorotation(True)
+        self.assertFalse(handler.getAutorotation())
+
+        # Leaving sniper restores the arcade setting saved on the way in.
+        handler.onControlModeChanged('arcade')
+        self.assertTrue(handler.getAutorotation())
+        self.assertEqual(1.0, battle._local_autorotation_turn(entity, 0.0))
+
+        # X does toggle it outside sniper, and moving turns it back on.
+        handler.switchAutorotation()
+        self.assertFalse(handler.getAutorotation())
+        self.assertEqual(0.0, battle._local_autorotation_turn(entity, 0.0))
+        handler.setAutorotation(True)
+        self.assertEqual(1.0, battle._local_autorotation_turn(entity, 0.0))
+
+    def test_sniper_keeps_autorotating_a_fully_rotating_turret(self):
+        """#1513 prefers autorotation on when the gun has no yaw limits."""
+        descriptor = _Descriptor()
+        descriptor.gun.turretYawLimits = None
+        descriptor.chassis.rotationIsAroundCenter = True
+        handler = _StockAutorotationHandler(descriptor)
+
+        handler.switchAutorotation()
+        self.assertFalse(handler.getAutorotation())
+        handler.onControlModeChanged('sniper')
+        self.assertTrue(handler.getAutorotation())
+        # ``enableSwitchAutorotationMode`` only rejects a preferred False.
+        handler.switchAutorotation()
+        self.assertFalse(handler.getAutorotation())
+
+    def test_limited_traverse_autorotation_composes_with_a_live_throttle(self):
         runtime = _runtime()
         battle = BattleRuntime(runtime)
         battle._avatar = runtime.bigworld.avatar
@@ -15788,14 +15923,9 @@ class BattleRuntimeContractTests(unittest.TestCase):
         battle._local_yaw = 0.0
         battle._avatar.inputHandler.getAutorotation = lambda: True
 
-        self.assertEqual(0.0, battle._local_autorotation_turn(
-            entity, 0.0, drive_intent=1.0))
-        self.assertEqual(0.0, battle._local_autorotation_turn(
-            entity, 0.0, drive_intent=-1.0))
-        self.assertEqual(0.0, battle._local_autorotation_turn(
-            entity, 0.0, drive_intent=0.25))
-        self.assertEqual(1.0, battle._local_autorotation_turn(
-            entity, 0.0, drive_intent=0.0))
+        # #1513's WGGunRotatorImpl publishes the rotation direction without
+        # reading any drive input, so driving does not suppress the hull turn.
+        self.assertEqual(1.0, battle._local_autorotation_turn(entity, 0.0))
 
     def test_limited_traverse_autorotation_respects_block_tracks(self):
         runtime = _runtime()
@@ -15828,7 +15958,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
         runtime.bigworld.entities[10] = entity
         battle._server = types.SimpleNamespace(vehicle_id=10)
         battle._sender = types.SimpleNamespace(
-            forward=0.0, turn=0.0, aim_yaw=0.75, handbrake=False,
+            forward=1.0, turn=0.0, aim_yaw=0.75, handbrake=False,
             send_current=lambda: client.send_input('current'))
         battle._local_descriptor = descriptor
         battle._attach_local_presentation()
@@ -15841,7 +15971,9 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertEqual(1.0, step.call_args.args[2])
         self.assertAlmostEqual(0.05, battle._local_yaw)
         self.assertEqual(0.5, battle._local_turn_speed)
-        self.assertEqual((2, 8), entity.engineMode)
+        # The hull turns while the throttle keeps driving, exactly like the
+        # ``FORWARD | ROTATE_RIGHT`` command #1513's rotator publishes.
+        self.assertEqual((2, 9), entity.engineMode)
         self.assertEqual(0.5, runtime.bigworld.avatar.positions[-1][3])
 
     def test_drowning_countdown_keeps_movement_until_the_vehicle_drowns(self):

--- a/tools/audit_client_abi.py
+++ b/tools/audit_client_abi.py
@@ -549,6 +549,7 @@ EXPECTED_ABI = {
             'self', 'period', '*args'),
         'AvatarInputHandler.getAutorotation': ('self',),
         'AvatarInputHandler.setAutorotation': ('self', 'bValue'),
+        'AvatarInputHandler.switchAutorotation': ('self',),
         '_Targeting.__init__': ('self',),
         '_Targeting.getTargetEntity': ('self',),
         '_Targeting.enable': ('self', 'flag'),
@@ -568,6 +569,10 @@ EXPECTED_ABI = {
         '_ShellingControl.setTargetModelMatrix': (
             'self', 'worldMatrix'),
         '_ShellingControl.__createTargetModel': ('self', 'bDelete'),
+        'IControlMode.getPreferredAutorotationMode': ('self',),
+        'IControlMode.enableSwitchAutorotationMode': ('self',),
+        'SniperControlMode.getPreferredAutorotationMode': ('self',),
+        'SniperControlMode.enableSwitchAutorotationMode': ('self',),
         'ArcadeControlMode.handleKeyEvent': (
             'self', 'isDown', 'key', 'mods', 'event'),
         'SniperControlMode.handleKeyEvent': (
@@ -1239,7 +1244,9 @@ EXPECTED_CODE_NAMES = {
             'CommandMapping', 'CRUISE_CONTROL25', 'CRUISE_CONTROL50',
             'CMD_BLOCK_TRACKS'),
         'PlayerAvatar.moveVehicle': (
-            'filter', 'notifyInputKeysDown', 'base', 'vehicle_moveWith'),
+            'filter', 'notifyInputKeysDown', 'base', 'vehicle_moveWith',
+            '_MOVEMENT_FLAGS', 'BLOCK_TRACKS', 'inputHandler',
+            'setAutorotation'),
         'PlayerAvatar.getOwnVehicleSpeeds': (
             'BigWorld', 'entity', 'playerVehicleID', 'speedInfo', 'value'),
         'PlayerAvatar.__onSetOwnVehicleAuxPhysicsData': (
@@ -1350,6 +1357,12 @@ EXPECTED_CODE_NAMES = {
         'SniperControlMode.__siegeModeStateChanged': (
             'VEHICLE_SIEGE_STATE', 'ENABLED', 'DISABLED', '_cam',
             'aimingSystem', 'forceFullStabilization'),
+        'SniperControlMode.getPreferredAutorotationMode': (
+            'BigWorld', 'entities', 'get', 'player', 'playerVehicleID',
+            'typeDescriptor', 'chassis', 'rotationIsAroundCenter', 'gun',
+            'turretYawLimits', 'isYawHullAimingAvailable'),
+        'SniperControlMode.enableSwitchAutorotationMode': (
+            'getPreferredAutorotationMode',),
         'PostMortemControlMode.enable': (
             '_PostMortemControlMode__cam', 'consistentMatrices',
             'attachedVehicleMatrix', 'vehicleMProv', 'PostmortemDelay',
@@ -1389,6 +1402,14 @@ EXPECTED_CODE_NAMES = {
             '_AvatarInputHandler__curCtrl',
             'enableSwitchAutorotationMode',
             '_AvatarInputHandler__isAutorotation',
+            'enableOwnVehicleAutorotation'),
+        'AvatarInputHandler.switchAutorotation': (
+            'setAutorotation', '_AvatarInputHandler__isAutorotation'),
+        'AvatarInputHandler.onControlModeChanged': (
+            '_AvatarInputHandler__curCtrl',
+            'getPreferredAutorotationMode',
+            '_AvatarInputHandler__isAutorotation',
+            '_AvatarInputHandler__prevModeAutorotation',
             'enableOwnVehicleAutorotation'),
         'AvatarInputHandler.activatePostmortem': (
             '_CTRL_MODE', 'POSTMORTEM', 'onControlModeChanged'),
@@ -2508,6 +2529,91 @@ EXPECTED_ORDERED_INSTRUCTION_PATTERNS = {
                 ('BINARY_SUBTRACT', None, None),
                 ('LOAD_ATTR', 'value', 'length'),
                 ('STORE_FAST', 'value', 'vehSpeedSum'),
+            )),
+        'PlayerAvatar.moveVehicle': (
+            'a movement command without Space re-enables autorotation', 0, (
+                ('LOAD_ATTR', 'value', 'BLOCK_TRACKS'),
+                ('BINARY_AND', None, None),
+                ('UNARY_NOT', None, None),
+                ('POP_JUMP_IF_FALSE', None, None),
+                ('LOAD_FAST', 'value', 'self'),
+                ('LOAD_ATTR', 'value', 'inputHandler'),
+                ('LOAD_ATTR', 'value', 'setAutorotation'),
+                ('LOAD_GLOBAL', 'value', 'True'),
+                ('CALL_FUNCTION', 'argument', 1),
+            )),
+    },
+    'scripts/client/AvatarInputHandler/__init__.pyc': {
+        'AvatarInputHandler.setAutorotation': (
+            'the control mode gates every autorotation request', 0, (
+                ('LOAD_FAST', 'value', 'self'),
+                ('LOAD_ATTR', 'value', '_AvatarInputHandler__curCtrl'),
+                ('LOAD_ATTR', 'value', 'enableSwitchAutorotationMode'),
+                ('CALL_FUNCTION', 'argument', 0),
+                ('POP_JUMP_IF_TRUE', None, None),
+                ('LOAD_CONST', 'value', None),
+                ('RETURN_VALUE', None, None),
+                ('LOAD_GLOBAL', 'value', 'BigWorld'),
+                ('LOAD_ATTR', 'value', 'player'),
+                ('CALL_FUNCTION', 'argument', 0),
+                ('LOAD_ATTR', 'value', 'isOnArena'),
+                ('POP_JUMP_IF_TRUE', None, None),
+            )),
+        'AvatarInputHandler.onControlModeChanged': (
+            'a preferring control mode saves and forces autorotation', 0, (
+                ('LOAD_ATTR', 'value', 'getPreferredAutorotationMode'),
+                ('CALL_FUNCTION', 'argument', 0),
+                ('STORE_FAST', 'value', 'newAutoRotationMode'),
+                ('LOAD_FAST', 'value', 'newAutoRotationMode'),
+                ('LOAD_CONST', 'value', None),
+                ('COMPARE_OP', 'argument', 9),
+                ('POP_JUMP_IF_FALSE', None, None),
+                ('LOAD_FAST', 'value', 'prevCtrl'),
+                ('LOAD_ATTR', 'value', 'getPreferredAutorotationMode'),
+                ('CALL_FUNCTION', 'argument', 0),
+                ('LOAD_CONST', 'value', None),
+                ('COMPARE_OP', 'argument', 8),
+                ('POP_JUMP_IF_FALSE', None, None),
+                ('LOAD_FAST', 'value', 'self'),
+                ('LOAD_ATTR', 'value',
+                 '_AvatarInputHandler__isAutorotation'),
+                ('LOAD_FAST', 'value', 'self'),
+                ('STORE_ATTR', 'value',
+                 '_AvatarInputHandler__prevModeAutorotation'),
+            )),
+    },
+    'scripts/client/AvatarInputHandler/control_modes.pyc': {
+        'SniperControlMode.getPreferredAutorotationMode': (
+            'sniper locks a limited-traverse hull', 0, (
+                ('LOAD_FAST', 'value', 'desc'),
+                ('LOAD_ATTR', 'value', 'chassis'),
+                ('LOAD_ATTR', 'value', 'rotationIsAroundCenter'),
+                ('STORE_FAST', 'value', 'isRotationAroundCenter'),
+                ('LOAD_FAST', 'value', 'desc'),
+                ('LOAD_ATTR', 'value', 'gun'),
+                ('LOAD_ATTR', 'value', 'turretYawLimits'),
+                ('LOAD_CONST', 'value', None),
+                ('COMPARE_OP', 'argument', 9),
+                ('STORE_FAST', 'value', 'turretHasYawLimits'),
+                ('LOAD_FAST', 'value', 'desc'),
+                ('LOAD_ATTR', 'value', 'isYawHullAimingAvailable'),
+                ('STORE_FAST', 'value', 'yawHullAimingAvailable'),
+                ('LOAD_FAST', 'value', 'yawHullAimingAvailable'),
+                ('JUMP_IF_TRUE_OR_POP', None, None),
+                ('LOAD_FAST', 'value', 'isRotationAroundCenter'),
+                ('JUMP_IF_FALSE_OR_POP', None, None),
+                ('LOAD_FAST', 'value', 'turretHasYawLimits'),
+                ('UNARY_NOT', None, None),
+                ('RETURN_VALUE', None, None),
+            )),
+        'SniperControlMode.enableSwitchAutorotationMode': (
+            'sniper refuses the X key only for a preferred lock', 0, (
+                ('LOAD_FAST', 'value', 'self'),
+                ('LOAD_ATTR', 'value', 'getPreferredAutorotationMode'),
+                ('CALL_FUNCTION', 'argument', 0),
+                ('LOAD_GLOBAL', 'value', 'False'),
+                ('COMPARE_OP', 'argument', 9),
+                ('RETURN_VALUE', None, None),
             )),
     },
     'scripts/client/ProjectileMover.pyc': {


### PR DESCRIPTION
Limited-traverse vehicles previously stopped automatic hull aiming whenever drive input was nonzero. The copied physics now combines the stock input handler's autorotation setting with forward or reverse driving, while manual A/D input and track blocking retain priority. Reverse driving converts the desired hull yaw into the steering convention used by `traverse_step`, so the hull turns toward the aim point in both directions.

The exact #1513 bytecode audit covers sniper-mode preferences, autorotation switching, control-mode transitions and movement re-enablement. Focused tests exercise the control-mode state machine and actual copied-physics yaw integration for forward, reverse and stationary input.

Validation: 855 battle-runtime tests passed; pinned #1513 client inspection and ABI audit passed; all 107 client Python files compiled with CPython 2.7.18. Review reproduced four reverse-steering failures before the correction and confirmed the corrected cases pass.

The retail server's movement-flag composition is not present in the client resources. The adapter's behavior is covered by local tests; exact Windows gameplay feel remains unverified.
