### PR TITLE
Preserve ammo-rack turret flight across asynchronous world entry

### DIFF
--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -2434,6 +2434,23 @@ target detaches nothing: retail has no `DetachedTurret` in AOI for a vehicle
 never spotted. A missing exploded model, a full turret budget or a failed
 `createEntity` leaves exactly the -5 burn-off wreck the port produced before.
 
+The synchronous constructor handshake is separate from asynchronous world
+entry. Exact `DetachedTurret.prerequisites` returns a `CompoundAssembler` and
+the vehicle descriptor's resources; `onEnterWorld(prereqs)` installs the
+assembled model. As with client-created Vehicles, a returned id can therefore
+precede `BigWorld.entity(id)`. Presentation retains this pending id until it
+appears, then binds the model at the elapsed point on the frozen arc. Only an
+already observed entity disappearing retires its animation; a reused id never
+authorizes writes to or destruction of a different entity. Closing presentation
+retains pending retirement records, retries them during the existing teardown
+poll, and leaves remaining prerequisite loads to battle-space retirement. It
+never calls `destroyEntity` for an id the engine does not yet own. One `TURRET`
+creation line and one binding line record the vehicle, entity and load delay.
+Regressions reproduce the old first-frame loss with an id that becomes visible
+only after loading. The reported FV4005 match's installed bytecode matched the
+reviewed source, but its logs lacked these lifecycle transitions; this confirms
+a reproducible adapter defect, not native Windows flight acceptance.
+
 A late ammo-bay cause can arrive after the ordinary death edge. It now admits
 one detachment from the existing wreck's turret pose, even though the health
 signature is already terminal. A per-record launch attempt fence and the

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -24559,8 +24559,9 @@ class BattleRuntime(object):
             # Detached turrets are separate client-created entities holding a
             # compound each.  Retire them at the synchronous leaveArena
             # boundary, before the Hangar app can replace the battle space.
-            # ``destroy_all`` is harmless after a partial start and safe to
-            # call twice.
+            # Pending prerequisite loads are not engine-owned yet.  Keep
+            # their tombstones for the second quiesce in _cleanup; the battle
+            # space retirement there cancels any loads still pending.
             try:
                 self._detached_turrets.destroy_all()
             except Exception as error:

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/entities/detached_turret.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/entities/detached_turret.py
@@ -31,6 +31,8 @@ projectiles and knows nothing about this object:
   drag/pull effect this version does not produce.
 """
 
+import sys
+
 from gui.mods.offline_lan_0922 import turret_detachment
 
 
@@ -62,6 +64,8 @@ class DetachedTurretPresentation(object):
         self._log = log
         self._max_active = int(max_active)
         self._turrets = []
+        self._retiring = []
+        self._closed = False
 
     def active(self):
         return len(self._turrets)
@@ -75,7 +79,7 @@ class DetachedTurretPresentation(object):
         this before writing the special health value, because
         ``onHealthChanged`` replaces the compound this pose is read from.
         """
-        if len(self._turrets) >= self._max_active:
+        if self._closed or len(self._turrets) >= self._max_active:
             return None
         descriptor = getattr(entity, 'typeDescriptor', None)
         appearance = getattr(entity, 'appearance', None)
@@ -132,6 +136,8 @@ class DetachedTurretPresentation(object):
         re-confirming and without seeding the turret filter from the
         vehicle's own unfed one.
         """
+        if self._closed:
+            return False
         vehicle_id = int(plan['entity_id'])
         for existing in self._turrets:
             if existing['vehicle_id'] == vehicle_id:
@@ -164,29 +170,43 @@ class DetachedTurretPresentation(object):
                 'spin': impulse['spin'],
                 'started': float(now),
                 'matrix': None,
+                'entity': None,
                 'impacted': False,
                 'settled': False,
             }
             self._turrets.append(turret)
+            sys.stdout.write(
+                '[Offline LAN 0.9.22] TURRET vehicle=%d entity=%d '
+                'state=created\n' % (vehicle_id, int(entity_id)))
         except Exception as error:
-            # Retire any allocated entity before the caller restores the
-            # burn-off health and requests the wreck assembler.
+            # An allocated id may still be loading prerequisites.  Retain it
+            # for safe retirement instead of destroying a not-yet-owned id.
             if entity_id is not None:
-                self._destroy_entity(int(entity_id))
+                self._retiring.append({'id': int(entity_id), 'entity': None})
+                self._retire_entities()
             self._note('detached turret creation failed', error)
             return False
         return True
 
     def advance(self, now):
         """Write this frame's pose for every live turret."""
+        self._retire_entities()
         if not self._turrets:
             return 0
         written = 0
         for turret in tuple(self._turrets):
             entity = self._entity(turret['id'])
             if entity is None:
