### PR TITLE
Trace garbage cycles and owners without probe-created retention chains

### DIFF
--- a/src/res/scripts/client/gui/mods/offline_lan_0922/python_heap.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/python_heap.py
@@ -43,6 +43,33 @@ SIGNATURE_SAMPLE = 4000
 EDGE_SAMPLE = 2000
 MAX_EDGE_REFERENTS = 32
 TOP_EDGES = 8
+
+# Finding an actual cycle, not just one edge of one.  `PYREF` reports pairs,
+# which cannot close a loop; reports 20260910-045317/-061701/-065631 all show
+# the dominant edge with no returning edge, because the cycle root is a small
+# set of objects far from the head of gc.garbage.
+#
+# Two walks, because they fail in different directions.  The forward one finds
+# a loop among plausible cycle members - anything that is not a plain
+# container, so instances, bound methods, cells and frames.  The backward one
+# walks referrers up from the shape that dominates the garbage and names what
+# retains it, which is useful even when the cycle does not pass through it.
+CYCLE_INDEX_LIMIT = 200000
+CYCLE_SEEDS = 48
+CYCLE_MAX_DEPTH = 24
+CYCLE_NODE_BUDGET = 30000
+TOP_CYCLES = 3
+# One `gc.get_referrers` call scans every tracked object, so the depth here
+# multiplies a whole-heap pass. Measured on CPython 2.7 at 303k tracked
+# objects: 60 ms per level. The field worker carries about 1M, and Peng's VM
+# emulates x86 on ARM64, so budget seconds rather than milliseconds. Four
+# levels is enough to cross container -> owner -> registry -> holder, which is
+# where a local reproduction of the observed shape gave the whole answer;
+# deeper levels were module-level noise.
+HOLD_SEEDS = 12
+HOLD_DEPTH = 4
+TOP_HOLDERS = 6
+_PLAIN_CONTAINERS = (dict, list, tuple, set, frozenset)
 TOP_SIGNATURES = 10
 MAX_SIGNATURE_KEYS = 8
 MAX_SIGNATURE_TEXT = 64
@@ -291,6 +318,152 @@ def edge_census(items, sample=EDGE_SAMPLE):
                                 for pair, count in ranked[:TOP_EDGES]]
 
 
