### PR TITLE
Make Bot target choice a difficulty ladder

### DIFF
--- a/server/server_bot_ai.py
+++ b/server/server_bot_ai.py
@@ -58,6 +58,26 @@ CAPTURE_STAGING_RADIUS = 30.0
 MIN_ROUTE_CLASS_AFFINITY = 0.20
 RECENT_HIT_SECONDS = 6.0
 RECENT_ATTACKER_SCORE_BONUS = 140.0
+# Target ranking weights.  A lower score wins, so a per-metre term prefers a
+# nearer enemy and a bonus is subtracted.  All four are product numbers for
+# this project; none of them is retail data.
+#
+# Every Bot pays the reach term at every rating.  How far a gun has to shoot
+# is a fact about the gun, not a tactic, and without it a Bot that has not
+# reached the nearest-enemy rung would rank a 400 m contact ahead of a 100 m
+# one on nothing but a contact id.
+TARGET_REACH_SCORE_PER_METRE = 0.018
+# Deliberately preferring the nearer enemy is the ladder's first rung, so it
+# is weighted to matter against the other rungs rather than to dominate them:
+# a weakened target still wins inside roughly 100 m of extra travel, and the
+# nearer target wins once the gap grows past roughly 200 m.
+NEAREST_TARGET_SCORE_PER_METRE = 0.12
+# The human is the round's real opponent, so the top rung goes for the player
+# ahead of an equally convenient Bot.  Deliberately below the point-blank
+# override: a tank in your face still comes first, at every rating.
+HUMAN_TARGET_SCORE_BONUS = 60.0
+# How much of the ranking the most nearly dead contact is worth.
+TARGET_HEALTH_SCORE_SPAN = 28.0
 LOW_HEALTH_BASE_FRACTION = 0.18
 CROSSFIRE_MIN_ANGLE = math.radians(55.0)
 CROSSFIRE_MAX_DISTANCE = 360.0
@@ -1744,6 +1764,11 @@ class BotPlanner(object):
         firing lane. The authority client reports the bot ids whose own static
         ray succeeded, so a shared red dot cannot pull the rest of a flank off
         its route.
