### PR TITLE
Expose bounded dictionary key samples in round-end diagnostics

### DIFF
--- a/src/res/scripts/client/gui/mods/offline_lan_0922/python_heap.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/python_heap.py
@@ -46,9 +46,8 @@ TOP_EDGES = 8
 TOP_SIGNATURES = 10
 MAX_SIGNATURE_KEYS = 8
 MAX_SIGNATURE_TEXT = 64
-# Keys examined before giving up on naming a dict.  Bounds the cost of
-# fingerprinting a pathologically wide mapping while still letting an ordinary
-# record - which is what leaked - identify itself.
+# Maximum dictionary entries visited for a key sample. Wider mappings report
+# a partial sample, whose members can vary with the runtime's dictionary order.
 KEY_SCAN_LIMIT = 64
 # List and tuple lengths are reported as exact small values and then in
 # powers-of-two buckets, so one dominant shape is still visible.
@@ -143,27 +142,26 @@ def _signature(item):
         # Exact types only: subclasses may override keys, length, or attribute
         # lookup and run application/native code while garbage is retained.
         if item_type is dict:
-            # Name the record even when it is wide.  Reports 20260910-045317
-            # and -061701 both had `dict(len=<=64)` as 84% of the sampled
-            # garbage: bailing out to a bare length above MAX_SIGNATURE_KEYS
-            # hid the identity of exactly the dicts that dominate.  The scan
-            # is bounded instead, so a pathological dict still costs nothing.
+            # Include key names beyond the display limit while bounding the
+            # scan itself. A sorted partial sample is not a stable mapping
+            # identity: Python 2 dictionary order can change which keys fit.
+            length = len(item)
             keys = []
             scanned = 0
-            for key in item:
+            for key in itertools.islice(item, KEY_SCAN_LIMIT):
                 scanned += 1
-                if scanned > KEY_SCAN_LIMIT:
-                    break
                 if _is_text(key):
                     keys.append(_label(key))
+            sampled = ('[sampled=%d/%d]' % (scanned, length)
+                       if scanned < length else '')
             if not keys:
-                return 'dict(len=%s)' % _bucket(len(item))
+                return 'dict(len=%s)%s' % (_bucket(length), sampled)
             keys.sort()
             shown = keys[:MAX_SIGNATURE_KEYS]
             more = ''
-            if len(item) > len(shown):
-                more = ',+%d' % (len(item) - len(shown))
-            return 'dict{%s%s}' % (','.join(shown), more)
+            if length > len(shown):
+                more = ',+%d' % (length - len(shown))
+            return 'dict{%s%s}%s' % (','.join(shown), more, sampled)
         if any(item_type is builtin for builtin in (list, tuple, set, frozenset)):
             return '%s(len=%s)' % (kind, _bucket(len(item)))
         code = None

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/python_heap.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/python_heap.py
@@ -46,6 +46,10 @@ TOP_EDGES = 8
 TOP_SIGNATURES = 10
 MAX_SIGNATURE_KEYS = 8
 MAX_SIGNATURE_TEXT = 64
+# Keys examined before giving up on naming a dict.  Bounds the cost of
+# fingerprinting a pathologically wide mapping while still letting an ordinary
+# record - which is what leaked - identify itself.
+KEY_SCAN_LIMIT = 64
 # List and tuple lengths are reported as exact small values and then in
 # powers-of-two buckets, so one dominant shape is still visible.
 SMALL_LENGTH = 8
@@ -139,12 +143,27 @@ def _signature(item):
         # Exact types only: subclasses may override keys, length, or attribute
         # lookup and run application/native code while garbage is retained.
         if item_type is dict:
-            if len(item) > MAX_SIGNATURE_KEYS:
-                return 'dict(len=%s)' % _bucket(len(item))
-            keys = sorted(_label(key) for key in item if _is_text(key))
+            # Name the record even when it is wide.  Reports 20260910-045317
+            # and -061701 both had `dict(len=<=64)` as 84% of the sampled
+            # garbage: bailing out to a bare length above MAX_SIGNATURE_KEYS
+            # hid the identity of exactly the dicts that dominate.  The scan
+            # is bounded instead, so a pathological dict still costs nothing.
+            keys = []
+            scanned = 0
+            for key in item:
+                scanned += 1
+                if scanned > KEY_SCAN_LIMIT:
+                    break
+                if _is_text(key):
+                    keys.append(_label(key))
             if not keys:
