### PR TITLE
Add profile Bot exclusions and an error report send reminder

### DIFF
--- a/launcher/core.py
+++ b/launcher/core.py
@@ -60,6 +60,7 @@ SERVER_TEAM_SIZE_ENV_0922 = "WOT_0922_TEAM_SIZE"
 SERVER_TEAM1_SIZE_ENV_0922 = "WOT_0922_TEAM1_SIZE"
 SERVER_TEAM2_SIZE_ENV_0922 = "WOT_0922_TEAM2_SIZE"
 SERVER_BOT_LINEUP_ENV_0922 = "WOT_0922_BOT_LINEUP"
+SERVER_BOT_EXCLUDED_VEHICLES_ENV_0922 = "WOT_0922_BOT_EXCLUDED_VEHICLES"
 SERVER_LOOPBACK_ONLY_ENV_0922 = "WOT_0922_LOOPBACK_ONLY"
 SERVER_VEHICLE_OVERLAY_ROOT_ENV_0922 = "WOT_0922_VEHICLE_OVERLAY_ROOT"
 VEHICLE_OVERLAY_CAPABILITY = "vehicle_overlay_v1"
@@ -1900,7 +1901,8 @@ def server_argv(port_version, base_dir=None):
 
 def server_environment(port_version, game_root, environment=None,
                        team_size=DEFAULT_TEAM_SIZE, loopback_only=False,
-                       team1_size=None, team2_size=None, bot_lineup=None):
+                       team1_size=None, team2_size=None, bot_lineup=None,
+                       bot_excluded_vehicles=None):
     """Build the endpoint and roster environment for one LAN server."""
     environment = dict(os.environ if environment is None else environment)
     if port_version == PORT_0_9_22:
@@ -1916,6 +1918,8 @@ def server_environment(port_version, game_root, environment=None,
         environment[SERVER_TEAM2_SIZE_ENV_0922] = str(team2_size)
         environment[SERVER_BOT_LINEUP_ENV_0922] = json.dumps(
             list(bot_lineup or ()), separators=(",", ":"))
+        environment[SERVER_BOT_EXCLUDED_VEHICLES_ENV_0922] = json.dumps(
+            list(bot_excluded_vehicles or ()), separators=(",", ":"))
         environment[SERVER_VEHICLE_OVERLAY_ROOT_ENV_0922] = os.path.abspath(
             game_root)
         if loopback_only:

--- a/launcher/tests/test_launcher_core.py
+++ b/launcher/tests/test_launcher_core.py
@@ -616,6 +616,15 @@ class ServerPayloadTest(unittest.TestCase):
             '[{"team":1,"slot":2,"vehicle":"ussr:R11_MS-1"}]',
             environment[core.SERVER_BOT_LINEUP_ENV_0922])
 
+    def test_server_receives_profile_exclusions_and_clears_inherited_values(self):
+        name = "ussr:R11_MS-1"
+        key = core.SERVER_BOT_EXCLUDED_VEHICLES_ENV_0922
+        environment = core.server_environment(
+            core.PORT_0_9_22, "/game", {}, bot_excluded_vehicles=[name])
+        self.assertEqual('["ussr:R11_MS-1"]', environment[key])
+        self.assertEqual("[]", core.server_environment(
+            core.PORT_0_9_22, "/game", environment)[key])
+
     def test_single_player_server_is_explicitly_loopback_only(self):
         environment = core.server_environment(
             core.PORT_0_9_22, "/game", {}, loopback_only=True)

--- a/launcher/tests/test_launcher_window.py
+++ b/launcher/tests/test_launcher_window.py
@@ -732,9 +732,10 @@ class WindowTest(unittest.TestCase):
                     "wot_launcher.vehicle_overlays.prepare_vehicle_profile",
                     return_value={"profile": "Fast MS-1",
                                   "installedMembers": 2,
-                                  "removedMembers": 0}) as prepare, \
+                                  "removedMembers": 0,
+                                  "botExcludedVehicles": ["ussr:R11_MS-1"]}) as prepare, \
                 mock.patch.object(
-                    self.window, "_start_server", return_value=True), \
+                    self.window, "_start_server", return_value=True) as start_server, \
                 mock.patch.object(
                     self.window, "_start_worker", return_value=True):
             self.window.vehicle_profile.set("Fast MS-1")
@@ -745,6 +746,9 @@ class WindowTest(unittest.TestCase):
                 time.sleep(0.01)
 
         prepare.assert_called_once_with(game_root, "Fast MS-1")
+        start_server.assert_called_once_with(
+            game_root, core.PORT_0_9_22, persistent=True, require_owned=True,
+            bot_excluded_vehicles=["ussr:R11_MS-1"])
         self.assertIn("pins vehicle profile", self._log_text())
         self.assertIn("Fast MS-1", self._log_text())
 
@@ -2073,6 +2077,7 @@ class WindowTest(unittest.TestCase):
             "profile": "Fast MS-1",
             "installedMembers": 1,
             "removedMembers": 0,
+            "botExcludedVehicles": ["ussr:R11_MS-1"],
         }
         with mock.patch("core.install_client_mod", return_value=[]), \
                 mock.patch(
@@ -2112,7 +2117,8 @@ class WindowTest(unittest.TestCase):
             self.window._run_session(self.settings_dir, session, "Peng")
 
         start_server.assert_called_once_with(
-            self.settings_dir, core.PORT_0_9_22, loopback_only=True)
+            self.settings_dir, core.PORT_0_9_22, loopback_only=True,
+            bot_excluded_vehicles=["ussr:R11_MS-1"])
         start_worker.assert_called_once_with(
             self.settings_dir, core.LOCAL_HOST, core.DEFAULT_SERVER_PORT)
         run_game.assert_called_once_with(

--- a/launcher/tests/test_launcher_window.py
+++ b/launcher/tests/test_launcher_window.py
@@ -534,11 +534,13 @@ class WindowTest(unittest.TestCase):
             "missing": ("hidden-worker.log",),
             "notRun": (),
         }
+        notice = mock.Mock()
+        tkinter = mock.Mock(messagebox=mock.Mock(showinfo=notice))
         with mock.patch.object(
                 wot_launcher.error_reports, "create_report",
                 return_value=report) as create, mock.patch.object(
                     wot_launcher.error_reports, "select_in_explorer") \
-                as select:
+                as select, mock.patch.dict("sys.modules", {"tkinter": tkinter}):
             self.assertTrue(self.window._create_error_report())
             for unused in range(200):
                 if not self.window._report_busy:
@@ -547,6 +549,11 @@ class WindowTest(unittest.TestCase):
 
         create.assert_called_once_with()
         select.assert_called_once_with(report["path"])
+        notice.assert_called_once_with(
+            "Error report ready",
+            "Please send this ZIP file to the author to report the problem:"
+            "\n\n%s" % report["path"],
+            parent=self.window.root)
         self.assertIn("Created error report", self._log_text())
         self.assertIn("server.log, visible-client.log", self._log_text())
         self.assertIn("hidden-worker.log", self._log_text())

--- a/launcher/tests/test_vehicle_editor_ui.py
+++ b/launcher/tests/test_vehicle_editor_ui.py
@@ -62,6 +62,8 @@ class _FakeTk(object):
     Label = _Widget
     Entry = _Widget
     Button = _Widget
+    Checkbutton = _Widget
+    BooleanVar = _StringVar
     StringVar = _StringVar
 
 
@@ -125,6 +127,9 @@ class _Service(object):
         self.conflict = ""
         self.current = "32"
         self.extra_fields = []
