### PR TITLE
Correct spotting credit across observer and lease transitions

### DIFF
--- a/server/lan_battle_server.py
+++ b/server/lan_battle_server.py
@@ -4745,7 +4745,7 @@ class BattleState:
                 (bot_id, set()) for bot_id in known_bots)
             direct_player_spots = dict(
                 (reporter_id, set()) for reporter_id in known_players)
-            team_lit = {1: set(), 2: set()}
+            team_lit = {1: {}, 2: {}}
             stale_observation = False
             contacts = []
             for raw in message.get("contacts"):
@@ -4797,8 +4797,16 @@ class BattleState:
                         int(target.get("team", 0)) == observing_team or
                         target_team != int(target.get("team", 0))):
                     return False
+                reported_fresh = bool(
+                    contact["visible_by_bot_ids"] or
+                    contact["visible_by_player_ids"])
+                if (contact["fresh"] != reported_fresh or
+                        contact["visible"] != (time_left > 0.0) or
+                        (reported_fresh and not contact["visible"]) or
+                        (not reported_fresh and
+                         contact["shootable_by_bot_ids"])):
+                    return False
                 bot_observer_ids = []
-                stale_contact = False
                 for raw_bot_id in contact.get("visible_by_bot_ids"):
                     try:
                         bot_id = _exact_int(
@@ -4806,15 +4814,15 @@ class BattleState:
                     except ValueError:
                         return False
                     bot = known_bots.get(bot_id)
-                    if bot is not None and not bot.get("alive"):
-                        stale_observation = True
-                        stale_contact = True
-                        continue
                     if (bot is None or
                             int(bot.get("team", 0)) != observing_team or
                             bot_id in bot_observer_ids):
                         return False
                     bot_observer_ids.append(bot_id)
+                    if not bot.get("alive"):
+                        stale_observation = True
+                bot_observer_ids = [bot_id for bot_id in bot_observer_ids
+                                    if known_bots[bot_id].get("alive")]
                 contact["visible_by_bot_ids"] = sorted(bot_observer_ids)
 
                 observer_ids = []
@@ -4826,17 +4834,15 @@ class BattleState:
                     except ValueError:
                         return False
                     observer = known_players.get(observer_id)
-                    if observer is not None and not observer.alive:
-                        stale_observation = True
-                        stale_contact = True
-                        continue
                     if (observer is None or
                             int(observer.team) != observing_team or
                             observer_id in observer_ids):
                         return False
                     observer_ids.append(observer_id)
-                if observer_ids and not contact["visible"]:
-                    return False
+                    if not observer.alive:
+                        stale_observation = True
+                observer_ids = [observer_id for observer_id in observer_ids
+                                if known_players[observer_id].alive]
                 contact["visible_by_player_ids"] = sorted(observer_ids)
                 shooter_ids = []
                 for raw_bot_id in contact.get("shootable_by_bot_ids"):
@@ -4846,15 +4852,15 @@ class BattleState:
                     except ValueError:
                         return False
                     bot = known_bots.get(bot_id)
-                    if bot is not None and not bot.get("alive"):
-                        stale_observation = True
-                        stale_contact = True
-                        continue
                     if (bot is None or
                             int(bot.get("team", 0)) != observing_team or
                             bot_id in shooter_ids):
                         return False
                     shooter_ids.append(bot_id)
+                    if not bot.get("alive"):
+                        stale_observation = True
+                shooter_ids = [bot_id for bot_id in shooter_ids
+                               if known_bots[bot_id].get("alive")]
                 contact["shootable_by_bot_ids"] = sorted(shooter_ids)
                 # A threat is advisory native geometry: a malformed row must
                 # not make an otherwise valid observation batch fail or give
@@ -4880,18 +4886,20 @@ class BattleState:
                     contact["threatened_bot_ids"] = sorted(
                         threatened_ids if contact["visible"] else ())
                 fresh = bool(bot_observer_ids or observer_ids)
-                if stale_contact and not fresh:
-                    continue
-                if (contact["fresh"] != fresh or
-                        contact["visible"] != (time_left > 0.0) or
-                        (fresh and not contact["visible"]) or
-                        (not fresh and shooter_ids)):
-                    return False
+                # An observer may die before its in-flight report arrives.
+                # Retire its direct sight and firing evidence, but keep the
+                # valid lease that still lights this target for the team.
+                contact["fresh"] = fresh
+                if not fresh:
+                    contact["shootable_by_bot_ids"] = []
+                    if "threatened_bot_ids" in contact:
+                        contact["threatened_bot_ids"] = []
                 contact["time_left"] = time_left
                 result_kind = ("player" if target_kind == "human"
                                else target_kind)
                 if contact["visible"]:
-                    team_lit[observing_team].add((result_kind, target_id))
+                    team_lit[observing_team][
+                        (result_kind, target_id)] = time_left
                 for bot_id in bot_observer_ids:
                     direct_bot_spots[bot_id].add(
                         (result_kind, target_id))
@@ -4900,6 +4908,10 @@ class BattleState:
                         (result_kind, target_id))
                 contacts.append(contact)
             now = time.monotonic()