+
+        Which of those lanes a Bot prefers is a difficulty ladder: see the
+        rungs and their onsets below and in ``bot_gunnery``. The focus cap
+        does not read the ladder, so a human contact is reserved exactly like
+        a Bot contact however hard the roster is.
         """
         if not bots or not contacts:
             return {}
@@ -1751,26 +1776,30 @@ class BotPlanner(object):
         assigned = {}
         candidates = []
         by_bot = {}
-        priority = {}
+        tactics = {}
         for bot in bots:
             bx = _number(bot["state"].get("x"))
             bz = _number(bot["state"].get("z"))
-            # Ranking a whole contact list by how nearly dead each target is,
-            # and turning on whoever last hit you, is a competence. The
-            # occasion is the target lease this assignment already runs on,
-            # not the wall clock: a Bot that re-decided on a timer would
-            # change its mind mid-lease, and every candidate's score would
-            # move at once for no reason the enemy gave it. Decided once per
-            # call and reused below, so the score and the attacker override
-            # cannot disagree. Distance and the point-blank override survive
-            # either way: closing to your own gun and answering a tank in
-            # your face are not tactics.
+            # Choosing an enemy is a ladder of separate competences, not one
+            # decision: preferring the nearer contact, finishing the most
+            # nearly dead one, turning on whoever just hit you, and going for
+            # the human instead of a Bot each have their own onset on the
+            # rating axis, so a stronger roster reaches for strictly more of
+            # them instead of only hesitating less often. The occasion is the
+            # target lease this assignment already runs on, not the wall
+            # clock: a Bot that re-decided on a timer would change its mind
+            # mid-lease, and every candidate's score would move at once for
+            # no reason the enemy gave it. Decided once per call and reused
+            # below, so a score and its override cannot disagree. Gun reach
+            # and the point-blank override survive at every rating: neither
+            # is a tactic.
             lease = self._target_assignments.get(bot["id"])
-            reads_priority = self._capable(
-                bot, bot_gunnery.CAPABILITY_TARGET_PRIORITY,
-                round(_number(lease.get("until")), 3)
-                if isinstance(lease, dict) else None)
-            priority[bot["id"]] = reads_priority
+            occasion = (round(_number(lease.get("until")), 3)
+                        if isinstance(lease, dict) else None)
+            reads = dict(
+                (capability, self._capable(bot, capability, occasion))
+                for capability in bot_gunnery.TARGET_CAPABILITIES)
+            tactics[bot["id"]] = reads
             for contact in contacts:
                 if (not contact.get("visible") or
                         bot["id"] not in contact.get(
@@ -1782,16 +1811,23 @@ class BotPlanner(object):
                 if distance > self._engagement_range(bot, contact):
                     continue
                 score = 0.0
-                if reads_priority:
-                    score += contact["health"] / float(
-                        max(1, contact["max_health"])) * 28.0
-                score += distance * 0.018
+                if reads[bot_gunnery.CAPABILITY_TARGET_PRIORITY]:
+                    score += (contact["health"] / float(
+                        max(1, contact["max_health"])) *
+                        TARGET_HEALTH_SCORE_SPAN)
+                score += distance * TARGET_REACH_SCORE_PER_METRE
+                if reads[bot_gunnery.CAPABILITY_TARGET_NEAREST]:
+                    score += distance * NEAREST_TARGET_SCORE_PER_METRE
                 hit = self._recent_hit(bot["id"], now)
-                if (reads_priority and hit is not None and
+                if (reads[bot_gunnery.CAPABILITY_TARGET_RETALIATION] and
+                        hit is not None and
                         hit.get("attacker") == (
                             str(contact.get("target_kind") or ""),
                             _integer(contact.get("id")))):
                     score -= RECENT_ATTACKER_SCORE_BONUS
+                if (reads[bot_gunnery.CAPABILITY_TARGET_HUMAN] and
+                        str(contact.get("target_kind") or "") == "human"):
+                    score -= HUMAN_TARGET_SCORE_BONUS
                 if distance <= CLOSE_THREAT_DISTANCE:
                     # A point-blank enemy is an immediate self-defence problem,
                     # even while a previous long-range target still owns a
@@ -1886,7 +1922,8 @@ class BotPlanner(object):
             attacker_override = bool(
                 hit is not None and best_key == hit.get("attacker") and
                 best_key != previous.get("target") and
-                priority.get(bot["id"], True))
+                tactics.get(bot["id"], {}).get(
+                    bot_gunnery.CAPABILITY_TARGET_RETALIATION, True))
             if close_override or attacker_override:
                 continue
             if (lease_expired and

--- a/server/server_bot_ai.py
+++ b/server/server_bot_ai.py
@@ -73,8 +73,8 @@ TARGET_REACH_SCORE_PER_METRE = 0.018
 # nearer target wins once the gap grows past roughly 200 m.
 NEAREST_TARGET_SCORE_PER_METRE = 0.12
 # The human is the round's real opponent, so the top rung goes for the player
-# ahead of an equally convenient Bot.  Deliberately below the point-blank
-# override: a tank in your face still comes first, at every rating.
+# ahead of an equally convenient Bot. This preference alone is weaker than
+# point-blank self-defence; retaliation also contributes to the total score.
 HUMAN_TARGET_SCORE_BONUS = 60.0
 # How much of the ranking the most nearly dead contact is worth.
 TARGET_HEALTH_SCORE_SPAN = 28.0
@@ -1758,7 +1758,7 @@ class BotPlanner(object):
         return order
 
     def _assign_targets(self, bots, contacts, now):
-        """Assign only locally shootable contacts, with a hard focus cap.
+        """Assign only locally shootable contacts, with a shared focus budget.
 
         Team spotting is shared intelligence, not proof that every tank has a
         firing lane. The authority client reports the bot ids whose own static

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bot_gunnery.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bot_gunnery.py
@@ -33,6 +33,11 @@ half is consumed by the server planner, not here: this module owns the number
 and the draw, so worker, server and launcher reach the same answer from
 identity alone.
 
+A capability may also declare an onset: the rating below which a Bot never
+reaches for it at all.  That is what turns one probability into a ladder, so
+a stronger roster does not merely hesitate less often, it has strictly more
+tactics available.  An onset of zero is the original behaviour exactly.
+
 Every draw is seeded from stable round, Bot and target identity, so authority
 takeover reproduces the same gunner rather than re-rolling one mid-engagement.
 The radius law matches ``bot_runtime._dispersed_barrel_angles`` so the project
@@ -73,7 +78,6 @@ PROVEN_CREW_LEVELS = (75, 90, 100)
 # hesitate uniformly.
 CAPABILITY_WEAK_SPOT = 'weak_spot'
 CAPABILITY_SHELL_CHOICE = 'shell_choice'
-CAPABILITY_TARGET_PRIORITY = 'target_priority'
 CAPABILITY_URGENT_COVER = 'urgent_cover'
 CAPABILITY_TACTICAL_COVER = 'tactical_cover'
 CAPABILITY_COVER_PEEK = 'cover_peek'
@@ -82,12 +86,26 @@ CAPABILITY_WITHDRAW = 'withdraw'
 CAPABILITY_HULL_ANGLING = 'hull_angling'
 CAPABILITY_FLANK = 'flank'
 
+# Choosing which enemy to shoot is four separate competences, each with its
+# own onset below.  They are deliberately not one draw: a Bot that ranked a
+# contact list by remaining health would otherwise also, in the same instant,
+# know to answer the tank that just hit it and to prefer the human over a
+# Bot, and the difficulty ladder would have one rung instead of four.
+CAPABILITY_TARGET_NEAREST = 'target_nearest'
+CAPABILITY_TARGET_PRIORITY = 'target_priority'
+CAPABILITY_TARGET_RETALIATION = 'target_retaliation'
+CAPABILITY_TARGET_HUMAN = 'target_human'
+
+TARGET_CAPABILITIES = (
+    CAPABILITY_TARGET_NEAREST, CAPABILITY_TARGET_PRIORITY,
+    CAPABILITY_TARGET_RETALIATION, CAPABILITY_TARGET_HUMAN)
+
 CAPABILITIES = (
     CAPABILITY_WEAK_SPOT, CAPABILITY_SHELL_CHOICE,
-    CAPABILITY_TARGET_PRIORITY, CAPABILITY_URGENT_COVER,
+    CAPABILITY_URGENT_COVER,
     CAPABILITY_TACTICAL_COVER, CAPABILITY_COVER_PEEK,
     CAPABILITY_CROSSFIRE, CAPABILITY_WITHDRAW,
-    CAPABILITY_HULL_ANGLING, CAPABILITY_FLANK)
+    CAPABILITY_HULL_ANGLING, CAPABILITY_FLANK) + TARGET_CAPABILITIES
 
 # Rolled once for the whole round from round and slot identity.
 LATCHED_CAPABILITIES = frozenset((
@@ -99,6 +117,35 @@ LATCHED_CAPABILITIES = frozenset((
 # one exponent is the whole correction if playtesting says the tactical half
 # bites harder than the gunnery half.
 CAPABILITY_EXPONENT = 1.0
+
+# The rating one capability first appears at.  Below its onset a Bot never
+# reaches for that tactic; from the onset the chance rises to certainty at
+# rating 1, so the ends of every preset stay exactly as honest as before and
+# a stronger Bot still never has fewer tactics than a weaker one.
+#
+# Target selection is what this table exists for, and the onsets are the
+# points where the tier labels change, so the launcher's own vocabulary
+# describes the ladder truthfully: every roster answers a tank in its face
+# and shoots what its gun can reach, a rookie-and-up may prefer the nearest
+# enemy, a regular-and-up may turn on whoever just hit it, and a
+# veteran-and-up may go for the human player instead of a Bot.  A capability
+# absent from this table starts at 0 and behaves exactly as it did before
+# the table existed.
+#
+# An onset is the midpoint between two anchors, not an anchor.  A rating at
+# its own onset never reaches the rung, and a launcher lineup pin resolves a
+# tier name to that tier's exact anchor - so an onset placed on the anchor
+# would hand a Bot labelled ``veteran`` a rung it can never use.
+# ``skill_for_rating`` rounds a tie down, which puts the midpoint in the
+# lower tier and makes "this tier and up" literally true.
+CAPABILITY_ONSETS = {
+    CAPABILITY_TARGET_NEAREST: RATING_ANCHORS[0],
+    CAPABILITY_TARGET_PRIORITY: RATING_ANCHORS[0],
+    CAPABILITY_TARGET_RETALIATION: (
+        RATING_ANCHORS[0] + RATING_ANCHORS[1]) * 0.5,
+    CAPABILITY_TARGET_HUMAN: (
+        RATING_ANCHORS[1] + RATING_ANCHORS[2]) * 0.5,
+}
 
 # One aim-point bias is held for this long before the gunner re-lays the gun.
 # A single frozen bias would make a whole engagement uniformly lucky or
@@ -361,6 +408,32 @@ def resolve_skill(mode, round_id, team, slot):
     return skill_for_rating(resolve_rating(mode, round_id, team, slot))
 
 
+def capability_onset(capability):
+    """Return the rating at which one capability starts to appear at all."""
+    return normalize_rating(CAPABILITY_ONSETS.get(capability, 0.0))
+
+
+def capability_probability(rating, capability):
+    """Return the chance one Bot reaches for one tactic on one occasion.
+
+    The rating is remapped onto the span above the capability's onset, so a
+    Bot at the onset never reaches for it, a Bot at rating 1 always does, and
+    the tactics with a higher onset are the ones only a strong roster brings.
+    """
+    rating = normalize_rating(rating)
+    if rating <= 0.0:
+        return 0.0
+    onset = capability_onset(capability)
+    if onset >= 1.0:
+        return 1.0 if rating >= 1.0 else 0.0
+    reach = (rating - onset) / (1.0 - onset)
+    if reach <= 0.0:
+        return 0.0
+    if reach >= 1.0:
+        return 1.0
+    return reach ** CAPABILITY_EXPONENT
+
+
 def capability_allowed(rating, capability, *occasion):
     """Return whether one Bot does the tactically right thing this time.
 
