### PR TITLE
Fix server medkit activation and consumable failure acknowledgements

### DIFF
--- a/server/lan_battle_server.py
+++ b/server/lan_battle_server.py
@@ -11516,8 +11516,24 @@ class BattleState:
                     player, intent_seq, False, "equipment_ineligible")
             payload = None
             if effect.get("action") != "set_rpm_limiter":
-                payload = player_critical_mechanics.apply_equipment(
-                    player, effect, now)
+                try:
+                    payload = player_critical_mechanics.apply_equipment(
+                        player, effect, now)
+                    if payload is not None:
+                        payload = _critical_payload(payload)
+                except Exception as error:
+                    # Resolution uses a detached target, before consuming the
+                    # kit or committing critical state. Finish this intent so
+                    # the client can retry with a new trigger after failure.
+                    detail = str(error).replace(
+                        "\r", " ").replace("\n", " ")[:160]
+                    _server_log(
+                        "EQUIPMENT INTENT failed sender=%d seq=%d item=%d "
+                        "error=%s detail=%s" % (
+                            player_id, intent_seq, equipment_id,
+                            type(error).__name__, detail))
+                    return self._finish_equipment_intent(
+                        player, intent_seq, False, "equipment_failed")
                 if payload is None and not effect.get("clearStun", False):
                     return self._finish_equipment_intent(
                         player, intent_seq, False, "equipment_no_effect")
@@ -11529,7 +11545,7 @@ class BattleState:
                     "canonical player equipment commit diverged")
             if payload is not None:
                 self._commit_player_critical_progress(
-                    player, _critical_payload(payload))
+                    player, payload)
             if effect.get("clearStun", False):
                 if not self._clear_vehicle_stun(("player", player_id)):
                     raise RuntimeError("canonical medkit stun clear diverged")

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/critical_damage.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/critical_damage.py
@@ -616,8 +616,14 @@ def _offh_internal_cone_hits(target_mock, td, burst_pos, direction, shell,
 
 
 def _device_td(mock):
-	import BigWorld
-	return getattr(mock, 'typeDescriptor', getattr(BigWorld.player(), 'vehicleTypeDescriptor', None))
+	# Server projections already own their descriptor and cannot import BigWorld.
+	# An explicit None also belongs to this vehicle; only a missing attribute
+	# retains the stock player-descriptor fallback.
+	try:
+		return mock.typeDescriptor
+	except AttributeError:
+		import BigWorld
+		return getattr(BigWorld.player(), 'vehicleTypeDescriptor', None)
 
 
 def _crew_roster(td):
@@ -1753,10 +1759,8 @@ def tick_fire(vehicle, dt, now=None, module_test_mode=False):
         # The interval may complete the final burn tick before the fire-out
         # transition. Only time after this exact boundary is excluded.
         _offh_extinguish(vehicle, False, 'burnt out')
-        # ``_offh_extinguish`` is a copied presentation helper and imports
-        # BigWorld before resolving the descriptor.  The authority simulator is
-        # intentionally engine-free, so complete the same fuel-tank transition
-        # through the pure descriptor seam as part of this public tick contract.
+        # Keep the public fire-tick contract explicit about restoring the
+        # destroyed fuel tank to its exact descriptor regeneration pool.
         _restore_fuel_regen_cap(vehicle)
     after = _state(vehicle)
     return damage, _payload(

--- a/tests/test_port_0922_critical_damage.py
+++ b/tests/test_port_0922_critical_damage.py
@@ -182,6 +182,49 @@ class CriticalDamageTests(unittest.TestCase):
         self.bigworld.time = lambda: 12.0
         self.math = types.ModuleType('Math')
 
+    def test_owned_descriptor_is_read_once_without_native_player_lookup(self):
+        descriptor = _descriptor()
+        for value in (descriptor, None):
+            with self.subTest(descriptor=value):
+                class Vehicle(object):
+                    reads = 0
+
+                    @property
+                    def typeDescriptor(self):
+                        self.reads += 1
+                        return value
+
+                vehicle = Vehicle()
+                with mock.patch.dict(sys.modules, {'BigWorld': None}):
+                    self.assertIs(value, critical_damage._device_td(vehicle))
+                self.assertEqual(1, vehicle.reads)
+
+    def test_missing_descriptor_keeps_native_player_fallback(self):
+        native_player = mock.Mock(return_value=self.player)
+        with mock.patch.dict(sys.modules, {'BigWorld': self.bigworld}), \
+                mock.patch.object(self.bigworld, 'player', native_player):
+            self.assertIs(self.player.vehicleTypeDescriptor,
+                          critical_damage._device_td(object()))
+        native_player.assert_called_once_with()
+
+    def test_medkit_preserves_surviving_casualty_combined_roles_without_native(self):
+        descriptor = _descriptor()
+        descriptor.type.crewRoles = (
+            ('commander', 'radioman'), ('driver',), ('loader', 'gunner'))
+        vehicle = types.SimpleNamespace(
+            typeDescriptor=descriptor, health=500,
+            devices_hp={}, _destroyed_devices=set(),
+            _crew_ko={'commander', 'loader1'}, is_on_fire=False)
+
+        with mock.patch.dict(sys.modules, {'BigWorld': None}):
+            payload = critical_damage.restore_crew(vehicle, 'commander')
+
+        self.assertEqual(['loader1'], payload['crew_ko'])
+        self.assertEqual(frozenset(('loader', 'gunner')), vehicle._crew_impaired)
+        self.assertEqual(
+            [{'kind': 'crew', 'name': 'commander', 'state': 'normal',
+              'cause': 'repair'}], payload['events'])
+
     def test_native_1513_components_never_call_forbidden_legacy_get(self):
         descriptor = _strict_1513_descriptor()
 
@@ -2057,6 +2100,64 @@ def _repair_player(hp, state, destroyed=()):
                  'regen_hp': 130.0}]},
             'loadout': {'repair_factor': device_damage.CREW_FACTOR_BASE,
                         'has_big_kit': False}})