+            team_lit = {
+                team: {target: now + time_left
+                       for target, time_left in targets.items()}
+                for team, targets in team_lit.items()}
             accepted_visibility = []
             accepted_contacts = self.bot_planner.report_contacts(
                 contacts, known_targets, now,
@@ -4911,7 +4923,7 @@ class BattleState:
                 message.get("affordances"), known_bots, known_targets, now)
             self._replace_bot_spotted(direct_bot_spots)
             self._replace_player_spotted(direct_player_spots)
-            self._replace_team_lit(team_lit)
+            self._replace_team_lit(team_lit, now=now)
             self._commit_detections()
             if accepted_visibility:
                 return {
@@ -4949,10 +4961,18 @@ class BattleState:
             self.player_spotted[int(player_id)] = spotted
         return True
 
-    def _replace_team_lit(self, lit_targets):
-        """Commit one complete validated team spot-lease batch."""
+    def _replace_team_lit(self, lit_targets, now=None):
+        """Expire old leases before committing a complete deadline batch."""
+        now = time.monotonic() if now is None else now
         for team in (1, 2):
-            self.team_lit_targets[team] = set(lit_targets.get(team, ()))
+            # A lease can expire between reports without an explicit hidden
+            # sample. Compare the previous lease before a fresh observer's
+            # renewal replaces it, so that observer gets the new detection.
+            still_lit = {
+                target for target, deadline in
+                self.team_lit_targets[team].items() if deadline > now}
+            self.team_visible_targets[team].intersection_update(still_lit)
+            self.team_lit_targets[team] = dict(lit_targets.get(team, {}))
         return True
 
     @staticmethod
@@ -11799,11 +11819,11 @@ class BattleState:
         # team -> the enemies that team can currently see, so a vehicle that
         # goes dark and reappears is a new detection for whoever finds it.
         self.team_visible_targets = {1: set(), 2: set()}
-        # team -> the enemies the worker's spot leases still light for that
-        # team.  A target stays detected for as long as its lease holds, so
+        # team -> enemy -> server monotonic deadline for the worker's spot
+        # lease. A target stays detected for as long as its lease holds, so
         # neither a blocked line of sight nor a budgeted-out visibility probe
         # can turn one continuous contact into a second detection.
-        self.team_lit_targets = {1: set(), 2: set()}
+        self.team_lit_targets = {1: {}, 2: {}}
         # every vehicle any enemy ever directly detected.
         self.ever_spotted_targets = set()
         # actor -> damage it dealt to its own team.
@@ -11861,7 +11881,7 @@ class BattleState:
         observer already revealed adds nothing, while an enemy whose lease
         expired and is found again credits whoever finds it that time.  This
         is the ``spotted`` column the results screen shows and the count
-        Patrol Duty (``scout``) reads.
+        Scout (``scout``) reads.
         """
         observers = [(("bot", int(bot_id)), spotted)
                      for bot_id, spotted in self.bot_spotted.items()]
@@ -12134,12 +12154,17 @@ class BattleState:
                 int(value.get("target_id", 0))))]
 
     def _spots_target(self, actor, target):
-        """Return whether one actor currently holds this target in sight."""
+        """Return whether one live observer currently sees this target."""
         actor = (str(actor[0]), int(actor[1]))
         target = (str(target[0]), int(target[1]))
         if actor[0] == "player":
-            return target in self.player_spotted.get(actor[1], ())
-        return target in self.bot_spotted.get(actor[1], ())
+            player = self.players.get(actor[1])
+            return bool(player is not None and player.connected and
+                        player.alive and
+                        target in self.player_spotted.get(actor[1], ()))
+        bot = self.bot_states.get(actor[1])
+        return bool(bot is not None and bot.get("alive") and
+                    target in self.bot_spotted.get(actor[1], ()))
 
     def _radio_assisters(self, attacker, target, target_team):
         """Return the live observers one spotting assist is divided between.

--- a/server/lan_battle_server.py
+++ b/server/lan_battle_server.py
@@ -1585,6 +1585,21 @@ def _track_repair_rows(value):
     return tuple(sorted(result, key=lambda row: row["name"]))
 
 
+def _even_shares(total, parts):
+    """Return ``parts`` integer shares of ``total`` that sum back to it.
+
+    A spotting assist is divided between the observers lighting the target,
+    and the statistic is a whole number of hit points, so the remainder goes
+    to the first shares in the caller's stable order rather than being lost.
+    """
+    parts = int(parts)
+    if parts <= 0:
+        return []
+    share, remainder = divmod(int(total), parts)
+    return [share + 1 if index < remainder else share
+            for index in range(parts)]
+
+
 def _destroyed_tracks(critical):
     """Return the track devices one critical payload reports as destroyed."""
     if not isinstance(critical, dict):
@@ -4730,6 +4745,7 @@ class BattleState:
                 (bot_id, set()) for bot_id in known_bots)
             direct_player_spots = dict(
                 (reporter_id, set()) for reporter_id in known_players)