+                # #1513 createEntity returns an id before prerequisites and
+                # onEnterWorld publish the entity.  Only a previously seen
+                # entity disappearing means retirement, not pending loading.
+                if turret['entity'] is not None:
+                    self._turrets.remove(turret)
+                continue
+            if turret['entity'] is not None and turret['entity'] is not entity:
                 self._turrets.remove(turret)
                 continue
+            turret['entity'] = entity
             model = getattr(entity, 'model', None)
             if model is None:
                 # #1513 enters a client-created entity only after its
@@ -200,8 +220,15 @@ class DetachedTurretPresentation(object):
                 continue
             if turret['matrix'] is None:
                 if not self._bind(entity, turret):
+                    self._retiring.append(turret)
+                    self._retire_entities()
                     self._turrets.remove(turret)
                     continue
+                sys.stdout.write(
+                    '[Offline LAN 0.9.22] TURRET vehicle=%d entity=%d '
+                    'state=bound elapsed_ms=%d\n' % (
+                        turret['vehicle_id'], turret['id'],
+                        max(0, int((float(now) - turret['started']) * 1000))))
             elapsed = max(0.0, float(now) - turret['started'])
             position, attitude = turret_detachment.pose_at(
                 turret['flight'], turret['attitude'], turret['spin'],
@@ -231,7 +258,6 @@ class DetachedTurretPresentation(object):
             turret['matrix'] = matrix
         except Exception as error:
             self._note('detached turret binding failed', error)
-            self._destroy_entity(turret['id'])
             return False
         try:
             # Reuse the reviewed LAN draw gate so stock dynamic collision,
@@ -267,12 +293,32 @@ class DetachedTurretPresentation(object):
         return True
 
     def destroy_all(self):
-        """Retire every turret entity.  Safe after a partial start, and twice."""
-        turrets = self._turrets
+        """Close presentation and retire only engine-owned turret entities.
+
+        A pending creation stays as a tombstone for the next teardown poll.
+        BattleRuntime polls again before retiring the battle space, whose
+        native teardown cancels any remaining prerequisite loads.  No timer
+        or animation from this closed owner can enter the next round.
+        """
+        self._closed = True
+        self._retiring.extend(self._turrets)
         self._turrets = []
-        for turret in turrets:
-            self._destroy_entity(turret['id'])
-        return len(turrets)
+        return self._retire_entities()
+
+    def _retire_entities(self):
+        retired = 0
+        for turret in tuple(self._retiring):
+            entity = self._entity(turret['id'])
+            previous = turret['entity']
+            if entity is None and previous is None:
+                continue
+            if entity is not None and (previous is None or previous is entity):
+                turret['entity'] = entity
+                if not self._destroy_entity(turret['id']):
+                    continue
+                retired += 1
+            self._retiring.remove(turret)
+        return retired
 
     def _destroy_entity(self, entity_id):
         destroy = getattr(self._bigworld, 'destroyEntity', None)

--- a/tests/test_port_0922_turret_detachment.py
+++ b/tests/test_port_0922_turret_detachment.py
@@ -342,13 +342,16 @@ class _TurretEntity(object):
 
 class _BigWorld(object):
 
-    def __init__(self, fail_create=False, model=True):
+    def __init__(self, fail_create=False, model=True, defer_enter=False):
         self.entities = {}
+        self.pending = {}
         self.created = []
         self.destroyed = []
+        self.destroy_attempts = []
         self._next_id = 900
         self._fail_create = fail_create
         self._model = model
+        self._defer_enter = defer_enter
 
     def createEntity(self, class_name, space_id, vehicle_id, position,
                      direction, state):
@@ -359,13 +362,24 @@ class _BigWorld(object):
         self._next_id += 1
         entity = _TurretEntity(self._next_id, state, position, direction,
                                self._model)
-        self.entities[self._next_id] = entity
+        if self._defer_enter:
+            self.pending[self._next_id] = entity
+        else:
+            self.entities[self._next_id] = entity
         return self._next_id
+
+    def enter_world(self, entity_id):
+        entity = self.pending.pop(entity_id)
+        self.entities[entity_id] = entity
+        return entity
 
     def entity(self, entity_id):
         return self.entities.get(entity_id)
 
     def destroyEntity(self, entity_id):
+        self.destroy_attempts.append(entity_id)
+        if entity_id in self.pending:
+            raise RuntimeError('pending entity cannot be destroyed before entry')
         self.destroyed.append(entity_id)
         self.entities.pop(entity_id, None)
 
@@ -498,14 +512,60 @@ class DetachedTurretPresentationTest(unittest.TestCase):
         self.assertEqual(presentation.advance(0.5), 0)
         self.assertEqual(presentation.active(), 1)
 
+    def test_async_entry_waits_then_binds_flies_and_lands_once(self):
+        """#1513 returns an ID before prerequisites make entity(id) visible."""
+        bigworld = _BigWorld(defer_enter=True)
+        presentation = self._presentation(bigworld)
+        plan = presentation.prepare(_Vehicle())
+        self.assertTrue(presentation.launch(plan, 77, 10.0))
+        self.assertIsNone(bigworld.entity(901))
+
+        for now in (10.01, 10.1, 10.2):
+            self.assertEqual(presentation.advance(now), 0)
+            self.assertEqual(presentation.active(), 1)
+        entity = bigworld.enter_world(901)
+        self.assertEqual(presentation.advance(10.3), 1)
+        matrix = entity.model.matrix
+        self.assertIsInstance(matrix, _Matrix)
+        initial_position = matrix.translation
+        self.assertEqual(entity.impacts, [])
+        self.assertEqual(presentation.advance(10.6), 1)
+        self.assertIs(entity.model.matrix, matrix)
+        self.assertNotEqual(matrix.translation, initial_position)
+        self.assertEqual(presentation.advance(60.0), 1)
+        self.assertEqual(len(entity.impacts), 1)
+        self.assertEqual(presentation.advance(90.0), 0)
+        self.assertEqual(len(entity.impacts), 1)
+        self.assertEqual(bigworld.destroy_attempts, [])
+        self.assertEqual(self.failures, [])
+
     def test_a_destroyed_entity_is_dropped_without_an_error(self):
         bigworld = _BigWorld()
         presentation = self._presentation(bigworld)
         plan = presentation.prepare(_Vehicle())
         presentation.launch(plan, 5, 0.0)
+        self.assertEqual(presentation.advance(0.0), 1)
+        entity = bigworld.entity(901)
+        rotations = list(entity.model.matrix.rotations)
         bigworld.entities.clear()
         self.assertEqual(presentation.advance(1.0), 0)
         self.assertEqual(presentation.active(), 0)
+        self.assertEqual(entity.model.matrix.rotations, rotations)
+        self.assertEqual(self.failures, [])
+
+    def test_a_seen_entity_lost_before_model_readiness_is_retired(self):
+        bigworld = _BigWorld(model=False, defer_enter=True)
+        presentation = self._presentation(bigworld)
+        plan = presentation.prepare(_Vehicle())
+        presentation.launch(plan, 5, 0.0)
+        bigworld.enter_world(901)
+        self.assertEqual(presentation.advance(0.1), 0)
+        self.assertEqual(presentation.active(), 1)
+        bigworld.entities.clear()
+
+        self.assertEqual(presentation.advance(0.2), 0)
+        self.assertEqual(presentation.active(), 0)
+        self.assertEqual(bigworld.destroy_attempts, [])
         self.assertEqual(self.failures, [])
 
     def test_one_vehicle_throws_one_turret(self):
@@ -521,12 +581,88 @@ class DetachedTurretPresentationTest(unittest.TestCase):
         bigworld = _BigWorld()
         presentation = self._presentation(bigworld)
         self.assertEqual(presentation.destroy_all(), 0)
+        self.assertEqual(presentation.destroy_all(), 0)
+        presentation = self._presentation(bigworld)
         plan = presentation.prepare(_Vehicle())
         presentation.launch(plan, 5, 0.0)
         self.assertEqual(presentation.destroy_all(), 1)
         self.assertEqual(bigworld.destroyed, [901])
         self.assertEqual(presentation.destroy_all(), 0)
         self.assertEqual(bigworld.destroyed, [901])
+
+    def test_pending_cleanup_waits_for_entry_and_never_starts_the_visual(self):
+        for retry in ('advance', 'destroy_all'):
+            with self.subTest(retry=retry):
+                bigworld = _BigWorld(defer_enter=True)
+                presentation = self._presentation(bigworld)
+                plan = presentation.prepare(_Vehicle())
+                presentation.launch(plan, 5, 0.0)
+
+                self.assertEqual(presentation.destroy_all(), 0)
+                self.assertEqual(presentation.destroy_all(), 0)
+                self.assertEqual(bigworld.destroy_attempts, [])
+                self.assertIsNone(presentation.prepare(_Vehicle(entity_id=18)))
+                self.assertFalse(presentation.launch(plan, 5, 0.1))
+                self.assertEqual(len(bigworld.created), 1)
+
+                entity = bigworld.enter_world(901)
+                if retry == 'advance':
+                    self.assertEqual(presentation.advance(0.2), 0)
+                else:
+                    self.assertEqual(presentation.destroy_all(), 1)
+                self.assertEqual(bigworld.destroyed, [901])
+                self.assertIsNone(entity.model.matrix)
+                self.assertEqual(entity.impacts, [])
+                self.assertEqual(presentation.active(), 0)
+                self.assertEqual(presentation.advance(0.3), 0)
+                self.assertEqual(presentation.destroy_all(), 0)
+                self.assertEqual(bigworld.destroy_attempts, [901])
+                self.assertEqual(self.failures, [])
+
+    def test_cleanup_retires_resident_and_pending_entities_when_each_is_safe(self):
+        bigworld = _BigWorld(defer_enter=True)
+        presentation = self._presentation(bigworld)
+        for vehicle_id in (17, 18):
+            plan = presentation.prepare(_Vehicle(entity_id=vehicle_id))
+            presentation.launch(plan, vehicle_id, 0.0)
+        resident = bigworld.enter_world(901)
+
+        self.assertEqual(presentation.destroy_all(), 1)
+        self.assertEqual(bigworld.destroy_attempts, [901])
+        self.assertIsNone(resident.model.matrix)
+        self.assertIn(902, bigworld.pending)
+        pending = bigworld.enter_world(902)
+        self.assertEqual(presentation.destroy_all(), 1)
+        self.assertEqual(bigworld.destroy_attempts, [901, 902])
+        self.assertIsNone(pending.model.matrix)
+        self.assertEqual(presentation.destroy_all(), 0)
+        self.assertEqual(self.failures, [])
+
+    def test_a_reused_id_never_writes_or_destroys_the_replacement_entity(self):
+        for retire in ('advance', 'destroy_all'):
+            with self.subTest(retire=retire):
+                bigworld = _BigWorld()
+                presentation = self._presentation(bigworld)
+                plan = presentation.prepare(_Vehicle())
+                presentation.launch(plan, 5, 0.0)
+                self.assertEqual(presentation.advance(0.0), 1)
+                old_entity = bigworld.entity(901)
+                rotations = list(old_entity.model.matrix.rotations)
+                replacement = _TurretEntity(
+                    901, {}, _Vector(0.0, 0.0, 0.0), (0.0, 0.0, 0.0))
+                bigworld.entities[901] = replacement
+
+                if retire == 'advance':
+                    self.assertEqual(presentation.advance(0.1), 0)
+                else:
+                    self.assertEqual(presentation.destroy_all(), 0)
+                self.assertEqual(presentation.active(), 0)
+                self.assertEqual(presentation.destroy_all(), 0)
+                self.assertIs(bigworld.entity(901), replacement)
+                self.assertIsNone(replacement.model.matrix)
+                self.assertEqual(old_entity.model.matrix.rotations, rotations)
+                self.assertEqual(bigworld.destroy_attempts, [])
+                self.assertEqual(self.failures, [])
 
 
 class HandshakeOrderTest(unittest.TestCase):

--- a/tools/audit_client_abi.py
+++ b/tools/audit_client_abi.py
@@ -1483,6 +1483,14 @@ EXPECTED_CODE_NAMES = {
         'Vehicle.drawEdge': ('appearance', 'highlighter', 'highlight'),
         'Vehicle.removeEdge': ('appearance', 'highlighter', 'highlight'),
     },
+    'scripts/client/DetachedTurret.pyc': {
+        'DetachedTurret.prerequisites': (
+            '_DetachedTurret__prepareModelAssembler',
+            '_DetachedTurret__vehDescr', 'prerequisites'),
+        'DetachedTurret.onEnterWorld': (
+            '_DetachedTurret__vehDescr', 'name', 'model', 'matrix',
+            '_DetachedTurret__detachConfirmationTimer', 'onEnterWorld'),
+    },
     'scripts/client/AvatarInputHandler/gun_marker_ctrl.pyc': {
         '_CrosshairShotResults._getAllCollisionDetails': (
             'collideSegmentExt',),


### PR DESCRIPTION
When an ammo rack detonates, #1513 can return a `DetachedTurret` ID while its prerequisites are still loading. The presentation loop treated the first missing `BigWorld.entity(id)` as destruction and permanently dropped the flight and cleanup owner. Keep that ID pending until world entry, then bind and advance the frozen flight; stop only when a previously observed entity disappears or changes identity.

Closing presentation now retains pending retirement records and destroys each entity only after the engine owns it. Existing battle teardown cancels remaining loads. Add bounded creation/binding diagnostics and pin the stock prerequisite/model-entry consumers in the ABI audit.

Validation:
- 35 turret presentation tests, including delayed entry, flight/landing, pending teardown and ID replacement.
- 860 battle runtime tests and 10 ABI-audit tests.
- Exact Chinese HD #1513 client inspection and CPython 2.7 bytecode ABI audit.
- CPython 2.7.18 source compilation for all 112 client files.

The reported FV4005 session loaded bytecode matching the pre-fix source, so this is not a stale installation. Its logs did not record turret lifecycle transitions; the regression proves the adapter defect, while actual flight/rendering still needs Windows #1513 acceptance. No protocol or flight-physics change.
