### PR TITLE
Fix autoloader shell transitions and ammunition accounting

### DIFF
--- a/server/lan_battle_server.py
+++ b/server/lan_battle_server.py
@@ -7884,12 +7884,10 @@ class BattleState:
                     shells_before_shot == 1)
             if shooter_kind == "player":
                 shooter.fire_seq = shot_seq
-                if bool(intent.get("shell_change_pending", False)):
-                    shooter.shell_index = int(intent["next_shell_index"])
-                else:
-                    shooter.shell_index = shell_index
-                shooter.next_shell_index = shooter.shell_index
-                shooter.shell_change_pending = False
+                # The visible gun reports the post-shot shell selection in
+                # its next input checkpoint. A launch alone cannot promote a
+                # queued shell: the cassette may still contain rounds, and
+                # a newer input may already have changed the queued choice.
                 shooter.pending_fire_intents.pop(fire_intent_seq, None)
                 shooter.fire_intent_results[fire_intent_seq] = (
                     True, projectile_id)
@@ -7905,12 +7903,9 @@ class BattleState:
                     launch_time_us)
             statistics = self._statistics_row(shooter_kind, shooter_id)
             statistics["shots_fired"] += 1
-            # A pending shell change is applied above, so the round actually
-            # drawn is the shooter's resolved index rather than the one the
-            # launch message carried.
-            fired_index = str(max(0, min(9, int(
-                shooter.shell_index if shooter_kind == "player"
-                else shell_index))))
+            # Charge the shell frozen into this launch, independent of later
+            # loaded or queued selections reported by the visible client.
+            fired_index = str(shell_index)
             # The key is a string because this row is broadcast as JSON, which
             # would turn an integer key into one anyway and make the row stop
             # round-tripping.

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -7961,6 +7961,32 @@ class BattleRuntime(object):
             self._present_loader_intuition()
         return True
 
+    @staticmethod
+    def _defer_gun_setting(pending, state, code, value):
+        # Later NEXT inputs may update the blinking selection immediately.
+        # Replay them after the queued CURRENT/R operation, not before it.
+        if 'deferred_gun_settings' not in pending:
+            pending['deferred_gun_settings'] = []
+            pending['deferred_gun_pending_index'] = state.pending_index
+        pending['deferred_gun_settings'].append((code, value))
+
+    def _apply_deferred_gun_settings(self, state, pending, intuition=False):
+        """Replay post-trigger inputs in order against the settled gun."""
+        settings = self._runtime.constants.VEHICLE_SETTING
+        intuition_used = False
+        for code, value in pending.get('deferred_gun_settings', ()):
+            if code == settings.CURRENT_SHELLS:
+                instant = (
+                    intuition and state.clip_size <= 1 and
+                    state.burst_count <= 1 and self._roll_loader_intuition())
+                changed = state.sync_shell_index(value, instant=instant)
+                intuition_used = intuition_used or (changed and instant)
+            elif code == settings.RELOAD_PARTIAL_CLIP:
+                state.reload_partial_clip()
+            elif code == settings.NEXT_SHELLS:
+                state.request_shell_index(value)
+        return intuition_used
+
     def change_vehicle_setting(self, code, value):
         settings = self._runtime.constants.VEHICLE_SETTING
         if code == getattr(settings, 'SIEGE_MODE_ENABLED', None):
@@ -7996,7 +8022,7 @@ class BattleRuntime(object):
             if isinstance(pending_fire, dict):
                 if state.clip_size <= 1 or not state.shots:
                     return False
-                pending_fire['deferred_partial_clip_reload'] = True
+                self._defer_gun_setting(pending_fire, state, code, value)
                 return True
             return self._reload_partial_clip_now(state)
         current_shells = getattr(settings, 'CURRENT_SHELLS', None)
@@ -8020,8 +8046,8 @@ class BattleRuntime(object):
                     previous_duration = state.reload_duration
                     previous_selection = (
                         int(state.shot_index), state.pending_index)
+                    self._defer_gun_setting(pending_fire, state, code, index)
                     changed = state.request_shell_index(index)