+            team_lit = {1: set(), 2: set()}
             stale_observation = False
             contacts = []
             for raw in message.get("contacts"):
@@ -4874,6 +4890,8 @@ class BattleState:
                 contact["time_left"] = time_left
                 result_kind = ("player" if target_kind == "human"
                                else target_kind)
+                if contact["visible"]:
+                    team_lit[observing_team].add((result_kind, target_id))
                 for bot_id in bot_observer_ids:
                     direct_bot_spots[bot_id].add(
                         (result_kind, target_id))
@@ -4893,6 +4911,7 @@ class BattleState:
                 message.get("affordances"), known_bots, known_targets, now)
             self._replace_bot_spotted(direct_bot_spots)
             self._replace_player_spotted(direct_player_spots)
+            self._replace_team_lit(team_lit)
             self._commit_detections()
             if accepted_visibility:
                 return {
@@ -4928,6 +4947,12 @@ class BattleState:
         for player_id in sorted(direct_spots):
             spotted = frozenset(direct_spots[player_id])
             self.player_spotted[int(player_id)] = spotted
+        return True
+
+    def _replace_team_lit(self, lit_targets):
+        """Commit one complete validated team spot-lease batch."""
+        for team in (1, 2):
+            self.team_lit_targets[team] = set(lit_targets.get(team, ()))
         return True
 
     @staticmethod
@@ -11774,6 +11799,11 @@ class BattleState:
         # team -> the enemies that team can currently see, so a vehicle that
         # goes dark and reappears is a new detection for whoever finds it.
         self.team_visible_targets = {1: set(), 2: set()}
+        # team -> the enemies the worker's spot leases still light for that
+        # team.  A target stays detected for as long as its lease holds, so
+        # neither a blocked line of sight nor a budgeted-out visibility probe
+        # can turn one continuous contact into a second detection.
+        self.team_lit_targets = {1: set(), 2: set()}
         # every vehicle any enemy ever directly detected.
         self.ever_spotted_targets = set()
         # actor -> damage it dealt to its own team.
@@ -11824,11 +11854,14 @@ class BattleState:
 
         A vehicle is detected when it becomes visible to a team that could
         not see it a moment ago; every direct observer on that team that saw
-        it at that instant detected it.  The statistic counts distinct
-        enemies, so re-acquiring a target the observer already revealed adds
-        nothing, while an enemy that goes dark and is revealed again credits
-        whoever found it that time.  This is the ``spotted`` column the
-        results screen shows and the count Patrol Duty (``scout``) reads.
+        it at that instant detected it.  A team keeps seeing a target for
+        as long as the worker's spot lease lights it, so a broken line of
+        sight or a budgeted-out visibility probe is not a second detection.
+        The statistic counts distinct enemies, so re-acquiring a target the
+        observer already revealed adds nothing, while an enemy whose lease
+        expired and is found again credits whoever finds it that time.  This
+        is the ``spotted`` column the results screen shows and the count
+        Patrol Duty (``scout``) reads.
         """
         observers = [(("bot", int(bot_id)), spotted)
                      for bot_id, spotted in self.bot_spotted.items()]
@@ -11856,7 +11889,8 @@ class BattleState:
                     interaction["spotted"] = 1
                     row = self._statistics_row(*reporter)
                     row["spotted"] = int(row.get("spotted", 0)) + 1
-            self.team_visible_targets[team] = set(visible)
+            self.team_visible_targets[team] = set(visible) | set(
+                self.team_lit_targets.get(team, ()))
 
     def _direct_spotters(self, target):
         """Return every enemy observer that directly sees ``target``.
@@ -12099,14 +12133,31 @@ class BattleState:
                 0 if value.get("target_kind") == "player" else 1,
                 int(value.get("target_id", 0))))]
 
+    def _spots_target(self, actor, target):
+        """Return whether one actor currently holds this target in sight."""
+        actor = (str(actor[0]), int(actor[1]))
+        target = (str(target[0]), int(target[1]))
+        if actor[0] == "player":
+            return target in self.player_spotted.get(actor[1], ())
+        return target in self.bot_spotted.get(actor[1], ())
+
     def _radio_assisters(self, attacker, target, target_team):