+        self.bot_exclusion = False
+        self.option_calls = []
+        self.option_error = None
         self.choices = [
             {"nation": "ussr", "vehicle": "R11_MS-1",
              "label": "MS-1", "vehicleClass": "lightTank", "level": 1,
@@ -138,6 +143,16 @@ class _Service(object):
              "member": (
                  "scripts/item_defs/vehicles/usa/A01_T1_Cunningham.xml")},
         ]
+
+    def get_vehicle_profile_options(self, game_root, profile_name):
+        return {"excludeEditedVehiclesFromBots": self.bot_exclusion}
+
+    def set_vehicle_profile_options(self, game_root, profile_name, selected):
+        self.option_calls.append((game_root, profile_name, selected))
+        if self.option_error:
+            raise self.VehicleOverlayError(self.option_error)
+        self.bot_exclusion = selected
+        return {"excludeEditedVehiclesFromBots": selected}
 
     def list_vehicle_choices(self, game_root):
         self.catalog_calls.append(game_root)
@@ -254,6 +269,24 @@ class VehicleEditorWindowTest(unittest.TestCase):
             self.parent, "C:/WoT", "Fast MS-1", _FakeTk, _FakeTtk,
             self.messagebox,
             log=self.log.append, service=self.service)
+
+    def test_bot_exclusion_option_saves_and_reloads_this_profile(self):
+        self.assertFalse(self.window.exclude_edited_vehicles_from_bots.get())
+        self.window.exclude_edited_vehicles_from_bots.set(True)
+        self.assertTrue(self.window.save_profile_options())
+        self.assertEqual([("C:/WoT", "Fast MS-1", True)],
+                         self.service.option_calls)
+        reopened = vehicle_editor_ui.VehicleEditorWindow(
+            self.parent, "C:/WoT", "Fast MS-1", _FakeTk, _FakeTtk,
+            self.messagebox, service=self.service)
+        self.assertTrue(reopened.exclude_edited_vehicles_from_bots.get())
+
+    def test_failed_bot_option_save_restores_the_displayed_value(self):
+        self.service.option_error = "profile store is read-only"
+        self.window.exclude_edited_vehicles_from_bots.set(True)
+        self.assertFalse(self.window.save_profile_options())
+        self.assertFalse(self.window.exclude_edited_vehicles_from_bots.get())
+        self.assertFalse(self.service.bot_exclusion)
 
     def test_opening_inspects_and_shows_the_original_contract(self):
         self.assertEqual(["C:/WoT"], self.service.catalog_calls)

--- a/launcher/tests/test_vehicle_overlays.py
+++ b/launcher/tests/test_vehicle_overlays.py
@@ -1858,6 +1858,197 @@ class VehicleOverlayTest(unittest.TestCase):
         self.assertEqual(["Heavy"],
                          vehicle_overlays.list_vehicle_profiles(self.game))
 