-                    pending_fire['deferred_current_shell_index'] = int(index)
                     if changed:
                         self._apply_current_reload_factor(state, entity)
                         self._publish_loaded_shell_change(
@@ -8038,6 +8064,10 @@ class BattleRuntime(object):
             previous_duration = state.reload_duration
             previous_selection = (
                 int(state.shot_index), state.pending_index)
+            pending_fire = self._local_fire_intent
+            if (isinstance(pending_fire, dict) and
+                    pending_fire.get('deferred_gun_settings')):
+                self._defer_gun_setting(pending_fire, state, code, index)
             changed = state.request_shell_index(index)
             if changed:
                 self._apply_current_reload_factor(state, entity)
@@ -8763,15 +8793,22 @@ class BattleRuntime(object):
             sys.stdout.write(
                 '[Offline LAN 0.9.22] FIRE INTENT rejected intent=%d '
                 'reason=%s repeats=%d\n' % (sequence, reason, seen + 1))
-        deferred_shell = pending.get('deferred_current_shell_index')
-        deferred_partial_reload = bool(
-            pending.get('deferred_partial_clip_reload'))
         self._local_fire_intent = None
         self._cancel_native_shot_wait()
-        if deferred_shell is not None and self._gun_state is not None:
-            self._switch_current_shell(self._gun_state, deferred_shell)
-        if deferred_partial_reload and self._gun_state is not None:
-            self._reload_partial_clip_now(self._gun_state)
+        if pending.get('deferred_gun_settings') and self._gun_state is not None:
+            state = self._gun_state
+            edge = self._advance_local_gun_edge(state)
+            entity = edge[0] if edge is not None else None
+            previous_reload = state.reload_time
+            previous_duration = state.reload_duration
+            state.pending_index = pending['deferred_gun_pending_index']
+            intuition_used = self._apply_deferred_gun_settings(
+                state, pending, intuition=True)
+            self._apply_current_reload_factor(state, entity)
+            self._publish_loaded_shell_change(
+                state, previous_reload, previous_duration)
+            if intuition_used:
+                self._present_loader_intuition()
         return True
 
     def _cancel_native_shot_wait(self):
@@ -11285,15 +11322,16 @@ class BattleRuntime(object):
             entity = (edge[0] if edge is not None else
                       self._server_entity(record['engine_id']))
             reload_factor = critical_damage.stat_factor(entity, 'reload')
+            if pending.get('deferred_gun_settings'):
+                gun.pending_index = pending['deferred_gun_pending_index']
             if (shell_index != gun.shot_index or
                     not gun.commit_fire(reload_factor)):
                 raise RuntimeError(
                     'canonical local shot violates presented gun state')
-            if pending.get('deferred_partial_clip_reload'):
-                gun.reload_partial_clip()
+            self._apply_deferred_gun_settings(gun, pending)
             # commit_fire applies the factor to a normal empty-magazine cycle.
-            # A queued shell promotion or deferred partial reload replaces that
-            # duration with the base reload, so normalize the final transaction
+            # A deferred shell change or partial reload replaces that duration
+            # with the base reload, so normalize the final transaction
             # state before its first native publication and checkpoint.
             self._rescale_current_reload(gun, reload_factor)
             self._publish_ammo_state(gun, force=True)

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/gun_mechanics.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/gun_mechanics.py
@@ -421,29 +421,29 @@ class GunState(object):
             self.reload_time = 0.0
             return True
         self._burst_total = 0
-        if self.clip > 0:
+        if self.clip > 0 and self.ammo[index] > 0:
             self.reload_time = self.clip_reload
             self.reload_duration = self.clip_reload
-        else:
-            self.reload_time = self.reload * max(0.0, float(reload_factor))
-            self.reload_duration = self.reload_time
-        if self.ammo[index] <= 0:
+            return True
+        # A queued shell waits for the whole cassette, not its next intra-clip
+        # interval. Select the next type before beginning one empty full
+        # reload; publishing loaded rounds here makes #1513 classify that
+        # full reload as an intra-clip interval.
+        pending = self.pending_index
+        self.pending_index = None
+        if (pending is not None and 0 <= pending < len(self.ammo) and
+                self.ammo[pending] > 0):
+            self.shot_index = pending
+        elif self.ammo[index] <= 0:
             for offset in range(1, len(self.ammo) + 1):
                 candidate = (index + offset) % len(self.ammo)
                 if self.ammo[candidate] > 0:
                     self.shot_index = candidate
-                    self.clip = min(self.clip_size, self.ammo[candidate])
-                    self.reload_time = max(self.reload_time, self.reload)
-                    self.reload_duration = self.reload_time
                     break
-        pending = self.pending_index
-        self.pending_index = None
-        if (pending is not None and pending != self.shot_index and
-                pending < len(self.ammo) and self.ammo[pending] > 0):
-            self.shot_index = pending
-            self.clip = 0
-            self.reload_time = self.reload
-            self.reload_duration = self.reload
+        self.clip = 0
+        self.reload_time = self.reload * max(0.0, float(reload_factor))
+        self.reload_duration = self.reload_time
+        if self.shot_index != index:
             self.load_started = False
         return True
 

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -8545,6 +8545,84 @@ class BattleRuntimeContractTests(unittest.TestCase):
         battle._publish_reload_event.assert_called_once_with(
             state.reload_time, state.reload_duration, force=True)
 
+    def test_exhausted_autoloader_publishes_full_reload_then_fires_new_shell(self):
+        for preselected in (False, True):
+            with self.subTest(preselected=preselected):
+                battle, state, settings, client, record = \
+                    self._pending_fire_shell_change_battle(clip_size=4, clip=1)
+                state.ammo = [1, 10]
+                stock = {'current': None, 'ammo': {}, 'reload': None}
+
+                def ammo_update(unused_id, compact, quantity, clip,
+                                unused_remaining):
+                    stock['ammo'][compact] = (quantity, clip)
+
+                def setting_update(unused_id, code, compact):
+                    if code == settings.CURRENT_SHELLS:
+                        stock['current'] = compact
+
+                def reload_update(unused_id, remaining, duration):
+                    # Exact #1513 AmmoController.setGunReloadTime uses the
+                    # current cassette count to choose full vs intra-clip
+                    # duration. A prematurely filled clip selects the latter.
+                    clip = stock['ammo'][stock['current']][1]
+                    if not ((clip == 1 and remaining == 0) or
+                            (clip == 0 and remaining > 0)):
+                        duration = state.clip_reload
+                    stock['reload'] = (remaining, duration)
+
+                battle._avatar.updateVehicleAmmo = ammo_update
+                battle._avatar.updateVehicleSetting = setting_update
+                battle._avatar.updateVehicleGunReloadTime = reload_update
+                if preselected:
+                    battle.change_vehicle_setting(settings.NEXT_SHELLS, 102)
+                self.assertTrue(battle.shoot(0.0, 0.0))
+                pending = dict(battle._local_fire_intent)
+                self.assertTrue(battle._accept_player_fire_commit({
+                    'shooter_kind': 'player', 'shooter_id': 1,
+                    'fire_intent_seq': pending['intent_seq'],
+                    'fire_input_seq': pending['input_seq'],
+                    'shot_seq': 1, 'shell_index': 0,
+                }, record))
+
+                self.assertEqual(102, stock['current'])
+                self.assertEqual((state.reload, state.reload), stock['reload'])
+                self.assertEqual((10, 0), stock['ammo'][102])
+                checkpoint = self._last_input_gun_checkpoint(client)
+                self.assertEqual(0, checkpoint['clip'])
+                self.assertEqual(state.reload, checkpoint['reload_time'])
+                self.assertFalse(battle.shoot(0.0, 0.0))
+
+                battle._runtime.bigworld.now += state.reload
+                battle._ammo_tick()
+                self.assertEqual(0.0, stock['reload'][0])
+                self.assertEqual((10, 4), stock['ammo'][102])
+                self.assertTrue(battle.shoot(0.0, 0.0))
+                fire = [message for message in client.sent
+                        if message[0] == 'fire_intent'][-1]
+                self.assertEqual((1,), fire[1])
+
+    def test_pending_fire_current_switch_reloads_remaining_autoloader_clip(self):
+        battle, state, settings, client, record = \
+            self._pending_fire_shell_change_battle(clip_size=4, clip=3)
+        self.assertTrue(battle.shoot(0.0, 0.0))
+        pending = dict(battle._local_fire_intent)
+        battle.change_vehicle_setting(settings.NEXT_SHELLS, 102)
+        battle.change_vehicle_setting(settings.CURRENT_SHELLS, 102)
+        self.assertEqual(0, state.shot_index)
+        self.assertTrue(battle._accept_player_fire_commit({
+            'shooter_kind': 'player', 'shooter_id': 1,
+            'fire_intent_seq': pending['intent_seq'],
+            'fire_input_seq': pending['input_seq'],
+            'shot_seq': 1, 'shell_index': 0,
+        }, record))
+        self.assertEqual([19, 10], state.ammo)
+        self.assertEqual(1, state.shot_index)
+        self.assertIsNone(state.pending_index)
+        self.assertEqual(0, state.clip)
+        self.assertEqual(state.reload, state.reload_time)
+        self.assertEqual(0, self._last_input_gun_checkpoint(client)['clip'])
+
     def test_pending_fire_commits_loaded_round_before_current_shell_switch(self):
         battle, state, settings, client, record = \
             self._pending_fire_shell_change_battle()

--- a/tests/test_port_0922_deferred_ammo.py
+++ b/tests/test_port_0922_deferred_ammo.py
@@ -1,0 +1,118 @@
+import copy
+import unittest
+
+import test_port_0922_battle_runtime as runtime_tests
+
+
+class DeferredAmmoSettingTests(unittest.TestCase):
+    def _pending_battle(self, third_shell=False):
+        fixture = runtime_tests.BattleRuntimeContractTests()
+        battle, gun, settings, client, record = \
+            fixture._pending_fire_shell_change_battle(clip_size=4, clip=3)
+        if third_shell:
+            shot = copy.copy(gun.shots[0])
+            shot.shell = copy.copy(shot.shell)
+            shot.shell.compactDescr = 103
+            gun.shots = tuple(gun.shots) + (shot,)
+            gun.ammo.append(8)
+        self.assertTrue(battle.shoot(0.0, 0.0))
+        return battle, gun, settings, client, record
+
+    def _resolve(self, battle, record, accepted):
+        pending = dict(battle._local_fire_intent)
+        if accepted:
+            self.assertTrue(battle._accept_player_fire_commit({
+                'shooter_kind': 'player', 'shooter_id': 1,
+                'fire_intent_seq': pending['intent_seq'],
+                'fire_input_seq': pending['input_seq'],
+                'shot_seq': 1, 'shell_index': 0,
+            }, record))
+        else:
+            self.assertTrue(battle.on_fire_intent_result({
+                'type': 'fire_intent_result', 'round_id': 7,
+                'player_id': 1, 'intent_seq': pending['intent_seq'],
+                'accepted': False, 'reason': 'projectile_launch_rejected',
+            }))
+            battle._avatar.cancelWaitingForShot.assert_called_once_with()
+        self.assertIsNone(battle._local_fire_intent)
+
+    def _assert_reloading_selection(self, gun, client, loaded, queued,
+                                    accepted, third_shell=False):
+        expected_ammo = [19 if accepted else 20, 10]
+        if third_shell:
+            expected_ammo.append(8)
+        self.assertEqual(expected_ammo, gun.ammo)
+        self.assertEqual(loaded, gun.shot_index)
+        self.assertEqual(queued, gun.pending_index)
+        self.assertEqual(0, gun.clip)
+        self.assertAlmostEqual(gun.reload, gun.reload_time)
+        self.assertAlmostEqual(gun.reload, gun.reload_duration)
+        self.assertFalse(gun.can_fire(True))
+        inputs = [message for message in client.sent
+                  if message[0] == 'input']
+        self.assertTrue(inputs)
+        checkpoint = inputs[-1][2]
+        self.assertEqual(loaded, checkpoint['shell_index'])
+        self.assertEqual(loaded if queued is None else queued,
+                         checkpoint['next_shell_index'])
+        self.assertEqual(queued is not None,
+                         checkpoint['shell_change_pending'])
+        self.assertEqual(0, checkpoint['gun_checkpoint']['clip'])
+        self.assertAlmostEqual(
+            gun.reload, checkpoint['gun_checkpoint']['reload_time'])
+
+    def test_current_switch_then_next_shell_preserves_the_later_queue(self):
+        for accepted in (True, False):
+            with self.subTest(accepted=accepted):
+                battle, gun, settings, client, record = self._pending_battle()
+                # The second press requests loading shell 2 now. A later
+                # press of shell 1 queues it after that new cassette.
+                battle.change_vehicle_setting(settings.NEXT_SHELLS, 102)
+                battle.change_vehicle_setting(settings.CURRENT_SHELLS, 102)
+                battle.change_vehicle_setting(settings.NEXT_SHELLS, 101)
+                self.assertEqual(0, gun.shot_index)
+                self.assertEqual([20, 10], gun.ammo)
+
+                self._resolve(battle, record, accepted)
+
+                self._assert_reloading_selection(
+                    gun, client, loaded=1, queued=0, accepted=accepted)
+                battle._runtime.bigworld.now += gun.reload
+                battle._ammo_tick()
+                self.assertTrue(gun.can_fire(True))
+                self.assertEqual(1, gun.shot_index)
+                self.assertEqual(0, gun.pending_index)
+
+    def test_partial_reload_then_next_shell_keeps_the_reload_shell(self):
+        for accepted in (True, False):
+            with self.subTest(accepted=accepted):
+                battle, gun, settings, client, record = self._pending_battle()
+                battle.change_vehicle_setting(settings.RELOAD_PARTIAL_CLIP, 0)
+                battle.change_vehicle_setting(settings.NEXT_SHELLS, 102)
+                self.assertEqual(0, gun.shot_index)
+
+                self._resolve(battle, record, accepted)
+
+                self._assert_reloading_selection(
+                    gun, client, loaded=0, queued=1, accepted=accepted)
+
+    def test_two_current_switches_keep_the_last_requested_shell(self):
+        for accepted in (True, False):
+            with self.subTest(accepted=accepted):
+                battle, gun, settings, client, record = \
+                    self._pending_battle(third_shell=True)
+                for compact in (102, 103):
+                    battle.change_vehicle_setting(settings.NEXT_SHELLS, compact)
+                    battle.change_vehicle_setting(
+                        settings.CURRENT_SHELLS, compact)
+                self.assertEqual(0, gun.shot_index)
+
+                self._resolve(battle, record, accepted)
+
+                self._assert_reloading_selection(
+                    gun, client, loaded=2, queued=None, accepted=accepted,
+                    third_shell=True)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_port_0922_gun_mechanics.py
+++ b/tests/test_port_0922_gun_mechanics.py
@@ -198,6 +198,77 @@ class GunMechanicsParityTests(unittest.TestCase):
         self.assertEqual(1.0, state.reload_time)
         self.assertEqual(1.0, state.reload_duration)
 
+    def test_exhausted_shell_starts_an_empty_full_reload(self):
+        for clip_size in (1, 3):
+            with self.subTest(clip_size=clip_size):
+                descriptor = _descriptor(clip=(clip_size, 1.0))
+                state = GunState(
+                    descriptor, ammo_layout={1: 1, 2: 5, 3: 4})
+                state.clip = 1
+                state.reload_time = 0.0
+
+                self.assertTrue(state.commit_fire(2.0))
+
+                self.assertEqual(1, state.shot_index)
+                self.assertEqual(0, state.clip)
+                self.assertEqual([0, 5, 4], state.ammo)
+                self.assertAlmostEqual(state.reload * 2.0, state.reload_time)
+                self.assertEqual(state.reload_time, state.reload_duration)
+                self.assertFalse(state.can_fire())
+                state.tick(state.reload_time / 2.0, True, 0, 0, 0, descriptor)
+                self.assertEqual(0, state.clip)
+                self.assertFalse(state.can_fire())
+                state.tick(state.reload_time, True, 0, 0, 0, descriptor)
+                self.assertEqual(clip_size, state.clip)
+                self.assertTrue(state.can_fire())
+                self.assertTrue(state.commit_fire())
+                self.assertEqual([0, 4, 4], state.ammo)
+
+    def test_queued_shell_waits_for_the_empty_cassette(self):
+        descriptor = _descriptor(clip=(3, 1.0))
+        state = GunState(descriptor, ammo_layout={1: 6, 2: 2, 3: 4})
+        state.clip = 3
+        state.reload_time = 0.0
+        self.assertFalse(state.request_shell_index(1))
+
+        for remaining in (2, 1):
+            self.assertTrue(state.commit_fire(2.0))
+            self.assertEqual(0, state.shot_index)
+            self.assertEqual(1, state.pending_index)
+            self.assertEqual(remaining, state.clip)
+            self.assertEqual(state.clip_reload, state.reload_time)
+            state.tick(state.reload_time, True, 0, 0, 0, descriptor)
+
+        self.assertTrue(state.commit_fire(2.0))
+        self.assertEqual(1, state.shot_index)
+        self.assertIsNone(state.pending_index)
+        self.assertEqual(0, state.clip)
+        self.assertEqual([3, 2, 4], state.ammo)
+        self.assertEqual(state.reload * 2.0, state.reload_time)
+        self.assertEqual(state.reload_time, state.reload_duration)
+        self.assertFalse(state.can_fire())
+        state.tick(state.reload_time, True, 0, 0, 0, descriptor)
+        self.assertEqual(2, state.clip)
+        self.assertTrue(state.commit_fire())
+        self.assertEqual([3, 1, 4], state.ammo)
+
+    def test_exhausted_shell_promotes_the_queued_choice_before_fallback(self):
+        for queued in (1, 2):
+            with self.subTest(queued=queued):
+                state = GunState(
+                    _descriptor(), ammo_layout={1: 1, 2: 5, 3: 4})
+                state.clip = 1
+                state.reload_time = 0.0
+                self.assertFalse(state.request_shell_index(queued))
+
+                self.assertTrue(state.commit_fire(2.0))
+
+                self.assertEqual(queued, state.shot_index)
+                self.assertIsNone(state.pending_index)
+                self.assertEqual(0, state.clip)
+                self.assertEqual(state.reload * 2.0, state.reload_time)
+                self.assertEqual(state.reload_time, state.reload_duration)
+
     def test_manual_shell_change_empties_clip_for_full_reload(self):
         state = GunState(_descriptor())
         state.clip = 3

--- a/tests/test_port_0922_server_projectiles.py
+++ b/tests/test_port_0922_server_projectiles.py
@@ -1730,7 +1730,76 @@ class ServerProjectileLedgerTests(unittest.TestCase):
         }))
         self.assertEqual(2, player.input_seq)
 