-        """Return live direct observers whose set contains this target."""
+        """Return the live observers one spotting assist is divided between.
+
+        Wargaming pays a spotting assist for damage done to a target the
+        observer is spotting "by team members who are not spotting them
+        themselves", divided "by the number of team members spotting the
+        target".  An attacker that sees its own target therefore earns
+        nobody an assist instead of merely being skipped, which is the rule
+        the Patrol Duty ledger in ``_record_damage`` already applies.
+        """
+        if self._spots_target(attacker, target):
+            return []
         result = []
         for reporter_id in sorted(self.player_spotted):
             reporter = self.players.get(reporter_id)
             if (reporter is None or not reporter.connected or
                     not reporter.alive or reporter.team == target_team or
-                    ("player", reporter_id) == attacker or
                     target not in self.player_spotted[reporter_id]):
                 continue
             result.append(("player", reporter_id))
@@ -12115,7 +12166,6 @@ class BattleState:
             reporter = ("bot", int(bot_id))
             if (bot is None or not bot.get("alive") or
                     int(bot.get("team", 0)) == target_team or
-                    reporter == attacker or
                     target not in self.bot_spotted[bot_id]):
                 continue
             result.append(reporter)
@@ -12183,26 +12233,32 @@ class BattleState:
         if (holder is not None and holder != attacker and
                 self._vehicle_team(*holder) != target_team and
                 _destroyed_tracks(target_critical)):
-            credits.append(("track", holder))
+            credits.append(("track", holder, damage))
         holder = self._active_stun_assister(target)
         if (holder is not None and holder != attacker and
                 self._vehicle_team(*holder) != target_team):
-            credits.append(("stun", holder))
+            credits.append(("stun", holder, damage))
+        # A track or a stun has one owner, but a spotting assist is shared by
+        # every observer lighting the target, so each of them is paid its
+        # share of this damage rather than the whole of it.
+        assisters = self._radio_assisters(attacker, target, target_team)
         credits.extend(
-            ("radio", assister) for assister in
-            self._radio_assisters(attacker, target, target_team))
-        for category, assister in credits:
+            ("radio", assister, share) for assister, share in
+            zip(assisters, _even_shares(damage, len(assisters))))
+        for category, assister, amount in credits:
+            if amount <= 0:
+                continue
             self._statistics_row(*assister)[
-                "damage_assisted_%s" % category] += damage
+                "damage_assisted_%s" % category] += amount
             self._increment_interaction(
-                assister, target, "assist_%s" % category, damage)
+                assister, target, "assist_%s" % category, amount)
             self.pending_events.append({
                 "kind": "assist",
                 "category": category,
                 "assister_kind": assister[0], "assister_id": assister[1],
                 "attacker_kind": attacker[0], "attacker_id": attacker[1],
                 "target_kind": target[0], "target_id": target[1],
-                "damage": damage,
+                "damage": amount,
             })
 
     def _frozen_player_participant(self, player_id):

--- a/tests/test_port_0922_battle_achievements.py
+++ b/tests/test_port_0922_battle_achievements.py
@@ -1200,13 +1200,34 @@ class DetectionTests(unittest.TestCase):
         state, unused_player = self._battle()
         state.bot_states[2]['team'] = 1
         state.player_spotted = {1: frozenset({('bot', 1)})}
+        state._replace_team_lit({1: {('bot', 1)}})
         state._commit_detections()
+        # The spot lease runs out, so the enemy is dark for the whole team.
         state.player_spotted = {1: frozenset()}
+        state._replace_team_lit({})
         state._commit_detections()
         state.bot_spotted = {2: frozenset({('bot', 1)})}
+        state._replace_team_lit({1: {('bot', 1)}})
         state._commit_detections()
         self.assertEqual(1, state._statistics_row('player', 1)['spotted'])
         self.assertEqual(1, state._statistics_row('bot', 2)['spotted'])
+
+    def test_a_live_lease_is_not_a_second_detection(self):
+        state, unused_player = self._battle()
+        state.bot_states[2]['team'] = 1
+        state.player_spotted = {1: frozenset({('bot', 1)})}
+        state._replace_team_lit({1: {('bot', 1)}})
+        state._commit_detections()
+        # A blocked line of sight, or a visibility probe the worker budgeted
+        # out, leaves the team lit by the lease alone.
+        state.player_spotted = {1: frozenset()}
+        state._replace_team_lit({1: {('bot', 1)}})
+        state._commit_detections()
+        state.bot_spotted = {2: frozenset({('bot', 1)})}
+        state._replace_team_lit({1: {('bot', 1)}})
+        state._commit_detections()
+        self.assertEqual(1, state._statistics_row('player', 1)['spotted'])
+        self.assertEqual(0, state._statistics_row('bot', 2)['spotted'])
 
     def test_a_teammate_is_never_a_detection(self):
         state, unused_player = self._battle()
@@ -1214,6 +1235,83 @@ class DetectionTests(unittest.TestCase):
         state.player_spotted = {1: frozenset({('bot', 1)})}
         state._commit_detections()
         self.assertEqual(0, state._statistics_row('player', 1)['spotted'])