+
+
+class ServerConsumableDescriptorTests(unittest.TestCase):
+
+    def test_medkit_server_projection_preserves_other_injuries_without_native(self):
+        for crew_ko, repair_all, expected in (
+                (['commander'], False, []),
+                (['commander', 'driver'], False, ['driver']),
+                (['commander', 'loader1', 'loader2'], False,
+                 ['loader1', 'loader2']),
+                (['commander', 'driver'], True, [])):
+            with self.subTest(crew_ko=crew_ko, repair_all=repair_all):
+                player = _repair_player(170.0, 'normal')
+                player.critical['crew_ko'] = list(crew_ko)
+                player.effective_params['critical']['crew_roster'] = list(crew_ko)
+                effect = {'action': 'restore_crew', 'repairAll': repair_all,
+                          'selected': None if repair_all else 'commander'}
+
+                with mock.patch.dict(sys.modules, {'BigWorld': None}):
+                    payload = player_critical_mechanics.apply_equipment(
+                        player, effect, 10.0)
+
+                self.assertEqual(expected, payload['crew_ko'])
+                self.assertEqual(crew_ko, player.critical['crew_ko'])
+                self.assertEqual(player.critical['devices'], payload['devices'])
+                self.assertEqual(
+                    [{'kind': 'crew', 'name': name, 'state': 'normal',
+                      'cause': 'repair'}
+                     for name in sorted(set(crew_ko) - set(expected))],
+                    payload['events'])
+
+    def test_server_extinguisher_restores_exact_fuel_regen_pool_without_native(self):
+        player = _repair_player(170.0, 'normal')
+        player.effective_params['critical']['devices'].append({
+            'name': 'fuelTankHealth', 'max_hp': 160.0, 'regen_hp': 120.0})
+        player.critical['devices'].append({
+            'name': 'fuelTankHealth', 'hp': 0.0,
+            'max_hp': 160.0, 'state': 'destroyed'})
+        player.critical.update(
+            fire=True, destroyed=['fuelTankHealth'], crew_ko=['commander'])
+
+        with mock.patch.dict(sys.modules, {'BigWorld': None}):
+            payload = player_critical_mechanics.apply_equipment(
+                player, {'action': 'extinguish_fire'}, 10.0)
+
+        self.assertFalse(payload['fire'])
+        self.assertEqual([], payload['destroyed'])
+        self.assertEqual(['commander'], payload['crew_ko'])
+        self.assertEqual(
+            {'name': 'fuelTankHealth', 'hp': 120.0,
+             'max_hp': 160.0, 'state': 'critical'}, payload['devices'][1])
+        self.assertEqual(
+            [{'kind': 'device', 'name': 'fuelTankHealth',
+              'old_state': 'destroyed', 'state': 'critical', 'cause': 'repair'},
+             {'kind': 'fire', 'state': False, 'cause': 'repair'}],
+            payload['events'])
+        self.assertTrue(player.critical['fire'])
+        self.assertEqual(0.0, player.critical['devices'][1]['hp'])
 
 
 class ModuleRepairSpeedTests(unittest.TestCase):