+def _walk_referents(item):
+    """Referents for traversal, over every type a cycle can run through.
+
+    ``_edge_referents`` is deliberately exact-type: it bounds fan-out for the
+    edge histogram and yields nothing for an instance or a bound method, which
+    are exactly the objects a cycle needs.  ``gc.get_referents`` is a C-level
+    ``tp_traverse`` call - it runs no Python code, so it is as safe here - and
+    it is the only way the walk can cross an instance.
+    """
+    try:
+        return itertools.islice(gc.get_referents(item), MAX_EDGE_REFERENTS)
+    except Exception:
+        return iter(())
+
+
+def _is_plain(item):
+    item_type = type(item)
+    return any(item_type is builtin for builtin in _PLAIN_CONTAINERS)
+
+
+def cycle_census(items):
+    """Return actual cycle paths found inside an unreachable set.
+
+    Depth-first over referents restricted to the set; when a referent is
+    already on the current path the loop is closed and rendered as
+    ``A -> B -> C -> A``.  Seeds are the non-plain-container members, because
+    a cycle needs something that can hold a back-reference and those are far
+    fewer than the dicts they retain.
+    """
+    members = {}
+    for item in itertools.islice(items, CYCLE_INDEX_LIMIT):
+        members[id(item)] = item
+    seeds = [item for item in members.values() if not _is_plain(item)]
+    truncated = len(members) >= CYCLE_INDEX_LIMIT
+    if not seeds:
+        seeds = list(members.values())
+    stride = max(1, len(seeds) // CYCLE_SEEDS)
+    seeds = seeds[::stride][:CYCLE_SEEDS]
+    budget = [CYCLE_NODE_BUDGET]
+    found = []
+    for seed in seeds:
+        if budget[0] <= 0:
+            break
+        path = _find_cycle(seed, members, budget)
+        if path and path not in found:
+            found.append(path)
+            if len(found) >= TOP_CYCLES:
+                break
+    return len(seeds), truncated, found
+
+
+def _find_cycle(seed, members, budget):
+    """Iterative DFS for one loop reachable from ``seed`` within the set."""
+    stack = [(id(seed), iter(_walk_referents(seed)))]
+    on_path = [id(seed)]
+    marked = set(on_path)
+    seen = set(on_path)
+    while stack and budget[0] > 0:
+        node_id, cursor = stack[-1]
+        advanced = False
+        for target in cursor:
+            target_id = id(target)
+            if target_id not in members:
+                continue
+            budget[0] -= 1
+            if budget[0] <= 0:
+                return None
+            if target_id in marked:
+                start = on_path.index(target_id)
+                loop = [_signature(members[step])
+                        for step in on_path[start:]]
+                # Rotate to a canonical start so three reported cycles are
+                # three different loops, not three entry points into one.
+                pivot = loop.index(min(loop))
+                loop = loop[pivot:] + loop[:pivot]
+                return ' -> '.join(loop + [loop[0]])
+            if target_id in seen or len(stack) >= CYCLE_MAX_DEPTH:
+                continue
+            seen.add(target_id)
+            stack.append((target_id, iter(_walk_referents(target))))
+            on_path.append(target_id)
+            marked.add(target_id)
+            advanced = True
+            break
+        if not advanced:
+            stack.pop()
+            marked.discard(on_path.pop())
+    return None
+
+
+def retention_census(items, own):
+    """Walk referrers up from the dominant shape and name what retains it.
+
+    ``own`` is the set of ids this probe itself holds, so the walk never
+    reports its own bookkeeping as a retainer.
+    """
+    members = {}
+    for item in itertools.islice(items, CYCLE_INDEX_LIMIT):
+        members[id(item)] = item
+    counts = {}
+    for item in members.values():
+        name = _signature(item)
+        counts[name] = counts.get(name, 0) + 1
+    if not counts:
+        return '-', ()
+    dominant = max(counts.items(), key=lambda pair: pair[1])[0]
+    frontier = []
+    for item in members.values():
+        if len(frontier) >= HOLD_SEEDS:
+            break
+        if _signature(item) == dominant:
+            frontier.append(item)
+    if not frontier:
+        return dominant, ()
+    levels = []
+    visited = set(id(item) for item in frontier)
+    for unused_level in range(HOLD_DEPTH):
+        try:
+            referrers = gc.get_referrers(*frontier)
+        except Exception:
+            break
+        tally = {}
+        following = []
+        for holder in referrers:
+            holder_id = id(holder)
+            if (holder_id in own or holder_id in visited or
+                    type(holder) is types.FrameType or
+                    type(holder) is types.ModuleType):
+                continue
+            visited.add(holder_id)
+            name = _signature(holder)
+            tally[name] = tally.get(name, 0) + 1
+            if len(following) < HOLD_SEEDS:
+                following.append(holder)
+        del referrers
+        if not tally:
+            break
+        ranked = sorted(tally.items(), key=lambda pair: pair[1],
+                        reverse=True)[:TOP_HOLDERS]
+        levels.append(','.join('%s x%d' % pair for pair in ranked))
+        if not following:
+            break
+        frontier = following
+    return dominant, levels
+
+
 def _collect_saved_sample(garbage, first):
     """Keep temporary object references and exception frames out of pass two."""
     try:
@@ -298,8 +471,17 @@ def _collect_saved_sample(garbage, first):
         sample = garbage[first:first + SIGNATURE_SAMPLE]
         scanned, signatures = signature_census(sample)
         edge_window, edge_count, edges = edge_census(sample)
+        # The whole unreachable set, not the head slice: the cycle root is a
+        # handful of objects and the head is dominated by what it retains.
+        whole = garbage[first:]
+        seeds, truncated, cycles = cycle_census(whole)
+        own = set((id(garbage), id(sample), id(whole), id(signatures),
+                   id(edges), id(cycles), id(globals()), id(gc.__dict__)))
+        dominant, holders = retention_census(whole, own)
+        del whole
         return (unreachable, scanned, signatures, _by_type(sample),
-                edge_window, edge_count, edges)
+                edge_window, edge_count, edges,
+                seeds, truncated, cycles, dominant, holders)
     except Exception:
         return None
 
@@ -342,7 +524,8 @@ def collect_once():
         if sample is None:
             return None
         (unreachable, scanned, signatures, garbage_types,
-         edge_window, edge_count, edges) = sample
+         edge_window, edge_count, edges,
+         seeds, seeds_truncated, cycles, dominant, holders) = sample
         elapsed_ms = int((time.time() - started) * 1000.0)
         after = len(gc.get_objects())
         return {
@@ -358,6 +541,11 @@ def collect_once():
             'edge_window': edge_window,
             'edge_count': edge_count,
             'edges': edges,
+            'seeds': seeds,
+            'seeds_truncated': 1 if seeds_truncated else 0,
+            'cycles': cycles,
+            'dominant': dominant,
+            'holders': holders,
         }
     except Exception:
         return None
@@ -388,7 +576,21 @@ def format_collect_lines(phase, round_id, state=None):
                 phase, round_id, state.get('edge_window', 0),
                 state.get('edge_count', 0),
                 ' | '.join('%s x%d' % pair for pair in edges) or '-'))