+
+
+class SpottingAssistTests(unittest.TestCase):
+    """A spotting assist needs a blind shooter, and is shared by spotters."""
+
+    @staticmethod
+    def _battle():
+        state, player = DetectionTests._battle()
+        # Bots 2 and 3 fight alongside the human player.
+        for bot_id in (2, 3):
+            state.bot_states[bot_id]['team'] = 1
+        return state, player
+
+    def test_a_shooter_that_sees_its_own_target_earns_nobody_an_assist(self):
+        state, unused_player = self._battle()
+        state.player_spotted = {1: frozenset({('bot', 1)})}
+        state.bot_spotted = {2: frozenset({('bot', 1)})}
+
+        state._record_damage(('player', 1), ('bot', 1), 240, {})
+
+        self.assertEqual(
+            0, state._statistics_row('bot', 2)['damage_assisted_radio'])
+        self.assertEqual([], [event for event in state.pending_events
+                              if event['kind'] == 'assist'])
+
+    def test_a_bot_shooter_that_sees_its_own_target_earns_nobody_an_assist(
+            self):
+        state, unused_player = self._battle()
+        state.player_spotted = {1: frozenset({('bot', 1)})}
+        state.bot_spotted = {2: frozenset({('bot', 1)})}
+
+        state._record_damage(('bot', 2), ('bot', 1), 240, {})
+
+        self.assertEqual(
+            0, state._statistics_row('player', 1)['damage_assisted_radio'])
+        self.assertEqual([], [event for event in state.pending_events
+                              if event['kind'] == 'assist'])
+
+    def test_a_blind_shooter_splits_the_assist_between_the_spotters(self):
+        state, unused_player = self._battle()
+        state.player_spotted = {1: frozenset({('bot', 1)})}
+        state.bot_spotted = {2: frozenset({('bot', 1)})}
+
+        state._record_damage(('bot', 3), ('bot', 1), 241, {})
+
+        self.assertEqual(
+            121, state._statistics_row('player', 1)['damage_assisted_radio'])
+        self.assertEqual(
+            120, state._statistics_row('bot', 2)['damage_assisted_radio'])
+        self.assertEqual(
+            [(('player', 1), 121), (('bot', 2), 120)],
+            [((event['assister_kind'], event['assister_id']),
+              event['damage'])
+             for event in state.pending_events
+             if event['kind'] == 'assist'])
+
+    def test_one_spotter_still_earns_the_whole_damage(self):
+        state, unused_player = self._battle()
+        state.player_spotted = {1: frozenset({('bot', 1)})}
+
+        state._record_damage(('bot', 3), ('bot', 1), 241, {})
+
+        self.assertEqual(
+            241, state._statistics_row('player', 1)['damage_assisted_radio'])
+
+    def test_a_track_assist_is_never_divided(self):
+        state, unused_player = self._battle()
+        state.player_spotted = {1: frozenset({('bot', 1)})}
+        state.bot_spotted = {2: frozenset({('bot', 1)})}
+        state.track_immobilisers[('bot', 1)] = ('player', 1)
+
+        state._record_damage(('bot', 3), ('bot', 1), 241, {
+            'destroyed': ['leftTrackHealth']})
+
+        row = state._statistics_row('player', 1)
+        self.assertEqual(241, row['damage_assisted_track'])
+        self.assertEqual(121, row['damage_assisted_radio'])
 
 
 class LuckyDevilTests(unittest.TestCase):

--- a/tests/test_port_0922_battle_achievements.py
+++ b/tests/test_port_0922_battle_achievements.py
@@ -1200,14 +1200,14 @@ class DetectionTests(unittest.TestCase):
         state, unused_player = self._battle()
         state.bot_states[2]['team'] = 1
         state.player_spotted = {1: frozenset({('bot', 1)})}
-        state._replace_team_lit({1: {('bot', 1)}})
+        state._replace_team_lit({1: {('bot', 1): float('inf')}})
         state._commit_detections()
         # The spot lease runs out, so the enemy is dark for the whole team.
         state.player_spotted = {1: frozenset()}
         state._replace_team_lit({})
         state._commit_detections()
         state.bot_spotted = {2: frozenset({('bot', 1)})}
-        state._replace_team_lit({1: {('bot', 1)}})
+        state._replace_team_lit({1: {('bot', 1): float('inf')}})
         state._commit_detections()
         self.assertEqual(1, state._statistics_row('player', 1)['spotted'])
         self.assertEqual(1, state._statistics_row('bot', 2)['spotted'])
@@ -1216,15 +1216,15 @@ class DetectionTests(unittest.TestCase):
         state, unused_player = self._battle()
         state.bot_states[2]['team'] = 1
         state.player_spotted = {1: frozenset({('bot', 1)})}