--- a/tests/test_port_0922_effective_params.py
+++ b/tests/test_port_0922_effective_params.py
@@ -88,6 +88,100 @@ def _snapshot_with_members(members):
 
 
 class EffectiveParamsContractTests(unittest.TestCase):
+    def test_small_medkit_intent_restores_only_selected_crew_and_spends_once(self):
+        from gui.mods.offline_lan_0922 import equipment_mechanics
+        member = effective_params()['crew']['members'][0]
+        params = _snapshot_with_members([
+            dict(member, instance='commander', roles=['commander']),
+            dict(member, instance='driver', roles=['driver'])])
+        params['critical']['activation_targets'] = [
+            {'index': 1, 'name': 'commander'}, {'index': 2, 'name': 'driver'}]
+        params['equipment'] = [equipment_mechanics.project_equipment(
+            types.SimpleNamespace(
+                name='medkit', id=(15, 2), compactDescr=763,
+                cooldownSeconds=90.0, reuseCount=1, repairAll=False))]
+        state = BattleState()
+        player, error = state.add_player(
+            _Connection(), ('127.0.0.1', 2000), _hello(params))
+        self.assertIsNone(error)
+        self.assertTrue(state._install_player_equipments(player))
+        state.phase = 'battle'
+        state.tick = 10000
+        player.participating = True
+        player.critical['crew_ko'] = ['commander', 'driver']
+        equipment = player.equipment_states[0]
+        before_uses = equipment.uses_left
+        before_revision = player.equipment_revision
+        intent = {
+            'type': 'equipment_intent', 'round_id': state.round_id,
+            'intent_seq': 1, 'equipment_id': 2,
+            'activation_code': (1 << 16) | 2,
+            'selected': 'commander', 'requested_active': None,
+        }
+
+        with mock.patch.dict(sys.modules, {'BigWorld': None}):
+            self.assertTrue(state.submit_equipment_intent(player.player_id, intent))
+            self.assertTrue(state.submit_equipment_intent(player.player_id, intent))
+
+        self.assertEqual({'intent_seq': 1, 'accepted': True, 'reason': ''},
+                         player.equipment_intent_result)
+        self.assertEqual(['driver'], player.critical['crew_ko'])
+        self.assertEqual(before_uses - 1, equipment.uses_left)
+        self.assertEqual(before_revision + 1, player.equipment_revision)
+        self.assertEqual({'763': 1}, state._statistics_row(
+            'player', player.player_id)['equipment_used'])
+
+    def test_equipment_resolution_failure_finishes_without_spending_the_kit(self):
+        import lan_battle_server as server
+        from gui.mods.offline_lan_0922 import equipment_mechanics
+        equipment = equipment_mechanics.project_equipment(types.SimpleNamespace(
+            name='handExtinguishers', id=(15, 0), compactDescr=251,
+            cooldownSeconds=90.0, reuseCount=1))
+        params = effective_params()
+        params['equipment'] = [equipment]
+        state = BattleState()
+        player, error = state.add_player(
+            _Connection(), ('127.0.0.1', 2000), _hello(params))
+        self.assertIsNone(error)
+        self.assertTrue(state._install_player_equipments(player))
+        state.phase = 'battle'
+        state.tick = 10000
+        player.participating = True
+        player.critical['fire'] = True
+        intent = {
+            'type': 'equipment_intent', 'round_id': state.round_id,
+            'intent_seq': 1, 'equipment_id': 0, 'activation_code': 0,
+            'selected': None, 'requested_active': None,
+        }
+        before_critical = copy.deepcopy(player.critical)
+        before_equipment = copy.deepcopy(player.equipment_states[0].snapshot(0.0))
+        before_revision = player.equipment_revision
+        with mock.patch.object(server.player_critical_mechanics,
+                               'apply_equipment',
+                               side_effect=ImportError('No module named BigWorld')) \
+                as resolve, mock.patch.object(server, '_server_log') as log:
+            self.assertTrue(state.submit_equipment_intent(player.player_id, intent))
+            self.assertEqual({
+                'intent_seq': 1, 'accepted': False,
+                'reason': 'equipment_failed'}, player.equipment_intent_result)
+            self.assertEqual(before_critical, player.critical)
+            self.assertEqual(before_equipment, player.equipment_states[0].snapshot(0.0))
+            self.assertEqual(before_revision, player.equipment_revision)
+            self.assertEqual({}, state._statistics_row(
+                'player', player.player_id)['equipment_used'])
+            self.assertTrue(state.submit_equipment_intent(player.player_id, intent))
+            resolve.assert_called_once()
+            self.assertIn('BigWorld', log.call_args[0][0])
+
+        # A failed operation is terminal; a new valid trigger can still use
+        # the unspent kit once the resolver is available again.
+        self.assertTrue(state.submit_equipment_intent(
+            player.player_id, dict(intent, intent_seq=2)))
+        self.assertTrue(player.equipment_intent_result['accepted'])
+        self.assertEqual(2, player.equipment_intent_result['intent_seq'])
+        self.assertFalse(player.critical['fire'])
+        self.assertEqual(before_revision + 1, player.equipment_revision)
+
     def test_zero_id_manual_extinguisher_joins_and_extinguishes_once(self):
         from gui.mods.offline_lan_0922 import equipment_mechanics
         # Exact #1513 handExtinguishers: local ID 0, packed equipment ID 251.