-                return 'dict(len=%d)' % len(item)
-            return 'dict{%s}' % ','.join(keys)
+                return 'dict(len=%s)' % _bucket(len(item))
+            keys.sort()
+            shown = keys[:MAX_SIGNATURE_KEYS]
+            more = ''
+            if len(item) > len(shown):
+                more = ',+%d' % (len(item) - len(shown))
+            return 'dict{%s%s}' % (','.join(shown), more)
         if any(item_type is builtin for builtin in (list, tuple, set, frozenset)):
             return '%s(len=%s)' % (kind, _bucket(len(item)))
         code = None

--- a/tests/test_port_0922_python_heap.py
+++ b/tests/test_port_0922_python_heap.py
@@ -350,8 +350,27 @@ class ForcedCollectTest(unittest.TestCase):
         shape = python_heap._signature({'a\n' + 'x' * 100000: 1})
         self.assertLess(len(shape), 200)
         self.assertNotIn('\n', shape)
+        # A wide dict still names itself, because that is what identifies the
+        # leaked record: `dict(len=<=64)` was 84% of the sampled garbage in
+        # reports 20260910-045317 and -061701 and said nothing about what it
+        # was. Bounded to MAX_SIGNATURE_KEYS names plus a remainder count.
         large = python_heap._signature(dict((str(n), n) for n in range(100)))
-        self.assertEqual('dict(len=<=128)', large)
+        self.assertTrue(large.startswith('dict{'), large)
+        self.assertTrue(large.endswith(',+92}'), large)
+        names = large[len('dict{'):-len(',+92}')].split(',')
+        self.assertEqual(python_heap.MAX_SIGNATURE_KEYS, len(names))
+        self.assertLess(len(large), 200)
+        self.assertNotIn('\n', large)
+        # Only a mapping with no text key at all falls back to a bare length.
+        self.assertEqual(
+            'dict(len=<=64)',
+            python_heap._signature(dict((n, n) for n in range(40))))
+        # The scan is bounded, so a pathologically wide mapping is cheap.
+        huge = python_heap._signature(
+            dict(('k%05d' % n, n) for n in range(200000)))
+        self.assertTrue(huge.startswith('dict{'), huge)
+        self.assertTrue(huge.endswith(',+199992}'), huge)
+        self.assertLess(len(huge), 200)
 
     def test_sampling_failure_does_not_keep_cycles_in_exception_frames(self):
         class Cycle(object):

--- a/tests/test_port_0922_python_heap.py
+++ b/tests/test_port_0922_python_heap.py
@@ -282,8 +282,10 @@ class ForcedCollectTest(unittest.TestCase):
             [record] + keys + values)
         self.assertEqual(32, count)
         holds = dict(ranked)
