### PR TITLE
Reduce visible-client contact work during active battles

### DIFF
--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -8252,8 +8252,14 @@ class BattleRuntime(object):
             if not timeline:
                 self._ram_bot_history_index.pop(bot_id, None)
 
-    def _ram_bot_state_at(self, bot_id, revision, sample_time_us):
-        """Interpolate one bot from the exact wire samples a player saw."""
+    def _ram_bot_state_at(self, bot_id, revision, sample_time_us,
+                          velocity_only=False):
+        """Read a wire pose, or just its velocity for presented contacts.
+
+        Both projections use the same brackets and exact-sample neighbour.
+        The render-frame contact path already has its displayed pose and must
+        not interpolate/copy the full combat checkpoint just to read velocity.
+        """
         try:
             bot_id = int(bot_id)
             revision = int(revision)
@@ -8261,6 +8267,8 @@ class BattleRuntime(object):
         except (TypeError, ValueError, OverflowError):
             return None
         cache_key = (bot_id, revision, sample_time_us)
+        if velocity_only:
+            cache_key += ('velocity',)
         if cache_key in self._ram_bot_lookup_cache:
             cached = self._ram_bot_lookup_cache[cache_key]
             return None if cached is None else dict(cached)
@@ -8292,7 +8300,7 @@ class BattleRuntime(object):
             self._ram_bot_lookup_cache[cache_key] = None
             return None
         if left_time == right_time:
-            result = dict(left_state)
+            result = {} if velocity_only else dict(left_state)
             result['ram_vx'] = 0.0
             result['ram_vy'] = 0.0
             result['ram_vz'] = 0.0
@@ -8324,22 +8332,24 @@ class BattleRuntime(object):
         if span_us <= 0.0:
             self._ram_bot_lookup_cache[cache_key] = None
             return None
-        progress = max(0.0, min(
-            (sample_time_us - left_time) / span_us, 1.0))
-        result = dict(left_state)
-        for name in ('x', 'y', 'z', 'pitch', 'roll', 'aim_yaw',
-                     'gun_pitch'):
-            if name in left_state and name in right_state:
-                result[name] = (_number(left_state.get(name)) +
-                                (_number(right_state.get(name)) -
-                                 _number(left_state.get(name))) * progress)
-        if 'yaw' in left_state and 'yaw' in right_state:
-            result['yaw'] = (_number(left_state.get('yaw')) +
-                             _angle_delta(
-                                 _number(left_state.get('yaw')),
-                                 _number(right_state.get('yaw'))) * progress)
-        if progress >= 1.0:
-            result['alive'] = bool(right_state.get('alive', True))
+        result = {}
+        if not velocity_only:
+            progress = max(0.0, min(
+                (sample_time_us - left_time) / span_us, 1.0))
+            result = dict(left_state)
+            for name in ('x', 'y', 'z', 'pitch', 'roll', 'aim_yaw',
+                         'gun_pitch'):
+                if name in left_state and name in right_state:
+                    result[name] = (_number(left_state.get(name)) +
+                                    (_number(right_state.get(name)) -
+                                     _number(left_state.get(name))) * progress)
+            if 'yaw' in left_state and 'yaw' in right_state:
+                result['yaw'] = (_number(left_state.get('yaw')) +
+                                 _angle_delta(
+                                     _number(left_state.get('yaw')),
+                                     _number(right_state.get('yaw'))) * progress)
+            if progress >= 1.0:
+                result['alive'] = bool(right_state.get('alive', True))
         result['ram_vx'] = (
             _number(right_state.get('x')) -
             _number(left_state.get('x'))) * 1000000.0 / span_us
@@ -18793,18 +18803,50 @@ class BattleRuntime(object):
             (previous & (overlapping | closing_gaps)) | newly_armed)
         return bool(newly_armed)
 