@@ -372,12 +445,12 @@ def capability_allowed(rating, capability, *occasion):
     tick and an authority takeover cannot make a Bot change its mind.
 
     A rating of 0 never succeeds and a rating of 1 always does, so the ends
-    of a preset stay honest.
+    of a preset stay honest.  In between, a capability with an onset above 0
+    stays out of reach until the rating passes it.
     """
-    rating = normalize_rating(rating)
-    if rating <= 0.0:
+    probability = capability_probability(rating, capability)
+    if probability <= 0.0:
         return False
-    probability = rating ** CAPABILITY_EXPONENT
     if probability >= 1.0:
         return True
     parts = ('bot-capability-v1', capability) + occasion

--- a/tests/test_port_0922_bot_gunnery.py
+++ b/tests/test_port_0922_bot_gunnery.py
@@ -431,6 +431,145 @@ class CapabilityTests(unittest.TestCase):
         self.assertEqual(1.0, gunnery.CAPABILITY_EXPONENT)
 
 
+class CapabilityOnsetTests(unittest.TestCase):
+    """An onset turns one probability into a difficulty ladder."""
+
+    def test_a_capability_without_an_onset_is_exactly_the_old_draw(self):
+        """Nothing the ladder did not name may move."""
+        for capability in gunnery.CAPABILITIES:
+            if gunnery.capability_onset(capability) > 0.0:
+                continue
+            for rating in (0.0, 0.05, 0.3, 0.5, 0.87, 1.0):
+                self.assertAlmostEqual(
+                    rating,
+                    gunnery.capability_probability(rating, capability),
+                    msg=(capability, rating))
+
+    def test_a_tactic_is_out_of_reach_below_its_onset(self):
+        for capability in gunnery.CAPABILITIES:
+            onset = gunnery.capability_onset(capability)
+            if onset <= 0.0:
+                continue
+            self.assertEqual(
+                0.0, gunnery.capability_probability(onset, capability))
+            for occasion in range(60):
+                self.assertFalse(gunnery.capability_allowed(
+                    onset, capability, 3, 11, occasion), capability)
+
+    def test_every_tactic_still_reaches_certainty_at_the_top(self):
+        for capability in gunnery.CAPABILITIES:
+            self.assertEqual(
+                1.0, gunnery.capability_probability(1.0, capability),
+                capability)
+            self.assertEqual(
+                0.0, gunnery.capability_probability(0.0, capability),
+                capability)
+
+    def test_a_stronger_bot_never_reaches_for_fewer_tactics(self):
+        previous = None
+        for index in range(21):
+            rating = index / 20.0
+            available = frozenset(
+                capability for capability in gunnery.CAPABILITIES
+                if gunnery.capability_probability(rating, capability) > 0.0)
+            if previous is not None:
+                self.assertTrue(previous <= available, rating)
+            previous = available
+
+    def test_the_ladder_really_has_more_than_one_rung(self):
+        """A rookie, a regular and a veteran must not be offered the same set."""
+        counts = []
+        for rating in gunnery.RATING_ANCHORS:
+            counts.append(len([
+                capability for capability in gunnery.TARGET_CAPABILITIES
+                if gunnery.capability_probability(
+                    rating + 1e-6, capability) > 0.0]))
+        self.assertEqual(sorted(counts), counts)
+        self.assertLess(counts[0], counts[-1])
+        self.assertEqual(len(gunnery.TARGET_CAPABILITIES), counts[-1])
+
+    def test_the_target_ladder_is_ordered_the_way_it_is_documented(self):
+        nearest = gunnery.capability_onset(
+            gunnery.CAPABILITY_TARGET_NEAREST)
+        priority = gunnery.capability_onset(
+            gunnery.CAPABILITY_TARGET_PRIORITY)
+        retaliation = gunnery.capability_onset(
+            gunnery.CAPABILITY_TARGET_RETALIATION)
+        human = gunnery.capability_onset(gunnery.CAPABILITY_TARGET_HUMAN)
+        self.assertEqual(0.0, nearest)
+        self.assertEqual(0.0, priority)
+        self.assertLess(priority, retaliation)
+        self.assertLess(retaliation, human)
+        self.assertLess(human, 1.0)
+        # An onset sits between two anchors, never on one. A launcher lineup
+        # pin resolves a tier name to that tier's exact anchor, so an onset
+        # on the anchor would promise a rung the labelled Bot never reaches.
+        self.assertLess(gunnery.RATING_ANCHORS[0], retaliation)
+        self.assertLess(retaliation, gunnery.RATING_ANCHORS[1])
+        self.assertLess(gunnery.RATING_ANCHORS[1], human)
+        self.assertLess(human, gunnery.RATING_ANCHORS[2])
+
+    def test_a_tier_label_never_promises_a_rung_the_bot_cannot_reach(self):
+        """A Bot the launcher calls veteran really does hunt the player."""
+        promises = {
+            gunnery.CAPABILITY_TARGET_NEAREST: gunnery.SKILL_ROOKIE,
+            gunnery.CAPABILITY_TARGET_PRIORITY: gunnery.SKILL_ROOKIE,
+            gunnery.CAPABILITY_TARGET_RETALIATION: gunnery.SKILL_REGULAR,
+            gunnery.CAPABILITY_TARGET_HUMAN: gunnery.SKILL_VETERAN,
+        }
+        for capability, promised in promises.items():
+            floor = gunnery.SKILL_TIERS.index(promised)
+            for index in range(2001):
+                rating = index / 2000.0
+                if rating <= 0.0:
+                    continue
+                labelled = gunnery.SKILL_TIERS.index(
+                    gunnery.skill_for_rating(rating))
+                reachable = gunnery.capability_probability(
+                    rating, capability) > 0.0
+                if labelled >= floor:
+                    self.assertTrue(
+                        reachable, (capability, rating))
+                else:
+                    self.assertFalse(
+                        reachable, (capability, rating))
+            # The pinned anchor itself is the case a launcher lineup
+            # creates.  The rookie anchor is rating 0, which is the honest
+            # floor of the whole spectrum and reaches nothing by design.
+            anchor = gunnery.rating_for_skill(promised)
+            if anchor > 0.0:
+                self.assertTrue(
+                    gunnery.capability_probability(anchor, capability) > 0.0,
+                    capability)
+
+    def test_the_target_capabilities_are_real_capabilities(self):
+        self.assertTrue(gunnery.TARGET_CAPABILITIES)
+        for capability in gunnery.TARGET_CAPABILITIES:
+            self.assertIn(capability, gunnery.CAPABILITIES)
+
+    def test_an_onset_capability_still_succeeds_at_its_own_rate(self):
+        capability = gunnery.CAPABILITY_TARGET_HUMAN
+        onset = gunnery.capability_onset(capability)
+        for rating in (0.75, 0.85, 0.95):
+            expected = (rating - onset) / (1.0 - onset)
+            hits = sum(
+                1 for index in range(4000)
+                if gunnery.capability_allowed(rating, capability, 1, index))
+            self.assertAlmostEqual(
+                expected, hits / 4000.0, delta=0.025, msg=rating)
+
+    def test_competence_never_costs_a_bot_an_onset_capability(self):
+        occasions = [(1, index) for index in range(600)]
+        counts = []
+        for index in range(11):
+            counts.append(sum(
+                1 for occasion in occasions
+                if gunnery.capability_allowed(
+                    index / 10.0, gunnery.CAPABILITY_TARGET_HUMAN,
+                    *occasion)))
+        self.assertEqual(sorted(counts), counts)
+
+
 class SkillVocabularyParityTests(unittest.TestCase):
     """One vocabulary, four owners: worker, wire, room panel and launcher."""
 

--- a/tests/test_port_0922_server_bot_ai.py
+++ b/tests/test_port_0922_server_bot_ai.py
@@ -7,7 +7,16 @@ import unittest
 PORT_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(PORT_ROOT / 'server'))
 
-from server_bot_ai import BotPlanner, _order_signature  # noqa: E402
+from server_bot_ai import (  # noqa: E402
+    CLOSE_THREAT_SCORE_BONUS,
+    HUMAN_TARGET_SCORE_BONUS,
+    NEAREST_TARGET_SCORE_PER_METRE,
+    RECENT_ATTACKER_SCORE_BONUS,
+    TARGET_HEALTH_SCORE_SPAN,
+    TARGET_REACH_SCORE_PER_METRE,
+    BotPlanner,
+    _order_signature,
+)
 from lan_battle_server import (  # noqa: E402
     BOT_PLANNER_INTERVAL_TICKS,
     CLIENT_BUILD_0922,
@@ -18,6 +27,7 @@ from lan_battle_server import (  # noqa: E402
     Player,
     SimulationWorker,
 )
+from gui.mods.offline_lan_0922 import bot_gunnery  # noqa: E402
 from gui.mods.offline_lan_0922.bot_runtime import (  # noqa: E402
     _overlay_live_target_pose,
 )
@@ -123,6 +133,12 @@ def _contact(target_id, x, z, observers, class_tag='mediumTank'):
         'max_health': 1000,
         'class_tag': class_tag,
     }
+
+
+def _bot_contact(target_id, x, z, observers, class_tag='mediumTank'):
+    result = _contact(target_id, x, z, observers, class_tag)
+    result['target_kind'] = 'bot'
+    return result
 
 
 def _cover_report(bot_id, target_id, candidate_id='rock', x=12.0,
@@ -2139,6 +2155,218 @@ class ServerBotCompetenceTests(unittest.TestCase):
             self.assertEqual(
                 first._capable(bot, capability, 'x'),
                 second._capable(bot, capability, 'x'), capability)
+
+
+class ServerBotTargetLadderTests(unittest.TestCase):
+    """Which enemy a Bot prefers is a ladder, not one on/off competence.
+
+    Every Bot shoots what its gun can reach and answers a tank in its face.
+    Above that, preferring the nearer contact and finishing the most nearly
+    dead one arrive with any competence at all, turning on whoever just hit
+    you arrives at the regular anchor, and going for the human player instead
+    of a Bot arrives at the veteran anchor.
+    """
+
+    def setUp(self):
+        self.route = _route('lane', [
+            (0, -100, False), (0, 100, False), (0, 500, False),
+        ])
+        self.manifest = [_bot(
+            11, 1, 0, self.route, 'mediumTank', {'support': 1.0})]
+        self.manifest[0]['profile'].update({
+            'armor': 120.0,
+            'dominant_role': 'support',
+            'desired_range': 180.0,
+            'fire_range': 520.0,
+        })
+        self.states = [_state(11, 1, 0, 0)]
+
+    def _rate(self, rating):
+        self.manifest[0]['skill_rating'] = rating
+
+    def _report(self, planner, contacts, enemy_bots=()):
+        """Report contacts of either kind and return the player roster."""
+        players = [
+            {'id': raw['target_id'], 'team': 2, 'alive': True}
+            for raw in contacts if raw['target_kind'] == 'human'
+        ]
+        states = list(self.states) + [
+            _state(bot_id, 2, 0.0, 0.0) for bot_id in enemy_bots
+        ]
+        self.states = states
+        self.assertEqual(len(contacts), planner.report_contacts(
+            contacts, planner.known_targets(states, players), 1.0))
+        return players
+
+    def _order(self, planner, players, now=1.0):
+        return next(
+            order for order in planner.build_orders(
+                self.manifest, self.states, players, now)['orders']
+            if order['id'] == 11)
+
+    def _target(self, planner, players, now=1.0):
+        order = self._order(planner, players, now)
+        return order['target_kind'], order['target_id']
+
+    def test_the_ranking_weights_stay_in_their_reviewed_order(self):
+        """Each rung must be able to outweigh the rung below it."""
+        # The nearest rung has to be able to beat finishing a wreck that is
+        # a couple of hundred metres further away, or it is decoration.
+        self.assertGreater(
+            (NEAREST_TARGET_SCORE_PER_METRE +
+             TARGET_REACH_SCORE_PER_METRE) * 220.0,
+            TARGET_HEALTH_SCORE_SPAN)
+        # Going for the player outweighs finishing a wreck, a tank in your
+        # face outweighs going for the player, and answering the tank that
+        # just hit you outweighs all of them.
+        self.assertLess(TARGET_HEALTH_SCORE_SPAN, HUMAN_TARGET_SCORE_BONUS)
+        self.assertLess(HUMAN_TARGET_SCORE_BONUS, CLOSE_THREAT_SCORE_BONUS)
+        self.assertLess(CLOSE_THREAT_SCORE_BONUS,
+                        RECENT_ATTACKER_SCORE_BONUS)
+
+    def test_a_hopeless_bot_does_not_answer_the_tank_that_hit_it(self):
+        planner = BotPlanner()
+        self._rate(0.0)
+        contacts = [
+            _contact(2, 0, 300, [11]),
+            _contact(3, 0, 120, [11]),
+        ]
+        players = self._report(planner, contacts)
+        planner.report_damage(11, 'player', 2, 200, 1.0)
+
+        self.assertEqual(('human', 3), self._target(planner, players))
+
+    def test_a_rookie_below_the_retaliation_rung_cannot_reach_it(self):
+        """The rung is a real onset, not a low probability."""
+        planner = BotPlanner()
+        onset = bot_gunnery.capability_onset(
+            bot_gunnery.CAPABILITY_TARGET_RETALIATION)
+        self._rate(onset - 0.01)
+        contacts = [
+            _contact(2, 0, 300, [11]),
+            _contact(3, 0, 120, [11]),
+        ]
+        players = self._report(planner, contacts)
+        planner.report_damage(11, 'player', 2, 200, 1.0)
+
+        self.assertEqual(('human', 3), self._target(planner, players))
+
+    def test_a_complete_bot_answers_the_tank_that_hit_it(self):
+        planner = BotPlanner()
+        self._rate(1.0)
+        contacts = [
+            _contact(2, 0, 300, [11]),
+            _contact(3, 0, 120, [11]),
+        ]
+        players = self._report(planner, contacts)
+        planner.report_damage(11, 'player', 2, 200, 1.0)
+
+        self.assertEqual(('human', 2), self._target(planner, players))
+
+    def test_a_bot_below_the_human_rung_shoots_the_nearer_enemy_bot(self):
+        planner = BotPlanner()
+        self._rate(bot_gunnery.capability_onset(
+            bot_gunnery.CAPABILITY_TARGET_HUMAN) - 0.01)
+        contacts = [
+            _contact(2, 0, 250, [11]),
+            _bot_contact(3, 0, 150, [11]),
+        ]
+        players = self._report(planner, contacts, enemy_bots=(3,))
+
+        self.assertEqual(('bot', 3), self._target(planner, players))
+
+    def test_a_complete_bot_goes_for_the_player(self):
+        planner = BotPlanner()
+        self._rate(1.0)
+        contacts = [
+            _contact(2, 0, 250, [11]),
+            _bot_contact(3, 0, 150, [11]),
+        ]
+        players = self._report(planner, contacts, enemy_bots=(3,))
+
+        self.assertEqual(('human', 2), self._target(planner, players))
+
+    def test_a_tank_in_your_face_still_beats_going_for_the_player(self):
+        """Self-defence is not a tactic and does not sit on the ladder."""
+        planner = BotPlanner()
+        self._rate(1.0)
+        contacts = [
+            _contact(2, 0, 340, [11]),
+            _bot_contact(3, 0, 30, [11]),
+        ]
+        players = self._report(planner, contacts, enemy_bots=(3,))
+
+        self.assertEqual(('bot', 3), self._target(planner, players))
+
+    def test_the_nearest_rung_holds_a_complete_bot_off_a_distant_wreck(self):
+        planner = BotPlanner()
+        self._rate(1.0)
+        contacts = [
+            _contact(2, 0, 100, [11]),
+            _contact(3, 0, 320, [11]),
+        ]
+        contacts[1]['health'] = 50
+        players = self._report(planner, contacts)
+
+        self.assertEqual(('human', 2), self._target(planner, players))
+
+    def test_a_nearby_wreck_is_still_finished_first(self):
+        """The nearest rung must not stop a Bot finishing a kill in reach."""
+        planner = BotPlanner()
+        self._rate(1.0)
+        contacts = [
+            _contact(2, 0, 100, [11]),
+            _contact(3, 0, 150, [11]),
+        ]
+        contacts[1]['health'] = 50
+        players = self._report(planner, contacts)
+
+        self.assertEqual(('human', 3), self._target(planner, players))
+
+    def test_the_focus_cap_treats_a_player_exactly_like_a_bot(self):
+        """Answers "will every Bot on brutal shoot only me": no, same cap."""
+        self.route = _route('lane', [
+            (0, -100, False), (0, 100, False), (0, 500, False),
+        ])
+        bot_ids = list(range(11, 26))
+        self.manifest = []
+        self.states = []
+        for slot, bot_id in enumerate(bot_ids):
+            entry = _bot(bot_id, 1, slot, self.route, 'mediumTank',
+                         {'support': 1.0})
+            entry['profile'].update({
+                'armor': 120.0,
+                'dominant_role': 'support',
+                'desired_range': 180.0,
+                'fire_range': 520.0,
+            })
+            entry['skill_rating'] = 1.0
+            self.manifest.append(entry)
+            self.states.append(_state(bot_id, 1, float(slot) * 4.0, 0))
+        baseline_states = list(self.states)
+
+        human_planner = BotPlanner()
+        human_players = self._report(
+            human_planner, [_contact(2, 0, 150, bot_ids)])
+        human_orders = human_planner.build_orders(
+            self.manifest, self.states, human_players, 1.0)['orders']
+        on_human = sum(1 for order in human_orders
+                       if order['target_id'] == 2)
+
+        self.states = baseline_states
+        bot_planner = BotPlanner()
+        bot_players = self._report(
+            bot_planner, [_bot_contact(2, 0, 150, bot_ids)],
+            enemy_bots=(2,))
+        bot_orders = bot_planner.build_orders(
+            self.manifest, self.states, bot_players, 1.0)['orders']
+        on_bot = sum(1 for order in bot_orders
+                     if order['target_id'] == 2 and
+                     order['target_kind'] == 'bot')
+
+        self.assertGreater(on_human, 0)
+        self.assertLess(on_human, len(bot_ids))
+        self.assertEqual(on_bot, on_human)
 
 
 class ServerBotArtilleryTests(unittest.TestCase):

--- a/tests/test_port_0922_server_bot_ai.py
+++ b/tests/test_port_0922_server_bot_ai.py
@@ -2163,8 +2163,8 @@ class ServerBotTargetLadderTests(unittest.TestCase):
     Every Bot shoots what its gun can reach and answers a tank in its face.
     Above that, preferring the nearer contact and finishing the most nearly
     dead one arrive with any competence at all, turning on whoever just hit
-    you arrives at the regular anchor, and going for the human player instead
-    of a Bot arrives at the veteran anchor.
+    you arrives at the regular label boundary, and going for the human player
+    instead of a Bot arrives at the veteran label boundary.
     """
 
     def setUp(self):