-        state._replace_team_lit({1: {('bot', 1)}})
+        state._replace_team_lit({1: {('bot', 1): float('inf')}})
         state._commit_detections()
         # A blocked line of sight, or a visibility probe the worker budgeted
         # out, leaves the team lit by the lease alone.
         state.player_spotted = {1: frozenset()}
-        state._replace_team_lit({1: {('bot', 1)}})
+        state._replace_team_lit({1: {('bot', 1): float('inf')}})
         state._commit_detections()
         state.bot_spotted = {2: frozenset({('bot', 1)})}
-        state._replace_team_lit({1: {('bot', 1)}})
+        state._replace_team_lit({1: {('bot', 1): float('inf')}})
         state._commit_detections()
         self.assertEqual(1, state._statistics_row('player', 1)['spotted'])
         self.assertEqual(0, state._statistics_row('bot', 2)['spotted'])
@@ -1272,6 +1272,43 @@ class SpottingAssistTests(unittest.TestCase):
             0, state._statistics_row('player', 1)['damage_assisted_radio'])
         self.assertEqual([], [event for event in state.pending_events
                               if event['kind'] == 'assist'])
+
+    def test_a_dead_shooters_in_flight_hit_credits_the_live_spotter(self):
+        for attacker in (('player', 1), ('bot', 3)):
+            with self.subTest(attacker=attacker):
+                state, player = self._battle()
+                target = ('bot', 1)
+                state.bot_spotted = {2: frozenset({target})}
+                # Death arrives before the next observation batch clears
+                # the shooter's old direct-vision set.
+                if attacker[0] == 'player':
+                    player.alive = False
+                    state.player_spotted = {1: frozenset({target})}
+                else:
+                    state.bot_states[3]['alive'] = False
+                    state.bot_spotted[3] = frozenset({target})
+
+                state._record_damage(attacker, target, 240, {})
+
+                self.assertEqual(240, state._statistics_row(
+                    'bot', 2)['damage_assisted_radio'])
+                self.assertEqual(240, state._statistics_interaction(
+                    ('bot', 2), target)['assist_radio'])
+                self.assertEqual([240], [
+                    event['damage'] for event in state.pending_events
+                    if event['kind'] == 'assist'])
+
+    def test_a_disconnected_shooters_old_sight_does_not_block_an_assist(self):
+        state, player = self._battle()
+        target = ('bot', 1)
+        state.player_spotted = {1: frozenset({target})}
+        state.bot_spotted = {2: frozenset({target})}
+        player.connected = False
+
+        state._record_damage(('player', 1), target, 240, {})
+
+        self.assertEqual(240, state._statistics_row(
+            'bot', 2)['damage_assisted_radio'])
 
     def test_a_blind_shooter_splits_the_assist_between_the_spotters(self):
         state, unused_player = self._battle()

--- a/tests/test_port_0922_bot_runtime.py
+++ b/tests/test_port_0922_bot_runtime.py
@@ -1402,7 +1402,7 @@ class ServerBotObservationRelayTests(unittest.TestCase):
         lease_only['contacts'][0]['fresh'] = False
         server.update_bot_observation(
             SIMULATION_WORKER_AUTHORITY_ID, lease_only)
