### PR TITLE
Avoid reporting Windows API-set contracts as missing DLLs

### DIFF
--- a/launcher/report_environment.py
+++ b/launcher/report_environment.py
@@ -10,9 +10,9 @@ without it:
   whether one worker was really mod-free, and the only evidence was the
   client's own ``Mod file`` lines, which name packaged wotmods and nothing
   else.
-* ``missing-dependencies.txt`` - report 20260909-205956 died with
-  ``0xC0000135`` (a load-time DLL was missing) and there is no way to name the
-  DLL from outside that machine.
+* ``missing-dependencies.txt`` - report 20260909-205956 exited with
+  ``0xC0000135`` without naming a DLL. A static import-file inventory can
+  identify candidates, but cannot replace the Windows loader's diagnosis.
 * ``crash-text.txt`` - report 20260909-232240 carried a 1.27 GB dump whose
   entire diagnostic value was one sentence BigWorld had already written into
   its own stack: ``FATAL ERROR: The device has been removed.``
@@ -410,11 +410,10 @@ def _search_directories(game_root):
 
 
 def missing_dependencies_report(game_root):
-    """Name the load-time DLLs Windows would not have found.
+    """Inventory ordinary import files in a bounded set of directories.
 
-    Report 20260909-205956 stopped at ``exit code 3221225781`` with no way to
-    learn which import was missing; this answers exactly that question on the
-    machine that has the problem.
+    API-set names are virtual contracts and need not name a file on disk.
+    This scan neither loads DLLs nor determines their runtime resolution.
     """
     executable = os.path.join(game_root, core.GAME_EXECUTABLE)
     lines = _lines("load-time imports of %s" % core.GAME_EXECUTABLE)
@@ -426,7 +425,15 @@ def missing_dependencies_report(game_root):
         return "\n".join(lines + ["no import table"]) + "\n"
     directories = _search_directories(game_root)
     missing = []
+    found_count = 0
+    contracts = 0
     for name in sorted(names, key=str.lower):
+        if name.lower().startswith(("api-ms-", "ext-ms-")):
+            contracts += 1
+            lines.append(
+                "API-SET  %s  (virtual contract; loader resolution not checked)"
+                % name)
+            continue
         found = None
         for directory in directories:
             candidate = os.path.join(directory, name)
@@ -437,16 +444,19 @@ def missing_dependencies_report(game_root):
             missing.append(name)
             lines.append("MISSING  %s" % name)
         else:
+            found_count += 1
             lines.append("found    %s  (%s)" % (name, found))
     lines.extend(_lines("verdict"))
-    if missing:
-        lines.append(
-            "%d import(s) resolved nowhere on the search path; this is what "
-            "0xC0000135 means: %s" % (len(missing), ", ".join(missing)))
-    else:
-        lines.append(
-            "every load-time import resolved; a 0xC0000135 here would come "
-            "from a dependency of one of these, not from the client itself")
+    lines.append(
+        "physical import files: found=%d not_found=%d (scanned directories)"
+        % (found_count, len(missing)))
+    lines.append("virtual API-set contracts: %d (loader resolution not checked)"
+                 % contracts)
+    lines.append(
+        "Missing files are candidates only; file presence does not prove "
+        "loadability. This static scan cannot identify the cause of "
+        "0xC0000135. API-set mapping, other loader search rules and transitive "
+        "dependencies are not checked.")
     return "\n".join(lines) + "\n"
 
 

--- a/launcher/tests/test_report_environment.py
+++ b/launcher/tests/test_report_environment.py
@@ -165,6 +165,68 @@ class SectionTest(unittest.TestCase):
         self.assertIn("== game", text)
         self.assertIn("client address space:", text)
 
+    def _dependency_report(self, names):
+        with mock.patch.object(report_environment, "_import_table",
+                               return_value=names), mock.patch.object(
+                report_environment, "_search_directories",
+                return_value=[self.game]):
+            return report_environment.missing_dependencies_report(self.game)
+
+    def test_api_set_names_are_virtual_contracts_in_any_case(self):
+        names = [
+            "api-ms-win-crt-runtime-l1-1-0.dll",
+            "API-MS-WIN-CRT-STDIO-L1-1-0.DLL",
+            "ext-ms-win-ntuser-window-l1-1-0.dll",
+            "EXT-MS-WIN-NTUSER-WINDOW-L1-1-0.DLL",
+        ]
+
+        text = self._dependency_report(names)
+
+        contracts = [line for line in text.splitlines()
+                     if line.startswith("API-SET")]
+        self.assertEqual(len(names), len(contracts))
+        for name in names:
+            matching = [line for line in contracts if name in line]
+            self.assertEqual(1, len(matching), name)
+            self.assertIn("virtual contract", matching[0])
+            self.assertIn("loader resolution not checked", matching[0])
+        self.assertFalse(any(line.startswith("MISSING")
+                             for line in text.splitlines()))
+        self.assertIn("physical import files: found=0 not_found=0", text)
+        self.assertIn("cannot identify the cause of 0xC0000135", text)
+
+    def test_missing_ordinary_imports_remain_a_physical_file_observation(self):
+        present = "shipped-helper.dll"
+        missing = "missing-helper.dll"
+        with open(os.path.join(self.game, present), "wb") as stream:
+            stream.write(b"physical file only\n")
+
+        text = self._dependency_report([
+            present, missing, "api-ms-win-crt-runtime-l1-1-0.dll"])
+
+        missing_names = [line.split()[1] for line in text.splitlines()
+                         if line.startswith("MISSING")]
+        self.assertEqual([missing], missing_names)
+        self.assertTrue(any(line.startswith("found") and present in line
+                            for line in text.splitlines()))
+        self.assertIn("scanned directories", text)
+        self.assertIn("physical import files: found=1 not_found=1", text)
+        self.assertIn("cannot identify the cause of 0xC0000135", text)
+        self.assertNotIn("this is what 0xC0000135 means", text)
+
+    def test_existing_import_files_do_not_prove_loader_resolution(self):
+        name = "shipped-helper.dll"
+        # The scanner observes existence; this is not a loadable DLL.
+        with open(os.path.join(self.game, name), "wb") as stream:
+            stream.write(b"physical file only\n")
+
+        text = self._dependency_report([name])
+
+        self.assertIn("physical import files: found=1 not_found=0", text)
+        self.assertIn("cannot identify the cause of 0xC0000135", text)
+        self.assertNotIn("every load-time import resolved", text)
+        self.assertNotIn("would come from a dependency", text)
+
     def test_loose_mod_files_are_listed_not_just_packaged_ones(self):
         # Blame for the address-space growth turned on whether a worker was
         # really mod-free, and a loose res_mods script announces nothing.


### PR DESCRIPTION
The dependency report classified Windows API-set contracts as missing physical DLLs and attributed them to startup failure. On the deployment VM, the 32-bit Windows loader successfully loaded two CRT API-set contracts that this report marked missing.

Classify `api-ms-` and `ext-ms-` names as virtual contracts whose loader resolution the static file scan does not assess. Preserve missing-file observations for ordinary DLLs, and describe both found and missing files as evidence from the scanned directories instead of claiming that they prove loadability or the cause of `0xC0000135`.

Validation covers mixed-case API-set names, missing ordinary DLLs, and the fact that file existence alone does not prove loadability. The change only affects diagnostic report generation; no client or server gameplay code changes.

- Focused report and error-report tests: 78 passed.
- Full launcher suite: 700 tests passed, 2 Windows junction checks skipped on macOS and subsequently passed in the Windows VM.
- `git diff --check`: passed.
- The original false positive was reproduced with a 32-bit Windows loader probe. The final x64 launcher was rebuilt, its frozen report module was compared against the merged source, and the same VM report now lists 35 physical files and 14 virtual contracts without the false missing-file diagnosis. All 80 focused report and junction tests passed on Windows.