-    def test_player_queued_shell_is_promoted_by_the_canonical_shot(self):
+    def test_player_queued_shell_changes_only_with_a_new_client_checkpoint(self):
+        for clip_size, clip in ((1, 1), (3, 1), (3, 3)):
+            with self.subTest(clip_size=clip_size, clip=clip):
+                state = _state()
+                player = state.players[1]
+                self.assertTrue(_update_player_input(
+                    state, 1, shell_index=0, next_shell_index=1,
+                    shell_change_pending=True,
+                    gun_checkpoint=_gun_checkpoint(
+                        clip=clip, clip_size=clip_size)))
+                self.assertTrue(state.submit_fire_intent(1, _fire_intent(
+                    state, shot_direction=[1.0, 0.0, 0.0])))
+                relay = player.pending_fire_intents[1]
+
+                self.assertTrue(state.launch_projectile(
+                    SIMULATION_WORKER_AUTHORITY_ID, _launch(
+                        authority_epoch=state.authority_epoch,
+                        fire_intent_seq=relay['intent_seq'],
+                        fire_input_seq=relay['input_seq'])))
+
+                public = state._public_player(player)
+                self.assertEqual(0, public['shell_index'])
+                self.assertEqual(1, public['next_shell_index'])
+                self.assertTrue(public['shell_change_pending'])
+                # The visible gun consumes the admitted round and reports
+                # whether this was an intra-clip or full reload boundary.
+                loaded = 1 if clip == 1 else 0
+                self.assertTrue(_update_player_input(
+                    state, 1, shell_index=loaded, next_shell_index=1,
+                    shell_change_pending=clip > 1,
+                    gun_checkpoint=_gun_checkpoint(
+                        reload_time=5.0 if clip == 1 else 1.0,
+                        clip=clip - 1, clip_size=clip_size)))
+                public = state._public_player(player)
+                self.assertEqual(loaded, public['shell_index'])
+                self.assertEqual(1, public['next_shell_index'])
+                self.assertEqual(clip > 1, public['shell_change_pending'])
+
+    def test_player_launch_preserves_a_later_queued_shell_input(self):
+        state = _state()
+        player = state.players[1]
+        self.assertTrue(_update_player_input(
+            state, 1, shell_index=0, next_shell_index=1,
+            shell_change_pending=True,
+            gun_checkpoint=_gun_checkpoint(clip=3, clip_size=3)))
+        self.assertTrue(state.submit_fire_intent(1, _fire_intent(
+            state, shot_direction=[1.0, 0.0, 0.0])))
+        relay = player.pending_fire_intents[1]
+        self.assertEqual(1, relay['next_shell_index'])
+        self.assertTrue(relay['shell_change_pending'])
+        self.assertTrue(_update_player_input(
+            state, 1, shell_index=0, next_shell_index=2,
+            shell_change_pending=True,
+            gun_checkpoint=_gun_checkpoint(clip=3, clip_size=3)))
+
+        self.assertTrue(state.launch_projectile(
+            SIMULATION_WORKER_AUTHORITY_ID, _launch(
+                authority_epoch=state.authority_epoch,
+                fire_intent_seq=relay['intent_seq'],
+                fire_input_seq=relay['input_seq'])))
+
+        self.assertEqual(0, player.shell_index)
+        self.assertEqual(2, player.next_shell_index)
+        self.assertTrue(player.shell_change_pending)
+        public = state._public_player(player)
+        self.assertEqual(0, public['shell_index'])
+        self.assertEqual(2, public['next_shell_index'])
+        self.assertTrue(public['shell_change_pending'])
+
+    def test_player_shell_cost_tracks_the_fired_type_once_across_a_swap(self):
         state = _state()
         player = state.players[1]
         self.assertTrue(_update_player_input(
@@ -1739,22 +1808,29 @@ class ServerProjectileLedgerTests(unittest.TestCase):
         self.assertTrue(state.submit_fire_intent(1, _fire_intent(
             state, shot_direction=[1.0, 0.0, 0.0])))
         relay = player.pending_fire_intents[1]
-        self.assertEqual(1, relay['next_shell_index'])
-        self.assertTrue(relay['shell_change_pending'])
+        launch = _launch(
+            authority_epoch=state.authority_epoch,
+            fire_intent_seq=relay['intent_seq'],
+            fire_input_seq=relay['input_seq'])
 
         self.assertTrue(state.launch_projectile(
-            SIMULATION_WORKER_AUTHORITY_ID, _launch(
-                authority_epoch=state.authority_epoch,
-                fire_intent_seq=relay['intent_seq'],
-                fire_input_seq=relay['input_seq'])))
+            SIMULATION_WORKER_AUTHORITY_ID, launch))
+        statistics = state._statistics_row('player', 1)
+        self.assertEqual(1, statistics['shots_fired'])
+        self.assertEqual({'0': 1}, statistics['shells_fired'])
+        self.assertEqual(0, state.pending_events[-1]['shell_index'])
+        self.assertTrue(state.launch_projectile(
+            SIMULATION_WORKER_AUTHORITY_ID, dict(launch)))
+        self.assertEqual(1, statistics['shots_fired'])
+        self.assertEqual({'0': 1}, statistics['shells_fired'])
 