-        self.assertEqual({('bot', 11)}, server.team_lit_targets[1])
+        self.assertEqual({('bot', 11)}, set(server.team_lit_targets[1]))
         self.assertEqual(frozenset(), server.player_spotted[1])
 
         self.assertIsInstance(server.update_bot_observation(
@@ -1421,7 +1421,7 @@ class ServerBotObservationRelayTests(unittest.TestCase):
         self.assertTrue(server.update_bot_observation(
             SIMULATION_WORKER_AUTHORITY_ID,
             self._human_message(server.round_id, (), visible=False)))
-        self.assertEqual(set(), server.team_lit_targets[1])
+        self.assertEqual({}, server.team_lit_targets[1])
 
         self.assertIsInstance(server.update_bot_observation(
             SIMULATION_WORKER_AUTHORITY_ID,
@@ -1429,6 +1429,119 @@ class ServerBotObservationRelayTests(unittest.TestCase):
 
         self.assertEqual(1, server._statistics_row('player', 1)['spotted'])
         self.assertEqual(1, server._statistics_row('player', 2)['spotted'])
+
+    def test_a_lease_expiring_between_batches_credits_the_next_observer(self):
+        from unittest.mock import patch
+
+        for observer_kind in ('player', 'bot'):
+            with self.subTest(observer_kind=observer_kind):
+                server, _, _ = self._server()
+                if observer_kind == 'player':
+                    initial = self._human_message(server.round_id, (1,))
+                    renewed = self._human_message(server.round_id, (2,))
+                    observer_id, target = 1, ('bot', 11)
+                else:
+                    server.bot_manifest.append(dict(
+                        server.bot_manifest[0], id=12))
+                    server.bot_states[12] = dict(
+                        server.bot_states[11], id=12)
+                    initial = self._message(server.round_id)
+                    renewed = copy.deepcopy(initial)
+                    renewed['contacts'][0]['visible_by_bot_ids'] = [12]
+                    observer_id, target = 11, ('player', 2)
+                with patch('lan_battle_server.time.monotonic',
+                           return_value=100.0):
+                    self.assertIsInstance(server.update_bot_observation(
+                        SIMULATION_WORKER_AUTHORITY_ID, initial), dict)
+                remembered = copy.deepcopy(initial)
+                remembered['contacts'][0].update({
+                    'fresh': False, 'time_left': 0.1,
+                    'visible_by_bot_ids': [],
+                    'visible_by_player_ids': []})
+                with patch('lan_battle_server.time.monotonic',
+                           return_value=109.9):
+                    self.assertIsInstance(server.update_bot_observation(
+                        SIMULATION_WORKER_AUTHORITY_ID, remembered), dict)
+                # No explicit hidden sample arrives before another observer
+                # renews this target after its previous lease has expired.
+                with patch('lan_battle_server.time.monotonic',
+                           return_value=110.2):
+                    self.assertIsInstance(server.update_bot_observation(
+                        SIMULATION_WORKER_AUTHORITY_ID, renewed), dict)
+                next_id = 2 if observer_kind == 'player' else 12
+                self.assertEqual(1, server._statistics_row(
+                    observer_kind, observer_id)['spotted'])
+                self.assertEqual(1, server._statistics_row(
+                    observer_kind, next_id)['spotted'])
+                self.assertEqual({target}, server.ever_spotted_targets)
+
+    def test_a_dead_last_observer_does_not_cancel_the_team_lease(self):
+        for observer_kind in ('player', 'bot'):
+            with self.subTest(observer_kind=observer_kind):
+                server, _, _ = self._server()
+                if observer_kind == 'player':
+                    initial = self._human_message(server.round_id, (1,))
+                    renewed = self._human_message(server.round_id, (2,))
+                    observer_id, team, target = 1, 1, ('bot', 11)
+                else:
+                    server.bot_manifest.append(dict(
+                        server.bot_manifest[0], id=12))
+                    server.bot_states[12] = dict(
+                        server.bot_states[11], id=12)
+                    initial = self._message(server.round_id)
+                    initial['contacts'][0]['shootable_by_bot_ids'] = [12]
+                    initial['contacts'][0]['threatened_bot_ids'] = [12]
+                    renewed = copy.deepcopy(initial)
+                    renewed['contacts'][0]['visible_by_bot_ids'] = [12]
+                    observer_id, team, target = 11, 2, ('player', 2)
+                self.assertIsInstance(server.update_bot_observation(
+                    SIMULATION_WORKER_AUTHORITY_ID, initial), dict)
+                if observer_kind == 'player':
+                    server.players[observer_id].alive = False
+                else:
+                    server.bot_states[observer_id]['alive'] = False
+                relay = server.update_bot_observation(
+                    SIMULATION_WORKER_AUTHORITY_ID, initial)
+                self.assertIsInstance(relay, dict)
+                contact = relay['contacts'][0]
+                self.assertTrue(contact['visible'])
+                self.assertFalse(contact['fresh'])
+                self.assertEqual(10.0, contact['time_left'])
+                self.assertEqual([], contact['visible_by_bot_ids'])
+                self.assertEqual([], contact['visible_by_player_ids'])
+                self.assertEqual([], contact['shootable_by_bot_ids'])
+                self.assertEqual([], contact.get('threatened_bot_ids', []))
+                self.assertEqual({target}, set(server.team_lit_targets[team]))
+                self.assertIsInstance(server.update_bot_observation(
+                    SIMULATION_WORKER_AUTHORITY_ID, renewed), dict)
+                next_id = 2 if observer_kind == 'player' else 12
+                self.assertEqual(1, server._statistics_row(
+                    observer_kind, observer_id)['spotted'])
+                self.assertEqual(0, server._statistics_row(
+                    observer_kind, next_id)['spotted'])
+
+    def test_a_malformed_retired_observer_batch_preserves_spot_state(self):
+        server, _, _ = self._server()
+        initial = self._human_message(server.round_id, (1,))
+        self.assertIsInstance(server.update_bot_observation(
+            SIMULATION_WORKER_AUTHORITY_ID, initial), dict)
+        server.players[1].alive = False
+        before = copy.deepcopy((server.player_spotted, server.bot_spotted,
+                                server.team_lit_targets,
+                                server.team_visible_targets,
+                                server.bot_planner._contacts))
+        malformed = self._human_message(server.round_id, (2,))
+        invalid = copy.deepcopy(initial['contacts'][0])
+        invalid['fresh'] = False
+        malformed['contacts'].append(invalid)
+
+        self.assertFalse(server.update_bot_observation(
+            SIMULATION_WORKER_AUTHORITY_ID, malformed))
+
+        self.assertEqual(before, (
+            server.player_spotted, server.bot_spotted,
+            server.team_lit_targets, server.team_visible_targets,
+            server.bot_planner._contacts))
 
     def test_worker_human_spot_rejects_forged_observers(self):
         server, unused_authority_socket, unused_guest_socket = self._server()

--- a/tests/test_port_0922_bot_runtime.py
+++ b/tests/test_port_0922_bot_runtime.py
@@ -1389,6 +1389,47 @@ class ServerBotObservationRelayTests(unittest.TestCase):
             75, server._statistics_row(
                 'player', 1)['damage_assisted_radio'])
 
+    def test_a_live_lease_keeps_a_teammate_from_re_detecting(self):
+        server, unused_authority_socket, unused_guest_socket = self._server()
+        self.assertIsInstance(server.update_bot_observation(
+            SIMULATION_WORKER_AUTHORITY_ID,
+            self._human_message(server.round_id, (1,))), dict)
+
+        # The worker still lights the enemy for the team while no observer
+        # currently holds it: a blocked line of sight, or a visibility probe
+        # the frame budget deferred.
+        lease_only = self._human_message(server.round_id, ())
+        lease_only['contacts'][0]['fresh'] = False
+        server.update_bot_observation(
+            SIMULATION_WORKER_AUTHORITY_ID, lease_only)
+        self.assertEqual({('bot', 11)}, server.team_lit_targets[1])
+        self.assertEqual(frozenset(), server.player_spotted[1])
+
+        self.assertIsInstance(server.update_bot_observation(
+            SIMULATION_WORKER_AUTHORITY_ID,
+            self._human_message(server.round_id, (2,))), dict)
+
+        self.assertEqual(1, server._statistics_row('player', 1)['spotted'])
+        self.assertEqual(0, server._statistics_row('player', 2)['spotted'])
+
+    def test_an_expired_lease_credits_the_next_observer(self):
+        server, unused_authority_socket, unused_guest_socket = self._server()
+        self.assertIsInstance(server.update_bot_observation(
+            SIMULATION_WORKER_AUTHORITY_ID,
+            self._human_message(server.round_id, (1,))), dict)
+
+        self.assertTrue(server.update_bot_observation(
+            SIMULATION_WORKER_AUTHORITY_ID,
+            self._human_message(server.round_id, (), visible=False)))
+        self.assertEqual(set(), server.team_lit_targets[1])
+
+        self.assertIsInstance(server.update_bot_observation(
+            SIMULATION_WORKER_AUTHORITY_ID,
+            self._human_message(server.round_id, (2,))), dict)
+
+        self.assertEqual(1, server._statistics_row('player', 1)['spotted'])
+        self.assertEqual(1, server._statistics_row('player', 2)['spotted'])
+
     def test_worker_human_spot_rejects_forged_observers(self):
         server, unused_authority_socket, unused_guest_socket = self._server()
         malformed = self._human_message(server.round_id)


### PR DESCRIPTION
A shooter that can directly see its target no longer awards spotting assistance to teammates. When the shooter depends on other observers, the damage is divided into integer shares whose sum equals the applied damage. Statistics, interaction details, assist events, and battle receipts use the same shares. Track and stun assistance retain their existing single-owner rules.

A dead or disconnected shooter's stale direct-vision set does not suppress assistance for a live observer when an in-flight shot or continuing fire deals damage.

Detection counts now use the worker's existing `visible` and `time_left` lease data. The server expires the previous lease before accepting its renewal, including when no explicit hidden sample arrives between observations. A valid lease survives an observer dying before its report arrives; that observer's direct sight and firing evidence are removed. Complete batch validation still precedes changes to detection state.

Validation on the reviewed tree, including current main and #132:

- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=tests python3 -m unittest test_port_0922_bot_runtime test_port_0922_battle_achievements`: 582 tests passed.
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=tests python3 -m unittest test_port_0922_lan_protocol test_port_0922_offline_rewards test_port_0922_postbattle test_port_0922_server_bot_ai`: 228 tests passed.
- New regressions reproduced missed lease expiry, premature loss of a dead observer's team lease, and stale sight suppressing posthumous-shot assistance before their fixes. Both human and Bot paths are covered, along with malformed-batch atomicity.
- `git diff --check` passed. CI is not being waited on, as requested.

This change divides the assisted-damage statistic as an offline product rule; it does not establish the proprietary #1513 server formula. Assistance still uses live direct observers because the protocol carries team leases rather than per-observer leases. The Last Effort perk and the existing shooter XP policy are unchanged. Exact Windows results-screen behavior remains unverified for this branch.