+    def _bot_exclusion_profile(self, name="Tuning"):
+        vehicle_overlays.create_vehicle_profile(self.game, name)
+        vehicle_overlays.set_vehicle_profile_options(self.game, name, True)
+        return name
+
+    def _profile_excluded_after_edit(self, member, field_path, value,
+                                     name="Tuning"):
+        vehicle_overlays.apply_profile_edit(
+            self.game, name, member, field_path, value,
+            is_running=lambda: False)
+        return vehicle_overlays.profile_bot_excluded_vehicles(self.game, name)
+
+    def test_bot_exclusion_defaults_false_for_new_and_legacy_profiles(self):
+        vehicle_overlays.create_vehicle_profile(self.game, "New")
+        self.assertEqual(
+            {"excludeEditedVehiclesFromBots": False},
+            vehicle_overlays.get_vehicle_profile_options(self.game, "New"))
+        path = vehicle_overlays.profile_store_path(self.game)
+        with open(path, "r", encoding="utf-8") as stream:
+            store = json.load(stream)
+        store["profiles"][0].pop("excludeEditedVehiclesFromBots", None)
+        with open(path, "w", encoding="utf-8") as stream:
+            json.dump(store, stream)
+        self.assertEqual(
+            {"excludeEditedVehiclesFromBots": False},
+            vehicle_overlays.get_vehicle_profile_options(self.game, "New"))
+        self.assertEqual([], self._profile_excluded_after_edit(
+            self.VEHICLE, "speedLimits/forward", "40", name="New"))
+        self.assertEqual([], vehicle_overlays.profile_bot_excluded_vehicles(
+            self.game, None))
+
+    def test_bot_exclusion_options_are_isolated_and_survive_clear(self):
+        self._bot_exclusion_profile("Fast")
+        vehicle_overlays.create_vehicle_profile(self.game, "Heavy")
+        self.assertEqual(
+            {"excludeEditedVehiclesFromBots": True},
+            vehicle_overlays.get_vehicle_profile_options(self.game, "Fast"))
+        self.assertEqual(
+            {"excludeEditedVehiclesFromBots": False},
+            vehicle_overlays.get_vehicle_profile_options(self.game, "Heavy"))
+        self.assertEqual([], vehicle_overlays.profile_bot_excluded_vehicles(
+            self.game, "Fast"))
+        self.assertEqual(["ussr:R11_MS-1"], self._profile_excluded_after_edit(
+            self.VEHICLE, "speedLimits/forward", "40", name="Fast"))
+        vehicle_overlays.clear_vehicle_profile(
+            self.game, "Fast", is_running=lambda: False)
+        self.assertEqual(
+            {"excludeEditedVehiclesFromBots": True},
+            vehicle_overlays.get_vehicle_profile_options(self.game, "Fast"))
+        self.assertEqual([], vehicle_overlays.profile_bot_excluded_vehicles(
+            self.game, "Fast"))
+
+    def test_bot_exclusion_option_requires_a_boolean_in_api_and_store(self):
+        vehicle_overlays.create_vehicle_profile(self.game, "Tuning")
+        for value in (None, 0, 1, "true", [], {}):
+            with self.subTest(value=value):
+                with self.assertRaises(vehicle_overlays.VehicleOverlayError):
+                    vehicle_overlays.set_vehicle_profile_options(
+                        self.game, "Tuning", value)
+                self.assertEqual(
+                    {"excludeEditedVehiclesFromBots": False},
+                    vehicle_overlays.get_vehicle_profile_options(
+                        self.game, "Tuning"))
+        path = vehicle_overlays.profile_store_path(self.game)
+        with open(path, "r", encoding="utf-8") as stream:
+            original = json.load(stream)
+        for value in (None, 0, 1, "true", [], {}):
+            store = copy.deepcopy(original)
+            store["profiles"][0]["excludeEditedVehiclesFromBots"] = value
+            with open(path, "w", encoding="utf-8") as stream:
+                json.dump(store, stream)
+            with self.subTest(stored_value=value):
+                with self.assertRaises(vehicle_overlays.VehicleOverlayError):
+                    vehicle_overlays.get_vehicle_profile_options(
+                        self.game, "Tuning")
+
+    def test_bot_exclusions_ignore_numeric_noops_and_deduplicate_direct_edits(self):
+        guns = packed.read_packed_xml(self.members[self.GUNS])
+        gun = child(child(guns, "shared").value, "Gun-A").value
+        child(gun, "reloadTime").value = b"2.50"
+        self.members[self.GUNS] = packed.write_packed_xml(guns)
+        self._write_package()
+        self._bot_exclusion_profile()
+        self.assertEqual([], self._profile_excluded_after_edit(
+            self.VEHICLE, "speedLimits/forward", "32"))
+        self.assertEqual([], self._profile_excluded_after_edit(
+            self.GUNS, "shared/Gun-A/reloadTime", "2.5"))
+        self.assertEqual(["ussr:R11_MS-1"], self._profile_excluded_after_edit(
+            self.VEHICLE, "speedLimits/forward", "40"))
+        self.assertEqual(["ussr:R11_MS-1"], self._profile_excluded_after_edit(
+            self.VEHICLE, "speedLimits/backward", "10"))
+        self.assertEqual(["ussr:R11_MS-1"], self._profile_excluded_after_edit(
+            self.VEHICLE, "speedLimits/forward", "32"))
+        self.assertEqual([], self._profile_excluded_after_edit(
+            self.VEHICLE, "speedLimits/backward", "8"))
+
+    def test_bot_exclusions_follow_component_leaves_and_local_overrides(self):
+        root = packed.read_packed_xml(self.members[self.VEHICLE])
+        engines = child(root, "engines").value
+        engines.children = [(b"GAZ-M1", element([
+            (b"power", scalar(packed.TYPE_INTEGER, 95)),
+        ]))]
+        self.members[self.VEHICLE] = packed.write_packed_xml(root)
+        engines_root = packed.read_packed_xml(self.members[self.ENGINES])
+        shared = child(engines_root, "shared").value
+        shared.children.append((b"Unused", copy.deepcopy(
+            child(shared, "GAZ-M1"))))
+        self.members[self.ENGINES] = packed.write_packed_xml(engines_root)
+        self._write_package()
+        self._bot_exclusion_profile()
+        self.assertEqual([], self._profile_excluded_after_edit(
+            self.ENGINES, "shared/Unused/power", "120"))
+        self.assertEqual(
+            ["ussr:Observer", "ussr:R12_Test"],
+            self._profile_excluded_after_edit(
+                self.ENGINES, "shared/GAZ-M1/power", "120"))
+        self.assertEqual(
+            ["ussr:Observer", "ussr:R11_MS-1", "ussr:R12_Test"],
+            self._profile_excluded_after_edit(
+                self.ENGINES, "shared/GAZ-M1/maxHealth", "60"))
+
+    def test_bot_exclusions_keep_a_shared_gun_user_with_one_inherited_mount(self):
+        root = packed.read_packed_xml(self.members[self.VEHICLE])
+        turrets = child(root, "turrets0").value
+        turret = child(turrets, "T-18_mod").value
+        gun = child(child(turret, "guns").value, "Gun-A").value
+        gun.children.append((b"reloadTime", scalar(packed.TYPE_STRING, b"3.2")))
+        self.members[self.VEHICLE] = packed.write_packed_xml(root)
+        self._write_package()
+        self._bot_exclusion_profile()
+        self.assertEqual(
+            ["ussr:Observer", "ussr:R12_Test"],
+            self._profile_excluded_after_edit(
+                self.GUNS, "shared/Gun-A/reloadTime", "1.5"))
+        second = copy.deepcopy(turret)
+        child(child(second, "guns").value, "Gun-A").value.children = []
+        turrets.children.append((b"Second-turret", element(second.children)))
+        self.members[self.VEHICLE] = packed.write_packed_xml(root)
+        self._write_package()
+        self.assertEqual(
+            ["ussr:Observer", "ussr:R11_MS-1", "ussr:R12_Test"],
+            vehicle_overlays.profile_bot_excluded_vehicles(self.game, "Tuning"))
+
+    def test_bot_exclusions_follow_shell_users_across_distinct_guns(self):
+        guns_root = packed.read_packed_xml(self.members[self.GUNS])
+        shared = child(guns_root, "shared").value
+        shared.children.append((b"Gun-B", copy.deepcopy(child(shared, "Gun-A"))))
+        third = copy.deepcopy(child(shared, "Gun-A"))
+        shots = child(third.value, "shots").value
+        shots.children = [(b"Shell-B", value) for unused, value in shots.children]
+        shared.children.append((b"Gun-C", third))
+        self.members[self.GUNS] = packed.write_packed_xml(guns_root)
+        for member, gun_name in ((self.VEHICLE_TWO, b"Gun-B"),
+                                 (self.OBSERVER, b"Gun-C")):
+            root = packed.read_packed_xml(self.members[member])
+            turret = child(child(root, "turrets0").value, "T-18_mod").value
+            child(turret, "guns").value.children = [(gun_name, element([]))]
+            self.members[member] = packed.write_packed_xml(root)
+        self._write_package()
+        self._bot_exclusion_profile("Shot")
+        self.assertEqual(["ussr:R11_MS-1"], self._profile_excluded_after_edit(
+            self.GUNS, "shared/Gun-A/shots/Shell-A/piercingPower", "30 24",
+            name="Shot"))
+        self._bot_exclusion_profile("Shell")
+        self.assertEqual(
+            ["ussr:R11_MS-1", "ussr:R12_Test"],
+            self._profile_excluded_after_edit(
+                self.SHELLS, "Shell-A/damage/armor", "20", name="Shell"))
+
+    def test_bot_exclusions_map_direct_and_shared_siege_edits_to_base_vehicle(self):
+        self._install_siege_pair()
+        self._bot_exclusion_profile("Direct siege")
+        self.assertEqual(["ussr:R13_Siege"], self._profile_excluded_after_edit(
+            self.SIEGE_MODE, "speedLimits/forward", "10", name="Direct siege"))
+        self.assertEqual(["ussr:R13_Siege"], self._profile_excluded_after_edit(
+            self.SIEGE_VEHICLE, "hull/weight", "2500", name="Direct siege"))
+        siege_root = packed.read_packed_xml(self.members[self.SIEGE_MODE])
+        child(siege_root, "engines").value.children = [
+            (b"Siege-engine", scalar(packed.TYPE_STRING, b"shared"))]
+        self.members[self.SIEGE_MODE] = packed.write_packed_xml(siege_root)
+        engines_root = packed.read_packed_xml(self.members[self.ENGINES])
+        shared = child(engines_root, "shared").value
+        shared.children.append((b"Siege-engine", copy.deepcopy(
+            child(shared, "GAZ-M1"))))
+        self.members[self.ENGINES] = packed.write_packed_xml(engines_root)
+        self._write_package()
+        self._bot_exclusion_profile("Shared siege")
+        self.assertEqual(["ussr:R13_Siege"], self._profile_excluded_after_edit(
+            self.ENGINES, "shared/Siege-engine/power", "120",
+            name="Shared siege"))
+
     def test_profile_names_are_trimmed_case_unique_and_reserve_original(self):
         self.assertEqual("Fast", vehicle_overlays.create_vehicle_profile(
             self.game, "  Fast  "))