-    return (head, detail, held)
+    cycles = state.get('cycles') or ()
+    loops = ('[Offline LAN 0.9.22] PYCYCLE phase=%s round=%s seeds=%d '
+             'truncated=%d found=%d %s' % (
+                 phase, round_id, state.get('seeds', 0),
+                 state.get('seeds_truncated', 0), len(cycles),
+                 ' || '.join(cycles) or 'none'))
+    holders = state.get('holders') or ()
+    chain = []
+    for index, level in enumerate(holders):
+        chain.append('L%d[%s]' % (index + 1, level))
+    holds = ('[Offline LAN 0.9.22] PYHOLD phase=%s round=%s dominant=%s '
+             'chain=%s' % (
+                 phase, round_id, state.get('dominant', '-'),
+                 ' <- '.join(chain) or 'none'))
+    return (head, detail, held, loops, holds)
 
 
 def log_collect(phase, round_id):

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/python_heap.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/python_heap.py
@@ -430,11 +430,18 @@ def retention_census(items, own):
             frontier.append(item)
     if not frontier:
         return dominant, ()
+    own = set(own)
+    own.add(id(members))
     levels = []
     visited = set(id(item) for item in frontier)
     for unused_level in range(HOLD_DEPTH):
+        # The index, work queue and call-argument tuple all retain the objects
+        # being inspected. Name the tuple explicitly: CPython 2.7 reports the
+        # temporary tuple created by ``*frontier`` as a referrer too.
+        targets = tuple(frontier)
+        own.update((id(frontier), id(targets)))
         try:
-            referrers = gc.get_referrers(*frontier)
+            referrers = gc.get_referrers(*targets)
         except Exception:
             break
         tally = {}

--- a/tests/test_port_0922_python_heap.py
+++ b/tests/test_port_0922_python_heap.py
@@ -164,7 +164,7 @@ class ForcedCollectTest(unittest.TestCase):
 
     def test_the_lines_report_the_accounting_and_the_cost(self):
         lines = python_heap.format_collect_lines('round_end', 6)
-        self.assertEqual(3, len(lines))
+        self.assertEqual(5, len(lines))
         self.assertIn('PYGC phase=round_end round=6', lines[0])
         for field in ('before=', 'unreachable=', 'after=', 'net_freed=',
                       'second_pass=', 'elapsed_ms=', 'gc_enabled_after='):
@@ -510,3 +510,113 @@ class ForcedCollectTest(unittest.TestCase):
         finally:
             if was_enabled:
                 gc.enable()
+
+
+class CycleAndRetentionTest(unittest.TestCase):
+    """Name the cycle itself, not one edge of it.
+
+    Reports 20260910-045317, -061701 and -065631 all show the dominant edge
+    with no returning edge, because `PYREF` reports pairs and a pair cannot
+    close a loop. These two walks close it: forward for the loop, backward for
+    what retains the shape that dominates.
+    """
+
+    class Registry(object):
+        def refresh(self):
+            return None
+
+    class Peer(object):
+        pass
+
+    def _leak_rounds(self, count):
+        for unused in range(count):
+            rows = dict((index, {'aim_yaw': 0.0, 'alive': True})
+                        for index in range(4))
+            registry = self.Registry()
+            registry.rows = rows
+            # instance -> dict -> bound method -> instance
+            registry.table = {'refresh': registry.refresh}
+            first = self.Peer()
+            second = self.Peer()
+            first.peer = second
+            second.peer = first
+
+    def _garbage(self):
+        gc.collect()
+        previous = gc.get_debug()
+        start = len(gc.garbage)
+        gc.set_debug(gc.DEBUG_SAVEALL)
+        try:
+            self._leak_rounds(40)
+            gc.collect()
+            captured = gc.garbage[start:]
+        finally:
+            gc.set_debug(previous)
+        self.addCleanup(gc.collect)
+        self.addCleanup(lambda: gc.garbage.__delitem__(slice(start, None)))
+        return captured
+
+    def test_a_bound_method_cycle_is_reported_as_a_closed_loop(self):
+        captured = self._garbage()
+        unused_seeds, unused_truncated, cycles = python_heap.cycle_census(
+            captured)
+        joined = ' || '.join(cycles)
+        # py2.7 (the game) calls it `instancemethod`, py3 `method`.
+        self.assertIn(':refresh', joined)
+        self.assertIn('dict{refresh}', joined)
+        self.assertIn('Registry', joined)
+        for path in cycles:
+            steps = path.split(' -> ')
+            self.assertGreater(len(steps), 2)
+            self.assertEqual(steps[0], steps[-1], path)
+
+    def test_distinct_loops_are_not_reported_as_rotations(self):
+        captured = self._garbage()
+        unused_seeds, unused_truncated, cycles = python_heap.cycle_census(
+            captured)
+        self.assertGreaterEqual(len(cycles), 2)
+        self.assertEqual(len(cycles), len(set(cycles)))
+        # Every reported loop starts at its own smallest signature, so two
+        # entry points into one loop collapse to one report.
+        for path in cycles:
+            steps = path.split(' -> ')[:-1]
+            self.assertEqual(min(steps), steps[0], path)
+
+    def test_the_walk_crosses_instances_and_bound_methods(self):
+        # `_edge_referents` is exact-type and yields nothing for an instance,
+        # which found zero cycles. `gc.get_referents` is a C-level traverse.
+        registry = self.Registry()
+        self.assertEqual([], list(python_heap._edge_referents(registry)))
+        self.assertTrue(list(python_heap._walk_referents(registry)))
+
+    def test_the_retention_walk_names_what_holds_the_dominant_shape(self):
+        captured = self._garbage()
+        dominant, holders = python_heap.retention_census(
+            captured, set([id(captured), id(gc.__dict__)]))
+        self.assertTrue(dominant)
+        self.assertTrue(holders)
+        self.assertNotIn('module', ' '.join(holders))
+
+    def test_both_walks_are_bounded(self):
+        captured = self._garbage()
+        seeds, unused_truncated, unused_cycles = python_heap.cycle_census(
+            captured)
+        self.assertLessEqual(seeds, python_heap.CYCLE_SEEDS)
+        unused_dominant, holders = python_heap.retention_census(
+            captured, set([id(captured)]))
+        self.assertLessEqual(len(holders), python_heap.HOLD_DEPTH)
+
+    def test_an_acyclic_set_reports_no_cycle(self):
+        plain = [{'a': index} for index in range(50)]
+        unused_seeds, unused_truncated, cycles = python_heap.cycle_census(plain)
+        self.assertEqual([], cycles)
+
+    def test_the_lines_carry_both_walks(self):
+        lines = python_heap.format_collect_lines('round_end', 7)
+        self.assertEqual(5, len(lines))
+        self.assertIn('PYCYCLE phase=round_end round=7', lines[3])
+        self.assertIn('seeds=', lines[3])
+        self.assertIn('found=', lines[3])
+        self.assertIn('PYHOLD phase=round_end round=7', lines[4])
+        self.assertIn('dominant=', lines[4])
+        self.assertIn('chain=', lines[4])