### PR DESCRIPTION
A small medkit failed on the server when other crew members remained injured after the selected crew member was restored. The shared descriptor helper imported the client-only `BigWorld` module even though the detached server target already supplied its descriptor. The same unnecessary lookup was swallowed during extinguishing, leaving a destroyed fuel tank unrestored.

Read the target's existing descriptor once before attempting the existing native fallback. This preserves explicit `None`, per-vehicle device pools, and the remaining crew injuries. Failed equipment resolution now produces a terminal rejection before inventory or critical state is committed; duplicate intents stay idempotent and a new trigger can retry. The failure log includes the exception detail.

Validation:

- The copied deployed launcher ran an isolated, non-listening frozen probe. Before the fix, the multiple-injury small-medkit case raised `No module named 'BigWorld'` and extinguishing left fuel-tank HP at zero. Replacing only the repaired shared module made all five probe cases pass without loading `BigWorld`.
- The real server intent path heals only the selected crew member, retains another injured member, consumes once, and accepts duplicate delivery without another use.
- Resolver-failure regression preserves kit quantity, critical state, revision, and settlement accounting, publishes rejection, and allows a subsequent trigger.
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=tests python3 -m unittest test_port_0922_critical_damage test_port_0922_effective_params test_port_0922_equipment_mechanics test_port_0922_loadout test_port_0922_worker_loadout test_port_0922_lan_client_projectiles test_port_0922_lan_protocol`: 283 tests passed.
- CPython 2.7 compilation and `git diff --check` passed.
- Combined with #135, `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -p 'test_*.py'` passed 5083 tests (2 skipped); all 112 client Python files compiled under CPython 2.7.18.

The running game and installed package were not changed. The frozen probe validates the server path; a real Windows gameplay retry is still pending. This fix does not establish the cause of the separately reported LAN disconnect. CI is not being waited on, as requested.