--- a/launcher/vehicle_editor_ui.py
+++ b/launcher/vehicle_editor_ui.py
@@ -67,6 +67,9 @@ _CHINESE = {
     "Replacement value": "新值",
     "Save field to profile": "保存到方案",
     "Clear all edits in this profile...": "清除该方案的全部修改…",
+    "Exclude edited vehicles from automatic Bots (exact lineup overrides)":
+        "随机/自动 Bot 不使用受此方案修改影响的车辆（精确阵容除外）",
+    "Bot exclusion option saved.": "已保存 Bot 车辆排除选项。",
     "Choose a vehicle field.": "请选择一项车辆属性。",
     "Choose one listed vehicle field.": "请选择列表中的一项车辆属性。",
     "Field is safe to edit.": "该属性可以安全修改。",
@@ -203,6 +206,7 @@ class VehicleEditorWindow(object):
         self._field_by_label = {}
         self._field_by_key = {}
         self._build(parent)
+        self._load_profile_options()
         self.refresh_catalog()
 
     def _build(self, parent):
@@ -244,7 +248,17 @@ class VehicleEditorWindow(object):
         self.overlay_path = tk.StringVar(value="-")
         self.status = tk.StringVar(value=self._t("Choose a vehicle field."))
 
-        row = 1
+        self.exclude_edited_vehicles_from_bots = tk.BooleanVar(value=False)
+        self.bot_exclusion_button = tk.Checkbutton(
+            frame, text=self._t(
+                "Exclude edited vehicles from automatic Bots "
+                "(exact lineup overrides)"),
+            variable=self.exclude_edited_vehicles_from_bots,
+            command=self.save_profile_options)
+        self.bot_exclusion_button.grid(
+            row=1, column=0, columnspan=3, sticky="w", pady=(0, 8))
+
+        row = 2
         row, self.nation_box = self._selector_row(
             frame, row, self._t("Nation"), self.nation,
             self._t("Only nations found in the original vehicle definitions."))
@@ -830,6 +844,28 @@ class VehicleEditorWindow(object):
         self.armor_viewer.update_field(
             member, field_path, result["currentValue"])
         self._log("Vehicle data editor: %s" % message)
+        return True
+
+    def _load_profile_options(self):
+        try:
+            options = self._service.get_vehicle_profile_options(
+                self._game_root, self._profile_name)
+        except self._service.VehicleOverlayError as error:
+            self.bot_exclusion_button.config(state="disabled")
+            return self._show_error(error)
+        self.exclude_edited_vehicles_from_bots.set(
+            options["excludeEditedVehiclesFromBots"])
+        return True
+
+    def save_profile_options(self):
+        selected = bool(self.exclude_edited_vehicles_from_bots.get())
+        try:
+            self._service.set_vehicle_profile_options(
+                self._game_root, self._profile_name, selected)
+        except self._service.VehicleOverlayError as error:
+            self.exclude_edited_vehicles_from_bots.set(not selected)
+            return self._show_error(error)
+        self.status.set(self._t("Bot exclusion option saved."))
         return True
 
     def restore_defaults(self):

--- a/launcher/vehicle_overlays.py
+++ b/launcher/vehicle_overlays.py
@@ -2705,6 +2705,10 @@ def _validate_profile_store(value):
         if not isinstance(profile.get("members"), list):
             raise VehicleOverlayError(
                 "A vehicle profile member list is invalid.")
+        if not isinstance(profile.get("excludeEditedVehiclesFromBots", False),
+                          bool):
+            raise VehicleOverlayError(
+                "The vehicle profile Bot exclusion option must be a boolean.")
         _profile_manifest(profile)
     return value
 
@@ -2867,6 +2871,136 @@ def _profile_index(store, profile_name):
     return matches[0]
 
 
+def _profile_changed_fields(profile, source_root):
+    """Return actual numeric changes, including normalized string scalars."""
+    changed = set()
+    for entry in profile["members"]:
+        member = entry["sourceMember"]
+        root = source_root(member)
+        for edit in entry["edits"]:
+            field_path = edit["fieldPath"]
+            rule = _field_rule(member, field_path)
+            original = _find_value(root, field_path)
+            _validate_original(original, rule)
+            original_value = _manifest_scalar(original)
+            if (edit["originalPackedType"] !=
+                    _TYPE_NAMES.get(original.value_type) or
+                    not _same_recorded_value(
+                        edit["originalValue"], original_value,
+                        original.value_type)):
+                raise VehicleOverlayError(
+                    "The original package contract changed for this saved edit.")
+            unused_original, normalized_original = _parse_replacement(
+                original_value, original, rule)
+            unused_replacement, normalized_replacement = _parse_replacement(
+                edit["replacementValue"], original, rule)
+            if normalized_original != normalized_replacement:
+                changed.add((member, field_path))
+    return changed
+
+
+def _profile_component_uses(root, shared_components, guns_root):
+    """Index component occurrences and their local overrides once per mode."""
+    uses = _vehicle_shared_component_occurrences(root, shared_components)
+    uses["guns"] = _vehicle_local_gun_overrides(root)
+    references = _vehicle_component_references(root, shared_components)
+    uses["turrets"] = dict((name, (set(),))
+                          for name in references["turrets"])
+    if guns_root is not None:
+        shells = _gun_shell_references(guns_root, references["guns"])
+        # The exact client also has vehicle-local shots on Observer.
+        for occurrences in uses["guns"].values():
+            for paths in occurrences:
+                shells.update(path.split("/")[1] for path in paths
+                              if path.startswith("shots/"))
+        uses["shells"] = dict((name, (set(),)) for name in shells)
+    return uses
+
+
+def profile_bot_excluded_vehicles(game_root, profile_name):
+    """List canonical Bot names affected by an opted-in profile's edits."""
+    if profile_name is None or profile_name == "":
+        return []
+    status, package_path = _require_target(game_root)
+    store, unused_exists = _load_profile_store(status["path"])
+    profile = store["profiles"][_profile_index(store, profile_name)]
+    if (not profile.get("excludeEditedVehiclesFromBots", False) or
+            not profile["members"]):
+        return []
+
+    try:
+        with zipfile.ZipFile(package_path, "r") as archive:
+            counts = {}
+            for info in archive.infolist():
+                counts[info.filename] = counts.get(info.filename, 0) + 1
+            roots = {}
+
+            def source_root(member):
+                if member not in roots:
+                    if counts.get(member) != 1:
+                        raise VehicleOverlayError(
+                            "A vehicle topology member is missing or repeated: "
+                            "%s" % member)
+                    roots[member] = packed_xml.read_packed_xml(
+                        archive.read(member))
+                return roots[member]
+
+            changed = _profile_changed_fields(profile, source_root)
+            if not changed:
+                return []
+            nations = set(member.split("/")[3] for member, unused in changed)
+            affected = set()
+            for nation in sorted(nations):
+                roster = _vehicle_roster_from_archive(
+                    archive, counts, nation=nation)
+                component_roots = {}
+                component_edits = []
+                for member, field_path in sorted(changed):
+                    match = _COMPONENT_MEMBER.fullmatch(member)
+                    if match is not None and match.group(1) == nation:
+                        category = match.group(2)
+                        component_roots[category] = source_root(member)
+                        component_edits.append((
+                            category, _component_name(category, field_path),
+                            "/".join(_field_parts(field_path)[
+                                1 if category == "shells" else 2:])))
+                guns_member = (
+                    "scripts/item_defs/vehicles/%s/components/guns.xml" %
+                    nation)
+                guns_root = (source_root(guns_member)
+                             if any(edit[0] == "shells"
+                                    for edit in component_edits) else None)
+                shared_components = dict(
+                    (category, _shared_component_names(root))
+                    for category, root in component_roots.items())
+                direct_members = set(member for member, unused in changed
+                                     if _VEHICLE_MEMBER.fullmatch(member))
+                for record in roster:
+                    members = [record["member"]]
+                    peer = _siege_peer_member(record["member"])
+                    if counts.get(peer, 0):
+                        members.append(peer)
+                    for member in members:
+                        uses = (_profile_component_uses(
+                            source_root(member), shared_components, guns_root)
+                            if component_edits else {})
+                        if (member in direct_members or any(
+                                any(suffix not in overrides for overrides in
+                                    uses.get(category, {}).get(component, ()))
+                                for category, component, suffix
+                                in component_edits)):
+                            affected.add(bot_lineup_profiles.vehicle_type_name(
+                                record))
+                            break
+            return sorted(affected)
+    except VehicleOverlayError:
+        raise
+    except (IOError, OSError, KeyError, TypeError, ValueError,
+            zipfile.BadZipFile) as error:
+        raise VehicleOverlayError(
+            "The original vehicle topology is unreadable: %s" % error)
+
+
 def list_vehicle_profiles(game_root):
     """List saved profiles without materializing anything into res_mods."""
     status, unused_package = _require_target(game_root)
@@ -2874,6 +3008,28 @@ def list_vehicle_profiles(game_root):
     return sorted(
         (profile["name"] for profile in store["profiles"]),
         key=lambda name: name.casefold())
+
+
+def get_vehicle_profile_options(game_root, profile_name):
+    status, unused_package = _require_target(game_root)
+    store, unused_exists = _load_profile_store(status["path"])
+    profile = store["profiles"][_profile_index(store, profile_name)]
+    return {"excludeEditedVehiclesFromBots": profile.get(
+        "excludeEditedVehiclesFromBots", False)}
+
+
+def set_vehicle_profile_options(game_root, profile_name,
+                                exclude_edited_vehicles_from_bots):
+    if not isinstance(exclude_edited_vehicles_from_bots, bool):
+        raise VehicleOverlayError(
+            "The vehicle profile Bot exclusion option must be a boolean.")
+    status, unused_package = _require_target(game_root)
+    store, unused_exists = _load_profile_store(status["path"])
+    profile = store["profiles"][_profile_index(store, profile_name)]
+    profile["excludeEditedVehiclesFromBots"] = exclude_edited_vehicles_from_bots
+    profile["updatedAt"] = _now()
+    _save_profile_store(status["path"], store)
+    return {"excludeEditedVehiclesFromBots": exclude_edited_vehicles_from_bots}
 
 
 def create_vehicle_profile(game_root, profile_name):
@@ -2890,6 +3046,7 @@ def create_vehicle_profile(game_root, profile_name):
         "createdAt": timestamp,
         "updatedAt": timestamp,
         "members": [],
+        "excludeEditedVehiclesFromBots": False,
     })
     store["profiles"].sort(key=lambda profile: profile["name"].casefold())
     _save_profile_store(status["path"], store)