--- a/tests/test_port_0922_python_heap.py
+++ b/tests/test_port_0922_python_heap.py
@@ -630,6 +630,24 @@ class CycleAndRetentionTest(unittest.TestCase):
         self.assertTrue(holders)
         self.assertNotIn('module', ' '.join(holders))
 
+    def test_retention_does_not_report_its_own_containers_as_holders(self):
+        captured = [{'aim_yaw': 0.0, 'alive': True} for unused in range(30)]
+        dominant, holders = python_heap.retention_census(
+            captured, set([id(captured), id(gc.__dict__)]))
+        self.assertEqual('dict{aim_yaw,alive}', dominant)
+        self.assertEqual([], holders)
+
+    def test_retention_reaches_a_real_owner_without_probe_container_levels(self):
+        owner = self.Registry()
+        owner.rows = [{'aim_yaw': 0.0, 'alive': True}
+                      for unused in range(4)]
+        captured = list(owner.rows)
+        unused_dominant, holders = python_heap.retention_census(
+            captured, set([id(captured), id(gc.__dict__)]))
+        self.assertEqual('list(len=4) x1', holders[0])
+        self.assertIn('Registry', ' '.join(holders))
+        self.assertNotIn('tuple(', ' '.join(holders))
+
     def test_both_walks_are_bounded(self):
         captured = self._garbage()
         seeds, unused_truncated, unused_cycles = python_heap.cycle_census(


### PR DESCRIPTION
Round-end reference-pair summaries could name a retained object shape without identifying its owner or closing the cycle. Add bounded `PYCYCLE` paths through GC referents and a `PYHOLD` walk back from the dominant sampled shape. The cycle index is limited to 200,000 unreachable objects, with 48 seeds, a 30,000-edge budget, and depth 24; the holder walk is limited to four levels and 12 frontier objects. Truncation is reported, and a missing cycle is not proof that none exists.

Exclude the probe's own index, frontier lists, and call-argument tuples from retention chains. A real CPython 2.7 reproduction showed that otherwise an unowned set of plain rows produced four false holder levels consisting only of diagnostic bookkeeping.

Validation: 48 focused heap tests passed. CPython 2.7.18 probes verified an empty chain for unowned rows, the real list/dictionary/instance owner chain, and collection of all 20 synthetic cycle owners after diagnosis. The final local client package's 132 members were validated, and all 112 compiled client modules were compared against the merged source. This diagnostic runs only at the existing round-end collection boundary and may take seconds on the target VM; it does not itself identify the production cycle or prove Windows memory stability.