@@ -2324,7 +2324,7 @@ class ServerBotTargetLadderTests(unittest.TestCase):
         self.assertEqual(('human', 3), self._target(planner, players))
 
     def test_the_focus_cap_treats_a_player_exactly_like_a_bot(self):
-        """Answers "will every Bot on brutal shoot only me": no, same cap."""
+        """Human preference uses the same descriptor-backed focus budget."""
         self.route = _route('lane', [
             (0, -100, False), (0, 100, False), (0, 500, False),
         ])
@@ -2345,28 +2345,38 @@ class ServerBotTargetLadderTests(unittest.TestCase):
             self.states.append(_state(bot_id, 1, float(slot) * 4.0, 0))
         baseline_states = list(self.states)
 
-        human_planner = BotPlanner()
-        human_players = self._report(
-            human_planner, [_contact(2, 0, 150, bot_ids)])
-        human_orders = human_planner.build_orders(
-            self.manifest, self.states, human_players, 1.0)['orders']
-        on_human = sum(1 for order in human_orders
-                       if order['target_id'] == 2)
-
-        self.states = baseline_states
-        bot_planner = BotPlanner()
-        bot_players = self._report(
-            bot_planner, [_bot_contact(2, 0, 150, bot_ids)],
-            enemy_bots=(2,))
-        bot_orders = bot_planner.build_orders(
-            self.manifest, self.states, bot_players, 1.0)['orders']
-        on_bot = sum(1 for order in bot_orders
-                     if order['target_id'] == 2 and
-                     order['target_kind'] == 'bot')
-
-        self.assertGreater(on_human, 0)
-        self.assertLess(on_human, len(bot_ids))
-        self.assertEqual(on_bot, on_human)
+        # Known damage reserves enough nominal damage plus a spare shot.
+        # Low damage can admit the whole roster; only missing descriptors
+        # use the fixed count fallback. Neither branch reads target kind.
+        for damage, expected in ((None, 2), (250.0, 5), (40.0, 15)):
+            with self.subTest(damage=damage):
+                for entry in self.manifest:
+                    entry['profile']['shells'] = ([] if damage is None else [{
+                        'index': 0,
+                        'kind': 'ARMOR_PIERCING',
+                        'penetration': 200.0,
+                        'damage': damage,
+                    }])
+                counts = {}
+                for kind in ('human', 'bot'):
+                    planner = BotPlanner()
+                    self.states = list(baseline_states)
+                    contact = (_contact(2, 0, 150, bot_ids)
+                               if kind == 'human' else
+                               _bot_contact(2, 0, 150, bot_ids))
+                    players = self._report(
+                        planner, [contact],
+                        enemy_bots=() if kind == 'human' else (2,))
+                    for now in (1.0, 1.1):
+                        orders = planner.build_orders(
+                            self.manifest, self.states, players, now)['orders']
+                        counts[kind, now] = sum(
+                            1 for order in orders
+                            if order['target_id'] == 2 and
+                            order['target_kind'] == kind)
+                        self.assertEqual(expected, counts[kind, now])
+                self.assertEqual(counts['bot', 1.0], counts['human', 1.0])
+                self.assertEqual(counts['bot', 1.1], counts['human', 1.1])
 
 
 class ServerBotArtilleryTests(unittest.TestCase):


### PR DESCRIPTION
Bot target ranking now uses separate difficulty draws for preferring nearby enemies, finishing low-health targets, retaliating against recent attackers, and preferring a human opponent. Retaliation starts above the regular-label boundary; human preference starts above the veteran-label boundary. Unlisted capabilities keep their previous probabilities, and all draws remain tied to the existing assignment occasion.

The distance, health, retaliation, human, and close-threat terms contribute to the same score. Their weights and onset positions are project tuning values. Close-threat and recent-attacker overrides can interrupt a target lease; the lease is not an absolute two-second switching limit.

Focus allocation preserves the existing rules for both human and Bot targets. With known shell damage at ordinary engagement distances it uses a damage budget, so it does not guarantee a fixed number of attackers: a 1000 HP target can admit five 250-damage guns or all fifteen 40-damage guns. The fallback for unknown shell damage and the point-blank limits are unchanged. Regression coverage checks identical human/Bot allocations with unknown damage and both known-damage cases, on initial assignment and lease reuse.

Validation: targeted AI tests and Python 2.7 source compilation pass. Actual Windows difficulty, targeting feel, and frame pacing remain unverified. No CI wait or deployment is part of this review.