@@ -3072,13 +3229,17 @@ def prepare_vehicle_profile(game_root, profile_name=None, is_running=None):
             "profile": None,
             "installedMembers": 0,
             "removedMembers": removed,
+            "botExcludedVehicles": [],
         }
+    bot_excluded_vehicles = profile_bot_excluded_vehicles(
+        game_root, profile_name)
     installed = activate_vehicle_profile(
         game_root, profile_name, is_running=is_running)
     return {
         "profile": _normalize_profile_name(profile_name),
         "installedMembers": installed,
         "removedMembers": 0,
+        "botExcludedVehicles": bot_excluded_vehicles,
     }
 
 

--- a/launcher/wot_launcher.py
+++ b/launcher/wot_launcher.py
@@ -289,6 +289,9 @@ _CHINESE = {
     "The latest diagnostic session boundary is unreadable.":
         "最近一局的日志边界无法读取；不会打包旧日志。",
     "Created error report: %s": "已创建错误报告：%s",
+    "Error report ready": "错误报告已生成",
+    "Please send this ZIP file to the author to report the problem:\n\n%s":
+        "请将下面的 ZIP 文件发送给作者，以便排查问题：\n\n%s",
     "Included files: %s": "已包含文件：%s",
     "Missing logs from this session: %s": "本局缺少日志：%s",
     "Not run in this session: %s": "本局未运行：%s",
@@ -1890,6 +1893,8 @@ class LauncherWindow(object):
                     self._log(self._t(
                         "Could not select the report in Windows Explorer: "
                         "%s") % error)
+                self.root.after(
+                    0, lambda: self._show_report_send_reminder(result["path"]))
             finally:
                 self._report_busy = False
                 self.root.after(0, self._update_action_controls)
@@ -1898,6 +1903,16 @@ class LauncherWindow(object):
         thread.daemon = True
         thread.start()
         return True
+
+    def _show_report_send_reminder(self, report_path):
+        from tkinter import messagebox
+
+        messagebox.showinfo(
+            self._t("Error report ready"),
+            self._t(
+                "Please send this ZIP file to the author to report the "
+                "problem:\n\n%s") % report_path,
+            parent=self.root)
 
     def _confirm_enable_crash_capture(self):
         from tkinter import messagebox

--- a/launcher/wot_launcher.py
+++ b/launcher/wot_launcher.py
@@ -2526,6 +2526,9 @@ class LauncherWindow(object):
                     "persistent": True,
                     "require_owned": True,
                 }
+                if prepared.get("botExcludedVehicles"):
+                    start_options["bot_excluded_vehicles"] = prepared[
+                        "botExcludedVehicles"]
                 if bot_lineup:
                     start_options["bot_lineup"] = bot_lineup
                 started = self._start_server(
@@ -2667,6 +2670,8 @@ class LauncherWindow(object):
                 else:
                     prepared = vehicle_overlays.prepare_vehicle_profile(
                         game_root, session.get("vehicle_profile"))
+                    session["bot_excluded_vehicles"] = prepared.get(
+                        "botExcludedVehicles", [])
                     if prepared["profile"] is None:
                         self._log(
                             "No launcher-owned vehicle profile is active; "
@@ -2689,6 +2694,9 @@ class LauncherWindow(object):
                 }
                 if session.get("bot_lineup"):
                     start_options["bot_lineup"] = session["bot_lineup"]
+                if session.get("bot_excluded_vehicles"):
+                    start_options["bot_excluded_vehicles"] = session[
+                        "bot_excluded_vehicles"]
                 started = self._start_server(
                     game_root, session["client"], **start_options)
                 if not started:
@@ -2914,21 +2922,24 @@ class LauncherWindow(object):
 
     def _start_server(self, game_root, port_version,
                       loopback_only=False, persistent=False,
-                      bot_lineup=None, require_owned=False):
+                      bot_lineup=None, require_owned=False,
+                      bot_excluded_vehicles=None):
         requested_context = {
             "game_root": os.path.normcase(os.path.realpath(
                 os.path.abspath(game_root))),
             "port_version": port_version,
             "loopback_only": bool(loopback_only),
             "bot_lineup": list(bot_lineup or ()),
+            "bot_excluded_vehicles": sorted(set(bot_excluded_vehicles or ())),
         }
         if self._server_is_running():
             current_context = dict(self._server_context or {})
             current_context.setdefault("bot_lineup", [])
+            current_context.setdefault("bot_excluded_vehicles", [])
             if current_context != requested_context:
                 self._log(
                     "The launcher-owned LAN server uses a different game "
-                    "or visibility setting, or a different exact lineup. "
+                    "or visibility setting, or different Bot roster rules. "
                     "Stop it before starting this session.")
                 return False
             self._log("Reusing the launcher-owned %s LAN server." %
@@ -2945,9 +2956,10 @@ class LauncherWindow(object):
                     "compatible server already uses port %d. Close it "
                     "first." % core.DEFAULT_SERVER_PORT)
                 return False
-            if bot_lineup:
+            if bot_lineup or bot_excluded_vehicles:
                 self._log(
-                    "The exact Bot lineup needs a fresh launcher-owned "
+                    "The exact Bot lineup or vehicle exclusions need a "
+                    "fresh launcher-owned "
                     "server. Stop the compatible server already using port "
                     "%d first." % core.DEFAULT_SERVER_PORT)
                 return False