-    def _contact_tanks(self):
-        """Return current non-local chassis bodies for 0.8.2 contact physics."""
+    def _contact_tanks(self, position, own_shape):
+        """Build only bodies that can contact this presented player pose.
+
+        Use the solver's conservative chassis-radius bound before projecting
+        history, mass or crew. Existing Bot compression episodes stay in the
+        set even across a presentation gap: relative motion must release them,
+        otherwise a returning hull could earn the same ram damage twice.
+        """
         result = []
+        own_radius = math.sqrt(
+            own_shape[0] * own_shape[0] + own_shape[1] * own_shape[1])
         bot_states = getattr(self._bots, 'states', {}) if self._bots else {}
         for record in self._records.values():
             if (record.get('local') or record.get('tombstone') or
                     not record.get('ready')):
                 continue
             state = record.get('state') or {}
+            presented_pose = None
             if record.get('kind') == 'bot':
                 state = bot_states.get(record.get('network_id'), state)
                 presented_pose = record.get('presented_pose')
+            pose = presented_pose if isinstance(presented_pose, dict) else {}
+            x = _number(pose.get('x', state.get('x')))
+            y = _number(pose.get('y', state.get('y')))
+            z = _number(pose.get('z', state.get('z')))
+            remote = self._server_entity(record['engine_id'])
+            descriptor = getattr(remote, 'typeDescriptor', None)
+            shape = state.get('collision_shape')
+            if shape is None:
+                shape = self._collision_shape(descriptor)
+            active_episode = (
+                record.get('kind') == 'bot' and
+                record.get('network_id') in self._local_ram_episode_contacts)
+            if not active_episode:
+                if not tank_collision.vertical_overlap(
+                        position[1], own_shape, y, shape):
+                    continue
+                radius = math.sqrt(shape[0] * shape[0] + shape[1] * shape[1])
+                reach = (own_radius + radius +
+                         tank_collision.CONTACT_BROADPHASE_PADDING)
+                dx, dz = position[0] - x, position[2] - z
+                if dx * dx + dz * dz > reach * reach:
+                    continue
+            if record.get('kind') == 'bot':
                 if isinstance(presented_pose, dict):
                     state = dict(state)
                     state.update(presented_pose)
@@ -18813,15 +18855,14 @@ class BattleRuntime(object):
                     record.get('network_id'), presentation_time_us)
                 historical = (self._ram_bot_state_at(
                     record.get('network_id'), revision,
-                    presentation_time_us) if revision is not None else None)
+                    presentation_time_us, velocity_only=True)
+                              if revision is not None else None)
                 if isinstance(historical, dict):
                     state = dict(state)
                     for name in ('ram_vx', 'ram_vy', 'ram_vz'):
                         if name in historical:
                             state[name] = historical[name]
             alive = bool(state.get('alive', True))
-            remote = self._server_entity(record['engine_id'])
-            descriptor = getattr(remote, 'typeDescriptor', None)
             yaw = _number(state.get('yaw'))
             speed = _number(state.get('speed')) if alive else 0.0
             player_effective = None
@@ -18831,10 +18872,7 @@ class BattleRuntime(object):
                     if player_effective is not None else state.get('mass'))
             if (mass is None and descriptor is not None and
                     record.get('kind') != 'player'):