-        self.assertEqual(1, player.shell_index)
-        self.assertEqual(1, player.next_shell_index)
-        self.assertFalse(player.shell_change_pending)
-        public = state._public_player(player)
-        self.assertEqual(1, public['shell_index'])
-        self.assertEqual(1, public['next_shell_index'])
-        self.assertFalse(public['shell_change_pending'])
+        self.assertTrue(_update_player_input(
+            state, 1, shell_index=1, next_shell_index=1,
+            shell_change_pending=False))
+        self.assertTrue(_launch_authority(
+            state, _launch(shot_seq=2, shell_index=1)))
+        self.assertEqual(2, statistics['shots_fired'])
+        self.assertEqual({'0': 1, '1': 1}, statistics['shells_fired'])
 
     def test_unidentifiable_fire_intents_do_not_advance_the_frontier(self):
         state = _state()


### PR DESCRIPTION
Exhausting an ammunition type could publish a full new cassette while its full reload was still running. The pinned #1513 ammo controller then used the intra-clip interval as the displayed reload duration. Keep the new cassette empty until the full reload completes, and keep a preselected shell queued until the current cassette is exhausted.

The adjacent transaction review also fixes two ordering problems: preserve CURRENT/NEXT/manual-reload input order while a shot awaits acceptance or rejection, and let the visible gun checkpoint publish post-shot selection without the server overwriting newer inputs. Charge ammunition statistics to the frozen shell actually launched, including across shell changes and duplicate launch messages.

Validation:
- Regression cases fail against the previous implementation and pass with the fix, covering exhaustion, preselection, partial magazines, deferred settings, accepted/rejected shots, and shell accounting.
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -p 'test_*.py'`: 4,992 tests passed with 2 skipped.
- CPython 2.7.18 compilation of all 111 client source files and the exact Chinese #1513 ABI audit.
- Executed the stock #1513 `AmmoController.setGunReloadTime` bytecode with controlled cassette counts to verify its full-reload versus intra-clip duration branch.

Windows gameplay and native HUD acceptance have not been performed on this change.