@@ -2962,7 +2974,8 @@ class LauncherWindow(object):
         command = core.server_child_command(port_version)
         environment = core.server_environment(
             port_version, game_root, loopback_only=loopback_only,
-            bot_lineup=bot_lineup)
+            bot_lineup=bot_lineup,
+            bot_excluded_vehicles=bot_excluded_vehicles)
         server_log_path = core.server_log_path()
         report_session = self._active_report_session
         if report_session is not None:

--- a/server/lan_battle_server.py
+++ b/server/lan_battle_server.py
@@ -2175,7 +2175,7 @@ class BattleState:
                  team_size=15,
                  receipt_state_path=None, team1_size=None, team2_size=None,
                  bot_tier_mode='random', bot_lineup=None,
-                 bot_skill_mode=None):
+                 bot_skill_mode=None, bot_excluded_vehicles=None):
         self.map_option = map_name
         self.map_name = self._choose_map()
         self.client_build = None
@@ -2191,6 +2191,8 @@ class BattleState:
         self.bot_skill_mode = bot_gunnery.normalize_skill_mode(
             bot_skill_mode)
         self.bot_lineup = self._normalize_bot_lineup(bot_lineup)
+        self.bot_excluded_vehicles = self._normalize_bot_excluded_vehicles(
+            bot_excluded_vehicles)
         # Keep the old scalar on the wire for older protocol-v5 consumers.
         # New consumers use team_sizes; max remains a safe roster upper bound.
         self.team_size = max(team1_size, team2_size)
@@ -2316,6 +2318,19 @@ class BattleState:
         self.last_projectile_resolve_reject = ""
         self.last_projectile_resolve_reject_code = ""
         self._logged_protocol_reject_codes = {}
+
+    @staticmethod
+    def _normalize_bot_excluded_vehicles(value):
+        if value is None:
+            return []
+        if not isinstance(value, (list, tuple)) or len(value) > 4096:
+            raise ValueError("invalid Bot vehicle exclusions")
+        for name in value:
+            if (not isinstance(name, str) or len(name) > 96 or
+                    re.fullmatch(r"[a-z][a-z0-9_]*:[A-Za-z0-9][A-Za-z0-9_.-]*",
+                                 name) is None):
+                raise ValueError("invalid Bot vehicle exclusion name")
+        return sorted(set(value))
 
     @staticmethod
     def _normalize_bot_lineup(value):
@@ -3658,6 +3673,7 @@ class BattleState:
                 "bot_tier_mode": self.bot_tier_mode,
                 "bot_skill_mode": self.bot_skill_mode,
                 "bot_lineup": list(self.bot_lineup),
+                "bot_excluded_vehicles": list(self.bot_excluded_vehicles),
                 "bot_authority_id": self.bot_authority_id,
                 "bot_manifest": list(self.bot_manifest),
                 "bot_order_revision": self.bot_orders["revision"],
@@ -4338,6 +4354,7 @@ class BattleState:
                 "bot_tier_mode": self.bot_tier_mode,
                 "bot_skill_mode": self.bot_skill_mode,
                 "bot_lineup": list(self.bot_lineup),
+                "bot_excluded_vehicles": list(self.bot_excluded_vehicles),
                 "bot_authority_id": self.bot_authority_id,
                 "bot_manifest": takeover_manifest,
                 "bot_order_revision": self.bot_orders["revision"],
@@ -13785,6 +13802,7 @@ class BattleState:
                     "bot_tier_mode": self.bot_tier_mode,
                     "bot_skill_mode": self.bot_skill_mode,
                     "bot_lineup": list(self.bot_lineup),
+                    "bot_excluded_vehicles": list(self.bot_excluded_vehicles),
                     "bot_authority_id": self.bot_authority_id,
                     "authority_epoch": self.authority_epoch,
                     "server_time_ms": self._server_time_ms(),
@@ -14778,7 +14796,7 @@ def run_server(host, port, map_name, max_players,
                team1_size=None, team2_size=None,
                bot_tier_mode="random", bot_lineup=None,
                bot_skill_mode=None,
-               vehicle_overlay_root=None):
+               vehicle_overlay_root=None, bot_excluded_vehicles=None):
     if receipt_state_path is None:
         receipt_state_path = _default_result_receipt_state_path(port)
     state = BattleState(map_name=map_name, max_players=max_players,
@@ -14787,7 +14805,8 @@ def run_server(host, port, map_name, max_players,
                         team1_size=team1_size, team2_size=team2_size,
                         bot_tier_mode=bot_tier_mode,
                         bot_lineup=bot_lineup,
-                        bot_skill_mode=bot_skill_mode)
+                        bot_skill_mode=bot_skill_mode,
+                        bot_excluded_vehicles=bot_excluded_vehicles)
     if vehicle_overlay_root:
         try:
             overlay = VehicleOverlayStore(vehicle_overlay_root)

--- a/server/windows_server.py
+++ b/server/windows_server.py
@@ -20,6 +20,7 @@ SERVER_TEAM_SIZE_ENV = "WOT_0922_TEAM_SIZE"
 SERVER_TEAM1_SIZE_ENV = "WOT_0922_TEAM1_SIZE"
 SERVER_TEAM2_SIZE_ENV = "WOT_0922_TEAM2_SIZE"
 SERVER_BOT_LINEUP_ENV = "WOT_0922_BOT_LINEUP"
+SERVER_BOT_EXCLUDED_VEHICLES_ENV = "WOT_0922_BOT_EXCLUDED_VEHICLES"
 SERVER_LOOPBACK_ONLY_ENV = "WOT_0922_LOOPBACK_ONLY"
 SERVER_VEHICLE_OVERLAY_ROOT_ENV = "WOT_0922_VEHICLE_OVERLAY_ROOT"
 BUILD_SEMANTIC_VERSION_ENV = "WOT_OFFLINE_SEMANTIC_VERSION"
@@ -229,6 +230,20 @@ def _vehicle_overlay_root_from_environment(environment=None):
     return str(root).strip()
 
 
+def _bot_excluded_vehicles_from_environment(environment=None):
+    environment = os.environ if environment is None else environment
+    raw_value = environment.get(SERVER_BOT_EXCLUDED_VEHICLES_ENV)
+    if raw_value is None:
+        return []
+    try:
+        value = json.loads(raw_value)
+    except (TypeError, ValueError) as error:
+        raise ValueError("invalid Bot vehicle exclusions JSON: %s" % error)
+    if not isinstance(value, list):
+        raise ValueError("Bot vehicle exclusions must be a JSON list")
+    return value
+
+
 def _session_identity(environment=None):
     """Return launcher-supplied diagnostic labels without validating peers."""
     environment = os.environ if environment is None else environment
@@ -258,6 +273,7 @@ def main():
         default_map, run_server = _load_server()
         team1_size, team2_size = _team_sizes_from_environment()
         bot_lineup = _bot_lineup_from_environment()
+        bot_excluded_vehicles = _bot_excluded_vehicles_from_environment()
         vehicle_overlay_root = _vehicle_overlay_root_from_environment()
         if not loopback_only:
             _ensure_windows_firewall_rule(SERVER_PORT)
@@ -267,6 +283,7 @@ def main():
             team1_size=team1_size,
             team2_size=team2_size,
             bot_lineup=bot_lineup,