-        self.assertEqual(16, holds['dict(len=<=128) -> tuple(len=1)'])
-        self.assertEqual(16, holds['dict(len=<=128) -> list(len=0)'])
+        self.assertEqual(
+            16, holds['dict(len=<=128)[sampled=64/100] -> tuple(len=1)'])
+        self.assertEqual(
+            16, holds['dict(len=<=128)[sampled=64/100] -> list(len=0)'])
 
     def test_edge_sampling_does_not_invoke_native_or_subclass_traversal(self):
         self.addCleanup(setattr, python_heap.gc, 'get_referents',
@@ -457,27 +459,58 @@ class ForcedCollectTest(unittest.TestCase):
         shape = python_heap._signature({'a\n' + 'x' * 100000: 1})
         self.assertLess(len(shape), 200)
         self.assertNotIn('\n', shape)
-        # A wide dict still names itself, because that is what identifies the
-        # leaked record: `dict(len=<=64)` was 84% of the sampled garbage in
-        # reports 20260910-045317 and -061701 and said nothing about what it
-        # was. Bounded to MAX_SIGNATURE_KEYS names plus a remainder count.
+        # Wide mappings expose a bounded key sample, not a complete identity.
         large = python_heap._signature(dict((str(n), n) for n in range(100)))
         self.assertTrue(large.startswith('dict{'), large)
-        self.assertTrue(large.endswith(',+92}'), large)
-        names = large[len('dict{'):-len(',+92}')].split(',')
+        self.assertTrue(large.endswith(',+92}[sampled=64/100]'), large)
+        names = large[len('dict{'):large.index(',+92}')].split(',')
         self.assertEqual(python_heap.MAX_SIGNATURE_KEYS, len(names))
         self.assertLess(len(large), 200)
         self.assertNotIn('\n', large)
-        # Only a mapping with no text key at all falls back to a bare length.
+        # A complete scan without text keys can report only its length.
         self.assertEqual(
             'dict(len=<=64)',
             python_heap._signature(dict((n, n) for n in range(40))))
-        # The scan is bounded, so a pathologically wide mapping is cheap.
+        # The number of visited entries does not grow with the mapping size.
         huge = python_heap._signature(
             dict(('k%05d' % n, n) for n in range(200000)))
         self.assertTrue(huge.startswith('dict{'), huge)
-        self.assertTrue(huge.endswith(',+199992}'), huge)
+        self.assertTrue(huge.endswith(',+199992}[sampled=64/200000]'), huge)
         self.assertLess(len(huge), 200)
+
+    def test_full_dictionary_key_samples_ignore_insertion_order(self):
+        pairs = [('field%02d' % n, n) for n in range(python_heap.KEY_SCAN_LIMIT)]
+        first = python_heap._signature(dict(pairs))
+        second = python_heap._signature(dict(reversed(pairs)))
+        self.assertEqual(first, second)
+        self.assertNotIn('sampled=', first)
+
+    def test_unvisited_text_key_is_reported_as_a_partial_key_sample(self):
+        mapping = dict((n, n) for n in range(python_heap.KEY_SCAN_LIMIT))
+        mapping['outside_sample'] = 0
+        signature = python_heap._signature(mapping)
+        self.assertEqual('dict(len=<=128)[sampled=64/65]', signature)
+
+    def test_signature_does_not_invoke_text_key_subclass_hooks(self):
+        calls = []
+
+        class HostileKey(str):
+            def __str__(self):
+                calls.append('str')
+                raise RuntimeError('must not inspect')
+
+            def __getitem__(self, unused):
+                calls.append('getitem')
+                raise RuntimeError('must not inspect')
+
+            def __len__(self):
+                calls.append('len')
+                raise RuntimeError('must not inspect')
+
+        self.assertEqual(
+            'dict{safe,+1}',
+            python_heap._signature({HostileKey('hidden'): 0, 'safe': 1}))
+        self.assertEqual([], calls)
 
     def test_sampling_failure_does_not_keep_cycles_in_exception_frames(self):
         class Cycle(object):


### PR DESCRIPTION
Round-end heap diagnostics previously reduced every dictionary with more than eight keys to a length bucket, hiding useful field names in ordinary records. Inspect a bounded window of up to 64 keys and report up to eight sanitized text labels plus the omitted-entry count.

Wide dictionaries are explicitly marked as partial samples. A window without text keys does not imply that the entire dictionary has none, and Python 2 dictionary layout can change which keys fall inside a partial window. Fully scanned dictionaries sort their labels; the result remains a structural clue rather than a unique object identity.

The review also makes the iteration limit exact and removes unsupported leak and zero-cost claims from the code and tests. Existing exact-type restrictions, bounded label text, automatic round-end collection, and failure containment remain in place. No switch or manual invocation is added.

Validation: 39 heap-diagnostic tests and 5 GC-sweep tests passed. CPython 2.7.18 compiled the module and executed native-dictionary, Unicode, insertion-order, and partial-window checks. The new regressions failed against the previous implementation before passing with the repair.

Combined with the merged #134 and #135, `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -p 'test_*.py'` passed 5086 tests (2 skipped). All 112 client Python files compiled under CPython 2.7.18, and the diff check passed. CI is not being waited on, as requested.

The new fingerprints have not yet been exercised in the Windows game. A stable object count does not establish that all memory growth is fixed, and the sampled reference census does not prove a complete cycle or its retaining owner.