-                mass = vehicle_physics.derive_params(descriptor).get('mass')
-            shape = state.get('collision_shape')
-            if shape is None:
-                shape = self._collision_shape(descriptor)
+                mass = vehicle_physics.descriptor_mass(descriptor)
             ram_profile = (
                 self._player_ram_profile(
                     player_effective, state.get('critical') or {})
@@ -18858,9 +18896,7 @@ class BattleRuntime(object):
                 # only keeps the player at full speed after a ram, so it
                 # immediately catches and damages the same Bot again.
                 'impulse': True,
-                'x': _number(state.get('x')),
-                'y': _number(state.get('y')),
-                'z': _number(state.get('z')),
+                'x': x, 'y': y, 'z': z,
                 'yaw': yaw,
                 'mass': _number(mass, 25000.0),
                 'shape': shape,
@@ -18879,7 +18915,6 @@ class BattleRuntime(object):
     def _resolve_local_tank_contacts(self, entity, position, yaw, dt):
         """Apply chassis OBB separation without pushing a tank into walls."""
         self._retry_native_ram_contact_proofs()
-        others = self._contact_tanks()
         own_mass = _number(
             (self._local_physics or {}).get('mass'), 25000.0)
         own = {
@@ -18896,6 +18931,7 @@ class BattleRuntime(object):
             'vy': self._local_vertical_speed,
             'vz': math.cos(yaw) * self._local_speed + self._local_push_z,
         }
+        others = self._contact_tanks(position, own['shape'])
         self._poll_local_ram_contact_episodes(entity, own, others)
         now = self._clock()
         contact = tank_collision.resolve_tank(

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/vehicle_physics.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/vehicle_physics.py
@@ -401,6 +401,22 @@ def _native_power_ratio(td, power_w):
 	return 1.0
 
 
+def descriptor_mass(td):
+	'''Read the same kilogram mass as derive_params without drive parameters.
+
+	Contact bodies do not consume engine power, traverse or terrain factors.
+	Read the mounted descriptor each time so an in-place equipment or Siege
+	change cannot leave a cached weight behind.
+	'''
+	try:
+		physics = getattr(td, 'physics', None) or {}
+		if 'weight' in physics:
+			return float(physics['weight'])
+	except Exception:
+		pass
+	return _DEFAULTS['mass']
+
+
 @observed('physics.derive_params')
 def derive_params(td, factors=None):
 	'''Real per-vehicle parameter set from a VehicleDescr. Every consumer

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -6740,6 +6740,153 @@ class BattleRuntimeContractTests(unittest.TestCase):
                          (native_direction.x, native_direction.y,
                           native_direction.z))
 
+    def test_distant_moving_contact_candidates_do_not_replay_or_derive(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        battle._bots = types.SimpleNamespace(states={})
+        battle._local_speed = 10.0
+        for actor_id in range(1, 30):
+            kind = 'player' if actor_id == 1 else 'bot'
+            engine_id = actor_id + 100
+            runtime.bigworld.entities[engine_id] = _Vehicle(
+                engine_id, _Descriptor(), _Vector(), (0, 0, 0),
+                {'health': 500})
+            battle._records['%s:%s' % (kind, actor_id)] = {
+                'engine_id': engine_id, 'network_id': actor_id,
+                'kind': kind, 'ready': True,
+                'state': {'id': actor_id, 'x': 200.0 + actor_id * 10,
+                          'y': 0.0, 'z': 0.0, 'yaw': 0.0,
+                          'speed': 10.0, 'team': 1 if actor_id < 15 else 2},
+                'presentation_time_us': 150000}
+        shape = tank_collision.chassis_shape(_Descriptor())
+        with mock.patch.object(
+                battle, '_ram_bot_state_at',
+                side_effect=AssertionError('far contact replayed history')), \
+                mock.patch.object(
+                    battle, '_player_effective_snapshot',
+                    side_effect=AssertionError('far contact projected crew')), \
+                mock.patch.object(
+                    vehicle_physics, 'derive_params',
+                    side_effect=AssertionError('far contact derived physics')):
+            for step in range(3):
+                # Both the observer and every candidate keep moving.
+                for record in battle._records.values():
+                    record['state']['z'] += 0.1
+                self.assertEqual(
+                    [], battle._contact_tanks((0.0, 0.0, step * 0.1), shape))
+
+    def test_contact_candidates_use_presented_pose_and_keep_active_episodes(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        shape = tank_collision.chassis_shape(_Descriptor())
+        for actor_id, canonical_z, presented_z in (
+                (11, 300.0, 1.0), (12, 1.0, 300.0), (13, 300.0, 300.0)):
+            runtime.bigworld.entities[actor_id] = _Vehicle(
+                actor_id, _Descriptor(), _Vector(), (0, 0, 0),
+                {'health': 500})
+            battle._records['bot:%s' % actor_id] = {
+                'engine_id': actor_id, 'network_id': actor_id,
+                'kind': 'bot', 'ready': True,
+                'state': {'id': actor_id, 'x': 0.0, 'y': 0.0,
+                          'z': canonical_z, 'yaw': 0.0, 'speed': 10.0,
+                          'team': 2},
+                'presented_pose': {'z': presented_z}}
+        battle._local_ram_episode_contacts = frozenset((13,))
+
+        bodies = battle._contact_tanks((0.0, 0.0, 0.0), shape)
+
+        self.assertEqual([11, 13], sorted(body['network_id'] for body in bodies))
+        self.assertEqual(1.0, next(
+            body['z'] for body in bodies if body['network_id'] == 11))
+
+    def test_near_contact_mass_tracks_descriptor_and_wire_changes(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        descriptor = _Descriptor()
+        descriptor.physics['weight'] = 21000.0
+        remote = _Vehicle(11, descriptor, _Vector(), (0, 0, 0),
+                          {'health': 500})
+        runtime.bigworld.entities[11] = remote
+        state = {'id': 11, 'x': 0.0, 'y': 0.0, 'z': 1.0, 'yaw': 0.0,
+                 'speed': 10.0, 'team': 2}
+        battle._records['bot:11'] = {
+            'engine_id': 11, 'network_id': 11, 'kind': 'bot',
+            'ready': True, 'state': state}
+        shape = tank_collision.chassis_shape(descriptor)
+        with mock.patch.object(
+                vehicle_physics, 'derive_params',
+                side_effect=AssertionError('contact derived unused physics')):
+            self.assertEqual(21000.0, battle._contact_tanks(
+                (0.0, 0.0, 0.0), shape)[0]['mass'])
+            descriptor.physics['weight'] = 23000.0
+            self.assertEqual(23000.0, battle._contact_tanks(
+                (0.0, 0.0, 0.0), shape)[0]['mass'])
+            remote.typeDescriptor = _Descriptor()
+            remote.typeDescriptor.physics['weight'] = 26000.0
+            self.assertEqual(26000.0, battle._contact_tanks(
+                (0.0, 0.0, 0.0), shape)[0]['mass'])
+            state['mass'] = 29000.0
+            self.assertEqual(29000.0, battle._contact_tanks(
+                (0.0, 0.0, 0.0), shape)[0]['mass'])
+
+    def test_contact_pruning_preserves_mixed_roster_collision_results(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        own_shape = (1.5, 3.5, -0.8, 2.0)
+        bodies = []
+        for index, (kind, team, alive, shape) in enumerate((
+                ('bot', 1, True, own_shape),
+                ('bot', 2, True, (4.0, 12.0, -0.5, 3.0)),
+                ('bot', 2, False, own_shape),
+                ('player', 1, True, own_shape),
+                ('player', 2, True, own_shape),
+                ('player', 2, False, own_shape))):
+            engine_id = 100 + index
+            actor_id = index + 1
+            mass = 20000.0 + index * 1000.0
+            state = {
+                'id': actor_id, 'team': team, 'alive': alive,
+                'mass': mass, 'collision_shape': shape,
+                'x': float(index * 12), 'y': 0.0, 'z': float(index * 8),
+                'yaw': index * 0.45, 'speed': 8.0 if alive else 0.0}
+            if kind == 'player':
+                state['effective_params'] = _effective_params_snapshot()
+                state['effective_params']['physics']['mass'] = mass
+            runtime.bigworld.entities[engine_id] = _Vehicle(
+                engine_id, _Descriptor(), _Vector(), (0, 0, 0),
+                {'health': 500 if alive else 0})
+            battle._records['%s:%s' % (kind, actor_id)] = {
+                'engine_id': engine_id, 'network_id': actor_id,
+                'kind': kind, 'ready': True, 'state': state,
+                # Visibility must not remove a solid body.
+                'spot_visible': False}
+            bodies.append({
+                'id': 1000000 + engine_id, 'team': team, 'alive': alive,
+                'x': state['x'], 'y': state['y'], 'z': state['z'],
+                'yaw': state['yaw'], 'mass': mass, 'shape': shape,
+                'vx': math.sin(state['yaw']) * state['speed'],
+                'vz': math.cos(state['yaw']) * state['speed']})
+        # Cross all six bodies from different headings and support levels,
+        # including the long hull's rotated corners and just-clear contacts.
+        for frame in range(32):
+            for height in (-0.5, 0.0, 2.0, 20.0):
+                position = (frame * 2.0, height, frame * 1.3)
+                yaw = frame * 0.37
+                own = {
+                    'id': -1, 'alive': True, 'team': 1,
+                    'x': position[0], 'y': height, 'z': position[2],
+                    'yaw': yaw, 'shape': own_shape, 'mass': 25000.0,
+                    'vx': math.sin(yaw) * 10.0, 'vz': math.cos(yaw) * 10.0}
+                with self.subTest(frame=frame, height=height):
+                    filtered = battle._contact_tanks(position, own_shape)
+                    self.assertEqual(
+                        tank_collision.resolve_tank(own, bodies),
+                        tank_collision.resolve_tank(own, filtered))
+
     def test_local_tank_contact_uses_copied_separation_and_impulse(self):
         runtime = _runtime()
         battle = BattleRuntime(runtime)
@@ -7631,6 +7778,39 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertEqual(37, battle._ram_bot_revision_at(11, 200000))
         self.assertIsNone(battle._ram_bot_revision_at(11, 50000))
         self.assertIsNone(battle._ram_bot_revision_at(11, 250000))
+
+    def test_ram_velocity_projection_matches_receipts_at_every_sample_edge(self):
+        battle = BattleRuntime(_runtime())
+        battle._bots = types.SimpleNamespace(states={})
+        for revision, stamp, x, y, z in (
+                (36, 100000, 0.0, 0.0, 0.0),
+                (39, 230000, 1.3, -0.65, 2.6),
+                (40, 300000, 1.3, 0.0, 4.0)):
+            battle._remember_ram_bot_snapshot({
+                'bot_state_revision': revision, 'bot_state_time_us': stamp,
+                'bots': [{'id': 11, 'x': x, 'y': y, 'z': z, 'yaw': 0.5,
+                          'pitch': 0.1, 'roll': -0.1, 'alive': True}]})
+        fields = ('ram_vx', 'ram_vy', 'ram_vz')
+        for stamp in (50000, 100000, 150000, 230000, 250000, 300000, 350000):
+            revision = battle._ram_bot_revision_at(11, stamp)
+            with self.subTest(stamp=stamp, revision=revision):
+                full = battle._ram_bot_state_at(11, revision, stamp)
+                velocity = battle._ram_bot_state_at(
+                    11, revision, stamp, velocity_only=True)
+                self.assertEqual(
+                    None if full is None else
+                    {field: full[field] for field in fields}, velocity)
+        # A repeated wire revision must invalidate either cached projection.
+        battle._remember_ram_bot_snapshot({
+            'bot_state_revision': 40, 'bot_state_time_us': 300000,
+            'bots': [{'id': 11, 'x': 1.3, 'y': 0.0, 'z': 5.4}]})
+        velocity = battle._ram_bot_state_at(
+            11, 40, 250000, velocity_only=True)
+        self.assertAlmostEqual(40.0, velocity['ram_vz'])
+        velocity['ram_vz'] = -999.0
+        self.assertAlmostEqual(40.0, battle._ram_bot_state_at(
+            11, 40, 250000, velocity_only=True)['ram_vz'])
+        self.assertIn('z', battle._ram_bot_state_at(11, 40, 250000))
 
     def test_ram_history_caches_repeated_receipt_decoration(self):
         class IterationForbiddenHistory(list):

--- a/tests/test_port_0922_vehicle_physics.py
+++ b/tests/test_port_0922_vehicle_physics.py
@@ -53,6 +53,28 @@ class VehiclePhysicsDescriptorTests(unittest.TestCase):
 
         self.assertEqual(0.75, params['rotSpd'])
 
+    def test_contact_mass_matches_drive_mass_without_reading_drive_fields(self):
+        class MassDescriptor(object):
+            physics = {'weight': 21000.0}
+
+            @property
+            def chassis(self):
+                raise AssertionError('mass read the traverse descriptor')
+
+            @property
+            def engine(self):
+                raise AssertionError('mass read the engine descriptor')
+
+        self.assertEqual(21000.0, vehicle_physics.descriptor_mass(MassDescriptor()))
+        for physics in ({'weight': 21000.0}, {'weight': '35000'}, {},
+                        {'weight': None}, {'weight': 'invalid'}):
+            descriptor = types.SimpleNamespace(
+                physics=physics,
+                chassis=_Strict1513Component(rotationSpeed=0.75))
+            with self.subTest(physics=physics):
+                self.assertEqual(vehicle_physics.derive_params(descriptor)['mass'],
+                                 vehicle_physics.descriptor_mass(descriptor))
+
     def test_zero_native_brake_force_keeps_track_grip_fallback(self):
         descriptor = types.SimpleNamespace(
             physics={'weight': 21000.0, 'brakeForce': 0.0},


### PR DESCRIPTION
The visible client builds contact bodies every live simulation frame. With 29 moving Bots, it currently projects history and derives full drive parameters for all 29 even when none can touch the player; ram episode polling then performs OBB tests on distant enemy hulls. The two supplied 0.7.4 sessions put roughly 59% of measured mod frame work in `local`, but their 30-second windows do not isolate this contact path or prove the reported instantaneous FPS drop.

Apply the collision solver's existing conservative height/radius bound before building contact state. Read descriptor mass directly and project only historical velocity for retained candidates. This saves work while driving and fighting at the existing simulation cadence. Nearby friendlies, humans, wrecks and unspotted vehicles remain solid. Existing Bot ram episodes remain eligible across presentation gaps, and receipt decoration keeps its full historical pose projection.

Validation:

- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=tests python3 -m unittest test_port_0922_battle_runtime test_port_0922_vehicle_physics test_port_0922_tank_collision test_port_0922_worker_diagnostics`: 984 tests passed.
- New coverage checks a moving distant roster, presented versus canonical poses, live descriptor/wire mass changes, 128 mixed-roster collision cases, and velocity parity at exact/interpolated/missing history samples and replacement revisions. Existing contact episode and receipt lifecycle tests also pass.
- CPython 2.7.18 in-memory compilation: all 110 client Python files passed. `git diff --cached --check` passed.

A synthetic Linux CPython 2.7.18 comparison against `b42a33372d479c538aa452cd1b2d96b42f1660fa` used the same 29 moving Bots, 10 Hz history samples and seven trials of 600 updates. The timed region was contact body preparation, local ram episode polling and the pure-data collision solver; snapshot setup and native plate queries were excluded. Values are medians of per-trial mean milliseconds per update:

| Nearby candidates | Before | After |
| --- | ---: | ---: |
| 0 of 29 | 1.765 ms | 0.187 ms |
| 1 of 29 | 1.806 ms | 0.229 ms |
| 29 of 29 | 2.666 ms | 1.927 ms |

These timings demonstrate reduced Python contact work, not Windows game FPS. Exact Chinese HD #1513 Windows acceptance is still needed for frame pacing and native gameplay, including crowded contacts and sustained ramming. Suspension, native queries, pose presentation and rendering remain outside this change's measured scope.