+            bot_excluded_vehicles=bot_excluded_vehicles,
             vehicle_overlay_root=vehicle_overlay_root,
         )
     except Exception:

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -3097,9 +3097,11 @@ class BattleRuntime(object):
             # this one startup callback; bot presentation staggering is a
             # separate later phase and never throttles this prewarm.
             lineup_ready = self._prepare_bot_vehicle_assignments(descriptor)
-            if self._start_message.get('bot_lineup') and not lineup_ready:
+            if (self._start_message.get('bot_lineup') or
+                    self._start_message.get('bot_excluded_vehicles')) and \
+                    not lineup_ready:
                 raise RuntimeError(
-                    'the exact Bot lineup is not available in this client')
+                    'the configured Bot roster is not available in this client')
             prewarm_enabled = getattr(
                 self._remote_factory, 'prewarm_wrecks_enabled', None)
             if callable(prewarm_enabled) and prewarm_enabled():
@@ -4638,6 +4640,8 @@ class BattleRuntime(object):
             tier = int(player_profile['level'])
             tier_mode = bot_planner.normalize_bot_tier_mode(
                 self._start_message.get('bot_tier_mode'))
+            excluded_names = set(
+                self._start_message.get('bot_excluded_vehicles') or ())
             all_candidates = []
             for nation in self._runtime.nations.AVAILABLE_NAMES:
                 nation_id = self._runtime.nations.INDICES[nation]
@@ -4654,6 +4658,14 @@ class BattleRuntime(object):
             ]
             if not candidates:
                 return False
+            automatic_candidates = [candidate for candidate in candidates
+                                    if candidate['name'] not in excluded_names]
+            if automatic_candidates:
+                candidates = automatic_candidates
+            # If every candidate was excluded, retain the template shape only
+            # until explicit slot overrides below can fill a fully pinned team.
+            # The final automatic pool and completeness check still forbid a
+            # fallback to an excluded player tank.
             candidates.sort(key=lambda value: (
                 int(value.get('level', 0)),
                 self._vehicle_class_order(value),
@@ -4738,18 +4750,26 @@ class BattleRuntime(object):
             template = bot_planner.build_match_template(
                 candidates, team_size, player_profile, match_tiers,
                 lineup_random, requirements)
+            automatic_candidates = [
+                candidate for candidate in candidates
+                if candidate['name'] not in excluded_names]
 
             assignments = {}
             for team in (1, 2):
                 team_bots = bots_by_team[team]
                 picked = bot_planner.remaining_match_template(
                     template, humans_by_team[team])
+                # Human tier/class reservations may mirror their exact tank.
+                # Apply profile exclusions after removing human slots so that
+                # those reservations cannot put an edited tank back in a Bot.
+                picked = [entry for entry in picked
+                          if entry['name'] not in excluded_names]
                 # Apply the bot-only quota after removing human slots. A human
                 # SPG must not force mirrored artillery onto the opposing bots.
                 # Explicit lineup overrides below retain the host's choices.
                 picked = bot_planner.select_bot_lineup(
-                    picked or candidates, len(team_bots), spg_limit=0,
-                    fallback_candidates=candidates)
+                    picked or automatic_candidates, len(team_bots),
+                    spg_limit=0, fallback_candidates=automatic_candidates)
                 picked = list(picked[:len(team_bots)])
                 lineup_random.shuffle(picked)
                 picked.sort(key=self._vehicle_class_order)
@@ -4758,6 +4778,8 @@ class BattleRuntime(object):
                         entry['name']
             allowed_names = set(
                 candidate['name'] for candidate in all_candidates)
+            bot_slots = set((team, int(raw.get('slot', 0)))
+                            for team in (1, 2) for raw in bots_by_team[team])
             for raw in self._start_message.get('bot_lineup') or ():
                 if not isinstance(raw, dict):
                     self._bot_vehicle_assignments = {}
@@ -4779,8 +4801,11 @@ class BattleRuntime(object):
                 if vehicle not in allowed_names:
                     self._bot_vehicle_assignments = {}
                     return False
-                if (team, slot) in assignments:
+                if (team, slot) in bot_slots:
                     assignments[(team, slot)] = vehicle
+            if excluded_names and set(assignments) != bot_slots:
+                self._bot_vehicle_assignments = {}
+                return False
             self._bot_vehicle_assignments = assignments
             return True
         except Exception:

--- a/tests/test_port_0922_bot_lineup_integration.py
+++ b/tests/test_port_0922_bot_lineup_integration.py
@@ -154,6 +154,72 @@ class BotLineupIntegrationTests(unittest.TestCase):
         self.assertEqual({(1, 1): 'ussr:regular', (2, 0): 'ussr:artillery'},
                          battle._bot_vehicle_assignments)
 
+    def _profile_exclusion_runtime(self, worker, mode, excluded, lineup=()):
+        names = ('ussr:Edited', 'usa:Regular', 'germany:Regular')
+        entries = {
+            index: types.SimpleNamespace(
+                name=name, level=8,
+                tags=('heavyTank' if index == 0 else 'mediumTank',))
+            for index, name in enumerate(names)
+        }
+        descriptor = types.SimpleNamespace(type=entries[0])
+        battle = BattleRuntime.__new__(BattleRuntime)
+        battle._runtime = types.SimpleNamespace(
+            nations=types.SimpleNamespace(
+                AVAILABLE_NAMES=('all',), INDICES={'all': 0}),
+            vehicles=types.SimpleNamespace(g_list=types.SimpleNamespace(
+                getList=lambda unused: entries)))
+        battle._worker_mode = worker
+        battle._config = {'vehicle': names[0]}
+        battle.client = types.SimpleNamespace(team=1, player_id=1)
+        battle._resolve_descriptor = lambda unused: descriptor
+        battle._start_message = {
+            'round_id': 21, 'map': '01_karelia',
+            'players': [{'id': 1, 'team': 1, 'slot': 0, 'vehicle': names[0]}],
+            'bots': [{'id': team * 100 + slot, 'team': team, 'slot': slot}
+                     for team in (1, 2) for slot in range(1 if team == 1 else 0, 4)],
+            'bot_tier_mode': mode, 'bot_excluded_vehicles': excluded,
+            'bot_lineup': list(lineup),
+        }
+        return battle, descriptor
+
+    def test_profile_exclusions_cover_automatic_and_mirrored_human_vehicles(self):
+        for mode in bot_planner.BOT_TIER_MODES:
+            assignments = []
+            for worker in (False, True):
+                battle, descriptor = self._profile_exclusion_runtime(
+                    worker, mode, ['ussr:Edited'],
+                    [{'team': 2, 'slot': 0, 'skill': 'veteran'}])
+                self.assertTrue(battle._prepare_bot_vehicle_assignments(descriptor))
+                self.assertEqual(7, len(battle._bot_vehicle_assignments))
+                self.assertNotIn('ussr:Edited',
+                                 battle._bot_vehicle_assignments.values())
+                assignments.append(battle._bot_vehicle_assignments)
+            self.assertEqual(assignments[0], assignments[1])
+
+    def test_profile_exclusions_allow_only_slots_with_an_explicit_vehicle(self):
+        battle, descriptor = self._profile_exclusion_runtime(
+            True, 'same', ['ussr:Edited'],
+            [{'team': 2, 'slot': 0, 'vehicle': 'ussr:Edited'},
+             {'team': 2, 'slot': 1, 'skill': 'veteran'}])
+        self.assertTrue(battle._prepare_bot_vehicle_assignments(descriptor))
+        self.assertEqual([(2, 0)], [key for key, name in
+                         battle._bot_vehicle_assignments.items()
+                         if name == 'ussr:Edited'])
+
+    def test_all_excluded_pool_requires_every_bot_to_have_an_exact_vehicle(self):
+        excluded = ['ussr:Edited', 'usa:Regular', 'germany:Regular']
+        battle, descriptor = self._profile_exclusion_runtime(True, 'same', excluded)
+        self.assertFalse(battle._prepare_bot_vehicle_assignments(descriptor))
+        self.assertEqual({}, battle._bot_vehicle_assignments)
+        battle._start_message['bot_lineup'] = [
+            {'team': raw['team'], 'slot': raw['slot'], 'vehicle': 'ussr:Edited'}
+            for raw in battle._start_message['bots']]
+        self.assertTrue(battle._prepare_bot_vehicle_assignments(descriptor))
+        self.assertEqual(7, len(battle._bot_vehicle_assignments))
+        self.assertEqual({'ussr:Edited'},
+                         set(battle._bot_vehicle_assignments.values()))
+
     def _ui_saved_assignment(self):
         store, profile_name = bot_lineup_profiles.create(
             bot_lineup_profiles.empty_store(), "Exact duel")
@@ -192,10 +258,13 @@ class BotLineupIntegrationTests(unittest.TestCase):
 
         environment = launcher_core.server_environment(
             launcher_core.PORT_0_9_22, "/game", {},
-            bot_lineup=assignments)
+            bot_lineup=assignments, bot_excluded_vehicles=[expected_name])
         server_lineup = windows_server._bot_lineup_from_environment(
             environment)
         self.assertEqual(assignments, server_lineup)
+        exclusions = windows_server._bot_excluded_vehicles_from_environment(
+            environment)
+        self.assertEqual([expected_name], exclusions)
 
         roster = ({"id": 21, "team": 2, "slot": 0},)
         entries = {
@@ -228,6 +297,7 @@ class BotLineupIntegrationTests(unittest.TestCase):
             "bots": list(roster),
             "bot_tier_mode": "same",
             "bot_lineup": server_lineup,
+            "bot_excluded_vehicles": exclusions,
         }
         battle.client = types.SimpleNamespace(team=1, player_id=1)
         battle._resolve_descriptor = descriptors.__getitem__

--- a/tests/test_port_0922_server_team_size.py
+++ b/tests/test_port_0922_server_team_size.py
@@ -76,6 +76,38 @@ def _attach_worker(state):
 
 
 class ServerTeamSizeTests(unittest.TestCase):
+    def test_profile_bot_exclusions_survive_every_battle_start_delivery(self):
+        excluded = ['ussr:R11_MS-1', 'germany:G12_Ltraktor']
+        state = BattleState(team_size=2, bot_excluded_vehicles=excluded)
+        worker = _attach_worker(state)
+        player, error = state.add_player(
+            _Connection(), ('10.0.0.1', 1001), _hello(1))
+        self.assertIsNone(error)
+        start, error = state.request_start(player.player_id)
+        self.assertIsNone(error)
+        self.assertEqual(sorted(excluded), start['bot_excluded_vehicles'])
+        stale = dict(start, bot_excluded_vehicles=[])
+        with mock.patch.object(player, 'offer_reliable', return_value=True) \
+                as visible_offer, mock.patch.object(
+                    worker, 'offer_reliable', return_value=True) as worker_offer:
+            self.assertTrue(state.broadcast_loading_transition(stale))
+        for offer in (visible_offer, worker_offer):
+            self.assertEqual(sorted(excluded),
+                             offer.call_args.args[0]['bot_excluded_vehicles'])
+        state.phase = 'battle'
+        self.assertEqual(sorted(excluded),
+                         state.current_battle_message()['bot_excluded_vehicles'])
+        state._reset_round()
+        self.assertEqual(sorted(excluded), state.bot_excluded_vehicles)
+
+    def test_profile_bot_exclusions_accept_only_vehicle_names(self):
+        for value in ('ussr:R11_MS-1', [True], ['R11_MS-1'], ['ussr:bad/name']):
+            with self.assertRaises(ValueError):
+                BattleState(bot_excluded_vehicles=value)
+        self.assertEqual(['ussr:R11_MS-1'], BattleState(
+            bot_excluded_vehicles=['ussr:R11_MS-1', 'ussr:R11_MS-1']
+        ).bot_excluded_vehicles)
+
     def test_0922_bot_callsigns_use_period_appropriate_chinese_names(self):
         self.assertGreaterEqual(len(BOT_CALLSIGNS_0922), 120)
         self.assertEqual(len(BOT_CALLSIGNS_0922), len(set(BOT_CALLSIGNS_0922)))

--- a/tests/test_port_0922_windows_server.py
+++ b/tests/test_port_0922_windows_server.py
@@ -42,6 +42,7 @@ class WindowsServerLauncherTests(unittest.TestCase):
             team_size=15,
             team1_size=15, team2_size=15,
             bot_lineup=[],
+            bot_excluded_vehicles=[],
             vehicle_overlay_root=None,
         )
 
@@ -88,6 +89,7 @@ class WindowsServerLauncherTests(unittest.TestCase):
             team_size=15,
             team1_size=15, team2_size=15,
             bot_lineup=[],
+            bot_excluded_vehicles=[],
             vehicle_overlay_root=None,
         )
 
@@ -129,6 +131,8 @@ class WindowsServerLauncherTests(unittest.TestCase):
                 windows_server.SERVER_BOT_LINEUP_ENV:
                     '[{"team":2,"slot":4,'
                     '"vehicle":"germany:G12_Ltraktor"}]',
+                windows_server.SERVER_BOT_EXCLUDED_VEHICLES_ENV:
+                    '["germany:G12_Ltraktor"]',
         }), mock.patch.object(
                 windows_server, '_load_server',
                 return_value=('server_random', run_server)), \
@@ -137,6 +141,14 @@ class WindowsServerLauncherTests(unittest.TestCase):
             self.assertEqual(0, windows_server.main())
 
         self.assertEqual(lineup, run_server.call_args.kwargs['bot_lineup'])
+        self.assertEqual(['germany:G12_Ltraktor'],
+                         run_server.call_args.kwargs['bot_excluded_vehicles'])
+
+    def test_invalid_bot_exclusions_do_not_silently_use_an_empty_list(self):
+        for value in ('{bad json', '{}', 'null'):
+            with self.assertRaises(ValueError):
+                windows_server._bot_excluded_vehicles_from_environment({
+                    windows_server.SERVER_BOT_EXCLUDED_VEHICLES_ENV: value})
 
     def test_invalid_exact_bot_lineup_json_fails_before_server_bind(self):
         run_server = mock.Mock()


### PR DESCRIPTION
Vehicle profiles now have an opt-in checkbox that excludes vehicles changed by that profile from automatic and random Bot rosters. Exclusions follow the original client topology, including shared component/shell users, local overrides, and siege-mode pairs. The room carries one fixed exclusion list to the worker and clients, and roster selection prevents mirrored player vehicles from reintroducing excluded types. An explicitly selected vehicle in an exact lineup remains allowed; a skill-only slot still follows automatic selection.

After the one-click error report creates its ZIP and selects it in Explorer, the launcher also shows a dialog with the file path and tells the user to send it to the author. The dialog runs on the Tk thread and still appears if Explorer selection fails.

Validation: 697 launcher tests passed (2 platform skips), focused Bot roster and server/entry tests passed, all 112 client sources compiled under CPython 2.7.18, and `git diff --check` passed. The combined runtime suite passed 5,101 tests (2 skips). No Windows gameplay/UI acceptance is claimed; this change does not update the currently installed PR139 test build.
