### PR TITLE
Prototype native Bot simulation with parity and CPU/threading evidence

### DIFF
--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -988,6 +988,108 @@ python3 tools/ffi_experiment/compare_runs.py --python "$FFI_PY27" \
   --components aiming,driver,contacts --rounds 3 --stage-timing
 ```
 
+A third experiment targets the heaviest remaining bounded calculation class:
+the horizontal world-collision controller inside `_resolve_bot_motion`. It
+ports `_check_horizontal_collision` and its numeric helpers, including pitched
+and rolled hull lanes, diagonal sweeps, clamped ray endpoints, terrain support
+and directional profiles, independent raised-wall checks, and ordered hit
+resolution. Python retains descriptor projection, actual engine queries,
+collision filters and destruction/recast operations. This is the inner sweep,
+not the entire motion resolver or a replacement for BigWorld physics.
+
+Two measurements separate computation throughput from the cost of that live
+boundary. Both retain the preceding production baseline and host environment.
+The computation measurement records the original Python controller's ordered
+engine/destruction leaves for the same 30-second scene: 5,038 sweeps and 82,273
+leaf requests. Each native tape is checked for exact query geometry, order and
+terminal result before registration. Python replay is also checked once before
+timing; C++ retains those checks during timing. The complete trace capture
+preserves all six workload snapshot families.
+
+| Recorded computation | Median CPU per 5,038-sweep pass |
+| --- | ---: |
+| Original Python controller with recorded leaf answers | 0.902043 s |
+| C++ controller with persistent numeric tapes, one bulk call | 0.002550 s |
+
+This is a 353.72x speedup and 99.72% reduction for the recorded controller.
+Five alternating pairs run in one CPython 2.7.18 process, with three corpus
+passes per Python sample and 300 per native sample, normalized per pass.
+Native timed samples last 0.763–0.792 s, avoiding a sub-millisecond timer claim.
+One-time native tape transfer, copy and validation costs another 0.124456 s.
+Both variants use preprojected descriptor extents. Python uses host
+`Math.Vector3` fakes; this measures controller logic and object plumbing,
+not isolated scalar arithmetic or exact Windows vector-object costs.
+Preknown leaf answers and persistent native tapes make this an optimistic
+computation estimate. It excludes live engine cost and ongoing marshalling;
+these tapes must never supply cached physics to a live battle.
+
+The actual adapter instead yields each original query to Python, retains hit
+objects and filters only on the Python stack, and resumes with owned numeric
+answers. Like the earlier driver prototype, continuation recomputes the C++
+prefix from saved answers without repeating engine calls. Every sweep drops
+its native job in `finally`. It neither removes collision checks nor changes
+destruction order. A three-round, rotating-order comparison, with nine fresh
+processes and no instrumentation, measures that integration separately:
+
+| Variant | Median loop CPU | Min–max loop CPU | Reduction against Python |
+| --- | ---: | ---: | ---: |
+| Unmodified Python | 11.236298 s | 11.138337–11.446382 s | 0.00% |
+| Previous A* + contacts + driving + aiming | 10.103238 s | 10.001199–10.181124 s | 10.08% |
+| Previous components + world controller | 10.650484 s | 10.629813–10.657850 s | 5.21% |
+
+All nine complete snapshots match exactly. The new boundary therefore adds
+about 0.55 s relative to the previous native control; its kernel throughput
+does not translate into an integration win. A separate one-round instrumented
+comparison also matches. The world stage grows from 1.344940 s in Python to
+2.196308 s with the adapter. Total native dispatches grow from 52,943 to
+145,292: 82,273 query continuations plus two owner calls per sweep. C++ prefix
+recomputation, Python object conversion, dispatch and retained leaves all remain
+costs. Instrumented totals include observer overhead and are not the primary
+speed estimate.
+
+In that instrumented Python run, the whole world stage takes 11.54% of loop
+CPU, including its leaves. Even making that entire stage free would save only
+that share. Making it free on top of the previous native control gives an
+optimistic 22.39% total reduction in this fixture. That bound includes removing
+leaf costs which the numeric port cannot actually remove. A 99.72% kernel
+reduction establishes adequate calculation throughput, but a 90% whole-loop
+target requires a much larger fraction of state and loop work to stay native
+with sufficiently cheap engine and publication boundaries. This experiment
+does not establish that such a complete migration reaches the target.
+
+The existing physical scenarios, executed by a Python 3 host runner, provide
+145 exact shadow traces and 75 tests passing through both the shadow and actual
+adapter. One additional source test
+replaces the entire terrain-profile helper with invented heights, so it remains
+source-only; it does not provide native leaf-contract evidence. The new world
+core also passes those checks with AddressSanitizer and UndefinedBehaviorSanitizer
+(`detect_leaks=0`, halt on error). The host bridges and unshipped x86 bridge
+build; the latter still imports only `KERNEL32.dll` and `msvcrt.dll`. Production
+source and shipping entry points remain unchanged. CPython 2.7 compiles all 97
+client modules and 12 portable experiment modules. The shared dispatcher's
+56-case A* regression also passes exact path and completion comparisons.
+Exact Windows #1513 loading,
+floating-point parity, real native-query cost and frame pacing remain unproved.
+
+Reproduce the new measurements after building the fixture and host module above:
+
+```bash
+"$FFI_PY27" tools/ffi_experiment/portable_workload.py \
+  --fixture /tmp/ffi-fixture.json --backend python \
+  --output /tmp/ffi-world-recording.json --world-trace-output /tmp/ffi-world-tapes.json
+"$FFI_PY27" tools/ffi_experiment/benchmark_world.py \
+  --fixture /tmp/ffi-fixture.json --module /tmp/ffi-host/offline_astar_native.so \
+  --trace /tmp/ffi-world-tapes.json --output /tmp/ffi-world-kernel.json \
+  --rounds 5 --loops 3 --native-loops 300
+python3 tools/ffi_experiment/compare_runs.py --python "$FFI_PY27" \
+  --module /tmp/ffi-host/offline_astar_native.so --fixture /tmp/ffi-fixture.json \
+  --components aiming,driver,contacts,world --control-components aiming,driver,contacts \
+  --rounds 3 --output /tmp/ffi-world-comparison
+tools/ffi_experiment/build_host.sh python3 /tmp/ffi-world-host3
+python3 tools/ffi_experiment/check_world_parity.py \
+  --module /tmp/ffi-world-host3/offline_astar_native.so
+```
+
 The previous 0.3.65 schema-v2 catalog supplied transformed OBBs but joined
 runtime slots by native filename taken from the chunk list. A slot may be
 present as `''`, while an unresolved, handlerless or NULL-name slot is absent;

--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -1222,6 +1222,112 @@ python3 tools/ffi_experiment/compare_runs.py --python "$FFI_PY27" \
 tools/ffi_experiment/build_1513.sh /tmp/ffi-flow-1513
 ```
 
+A subsequent owned-Bot-kernel experiment replaces `BotRuntime.update` itself,
+using the same production baseline (`900744ce`) and the unchanged 29-Bot fixture.
+The `kernel,world-sync` runner initializes descriptor coefficients once, then
+C++ owns the mutable Bot roster, decision and perception caches, route/lane
+assignment, traffic leases, fair motion-receipt queue, horizontal and vertical
+motion, tank contact episodes, weapon/ammunition/burst clocks, health/equipment,
+Siege descriptor transitions, and wire publication. Server-order revisions
+invalidate the same decision, motion and route-binding state as Python. Late
+callbacks consume their banked elapsed time in the source's bounded slice order;
+shots remain in the ordered launch outbox until acknowledged.
+
+The native update composes the existing navigation, driver, motion and combat
+cores directly. Numeric borrowed callbacks carry the current actor pose and
+slice clocks to Python only for engine/catalog queries. State-dependent native
+callbacks observe each Bot's committed pose before the next Bot advances. The
+Python adapter does not execute a per-Bot simulation or publication loop.
+MT19937 integer seeding, Gaussian pair caching, dispersion and the Python 2
+rounding contract have independent differential checks. Optional aim/cover
+receipts keep opaque Python values behind numeric tokens, reclaimed when no
+native cache, intent, pending launch or current output references them. Packed
+JSON output is copied into a capacity-checked caller-owned buffer; native code
+retains neither that buffer nor a Python callback result.
+
+This remains a bounded, unshipped experiment. It requires complete server Bot
+orders and the copied vertical controller; native-motion and the optional
+ten-spring trial are explicitly rejected at construction. Local tactical
+fallback, `BattleRuntime` damage/reconciliation ingress, authority takeover,
+real native-query implementations, destructible catalog ownership and
+projectile terminal processing are not replaced by this adapter. It is created
+at fixture startup and destroyed at teardown, not installed into a running
+battle. The mutable native state still uses dynamic field maps alongside typed
+weapon/physics records; C++ ownership does not eliminate field lookup,
+allocation, marshalling or retained Python engine-query cost.
+
+The final comparison runs nine independent CPython 2.7.18 processes in
+rotating order on the shared Linux aarch64 host, after all validation/build
+processes finish. Each variant uses Great Wall combat, 29 Bots, 30 simulated
+seconds and 15 frame callbacks/second. Loop CPU includes marshalling and
+per-frame snapshot/navigation capture; process/fixture startup and final JSON
+file serialization are excluded, and native initialization is reported
+separately.
+
+| Variant | Median loop CPU | Min–max loop CPU | Reduction against Python |
+| --- | ---: | ---: | ---: |
+| Unmodified Python | 10.993966 s | 10.935670–11.028345 s | 0.00% |
+| Previous persistent motion/navigation with aiming, contacts and synchronous world queries | 8.848982 s | 8.783967–8.865380 s | 19.51% |
+| Owned Bot kernel with synchronous world queries | 7.637579 s | 7.601436–7.659896 s | 30.53% |
+
+The owned kernel saves another 13.69% against the previous variant. Its median
+initialization is 0.162707 s and median loop-plus-initialization CPU is
+7.800404 s. Recorded Python-to-FFI dispatches fall from 91,697 to 7,600; these
+include owner setup and diagnostic readbacks, not only update calls. All nine
+complete snapshots match across messages, ordered engine queries, probe and
+decision counters, navigation progress and diagnostics. The 77,172 recorded
+engine queries remain identical: reducing FFI entry count does not remove the
+retained Python query leaves. The fixture acknowledges launches without
+simulating projectile terminals and uses deterministic native-query fakes.
+This 30.53% host-workload reduction remains far below 90% (about 1.10 s in this
+comparison); it is neither a Windows FPS measurement nor a whole-game saving.
+
+Focused CPython 2.7.18 checks compare 13,632 weapon transitions, 2,097 launch
+transactions, 3,165 gunner actions, 2,320 aim transitions, 6,488 perception/lane
+actions, 2,480 motion transitions, 1,956 route/driver/traffic transitions across
+three maps, 612 contact/ram lifecycle transitions, 2,015 health/publication
+transitions, equipment and wire rows. Whole-update comparisons cover ordinary
+combat, Siege, human targets, queued cover work, order revisions and delayed
+callbacks, both separately and together. A second whole-update scene checks
+Himmelsdorf navigation. All compared messages, complete owned state, ordered
+engine leaves, control slices, probes and diagnostic counters match the
+unchanged Python 2 source. The deliberately opaque Python descriptor cache is
+excluded from state equality; its consumed aim results are compared.
+
+Both host ABIs and the x86 prototype build with warnings treated as errors.
+PE inspection reports only `KERNEL32.dll` and `msvcrt.dll` imports. CPython 2.7
+compiles all 97 client and 34 experiment modules without writing adjacent
+bytecode. Python 3.12 passes the weapon/health/wire and buffer-ownership checks,
+but additional whole-loop comparisons expose last-bit floating-point differences
+in aim and navigation; it is not used as the exact-client numerical oracle.
+AddressSanitizer and UndefinedBehaviorSanitizer pass the packed-buffer and
+owner-lifecycle guards, weapon/health/wire suite, callback bridge, and bounded
+motion, aim, perception, route/traffic, contact, gunner/launch and combined
+whole-update suites on the CPython 2.7 host. Both halt on error; leak detection
+is disabled. The harness preloads both the sanitizer and C++ runtimes before
+loading the instrumented extension, so C++ exception interception is active.
+No production entry point, launcher or package imports the kernel. Exact
+Windows loading, x86 floating-point parity, callback/native memory ownership,
+real frame pacing and gameplay remain unproved.
+
+Reproduce the owned-kernel comparison:
+
+```bash
+sh tools/ffi_experiment/build_host.sh "$FFI_PY27" /tmp/ffi-kernel-host
+python3 tools/ffi_experiment/export_fixture.py /tmp/ffi-kernel-fixture.json
+"$FFI_PY27" tools/ffi_experiment/check_kernel_state.py \
+  --module /tmp/ffi-kernel-host/offline_astar_native.so --fixture /tmp/ffi-kernel-fixture.json
+"$FFI_PY27" tools/ffi_experiment/check_kernel_update.py \
+  --module /tmp/ffi-kernel-host/offline_astar_native.so --fixture /tmp/ffi-kernel-fixture.json \
+  --frames 80 --siege --human --cover --orders
+python3 tools/ffi_experiment/compare_runs.py --python "$FFI_PY27" \
+  --module /tmp/ffi-kernel-host/offline_astar_native.so --fixture /tmp/ffi-kernel-fixture.json \
+  --components kernel,world-sync \
+  --control-components aiming,driver-flow,contacts,world-sync,navigation-flow,motion-flow \
+  --seconds 30 --rounds 3 --output /tmp/ffi-kernel-comparison
+sh tools/ffi_experiment/build_1513.sh /tmp/ffi-kernel-1513
+```
+
 The previous 0.3.65 schema-v2 catalog supplied transformed OBBs but joined
 runtime slots by native filename taken from the chunk list. A slot may be
 present as `''`, while an unresolved, handlerless or NULL-name slot is absent;

--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -1090,6 +1090,138 @@ python3 tools/ffi_experiment/check_world_parity.py \
   --module /tmp/ffi-world-host3/offline_astar_native.so
 ```
 
+A subsequent opt-in motion/navigation experiment (2026-09-08) replaces the
+persistent route controller and the copied-physics motion flow, retaining the
+same production source baseline (`900744ce`) and fixture as the core/world
+experiments. An earlier instrumented, exclusive-time attribution assigned
+49.4% of this fixture's loop CPU to motion, navigation and their safety checks.
+That is the affected workflow's original cost, not a promised saving or a claim
+that all its code has now become native.
+
+C++ now owns the baked grid geometry, navigation paths and search jobs, fair
+expansion credits, expiry and cancellation, direct-route progress leases,
+lookahead and smoothing, shallow-water recovery and blocked-edge memory.
+Driving, the horizontal motion preparation/integration block and its probe-cache
+decisions execute on uninterrupted native stacks. Driver and motion safety
+checks share the native navigator directly. Descriptor-derived physics profiles
+are registered once per numeric profile. The copied vertical-motion controller,
+slope calculation, complete coast-to-stop integration, final pose hazard guard
+and contact impulse/push response also run in C++. Each Bot still commits its
+pose before the next Bot observes it; batching all Bot poses at the end would
+change this source contract.
+
+A synchronous borrowed callback bridge replaces prefix replay in driving and
+world sweeps. It holds the GIL, returns to the same C++ stack after each engine
+query, and releases every Python callback result. It retains no Python pointer
+across dispatches. Only reviewed geometry/expiry queries and stack-owned world
+queries may nest, on the original caller thread, using non-overlapping borrowed
+buffers. Reset/reentrant mutation and buffer aliasing are rejected before
+mutation; callback exceptions retain their Python identity and unwind the owner.
+The x86 experiment adds an exact function/tuple layout and function-call
+signature preflight, with a callback self-test before this new ABI is enabled.
+Static inspection and a successful cross-build do not establish that this ABI
+loads or behaves correctly inside Windows #1513.
+
+Opaque motion probes and receipts stay Python-owned, referenced by bounded
+numeric identities in C++. Callback-visible yaw, speed, diagnostic and cache
+updates follow source order, including a failed engine query. A blocked motion
+step can cancel a pending navigation search on the same C++ stack; its identity
+retirement is routed to the navigation owner. Retired cache identities are
+removed once no path, search or fairness cursor owns them.
+
+Python still produces tactical/macro route goals and radio/lane adjustments,
+projects descriptor and critical-device state, owns the fair native-receipt
+queue, and performs the actual engine/destruction queries. The outer
+`BattleRuntime._resolve_bot_motion` catalog adapter, tank-pair SAT/ram solver and
+destructible catalog remain source-owned. Weapon/perception orchestration and
+publication also remain Python. The optional ten-spring suspension trial is
+explicitly counted as `suspension_source`; this fixture exercises the migrated
+copied vertical controller. The experiment neither ports every branch included
+in the 49.4% attribution nor changes the product's physical authority path.
+
+The final uninstrumented comparison runs nine fresh CPython 2.7.18 processes
+in rotating order on the same shared Linux aarch64 host: Great Wall combat,
+29 Bots, 30 simulated seconds, 15 frame callbacks/second. It includes adapter
+marshalling and normal snapshot capture, excludes process/fixture startup and
+JSON serialization, and reports native initialization separately.
+
+| Variant | Median loop CPU | Min–max loop CPU | Reduction against Python |
+| --- | ---: | ---: | ---: |
+| Unmodified Python | 11.046064 s | 10.999241–11.174757 s | 0.00% |
+| Previous A* + contacts + driving + aiming | 9.866947 s | 9.781824–9.931816 s | 10.67% |
+| Persistent navigation + motion + synchronous driver/world, with aiming/contacts | 8.859842 s | 8.820707–8.943107 s | 19.79% |
+
+The new variant saves another 10.21% against the preceding best integrated
+variant. Median initialization is 0.098311 s and the median loop-plus-native-init
+total is 8.958153 s. All nine snapshots match exactly across messages, ordered
+native queries, probe counters, decision counters, navigation progress and
+diagnostics. The fixture acknowledges launches without simulating projectile
+terminals, and uses deterministic engine-query fakes; these are complete
+snapshots of this bounded fixture, not complete real-battle acceptance.
+The measured whole-loop gain is 19.79%, far below a 90% reduction. Neither the
+49.4% original workflow attribution nor isolated native kernel throughput
+predicts the gain after retained Python state and engine boundaries.
+
+A separate instrumented pair also preserves the complete snapshots. Inclusive
+route/driving time falls from 1.6982 s to 0.5463 s, while the world sweep with
+its retained query leaves falls only from 1.3802 s to 1.2382 s. Motion preparation
+with its callback/state conversion grows from 0.3626 s to 0.6317 s. These scoped
+measurements include observer overhead and are explanatory, not replacements
+for the nine uninstrumented samples. They show why migrating controller logic
+does not remove the Python callback and shared-state boundary cost. Each native
+sample records 6,166 migrated vertical updates and zero suspension-source updates.
+
+Focused differential validation covers 150,000 copied-physics results; 3,000
+horizontal-motion cases with ordered callback-visible state, injected query
+failures and bounded opaque caches; 21,000 vertical/slope/coast/final-guard/contact
+checks; and 115,200 navigation operations with 3,600 complete frame-state
+comparisons. The horizontal suite also exercises 37 pending-search retirements
+from within motion and compares final navigation state. The shared dispatcher
+passes 86 exact A* cases and 1,200 aiming/driver cases (3,600 driver steps).
+World validation retains 145 exact query/result traces and 75 physical scenarios
+through both shadow and synchronous adapters; its internal-helper mock remains
+source-only. The bridge suite checks exception identity, result release,
+reset, nested queries, overlapping buffers and cross-thread rejection.
+
+AddressSanitizer and UndefinedBehaviorSanitizer pass the bridge, horizontal and
+vertical motion, navigation and world suites on the Python 3 host, with leak
+detection disabled and halt-on-error enabled. CPython 2.7 compiles all 97 client
+modules and 20 portable experiment modules. Both host ABIs and the unshipped
+x86 bridge build; the PE inspection reports only `KERNEL32.dll` and `msvcrt.dll`
+imports. No production entry point, launcher or shipping package installs the
+experiment. Exact Windows loading, x86 floating-point parity, native query
+latency, frame pacing and gameplay remain unproved.
+
+Reproduce the flow comparison and focused contracts using the fixture creation
+command from the preceding experiment:
+
+```bash
+tools/ffi_experiment/build_host.sh "$FFI_PY27" /tmp/ffi-flow-host
+"$FFI_PY27" tools/ffi_experiment/check_query_bridge.py \
+  --module /tmp/ffi-flow-host/offline_astar_native.so
+"$FFI_PY27" tools/ffi_experiment/check_motion_physics.py \
+  --module /tmp/ffi-flow-host/offline_astar_native.so --fixture /tmp/ffi-fixture.json
+"$FFI_PY27" tools/ffi_experiment/check_navigation_grid.py \
+  --module /tmp/ffi-flow-host/offline_astar_native.so
+"$FFI_PY27" tools/ffi_experiment/check_navigation_flow.py \
+  --module /tmp/ffi-flow-host/offline_astar_native.so --cases 12 --frames 200
+"$FFI_PY27" tools/ffi_experiment/check_motion_flow.py \
+  --module /tmp/ffi-flow-host/offline_astar_native.so \
+  --fixture /tmp/ffi-fixture.json --cases 3000
+"$FFI_PY27" tools/ffi_experiment/check_motion_vertical.py \
+  --module /tmp/ffi-flow-host/offline_astar_native.so \
+  --fixture /tmp/ffi-fixture.json --cases 3000
+"$FFI_PY27" tools/ffi_experiment/check_core_parity.py \
+  --module /tmp/ffi-flow-host/offline_astar_native.so \
+  --fixture /tmp/ffi-fixture.json --sync-driver
+python3 tools/ffi_experiment/compare_runs.py --python "$FFI_PY27" \
+  --module /tmp/ffi-flow-host/offline_astar_native.so --fixture /tmp/ffi-fixture.json \
+  --components aiming,driver-flow,contacts,world-sync,navigation-flow,motion-flow \
+  --control-components aiming,driver,contacts --seconds 30 --rounds 3 \
+  --output /tmp/ffi-flow-comparison
+tools/ffi_experiment/build_1513.sh /tmp/ffi-flow-1513
+```
+
 The previous 0.3.65 schema-v2 catalog supplied transformed OBBs but joined
 runtime slots by native filename taken from the chunk list. A slot may be
 present as `''`, while an unresolved, handlerless or NULL-name slot is absent;

--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -1252,12 +1252,13 @@ fallback, `BattleRuntime` damage/reconciliation ingress, authority takeover,
 real native-query implementations, destructible catalog ownership and
 projectile terminal processing are not replaced by this adapter. It is created
 at fixture startup and destroyed at teardown, not installed into a running
-battle. The mutable native state still uses dynamic field maps alongside typed
-weapon/physics records; C++ ownership does not eliminate field lookup,
+battle. The original `fabc7e6e` kernel kept mutable state in dynamic field maps
+alongside typed weapon/physics records. The fixed-field follow-up below removes
+part of that cost; C++ ownership alone does not eliminate field lookup,
 allocation, marshalling or retained Python engine-query cost.
 
-The final comparison runs nine independent CPython 2.7.18 processes in
-rotating order on the shared Linux aarch64 host, after all validation/build
+The original owned-kernel comparison ran nine independent CPython 2.7.18
+processes in rotating order on the shared Linux aarch64 host, after all validation/build
 processes finish. Each variant uses Great Wall combat, 29 Bots, 30 simulated
 seconds and 15 frame callbacks/second. Loop CPU includes marshalling and
 per-frame snapshot/navigation capture; process/fixture startup and final JSON
@@ -1326,6 +1327,110 @@ python3 tools/ffi_experiment/compare_runs.py --python "$FFI_PY27" \
   --control-components aiming,driver-flow,contacts,world-sync,navigation-flow,motion-flow \
   --seconds 30 --rounds 3 --output /tmp/ffi-kernel-comparison
 sh tools/ffi_experiment/build_1513.sh /tmp/ffi-kernel-1513
+```
+
+The fixed-field follow-up keeps that same production baseline and frozen
+`fabc7e6e` implementation as controls. Profiling the original measured loop
+counted 53,854 kernel bridge callbacks plus 82,273 nested world callbacks:
+136,127 C++-to-Python calls, distinct from the 7,600 forward FFI entries.
+The kernel total includes 134 navigation notifications and 53,720 engine leaves.
+It also counted 107,440 actor reads and 32,941 full actor decodes. Native stack
+sampling identified hash-table lookup, destruction and allocation among the
+remaining hot operations. These are deterministic fixture counts and sampled
+host evidence, not measurements of BigWorld's real implementation.
+
+`kernel_fields.h` now assigns 139 compile-time slots to the reviewed state and
+projection fields. Bot state and perception/aim pose projections store values
+contiguously, with explicit presence flags; missing and present-null fields
+remain distinct. Descriptor coefficients and irregular ledger keys retain
+mapping storage. Publication columns, perception projections and callback
+columns bind their field names once. Slot values still use the tagged `Value`
+representation: this is not a fully typed rewrite of every native subsystem.
+Shared container allocation and three-component vectors also avoid redundant
+allocations. Shallow copies preserve nested ownership, deep copies detach it,
+and serialization visits both fixed slots and irregular keys.
+
+Primitive motion, ground, water, destructible-scan and cancellation leaves
+project and consume only their actual inputs. Callbacks that consume vehicle
+mappings still receive fresh dictionary copies, including the synchronous
+motion resolver's callback-visible pose. Exact numeric projection variants can
+share a decoded template within one owned update. Writes to decoded top-level
+fields cannot change that template; nested ownership follows the original
+shallow-copy contract. The cache clears at each update and teardown, while
+standalone leaf audits keep only one entry per actor. Required scan fields
+still fail when absent; a water probe still reads BotRuntime's x/y/z contract,
+not a separately projected target position. Siege descriptor selection and
+ordered engine calls are unchanged.
+
+The final nine fresh-process, three-round rotating comparison uses the same
+29-Bot Great Wall combat scene, 30 simulated seconds, 15 callbacks/second and
+CPython 2.7.18 Linux aarch64 host. All build and validation processes have
+finished before timing. All nine full snapshots match the unmodified Python
+oracle, including messages, ordered queries, probes, decisions, navigation and
+diagnostics. Initialization and final file output remain outside loop CPU.
+
+| Variant | Median loop CPU | Min–max loop CPU | Reduction against Python |
+| --- | ---: | ---: | ---: |
+| Unmodified Python | 11.244537 s | 11.238067–11.332941 s | 0.00% |
+| Frozen `fabc7e6e` kernel and Python adapters | 7.974894 s | 7.949418–8.031234 s | 29.08% |
+| Fixed fields and narrower callback projections | 6.491684 s | 6.489070–6.549257 s | 42.27% |
+
+The follow-up reduces loop CPU another 18.60% against the frozen kernel. Its
+median initialization is 0.165740 s; median loop-plus-initialization CPU is
+6.657545 s. Actor reads fall from 107,440 to 44,678, and full decodes from 32,941
+to 22,924. There are still 53,720 engine leaves and 77,172 recorded fake collision
+rays. The runner reports engine-leaf callback counts separately from actor work;
+nested world calls and navigation notifications are not included in that count.
+A separate final profile reconfirms 53,854 kernel-bridge and 82,273 nested-world
+callbacks (136,127 total); its instrumented CPU time is not used in the table.
+No probe cadence, collision work, control slice or accepted shot is removed.
+These results remain far below a 90% reduction and do not predict Windows FPS.
+
+A separate six-process, alternating-order storage ablation keeps the final
+Python adapters, field bindings and allocation improvements in both variants.
+Only `Value::record()`/`as_record()` are changed in a temporary source copy to
+retain dictionary storage. Its median is 7.362928 s versus 6.485199 s with slots:
+fixed storage saves 11.92% in this comparison. All six full snapshots match.
+Fixed capacity trades some memory for fewer hash nodes: median whole-process
+peak RSS is 90,000 KiB with slots versus 88,696 KiB with dictionaries, an increase
+of 1,304 KiB. This includes fixture startup and serialization; it is not a
+measurement of native kernel heap usage or Windows memory consumption.
+
+The new focused checks exercise 20,000 storage mutations against an independent
+mapping oracle, missing/null distinctions, embedded-NUL irregular keys, stable
+references, alias/copy/clone semantics, merges and JSON round trips. Python 2.7
+leaf tests cover projection variants, caller mutation and retained dictionaries,
+actor identity, bounded standalone caches and primitive leaf contracts. The
+whole-update and subsystem differential checks use the unchanged Python 2.7
+implementation as their oracle. The final host module passes all kernel
+subsystem checks and six 80-frame whole-update variants. ASan/UBSan pass the
+storage oracle and a 40-frame combined Siege/human/cover/order scene; native
+extension leak detection is disabled and both sanitizers halt on errors.
+Existing production CI does not execute this opt-in experiment; its local checks and host benchmark are the relevant evidence.
+The x86 build is unshipped, and Windows loading, floating-point parity, native
+ownership and real frame pacing remain unproved.
+
+Reproduce the frozen-source comparison (the control runner must come from
+`fabc7e6e`, so Python adapters are frozen along with its native module):
+
+```bash
+sh tools/ffi_experiment/build_host.sh "$FFI_PY27" /tmp/ffi-hot-host
+sh "$FFI_KERNEL_CONTROL/tools/ffi_experiment/build_host.sh" "$FFI_PY27" /tmp/ffi-old-host
+PYTHONDONTWRITEBYTECODE=1 "$FFI_PY27" tools/ffi_experiment/check_kernel_engine.py
+c++ -std=c++11 -O1 -g -Wall -Wextra -Werror \
+  -fsanitize=address,undefined -fno-sanitize-recover=all \
+  tools/ffi_experiment/check_kernel_fields.cpp -o /tmp/ffi-fields-check
+/tmp/ffi-fields-check
+PYTHONDONTWRITEBYTECODE=1 "$FFI_PY27" tools/ffi_experiment/check_kernel_update.py \
+  --module /tmp/ffi-hot-host/offline_astar_native.so --fixture /tmp/ffi-kernel-fixture.json \
+  --frames 80 --siege --human --cover --orders
+python3 tools/ffi_experiment/compare_runs.py --python "$FFI_PY27" \
+  --module /tmp/ffi-hot-host/offline_astar_native.so --fixture /tmp/ffi-kernel-fixture.json \
+  --components kernel,world-sync --control-components kernel,world-sync \
+  --control-module /tmp/ffi-old-host/offline_astar_native.so \
+  --control-runner "$FFI_KERNEL_CONTROL/tools/ffi_experiment/portable_workload.py" \
+  --seconds 30 --rounds 3 --output /tmp/ffi-hot-comparison
+sh tools/ffi_experiment/build_1513.sh /tmp/ffi-hot-1513
 ```
 
 The previous 0.3.65 schema-v2 catalog supplied transformed OBBs but joined

--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -1673,6 +1673,130 @@ py-spy record --native --rate 200 --format raw --full-filenames \
   --output /tmp/ffi-boundary-sampled.json
 ```
 
+The publication follow-up replaces the nested temporary signature with two
+reusable native buffers. Bound scalar fields retain explicit presence and
+`Value` equality; ordered Bot, ammunition, equipment, shot, launch and ram
+records retain the previous shallow ownership. Equipment readiness changes
+only at the same cooldown boundary, while inactive pending timestamps and
+ordinary pose/time changes do not create durable events. Wire rows reserve
+their fixed and optional widths once, and optional groups bind field slots at
+configuration. No publication cadence, event ordering or engine query changes.
+
+Fifteen fresh processes in three rotating rounds repeat the same 29-Bot,
+30-second Great Wall scene on CPython 2.7.18, with frozen `3c9bc7d7` as the
+previous runner/binary and production `900744ce` as the Python oracle:
+
+| Variant | Median loop CPU | Observed range | Reduction vs Python |
+| --- | ---: | ---: | ---: |
+| Unmodified production Python | 10.881820 s | 10.798626–10.969403 s | 0.00% |
+| Frozen bounded-argument kernel (`3c9bc7d7`) | 5.737643 s | 5.694688–5.755725 s | 47.27% |
+| Reusable C++ publication records | 5.547883 s | 5.479581–5.568934 s | 49.02% |
+
+The new native representation removes another 3.31% of loop CPU against the
+control measured in these same rounds. Median initialization is 0.167041 s.
+All fifteen complete snapshots match, including 225 state publications,
+77,172 fake collision rays, 111,533 reverse callbacks and 2,562 forward
+dispatches. No whole-update thread pool is enabled. The distinct profiling
+binary takes 5.520867 s with observation disabled and 5.875001 s enabled
+(observed deltas of -0.49% against the normal binary and +6.41% for enabling
+the observer). These are observer controls, not additional optimizations.
+Its mean zones are 2.209018 s native body (37.02%), 3.172138 s Python callbacks
+(53.16%), 0.468830 s Python outer/conversion work (7.86%), and 0.116917 s C
+bridge copying/release (1.96%). The preceding ownership and fake-engine
+limitations still apply; none of these shares is an optimization floor.
+
+The native-thread probe is deliberately a separate host executable,
+`benchmark_codec_threads.cpp`. It compares one calling thread with the caller
+plus one persistent helper, using disjoint halves of the same immutable
+29-row publication fixture. The fixture is reconstructed from final Python
+wire rows, with the source equipment contracts; it is not a live native-engine
+snapshot. Each batch waits for both halves and retains original row order.
+Both modes verify Python row equality and recovery after simultaneous first-
+and last-row failures. No Python object, query bridge or engine call is
+reachable from the helper. Each mode runs in a fresh process because creating
+a thread can change the standard library's shared-reference implementation.
+Timing includes repeated row allocation/release and, in the parallel mode,
+dispatch and completion barriers; thread startup and 20 warmup batches are excluded.
+This intentionally favorable fixed-input probe does not establish Windows
+thread performance or justify parallelizing the stateful Bot loop.
+
+Seven alternating rounds (14 fresh processes, 10,000 batches each) on this
+two-CPU Linux aarch64 host give the following uninstrumented results:
+
+| Encoding workers | Median wall time per batch | Wall range per batch | Median total CPU per batch |
+| --- | ---: | ---: | ---: |
+| Caller only | 66.954 us | 66.755–67.764 us | 66.934 us |
+| Caller plus persistent helper | 44.238 us | 43.050–45.044 us | 77.897 us |
+
+The two-thread batch finishes 33.93% sooner while using 16.38% more aggregate
+CPU. Thus this pure C++ stage does benefit from parallelism; its absolute saving
+is only 22.716 us per 29-row batch. This measures encoding alone, excluding
+equipment-state construction, edge comparison, JSON serialization and callbacks.
+Applying that isolated difference to 225 publications would save about 5.1 ms
+of encoding wall time; that extrapolation is not an end-to-end measurement.
+The helper remains a benchmark, rather than a thread pool in the Bot kernel;
+end-to-end benefit and the Windows ownership/lifecycle cost have not been
+established. A larger independent computation stage is the next candidate for
+parallel execution.
+
+The existing Bot loop commits each actor's motion before later actors consume
+it, and shares perception caches, query budgets and event ledgers. Its borrowed
+query route also has caller-thread/GIL ownership and process-global active
+buffers. Parallelizing that loop requires a separately proved immutable
+computation stage with ordered commits; putting its current callbacks on
+worker threads would violate those contracts.
+
+The publication record audit passes 884 comparisons with the previous nested
+signature oracle, including isolated field, ammunition, shot, equipment and
+cooldown changes, missing/null values, empty/shrinking/reordered rosters, launches
+and ram events. Normal and ASan/UBSan runs also pass 13,632 weapon transitions,
+311 wire/invalid rows, 900 equipment transitions, 4,256 decimal cases, 2,015
+health/publication transitions and 13 packed-output/lifecycle checks. The
+combined 80-frame native-world Siege/human/cover/order comparison passes in
+both builds; normal checks also cover 80-frame Himmelsdorf navigation and the
+original Python world-callback path. Bridge ownership and host-profile checks
+pass. Host and x86 builds treat warnings as errors; the `.pyd` still imports
+only `KERNEL32.dll` and `msvcrt.dll`. Sanitizers halt on error with leak checking
+disabled. Production CI does not compile or run this opt-in experiment, and
+the standalone thread probe is not linked into either bridge.
+
+Reproduce this stage with `FFI_PY27` and the exported fixture from above:
+
+```bash
+FFI_PUBLICATION_CONTROL=/tmp/ffi-publication-control
+git worktree add --detach "$FFI_PUBLICATION_CONTROL" 3c9bc7d7
+sh tools/ffi_experiment/build_host.sh "$FFI_PY27" /tmp/ffi-publication-host
+sh tools/ffi_experiment/build_host.sh "$FFI_PY27" /tmp/ffi-publication-profile --profile
+(cd "$FFI_PUBLICATION_CONTROL" && sh tools/ffi_experiment/build_host.sh \
+  "$FFI_PY27" /tmp/ffi-publication-control-host)
+c++ -std=c++11 -O2 -Wall -Wextra -Werror \
+  tools/ffi_experiment/check_kernel_publication.cpp -o /tmp/ffi-check-publication
+/tmp/ffi-check-publication
+"$FFI_PY27" tools/ffi_experiment/check_kernel_state.py \
+  --module /tmp/ffi-publication-host/offline_astar_native.so --fixture /tmp/ffi-boundary-fixture.json
+"$FFI_PY27" tools/ffi_experiment/check_kernel_update.py \
+  --module /tmp/ffi-publication-host/offline_astar_native.so --fixture /tmp/ffi-boundary-fixture.json \
+  --frames 80 --native-world --siege --human --cover --orders
+python3 tools/ffi_experiment/compare_runs.py --python "$FFI_PY27" \
+  --fixture /tmp/ffi-boundary-fixture.json --seconds 30 --rounds 3 \
+  --module /tmp/ffi-publication-host/offline_astar_native.so \
+  --components kernel,world-sync,world-resolver \
+  --control-components kernel,world-sync,world-resolver \
+  --control-module /tmp/ffi-publication-control-host/offline_astar_native.so \
+  --control-runner "$FFI_PUBLICATION_CONTROL/tools/ffi_experiment/portable_workload.py" \
+  --profile-module /tmp/ffi-publication-profile/offline_astar_native.so \
+  --output /tmp/ffi-publication-comparison
+"$FFI_PY27" tools/ffi_experiment/portable_workload.py \
+  --fixture /tmp/ffi-boundary-fixture.json --backend python --seconds 30 \
+  --output /tmp/ffi-codec-source.json --codec-fixture-output /tmp/ffi-codec-fixture.json
+c++ -std=c++11 -O2 -Wall -Wextra -Werror -ffp-contract=off -fno-fast-math -pthread \
+  tools/ffi_experiment/benchmark_codec_threads.cpp -o /tmp/ffi-codec-threads
+# Repeat these fresh processes in alternating order for seven rounds.
+/tmp/ffi-codec-threads /tmp/ffi-codec-fixture.json 1 10000
+/tmp/ffi-codec-threads /tmp/ffi-codec-fixture.json 2 10000
+sh tools/ffi_experiment/build_1513.sh /tmp/ffi-publication-1513
+```
+
 The previous 0.3.65 schema-v2 catalog supplied transformed OBBs but joined
 runtime slots by native filename taken from the chunk list. A slot may be
 present as `''`, while an unresolved, handlerless or NULL-name slot is absent;

--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -868,6 +868,126 @@ The measured reduction concerns this Bot loop only; it establishes neither
 Windows FPS improvement nor lower process memory use. The native graph is an
 additional copy, and no process-memory attribution was measured.
 
+A second, wider experiment extends the same bridge on production baseline
+`900744ce30c2d4b59ec86e21438b3038eec2facf`. Select it explicitly with
+`--components aiming,driver,contacts`; production source, launcher and package
+entry points still do not import the experiment. The transferred scope is:
+
+| Area | C++ ownership | Python retained at the boundary |
+| --- | --- | --- |
+| Perception | Ordered contact traversal, visibility cache, shot edges, fair probe admission/debt and team visibility leases | Exact descriptor/equipment projections, native LOS calls, human observation orchestration and publication/remembered-pose dictionaries |
+| Local driving | Complete driver state, steering leases, progress/recovery/braking, candidate fan, wreck/reverse/pivot geometry | Route orchestration and smoothing, normalized neighbour transfer and native direction/pose probes |
+| Ballistics and gun aim | Iterative moving-target intercept, physical gun reach, float32 pitch curves, hydraulic correction, gun/turret slew and final barrel orientation | Exact muzzle/part selection, mounted loadout/critical projections, gunnery rating/error/fire gating and asynchronous SPG query lifecycle |
+
+The native driver retains its state between calls. A query yield resumes the
+same operation from its initial state and already collected numeric answers;
+only C++ computation is replayed, never a Python/native query. Perception
+transfers an actor template once per pre/post-motion phase in a slice, keeps
+cache/fairness/lease state in C++, and returns at descriptor or engine leaves.
+Python materializes the original contact/message shape for existing consumers.
+Neither boundary changes elapsed time, planning budgets, accepted shots or
+one-shot events. Owned numeric buffers are synchronous; the core retains no
+Python objects, buffer addresses or BigWorld objects. Round reset retires the
+old perception owner, and runner teardown restores patches before core reset.
+
+| Variant | Median loop CPU | Min–max loop CPU | Reduction | Median initialization |
+| --- | ---: | ---: | ---: | ---: |
+| Unmodified Python | 11.127597 s | 11.089077–11.275623 s | 0.00% | 0.000004 s |
+| Native A* only | 10.550740 s | 10.456242–10.628824 s | 5.18% | 0.055985 s |
+| Native A* + contacts + driving + aiming | 9.958523 s | 9.863221–10.280073 s | 10.51% | 0.061130 s |
+
+The expanded variant reduces loop CPU by 10.51% against Python and 5.61%
+against the A*-only control. Including initialization, its median cold CPU
+is 10.019653 s against 11.127600 s for Python, a 9.96% reduction.
+
+This comparison uses the same Linux aarch64 CPython 2.7.18 environment and
+29-Bot Great Wall combat scene described above. All three variants run on the
+same production baseline, sequentially in rotating order, with seven processes
+per variant and no stage instrumentation. Timing includes ordinary FFI
+marshalling and per-frame snapshot capture; initialization is separate.
+All 21 snapshots match in complete messages, native-query geometry/order,
+logical probes, decisions, per-frame navigation state, and visibility fairness
+diagnostics. Equality does not round values or use a numerical tolerance.
+
+A separate three-round instrumented comparison also preserves every snapshot.
+Its median loop reduction is 8.34%; the observer wraps roughly 53,000 native
+dispatches, so it is not the primary speed estimate. Selected inclusive stage
+medians explain where the uninstrumented gain comes from:
+
+| Stage | Python | Expanded native variant |
+| --- | ---: | ---: |
+| A* batch | 0.703828 s | 0.166939 s |
+| Ballistic stage, including retained gunnery/muzzle work | 1.140016 s | 0.790529 s |
+| Gun aiming | 0.510161 s | 0.234527 s |
+| Contacts, including adapter and message materialization | 1.114098 s | 1.262330 s |
+| Driving and route work, including the A* row above | 1.619781 s | 1.199476 s |
+
+These rows are not additive because driving includes A*. In particular, the
+contact stage becomes more expensive; the native fair scheduler also saves
+work outside that scope, so the row alone is not a total-perception estimate.
+Driver/route work outside A* remains expensive too. All native dispatches
+together take 0.475700 s, including the C++ core but excluding Python-side
+marshalling and object materialization. Remaining Python gunnery, descriptor
+projection, world-query seams and publication still execute in the loop.
+Moving these three areas therefore does not turn their entire Python parent
+stages into native computation, and calling only the fast C++ kernels a
+whole-stage speedup would be misleading.
+
+The differential checks also compare 1,200 random intercepts, 1,200 full gun
+updates and low-arc/physical-reach solves across 12 descriptor profiles, and
+3,600 driver steps with every state field and query sequence checked. They
+cover all six drive modes, hydraulic/static/missing pitch limits, critical
+module and siege states, anonymous blocker result types, and rejected opcode
+or reset packets preserving an existing owner. Perception checks cover 1,080
+Bot contact batches and 180 human observer slices with a two-probe budget:
+human/selected/fire priorities, parked debt, fire-sequence reset, pre/post-motion
+poses, hidden memory expiry, native-probe failure and round reset. These are
+synthetic contract cases, not coverage of every client descriptor or a native
+Windows acceptance session.
+
+All expanded differential checks pass against CPython 2.7.18, including the
+new aiming/driving/perception core built with AddressSanitizer and
+UndefinedBehaviorSanitizer (`detect_leaks=0`). The 236-case A* sanitizer suite
+passes with the Python 3 host bridge. A* and perception also pass ordinary
+Python 3.12.3 differential checks. Random gun updates expose one-ULP
+reference differences under Python 3.12's changed floating-point `sum`;
+restoring only Python 2's left-to-right sum in a diagnostic run removes all
+those differences. The committed core and primary measurements retain the
+unmodified Python 2 contract; Python 3 aiming is not an acceptance reference.
+Five-second full-component checks on Karelia at 30 callbacks/second and
+Prohorovka at 10 callbacks/second match every snapshot family. All 97 client
+modules and nine portable experiment modules compile with CPython 2.7 without
+writing adjacent bytecode. Host bridges build for Python 2.7 and 3, and the
+unshipped x86 PE still imports only `KERNEL32.dll` and `msvcrt.dll`.
+
+The prototype requires normalized finite numeric inputs, valid descriptor
+curves and at most 30 actors per room. It explicitly rejects unsupported
+unbounded identity streams instead of approximating the Python cache's
+over-capacity pruning order. It does not replace all `BotRuntime` logic or
+the whole hidden-worker process. The Windows bridge remains unexecuted here;
+x86 loading, floating-point parity, actual native query costs, frame pacing,
+projectile terminals, gameplay feel and process memory remain unmeasured.
+The result therefore establishes neither a 90% whole-loop CPU reduction nor
+any Windows FPS/RAM improvement.
+
+Reproduce the expanded comparison after the fixture and host build commands
+above, using fresh output directories:
+
+```bash
+"$FFI_PY27" tools/ffi_experiment/check_core_parity.py \
+  --module /tmp/ffi-host/offline_astar_native.so --fixture /tmp/ffi-fixture.json
+"$FFI_PY27" tools/ffi_experiment/check_perception_parity.py \
+  --module /tmp/ffi-host/offline_astar_native.so --fixture /tmp/ffi-fixture.json
+python3 tools/ffi_experiment/compare_runs.py --python "$FFI_PY27" \
+  --module /tmp/ffi-host/offline_astar_native.so \
+  --fixture /tmp/ffi-fixture.json --output /tmp/ffi-core-comparison \
+  --components aiming,driver,contacts --include-astar-control --rounds 7
+python3 tools/ffi_experiment/compare_runs.py --python "$FFI_PY27" \
+  --module /tmp/ffi-host/offline_astar_native.so \
+  --fixture /tmp/ffi-fixture.json --output /tmp/ffi-core-stages \
+  --components aiming,driver,contacts --rounds 3 --stage-timing
+```
+
 The previous 0.3.65 schema-v2 catalog supplied transformed OBBs but joined
 runtime slots by native filename taken from the chunk list. A slot may be
 present as `''`, while an unresolved, handlerless or NULL-name slot is absent;

--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -758,6 +758,116 @@ one authority slice and template/remembered-pose identity. Each observer keeps
 its own contact object and visibility flags; new poses and slices invalidate
 that reuse.
 
+An isolated A* FFI experiment lives under `tools/ffi_experiment/`; no production
+module, launcher or package imports it. Its baseline is
+`e0600d4851dbca350849568a261bf77bfab7d3f7`. The C++ core retains a copied baked
+graph and resumable search heaps, costs and parents. The adapter transfers
+changed penalties and batches paid expansions in the existing fair order,
+returning at each completed search so the unchanged Python finalizer runs
+before another search advances. Nearest-cell selection, ground/native probes,
+path smoothing, tactical decisions, motion and publication remain Python-owned.
+There is no change to cadence, expansion credits, hazards or collision safety.
+Only explicit experiment runners install and restore the temporary patches;
+the experiment requires a baked graph and one backend owner per process.
+
+The 2026-09-07 Linux aarch64 measurement used CPython 2.7.18, the Great Wall
+combat fixture, 29 Bots, 30 simulated seconds and 15 frame callbacks/second.
+Seven independent processes per variant ran sequentially in rotating order
+on a shared development host; this was not a dedicated hardware benchmark.
+The following CPU times include normal adapter marshalling and per-frame
+snapshot capture, but exclude fixture/process startup and JSON serialization.
+The separate native initialization includes module loading and graph transfer.
+
+| Variant | Median loop CPU | Min–max loop CPU | Reduction | Median initialization |
+| --- | ---: | ---: | ---: | ---: |
+| Unmodified Python | 11.298922 s | 11.256200–11.394970 s | — | 0.000006 s |
+| Native A*, one FFI call per paid step | 10.941449 s | 10.852666–11.318563 s | 3.16% | 0.055710 s |
+| Native A*, fair batch | 10.640391 s | 10.530723–10.886375 s | 5.83% | 0.055796 s |
+
+Including initialization, median cold CPU was 11.298928 s for Python and
+10.695704 s for the batch variant, a 5.34% reduction. Both native variants
+performed 28,800 expansions and completed 51 searches. Total dispatch calls
+fell from 29,046 to 520 with batching; these include setup and result transfers.
+All 21 runs matched the Python reference exactly for complete outgoing
+messages, native-query geometry/order, logical probes, decisions, and every
+frame's navigation queues, paths, credits, completion counters and last-frame
+markers. Equality uses complete values, without rounding or tolerances.
+
+A separate three-round Python/batch comparison with `--stage-timing` explains
+the scope of that gain. Median inclusive A* batch CPU fell from 0.718622 s to
+0.170766 s: 76.24% less CPU, or 4.21 times faster, including dispatch,
+marshalling, scheduling and the unchanged Python path finalizer. A* accounted
+for only 6.10% of the instrumented baseline loop. Native dispatch itself took
+0.067323 s, but it excludes Python-side transfer and finalization, so comparing
+that number alone with the original complete A* stage would overstate speedup.
+Instrumentation is separate from the primary seven-round timing above.
+
+Selected mutually exclusive stage medians in that instrumented baseline were
+17.51% for motion/collision handling, 10.14% for contacts, 9.91% for ballistics,
+7.95% for driving/route work outside A*, 4.75% for gun aim, 3.17% for publication
+encoding, 2.86% for supplemental shot lanes, and 1.73% for longitudinal/traverse
+formulas. Another 31.93% remained inside the control slice outside those chosen
+scopes; work outside the slice and observer overhead also remain. These are
+host fixture costs, not measured Windows native-engine costs. They identify
+unmigrated work, not a claim that all of it is independently safe to move.
+This experiment therefore does not measure the ceiling of migrating the whole
+Bot loop, and does not establish a 90% whole-loop reduction.
+
+`check_parity.py` additionally compares exact paths, completion-step boundaries
+and timed-penalty expiry across 200 generated graphs and 36 searches on the
+shipped Karelia, Prohorovka and Great Wall graphs. It exercises missing cells,
+disconnection, shallow/fatal hazards, avoidance, changing local/global/hard
+penalties, expansion caps, cancellation, invalid commands and repeated cleanup.
+The workload exporter adapts only test scaffolding to Python 2; it executes
+production client modules directly. Its Python 3 output is independently
+checked against the runner importing the original fixtures.
+
+The final differential suite passed separately on CPython 2.7.18 and 3.12.3.
+Five-second workload checks also matched on Karelia at 30 callbacks/second and
+Prohorovka at 10 callbacks/second; these smoke runs are behavior evidence only,
+not additional timing estimates.
+The same 236-case suite passed with the host core and bridge compiled with
+AddressSanitizer and UndefinedBehaviorSanitizer (`detect_leaks=0`); this checks
+the exercised host bounds/undefined-behavior paths, not Windows bridge safety
+or leak freedom.
+
+Reproduce the primary comparison with a compatible host CPython 2.7.18 and
+Python 3 for fixture extraction/orchestration (each output directory must be
+new):
+
+```bash
+export PYTHONDONTWRITEBYTECODE=1
+export FFI_PY27=/path/to/cpython-2.7.18/bin/python2.7
+sh tools/ffi_experiment/build_host.sh "$FFI_PY27" /tmp/ffi-host
+python3 tools/ffi_experiment/export_fixture.py /tmp/ffi-fixture.json
+"$FFI_PY27" tools/ffi_experiment/check_parity.py \
+  --module /tmp/ffi-host/offline_astar_native.so --random-cases 200
+python3 tools/ffi_experiment/compare_runs.py --python "$FFI_PY27" \
+  --module /tmp/ffi-host/offline_astar_native.so \
+  --fixture /tmp/ffi-fixture.json --output /tmp/ffi-comparison \
+  --rounds 7 --include-step
+python3 tools/ffi_experiment/compare_runs.py --python "$FFI_PY27" \
+  --module /tmp/ffi-host/offline_astar_native.so \
+  --fixture /tmp/ffi-fixture.json --output /tmp/ffi-stages \
+  --rounds 3 --stage-timing
+sh tools/ffi_experiment/build_1513.sh /tmp/ffi-x86
+```
+
+The last command cross-compiles a separate, unshipped x86 `.pyd` and checks its
+PE export/import contract. Its bridge reuses the reviewed instance-guard
+`Py_InitModule4`/`PyInt_FromLong` RVAs, checks the executable identity and code
+prologues, and requires a tuple/int layout self-test before dispatch. It passes
+only owned numeric buffers and retains no Python/native-engine objects. The
+host bridge uses the host Python C API instead; its timing does not include
+the Windows bridge's `VirtualQuery` guards. Cross-compilation does not prove
+loading, pointer/layout safety, x86 floating-point parity or speed in the
+embedded CPython 2.7.7 runtime. The experiment has not run on exact Windows
+#1513, and the synthetic workload acknowledges launches without simulating
+projectile terminals, rendering, real native-query cost or network delay.
+The measured reduction concerns this Bot loop only; it establishes neither
+Windows FPS improvement nor lower process memory use. The native graph is an
+additional copy, and no process-memory attribution was measured.
+
 The previous 0.3.65 schema-v2 catalog supplied transformed OBBs but joined
 runtime slots by native filename taken from the chunk list. A slot may be
 present as `''`, while an unresolved, handlerless or NULL-name slot is absent;

--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -1433,6 +1433,132 @@ python3 tools/ffi_experiment/compare_runs.py --python "$FFI_PY27" \
 sh tools/ffi_experiment/build_1513.sh /tmp/ffi-hot-1513
 ```
 
+The next experiment composes collision arbitration and the world sweep directly
+inside the owned motion kernel (`kernel,world-sync,world-resolver`). Its review
+still belongs to the complete experimental PR against `main`. The frozen
+`fb2ba3cf` kernel, adapters and production source remain the previous-performance
+control; the Python oracle remains production source `900744ce`.
+
+The resolver reads current native Bot state, computes corridor eligibility and
+directional kinetic admission, runs the C++ world sweep, and combines its result
+with the source catalog's exact contact receipt. Collision extents and the
+unmodified descriptor's forward/backward limits are compiled once per vehicle
+mode. They are distinct from crew/equipment-adjusted driving parameters. Siege
+transitions select the corresponding compiled profile. Missing collision
+extents reject construction; partially installed adapters are restored on
+failure. No production entry point or package installs this experiment.
+
+The exported fixture exposes its existing battle owner explicitly; it retains
+the source resolver for Python and frozen-control runs. Native callbacks use a
+64-double packet for begin, scalar query, completion and paired query operations.
+Python owns fresh operation-local native hit/filter references and every actual
+engine/catalog call. Native code retains none of those Python objects. Both
+normal completion and failed updates clear the operation; repeated teardown is
+safe. Callback entry checks the Bot runtime, round, space and catalog owner, and
+paired queries recheck those identities between their two native calls.
+Reuse and completion also check ownership after the catalog callback returns.
+
+Only queries already unconditional in the source are paired: the two initial
+under-hull ground columns and the two ordinary upper collision rays. Their
+engine calls still run sequentially in the original order. Ground-dependent
+geometry, midpoint/profile probes, slope-branch early exits, destruction/recast
+and catalog commits remain barriers. A first-query exception or non-finite
+answer stops the second query. The source catalog continues to own spatial
+indexes, live destruction, delayed skins, filters and canonical publication.
+This change does not claim migration of that catalog or projectile terminals.
+
+Expanded variable-step whole-update coverage found an existing C++ arithmetic
+mismatch in the previously isolated world core: optimizing `pow(x, 2)` to `x*x`
+changed an inside-hull length from `4.000000000000032` to
+`4.0000000000000329`, then changed a ray endpoint from `0.9719008512196334` to
+`0.9719008512196335`. Replaying the source's single-sweep trace reproduced it
+without batching. All source power expressions in the world core now retain
+the libm call used by CPython 2, including constant exponents. A regression uses
+that exact pose and ground transition; comparisons still require exact equality.
+
+On the final source, 480 focused source comparisons cover resolver branches,
+query exceptions, malformed receipts, varied extents/speed caps, and populated
+fragile/structure catalogs. The latter compare ordered native destruction,
+canonical publications, pending skins and subsequent filter decisions. Separate
+lifetime checks retire the round during an upper ray or catalog completion,
+reject an unrelated world owner after partial startup, and verify restoration.
+Seven 80-frame whole-update variants pass: six with this resolver (including
+combined Siege/human/cover/order changes and Himmelsdorf navigation), plus the
+previous callback path. New-path checks also inject a failed engine leaf and
+verify update cleanup and repeated teardown. The state, gunnery/launch,
+perception/lane, motion, aim, route/driver/traffic, contact and borrowed-buffer
+suites pass. Both scalar and synchronous world adapters pass 75 physical tests
+and 145 recorded query/result traces; one internal-helper mock remains a
+source-only test. ASan/UBSan pass the 480-case audit, borrowed callbacks and an
+80-frame combined update, with errors fatal and extension leak detection
+disabled. Host and x86 builds pass with warnings as errors; the x86 PE imports
+only `KERNEL32.dll` and `msvcrt.dll`. Client and changed runtime-side experiment
+sources compile under CPython 2.7.
+
+Three rotating rounds (nine fresh processes) on the same Linux aarch64 host
+under CPython 2.7.18 use Great Wall combat, 29 Bots and 30 simulated seconds at
+15 callbacks/second. The previous kernel and runner are frozen at `fb2ba3cf`;
+all nine complete snapshots match, including messages, ordered engine queries,
+motion probes, decisions, navigation progress and diagnostics.
+
+| Variant | Median loop CPU | Observed range | Reduction vs Python |
+| --- | ---: | ---: | ---: |
+| Unmodified production Python | 11.130556 s | 11.066111–11.145113 s | 0.00% |
+| Frozen kernel and adapters (`fb2ba3cf`) | 6.462702 s | 6.357355–6.573080 s | 41.94% |
+| Direct collision flow and paired queries | 6.244988 s | 6.156629–6.256726 s | 43.89% |
+
+The incremental median reduction is 3.37%, not another 43.89%. Median native
+initialization is 0.167170 s (control: 0.164288 s). Loop timing includes ordinary
+callback marshalling and per-frame snapshot/navigation capture, but excludes
+fixture/process startup and final file serialization. Earlier measurements use
+their own controls; their savings must not be added to this result.
+
+Forward dispatches fall from 7,600 to 2,562. Native-to-Python callbacks fall from
+136,127 to 111,533: 48,682 engine leaves, 134 navigation notifications and 62,717
+world callbacks. The latter comprise 5,038 begins, 5,038 completions, 23,009 scalar
+queries and 29,632 query pairs. They still execute 82,273 ordered world leaves
+and exactly 77,172 fake collision rays. Actor reads fall from 44,678 to 39,640
+and decodes from 22,924 to 17,955. A separate final-source loop profile confirms
+those counts and its snapshot also matches; its instrumented timings are not
+included above. It still records 241,222 vector constructions, 3,830
+`_fell_trees_near` calls and 8,516 spatial-signature calls. These are remaining
+allocation/catalog costs, not evidence that all of them can be removed.
+
+This modest gain supports direct composition but does not establish a route to
+90% CPU savings. The measured registry is empty and projectile launches are
+acknowledged without terminal simulation. Populated catalog checks prove local
+ordering and outcome parity, not representative catalog performance. Further
+allocation work should identify redundant object construction and measure
+populated scenes before changing ownership. The oracle remains source
+`900744ce`, not the newer `main`. Host fake-query CPU is not Windows FPS;
+#1513 loading, x86 numerical parity, native ownership and frame pacing still
+require the exact Windows client. The extension remains unshipped.
+
+Reproduce this stage with a fresh fixture and separately built frozen control
+(set `FFI_PY27` to the CPython 2.7.18 executable):
+
+```bash
+export PYTHONDONTWRITEBYTECODE=1
+FFI_WORLD_CONTROL=/tmp/ffi-world-control
+git worktree add --detach "$FFI_WORLD_CONTROL" fb2ba3cf
+python3 tools/ffi_experiment/export_fixture.py /tmp/ffi-world-fixture.json
+sh tools/ffi_experiment/build_host.sh "$FFI_PY27" /tmp/ffi-world-host
+(cd "$FFI_WORLD_CONTROL" && sh tools/ffi_experiment/build_host.sh \
+  "$FFI_PY27" /tmp/ffi-world-control-host)
+"$FFI_PY27" tools/ffi_experiment/check_kernel_world.py \
+  --module /tmp/ffi-world-host/offline_astar_native.so --fixture /tmp/ffi-world-fixture.json
+"$FFI_PY27" tools/ffi_experiment/check_kernel_update.py \
+  --module /tmp/ffi-world-host/offline_astar_native.so --fixture /tmp/ffi-world-fixture.json \
+  --frames 80 --native-world --siege --human --cover --orders
+python3 tools/ffi_experiment/compare_runs.py --python "$FFI_PY27" \
+  --module /tmp/ffi-world-host/offline_astar_native.so --fixture /tmp/ffi-world-fixture.json \
+  --components kernel,world-sync,world-resolver --control-components kernel,world-sync \
+  --control-module /tmp/ffi-world-control-host/offline_astar_native.so \
+  --control-runner "$FFI_WORLD_CONTROL/tools/ffi_experiment/portable_workload.py" \
+  --seconds 30 --rounds 3 --output /tmp/ffi-world-comparison
+sh tools/ffi_experiment/build_1513.sh /tmp/ffi-world-1513
+```
+
 The previous 0.3.65 schema-v2 catalog supplied transformed OBBs but joined
 runtime slots by native filename taken from the chunk list. A slot may be
 present as `''`, while an unresolved, handlerless or NULL-name slot is absent;

--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -1559,6 +1559,120 @@ python3 tools/ffi_experiment/compare_runs.py --python "$FFI_PY27" \
 sh tools/ffi_experiment/build_1513.sh /tmp/ffi-world-1513
 ```
 
+The boundary-cost follow-up separates remaining native execution from Python
+callbacks instead of treating all time inside `dispatch_sync` as C++. The
+earlier full cProfile observer increased a roughly 6.2 s loop to 12.168 s;
+its call counts are useful, but its percentages cannot be applied to the
+uninstrumented loop. The optional host-only `build_host.sh --profile` build
+instead partitions process CPU at synchronous dispatch/callback boundaries.
+Its four zones restore their previous owner across nested dispatch and failure.
+Observation starts after owner setup and stops before final report-file serialization.
+It is absent from normal builds and the #1513 bridge.
+
+The Python aim adapter also copied the unused tail of its 32,768-double shared
+buffer on every request. The native producer lends a 256-double packet, and
+the widest aim request uses 17 parameters. Bounding that copy to those 17
+parameters reduces the 8,914 aim slices in this workload from 2,329,691,728 to
+1,212,304 bytes. The native packets, actor projections, callback order, query
+count and gameplay results are unchanged. A guarded borrowed-packet regression
+fails on the original adapter's out-of-request read and passes after the fix.
+
+Fifteen fresh processes in three rotating rounds compare the unchanged Python,
+frozen `49c03342` runner/binary, final normal binary, and a profiling binary with
+observation disabled/enabled. The scene, interpreter and source oracle remain
+as above. All fifteen complete snapshots match. Primary timings exclude the
+optional observer:
+
+| Variant | Median loop CPU | Observed range | Reduction vs Python |
+| --- | ---: | ---: | ---: |
+| Unmodified production Python | 11.165138 s | 11.060664–11.253421 s | 0.00% |
+| Frozen collision-flow kernel (`49c03342`) | 6.255879 s | 6.241917–6.267949 s | 43.97% |
+| Bounded Python aim arguments | 6.001333 s | 5.971952–6.022205 s | 46.25% |
+
+This removes another 4.07% of loop CPU without moving another gameplay algorithm
+to C++. Median initialization is 0.166846 s. The profiling binary takes 6.088295 s
+with observation off and 6.366738 s with it on: observed deltas are 1.45% for
+compiled-in instrumentation and another 4.57% when enabled, with overlapping
+run ranges. These are observer-effect measurements, not performance gains.
+
+Mean ownership attribution across the three observed loops is:
+
+| CPU owner | Mean observed CPU | Share |
+| --- | ---: | ---: |
+| Native dispatch body, excluding callbacks | 2.485329 s | 39.13% |
+| Python callbacks, including call entry and ordinary callees | 3.265702 s | 51.41% |
+| Python outer loop, input/output conversion and snapshot capture | 0.483124 s | 7.61% |
+| C callback-buffer copies and result release | 0.117789 s | 1.85% |
+
+These are ownership zones, not irreducible costs or opcode-level language
+timings. Clock overhead remains included. In particular, the 1.85% C bridge
+zone is not all FFI overhead: Python argument decoding, actor dictionaries,
+vector construction and call entry are charged to Python callbacks. The latter
+also include builtin operations and deterministic engine fakes, so 51.41%
+cannot be advertised as removable production Python. Inclusive callback rows
+can overlap during nesting; only the four zones form a partition. For hotspot
+orientation, observed world-query leaves total about 1.307 s, catalog completion
+plus body scanning 0.810 s, and aim/origin/friendly-lane callbacks 0.351 s.
+
+A separate 200 Hz native stack sample of the final normal binary selects 1,726
+samples whose workload frame is inside the measured loop. The deepest Python
+frame attributes 669 samples to native dispatch/bridge, 484 to callback
+adapters, 191 to the Python catalog, 137 to fixture fakes, and 245 to other
+Python work. Of the 669 native-side samples, 133 end in allocation/free, 40 in
+shared-container destruction, and 100 in hash-table operations. Those 273
+samples (40.8% of the native-side sample) identify remaining representation and
+allocation costs; they do not establish that these costs can all be removed.
+Inlining, sampling error and one failed unwind limit attribution precision.
+The sampler wrote its result before a post-exit `No child process` error; the
+sampled workload completed and its entire snapshot matches the Python oracle.
+Its timing is excluded from the primary comparison.
+
+Thus about 39% of the observed loop is already native, but no measured share
+has been proved an optimization floor. Python adapters and catalog work remain
+specific candidates, and the bounded-copy fix demonstrates one removable cost.
+The native container/lookup sample argues for further native representation
+work too. Empty-catalog/fake-engine results do not quantify a populated Windows
+battle, and no percentage of remaining Python is promised removable.
+
+Both normal and profiling CPython 2.7 host builds pass with warnings as errors.
+The bridge audit passes with and without profiling, including nested buffers,
+230 callbacks during observation, original exception identity, result release,
+profile ownership guards and repeated start/stop. Seven Python leaf tests pass
+on Python 2.7 and Python 3; 2,320 aim transitions and 1,410 ordered queries pass,
+as does the 80-frame combined Siege/human/cover/order native-world comparison.
+Client and changed runtime-side experiment sources compile under Python 2.7.
+This stage changes no C++ gameplay core or #1513 bridge; their previous native
+acceptance limitations still apply.
+
+Reproduce the boundary comparison using `FFI_PY27` as above:
+
+```bash
+FFI_BOUNDARY_CONTROL=/tmp/ffi-boundary-control
+git worktree add --detach "$FFI_BOUNDARY_CONTROL" 49c03342
+sh tools/ffi_experiment/build_host.sh "$FFI_PY27" /tmp/ffi-boundary-host
+sh tools/ffi_experiment/build_host.sh "$FFI_PY27" /tmp/ffi-boundary-profile --profile
+(cd "$FFI_BOUNDARY_CONTROL" && sh tools/ffi_experiment/build_host.sh \
+  "$FFI_PY27" /tmp/ffi-boundary-control-host)
+python3 tools/ffi_experiment/export_fixture.py /tmp/ffi-boundary-fixture.json
+"$FFI_PY27" tools/ffi_experiment/check_host_profile.py \
+  --module /tmp/ffi-boundary-profile/offline_astar_native.so
+python3 tools/ffi_experiment/compare_runs.py --python "$FFI_PY27" \
+  --fixture /tmp/ffi-boundary-fixture.json --seconds 30 --rounds 3 \
+  --module /tmp/ffi-boundary-host/offline_astar_native.so \
+  --components kernel,world-sync,world-resolver \
+  --control-components kernel,world-sync,world-resolver \
+  --control-module /tmp/ffi-boundary-control-host/offline_astar_native.so \
+  --control-runner "$FFI_BOUNDARY_CONTROL/tools/ffi_experiment/portable_workload.py" \
+  --profile-module /tmp/ffi-boundary-profile/offline_astar_native.so \
+  --output /tmp/ffi-boundary-comparison
+py-spy record --native --rate 200 --format raw --full-filenames \
+  --output /tmp/ffi-boundary-stacks.txt -- "$FFI_PY27" \
+  tools/ffi_experiment/portable_workload.py --fixture /tmp/ffi-boundary-fixture.json \
+  --backend native --module /tmp/ffi-boundary-host/offline_astar_native.so \
+  --components kernel,world-sync,world-resolver --seconds 30 \
+  --output /tmp/ffi-boundary-sampled.json
+```
+
 The previous 0.3.65 schema-v2 catalog supplied transformed OBBs but joined
 runtime slots by native filename taken from the chunk list. A slot may be
 present as `''`, while an unresolved, handlerless or NULL-name slot is absent;

--- a/tools/ffi_experiment/astar_1513.c
+++ b/tools/ffi_experiment/astar_1513.c
@@ -28,6 +28,7 @@
 #include <stdint.h>
 
 #include "astar_core.h"
+#include "query_bridge.h"
 #include <string.h>
 
 #define OFFLINE_COMPUTE_OK 0
@@ -68,6 +69,9 @@ typedef PyObject *(__cdecl *PyIntFromLongFn)(long);
 #define RVA_PY_INIT_MODULE4 0x00be1940U
 #define RVA_PY_INT_FROM_LONG 0x00be1180U
 #define RVA_PY_INT_TYPE 0x01664bf0U
+#define RVA_PY_TUPLE_TYPE 0x0165c398U
+#define RVA_PY_FUNCTION_TYPE 0x01673218U
+#define RVA_FUNCTION_CALL 0x00c271c0U
 
 /* PyObject header, then PyIntObject.ob_ival; PyVarObject.ob_size, then items. */
 #define OFFSET_OB_TYPE 4U
@@ -87,6 +91,11 @@ static unsigned char *g_image_base = 0;
 static PyIntFromLongFn g_py_int_from_long = 0;
 static void *g_py_int_type = 0;
 static int g_layout_proven = 0;
+static int g_callback_proven = 0;
+static DWORD g_callback_thread = 0;
+typedef PyObject *(__cdecl *FunctionCallFn)(PyObject *, PyObject *, PyObject *);
+typedef void (__cdecl *DestructorFn)(PyObject *);
+static FunctionCallFn g_function_call = 0;
 
 
 static int readable_region(const void *address, SIZE_T bytes)
@@ -259,6 +268,7 @@ static PyObject *layout_self_test(PyObject *unused_self, PyObject *args)
 	long values[3];
 	int status;
 	(void)unused_self;
+	if (offline_query_active()) return python_int(-18);
 	status = read_int_arguments(args, values, 3);
 	if (status != OFFLINE_COMPUTE_OK) {
 		g_layout_proven = 0;
@@ -311,7 +321,135 @@ static PyObject *dispatch(PyObject *unused_self, PyObject *args)
 			!writable_region(buffer, (SIZE_T)count * sizeof(double))) {
 		return python_int(OFFLINE_COMPUTE_ADDRESS_UNREADABLE);
 	}
+	if (offline_query_active() && g_callback_thread != GetCurrentThreadId()) return python_int(18);
+	if (!offline_query_can_enter(buffer, (int)count)) return python_int(18);
 	return python_int(offline_astar_dispatch(buffer, (int)count));
+}
+
+/* Exact release-build CPython ownership: calls return a new reference even
+ * for None. Keep the GIL throughout, borrow callback/tuple only for this call,
+ * and release each result before the native computation continues. */
+static void release_result(PyObject *result)
+{
+    if (--result->ob_refcnt == 0) {
+        DestructorFn destroy = *(DestructorFn *)((unsigned char *)result->ob_type + 24);
+        destroy(result);
+    }
+}
+
+static PyObject **tuple_items(PyObject *args, long wanted)
+{
+    unsigned char *tuple = (unsigned char *)args;
+    if (!readable_region(tuple, 12 + (SIZE_T)wanted * 4) ||
+            args->ob_type != (void *)(g_image_base + RVA_PY_TUPLE_TYPE) ||
+            *(long *)(tuple + 8) != wanted) return 0;
+    return (PyObject **)(tuple + 12);
+}
+
+static int callback_arguments(PyObject *callback, PyObject *arguments)
+{
+    return readable_region(callback, 8) && readable_region(arguments, 12) &&
+        callback->ob_type == (void *)(g_image_base + RVA_PY_FUNCTION_TYPE) &&
+        arguments->ob_type == (void *)(g_image_base + RVA_PY_TUPLE_TYPE);
+}
+
+static int validate_callback_layout(void)
+{
+    unsigned char *type = g_image_base + RVA_PY_FUNCTION_TYPE;
+    unsigned char *tuple = g_image_base + RVA_PY_TUPLE_TYPE;
+    static const unsigned char signature[] = {
+        0x55, 0x8b, 0xec, 0x8b, 0x4d, 0x08, 0x83, 0xec,
+        0x18, 0x8b, 0x49, 0x10, 0x53, 0x56, 0x33, 0xf6
+    };
+    if (!readable_region(type, 68) || !readable_region(tuple, 24) ||
+            *(long *)(type + 16) != 44 || *(long *)(type + 20) != 0 ||
+            *(long *)(tuple + 16) != 12 || *(long *)(tuple + 20) != 4 ||
+            *(void **)(type + 64) != (void *)(g_image_base + RVA_FUNCTION_CALL) ||
+            !readable_region(g_image_base + RVA_FUNCTION_CALL, sizeof(signature)) ||
+            memcmp(g_image_base + RVA_FUNCTION_CALL, signature, sizeof(signature)))
+        return 0;
+    g_function_call = *(FunctionCallFn *)(type + 64);
+    return 1;
+}
+
+static PyObject *callback_self_test(PyObject *self, PyObject *args)
+{
+    PyObject **items, *result;
+    long value;
+    (void)self;
+    if (!g_layout_proven || offline_query_active()) return python_int(-17);
+    g_callback_proven = 0;
+    if (!validate_callback_layout()) return python_int(-17);
+    items = tuple_items(args, 2);
+    if (!items || !callback_arguments(items[0], items[1])) return python_int(-17);
+    result = g_function_call(items[0], items[1], 0);
+    if (!result) return 0; /* Preserve the callback's original Python exception. */
+    value = result->ob_type == g_py_int_type ? *(long *)((unsigned char *)result + 8) : -17;
+    release_result(result);
+    if (value != SELF_TEST_RESULT) return python_int(-17);
+    g_callback_proven = 1;
+    return python_int(value);
+}
+
+typedef struct {
+    double *packet;
+    int capacity, failed;
+    PyObject *callback, *arguments;
+} QueryOwner;
+
+static int invoke_query(void *opaque, double *packet, int count)
+{
+    QueryOwner *owner = (QueryOwner *)opaque;
+    PyObject *result;
+    if (count < 1 || count > owner->capacity) return 18;
+    memcpy(owner->packet, packet, (SIZE_T)count * sizeof(double));
+    result = g_function_call(owner->callback, owner->arguments, 0);
+    if (!result) { owner->failed = 1; return 18; }
+    release_result(result);
+    memcpy(packet, owner->packet, (SIZE_T)count * sizeof(double));
+    return 0;
+}
+
+static PyObject *dispatch_sync(PyObject *self, PyObject *args)
+{
+    PyObject **items;
+    long values[6];
+    uintptr_t address, query_address;
+    QueryOwner owner;
+    int index, status;
+    DWORD previous_thread;
+    (void)self;
+    if (!g_callback_proven) return python_int(18);
+    items = tuple_items(args, 8);
+    if (!items) return python_int(12);
+    for (index = 0; index < 6; ++index) {
+        if (!readable_region(items[index], 12) || items[index]->ob_type != g_py_int_type)
+            return python_int(13);
+        values[index] = *(long *)((unsigned char *)items[index] + 8);
+    }
+    if (values[0] < 0 || values[0] > 65535 || values[1] < 0 || values[1] > 65535 ||
+            values[3] < 0 || values[3] > 65535 || values[4] < 0 || values[4] > 65535 ||
+            values[2] < 1 || values[2] > 12000012 || values[5] < 16 || values[5] > 12000012 ||
+            !callback_arguments(items[6], items[7])) return python_int(18);
+    address = ((uintptr_t)values[1] << 16) | (uintptr_t)values[0];
+    query_address = ((uintptr_t)values[4] << 16) | (uintptr_t)values[3];
+    if (address % sizeof(double) || query_address % sizeof(double) ||
+            !writable_region((void *)address, (SIZE_T)values[2] * sizeof(double)) ||
+            !writable_region((void *)query_address, (SIZE_T)values[5] * sizeof(double)))
+        return python_int(14);
+    if (offline_query_active() && g_callback_thread != GetCurrentThreadId()) return python_int(18);
+    if (!offline_query_can_enter((double *)address, (int)values[2])) return python_int(18);
+    owner.packet = (double *)query_address;
+    owner.capacity = (int)values[5];
+    owner.failed = 0;
+    owner.callback = items[6];
+    owner.arguments = items[7];
+    previous_thread = g_callback_thread;
+    g_callback_thread = GetCurrentThreadId();
+    status = offline_query_dispatch((double *)address, (int)values[2], owner.packet, (int)values[5], invoke_query, &owner);
+    g_callback_thread = previous_thread;
+    if (owner.failed) return 0;
+    return python_int(status);
 }
 
 
@@ -324,6 +462,10 @@ static PyObject *buffer_values(PyObject *unused_self, PyObject *unused_args)
 
 
 static PyMethodDef MODULE_METHODS[] = {
+    {"callback_self_test", callback_self_test, METH_VARARGS,
+     "Validate this interpreter's exact function-call and result ownership ABI."},
+    {"dispatch_sync", dispatch_sync, METH_VARARGS,
+     "Run a complete computation with synchronous borrowed engine callbacks."},
 	{
 		"layout_self_test", layout_self_test, METH_VARARGS,
 		"Prove this interpreter's int and tuple layout before computing."

--- a/tools/ffi_experiment/astar_1513.c
+++ b/tools/ffi_experiment/astar_1513.c
@@ -1,0 +1,376 @@
+/*
+ * Experimental A* bridge for World of Tanks 0.9.22 #1513.
+ * Derived from the reviewed compute experiment; never automatically shipped.
+ *
+ * The embedded interpreter ships no _ctypes and exports no Python C API, so
+ * this module resolves the same two validated RVAs the instance-guard bridge
+ * already uses, and reads its arguments through the exact object layout of
+ * that executable:
+ *
+ *   PyInt_FromLong   +0x00be1180   ob_refcnt +0, ob_type +4, ob_ival +8
+ *   Py_InitModule4   +0x00be1940
+ *   PyInt_Type       +0x01664bf0   tp_basicsize 12
+ *   PyTuple_Type     +0x0165c398   tp_basicsize 12, tp_itemsize 4
+ *
+ * No new C API function is resolved.  Arguments are plain ints, the result is
+ * a status int, and every double crosses inside one caller-owned buffer whose
+ * address the caller passes as two 16-bit halves.  #1513 is large-address
+ * aware, so a whole address can exceed the signed 32-bit range that
+ * PyInt_FromLong round-trips.
+ *
+ * The layout is proven inside this process before any computation runs:
+ * layout_self_test() reads a known argument tuple and returns what it read.
+ * Until the Python loader has confirmed that value, dispatch() refuses.
+ */
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <stdint.h>
+
+#include "astar_core.h"
+#include <string.h>
+
+#define OFFLINE_COMPUTE_OK 0
+#define OFFLINE_COMPUTE_BUFFER_TOO_SMALL 1
+#define OFFLINE_COMPUTE_HOST_UNVALIDATED 11
+#define OFFLINE_COMPUTE_ARGUMENT_COUNT 12
+#define OFFLINE_COMPUTE_ARGUMENT_TYPE 13
+#define OFFLINE_COMPUTE_ADDRESS_UNREADABLE 14
+#define OFFLINE_COMPUTE_LAYOUT_UNPROVEN 15
+
+
+typedef struct _PyObject {
+	long ob_refcnt;
+	void *ob_type;
+} PyObject;
+
+typedef PyObject *(__cdecl *PyCFunction)(PyObject *, PyObject *);
+
+typedef struct _PyMethodDef {
+	const char *ml_name;
+	PyCFunction ml_meth;
+	int ml_flags;
+	const char *ml_doc;
+} PyMethodDef;
+
+typedef PyObject *(__cdecl *PyInitModule4Fn)(
+	const char *, PyMethodDef *, const char *, PyObject *, int);
+typedef PyObject *(__cdecl *PyIntFromLongFn)(long);
+
+
+#define PYTHON_API_VERSION_27 1013
+#define METH_VARARGS 0x0001
+
+#define EXPECTED_PE_TIMESTAMP 0x5a6edca4U
+#define EXPECTED_IMAGE_BASE 0x00400000U
+#define EXPECTED_IMAGE_SIZE 0x0206a000U
+
+#define RVA_PY_INIT_MODULE4 0x00be1940U
+#define RVA_PY_INT_FROM_LONG 0x00be1180U
+#define RVA_PY_INT_TYPE 0x01664bf0U
+
+/* PyObject header, then PyIntObject.ob_ival; PyVarObject.ob_size, then items. */
+#define OFFSET_OB_TYPE 4U
+#define OFFSET_OB_IVAL 8U
+#define OFFSET_OB_SIZE 8U
+#define OFFSET_OB_ITEM 12U
+
+#define SELF_TEST_FIRST 11L
+#define SELF_TEST_SECOND 22L
+#define SELF_TEST_THIRD 33L
+#define SELF_TEST_RESULT 112233L
+
+#define MAXIMUM_ARGUMENTS 4
+
+
+static unsigned char *g_image_base = 0;
+static PyIntFromLongFn g_py_int_from_long = 0;
+static void *g_py_int_type = 0;
+static int g_layout_proven = 0;
+
+
+static int readable_region(const void *address, SIZE_T bytes)
+{
+	MEMORY_BASIC_INFORMATION info;
+	uintptr_t cursor = (uintptr_t)address;
+	uintptr_t end;
+	uintptr_t previous;
+	DWORD protection;
+	if (address == 0 || bytes == 0 ||
+			bytes > (SIZE_T)((uintptr_t)-1 - cursor)) {
+		return 0;
+	}
+	end = cursor + bytes;
+	while (cursor < end) {
+		if (VirtualQuery((const void *)cursor, &info, sizeof(info)) !=
+				sizeof(info) || info.State != MEM_COMMIT) {
+			return 0;
+		}
+		if ((info.Protect & PAGE_GUARD) != 0) {
+			return 0;
+		}
+		protection = info.Protect & 0xffU;
+		if (protection != PAGE_READONLY &&
+				protection != PAGE_READWRITE &&
+				protection != PAGE_WRITECOPY &&
+				protection != PAGE_EXECUTE_READ &&
+				protection != PAGE_EXECUTE_READWRITE &&
+				protection != PAGE_EXECUTE_WRITECOPY) {
+			return 0;
+		}
+		if (info.RegionSize > (SIZE_T)((uintptr_t)-1 -
+				(uintptr_t)info.BaseAddress)) {
+			return 0;
+		}
+		previous = cursor;
+		cursor = (uintptr_t)info.BaseAddress + info.RegionSize;
+		if (cursor <= previous) {
+			return 0;
+		}
+	}
+	return 1;
+}
+
+
+static int writable_region(const void *address, SIZE_T bytes)
+{
+	MEMORY_BASIC_INFORMATION info;
+	uintptr_t cursor = (uintptr_t)address;
+	uintptr_t end;
+	uintptr_t previous;
+	DWORD protection;
+	if (address == 0 || bytes == 0 ||
+			bytes > (SIZE_T)((uintptr_t)-1 - cursor)) {
+		return 0;
+	}
+	end = cursor + bytes;
+	while (cursor < end) {
+		if (VirtualQuery((const void *)cursor, &info, sizeof(info)) !=
+				sizeof(info) || info.State != MEM_COMMIT) {
+			return 0;
+		}
+		if ((info.Protect & PAGE_GUARD) != 0) {
+			return 0;
+		}
+		protection = info.Protect & 0xffU;
+		if (protection != PAGE_READWRITE &&
+				protection != PAGE_WRITECOPY &&
+				protection != PAGE_EXECUTE_READWRITE &&
+				protection != PAGE_EXECUTE_WRITECOPY) {
+			return 0;
+		}
+		previous = cursor;
+		cursor = (uintptr_t)info.BaseAddress + info.RegionSize;
+		if (cursor <= previous) {
+			return 0;
+		}
+	}
+	return 1;
+}
+
+
+static int validate_host(unsigned char *base)
+{
+	IMAGE_DOS_HEADER *dos = (IMAGE_DOS_HEADER *)base;
+	IMAGE_NT_HEADERS32 *nt;
+	if (!readable_region(base, sizeof(IMAGE_DOS_HEADER)) ||
+			dos->e_magic != IMAGE_DOS_SIGNATURE ||
+			dos->e_lfanew <= 0 ||
+			(DWORD)dos->e_lfanew > EXPECTED_IMAGE_SIZE) {
+		return 0;
+	}
+	nt = (IMAGE_NT_HEADERS32 *)(base + dos->e_lfanew);
+	if (!readable_region(nt, sizeof(IMAGE_NT_HEADERS32)) ||
+			nt->Signature != IMAGE_NT_SIGNATURE ||
+			nt->FileHeader.Machine != IMAGE_FILE_MACHINE_I386 ||
+			nt->FileHeader.TimeDateStamp != EXPECTED_PE_TIMESTAMP ||
+			nt->OptionalHeader.ImageBase != EXPECTED_IMAGE_BASE ||
+			nt->OptionalHeader.SizeOfImage != EXPECTED_IMAGE_SIZE) {
+		return 0;
+	}
+	{
+        static const unsigned char init_signature[] = {
+            0x55, 0x8b, 0xec, 0x81, 0xec, 0x14, 0x02, 0x00,
+            0x00, 0xa1, 0x70, 0x35, 0xce, 0x01, 0x33, 0xc5
+        };
+        static const unsigned char int_signature[] = {
+            0x55, 0x8b, 0xec, 0x56, 0x8b, 0x75, 0x08, 0x8d,
+            0x46, 0x05, 0x3d, 0x05, 0x01, 0x00, 0x00, 0x77
+        };
+        if (!readable_region(base + RVA_PY_INIT_MODULE4, sizeof(init_signature)) ||
+                !readable_region(base + RVA_PY_INT_FROM_LONG, sizeof(int_signature)) ||
+                memcmp(base + RVA_PY_INIT_MODULE4, init_signature, sizeof(init_signature)) ||
+                memcmp(base + RVA_PY_INT_FROM_LONG, int_signature, sizeof(int_signature))) {
+            return 0;
+        }
+    }
+	return (unsigned char *)EXPECTED_IMAGE_BASE == base;
+}
+
+
+static PyObject *python_int(long value)
+{
+	if (g_py_int_from_long == 0) {
+		return 0;
+	}
+	return g_py_int_from_long(value);
+}
+
+
+/*
+ * Read up to MAXIMUM_ARGUMENTS plain ints out of a METH_VARARGS tuple.
+ * Every dereference is bounds- and type-checked first: the exact tuple and
+ * int layouts above are the only assumption, and layout_self_test() proves
+ * them inside this interpreter before any caller relies on a result.
+ */
+static int read_int_arguments(PyObject *args, long *out, int wanted)
+{
+	unsigned char *tuple = (unsigned char *)args;
+	long size;
+	int index;
+	if (wanted < 0 || wanted > MAXIMUM_ARGUMENTS) {
+		return OFFLINE_COMPUTE_ARGUMENT_COUNT;
+	}
+	if (!readable_region(tuple, OFFSET_OB_ITEM +
+			(SIZE_T)wanted * sizeof(void *))) {
+		return OFFLINE_COMPUTE_ADDRESS_UNREADABLE;
+	}
+	size = *(long *)(tuple + OFFSET_OB_SIZE);
+	if (size != (long)wanted) {
+		return OFFLINE_COMPUTE_ARGUMENT_COUNT;
+	}
+	for (index = 0; index < wanted; ++index) {
+		unsigned char *item = *(unsigned char **)(
+			tuple + OFFSET_OB_ITEM + (unsigned)index * sizeof(void *));
+		if (!readable_region(item, OFFSET_OB_IVAL + sizeof(long))) {
+			return OFFLINE_COMPUTE_ADDRESS_UNREADABLE;
+		}
+		if (*(void **)(item + OFFSET_OB_TYPE) != g_py_int_type) {
+			return OFFLINE_COMPUTE_ARGUMENT_TYPE;
+		}
+		out[index] = *(long *)(item + OFFSET_OB_IVAL);
+	}
+	return OFFLINE_COMPUTE_OK;
+}
+
+
+static PyObject *layout_self_test(PyObject *unused_self, PyObject *args)
+{
+	long values[3];
+	int status;
+	(void)unused_self;
+	status = read_int_arguments(args, values, 3);
+	if (status != OFFLINE_COMPUTE_OK) {
+		g_layout_proven = 0;
+		return python_int(-status);
+	}
+	if (values[0] != SELF_TEST_FIRST || values[1] != SELF_TEST_SECOND ||
+			values[2] != SELF_TEST_THIRD) {
+		g_layout_proven = 0;
+		return python_int(-OFFLINE_COMPUTE_LAYOUT_UNPROVEN);
+	}
+	g_layout_proven = 1;
+	/* Every argument reaches the result, so the caller's comparison with
+	 * SELF_TEST_RESULT proves the tuple size, the item pointers and the
+	 * integer field were all read correctly. */
+	return python_int(
+		values[0] * 10000L + values[1] * 100L + values[2]);
+}
+
+
+static PyObject *dispatch(PyObject *unused_self, PyObject *args)
+{
+	long values[3];
+	unsigned long address;
+	double *buffer;
+	long count;
+	int status;
+	(void)unused_self;
+	if (g_image_base == 0 || g_py_int_type == 0) {
+		return python_int(OFFLINE_COMPUTE_HOST_UNVALIDATED);
+	}
+	if (!g_layout_proven) {
+		return python_int(OFFLINE_COMPUTE_LAYOUT_UNPROVEN);
+	}
+	status = read_int_arguments(args, values, 3);
+	if (status != OFFLINE_COMPUTE_OK) {
+		return python_int(status);
+	}
+	if (values[0] < 0 || values[0] > 0xffffL ||
+			values[1] < 0 || values[1] > 0xffffL) {
+		return python_int(OFFLINE_COMPUTE_ADDRESS_UNREADABLE);
+	}
+	count = values[2];
+	if (count < 1L ||
+			count > 12000012L) {
+		return python_int(OFFLINE_COMPUTE_BUFFER_TOO_SMALL);
+	}
+	address = ((unsigned long)values[1] << 16) | (unsigned long)values[0];
+	buffer = (double *)(uintptr_t)address;
+	if (((uintptr_t)buffer % sizeof(double)) != 0 ||
+			!writable_region(buffer, (SIZE_T)count * sizeof(double))) {
+		return python_int(OFFLINE_COMPUTE_ADDRESS_UNREADABLE);
+	}
+	return python_int(offline_astar_dispatch(buffer, (int)count));
+}
+
+
+static PyObject *buffer_values(PyObject *unused_self, PyObject *unused_args)
+{
+	(void)unused_self;
+	(void)unused_args;
+	return python_int((long)1L);
+}
+
+
+static PyMethodDef MODULE_METHODS[] = {
+	{
+		"layout_self_test", layout_self_test, METH_VARARGS,
+		"Prove this interpreter's int and tuple layout before computing."
+	},
+	{
+		"dispatch", dispatch, METH_VARARGS,
+		"Execute one A* command inside a caller-owned buffer."
+	},
+	{
+		"buffer_values", buffer_values, METH_VARARGS,
+		"Return the number of doubles the preparation buffer must hold."
+	},
+	{0, 0, 0, 0}
+};
+
+
+__declspec(dllexport) void __cdecl initoffline_astar_native(void)
+{
+	PyInitModule4Fn init_module;
+	PyObject *probe;
+	unsigned char *base = (unsigned char *)GetModuleHandleW(0);
+	if (base == 0 || !validate_host(base)) {
+		return;
+	}
+	g_image_base = base;
+	g_py_int_from_long =
+		(PyIntFromLongFn)(g_image_base + RVA_PY_INT_FROM_LONG);
+	/* Derive the int type from a real object, then confirm the reviewed RVA.
+	 * The probe is a cached small int, so the retained reference is the
+	 * interpreter's own and nothing is leaked per call. */
+	probe = g_py_int_from_long(64);
+	if (probe == 0 || !readable_region(probe, OFFSET_OB_IVAL + sizeof(long))) {
+		g_py_int_from_long = 0;
+		g_image_base = 0;
+		return;
+	}
+	g_py_int_type = *(void **)((unsigned char *)probe + OFFSET_OB_TYPE);
+	if (g_py_int_type != (void *)(g_image_base + RVA_PY_INT_TYPE) ||
+			*(long *)((unsigned char *)probe + OFFSET_OB_IVAL) != 64L) {
+		g_py_int_type = 0;
+		g_py_int_from_long = 0;
+		g_image_base = 0;
+		return;
+	}
+	init_module = (PyInitModule4Fn)(g_image_base + RVA_PY_INIT_MODULE4);
+	init_module(
+		"offline_astar_native", MODULE_METHODS,
+		"Experimental baked A* for the offline LAN hidden worker.",
+		0, PYTHON_API_VERSION_27);
+}

--- a/tools/ffi_experiment/astar_core.cpp
+++ b/tools/ffi_experiment/astar_core.cpp
@@ -5,6 +5,7 @@
 #include "combat_core.h"
 #include "driver_core.h"
 #include "perception_core.h"
+#include "world_core.h"
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
@@ -287,7 +288,8 @@ extern "C" int offline_astar_dispatch(double *buffer, int count) {
         if (!std::isfinite(buffer[0]) || buffer[0] != std::floor(buffer[0]) ||
             buffer[0] < 0 || buffer[0] > 1000000000) return 2;
         if (buffer[0] == 0 && count != 1) return 2;
-        if (buffer[0] == 0) { offline_combat_reset(); offline_driver_reset(); offline_perception_reset(); }
+        if (buffer[0] == 0) { offline_combat_reset(); offline_driver_reset(); offline_perception_reset(); offline_world_reset(); }
+        if (buffer[0] >= 400) return offline_world_dispatch(buffer, count);
         if (buffer[0] >= 300) return offline_perception_dispatch(buffer, count);
         if (buffer[0] >= 200) return offline_driver_dispatch(buffer, count);
         if (buffer[0] >= 100) return offline_combat_dispatch(buffer, count);

--- a/tools/ffi_experiment/astar_core.cpp
+++ b/tools/ffi_experiment/astar_core.cpp
@@ -2,6 +2,9 @@
  * floating-point addition order, partial-path rules and fair scheduling.
  * Geometry probing and path finalization remain with the Python owner. */
 #include "astar_core.h"
+#include "combat_core.h"
+#include "driver_core.h"
+#include "perception_core.h"
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
@@ -280,7 +283,16 @@ int execute(double *b, int n) {
 }
 extern "C" int offline_astar_dispatch(double *buffer, int count) {
     if (!buffer || count < 1 || count > 12000012) return 1;
-    try { return execute(buffer, count); }
+    try {
+        if (!std::isfinite(buffer[0]) || buffer[0] != std::floor(buffer[0]) ||
+            buffer[0] < 0 || buffer[0] > 1000000000) return 2;
+        if (buffer[0] == 0 && count != 1) return 2;
+        if (buffer[0] == 0) { offline_combat_reset(); offline_driver_reset(); offline_perception_reset(); }
+        if (buffer[0] >= 300) return offline_perception_dispatch(buffer, count);
+        if (buffer[0] >= 200) return offline_driver_dispatch(buffer, count);
+        if (buffer[0] >= 100) return offline_combat_dispatch(buffer, count);
+        return execute(buffer, count);
+    }
     catch (const Invalid &) { return 2; }
     catch (const std::bad_alloc &) { return 3; }
     catch (const std::exception &) { return 4; }

--- a/tools/ffi_experiment/astar_core.cpp
+++ b/tools/ffi_experiment/astar_core.cpp
@@ -1,0 +1,288 @@
+/* Resumable baked A* experiment. Preserve navigation.py's expansion order,
+ * floating-point addition order, partial-path rules and fair scheduling.
+ * Geometry probing and path finalization remain with the Python owner. */
+#include "astar_core.h"
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <deque>
+#include <limits>
+#include <memory>
+#include <queue>
+#include <stdexcept>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace {
+struct Invalid : std::runtime_error { Invalid() : std::runtime_error("invalid command") {} };
+struct Reader {
+    double *b; int n; int p;
+    double number() {
+        if (p >= n || !std::isfinite(b[p])) throw Invalid();
+        return b[p++];
+    }
+    int integer(int minimum = 0, int maximum = 20000000) {
+        double v = number();
+        if (v < minimum || v > maximum || v != std::floor(v)) throw Invalid();
+        return static_cast<int>(v);
+    }
+    void end() { if (p != n) throw Invalid(); }
+};
+using Edge = uint64_t;
+Edge edge_key(int a, int b) {
+    if (a > b) std::swap(a, b);
+    return (static_cast<uint64_t>(a) << 32) | static_cast<uint32_t>(b);
+}
+struct Graph {
+    int width, height;
+    double cell, ox, oz, grade, heuristic, clearance, shallow, diagonal;
+    std::vector<double> heights;
+    std::vector<unsigned char> links, hazards;
+    std::unordered_map<Edge, std::pair<double, double> > failed;
+    std::unordered_map<Edge, double> hulls;
+    std::vector<Edge> expired;
+    bool valid(int i) const {
+        // The graph's links encode traversability. Match _baked_index exactly;
+        // do not invent a second hazard admission rule in the native adapter.
+        return i >= 0 && i < width * height && std::isfinite(heights[i]);
+    }
+    double distance(int a, int b) const {
+        double dx = a % width - b % width, dz = a / width - b / width;
+        return std::sqrt(dx * dx + dz * dz);
+    }
+};
+struct Entry { double priority; uint64_t sequence; int cell; double cost; };
+struct Later {
+    bool operator()(const Entry &a, const Entry &b) const {
+        if (a.priority != b.priority) return a.priority > b.priority;
+        return a.sequence > b.sequence;
+    }
+};
+struct Search {
+    std::shared_ptr<Graph> graph;
+    int start, goal, maximum, expansions = 0, closest;
+    double now, closest_distance;
+    bool prefer, done = false, hard_present = false;
+    uint64_t sequence = 0;
+    std::priority_queue<Entry, std::vector<Entry>, Later> frontier;
+    std::unordered_map<int, double> costs;
+    std::unordered_map<int, int> parents;
+    std::unordered_map<Edge, double> local;
+    std::unordered_set<Edge> hard;
+    std::vector<std::pair<double, double> > avoid;
+    std::vector<int> path;
+
+    void finish(int reached = -1) {
+        done = true;
+        if (reached < 0) {
+            if (hard_present && closest == start) return;
+            if (closest_distance <= 3.0 || (!frontier.empty() && closest != start))
+                reached = closest;
+            else return;
+        }
+        path.push_back(reached);
+        while (path.back() != start) {
+            auto parent = parents.find(path.back());
+            if (parent == parents.end() || path.size() > costs.size()) throw Invalid();
+            path.push_back(parent->second);
+        }
+        std::reverse(path.begin(), path.end());
+    }
+    void step() {
+        if (done) return;
+        Graph &g = *graph;
+        if (start < 0 || goal < 0) { done = true; return; }
+        if (expansions >= maximum) { finish(); return; }
+        Entry current;
+        bool found = false;
+        while (!frontier.empty()) {
+            current = frontier.top(); frontier.pop();
+            if (current.cost == costs.at(current.cell)) { found = true; break; }
+        }
+        if (!found) { finish(); return; }
+        ++expansions;
+        double distance = g.distance(current.cell, goal);
+        if (distance < closest_distance) {
+            closest = current.cell; closest_distance = distance;
+        }
+        if (current.cell == goal) { finish(current.cell); return; }
+        static const int dxs[] = {-1, 0, 1, -1, 1, -1, 0, 1};
+        static const int dzs[] = {-1, -1, -1, 0, 0, 1, 1, 1};
+        int x = current.cell % g.width, z = current.cell / g.width;
+        for (int direction = 0; direction < 8; ++direction) {
+            if (!(g.links[current.cell] & (1 << direction))) continue;
+            int nx = x + dxs[direction], nz = z + dzs[direction];
+            if (nx < 0 || nz < 0 || nx >= g.width || nz >= g.height) continue;
+            int next = nz * g.width + nx;
+            if (!g.valid(next)) continue;
+            Edge edge = edge_key(current.cell, next);
+            if (hard.count(edge)) continue;
+            double run = g.cell * ((dxs[direction] && dzs[direction]) ? g.diagonal : 1.0);
+            double delta = g.heights[next] / 1000.0 - g.heights[current.cell] / 1000.0;
+            double slope = std::fabs(delta) / std::max(run, 0.1);
+            double ratio = slope / std::max(0.05, g.grade);
+            double slope_cost = run * ratio * ratio * 6.0;
+            if (delta < 0.0) slope_cost *= 1.25;
+            int links = 0;
+            for (int bit = 0; bit < 8; ++bit) links += !!(g.links[next] & (1 << bit));
+            double terrain = prefer ? static_cast<double>(8 - links) * g.cell * g.clearance : 0.0;
+            if (g.hazards[next] & 4) terrain += g.cell * g.shallow;
+            double px = g.ox + nx * g.cell, pz = g.oz + nz * g.cell;
+            for (auto point : avoid) {
+                double dx = px - point.first, dz = pz - point.second;
+                double d = std::sqrt(dx * dx + dz * dz);
+                if (d < g.cell * 1.5) terrain += (g.cell * 1.5 - d) * 3.0;
+            }
+            double local_cost = 0.0, failed_cost = 0.0;
+            auto local_it = local.find(edge);
+            if (local_it != local.end()) local_cost = local_it->second;
+            auto hull_it = g.hulls.find(edge);
+            if (hull_it != g.hulls.end()) failed_cost = hull_it->second;
+            double timed_cost = 0.0;
+            auto failed_it = g.failed.find(edge);
+            if (failed_it != g.failed.end()) {
+                if (now >= failed_it->second.first) {
+                    g.expired.push_back(edge); g.failed.erase(failed_it);
+                } else timed_cost = failed_it->second.second;
+            }
+            failed_cost = std::max(failed_cost, timed_cost);
+            double cost = current.cost + run + slope_cost + terrain + failed_cost + local_cost;
+            auto previous = costs.find(next);
+            if (previous == costs.end() || cost < previous->second) {
+                costs[next] = cost; parents[next] = current.cell;
+                double heuristic = g.distance(next, goal) * g.cell * g.heuristic;
+                frontier.push({cost + heuristic, ++sequence, next, cost});
+            }
+        }
+        // Exactly one Python generator yield occurs after this expansion.
+        // Exhaustion is observed on the next paid step, including at the cap.
+    }
+};
+std::unordered_map<int, std::shared_ptr<Graph> > graphs;
+std::unordered_map<int, std::unique_ptr<Search> > searches;
+int next_graph = 1, next_search = 1;
+
+std::shared_ptr<Graph> get_graph(int id) {
+    auto it = graphs.find(id); if (it == graphs.end()) throw Invalid(); return it->second;
+}
+Search &get_search(int id) {
+    auto it = searches.find(id); if (it == searches.end()) throw Invalid(); return *it->second;
+}
+int cell_index(Reader &r, const Graph &g, bool allow_missing = false) {
+    return r.integer(allow_missing ? -1 : 0, g.width * g.height - 1);
+}
+Edge read_edge(Reader &r, const Graph &g) {
+    int a = cell_index(r, g), b = cell_index(r, g); return edge_key(a, b);
+}
+int execute(double *b, int n) {
+    Reader r{b, n, 0}; int op = r.integer(0, 9);
+    if (op == 0) { r.end(); searches.clear(); graphs.clear(); return 0; }
+    if (op == 1) {
+        auto g = std::make_shared<Graph>();
+        g->width = r.integer(1, 4096); g->height = r.integer(1, 4096);
+        int cells = g->width * g->height;
+        if (cells > 4000000) throw Invalid();
+        g->cell = r.number(); g->ox = r.number(); g->oz = r.number();
+        g->grade = r.number(); g->heuristic = r.number();
+        g->clearance = r.number(); g->shallow = r.number(); g->diagonal = r.number();
+        if (g->cell < 1.0 || g->grade < 0.05 || g->heuristic < 0 || g->diagonal < 1.0 || n != 11 + cells * 3) throw Invalid();
+        g->heights.reserve(cells); g->links.reserve(cells); g->hazards.reserve(cells);
+        for (int i = 0; i < cells; ++i) {
+            double height = b[r.p++];
+            if (std::isinf(height)) throw Invalid();
+            g->heights.push_back(height);
+            g->links.push_back(static_cast<unsigned char>(r.integer(0, 255)));
+            g->hazards.push_back(static_cast<unsigned char>(r.integer(0, 255)));
+        }
+        int id = next_graph++; graphs[id] = g; b[0] = id; return 0;
+    }
+    if (op == 2) {
+        auto g = get_graph(r.integer()); int count = r.integer();
+        std::unordered_map<Edge, std::pair<double, double> > failed;
+        for (int i = 0; i < count; ++i) {
+            Edge edge = read_edge(r, *g); double expiry = r.number(), penalty = r.number();
+            failed[edge] = {expiry, penalty};
+        }
+        count = r.integer(); std::unordered_map<Edge, double> hulls;
+        for (int i = 0; i < count; ++i) {
+            Edge edge = read_edge(r, *g); double penalty = r.number();
+            hulls[edge] = penalty;
+        }
+        r.end(); g->failed.swap(failed); g->hulls.swap(hulls); return 0;
+    }
+    if (op == 3) {
+        std::unique_ptr<Search> s(new Search()); s->graph = get_graph(r.integer());
+        s->start = cell_index(r, *s->graph, true); s->goal = cell_index(r, *s->graph, true);
+        s->maximum = r.integer(-1000000, 1000000); s->now = r.number();
+        s->prefer = r.integer(0, 1) != 0; r.end();
+        if ((s->start >= 0 && !s->graph->valid(s->start)) || (s->goal >= 0 && !s->graph->valid(s->goal))) throw Invalid();
+        s->closest = s->start;
+        s->closest_distance = s->graph->distance(s->start, s->goal);
+        if (s->start >= 0) {
+            s->costs[s->start] = 0.0; s->frontier.push({0.0, 0, s->start, 0.0});
+        }
+        int id = next_search++; searches[id] = std::move(s); b[0] = id; return 0;
+    }
+    if (op == 4) {
+        Search &s = get_search(r.integer()); int count = r.integer();
+        std::vector<std::pair<double, double> > avoid;
+        for (int i = 0; i < count; ++i) { double x = r.number(), z = r.number(); avoid.push_back({x, z}); }
+        std::unordered_map<Edge, double> local; count = r.integer();
+        for (int i = 0; i < count; ++i) {
+            Edge edge = read_edge(r, *s.graph); double cost = r.number();
+            local[edge] = cost;
+        }
+        bool hard_present = r.integer(0, 1) != 0;
+        std::unordered_set<Edge> hard; count = r.integer();
+        for (int i = 0; i < count; ++i) hard.insert(read_edge(r, *s.graph));
+        r.end(); s.avoid.swap(avoid); s.local.swap(local); s.hard.swap(hard);
+        s.hard_present = hard_present; return 0;
+    }
+    if (op == 5) {
+        int budget = r.integer(0, 1000000), count = r.integer(0, 4096);
+        if (n != 8 + count) throw Invalid();
+        r.p = 8; std::deque<int> queue;
+        for (int i = 0; i < count; ++i) { int id = r.integer(); get_search(id); queue.push_back(id); }
+        int consumed = 0, completed = 0, expansions = 0;
+        while (consumed < budget && !queue.empty()) {
+            int id = queue.front(); queue.pop_front(); Search &s = get_search(id);
+            int previous = s.expansions; s.step(); expansions += s.expansions - previous; ++consumed;
+            if (s.done) { completed = id; break; }
+            queue.push_back(id);
+        }
+        b[3] = consumed; b[4] = completed; b[5] = queue.size(); b[6] = expansions;
+        for (size_t i = 0; i < queue.size(); ++i) b[8 + i] = queue[i];
+        return 0;
+    }
+    if (op == 6) {
+        Search &s = get_search(r.integer());
+        if (!s.done || n < static_cast<int>(2 + s.path.size())) throw Invalid();
+        b[0] = s.path.size(); b[1] = s.expansions;
+        for (size_t i = 0; i < s.path.size(); ++i) b[2 + i] = s.path[i];
+        return 0;
+    }
+    if (op == 7) {
+        auto g = get_graph(r.integer());
+        if (n < static_cast<int>(1 + 2 * g->expired.size())) throw Invalid();
+        b[0] = g->expired.size();
+        for (size_t i = 0; i < g->expired.size(); ++i) {
+            b[1 + i * 2] = g->expired[i] >> 32;
+            b[2 + i * 2] = static_cast<uint32_t>(g->expired[i]);
+        }
+        g->expired.clear(); return 0;
+    }
+    if (op == 8) { int id = r.integer(); r.end(); searches.erase(id); return 0; }
+    if (op == 9) { int id = r.integer(); r.end(); graphs.erase(id); return 0; }
+    throw Invalid();
+}
+}
+extern "C" int offline_astar_dispatch(double *buffer, int count) {
+    if (!buffer || count < 1 || count > 12000012) return 1;
+    try { return execute(buffer, count); }
+    catch (const Invalid &) { return 2; }
+    catch (const std::bad_alloc &) { return 3; }
+    catch (const std::exception &) { return 4; }
+    catch (...) { return 5; }
+}

--- a/tools/ffi_experiment/astar_core.cpp
+++ b/tools/ffi_experiment/astar_core.cpp
@@ -10,6 +10,7 @@
 #include "navigation_flow.h"
 #include "navigation_search.h"
 #include "motion_core.h"
+#include "kernel_core.h"
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
@@ -295,7 +296,8 @@ extern "C" int offline_astar_dispatch(double *buffer, int count) {
         if (!std::isfinite(buffer[0]) || buffer[0] != std::floor(buffer[0]) ||
             buffer[0] < 0 || buffer[0] > 1000000000) return 2;
         if (buffer[0] == 0 && count != 1) return 2;
-        if (buffer[0] == 0) { offline_combat_reset(); offline_driver_reset(); offline_perception_reset(); offline_world_reset(); offline_navigation_reset(); offline_motion_reset(); }
+        if (buffer[0] == 0) { offline_kernel_reset(); offline_combat_reset(); offline_driver_reset(); offline_perception_reset(); offline_world_reset(); offline_navigation_reset(); offline_motion_reset(); }
+        if (buffer[0] >= 700) return offline_kernel_dispatch(buffer, count);
         if (buffer[0] >= 600) return offline_motion_dispatch(buffer, count);
         if (buffer[0] >= 500) return offline_navigation_dispatch(buffer, count);
         if (buffer[0] >= 400) return offline_world_dispatch(buffer, count);

--- a/tools/ffi_experiment/astar_core.cpp
+++ b/tools/ffi_experiment/astar_core.cpp
@@ -6,6 +6,10 @@
 #include "driver_core.h"
 #include "perception_core.h"
 #include "world_core.h"
+#include "navigation_graph.h"
+#include "navigation_flow.h"
+#include "navigation_search.h"
+#include "motion_core.h"
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
@@ -39,24 +43,7 @@ Edge edge_key(int a, int b) {
     if (a > b) std::swap(a, b);
     return (static_cast<uint64_t>(a) << 32) | static_cast<uint32_t>(b);
 }
-struct Graph {
-    int width, height;
-    double cell, ox, oz, grade, heuristic, clearance, shallow, diagonal;
-    std::vector<double> heights;
-    std::vector<unsigned char> links, hazards;
-    std::unordered_map<Edge, std::pair<double, double> > failed;
-    std::unordered_map<Edge, double> hulls;
-    std::vector<Edge> expired;
-    bool valid(int i) const {
-        // The graph's links encode traversability. Match _baked_index exactly;
-        // do not invent a second hazard admission rule in the native adapter.
-        return i >= 0 && i < width * height && std::isfinite(heights[i]);
-    }
-    double distance(int a, int b) const {
-        double dx = a % width - b % width, dz = a / width - b / width;
-        return std::sqrt(dx * dx + dz * dz);
-    }
-};
+using Graph = OfflineNavGraph;
 struct Entry { double priority; uint64_t sequence; int cell; double cost; };
 struct Later {
     bool operator()(const Entry &a, const Entry &b) const {
@@ -282,13 +269,35 @@ int execute(double *b, int n) {
     throw Invalid();
 }
 }
+std::shared_ptr<OfflineNavGraph> offline_navigation_graph(int handle) {
+    return get_graph(handle);
+}
+struct OfflineNavigationSearch::Impl { Search search; };
+OfflineNavigationSearch::OfflineNavigationSearch(std::shared_ptr<OfflineNavGraph> graph,
+        int start,int goal,int maximum,double now,bool prefer):impl(new Impl()) {
+    Search &s=impl->search;s.graph=graph;s.start=start;s.goal=goal;s.maximum=maximum;
+    s.now=now;s.prefer=prefer;s.closest=start;s.closest_distance=graph->distance(start,goal);
+    if(start>=0){s.costs[start]=0.0;s.frontier.push({0.0,0,start,0.0});}
+}
+OfflineNavigationSearch::~OfflineNavigationSearch(){}
+void OfflineNavigationSearch::inputs(const std::vector<std::pair<double,double> > &avoid,
+        const std::unordered_map<uint64_t,double> &local,
+        const std::unordered_set<uint64_t> &hard,bool hard_present){
+    Search &s=impl->search;s.avoid=avoid;s.local=local;s.hard=hard;s.hard_present=hard_present;
+}
+void OfflineNavigationSearch::step(){impl->search.step();}
+bool OfflineNavigationSearch::done() const{return impl->search.done;}
+int OfflineNavigationSearch::expansions() const{return impl->search.expansions;}
+const std::vector<int> &OfflineNavigationSearch::path() const{return impl->search.path;}
 extern "C" int offline_astar_dispatch(double *buffer, int count) {
     if (!buffer || count < 1 || count > 12000012) return 1;
     try {
         if (!std::isfinite(buffer[0]) || buffer[0] != std::floor(buffer[0]) ||
             buffer[0] < 0 || buffer[0] > 1000000000) return 2;
         if (buffer[0] == 0 && count != 1) return 2;
-        if (buffer[0] == 0) { offline_combat_reset(); offline_driver_reset(); offline_perception_reset(); offline_world_reset(); }
+        if (buffer[0] == 0) { offline_combat_reset(); offline_driver_reset(); offline_perception_reset(); offline_world_reset(); offline_navigation_reset(); offline_motion_reset(); }
+        if (buffer[0] >= 600) return offline_motion_dispatch(buffer, count);
+        if (buffer[0] >= 500) return offline_navigation_dispatch(buffer, count);
         if (buffer[0] >= 400) return offline_world_dispatch(buffer, count);
         if (buffer[0] >= 300) return offline_perception_dispatch(buffer, count);
         if (buffer[0] >= 200) return offline_driver_dispatch(buffer, count);

--- a/tools/ffi_experiment/astar_core.h
+++ b/tools/ffi_experiment/astar_core.h
@@ -1,0 +1,14 @@
+#ifndef OFFLINE_ASTAR_CORE_H
+#define OFFLINE_ASTAR_CORE_H
+
+/* Experimental, synchronous C ABI. The caller owns the complete buffer.
+ * Commands and their layouts are defined alongside the Python adapter.
+ * No Python object or BigWorld object crosses this boundary. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+int offline_astar_dispatch(double *buffer, int count);
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/tools/ffi_experiment/astar_host.c
+++ b/tools/ffi_experiment/astar_host.c
@@ -1,0 +1,49 @@
+/* Linux host bridge for computation and conversion measurements only.
+ * The #1513 bridge has a separate executable/layout validation boundary. */
+#include <Python.h>
+#include <stdint.h>
+#include "astar_core.h"
+
+static PyObject *layout_self_test(PyObject *self, PyObject *args)
+{
+    long a, b, c;
+    (void)self;
+    if (!PyArg_ParseTuple(args, "lll", &a, &b, &c)) return NULL;
+    if (a != 11 || b != 22 || c != 33) return PyLong_FromLong(-15);
+    return PyLong_FromLong(a * 10000 + b * 100 + c);
+}
+static PyObject *dispatch(PyObject *self, PyObject *args)
+{
+    unsigned long low, high;
+    int count;
+    uintptr_t address;
+    (void)self;
+    if (!PyArg_ParseTuple(args, "kki", &low, &high, &count)) return NULL;
+    if (low > 65535 || count < 1 || count > 12000012 ||
+            high > (UINTPTR_MAX >> 16)) {
+        PyErr_SetString(PyExc_ValueError, "invalid owned-buffer contract");
+        return NULL;
+    }
+    address = ((uintptr_t)high << 16) | low;
+    if (!address || address % sizeof(double)) {
+        PyErr_SetString(PyExc_ValueError, "invalid owned-buffer alignment");
+        return NULL;
+    }
+    return PyLong_FromLong(offline_astar_dispatch((double *)address, count));
+}
+static PyMethodDef methods[] = {
+    {"layout_self_test", layout_self_test, METH_VARARGS, "Check bridge argument layout."},
+    {"dispatch", dispatch, METH_VARARGS, "Execute one owned-buffer command."},
+    {NULL, NULL, 0, NULL}
+};
+#if PY_MAJOR_VERSION >= 3
+static struct PyModuleDef module = {
+    PyModuleDef_HEAD_INIT, "offline_astar_native", NULL, -1, methods,
+    NULL, NULL, NULL, NULL
+};
+PyMODINIT_FUNC PyInit_offline_astar_native(void) { return PyModule_Create(&module); }
+#else
+PyMODINIT_FUNC initoffline_astar_native(void) {
+    Py_InitModule3("offline_astar_native", methods, NULL);
+}
+#endif

--- a/tools/ffi_experiment/astar_host.c
+++ b/tools/ffi_experiment/astar_host.c
@@ -6,6 +6,9 @@
 #include "astar_core.h"
 #include "query_bridge.h"
 #include <string.h>
+#ifdef OFFLINE_FFI_PROFILE
+#include "host_profile.h"
+#endif
 
 static int callback_proven = 0;
 static unsigned long callback_thread = 0;
@@ -24,6 +27,7 @@ static PyObject *dispatch(PyObject *self, PyObject *args)
     unsigned long low, high;
     int count;
     uintptr_t address;
+    int status;
     (void)self;
     if (!PyArg_ParseTuple(args, "kki", &low, &high, &count)) return NULL;
     if (low > 65535 || count < 1 || count > 12000012 ||
@@ -38,7 +42,17 @@ static PyObject *dispatch(PyObject *self, PyObject *args)
     }
     if (offline_query_active() && callback_thread != (unsigned long)PyThread_get_thread_ident()) return PyLong_FromLong(18);
     if (!offline_query_can_enter((double *)address, count)) return PyLong_FromLong(18);
-    return PyLong_FromLong(offline_astar_dispatch((double *)address, count));
+#ifdef OFFLINE_FFI_PROFILE
+    {
+        int previous = host_profile.zone;
+        profile_zone(PROFILE_CORE);
+        status = offline_astar_dispatch((double *)address, count);
+        profile_zone(previous);
+    }
+#else
+    status = offline_astar_dispatch((double *)address, count);
+#endif
+    return PyLong_FromLong(status);
 }
 
 static PyObject *callback_self_test(PyObject *self, PyObject *args)
@@ -70,12 +84,37 @@ static int invoke_query(void *opaque, double *packet, int count)
 {
     QueryOwner *owner = (QueryOwner *)opaque;
     PyObject *result;
+#ifdef OFFLINE_FFI_PROFILE
+    int previous = host_profile.zone, key;
+    double started;
+#endif
     if (count < 1 || count > owner->capacity) return 18;
+#ifdef OFFLINE_FFI_PROFILE
+    profile_zone(PROFILE_BRIDGE);
+    started = host_profile.last;
+    key = profile_key(packet, count);
+#endif
     memcpy(owner->packet, packet, (size_t)count * sizeof(double));
+#ifdef OFFLINE_FFI_PROFILE
+    profile_zone(PROFILE_CALLBACK);
+#endif
     result = PyObject_CallObject(owner->callback, owner->arguments);
-    if (!result) { owner->failed = 1; return 18; }
-    Py_DECREF(result);
-    memcpy(packet, owner->packet, (size_t)count * sizeof(double));
+#ifdef OFFLINE_FFI_PROFILE
+    profile_zone(PROFILE_BRIDGE);
+#endif
+    if (!result) owner->failed = 1;
+    else {
+        Py_DECREF(result);
+        memcpy(packet, owner->packet, (size_t)count * sizeof(double));
+    }
+#ifdef OFFLINE_FFI_PROFILE
+    profile_zone(previous);
+    if (host_profile.enabled) {
+        ++host_profile.calls[key];
+        host_profile.callbacks[key] += host_profile.last - started;
+    }
+#endif
+    if (!result) return 18;
     return 0;
 }
 static PyObject *dispatch_sync(PyObject *self, PyObject *args)
@@ -106,12 +145,25 @@ static PyObject *dispatch_sync(PyObject *self, PyObject *args)
     owner.failed = 0;
     previous_thread = callback_thread;
     callback_thread = (unsigned long)PyThread_get_thread_ident();
+#ifdef OFFLINE_FFI_PROFILE
+    {
+        int previous = host_profile.zone;
+        profile_zone(PROFILE_CORE);
+        status = offline_query_dispatch((double *)address, count, owner.packet, query_count, invoke_query, &owner);
+        profile_zone(previous);
+    }
+#else
     status = offline_query_dispatch((double *)address, count, owner.packet, query_count, invoke_query, &owner);
+#endif
     callback_thread = previous_thread;
     if (owner.failed) return NULL;
     return PyLong_FromLong(status);
 }
 static PyMethodDef methods[] = {
+#ifdef OFFLINE_FFI_PROFILE
+    {"profile_start", profile_start, METH_VARARGS, "Start optional host CPU boundary attribution."},
+    {"profile_stop", profile_stop, METH_VARARGS, "Stop host CPU attribution before serializing its counters."},
+#endif
     {"layout_self_test", layout_self_test, METH_VARARGS, "Check bridge argument layout."},
     {"dispatch", dispatch, METH_VARARGS, "Execute one owned-buffer command."},
     {"callback_self_test", callback_self_test, METH_VARARGS, "Check synchronous callback ownership."},

--- a/tools/ffi_experiment/astar_host.c
+++ b/tools/ffi_experiment/astar_host.c
@@ -1,13 +1,20 @@
 /* Linux host bridge for computation and conversion measurements only.
  * The #1513 bridge has a separate executable/layout validation boundary. */
 #include <Python.h>
+#include <pythread.h>
 #include <stdint.h>
 #include "astar_core.h"
+#include "query_bridge.h"
+#include <string.h>
+
+static int callback_proven = 0;
+static unsigned long callback_thread = 0;
 
 static PyObject *layout_self_test(PyObject *self, PyObject *args)
 {
     long a, b, c;
     (void)self;
+    if (offline_query_active()) return PyLong_FromLong(-18);
     if (!PyArg_ParseTuple(args, "lll", &a, &b, &c)) return NULL;
     if (a != 11 || b != 22 || c != 33) return PyLong_FromLong(-15);
     return PyLong_FromLong(a * 10000 + b * 100 + c);
@@ -29,11 +36,86 @@ static PyObject *dispatch(PyObject *self, PyObject *args)
         PyErr_SetString(PyExc_ValueError, "invalid owned-buffer alignment");
         return NULL;
     }
+    if (offline_query_active() && callback_thread != (unsigned long)PyThread_get_thread_ident()) return PyLong_FromLong(18);
+    if (!offline_query_can_enter((double *)address, count)) return PyLong_FromLong(18);
     return PyLong_FromLong(offline_astar_dispatch((double *)address, count));
+}
+
+static PyObject *callback_self_test(PyObject *self, PyObject *args)
+{
+    PyObject *callback, *arguments, *result;
+    long value;
+    (void)self;
+    if (offline_query_active()) return PyLong_FromLong(-18);
+    if (!PyArg_ParseTuple(args, "OO", &callback, &arguments)) return NULL;
+    callback_proven = 0;
+    if (!PyFunction_Check(callback) || !PyTuple_CheckExact(arguments))
+        return PyLong_FromLong(-17);
+    result = PyObject_CallObject(callback, arguments);
+    if (!result) return NULL;
+    value = PyLong_AsLong(result);
+    if (PyErr_Occurred()) { Py_DECREF(result); return NULL; }
+    if (value != 112233) { Py_DECREF(result); return PyLong_FromLong(-17); }
+    callback_proven = 1;
+    return result;
+}
+typedef struct {
+    double *packet;
+    int capacity;
+    PyObject *callback, *arguments;
+    int failed;
+} QueryOwner;
+
+static int invoke_query(void *opaque, double *packet, int count)
+{
+    QueryOwner *owner = (QueryOwner *)opaque;
+    PyObject *result;
+    if (count < 1 || count > owner->capacity) return 18;
+    memcpy(owner->packet, packet, (size_t)count * sizeof(double));
+    result = PyObject_CallObject(owner->callback, owner->arguments);
+    if (!result) { owner->failed = 1; return 18; }
+    Py_DECREF(result);
+    memcpy(packet, owner->packet, (size_t)count * sizeof(double));
+    return 0;
+}
+static PyObject *dispatch_sync(PyObject *self, PyObject *args)
+{
+    unsigned long low, high, query_low, query_high;
+    int count, query_count, status;
+    uintptr_t address, query_address;
+    QueryOwner owner;
+    unsigned long previous_thread;
+    (void)self;
+    if (!callback_proven) return PyLong_FromLong(18);
+    if (!PyArg_ParseTuple(args, "kkikkiOO", &low, &high, &count,
+                         &query_low, &query_high, &query_count,
+                         &owner.callback, &owner.arguments)) return NULL;
+    if (low > 65535 || query_low > 65535 ||
+            high > (UINTPTR_MAX >> 16) || query_high > (UINTPTR_MAX >> 16) ||
+            count < 1 || count > 12000012 || query_count < 16 || query_count > 12000012 ||
+            !PyFunction_Check(owner.callback) || !PyTuple_CheckExact(owner.arguments))
+        return PyLong_FromLong(18);
+    address = ((uintptr_t)high << 16) | low;
+    query_address = ((uintptr_t)query_high << 16) | query_low;
+    if (!address || !query_address || address % sizeof(double) ||
+            query_address % sizeof(double)) return PyLong_FromLong(18);
+    if (offline_query_active() && callback_thread != (unsigned long)PyThread_get_thread_ident()) return PyLong_FromLong(18);
+    if (!offline_query_can_enter((double *)address, count)) return PyLong_FromLong(18);
+    owner.packet = (double *)query_address;
+    owner.capacity = query_count;
+    owner.failed = 0;
+    previous_thread = callback_thread;
+    callback_thread = (unsigned long)PyThread_get_thread_ident();
+    status = offline_query_dispatch((double *)address, count, owner.packet, query_count, invoke_query, &owner);
+    callback_thread = previous_thread;
+    if (owner.failed) return NULL;
+    return PyLong_FromLong(status);
 }
 static PyMethodDef methods[] = {
     {"layout_self_test", layout_self_test, METH_VARARGS, "Check bridge argument layout."},
     {"dispatch", dispatch, METH_VARARGS, "Execute one owned-buffer command."},
+    {"callback_self_test", callback_self_test, METH_VARARGS, "Check synchronous callback ownership."},
+    {"dispatch_sync", dispatch_sync, METH_VARARGS, "Run a complete computation with borrowed engine leaves."},
     {NULL, NULL, 0, NULL}
 };
 #if PY_MAJOR_VERSION >= 3

--- a/tools/ffi_experiment/benchmark_codec_threads.cpp
+++ b/tools/ffi_experiment/benchmark_codec_threads.cpp
@@ -1,0 +1,127 @@
+// Host-only parallelism probe. No Python objects, query bridge, engine calls or
+// state mutation are reachable from the helper. Run each mode in a fresh process
+// because creating a thread can change the standard library's reference counts.
+#include "kernel_codec.h"
+#include <chrono>
+#include <condition_variable>
+#include <ctime>
+#include <fstream>
+#include <iostream>
+#include <mutex>
+#include <thread>
+
+using namespace offline_kernel;
+
+int main(int argc, char **argv) {
+    if (argc != 4)
+        throw std::invalid_argument("usage: benchmark_codec_threads fixture.json workers batches");
+    int workers = std::stoi(argv[2]), batches = std::stoi(argv[3]);
+    if ((workers != 1 && workers != 2) || batches <= 0)
+        throw std::invalid_argument("workers must be 1 or 2; batches must be positive");
+    std::ifstream input(argv[1]);
+    if (!input)
+        throw std::invalid_argument("cannot read codec fixture");
+    std::string source((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>());
+    Value fixture = JsonReader(source).read();
+    Codec codec(fixture.get("codec"));
+    std::vector<Value> states, rows;
+    for (const Value &state : elements(fixture.get("states")))
+        states.push_back(state.as_record());
+    if (states.empty() || states.size() != fixture.get("rows").size())
+        throw std::invalid_argument("codec fixture row count");
+    rows.resize(states.size());
+    std::vector<std::exception_ptr> errors(states.size());
+    const size_t split = workers == 1 ? states.size() : (states.size() + 1) / 2;
+    auto encode = [&](size_t start, size_t end) {
+        for (size_t i = start; i < end; ++i) {
+            errors[i] = nullptr;
+            try {
+                rows[i] = codec.row(states[i]);
+            } catch (...) {
+                errors[i] = std::current_exception();
+            }
+        }
+    };
+    std::mutex mutex;
+    std::condition_variable ready, completed;
+    bool stopping = false;
+    unsigned issued = 0, finished = 0;
+    std::thread helper;
+    if (workers == 2)
+        helper = std::thread([&]() {
+            std::unique_lock<std::mutex> lock(mutex);
+            for (;;) {
+                ready.wait(lock, [&]() { return stopping || issued != finished; });
+                if (stopping)
+                    return;
+                unsigned job = issued;
+                lock.unlock();
+                encode(split, states.size());
+                lock.lock();
+                finished = job;
+                completed.notify_one();
+            }
+        });
+    auto batch = [&]() {
+        if (workers == 2) {
+            std::lock_guard<std::mutex> lock(mutex);
+            ++issued;
+            ready.notify_one();
+        }
+        encode(0, split);
+        if (workers == 2) {
+            std::unique_lock<std::mutex> lock(mutex);
+            completed.wait(lock, [&]() { return finished == issued; });
+        }
+    };
+    auto verify = [&]() {
+        for (size_t i = 0; i < rows.size(); ++i) {
+            if (errors[i])
+                std::rethrow_exception(errors[i]);
+            if (rows[i] != fixture.get("rows")[i])
+                throw std::runtime_error("threaded row differs from Python oracle");
+        }
+    };
+    double wall = 0, cpu = 0;
+    std::exception_ptr failure;
+    try {
+        for (int i = 0; i < 20; ++i)
+            batch();
+        verify();
+        auto start = std::chrono::steady_clock::now();
+        std::clock_t cpu_start = std::clock();
+        for (int i = 0; i < batches; ++i)
+            batch();
+        cpu = static_cast<double>(std::clock() - cpu_start) / CLOCKS_PER_SEC;
+        wall = std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count();
+        verify();
+        // Both partitions finish even when a row fails. A later batch recovers;
+        // the caller can select the first error in original row order.
+        Value first = states.front(), last = states.back();
+        states.front() = Value();
+        states.back() = Value();
+        batch();
+        if (!errors.front() || !errors.back())
+            throw std::runtime_error("row failure was lost");
+        states.front() = first;
+        states.back() = last;
+        batch();
+        verify();
+    } catch (...) {
+        failure = std::current_exception();
+    }
+    if (workers == 2) {
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            stopping = true;
+            ready.notify_one();
+        }
+        helper.join();
+    }
+    if (failure)
+        std::rethrow_exception(failure);
+    std::cout << std::setprecision(12) << "{\"workers\":" << workers
+              << ",\"rows\":" << states.size() << ",\"batches\":" << batches
+              << ",\"wall_seconds\":" << wall << ",\"cpu_seconds\":" << cpu
+              << ",\"python_row_parity\":true,\"failure_recovery\":true}\n";
+}

--- a/tools/ffi_experiment/benchmark_workload.py
+++ b/tools/ffi_experiment/benchmark_workload.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Measure the complete existing Bot workload with opt-in native A*.
+
+Examples:
+  python3 tools/ffi_experiment/benchmark_workload.py --backend python --output /tmp/a.json
+  python3 tools/ffi_experiment/benchmark_workload.py --backend native --module /tmp/build/offline_astar_native.so --output /tmp/b.json
+
+The output contains full state/event/query evidence for comparison, including
+per-frame navigation queue progress. No real Windows native cost is simulated.
+Use independent processes and alternate backend order for timing evidence.
+"""
+import argparse
+import contextlib
+import importlib.util
+import io
+import json
+from pathlib import Path
+import random
+import sys
+import time
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / 'tools'))
+import benchmark_bot_workload as workload
+from navigation_adapter import Backend
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--backend', choices=('python', 'native'), required=True)
+    parser.add_argument('--module')
+    parser.add_argument('--map', default='59_asia_great_wall')
+    parser.add_argument('--scenario', choices=('navigation', 'combat'), default='combat')
+    parser.add_argument('--seconds', type=float, default=30.0)
+    parser.add_argument('--fps', type=float, default=15.0)
+    parser.add_argument('--output', type=Path, required=True)
+    args = parser.parse_args()
+    if args.backend == 'native' and not args.module:
+        parser.error('--module is required for native')
+    random.seed(17)
+    backend = None
+    messages, progress = [], []
+    with contextlib.redirect_stdout(io.StringIO()):
+        runtime, ground = workload.make_runtime(ROOT, args.map, args.scenario)
+        from gui.mods.offline_lan_0922.ai import navigation
+        init_started = time.process_time()
+        if args.backend == 'native':
+            backend = Backend(args.module).install(navigation)
+            backend.graph(runtime.navigator.grid, navigation)
+        init_seconds = time.process_time() - init_started
+        query_context = (workload.combat_native_queries(runtime, ground)
+                         if args.scenario == 'combat' else contextlib.nullcontext([]))
+        try:
+            with query_context as queries:
+                started = time.process_time()
+                for frame in range(int(round(args.seconds * args.fps))):
+                    outgoing = runtime.update(1.0 / args.fps, 100.0 + (frame + 1) / args.fps)
+                    messages.extend(outgoing)
+                    for message in outgoing:
+                        for launch in message.get('launches', ()):
+                            runtime.ack_projectile_launch(launch['id'], launch['fire_seq'])
+                    nav = runtime.navigator
+                    progress.append({
+                        'pending': sorted(repr(key) for key in nav.searches),
+                        'next': repr(nav.search_next_key),
+                        'credit': nav.search_credit, 'budget': nav.search_frame_budget,
+                        'completed': nav.search_completed, 'failed': nav.search_failed,
+                        'last_frames': sorted((repr(key), search.last_frame)
+                                              for key, search in nav.searches.items()),
+                        'paths': sorted((repr(key), path) for key, path in nav.paths.items()),
+                    })
+                cpu_seconds = time.process_time() - started
+            counts = ({'calls': backend.calls, 'expansions': backend.expansions,
+                       'completed': backend.completed} if backend else {})
+            snapshot = {'messages': messages, 'native_queries': queries,
+                        'probes': runtime.probe_totals(), 'decisions': runtime._decision_counts,
+                        'navigation': progress}
+        finally:
+            if backend is not None:
+                backend.close()
+    report = {
+        'backend': args.backend, 'cpu_seconds': cpu_seconds,
+        'initialization_cpu_seconds': init_seconds, 'native_counts': counts,
+        'python': sys.version, 'scenario': args.scenario, 'map': args.map,
+        'seconds': args.seconds, 'fps': args.fps,
+        'real_native_timing': False, 'projectile_terminals_simulated': False,
+        'snapshot': snapshot,
+    }
+    args.output.write_text(json.dumps(report, sort_keys=True))
+    print(json.dumps({key: value for key, value in report.items() if key != 'snapshot'}, sort_keys=True))
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/ffi_experiment/benchmark_world.py
+++ b/tools/ffi_experiment/benchmark_world.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+"""Compare a complete recorded world-collision computation in Python and C++.
+
+The native case executes all already transferred tapes in one dispatch.
+Engine/destructible outcomes are frozen inputs, not eliminated live work.
+"""
+from __future__ import print_function
+import argparse
+import json
+import time
+
+from navigation_adapter import Backend
+from portable_workload import load_fixture
+from world_trace import Replay, register
+
+CLOCK = time.process_time if hasattr(time, 'process_time') else time.clock
+
+
+def median(values):
+    values = sorted(values)
+    return values[len(values)//2] if len(values)%2 else (values[len(values)//2-1]+values[len(values)//2])*0.5
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--module', required=True)
+    parser.add_argument('--fixture', required=True)
+    parser.add_argument('--trace', required=True)
+    parser.add_argument('--output', required=True)
+    parser.add_argument('--rounds', type=int, default=5)
+    parser.add_argument('--loops', type=int, default=5)
+    parser.add_argument('--native-loops', type=int, default=500,
+                        help='amortize clock resolution; results are normalized per corpus pass')
+    args = parser.parse_args()
+    load_fixture(args.fixture)['fixtures']._load()
+    with open(args.trace) as stream:
+        traces = json.load(stream)
+    backend = Backend(args.module)
+    replay = Replay()
+    try:
+        started = CLOCK()
+        for trace in traces:
+            register(backend, trace)
+        transfer = CLOCK()-started
+        for trace in traces:
+            replay.run(trace)
+        # Equality has been established for every request and terminal result.
+        # Keep native tape validation enabled; Python timing excludes only
+        # the extra diagnostic construction/comparison of each request list.
+        replay.verify = False
+        expected = sum(trace['status'] for trace in traces)
+        records = []
+        for repeat in range(args.rounds):
+            order = ('python','native') if repeat%2==0 else ('native','python')
+            for kind in order:
+                started = CLOCK()
+                loops = args.native_loops if kind == 'native' else args.loops
+                if kind == 'native':
+                    native_result = backend.call([404,loops])
+                    total = native_result[0]
+                    if int(native_result[1]) != len(traces):
+                        raise AssertionError('native corpus size differs')
+                else:
+                    total = 0
+                    for unused in range(loops):
+                        for trace in traces:
+                            total += replay.run(trace)
+                elapsed = CLOCK()-started
+                if total != expected*loops:
+                    raise AssertionError('computation result differs')
+                records.append(dict(backend=kind,cpu_seconds=elapsed/loops,
+                                    total_cpu_seconds=elapsed,loops=loops,round=repeat))
+                print('%d %s %.6f' % (repeat,kind,elapsed))
+        medians = dict((kind,median([r['cpu_seconds'] for r in records if r['backend']==kind])) for kind in ('python','native'))
+        result = dict(records=records,median_cpu_seconds=medians,
+                      speedup=medians['python']/medians['native'],
+                      reduction_percent=100*(1-medians['native']/medians['python']),
+                      traces=len(traces),queries=sum(len(t['queries']) for t in traces),
+                      python_loops=args.loops,native_loops=args.native_loops,
+                      native_transfer_cpu_seconds=transfer,
+                      exact_query_and_result_parity=True,
+                      limitations=['Recorded engine/destruction answers; no real native cost',
+                                   'Native persistent tapes and one bulk call; not a live adapter speedup',
+                                   'Descriptor extents are preprojected for both variants',
+                                   'Python reference uses host Math.Vector3 fakes, not Windows engine objects'])
+        with open(args.output,'w') as stream:
+            json.dump(result,stream,indent=2,sort_keys=True)
+        print(json.dumps(result,sort_keys=True))
+    finally:
+        replay.close()
+        backend.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/ffi_experiment/build_1513.sh
+++ b/tools/ffi_experiment/build_1513.sh
@@ -15,6 +15,9 @@ i686-w64-mingw32-g++ -std=c++11 -O2 -Wall -Wextra -Werror \
     "$EXPERIMENT_ROOT/driver_core.cpp" \
     "$EXPERIMENT_ROOT/perception_core.cpp" \
     "$EXPERIMENT_ROOT/world_core.cpp" \
+    "$EXPERIMENT_ROOT/query_bridge.cpp" \
+    "$EXPERIMENT_ROOT/navigation_flow.cpp" \
+    "$EXPERIMENT_ROOT/motion_core.cpp" \
     "$EXPERIMENT_OUTPUT/astar_1513.o" \
     -o "$EXPERIMENT_OUTPUT/offline_astar_native.pyd"
 i686-w64-mingw32-objdump -p "$EXPERIMENT_OUTPUT/offline_astar_native.pyd" \

--- a/tools/ffi_experiment/build_1513.sh
+++ b/tools/ffi_experiment/build_1513.sh
@@ -18,6 +18,7 @@ i686-w64-mingw32-g++ -std=c++11 -O2 -Wall -Wextra -Werror \
     "$EXPERIMENT_ROOT/query_bridge.cpp" \
     "$EXPERIMENT_ROOT/navigation_flow.cpp" \
     "$EXPERIMENT_ROOT/motion_core.cpp" \
+    "$EXPERIMENT_ROOT/kernel_core.cpp" \
     "$EXPERIMENT_OUTPUT/astar_1513.o" \
     -o "$EXPERIMENT_OUTPUT/offline_astar_native.pyd"
 i686-w64-mingw32-objdump -p "$EXPERIMENT_OUTPUT/offline_astar_native.pyd" \

--- a/tools/ffi_experiment/build_1513.sh
+++ b/tools/ffi_experiment/build_1513.sh
@@ -14,6 +14,7 @@ i686-w64-mingw32-g++ -std=c++11 -O2 -Wall -Wextra -Werror \
     "$EXPERIMENT_ROOT/astar_core.cpp" "$EXPERIMENT_ROOT/combat_core.cpp" \
     "$EXPERIMENT_ROOT/driver_core.cpp" \
     "$EXPERIMENT_ROOT/perception_core.cpp" \
+    "$EXPERIMENT_ROOT/world_core.cpp" \
     "$EXPERIMENT_OUTPUT/astar_1513.o" \
     -o "$EXPERIMENT_OUTPUT/offline_astar_native.pyd"
 i686-w64-mingw32-objdump -p "$EXPERIMENT_OUTPUT/offline_astar_native.pyd" \

--- a/tools/ffi_experiment/build_1513.sh
+++ b/tools/ffi_experiment/build_1513.sh
@@ -11,7 +11,10 @@ i686-w64-mingw32-g++ -std=c++11 -O2 -Wall -Wextra -Werror \
     -msse2 -mfpmath=sse -ffp-contract=off -fno-fast-math \
     -static -static-libgcc -static-libstdc++ -shared -s \
     -Wl,--no-insert-timestamp -Wl,--kill-at \
-    "$EXPERIMENT_ROOT/astar_core.cpp" "$EXPERIMENT_OUTPUT/astar_1513.o" \
+    "$EXPERIMENT_ROOT/astar_core.cpp" "$EXPERIMENT_ROOT/combat_core.cpp" \
+    "$EXPERIMENT_ROOT/driver_core.cpp" \
+    "$EXPERIMENT_ROOT/perception_core.cpp" \
+    "$EXPERIMENT_OUTPUT/astar_1513.o" \
     -o "$EXPERIMENT_OUTPUT/offline_astar_native.pyd"
 i686-w64-mingw32-objdump -p "$EXPERIMENT_OUTPUT/offline_astar_native.pyd" \
     > "$EXPERIMENT_OUTPUT/astar_1513.pe.txt"

--- a/tools/ffi_experiment/build_1513.sh
+++ b/tools/ffi_experiment/build_1513.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Build a separate, unshipped x86 #1513 prototype. No game files are changed.
+set -eu
+EXPERIMENT_ROOT=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+EXPERIMENT_OUTPUT=${1:?Pass a temporary build directory}
+mkdir -p "$EXPERIMENT_OUTPUT"
+i686-w64-mingw32-gcc -std=c99 -O2 -Wall -Wextra -Werror \
+    -msse2 -mfpmath=sse -ffp-contract=off \
+    -c "$EXPERIMENT_ROOT/astar_1513.c" -o "$EXPERIMENT_OUTPUT/astar_1513.o"
+i686-w64-mingw32-g++ -std=c++11 -O2 -Wall -Wextra -Werror \
+    -msse2 -mfpmath=sse -ffp-contract=off -fno-fast-math \
+    -static -static-libgcc -static-libstdc++ -shared -s \
+    -Wl,--no-insert-timestamp -Wl,--kill-at \
+    "$EXPERIMENT_ROOT/astar_core.cpp" "$EXPERIMENT_OUTPUT/astar_1513.o" \
+    -o "$EXPERIMENT_OUTPUT/offline_astar_native.pyd"
+i686-w64-mingw32-objdump -p "$EXPERIMENT_OUTPUT/offline_astar_native.pyd" \
+    > "$EXPERIMENT_OUTPUT/astar_1513.pe.txt"
+python3 - "$EXPERIMENT_OUTPUT/astar_1513.pe.txt" <<'PY'
+import re
+import sys
+text = open(sys.argv[1]).read()
+assert 'file format pei-i386' in text
+assert 'initoffline_astar_native' in text
+imports = re.findall(r'DLL Name: (\S+)', text)
+assert set(name.lower() for name in imports) <= {'kernel32.dll', 'msvcrt.dll'}, imports
+print('Unshipped #1513 prototype: x86; imports: ' + ', '.join(imports))
+PY

--- a/tools/ffi_experiment/build_host.sh
+++ b/tools/ffi_experiment/build_host.sh
@@ -17,4 +17,5 @@ c++ -std=c++11 -O2 -fPIC -Wall -Wextra -Werror -ffp-contract=off \
     "$EXPERIMENT_ROOT/query_bridge.cpp" \
     "$EXPERIMENT_ROOT/navigation_flow.cpp" \
     "$EXPERIMENT_ROOT/motion_core.cpp" \
+    "$EXPERIMENT_ROOT/kernel_core.cpp" \
     "$EXPERIMENT_OUTPUT/astar_host.o" -o "$EXPERIMENT_OUTPUT/offline_astar_native.so"

--- a/tools/ffi_experiment/build_host.sh
+++ b/tools/ffi_experiment/build_host.sh
@@ -10,4 +10,7 @@ cc -std=c99 -O2 -fPIC -Wall -Wextra -Werror -I"$EXPERIMENT_INCLUDE" \
     -c "$EXPERIMENT_ROOT/astar_host.c" -o "$EXPERIMENT_OUTPUT/astar_host.o"
 c++ -std=c++11 -O2 -fPIC -Wall -Wextra -Werror -ffp-contract=off \
     -fno-fast-math -shared "$EXPERIMENT_ROOT/astar_core.cpp" \
+    "$EXPERIMENT_ROOT/combat_core.cpp" \
+    "$EXPERIMENT_ROOT/driver_core.cpp" \
+    "$EXPERIMENT_ROOT/perception_core.cpp" \
     "$EXPERIMENT_OUTPUT/astar_host.o" -o "$EXPERIMENT_OUTPUT/offline_astar_native.so"

--- a/tools/ffi_experiment/build_host.sh
+++ b/tools/ffi_experiment/build_host.sh
@@ -14,4 +14,7 @@ c++ -std=c++11 -O2 -fPIC -Wall -Wextra -Werror -ffp-contract=off \
     "$EXPERIMENT_ROOT/driver_core.cpp" \
     "$EXPERIMENT_ROOT/perception_core.cpp" \
     "$EXPERIMENT_ROOT/world_core.cpp" \
+    "$EXPERIMENT_ROOT/query_bridge.cpp" \
+    "$EXPERIMENT_ROOT/navigation_flow.cpp" \
+    "$EXPERIMENT_ROOT/motion_core.cpp" \
     "$EXPERIMENT_OUTPUT/astar_host.o" -o "$EXPERIMENT_OUTPUT/offline_astar_native.so"

--- a/tools/ffi_experiment/build_host.sh
+++ b/tools/ffi_experiment/build_host.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Build an unshipped host bridge with the caller's CPython ABI.
+set -eu
+EXPERIMENT_ROOT=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+EXPERIMENT_PYTHON=${1:-python3}
+EXPERIMENT_OUTPUT=${2:?Pass a temporary build directory}
+EXPERIMENT_INCLUDE=$("$EXPERIMENT_PYTHON" -c 'import sysconfig; print(sysconfig.get_paths()["include"])')
+mkdir -p "$EXPERIMENT_OUTPUT"
+cc -std=c99 -O2 -fPIC -Wall -Wextra -Werror -I"$EXPERIMENT_INCLUDE" \
+    -c "$EXPERIMENT_ROOT/astar_host.c" -o "$EXPERIMENT_OUTPUT/astar_host.o"
+c++ -std=c++11 -O2 -fPIC -Wall -Wextra -Werror -ffp-contract=off \
+    -fno-fast-math -shared "$EXPERIMENT_ROOT/astar_core.cpp" \
+    "$EXPERIMENT_OUTPUT/astar_host.o" -o "$EXPERIMENT_OUTPUT/offline_astar_native.so"

--- a/tools/ffi_experiment/build_host.sh
+++ b/tools/ffi_experiment/build_host.sh
@@ -13,4 +13,5 @@ c++ -std=c++11 -O2 -fPIC -Wall -Wextra -Werror -ffp-contract=off \
     "$EXPERIMENT_ROOT/combat_core.cpp" \
     "$EXPERIMENT_ROOT/driver_core.cpp" \
     "$EXPERIMENT_ROOT/perception_core.cpp" \
+    "$EXPERIMENT_ROOT/world_core.cpp" \
     "$EXPERIMENT_OUTPUT/astar_host.o" -o "$EXPERIMENT_OUTPUT/offline_astar_native.so"

--- a/tools/ffi_experiment/build_host.sh
+++ b/tools/ffi_experiment/build_host.sh
@@ -4,9 +4,15 @@ set -eu
 EXPERIMENT_ROOT=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 EXPERIMENT_PYTHON=${1:-python3}
 EXPERIMENT_OUTPUT=${2:?Pass a temporary build directory}
+EXPERIMENT_PROFILE_FLAGS=
+case "${3:-}" in
+    '') ;;
+    --profile) EXPERIMENT_PROFILE_FLAGS='-DOFFLINE_FFI_PROFILE' ;;
+    *) exit 2 ;;
+esac
 EXPERIMENT_INCLUDE=$("$EXPERIMENT_PYTHON" -c 'import sysconfig; print(sysconfig.get_paths()["include"])')
 mkdir -p "$EXPERIMENT_OUTPUT"
-cc -std=c99 -O2 -fPIC -Wall -Wextra -Werror -I"$EXPERIMENT_INCLUDE" \
+cc -std=c99 -O2 -fPIC -Wall -Wextra -Werror $EXPERIMENT_PROFILE_FLAGS -I"$EXPERIMENT_INCLUDE" \
     -c "$EXPERIMENT_ROOT/astar_host.c" -o "$EXPERIMENT_OUTPUT/astar_host.o"
 c++ -std=c++11 -O2 -fPIC -Wall -Wextra -Werror -ffp-contract=off \
     -fno-fast-math -shared "$EXPERIMENT_ROOT/astar_core.cpp" \

--- a/tools/ffi_experiment/check_core_parity.py
+++ b/tools/ffi_experiment/check_core_parity.py
@@ -23,9 +23,9 @@ def equal(actual, expected, label):
         raise AssertionError('%s\nactual=%r\nexpected=%r' % (label, actual, expected))
 
 
-def check_boundaries(backend, rt):
+def check_boundaries(backend, rt, synchronous=False):
     original = rt.ai_driver.LocalDriver()
-    native = NativeDriver(backend, rt.ai_driver.LocalDriver())
+    native = NativeDriver(backend, rt.ai_driver.LocalDriver(), synchronous)
     neighbour = dict(position=(0.0, 0.0, -3.0), yaw=0.0,
                      half_length=3.5, half_width=1.7, alive=True)
     def clear(unused_yaw, maximum_distance=None):
@@ -150,9 +150,9 @@ def check_aim(backend, rt, rng, cases):
     owner.close()
 
 
-def check_driver(backend, rt, rng, ticks):
+def check_driver(backend, rt, rng, ticks, synchronous=False):
     original = rt.ai_driver.LocalDriver()
-    native = NativeDriver(backend, rt.ai_driver.LocalDriver())
+    native = NativeDriver(backend, rt.ai_driver.LocalDriver(), synchronous)
     modes = set()
     for index in range(ticks):
         bot = index % 15
@@ -214,16 +214,17 @@ def main():
     parser.add_argument('--module', required=True)
     parser.add_argument('--fixture', required=True)
     parser.add_argument('--cases', type=int, default=1200)
+    parser.add_argument('--sync-driver', action='store_true')
     args = parser.parse_args()
     fixtures = load_fixture(args.fixture)
     rt = fixtures['fixtures']._load()
     backend = Backend(args.module)
     try:
-        check_boundaries(backend, rt)
+        check_boundaries(backend, rt, args.sync_driver)
         rng = random.Random(7812)
         valid = check_intercepts(backend, rt, rng, args.cases)
         check_aim(backend, rt, rng, args.cases)
-        queries = check_driver(backend, rt, rng, args.cases * 3)
+        queries = check_driver(backend, rt, rng, args.cases * 3, args.sync_driver)
         print('Exact parity: %d intercepts (%d solutions), %d full gun updates plus low-arc/reach solves, %d driver steps / %d queries; all six drive modes and invalid-command/anonymous-blocker boundaries.' %
               (args.cases, valid, args.cases, args.cases * 3, queries))
     finally:

--- a/tools/ffi_experiment/check_core_parity.py
+++ b/tools/ffi_experiment/check_core_parity.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python
+"""Differential state/query tests against the CPython 2.7 client contract.
+
+Use CPython 2.7 for the reference: Python 3.12 changed float sum arithmetic
+in shot_geometry's direction normalization. Its random aiming cases can
+differ by one ULP even though the target Python 2 calculation is unchanged.
+Do not mask that interpreter difference with approximate comparisons.
+"""
+from __future__ import print_function
+import argparse
+import copy
+import math
+import random
+
+from combat_adapter import CombatBackend
+from driver_adapter import NativeDriver
+from navigation_adapter import Backend
+from portable_workload import load_fixture, Namespace
+
+
+def equal(actual, expected, label):
+    if actual != expected:
+        raise AssertionError('%s\nactual=%r\nexpected=%r' % (label, actual, expected))
+
+
+def check_boundaries(backend, rt):
+    original = rt.ai_driver.LocalDriver()
+    native = NativeDriver(backend, rt.ai_driver.LocalDriver())
+    neighbour = dict(position=(0.0, 0.0, -3.0), yaw=0.0,
+                     half_length=3.5, half_width=1.7, alive=True)
+    def clear(unused_yaw, maximum_distance=None):
+        return True
+    def blocked_pose(unused_yaw):
+        return False
+    args = (1, 0, (0.0, 0.0, 0.0), 0.0, 0.0, 2.0,
+            (0.0, 0.0, 30.0), [neighbour], clear)
+    expected = original.drive(*args, pose_clear=blocked_pose)
+    actual = native.drive(*args, pose_clear=blocked_pose)
+    equal(actual, expected, 'anonymous reverse blocker')
+    assert actual['reverse_blocked_by'] is True
+    assert expected['reverse_blocked_by'] is True
+    before = native.dump_state(1)
+    for packet in ([float('nan')], [float('inf')], [1e100], [200.5], [300.5], [0, 0]):
+        try:
+            backend.call(packet)
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError('invalid command was admitted: %r' % packet)
+        equal(native.dump_state(1), before, 'rejected command preserves owner')
+    native.forget(1)
+
+
+def check_intercepts(backend, rt, rng, cases):
+    valid = 0
+    for index in range(cases):
+        shooter = [rng.uniform(-600, 600), rng.uniform(-30, 100), rng.uniform(-600, 600)]
+        target = [rng.uniform(-600, 600), rng.uniform(-30, 100), rng.uniform(-600, 600)]
+        velocity = [rng.uniform(-20, 20), rng.uniform(-2, 2), rng.uniform(-20, 20)]
+        speed, gravity = rng.uniform(0, 1300), rng.uniform(-30, 30)
+        minimum, maximum = rng.uniform(-math.pi / 2, 0), rng.uniform(0, math.pi / 2)
+        high, max_time = bool(index % 2), rng.choice([0, 1.0, 10.0, 20.0])
+        if index % 37 == 0:
+            target = list(shooter)
+        original = rt.ballistics.ballistic_intercept(shooter, target, velocity, speed,
+                                                     gravity, minimum, maximum, high, max_time)
+        packet = backend.call([103] + shooter + target + velocity +
+                              [speed, gravity, minimum, maximum, int(high), max_time, 0] + [0] * 7)[-7:]
+        native = (tuple(packet[1:4]), packet[4], packet[5]) if packet[0] else None
+        equal(native, original, 'intercept %d' % index)
+        valid += original is not None
+    return valid
+
+
+def check_aim(backend, rt, rng, cases):
+    owner = CombatBackend(backend, rt)
+    original = rt.BotRuntime._update_gun_aim
+    fields = ('terrain_pitch', 'suspension_pitch', 'pitch', 'turret_yaw', 'gun_pitch',
+              'desired_gun_pitch', 'aim_yaw', 'gun_aligned')
+    # Fresh profiles exercise missing, absolute, yaw-dependent and static guns,
+    # damaged modules, switching siege mode, and active hydraulic suspension.
+    profiles = []
+    for index in range(12):
+        gun = dict(rotationSpeed=0.35,
+                   shots=[dict(speed=200.0 + index * 40, gravity=9.81, maxDistance=700.0)])
+        if index % 4 == 0:
+            gun['pitchLimits'] = None
+        elif index % 4 == 1:
+            gun['pitchLimits'] = (-0.2, 0.35)
+        else:
+            gun['pitchLimits'] = dict(
+                minPitch=[(0, -0.18), (1.8, -0.10), (3.8, -0.12), (2 * math.pi, -0.18)],
+                maxPitch=[(0, 0.30), (2.5, 0.20), (2 * math.pi, 0.30)])
+        if index % 3 == 0:
+            gun.update(staticPitch=-0.02, staticTurretYaw=0.01)
+        if index % 2:
+            gun['turretYawLimits'] = (-0.15, 0.15)
+        descriptor = dict(gun=gun, turret=dict(rotationSpeed=0.5))
+        if index >= 6:
+            descriptor['hullAimingParams'] = dict(pitch=dict(
+                isAvailable=True, isEnabled=True,
+                wheelsCorrectionAngles=dict(pitchMin=-0.25, pitchMax=0.20),
+                wheelsCorrectionSpeed=0.05))
+        profiles.append(descriptor)
+    for index in range(cases):
+        descriptor = profiles[index % len(profiles)]
+        state = dict(id=1, yaw=rng.uniform(-math.pi, math.pi),
+                     pitch=rng.uniform(-0.4, 0.4), roll=rng.uniform(-0.3, 0.3),
+                     suspension_pitch=rng.uniform(-0.25, 0.20),
+                     turret_yaw=rng.uniform(-math.pi, math.pi),
+                     gun_pitch=rng.uniform(-0.25, 0.35), aim_yaw=rng.uniform(-math.pi, math.pi),
+                     movement_dir=rng.choice([-1, 0, 1]), siege_state=index % 4,
+                     _overturned=bool(index % 17 == 0),
+                     critical={'destroyed': rng.choice([[], ['engineHealth'], ['leftTrackHealth']])})
+        if index % 5 == 0:
+            state['pitch'] = state['roll'] = 0.0
+        if index % 2:
+            state['terrain_pitch'] = rng.uniform(-0.2, 0.2)
+        target = dict(position=(100.0, 10.0, 120.0)) if index % 7 else None
+        solution = dict(aim_position=(100.0, 10.0, 120.0), yaw=rng.uniform(-math.pi, math.pi),
+                        pitch=rng.uniform(-0.5, 0.5), _origin=(0.0, 0.0, 0.0))
+        command = {'_ballistic_solution': solution} if index % 9 else {}
+        runtime = rt.BotRuntime.__new__(rt.BotRuntime)
+        runtime._descriptors = {1: descriptor}
+        runtime._gun_states = {1: Namespace(loadout={'crew_factor': 0.83, 'gun_rotation_factor': 1.1})}
+        runtime._gun_yaw_limits = {}
+        runtime._exact_shot_origin = lambda *unused: ((0.0, 0.0, 0.0) if index % 23 else None)
+        first, second = copy.deepcopy(state), copy.deepcopy(state)
+        step = rng.choice([0, 1.0/60, 1.0/15, 0.35])
+        expected = original(runtime, first, command, target, step)
+        actual = owner.aim(runtime, second, command, target, step)
+        equal(actual, expected, 'aim return %d' % index)
+        equal(dict((k, second[k]) for k in fields if k in second),
+              dict((k, first[k]) for k in fields if k in first), 'aim state %d' % index)
+        yaw, pitch = rng.uniform(-math.pi, math.pi), rng.uniform(-0.7, 0.7)
+        distance = 50.0 + index % 800
+        moving_target = dict(position=(math.sin(yaw) * distance, pitch * 100,
+                                       math.cos(yaw) * distance),
+                             velocity=(3.0, 0.0, -2.0))
+        runtime.direct_aim_point_probe = None
+        if index % 3 == 0:
+            runtime.direct_aim_point_probe = lambda *unused: dict(
+                aim_position=moving_target['position'], aim_token=('hull', index))
+        elif index % 11 == 0:
+            runtime.direct_aim_point_probe = lambda *unused: None
+        expected = rt.BotRuntime._local_ballistic_solution(
+            runtime, first, moving_target, descriptor, 0)
+        actual = owner.ballistic(runtime, second, moving_target, descriptor, 0)
+        equal(actual, expected, 'full low arc and physical gun reach %d' % index)
+    owner.close()
+
+
+def check_driver(backend, rt, rng, ticks):
+    original = rt.ai_driver.LocalDriver()
+    native = NativeDriver(backend, rt.ai_driver.LocalDriver())
+    modes = set()
+    for index in range(ticks):
+        bot = index % 15
+        phase = (index // 15) % 12
+        pos = (float(bot * 20), 0.0, 0.0)
+        # Long stationary intervals force timed recovery. Later translation
+        # and changing targets exercise progress anchors and braking release.
+        if phase >= 8:
+            pos = (pos[0], 0.0, float(index % 9))
+        target = (pos[0] + (0.0 if phase == 9 else 20.0),
+                  8.0 if phase == 10 else 0.0, pos[2] + (0.0 if phase == 9 else 15.0))
+        yaw = rng.choice([0.0, math.pi, -math.pi, rng.uniform(-math.pi, math.pi)])
+        speed, dt = rng.uniform(-4, 15), rng.choice([1.0/60, 1.0/15, 0.5, 1.25])
+        neighbours = []
+        if phase in (1, 2, 3, 4, 5):
+            neighbours = [dict(id=100+bot, position=(pos[0], 0.0, pos[2]-5.0),
+                               yaw=0.0, half_length=3.5, half_width=1.7, alive=phase != 5)]
+        first_queries, second_queries = [], []
+        def probes(log):
+            def clear(yaw, maximum_distance=None):
+                log.append(('direction', yaw, maximum_distance))
+                if phase in (0, 3):
+                    return False
+                return phase >= 6 or math.sin(yaw * 3.0 + index) > -0.2
+            def pose(yaw):
+                log.append(('pose', yaw))
+                return phase not in (0, 1) and math.cos(yaw) > -0.5
+            return clear, pose
+        clear_a, pose_a = probes(first_queries)
+        clear_b, pose_b = probes(second_queries)
+        kwargs = dict(half_length=3.5, half_width=1.7, movement_intent=phase != 11,
+                      stopping_distance=3.0, stop_at_target=bool(index % 3), decision_horizon=0.1)
+        expected = original.drive(bot, bot, pos, yaw, speed, dt, target, neighbours,
+                                  clear_a, pose_clear=pose_a, **kwargs)
+        actual = native.drive(bot, bot, pos, yaw, speed, dt, target, neighbours,
+                              clear_b, pose_clear=pose_b, **kwargs)
+        equal(actual, expected, 'driver output %d' % index)
+        equal(second_queries, first_queries, 'driver queries %d' % index)
+        equal(native.dump_state(bot), original.states[bot], 'driver state %d' % index)
+        modes.add(actual['recovery_mode'])
+        if index % 7 == 0:
+            elapsed = None if index % 2 else 0.25
+            equal(native.wait_for_traffic(bot, elapsed), original.wait_for_traffic(bot, elapsed), 'traffic result')
+        if index % 11 == 0:
+            ttl = None if index % 2 else 5.0
+            native.remember_failure(bot, yaw, ttl)
+            original.remember_failure(bot, yaw, ttl)
+        equal(native.dump_state(bot), original.states[bot], 'driver events %d' % index)
+        if index % 47 == 0:
+            native.forget(bot)
+            original.forget(bot)
+            equal(native.dump_state(bot), None, 'driver forget')
+    equal(modes, set(('arrived', 'blocked', 'pivot_recovery', 'reverse_turn', 'avoid', 'drive')), 'driver branch coverage')
+    return native.queries
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--module', required=True)
+    parser.add_argument('--fixture', required=True)
+    parser.add_argument('--cases', type=int, default=1200)
+    args = parser.parse_args()
+    fixtures = load_fixture(args.fixture)
+    rt = fixtures['fixtures']._load()
+    backend = Backend(args.module)
+    try:
+        check_boundaries(backend, rt)
+        rng = random.Random(7812)
+        valid = check_intercepts(backend, rt, rng, args.cases)
+        check_aim(backend, rt, rng, args.cases)
+        queries = check_driver(backend, rt, rng, args.cases * 3)
+        print('Exact parity: %d intercepts (%d solutions), %d full gun updates plus low-arc/reach solves, %d driver steps / %d queries; all six drive modes and invalid-command/anonymous-blocker boundaries.' %
+              (args.cases, valid, args.cases, args.cases * 3, queries))
+    finally:
+        backend.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/ffi_experiment/check_host_profile.py
+++ b/tools/ffi_experiment/check_host_profile.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+"""Check boundary accounting across borrowed callbacks, nesting and failure."""
+from __future__ import print_function
+import argparse
+from array import array
+import time
+
+from navigation_adapter import Backend
+import check_query_bridge
+
+
+def rejected(callback):
+    try:
+        callback()
+    except RuntimeError:
+        return
+    raise AssertionError('Profile ownership guard admitted the call')
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--module', required=True)
+    args = parser.parse_args()
+    backend = Backend(args.module)
+    module = backend.module
+    clock = time.process_time if hasattr(time, 'process_time') else time.clock
+    try:
+        rejected(module.profile_stop)
+        started = clock()
+        module.profile_start()
+        rejected(module.profile_start)
+        # This audit includes a disjoint nested sweep, callback exceptions,
+        # aliased buffers, a rejected second thread and repeated owner reuse.
+        check_query_bridge.main()
+        report = module.profile_stop()
+        elapsed = clock() - started
+        names = ('native_core', 'python_callbacks', 'callback_bridge', 'python_outer')
+        assert all(report[name] > 0 for name in names), report
+        total = sum(report[name] for name in names)
+        assert 0 <= elapsed - total < .02, (elapsed, report)
+        assert sum(row['calls'] for row in report['callbacks']) == 230, report
+        assert report['clock_transitions'] > 4 * 230, report
+        # Entry guards also hold inside an actual native query callback, and
+        # an exception restores the outer phase before profiling is stopped.
+        packet = array('d', [0]) * 16
+        command = [405, 0, 0, 0, 0, 1, 1.7, 3.5, 3.5, 0, .1, 0, 0, 0, 0]
+        error = RuntimeError('profile callback failure')
+        def failed():
+            rejected(module.profile_start)
+            rejected(module.profile_stop)
+            raise error
+        module.profile_start()
+        try:
+            backend.call_sync(command, packet, failed)
+        except RuntimeError as observed:
+            assert observed is error
+        else:
+            raise AssertionError('Callback failure was lost')
+        report = module.profile_stop()
+        assert sum(row['calls'] for row in report['callbacks']) == 1, report
+        rejected(module.profile_stop)
+        module.profile_start()
+        assert not module.profile_stop()['callbacks']
+        print('Host CPU partition: nesting, 230 callbacks, exceptions and owner reuse passed.')
+    finally:
+        backend.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/ffi_experiment/check_kernel_aim.py
+++ b/tools/ffi_experiment/check_kernel_aim.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python
+"""Differential native aim, muzzle, intent and exact launch receipt lifecycles."""
+from __future__ import print_function
+
+import argparse
+import copy
+import math
+import random
+
+from check_kernel_state import compare, plain
+from combat_adapter import CombatBackend
+from kernel_adapter import (Kernel, ENGINE_FIELDS, bot_config, critical_config,
+                            gunner_config, aim_config, aim_profile)
+from kernel_engine import EngineLeaves
+from navigation_adapter import Backend
+from portable_workload import load_fixture, Path, ROOT, redirected
+
+
+def run(backend, fixture, variant, frames):
+    with redirected():
+        runtime, unused = fixture['make_runtime'](Path(ROOT), '59_asia_great_wall', 'combat')
+    rt = fixture['fixtures']._load()
+    identity = next(iter(runtime.states))
+    state = runtime.states[identity]
+    descriptor = copy.deepcopy(runtime._descriptors[identity])
+    if variant == 1:
+        descriptor.gun.pitchLimits = dict(
+            minPitch=[(0, -.18), (1.8, -.10), (3.8, -.12), (2 * math.pi, -.18)],
+            maxPitch=[(0, .30), (2.5, .20), (2 * math.pi, .30)])
+    elif variant == 2:
+        descriptor.gun.staticPitch = -.02
+        descriptor.gun.staticTurretYaw = .01
+        descriptor.gun.turretYawLimits = (-.15, .15)
+        descriptor.hullAimingParams = dict(pitch=dict(
+            isAvailable=True, isEnabled=True,
+            wheelsCorrectionAngles=dict(pitchMin=-.25, pitchMax=.20),
+            wheelsCorrectionSpeed=.05))
+    elif variant == 3:
+        state['profile']['class_tag'] = 'SPG'
+    runtime._descriptors[identity] = descriptor
+    runtime._gun_yaw_limits.pop(identity, None)
+    gun = runtime._gun_states[identity]
+    tape, mode = [], [0]
+
+    def note(kind, source, target, args):
+        pose = tuple(source.get(name, 0) for name in (
+            'id', 'x', 'y', 'z', 'yaw', 'pitch', 'roll', 'turret_yaw', 'gun_pitch'))
+        target_pose = None if target is None else (
+            target.get('kind'), target.get('network_id'),
+            tuple(target['position']), tuple(runtime._target_velocity(target)))
+        tape.append((kind, pose, target_pose, args))
+
+    def origin(source, desc, shell, seq, yaw, pitch, time):
+        note('origin', source, None, (shell, seq, yaw, pitch, time))
+        if mode[0] == 1:
+            raise RuntimeError('missing muzzle')
+        if mode[0] == 2:
+            return (0, float('nan'), 0)
+        return (source['x'] + .3, source['y'] + 2.1, source['z'] + 1.7)
+
+    def part(source, target):
+        note('part', source, target, ())
+        if mode[0] == 3:
+            return None
+        point = target['position']
+        return dict(aim_position=(point[0], point[1] + 1, point[2]),
+                    aim_token=('hull', target['network_id'], mode[0] == 4))
+
+    def ballistic(source, target, desc, shell, now):
+        note('ballistic', source, target, (shell, now))
+        if mode[0] == 5:
+            return None
+        position = target['position']
+        start = (source['x'] + .3, source['y'] + 2.1, source['z'] + 1.7)
+        aim = (position[0], position[1] + 1, position[2])
+        speed, gravity, maximum = rt._shot_ballistics(desc, shell)
+        answer = rt.ballistics.ballistic_intercept(
+            start, aim, runtime._target_velocity(target), speed, gravity,
+            -math.pi * .5, math.pi * .5)
+        if answer is None:
+            return None
+        aim, pitch, time = answer
+        return dict(aim_position=aim, pitch=pitch, flight_time=time,
+                    yaw=math.atan2(aim[0] - start[0], aim[2] - start[2]),
+                    arc='low', proof_metadata=('native', (17, 9)))
+
+    def receipt(source, target, desc, shell, seq, yaw, pitch, time, now):
+        note('receipt', source, target, (shell, seq, yaw, pitch, time, now))
+        if mode[0] == 6:
+            return None
+        speed, gravity, maximum = rt._shot_ballistics(desc, shell)
+        velocity = (math.sin(yaw) * math.cos(pitch) * speed,
+                    math.sin(pitch) * speed, math.cos(yaw) * math.cos(pitch) * speed)
+        result = dict(origin=(source['x'] + .3, source['y'] + 2.1, source['z'] + 1.7),
+                      velocity=velocity, shot_yaw=yaw, shot_pitch=pitch,
+                      gravity=gravity, max_distance=maximum, max_time_ms=20000,
+                      fire_seq=seq, shell_index=shell, flight_time=time,
+                      proof_key=('exact', seq, (yaw, pitch, time)))
+        if mode[0] == 7:
+            result['fire_seq'] += 1
+        elif mode[0] == 8:
+            result['velocity'] = (velocity[0] + .01, velocity[1], velocity[2])
+        return result
+
+    def cancel(source):
+        tape.append(('cancel', dict(source)))
+
+    runtime.direct_launch_origin_probe = origin
+    runtime.direct_aim_point_probe = part
+    runtime.ballistic_solution_probe = ballistic
+    runtime.artillery_launch_probe = receipt
+    runtime.artillery_launch_cancel = cancel
+    combat = CombatBackend(backend, rt)
+    bot = bot_config(state, gun, runtime._ammo_states[identity], runtime._burst_states[identity])
+    bot['critical_config'] = critical_config(rt, runtime, identity)
+    bot['config'] = dict(gunnery=gunner_config(rt, runtime, identity),
+                         aim=aim_profile(rt, runtime, identity, combat))
+    kernel = Kernel(backend, rt.bot_state_codec, [bot], round_id=runtime.round_id,
+                    aim=aim_config(rt, runtime), engine=dict(fields=ENGINE_FIELDS))
+    leaves = EngineLeaves(rt, runtime)
+    checks, queries = [0], [0]
+
+    def act(method, **kwargs):
+        action = dict(kwargs, id=identity, method=method)
+        target, now, shell = kwargs.get('target'), kwargs.get('now', 0), kwargs.get('shell', state.get('shell_index', 0))
+        del tape[:]
+        result = None
+        if method == 'set':
+            state.update(kwargs['state'])
+        elif method == 'cadenced':
+            runtime._refresh_control_this_step = kwargs.get('refresh', False)
+            result = runtime._cadenced_ballistic_solution(state, target, descriptor, shell, now, kwargs.get('force', False))
+        elif method == 'local':
+            result = runtime._local_ballistic_solution(state, target, descriptor, shell)
+        elif method == 'slew':
+            result = runtime._update_gun_aim(state, kwargs['command'], target, kwargs['dt'])
+        elif method == 'matches':
+            result = runtime._direct_aim_matches(state, target, kwargs['solution'])
+        elif method == 'preview':
+            result = runtime._direct_launch_preview(state, descriptor, shell, gun, kwargs['solution'])
+        elif method == 'intent':
+            result = runtime._create_artillery_intent(state, target, descriptor, shell, gun, kwargs['solution'], now)
+        elif method == 'active':
+            result = runtime._active_artillery_intent(state, target, descriptor, shell, now)
+        elif method == 'proof':
+            result = runtime._active_artillery_reproof(state, target, descriptor, shell, now)
+        elif method == 'receipt':
+            result = runtime._artillery_launch_receipt(state, target, descriptor, shell, gun, kwargs['solution'], now)
+        elif method == 'cancel':
+            result = runtime._cancel_artillery_intent(identity, kwargs.get('preserve', False))
+        else:
+            raise AssertionError(method)
+        observed_state = dict((key, value) for key, value in state.items()
+                              if key != rt._GUN_PITCH_LIMIT_CACHE)
+        expected = plain(dict(result=result, state=observed_state,
+                              hold=runtime._gunnery_holds.get(identity),
+                              intent=runtime._artillery_intents.get(identity),
+                              proof=runtime._artillery_reproofs.get(identity)))
+        expected_tape = plain(tape)
+        del tape[:]
+        actual = kernel.aim_actions([action], leaves)[0]
+        compare(expected_tape, plain(tape), (variant, checks[0], method, 'engine'))
+        compare(expected, actual, (variant, checks[0], method))
+        checks[0] += 1
+        queries[0] += len(tape)
+        return copy.deepcopy(result)
+
+    rng = random.Random(9181513)
+    try:
+        for frame in range(frames):
+            now = 100 + frame * .07
+            target = dict(kind='human' if frame % 13 < 3 else 'bot', network_id=51,
+                          position=(state['x'] + 30 + frame * .2, state['y'], state['z'] + 90),
+                          velocity=(1.1, 0, -2.3), alive=True, health=100)
+            if variant != 3:
+                mode[0] = frame % 16
+                act('set', state=dict(yaw=rng.uniform(-.3, .3), pitch=rng.uniform(-.2, .2),
+                                      roll=rng.uniform(-.2, .2), fire_seq=frame // 20,
+                                      movement_dir=frame % 3 - 1, siege_state=frame % 4))
+                solution, fresh = act('cadenced', target=target, now=now, refresh=frame % 3 == 0)
+                act('slew', target=target, command=dict(_ballistic_solution=solution), dt=.07)
+                act('matches', target=target, solution=solution)
+                act('preview', solution=solution)
+                act('slew', target=None, command={}, dt=.07)
+            else:
+                mode[0] = 0
+                act('cancel')
+                act('set', state=dict(yaw=0, pitch=0, roll=0, terrain_pitch=0, suspension_pitch=0,
+                                      turret_yaw=0, gun_pitch=0, speed=0, fire_seq=frame))
+                # Use an ordinary unbiassed solve to isolate proof lifetime from gunner error.
+                solution = act('local', target=target)
+                assert solution is not None
+                act('set', state=dict(turret_yaw=solution['yaw'], aim_yaw=solution['yaw'],
+                                      gun_pitch=solution['pitch'], gun_aligned=True))
+                intent = act('intent', target=target, solution=solution, now=now)
+                assert intent is not None
+                act('active', target=target, now=now + .01)
+                mode[0] = 6 + frame % 4
+                act('receipt', target=target, solution=solution, now=now + .02)
+                mode[0] = 0
+                moved = copy.deepcopy(target)
+                moved['position'] = (target['position'][0] + 8, target['position'][1], target['position'][2])
+                act('receipt', target=moved, solution=solution, now=now + .3)
+                act('cadenced', target=moved, now=now + .31, force=True)
+                act('proof', target=target, now=now + 20)
+                act('cancel')
+    finally:
+        kernel.close()
+        combat.close()
+    return checks[0], queries[0]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--module', required=True)
+    parser.add_argument('--fixture', required=True)
+    parser.add_argument('--frames', type=int, default=80)
+    args = parser.parse_args()
+    fixture, backend = load_fixture(args.fixture), Backend(args.module)
+    results = [run(backend, fixture, variant, args.frames) for variant in range(4)]
+    print('Native aim parity: %d transitions and %d ordered engine queries.' % (
+        sum(row[0] for row in results), sum(row[1] for row in results)))
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/ffi_experiment/check_kernel_contacts.py
+++ b/tools/ffi_experiment/check_kernel_contacts.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python
+"""Compare native chassis contact episodes and reliable human ram receipts."""
+from __future__ import print_function
+
+import argparse
+import copy
+import json
+import math
+import random
+
+from check_kernel_state import compare, plain
+from kernel_adapter import Kernel, ENGINE_FIELDS, bot_config, motion_config
+from kernel_engine import EngineLeaves
+from navigation_adapter import Backend
+from portable_workload import load_fixture, Path, ROOT, redirected
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--module', required=True)
+    parser.add_argument('--fixture', required=True)
+    parser.add_argument('--cases', type=int, default=240)
+    args = parser.parse_args()
+    fixture = load_fixture(args.fixture)
+    with redirected():
+        source, unused = fixture['make_runtime'](Path(ROOT), '59_asia_great_wall', 'combat')
+        native, unused = fixture['make_runtime'](Path(ROOT), '59_asia_great_wall', 'combat')
+    rt = fixture['fixtures']._load()
+    ids = list(source.states)[:8]
+    for runtime in (source, native):
+        runtime.states = dict((key, runtime.states[key]) for key in ids)
+        runtime.navigator = None
+    backend = Backend(args.module)
+    bots = [bot_config(native.states[identity], native._gun_states[identity],
+                       native._ammo_states[identity], native._burst_states[identity]) for identity in ids]
+    kernel = Kernel(backend, rt.bot_state_codec, bots, engine=dict(fields=ENGINE_FIELDS),
+                    motion=motion_config(rt, native),
+                    contacts=dict(human_base=rt.HUMAN_TARGET_ID_BASE, has_armor=True, py2=True))
+    leaves = EngineLeaves(rt, native)
+    source_queries, native_queries, frame_box = [], [], [0]
+    def install(runtime, tape):
+        def direction(position, yaw, speed, descriptor, maximum=None, width=None):
+            tape.append(('direction', position, yaw, speed, maximum, width))
+            if frame_box[0] % 13 == 7:
+                raise RuntimeError('injected blocked contact sweep')
+            return dict(clear=True, collision=False, water=False)
+        def armor(first, second, contact):
+            tape.append(('armor', first, second, contact))
+            return None if frame_box[0] % 11 == 3 else (40.0, 65.0)
+        runtime.direction_probe = direction
+        runtime.ram_contact_probe = armor
+    install(source, source_queries)
+    install(native, native_queries)
+    checks = [0]
+
+    def act(method, **kwargs):
+        action = dict(kwargs, method=method)
+        result = None
+        if method == 'set':
+            source.states[kwargs['id']].update(kwargs['state'])
+        elif method == 'resolve':
+            result = rt.tank_collision.resolve_tank(
+                kwargs['body'], kwargs['others'], now=kwargs.get('now'),
+                ram_cooldowns=source._ram_cooldowns,
+                active_ram_contacts=kwargs['previous'])
+            source._ram_cooldowns = result.pop('cooldowns')
+            result['contacts'] = sorted(result['contacts'])
+        elif method == 'step':
+            with redirected():
+                result = source._resolve_tank_contacts(kwargs['players'], kwargs['now'], kwargs['dt'])
+        elif method == 'ack':
+            result = source.ack_human_ram_receipt(kwargs['player'], kwargs['seq'])
+        expected = plain(dict(result=result, states=source.states,
+                              contacts=sorted(source._ram_contacts),
+                              leases=source._contact_lease_elapsed,
+                              cooldowns=sorted((key[0], key[1], value) for key, value in source._ram_cooldowns.items())))
+        actual = kernel.contact_actions([action], leaves)[0]
+        compare(plain(source_queries), plain(native_queries), (checks[0], method, 'engine'))
+        compare(expected, actual, (checks[0], method))
+        del source_queries[:]
+        del native_queries[:]
+        checks[0] += 1
+        return result
+
+    rng = random.Random(7231513)
+    try:
+        previous = []
+        for index in range(args.cases):
+            shape = (rng.uniform(.8, 3), rng.uniform(1.5, 5), -.8, rng.uniform(1, 4))
+            def body(identity):
+                return dict(id=identity, team=1 if identity % 3 else 2,
+                            alive=index % 17 != identity % 17,
+                            x=rng.uniform(-4, 4), y=rng.uniform(-.8, .8), z=rng.uniform(-4, 4),
+                            yaw=rng.uniform(-math.pi, math.pi), mass=rng.uniform(3000, 95000),
+                            vx=rng.uniform(-20, 20), vy=rng.uniform(-25, 25), vz=rng.uniform(-20, 20),
+                            shape=shape, contact_armor=None if index % 5 else rng.uniform(5, 200),
+                            ram_profile=dict(spall_coefficient=1.25, ramming_bonus=.12),
+                            impulse=index % 7 != identity % 7, vehicle='fixture')
+            result = act('resolve', body=body(11), others=[body(value) for value in (12, 13, 14)],
+                         now=index * .07 if index % 19 else None, previous=previous)
+            previous = result['contacts']
+        for frame in range(32):
+            frame_box[0] = frame
+            for index, identity in enumerate(ids):
+                act('set', id=identity, state=dict(
+                    x=(index % 4) * 5.5, y=0, z=(index // 4) * 8 + (frame % 5) * .2,
+                    yaw=0 if index < 4 else math.pi,
+                    speed=10 if frame % 9 else 0, push_x=0, push_z=0,
+                    alive=frame % 8 != index, team=1 if index < 4 else 2))
+            act('step', players=[], now=100 + frame * .11, dt=.11)
+
+        with open(args.fixture) as stream:
+            body = json.load(stream)['_effective_params_snapshot']
+        scope = {}
+        eval(compile(body, '<exact-player-effective-fixture>', 'exec'), scope)
+        player = dict(id=1, team=2, vehicle='ussr:R11_MS-1', alive=True,
+                      x=0, y=0, z=5.8, yaw=math.pi, speed=10,
+                      effective_params=scope['_effective_params_snapshot']())
+        player['_kernel'] = dict(collision=source._player_collision_profile(player))
+        leaves.players[1] = dict(player)
+        identity = ids[0]
+        for seq in range(1, 17):
+            act('set', id=identity, state=dict(x=0, y=0, z=0, yaw=0, speed=10, pitch=0,
+                                              roll=0, alive=True, team=1, push_x=0, push_z=0))
+            historical = copy.deepcopy(source.states[identity])
+            receipt = dict(seq=seq, bot_id=identity, x=0, y=0, z=5.8, yaw=math.pi,
+                           vx=0, vy=0, vz=-10, bot_vx=0, bot_vy=0, bot_vz=10,
+                           presentation_time_us=10000000, contact_x=0, contact_y=0,
+                           contact_z=2.9, contact_armor_player=50, contact_armor_bot=70,
+                           contact_normal_x=0, contact_normal_z=1,
+                           contact_spall_player=1.25, contact_bonus_player=.1)
+            if seq % 5 == 2:
+                receipt['contact_armor_bot'] = 0
+            if seq % 5 == 3:
+                receipt['contact_z'] = 100
+            current = dict(player, ram_contact=receipt, _ram_contact_bot_state=historical)
+            if seq % 5 == 1:
+                act('step', players=[dict(current, _ram_contact_bot_state=None)], now=120 + seq, dt=.07)
+            act('step', players=[current], now=120 + seq, dt=.07)
+            act('step', players=[current], now=120 + seq + .1, dt=.07)
+            act('ack', player=1, seq=seq)
+            act('step', players=[current], now=120 + seq + .2, dt=.07)
+    finally:
+        kernel.close()
+    print('Native tank contact parity: %d solver/lifecycle transitions.' % checks[0])
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/ffi_experiment/check_kernel_driver.py
+++ b/tools/ffi_experiment/check_kernel_driver.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python
+"""Compare route cohorts, whole driver orders and crossing lease outcomes."""
+from __future__ import print_function
+
+import argparse
+import copy
+import math
+import random
+
+from check_kernel_state import compare, plain
+from driver_adapter import DriverBackend
+from kernel_adapter import (Kernel, ENGINE_FIELDS, bot_config, critical_config,
+                            motion_config, driver_config)
+from kernel_engine import EngineLeaves
+from navigation_adapter import Backend
+from navigation_flow_adapter import NavigationFlowBackend
+from portable_workload import load_fixture, Path, ROOT, redirected
+
+
+def run(backend, fixture, map_name, frames):
+    with redirected():
+        source, unused = fixture['make_runtime'](Path(ROOT), map_name, 'navigation')
+        native, unused = fixture['make_runtime'](Path(ROOT), map_name, 'navigation')
+    rt = fixture['fixtures']._load()
+    from gui.mods.offline_lan_0922.ai import navigation
+    components = [NavigationFlowBackend(backend, native, navigation),
+                  DriverBackend(backend, native, True)]
+    bots = []
+    ids = list(source.states)
+    for identity in ids:
+        state = native.states[identity]
+        bot = bot_config(state, native._gun_states[identity],
+                         native._ammo_states[identity], native._burst_states[identity])
+        bot['critical_config'] = critical_config(rt, native, identity)
+        bot['config'] = {}
+        bots.append(bot)
+    kernel = Kernel(backend, rt.bot_state_codec, bots,
+                    engine=dict(fields=ENGINE_FIELDS), motion=motion_config(rt, native),
+                    driver=driver_config(rt, native), orders=list(native._server_orders.items()))
+    leaves = EngineLeaves(rt, native)
+    checks = [0]
+    tape, frame_box = [], [0]
+    source_queries, native_queries = [], []
+
+    def install(runtime, tape):
+        def probe(position, yaw, speed, descriptor, maximum=None, width=None):
+            tape.append((position, yaw, speed, maximum, width))
+            if frame_box[0] % 19 == 7:
+                return None
+            return dict(clear=frame_box[0] % 17 != 9, collision=frame_box[0] % 17 == 9,
+                        deferred=frame_box[0] % 11 == 4,
+                        slope=.63 if frame_box[0] % 13 == 10 else 0, water=False)
+        runtime.direction_probe = probe
+    install(source, source_queries)
+    install(native, native_queries)
+
+    def act(method, identity=ids[0], **kwargs):
+        action = dict(kwargs, id=identity, method=method)
+        result = None
+        state = source.states[identity]
+        decision = copy.deepcopy(kwargs.get('decision'))
+        if method == 'begin':
+            source.navigator.begin_frame(kwargs['dt'])
+        elif method == 'end':
+            source.navigator.end_frame()
+        elif method == 'set':
+            state.update(kwargs['state'])
+        elif method == 'orders':
+            source._server_orders = dict(kwargs['orders'])
+        elif method == 'binding':
+            result = source._route_lane_binding(identity, tuple(kwargs['group']),
+                                                 kwargs['goal'], kwargs['order'])
+        elif method == 'lane_goal':
+            result = source._route_lane_goal(identity, kwargs['position'], kwargs['goal'],
+                                             kwargs['order'], kwargs['now'], kwargs['joining'])
+        elif method == 'route':
+            result = source._navigation_target(identity, kwargs['position'], kwargs['goal'], kwargs['order'], decision)
+        elif method in ('drive', 'traffic'):
+            position = rt._position(state)
+            samples = {}
+
+            def clear(yaw, maximum=None):
+                grid = source.navigator.grid
+                shallow = grid.point_has_baked_hazard(position, rt.BAKED_SHALLOW_WATER)
+                advisory = source._planner_corridor_clear(
+                    position, yaw, state['speed'], maximum_distance=maximum,
+                    wet_escape=shallow or state.get('_water_depth', -1) > rt.BOT_WATER_AVOID_DEPTH,
+                    allow_shallow=source.navigator.controlled_shallow_step(identity, position, yaw))
+                if advisory is not None:
+                    return bool(advisory)
+                key = (round((yaw + math.pi) % (2 * math.pi) - math.pi, 4),
+                       None if maximum is None else round(maximum, 2))
+                if key not in samples:
+                    samples[key] = source._probe_direction(position, yaw, state['speed'], source._descriptors[identity], maximum)
+                value = samples[key]
+                return True if value is None or isinstance(value, dict) and value.get('deferred') else source._probe_is_clear(value)
+
+            if method == 'drive':
+                decision['pose_clear'] = lambda yaw: source.navigator.grid.hull_pose_clear(
+                    position, yaw, state.get('half_length', 3.5), state.get('half_width', 1.7))
+                result = source.adapter.decide_with_order(decision, kwargs['order'], clear)
+                decision.pop('pose_clear', None)
+            else:
+                result = source._traffic_coordinator.adjust(identity, kwargs['body'], kwargs['command'], kwargs['neighbours'], kwargs['now'], clear)
+        expected = plain(dict(result=result, states=source.states, decision=decision))
+        actual = kernel.driver_actions([action], leaves)[0]
+        compare(expected, actual, (map_name, checks[0], method, identity))
+        compare(plain(source_queries), plain(native_queries), (map_name, checks[0], method, 'engine'))
+        del source_queries[:]
+        del native_queries[:]
+        checks[0] += 1
+        return result
+
+    try:
+        rng = random.Random(7221513)
+        for frame in range(frames):
+            frame_box[0] = frame
+            now = 100 + frame * .13
+            act('begin', dt=.13)
+            if frame % 7 == 0:
+                orders = {}
+                for identity in ids:
+                    state = source.states[identity]
+                    order = copy.deepcopy(source._server_orders[identity])
+                    order.update(route_id='group-%d' % (state['slot'] % 2), route_index=frame // 7,
+                                 route_join=frame % 14 == 0,
+                                 route_anchor=rt._position(source.states[ids[0]]),
+                                 combat_mode='route')
+                    orders[identity] = order
+                act('orders', orders=list(orders.items()))
+            for index, identity in enumerate(ids[:8]):
+                state = source.states[identity]
+                order = source._server_orders[identity]
+                position = rt._position(state)
+                if frame % 9 == 3:
+                    act('set', identity, state=dict(alive=index % 3 != 1))
+                if frame % 9 == 4:
+                    act('set', identity, state=dict(alive=True))
+                if frame % 6 == 1:
+                    act('binding', identity, group=(state['team'], order['route_id']),
+                        goal=order['move_position'], order=order)
+                decision = dict(id=identity, slot=state['slot'], position=position,
+                                yaw=state['yaw'], speed=state['speed'], dt=.13, now=now,
+                                half_length=state['half_length'], half_width=state['half_width'],
+                                neighbours=[], decision_horizon=.1, stopping_distance=None)
+                if frame % 8 == 5:
+                    order = dict(order, move_area_bounds=(position[0] - 20, position[2] - 20,
+                                                         position[0] + 20, position[2] + 20),
+                                 team_command_id=frame)
+                command = act('drive', identity, decision=decision, order=order)
+                if frame % 4 == 2:
+                    next_pose = command['move_position']
+                    act('set', identity, state=dict(x=next_pose[0], y=next_pose[1], z=next_pose[2],
+                                                    speed=rng.uniform(0, 7), yaw=command['target_yaw']))
+                # Crossings and head-on pairs retain the actual body geometry.
+                yaw = 0.0
+                body = dict(id=identity, team=1, alive=True, position=(0, 0, 0), yaw=yaw,
+                            velocity=(0, 0, 4), half_width=1.7, half_length=3.5,
+                            shape=(1.7, 3.5, 0, 2))
+                peer_yaw = math.pi if frame % 2 else -math.pi * .5
+                peer = dict(body, id=100 + index, position=(0, 0, 9) if frame % 2 else (6, 0, 5),
+                            yaw=peer_yaw, velocity=(math.sin(peer_yaw) * 4, 0, math.cos(peer_yaw) * 4))
+                act('traffic', identity, body=body, neighbours=[peer], now=now,
+                    command=dict(throttle=1, turn=0, target_yaw=0, combat_mode='route', recovery_mode='drive'))
+            act('end')
+    finally:
+        kernel.close()
+        for component in reversed(components):
+            component.close()
+    return checks[0]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--module', required=True)
+    parser.add_argument('--fixture', required=True)
+    parser.add_argument('--frames', type=int, default=28)
+    args = parser.parse_args()
+    fixture, backend = load_fixture(args.fixture), Backend(args.module)
+    total = sum(run(backend, fixture, name, args.frames) for name in (
+        '59_asia_great_wall', '04_himmelsdorf', '10_hills'))
+    print('Native route, driver and traffic parity: %d transitions.' % total)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/ffi_experiment/check_kernel_engine.py
+++ b/tools/ffi_experiment/check_kernel_engine.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+"""Check projection reuse and primitive leaves without a native engine."""
+from __future__ import print_function
+from array import array
+import unittest
+
+from kernel_adapter import ENGINE_FIELDS
+from kernel_engine import EngineLeaves, _ACTOR_ARGS
+
+
+class Object(object):
+    def __init__(self, **values):
+        self.__dict__.update(values)
+
+
+def packet(kind, source, target=None, args=()):
+    result = array('d', [0]) * 256
+    result[0] = kind
+    at = 1
+    for actor in (source, target or {}):
+        result[at] = actor.get('kind') == 'human'
+        result[at + 1] = actor.get('network_id', actor.get('id', 0))
+        mask = 0
+        for index, name in enumerate(ENGINE_FIELDS):
+            if actor.get(name) is not None:
+                mask |= 1 << index
+                result[at + 3 + index] = actor[name]
+        result[at + 2] = mask
+        at += 3 + len(ENGINE_FIELDS)
+        for name in ('position', 'velocity'):
+            if name in actor:
+                result[at] = 1
+                result[at + 1:at + 4] = array('d', actor[name])
+            at += 4
+    assert at == _ACTOR_ARGS
+    result[at:at + len(args)] = array('d', args)
+    return result
+
+
+class EngineTests(unittest.TestCase):
+    def setUp(self):
+        self.state = dict(id=3, x=1.0, y=2.0, z=3.0, yaw=.4, speed=5.0,
+                          alive=True, vehicle='test', position=(99, 98, 97))
+        self.runtime = Object(states={3: self.state}, _descriptor_pairs={}, _descriptors={})
+        self.module = Object(_position=lambda state: tuple(state.get(name, 0.0) for name in ('x', 'y', 'z')))
+        self.leaves = EngineLeaves(self.module, self.runtime)
+        self.leaves.owned = True
+
+    def no_actors(self):
+        def rejected(*unused):
+            raise AssertionError('primitive leaf decoded a vehicle')
+        self.leaves.actor = rejected
+
+    def test_exact_variants_and_mutation_isolation(self):
+        first = packet(751, self.state)
+        second = packet(751, dict(self.state, x=7, alive=False))
+        a = self.leaves.actor(first, 1)[0]
+        a['x'] = 1000
+        b = self.leaves.actor(second, 1)[0]
+        b.pop('vehicle')
+        again = self.leaves.actor(first, 1)[0]
+        self.assertEqual(again['x'], 1)
+        self.assertEqual(again['vehicle'], 'test')
+        self.assertIs(again['alive'], True)
+        self.assertIsInstance(again['id'], int)
+        self.assertEqual(a['x'], 1000)
+        self.assertEqual(self.leaves.actor_decodes, 2)
+        self.assertEqual(len(self.leaves.actor_cache), 2)
+        self.leaves.actor_cache.clear()
+        self.leaves.actor(first, 1)
+        self.assertEqual(self.leaves.actor_decodes, 3)
+
+    def test_presence_and_actor_identity(self):
+        raw = dict(self.state)
+        del raw['x']
+        raw.pop('position')
+        value = self.leaves.actor(packet(751, raw), 1)[0]
+        self.assertNotIn('x', value)
+        self.assertEqual(value['position'], (0, 2, 3))
+        self.leaves.players = {3: dict(vehicle='human')}
+        human = self.leaves.actor(packet(751, dict(self.state, kind='human')), 1)[0]
+        self.assertEqual(human['vehicle'], 'human')
+        self.assertEqual(human['kind'], 'human')
+
+    def test_standalone_cache_stays_bounded(self):
+        self.leaves.owned = False
+        for index in range(100):
+            self.leaves.actor(packet(751, dict(self.state, x=index)), 1)
+        self.assertEqual(len(self.leaves.actor_cache), 1)
+
+    def test_water_reads_xyz_and_contains_failure(self):
+        self.no_actors()
+        positions = []
+        def depth(position):
+            positions.append(position)
+            return float('nan') if len(positions) > 1 else 2.5
+        self.runtime._water_depth_probe = depth
+        query = packet(769, self.state)
+        self.leaves(query)
+        self.assertEqual(positions, [(1, 2, 3)])
+        self.assertEqual(list(query[:2]), [1, 2.5])
+        query = packet(769, self.state)
+        self.leaves(query)
+        self.assertEqual(list(query[:2]), [0, -1])
+
+    def test_ground_and_report_need_no_descriptor(self):
+        self.no_actors()
+        calls = []
+        self.runtime._physics_ground_probe = lambda *args: calls.append(args)
+        self.runtime.motion_report = lambda *args: calls.append(args)
+        self.leaves(packet(760, self.state, args=(630, 3, 1, 2, 3)))
+        self.leaves(packet(760, self.state, args=(616, 3, 1, 4, 5)))
+        self.assertEqual(calls, [(1, 2, 3), (3, 'crushed', 4, 5)])
+
+    def test_scan_cancel_required_fields(self):
+        self.no_actors()
+        calls = []
+        self.runtime.destructible_body_scan = lambda *args: calls.append(args)
+        self.runtime.artillery_launch_cancel = lambda value: calls.append(value)
+        self.leaves(packet(771, self.state))
+        self.leaves(packet(766, self.state))
+        self.assertEqual(calls, [(3, (1, 2, 3), .4, 5), dict(id=3)])
+        missing = dict(self.state)
+        del missing['yaw']
+        with self.assertRaises(KeyError):
+            self.leaves(packet(771, missing))
+        self.leaves(packet(766, {}))
+        self.assertEqual(len(calls), 2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/ffi_experiment/check_kernel_engine.py
+++ b/tools/ffi_experiment/check_kernel_engine.py
@@ -127,6 +127,32 @@ class EngineTests(unittest.TestCase):
         self.leaves(packet(766, {}))
         self.assertEqual(len(calls), 2)
 
+    def test_aim_reads_only_borrowed_request(self):
+        class BorrowedPacket(object):
+            # The provider owns 32,768 doubles, but this native request lends
+            # only its 256-double packet. The remaining capacity is unrelated.
+            def __init__(self, values):
+                self.values = values
+            def __getitem__(self, key):
+                if isinstance(key, slice):
+                    if key.stop is None or key.stop > len(self.values):
+                        raise AssertionError('Read beyond borrowed request')
+                elif key >= len(self.values):
+                    raise AssertionError('Read beyond borrowed request')
+                return self.values[key]
+            def __setitem__(self, key, value):
+                self.values[key] = value
+
+        calls = []
+        def origin(*args):
+            calls.append(args)
+            return (4, 5, 6)
+        self.runtime.direct_launch_origin_probe = origin
+        query = BorrowedPacket(packet(761, self.state, args=(2, 3, .4, .5, .6)))
+        self.leaves(query)
+        self.assertEqual(list(query[:4]), [1, 4, 5, 6])
+        self.assertEqual(calls[0][2:], (2, 3, .4, .5, .6))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tools/ffi_experiment/check_kernel_fields.cpp
+++ b/tools/ffi_experiment/check_kernel_fields.cpp
@@ -1,0 +1,119 @@
+// Exercise storage semantics independently of the gameplay port. Run with
+// ASan/UBSan as well as the host compiler; no Python or native engine required.
+#include "kernel_value.h"
+#include <cassert>
+#include <iostream>
+#include <random>
+#include <set>
+
+using namespace offline_kernel;
+
+int main() {
+    std::mt19937 random(1513);
+    Value record = Value::record();
+    std::map<std::string, Value> oracle;
+    std::set<std::string> names;
+    for (int slot = 0; slot < sf::count; ++slot) {
+        std::string name = field_name(slot);
+        assert(names.insert(name).second);
+        assert(field_slot(name) == slot);
+        assert(field_string(slot) == name);
+    }
+    assert(field_slot("unknown-descriptor-field") == -1);
+    for (int step = 0; step < 20000; ++step) {
+        int slot = static_cast<int>(random() % sf::count);
+        std::string name = step % 7 ? field_name(slot) : "extra-" + std::to_string(slot);
+        Field key{field_slot(name), name.c_str()};
+        if (step % 5 == 0) {
+            record.erase(key);
+            oracle.erase(name);
+        } else {
+            Value value = step % 3 ? Value(step) : Value();
+            if (step % 2)
+                record[key] = value;
+            else
+                record[name] = value;
+            oracle[name] = value;
+        }
+        assert(record.size() == oracle.size());
+        assert(record.truth() == !oracle.empty());
+        assert(record.has(name) == (oracle.count(name) != 0));
+        assert(record.has(key) == record.has(name));
+        assert(record.get(key) == (oracle.count(name) ? oracle.at(name) : Value()));
+        if (step % 173 == 0) {
+            Value mapping = Value::object();
+            for (const auto &item : oracle)
+                mapping[item.first] = item.second;
+            assert(record == mapping && mapping == record);
+            assert(JsonReader(json(record)).read() == mapping);
+            assert(mapping.as_record() == record);
+            std::map<std::string, Value> visited;
+            record.visit([&](const std::string &field, const Value &value) {
+                assert(visited.emplace(field, value).second);
+            });
+            assert(visited == oracle);
+        }
+    }
+    record[sf::x] = Value();
+    assert(record.has(sf::x) && record.get(sf::x).kind == Value::Null);
+    Value omitted = record.copy();
+    omitted.erase(sf::x);
+    assert(omitted != record && !omitted.has(sf::x));
+    omitted.erase("x");
+    assert(!omitted.has(sf::x));
+    Value &stable = record[sf::x];
+    record[sf::position] = JsonReader("[1,2,3]").read();
+    Value alias = record, shallow = record.copy(), deep = record.clone();
+    for (int i = 0; i < 2000; ++i)
+        record["new-" + std::to_string(i)] = Value(i);
+    stable = Value(1513);
+    assert(alias.get(sf::x).exact() == 1513);
+    assert(shallow.get(sf::x).kind == Value::Null);
+    assert(deep.get(sf::x).kind == Value::Null);
+    shallow[sf::position][size_t(1)] = Value(42);
+    assert(record.get(sf::position)[1].exact() == 42);
+    assert(deep.get(sf::position)[1].exact() == 2);
+    for (bool dense : {false, true}) {
+        Value destination = dense ? Value::record() : Value::object();
+        destination["keep"] = Value(7);
+        destination.assign_fields(record);
+        assert(destination.get("keep").exact() == 7);
+        destination.erase("keep");
+        assert(destination == record);
+        destination.assign_fields(destination);
+        assert(destination == record);
+        destination.erase(sf::position);
+        assert(record.has(sf::position));
+    }
+    // Conversion and aliasing do not depend on the source object's lifetime.
+    Value retained;
+    {
+        Value temporary = JsonReader("{\"x\":1,\"extra\":{\"nested\":2}}").read();
+        retained = temporary.as_record();
+    }
+    assert(retained.get(sf::x).exact() == 1);
+    assert(retained.get("extra").get("nested").exact() == 2);
+    // JSON permits embedded NULs in irregular keys. They are not C strings.
+    for (bool dense : {false, true}) {
+        Value embedded = JsonReader("{\"x\\u0000extra\":4,\"x\":9}").read();
+        if (dense)
+            embedded = embedded.as_record();
+        std::string name("x\0extra", 7);
+        Field key{field_slot(name), name.c_str(), name.size()};
+        assert(embedded.size() == 2 && embedded.get(key).exact() == 4);
+        assert(embedded.get(name).exact() == 4);
+        assert(embedded.has(key) && embedded.has(name));
+        assert(JsonReader(json(embedded)).read() == embedded);
+        embedded.erase(key);
+        assert(!embedded.has(name) && embedded.get(sf::x).exact() == 9);
+    }
+    bool rejected = false;
+    try {
+        Value().as_record();
+    } catch (const std::invalid_argument &) {
+        rejected = true;
+    }
+    assert(rejected);
+    std::cout << "State storage: 20000 oracle mutations, presence, alias/copy/clone, "
+                 "merge, stable references and JSON parity passed.\n";
+}

--- a/tools/ffi_experiment/check_kernel_gunnery.py
+++ b/tools/ffi_experiment/check_kernel_gunnery.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python
+"""Compare native gunner randomness, frozen launches and reliable shot outbox."""
+from __future__ import print_function
+
+import argparse
+import copy
+import hashlib
+import random
+
+from check_kernel_state import compare, plain
+from kernel_adapter import Kernel, bot_config
+from navigation_adapter import Backend
+from portable_workload import load_fixture, Path, ROOT, redirected
+
+
+def gunner_cases(backend, rt, runtime, count):
+    checks = 0
+    bot_id = next(iter(runtime.states))
+    state = runtime.states[bot_id]
+    base = copy.deepcopy(state)
+    for rating in (0.0, .21, .59, .82, 1.0):
+        state.clear()
+        state.update(copy.deepcopy(base))
+        runtime._gunnery_holds.clear()
+        runtime.bot_rating = lambda unused: rating
+        config = dict(rt.bot_gunnery.rating_parameters(rating))
+        config.update(epoch_seconds=rt.bot_gunnery.AIM_BIAS_SECONDS,
+                      maximum_offset=rt.bot_gunnery.MAX_AIM_OFFSET_METRES,
+                      vertical_share=rt.bot_gunnery.VERTICAL_BIAS_SHARE)
+        bot = bot_config(state, runtime._gun_states[bot_id],
+                         runtime._ammo_states[bot_id], runtime._burst_states[bot_id])
+        bot['config'] = dict(gunnery=config)
+        kernel = Kernel(backend, rt.bot_state_codec, [bot], round_id=runtime.round_id)
+        rng = random.Random(1513)
+        actions, expected = [], []
+
+        def act(action):
+            method = action['method']
+            target, now = action.get('target'), action.get('now', 0)
+            if method == 'set':
+                state.update(action['state'])
+                result = None
+            elif method == 'random':
+                generator = random.Random(action['seed'])
+                result = [generator.gauss(0, action.get('sigma', 1))
+                          if action.get('gauss') else generator.random()
+                          for unused in range(action['count'])]
+            elif method == 'hash':
+                result = int(hashlib.sha1(action['text'].encode('utf-8')).hexdigest()[:8], 16) & 0x7fffffff
+            elif method == 'dispersed':
+                result = rt._dispersed_barrel_angles(
+                    bot_id, runtime.round_id, action['seq'], action['yaw'],
+                    action['pitch'], action['dispersion'], action.get('index', 0),
+                    action.get('group'), base_direction=action.get('base'))
+            else:
+                methods = dict(hold=runtime._track_gunnery_hold,
+                               error=runtime._gunnery_error,
+                               aimed=runtime._aimed_target,
+                               ready=lambda s, t, n: runtime._gunner_ready(
+                                   s, runtime._gun_states[bot_id], t, n))
+                result = methods[method](state, target, now)
+            actions.append(action)
+            expected.append(plain(dict(result=result,
+                                       hold=runtime._gunnery_holds.get(bot_id))))
+
+        for seed in (0, 1, 1513, 0x7fffffff, 0xffffffff):
+            for gaussian in (False, True):
+                act(dict(method='random', seed=seed, count=1250, gauss=gaussian, sigma=.037))
+        for text in ('', 'abc', 'a' * 55, 'b' * 56, 'c' * 64, 'd' * 1000):
+            act(dict(method='hash', text=text))
+        for frame in range(count):
+            target = dict(kind='human' if frame % 19 < 8 else 'bot',
+                          network_id=1 + frame // 31,
+                          position=(state['x'] + rng.uniform(-500, 500),
+                                    rng.uniform(-100, 100), state['z'] + rng.uniform(-500, 500)),
+                          yaw=rng.uniform(-3, 3), speed=rng.uniform(-18, 25),
+                          alive=True, visible=True)
+            if frame % 5 == 0:
+                target['velocity'] = (1.7, 3.1, -2.3)
+            if frame % 13 == 1:
+                target = None
+            if frame % 7 == 2:
+                act(dict(method='set', state=dict(fire_seq=frame // 7)))
+            for method in ('hold', 'error', 'aimed', 'ready'):
+                act(dict(method=method, target=target, now=100 + frame * .27))
+            shot = dict(method='dispersed', seq=frame + 1, index=frame % 4,
+                        group=frame + 1 - frame % 4, yaw=rng.uniform(-3, 3),
+                        pitch=rng.uniform(-1, 1), dispersion=rng.uniform(.001, .04))
+            if frame % 2:
+                shot['base'] = (rng.uniform(-2, 2), rng.uniform(-2, 2), rng.uniform(-2, 2))
+            act(shot)
+        try:
+            actual = kernel.gunnery_actions(bot_id, actions)
+            compare(expected, actual, ('gunner', rating))
+            checks += len(actions)
+        finally:
+            kernel.close()
+    return checks
+
+
+def launch_cases(backend, rt, runtime, count):
+    checks = 0
+    bot_id = next(iter(runtime.states))
+    original = copy.deepcopy(runtime.states[bot_id])
+    descriptor = runtime._descriptors[bot_id]
+    for clip_size, burst_count in ((1, 1), (3, 1), (7, 3)):
+        installed = copy.deepcopy(descriptor)
+        installed.gun.clip = (clip_size, .19)
+        installed.gun.burst = (burst_count, .11 if burst_count > 1 else 0.0)
+        state = runtime.states[bot_id]
+        state.clear()
+        state.update(copy.deepcopy(original))
+        gun = rt._BotGunState(installed)
+        ammo = rt._BotAmmoState(installed, state['profile'])
+        burst = rt.burst_mechanics.BurstClock()
+        runtime._gun_states[bot_id] = gun
+        runtime._ammo_states[bot_id] = ammo
+        runtime._burst_states[bot_id] = burst
+        runtime._descriptors[bot_id] = installed
+        runtime._pending_launches = []
+        runtime._pending_launch_keys = {}
+        runtime._pending_launch_by_bot = {}
+        kernel = Kernel(backend, rt.bot_state_codec,
+                        [bot_config(state, gun, ammo, burst)], round_id=runtime.round_id)
+        rng = random.Random(3001513)
+        actions, expected = [], []
+
+        def act(action):
+            method = action['method']
+            factor = action.get('factor', 1)
+            if method == 'set':
+                state.update(action['state'])
+                result = None
+            elif method == 'weapon':
+                owner, name = action['action']['method'].split('.')
+                result = getattr(dict(gun=gun, ammo=ammo, burst=burst)[owner], name)(
+                    *action['action'].get('args', ()))
+            elif method == 'fire':
+                result = runtime._fire(state, gun, factor, installed,
+                                       launch_receipt=action.get('receipt'), ammo_state=ammo,
+                                       launch_preview=action.get('preview'),
+                                       launch_time_us=action['time'])
+            elif method == 'cancel':
+                result = runtime._cancel_active_burst(state, gun, ammo, burst)
+            elif method == 'ack':
+                result = runtime.ack_projectile_launch(action.get('id', bot_id), action['seq'])
+            elif method == 'advance':
+                result = []
+                for edge in burst.advance(action['dt']):
+                    time = min(action['end'], action['time'] + max(0, int(round(edge['due_offset'] * 1000000))))
+                    preview = action.get('preview')
+                    if action.get('sequence_preview') and preview is not None:
+                        preview = dict(preview, fire_seq=edge['shot_seq'])
+                    accepted = runtime._commit_burst_edge(
+                        state, gun, factor, installed, edge, ammo,
+                        launch_receipt=action.get('receipt'), launch_preview=preview,
+                        launch_time_us=time)
+                    result.append(accepted)
+                    if not accepted:
+                        runtime._cancel_active_burst(state, gun, ammo, burst)
+                        break
+                burst.publish(state)
+            record = bot_config(state, gun, ammo, burst)
+            record = plain(record)
+            for name in ('crew_level', 'loadout'):
+                record['gun'].pop(name, None)
+            expected.append(plain(dict(result=result, state=record,
+                                       launches=runtime._pending_launches)))
+            actions.append(action)
+
+        for frame in range(count):
+            act(dict(method='set', state=dict(_drowning=frame % 23 == 3,
+                                              _overturned=frame % 31 == 4,
+                                              pitch=.15 if frame % 29 == 4 else 0,
+                                              x=original['x'] + frame * .8)))
+            if not burst.active:
+                act(dict(method='weapon', action=dict(method='gun.tick', args=[rng.choice((.1, .19, 2.7, 8.1))])))
+                kind = 'full' if gun.reload_kind == 'full' else 'intra'
+                ready = gun.ready()
+                act(dict(method='weapon', action=dict(method='gun.complete_reload', args=[1, ammo.planned_rounds()])))
+                act(dict(method='weapon', action=dict(method='ammo.stage', args=[frame % 3, ready, kind == 'full'])))
+                preview = dict(fire_seq=state.get('fire_seq', 0) + (2 if frame % 17 == 7 else 1),
+                               shot_yaw=.24, shot_pitch=.017, origin=(1.5, 7.3, 2.7))
+                act(dict(method='fire', time=frame * 200000,
+                         preview=preview if frame % 3 else None))
+            else:
+                if frame % 5 == 3:
+                    act(dict(method='cancel'))
+                else:
+                    act(dict(method='advance', dt=.23, time=frame * 200000,
+                             end=frame * 200000 + 230000,
+                             sequence_preview=True,
+                             preview=dict(fire_seq=1, shot_yaw=.31, shot_pitch=.028,
+                                          origin=(frame * 1.5, 7.3, 2.7))))
+            if runtime._pending_launches and frame % 3 == 1:
+                oldest = runtime._pending_launches[0]['fire_seq']
+                act(dict(method='ack', seq=oldest + 1))
+                act(dict(method='ack', seq=oldest))
+                act(dict(method='ack', seq=oldest))
+        try:
+            actual = kernel.launch_actions(bot_id, actions)
+            for index, (left, right) in enumerate(zip(expected, actual)):
+                compare(left, right, ('launch', clip_size, burst_count, index, actions[index]))
+            checks += len(actions)
+        finally:
+            kernel.close()
+    return checks
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--module', required=True)
+    parser.add_argument('--fixture', required=True)
+    parser.add_argument('--cases', type=int, default=120)
+    args = parser.parse_args()
+    with redirected():
+        fixture = load_fixture(args.fixture)
+        runtime, unused = fixture['make_runtime'](Path(ROOT), '59_asia_great_wall', 'combat')
+    rt = fixture['fixtures']._load()
+    backend = Backend(args.module)
+    gunners = gunner_cases(backend, rt, runtime, args.cases)
+    launches = launch_cases(backend, rt, runtime, args.cases)
+    print('Exact native gunner flow: %d actions; atomic launch/outbox: %d transitions.' % (gunners, launches))
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/ffi_experiment/check_kernel_motion.py
+++ b/tools/ffi_experiment/check_kernel_motion.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python
+"""Compare owned native motion, receipt fairness and callback-time poses."""
+from __future__ import print_function
+
+import argparse
+import copy
+import math
+import random
+
+from check_kernel_state import compare, plain
+from check_motion_flow import reference
+from kernel_adapter import (Kernel, bot_config, critical_config, motion_config,
+                            ENGINE_FIELDS)
+from kernel_engine import EngineLeaves
+from navigation_adapter import Backend
+from portable_workload import load_fixture, Path, ROOT, redirected
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--module', required=True)
+    parser.add_argument('--fixture', required=True)
+    parser.add_argument('--frames', type=int, default=120)
+    args = parser.parse_args()
+    with redirected():
+        fixture = load_fixture(args.fixture)
+        source, unused = fixture['make_runtime'](Path(ROOT), '59_asia_great_wall', 'combat')
+        native, unused = fixture['make_runtime'](Path(ROOT), '59_asia_great_wall', 'combat')
+    rt = fixture['fixtures']._load()
+    backend = Backend(args.module)
+    selected = list(source.states)[:8]
+    original = dict((key, copy.deepcopy(source.states[key])) for key in selected)
+    source_tape, native_tape = [], []
+    frame_box = [0]
+    for runtime, tape in ((source, source_tape), (native, native_tape)):
+        runtime.states = copy.deepcopy(original)
+        runtime.navigator = None
+        runtime.baked_graph = None
+        runtime._log_motion_stall = lambda *unused: None
+        runtime._log_direction_flip = lambda *unused: None
+
+        def install(runtime, tape):
+            def direction(position, yaw, speed, descriptor, maximum=None, width=None):
+                tape.append(('direction', position, yaw, speed, maximum, width))
+                kind = int(abs(position[0]) + frame_box[0]) % 17
+                if kind == 4:
+                    raise RuntimeError('injected direction query failure')
+                if kind == 5:
+                    return {}
+                return dict(clear=kind != 3, collision=kind == 3, water=False,
+                            slope=.03 if kind == 6 else 0.0, deferred=kind == 7)
+
+            def receipt(position, yaw, speed, descriptor, maximum=None):
+                tape.append(('receipt', position, yaw, speed, maximum))
+                kind = int(abs(position[0]) + frame_box[0]) % 7
+                if kind == 1:
+                    return 'deferred'
+                if kind == 2:
+                    return False
+                if kind == 3:
+                    return None
+                return dict(origin=position, yaw=yaw, direction=-1 if speed < 0 else 1,
+                            leading=3.5, distance=30.0)
+
+            def resolver(bot_id, position, yaw, speed, descriptor, dt, now,
+                         commit=True, motion_yaw=None):
+                state = runtime.states[bot_id]
+                tape.append(('resolver', bot_id, position, yaw, speed, dt, now,
+                             commit, motion_yaw,
+                             tuple(state.get(name) for name in (
+                                 'x', 'y', 'z', 'yaw', 'speed', 'movement_dir',
+                                 'rotation_dir', 'airborne', 'grounded_once')),
+                             runtime._turn_speeds.get(bot_id, 0)))
+                kind = (bot_id + frame_box[0]) % 19
+                return 'hard' if kind == 1 else 'soft' if kind == 2 else 'clear'
+
+            def report(*values):
+                tape.append(('report', values))
+
+            def ground(x, z, hint):
+                tape.append(('ground', x, z, hint))
+                return None if frame_box[0] % 11 == 8 else 5 + .03 * math.sin(x / 20) + .06 * math.cos(z / 13)
+
+            runtime.direction_probe = direction
+            runtime.world_receipt_probe = receipt
+            runtime.motion_resolver = resolver
+            runtime.motion_report = report
+            runtime.ground_probe = ground
+            runtime._physics_ground_probe = ground
+        install(runtime, tape)
+    bots = []
+    for bot_id in selected:
+        state = source.states[bot_id]
+        descriptor = source._descriptors[bot_id]
+        value = bot_config(state, source._gun_states[bot_id],
+                           source._ammo_states[bot_id], source._burst_states[bot_id])
+        value['critical_config'] = critical_config(rt, source, bot_id)
+        value['config'] = dict(motion=dict(physics=source._physics_params_for(bot_id),
+                                          yaw_limits=rt.ai_driver.gun_yaw_limits(descriptor)))
+        bots.append(value)
+    kernel = Kernel(backend, rt.bot_state_codec, bots,
+                    engine=dict(fields=ENGINE_FIELDS), motion=motion_config(rt, native))
+    engine = EngineLeaves(rt, native)
+    original_step = reference(rt)
+    rng = random.Random(715131)
+    count = 0
+    try:
+        for frame in range(args.frames):
+            frame_box[0] = frame
+            actions, expected = [], []
+            dt, now = (.02, .07, .13)[frame % 3], 100 + frame * .13
+
+            def act(action):
+                method = action['method']
+                command = action.get('command')
+                result = None
+                if method == 'begin':
+                    source._begin_world_receipt_frame()
+                elif method == 'finish':
+                    source._finish_world_receipt_frame()
+                else:
+                    bot_id = action['id']
+                    state = source.states[bot_id]
+                    if method == 'set':
+                        state.update(action['state'])
+                        if 'turn_speed' in action:
+                            source._turn_speeds[bot_id] = action['turn_speed']
+                    elif method == 'step':
+                        command = copy.deepcopy(command)
+                        original_step(source, state, command, action.get('target'),
+                                      source._descriptors[bot_id], rt._position(state),
+                                      action['dt'], action['now'], action['decision_due'],
+                                      action['refresh'], action['siege_lock'],
+                                      action['siege_yaw'], {}, {}, False, None)
+                    elif method == 'vertical':
+                        result = source._update_vertical_motion(state, action['dt'],
+                                                               action['tick'], action['attempted'])
+                    elif method == 'slope':
+                        result = source._update_slope_pose(state, action.get('allow_ungrounded', False))
+                    elif method == 'landing':
+                        result = source._apply_bot_landing_impact(state, action['speed'])
+                expected.append(plain(dict(result=result, states=source.states,
+                    turns=dict((key, source._turn_speeds.get(key, 0)) for key in selected),
+                    command=command, waiting=source._world_receipt_waiting)))
+                actions.append(action)
+
+            act(dict(method='begin'))
+            tick_poses = {}
+            for index, bot_id in enumerate(selected):
+                state = source.states[bot_id]
+                if frame % 13 == 0:
+                    act(dict(method='set', id=bot_id, state=dict(
+                        x=original[bot_id]['x'] + rng.uniform(-20, 20),
+                        y=7 + index * .15, z=original[bot_id]['z'],
+                        yaw=rng.uniform(-3, 3), speed=(-1 if index % 3 == 1 else 1) * 4,
+                        health=1000, max_health=1000, alive=True,
+                        grounded_once=True, airborne=False,
+                        pitch=0, roll=0, terrain_pitch=0),
+                        turn_speed=.2 if index % 3 == 0 else 0))
+                command = dict(throttle=(-.7, 1., 0., .3)[(index + frame // 5) % 4],
+                    turn=0 if index % 3 else .4, movement_intent=True,
+                    move_position=(state['x'] + 10, state['y'], state['z'] + 15),
+                    aim_position=(state['x'] + 30, state['y'], state['z'] - 7),
+                    recovery_mode='reverse_turn' if index % 4 == 0 else 'drive',
+                    combat_mode='engage', fire_allowed=True)
+                tick_poses[bot_id] = rt._position(state)
+                act(dict(method='step', id=bot_id, command=command,
+                         target=dict(position=command['aim_position']) if index % 2 else None,
+                         dt=dt, now=now, decision_due=frame % 4 == 0,
+                         refresh=frame % 3 != 2, siege_lock=frame % 23 == 21,
+                         siege_yaw=state['yaw']))
+            for bot_id in selected:
+                act(dict(method='vertical', id=bot_id, dt=dt, tick=tick_poses[bot_id],
+                         attempted=source.states[bot_id]['yaw']))
+                if frame % 4 == 0:
+                    act(dict(method='slope', id=bot_id, tier=source._detail_tier(source.states[bot_id])))
+            act(dict(method='finish'))
+            actual = kernel.motion_actions(actions, engine)
+            for index, (left, right) in enumerate(zip(expected, actual)):
+                compare(left, right, ('motion', frame, index, actions[index]))
+            compare(plain(source_tape), plain(native_tape), ('ordered engine leaves', frame))
+            count += len(actions)
+        print('Exact owned native motion: %d transitions, %d ordered engine queries, %d frames.' % (count, len(source_tape), args.frames))
+    finally:
+        kernel.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/ffi_experiment/check_kernel_perception.py
+++ b/tools/ffi_experiment/check_kernel_perception.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python
+"""Compare complete native target ownership, visibility and cached poses."""
+from __future__ import print_function
+
+import argparse
+import copy
+import json
+import random
+
+from check_kernel_state import compare, plain
+from kernel_adapter import (Kernel, bot_config, critical_config, perception_config,
+                            player_config, lane_config, ENGINE_FIELDS)
+from navigation_adapter import Backend
+from portable_workload import load_fixture, Path, ROOT, redirected
+
+
+def configuration(rt, runtime):
+    bots = []
+    for bot_id, state in runtime.states.items():
+        value = bot_config(state, runtime._gun_states[bot_id],
+                           runtime._ammo_states[bot_id],
+                           runtime._burst_states[bot_id])
+        target = dict(state, kind='bot', network_id=bot_id)
+        value.update(critical_config=critical_config(rt, runtime, bot_id),
+                     config=dict(perception=dict(
+                         profile=runtime._spotting_profile(target),
+                         vision=runtime._vision_ranges.get(bot_id))))
+        bots.append(value)
+    return bots
+
+
+def snapshot(runtime, team):
+    def kind(value):
+        return int(value == 'human')
+    remembered = sorted([a, kind(b), c, v] for (a, b, c), v in
+                        runtime._visible_target_poses.items())
+    source = sorted([kind(key[0]), key[1], value] if isinstance(key, tuple)
+                    else [0, key, value]
+                    for key, value in runtime._source_still.items())
+    target = sorted([kind(key[0]), key[1], value]
+                    for key, value in runtime._visibility_still.items())
+    visible = sorted([a, kind(b), c] for (a, b, c), v in team.items() if v)
+    return dict(remembered=remembered, source_still=source,
+                target_still=target, team_visible=visible)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--module', required=True)
+    parser.add_argument('--fixture', required=True)
+    parser.add_argument('--frames', type=int, default=40)
+    parser.add_argument('--human', action='store_true')
+    parser.add_argument('--lanes', action='store_true')
+    args = parser.parse_args()
+    with redirected():
+        fixture = load_fixture(args.fixture)
+        runtime, unused = fixture['make_runtime'](Path(ROOT), '59_asia_great_wall', 'combat')
+    rt = fixture['fixtures']._load()
+    backend = Backend(args.module)
+    rng = random.Random(271513)
+    original = copy.deepcopy(runtime.states)
+    source_queries, native_queries = [], []
+    human = None
+    if args.human:
+        with open(args.fixture) as stream:
+            body = json.load(stream)['_effective_params_snapshot']
+        scope = {}
+        eval(compile(body, 'human_fixture', 'exec'), scope)
+        effective = scope['_effective_params_snapshot']()
+        effective['crew']['members'][0]['roles'] = ['commander', 'gunner', 'radioman']
+        effective['crew']['members'][0]['skills'] = [dict(
+            name=name, level=100.0, active=True, enabled=True)
+            for name in ('gunner_rancorous', 'radioman_lasteffort')]
+        effective['skills']['designated_target'] = True
+        effective['skills']['last_effort'] = True
+        center_x = sum(s['x'] for s in original.values()) / len(original)
+        center_z = sum(s['z'] for s in original.values()) / len(original)
+        human = dict(id=1, team=1, vehicle=next(iter(original.values()))['vehicle'],
+                     x=center_x, y=1, z=center_z, yaw=0, aim_yaw=0,
+                     speed=0, alive=True, health=1000, max_health=1000,
+                     fire_seq=0, critical={}, effective_params=effective)
+
+    def visibility(trace, source, target, fired):
+        row = (rt._position(source), tuple(target['position']), bool(fired))
+        trace.append(row)
+        if int(abs(source['x'] + target['z'])) % 13 == 0:
+            raise RuntimeError('injected native visibility failure')
+        return dict(line_of_sight=int(abs(source['x'] - target['z'])) % 7 != 0,
+                    foliage_bonus=.23 if fired else .17)
+
+    runtime.visibility_probe = lambda source, target, fired=False: visibility(
+        source_queries, source, target, fired)
+    source_lanes, native_lanes = [], []
+
+    def lane(trace, kind, source, target):
+        trace.append((kind, source['id'], target['kind'], target['network_id'],
+                      rt._position(source), target['position'],
+                      source.get('yaw', 0), target.get('yaw', 0),
+                      source.get('fire_seq', 0), target.get('fire_seq', 0)))
+        value = (int(abs(source['x'] + target['z'])) + kind) % 5
+        return None if kind == 752 and value == 0 else value > 1
+
+    runtime.firing_lane_probe = lambda source, target: lane(source_lanes, 751, source, target)
+    runtime.incoming_lane_probe = lambda source, target: lane(source_lanes, 752, source, target)
+    kernel = Kernel(backend, rt.bot_state_codec, configuration(rt, runtime),
+                    perception=perception_config(rt, runtime),
+                    engine=dict(fields=ENGINE_FIELDS), lanes=lane_config(rt, runtime))
+    actions, expected = [], []
+    tick, team, processed, players, aggregate = {}, {}, set(), [], {}
+    cached_contacts, probe_targets = {}, {}
+
+    def engine(query):
+        def actor(at):
+            kind, identity, mask = (int(value) for value in query[at:at + 3])
+            raw = next(player for player in players if player['id'] == identity) if kind else original[identity]
+            value = dict(raw, kind='human' if kind else 'bot', network_id=identity)
+            for index, name in enumerate(ENGINE_FIELDS):
+                if mask & (1 << index):
+                    value[name] = query[at + 3 + index]
+                else:
+                    value.pop(name, None)
+            at += 3 + len(ENGINE_FIELDS)
+            for name in ('position', 'velocity'):
+                if query[at]:
+                    value[name] = tuple(query[at + 1:at + 4])
+                else:
+                    value.pop(name, None)
+                at += 4
+            value.setdefault('position', rt._position(value))
+            return value, at
+        source, at = actor(1)
+        target, at = actor(at)
+        kind = int(query[0])
+        result = lane(native_lanes, kind, source, target)
+        query[0] = bool(result) if kind == 751 else result is not None
+        query[1] = bool(result)
+        return 0
+
+    def act(action):
+        method, now = action['method'], action.get('now', 0.0)
+        result = None
+        if method == 'begin':
+            runtime._begin_visibility_frame()
+        elif method == 'finish':
+            runtime._finish_visibility_frame()
+        elif method == 'prepare':
+            runtime._prepare_visibility_frame(players, now, bool(players))
+        elif method == 'lifecycle':
+            runtime._track_human_observer_lifecycle(players, now, tick)
+        elif method == 'humans':
+            runtime._append_human_observations(players, now, aggregate, team, tick)
+        elif method == 'set':
+            runtime.states[action['bot']].update(action['state'])
+        elif method == 'still':
+            runtime._note_source_stillness(runtime.states[action['bot']], now)
+        elif method == 'contacts':
+            contacts, targets = runtime._contacts_for(
+                runtime.states[action['bot']], players, now, team, tick, processed)
+            result = dict(contacts=contacts, targets=targets)
+            cached_contacts[action['bot']] = contacts, targets
+        elif method == 'collect':
+            source = runtime.states[action['bot']]
+            contacts, targets = cached_contacts[action['bot']]
+            live = runtime._refresh_target_poses(
+                targets, live_players=runtime._index_live_players(players),
+                probe_targets=probe_targets, processed_bot_ids=processed)
+            for cached in contacts:
+                target = live.get(cached.get('id'), cached)
+                key = (int(source['team']), target['kind'], target['network_id'])
+                fresh = cached.get('fresh_visible', False)
+                team[key] = bool(fresh or team.get(key, False))
+                if fresh:
+                    remembered = runtime._target_pose_snapshot(target, tick.setdefault('target_pose_snapshots', {}))
+                    runtime._visible_target_poses[key] = remembered
+                    target.update(remembered)
+                entry = aggregate.setdefault(key, [False, set(), target, set(), set()])
+                entry[0] = bool(cached['visible'] or entry[0])
+                entry[2] = target
+                if cached.get('direct_visible'):
+                    entry[4].add(action['bot'])
+        elif method == 'service':
+            priorities = dict(((row[0], 'human' if row[1] else 'bot', row[2]), row[3])
+                              for row in action['selected'])
+            budget = [action['budget']]
+            runtime._incoming_lane_budget = action['incoming_budget']
+            pending = runtime._service_shot_lane_work(
+                now, action['cycle'], team, players, tick, processed, priorities, budget)
+            result = pending, budget[0], runtime._incoming_lane_budget
+        elif method == 'merge':
+            result = runtime._merge_observation_shot_lanes(aggregate, team, now)
+        elif method == 'pack':
+            result = runtime._pack_observations(aggregate, now)
+        elif method == 'processed':
+            processed.add(action['bot'])
+        expected.append(plain(dict(
+            result=result, state=snapshot(runtime, team) if action.get('snapshot') else None)))
+        actions.append(action)
+
+    try:
+        action_count = 0
+        for frame in range(args.frames):
+            actions, expected = [], []
+            cadence = .41 if args.human else .11
+            now = 100 + frame * cadence
+            tick, team, processed, aggregate = {}, {}, set(), {}
+            cached_contacts, probe_targets = {}, {}
+            players = []
+            if human is not None:
+                # Repeated death, revival, absent actor and crew injury edges
+                # exercise both the live and Last Effort observer paths.
+                human['alive'] = frame % 13 < 6
+                human['fire_seq'] = frame // 4
+                human['speed'] = 0 if frame % 5 else 7
+                human['critical'] = dict(crew_ko=['commander'] if frame % 11 == 2 else [], fire=frame % 6 == 1)
+                if frame % 17 != 16:
+                    players = [player_config(rt, runtime, copy.deepcopy(human))]
+            act(dict(method='begin'))
+            # Motion-phase templates must retain the birth-of-slice pose while
+            # later observers see already integrated actors in the same slice.
+            for bot_id, state in runtime.states.items():
+                base = original[bot_id]
+                act(dict(method='set', bot=bot_id, state=dict(
+                    x=base['x'] + rng.uniform(-70, 70),
+                    z=base['z'] + rng.uniform(-70, 70),
+                    yaw=rng.uniform(-3, 3), speed=rng.choice((0, 0, 8)),
+                    fire_seq=frame // 3, alive=(bot_id % 7 != frame % 7))))
+            act(dict(method='slice', players=players))
+            act(dict(method='lifecycle', now=now))
+            selected = []
+            due = []
+            for bot_id, state in runtime.states.items():
+                target = runtime._selected_visibility_target(state)
+                if target:
+                    selected.append((bot_id, int(target[0] == 'human'), target[1]))
+                if runtime._visibility_decision_due(state, now):
+                    due.append(bot_id)
+            act(dict(method='prepare', now=now, selected=selected, due=due,
+                     include_humans=bool(players)))
+            if players:
+                act(dict(method='humans', now=now))
+            for bot_id, state in runtime.states.items():
+                if not state['alive']:
+                    continue
+                act(dict(method='still', bot=bot_id, now=now))
+                act(dict(method='contacts', bot=bot_id, now=now))
+                if args.lanes:
+                    act(dict(method='collect', bot=bot_id, now=now))
+                act(dict(method='set', bot=bot_id, state=dict(
+                    x=state['x'] + 4.1, speed=0 if state['speed'] else 8,
+                    turret_yaw=rng.uniform(-2, 2))))
+                act(dict(method='processed', bot=bot_id))
+            if args.lanes:
+                selected_lanes = []
+                for bot_id, (contacts, targets) in sorted(cached_contacts.items()):
+                    for target in contacts[:2]:
+                        selected_lanes.append((bot_id, int(target['kind'] == 'human'),
+                                               target['network_id'], bot_id % 2))
+                act(dict(method='service', now=now,
+                         cycle=100 + (frame // 7 + 1) * cadence * 7,
+                         selected=selected_lanes, budget=(0, 1, 4)[frame % 3],
+                         incoming_budget=int(frame % 2 == 0)))
+                act(dict(method='merge', now=now))
+                act(dict(method='pack', now=now))
+            act(dict(method='finish', snapshot=True))
+            actual = kernel.perception_actions(actions, lambda source, target, fired: visibility(
+                native_queries, source, target, fired), engine=engine)
+            compare(expected, actual, ('perception', frame))
+            action_count += len(actions)
+        compare(source_queries, native_queries, ('ordered native leaves',))
+        compare(source_lanes, native_lanes, ('ordered lane leaves',))
+        if args.lanes and args.frames >= 8 and not source_lanes:
+            raise AssertionError('lane workload made no native requests')
+        print('Exact native target flow: %d actions, %d ordered visibility queries, %d lane queries, %d complete frames.' % (action_count, len(source_queries), len(source_lanes), args.frames))
+    finally:
+        kernel.close()
+        backend.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/ffi_experiment/check_kernel_publication.cpp
+++ b/tools/ffi_experiment/check_kernel_publication.cpp
@@ -1,0 +1,184 @@
+// Compare retained native edge records with the previous nested-tuple oracle.
+#include "kernel_publication.h"
+#include <cassert>
+#include <iostream>
+
+using namespace offline_kernel;
+
+static Value tuple(std::initializer_list<Value> values) {
+    Value result = Value::array();
+    for (const Value &value : values)
+        result.append(value);
+    return result;
+}
+
+static Value oracle(const Value &fields, const std::vector<Value> &states,
+                    const std::vector<std::vector<Equipment>> &equipment,
+                    const Value &launches, const Value &rams, double now) {
+    Value bots = Value::array(), shots = Value::array(), impacts = Value::array();
+    for (size_t i = 0; i < states.size(); ++i) {
+        const Value &state = states[i];
+        Value scalar = Value::array(), items = Value::array(), angles = Value::array();
+        for (const Value &name : elements(fields))
+            scalar.append(tuple({Value(state.has(name.text())), state.get(name.text())}));
+        for (const Equipment &e : equipment[i])
+            items.append(tuple({e.contract, Value(e.uses), Value(e.active), Value(e.ready_at),
+                                Value(now >= e.ready_at),
+                                e.auto_pending ? Value(e.auto_since) : Value(),
+                                e.ai_pending ? Value(e.ai_since) : Value()}));
+        for (const char *name : {"shot_yaw", "shot_pitch"})
+            angles.append(tuple({Value(state.has(name)), state.get(name)}));
+        bots.append(tuple({scalar, state.get(sf::ammo_remaining), items, angles}));
+    }
+    for (const Value &v : elements(launches))
+        shots.append(tuple({v.get(sf::id), v.get(sf::fire_seq)}));
+    for (const Value &v : elements(rams))
+        impacts.append(tuple({v.get("bot_id"), v.get(sf::target_kind), v.get(sf::target_id),
+                              v.get("ram_seq")}));
+    return tuple({bots, shots, impacts});
+}
+
+int main() {
+    Value fields = tuple({Value("id"), Value("health"), Value("custom")});
+    PublicationEdges edges(fields);
+    Value old, launches = Value::array(), rams = Value::array();
+    std::vector<Value> states;
+    std::vector<std::vector<Equipment>> equipment;
+    double now = 0;
+    int cases = 0, changes = 0;
+    auto check = [&]() {
+        Value expected = oracle(fields, states, equipment, launches, rams, now);
+        edges.begin(states.size());
+        for (size_t i = 0; i < states.size(); ++i)
+            edges.capture(i, states[i], equipment[i], now);
+        bool changed = edges.finish(launches, rams);
+        assert(changed == (old != expected));
+        if (changed) {
+            old = expected;
+            ++changes;
+        }
+        ++cases;
+        return changed;
+    };
+    assert(check()); // The first empty publication is still an edge.
+    assert(!check());
+    for (bool record : {false, true}) {
+        states = {record ? Value::record() : Value::object()};
+        equipment.resize(1);
+        assert(check());
+        assert(!check());
+        states[0][sf::health] = Value();
+        assert(check()); // A present null differs from a missing field.
+        states[0].erase(sf::health);
+        assert(check());
+        states[0][sf::health] = Value(1);
+        assert(check());
+        states[0][sf::health] = Value(true);
+        assert(!check()); // Preserve Value's numeric equality.
+        states[0][sf::x] = Value(70);
+        now += .01;
+        assert(!check()); // Continuous state does not create durable edges.
+        states[0]["custom"] = Value("descriptor");
+        assert(check());
+        auto transition = [&]() {
+            assert(check());
+            assert(!check());
+        };
+        states[0][sf::ammo_remaining] = tuple({Value(20)});
+        transition();
+        states[0][sf::ammo_remaining] = tuple({Value(19)});
+        transition();
+        states[0][sf::shot_yaw] = Value();
+        transition();
+        states[0][sf::shot_yaw] = Value(.25);
+        transition();
+        states[0][sf::shot_pitch] = Value(.1);
+        transition();
+        Value equipment_config = Value::object();
+        equipment_config["contract"] = Value::object();
+        equipment[0].emplace_back(equipment_config);
+        transition();
+        Equipment &item = equipment[0][0];
+        item.uses = 2;
+        transition();
+        item.active = true;
+        transition();
+        item.ready_at = now + 1;
+        transition();
+        now += .5;
+        assert(!check());
+        now = item.ready_at;
+        transition();
+        item.auto_since = now;
+        item.ai_since = now;
+        assert(!check()); // Inactive pending timestamps are not edges.
+        item.auto_pending = true;
+        transition();
+        item.auto_since += .5;
+        transition();
+        item.ai_pending = true;
+        transition();
+        item.ai_since += .5;
+        transition();
+        item.contract = JsonReader("{\"kind\":\"repairkit\"}").read();
+        transition();
+        for (int step = 0; step < 100; ++step) {
+            now = step / 10.0;
+            states.resize(1 + step % 7, Value::object());
+            equipment.resize(states.size());
+            for (size_t i = 0; i < states.size(); ++i) {
+                states[i] = states[i].copy();
+                states[i][sf::id] = Value(static_cast<int>(i));
+                states[i][sf::ammo_remaining] = tuple({Value(step % 9), Value(20)});
+                if (step % 3) {
+                    states[i][sf::shot_yaw] = Value(now);
+                    states[i][sf::shot_pitch] = Value();
+                } else {
+                    states[i].erase(sf::shot_yaw);
+                    states[i].erase(sf::shot_pitch);
+                }
+                equipment[i].clear();
+                for (int j = 0; j < step % 4; ++j) {
+                    Value config = Value::object();
+                    config["contract"] = JsonReader("{\"kind\":\"repairkit\"}").read();
+                    Equipment e(config);
+                    e.uses = step % 5;
+                    e.active = step % 2;
+                    e.ready_at = (step + j % 2) / 10.0;
+                    e.auto_pending = step % 7;
+                    e.auto_since = now - .3;
+                    e.ai_pending = step % 11;
+                    e.ai_since = now - .5;
+                    equipment[i].push_back(e);
+                }
+            }
+            launches = Value::array();
+            rams = Value::array();
+            for (int j = 0; j < step % 3; ++j) {
+                Value event = Value::object();
+                event[sf::id] = Value(j);
+                event[sf::fire_seq] = Value(step);
+                launches.append(event);
+                event = Value::object();
+                event["bot_id"] = Value(j);
+                event[sf::target_kind] = Value(step % 2 ? "bot" : "player");
+                event[sf::target_id] = Value(j + 7);
+                event["ram_seq"] = Value(step / 2);
+                rams.append(event);
+            }
+            check();
+            assert(!check());
+            std::reverse(states.begin(), states.end());
+            std::reverse(equipment.begin(), equipment.end());
+            std::reverse(launches.data->array.begin(), launches.data->array.end());
+            std::reverse(rams.data->array.begin(), rams.data->array.end());
+            check();
+            assert(!check());
+        }
+        states.clear();
+        equipment.clear();
+        check();
+    }
+    std::cout << "Publication edges: " << cases << " ordered oracle comparisons, " << changes
+              << " transitions; missing/null, cooldown, rosters, shots and ram parity passed.\n";
+}

--- a/tools/ffi_experiment/check_kernel_state.py
+++ b/tools/ffi_experiment/check_kernel_state.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python
+"""Compare owned native weapon clocks and wire rows with the source runtime."""
+from __future__ import print_function
+
+from array import array
+import argparse
+import copy
+import json
+import random
+
+from kernel_adapter import Kernel, bot_config, packet, critical_config, health_config
+from navigation_adapter import Backend
+from portable_workload import load_fixture, Path, ROOT, redirected
+
+
+def plain(value):
+    return json.loads(json.dumps(value, allow_nan=False))
+
+
+def compare(expected, actual, path=()):
+    if isinstance(expected, dict):
+        if set(expected) != set(actual):
+            raise AssertionError((path, set(expected), set(actual)))
+        for name in expected:
+            compare(expected[name], actual[name], path + (name,))
+    elif isinstance(expected, (list, tuple)):
+        if len(expected) != len(actual):
+            raise AssertionError((path, len(expected), len(actual)))
+        for index, (left, right) in enumerate(zip(expected, actual)):
+            compare(left, right, path + (index,))
+    elif expected != actual:
+        raise AssertionError((path, expected, actual))
+
+
+def weapon_cases(backend, rt, runtime, rng, count):
+    checks = 0
+    source_id = next(iter(runtime.states))
+    base = runtime._descriptors[source_id]
+    for clip_size in (1, 3, 7):
+        descriptor = copy.deepcopy(base)
+        descriptor.gun.clip = (clip_size, 0.19)
+        gun = rt._BotGunState(descriptor)
+        ammo = rt._BotAmmoState(descriptor, runtime.states[source_id]['profile'])
+        burst = rt.burst_mechanics.BurstClock()
+        state = {'id': 1}
+        kernel = Kernel(backend, rt.bot_state_codec,
+                        [bot_config(state, gun, ammo, burst)])
+        actions, expected = [], []
+        objects = dict(gun=gun, ammo=ammo, burst=burst)
+
+        def act(method, args=()):
+            owner, name = method.split('.')
+            result = getattr(objects[owner], name)(*args)
+            actions.append(dict(method=method, args=args))
+            expected.append(plain(dict(
+                result=result, state=bot_config(state, gun, ammo, burst))))
+
+        for frame in range(count):
+            dt = rng.choice((0, .01, .19, 1.0 / 15, .8, 4.7))
+            factor = rng.choice((0.5, 1., 1.8))
+            act('gun.rescale_reload', (factor,))
+            act('gun.tick', (dt,))
+            act('gun.tick_dispersion',
+                (dt, rng.uniform(-15, 22), rng.uniform(-.7, .7),
+                 rng.uniform(-1, 1), factor, factor))
+            act('gun.ready', (factor,))
+            act('gun.duration', (factor,))
+            act('gun.remaining', (factor,))
+            act('gun.complete_reload', (factor, ammo.planned_rounds()))
+            act('ammo.stage', (rng.randrange(-1, 5), gun.ready(factor),
+                              gun.reload_kind == 'full'))
+            act('ammo.can_fire')
+            if frame % 11 == 0:
+                act('gun.require_full_reload')
+            elif frame % 7 == 0:
+                act('gun.cancel_burst')
+            elif frame % 3 == 0:
+                act('gun.fire', (factor,))
+                act('ammo.consume_loaded', (bool(frame % 2),))
+                act('gun.commit_shot_bloom', (factor, bool(frame % 2)))
+            else:
+                act('gun.begin_burst', (rng.randrange(-1, clip_size + 2), factor))
+                act('gun.fire_burst_round', (bool(frame % 2),))
+            act('ammo.planned_rounds')
+            act('ammo.loaded_shell_requires_full_reload')
+            act('burst.start', (frame + 1, rng.choice((1, 2, 7)), .19, 1))
+            act('burst.advance', (dt,))
+            if frame % 9 == 0:
+                act('burst.cancel', (rng.randrange(burst.next_index + 1),))
+        actual = kernel.weapon_actions(1, actions)
+        # Descriptor/crew initialization is a Python producer. The native gun
+        # owns only mutable clocks and the numeric coefficients it consumes.
+        for index, (left, right) in enumerate(zip(expected, actual)):
+            for name in ('crew_level', 'loadout'):
+                left['state']['gun'].pop(name, None)
+            compare(left, right, ('weapon', clip_size, index, actions[index]))
+            checks += 1
+        kernel.close()
+    return checks
+
+
+def codec_cases(backend, rt, runtime, rng, count):
+    kernel = Kernel(backend, rt.bot_state_codec, [])
+    states = [{}]
+    for unused in range(count):
+        state = copy.deepcopy(rng.choice(list(runtime.states.values())))
+        for name, scale in rt.bot_state_codec.SCALARS:
+            if name == '_flags':
+                continue
+            state[name] = rng.uniform(-3000, 3000) if scale else rng.randrange(1000)
+        state['movement_dir'] = rng.choice((-1, -.01, 0, .01, 1))
+        state['rotation_dir'] = rng.choice((-1, -.01, 0, .01, 1))
+        state['critical'] = dict(
+            devices=[dict(name=name, hp=rng.uniform(0, 500), max_hp=500,
+                          state=rng.choice(rt.bot_state_codec.DEVICE_STATES))
+                     for name in rng.sample(rt.bot_state_codec.DEVICE_NAMES,
+                                            rng.randrange(10))],
+            crew_ko=rng.sample(rt.bot_state_codec.CREW_NAMES, rng.randrange(9)),
+            crew_roster=list(rt.bot_state_codec.CREW_NAMES),
+            fire=bool(rng.randrange(2)), ammo_rack_death=bool(rng.randrange(2)))
+        state['equipment_states'] = [dict(
+            usesLeft=rng.randrange(10), cooldownTimeLeft=rng.uniform(0, 90),
+            active=bool(rng.randrange(2)),
+            autoPendingElapsed=rng.choice((None, rng.random())),
+            aiPendingElapsed=rng.choice((None, rng.random()))) for i in range(3)]
+        for bit, names in rt.bot_state_codec.OPTIONAL_GROUPS:
+            if rng.randrange(2):
+                for name in names:
+                    state.pop(name, None)
+        states.append(state)
+    expected = [rt.bot_state_codec.encode_row(state) for state in states]
+    compare(expected, kernel.encode(states), ('codec',))
+    invalid = [None, [], dict(id=True), dict(id=None), dict(x=None),
+               dict(x='bad'), dict(id='1.2'), dict(shot_yaw=1),
+               dict(clip=1), dict(equipment_states=[None])]
+    for state in invalid:
+        try:
+            rt.bot_state_codec.encode_row(state)
+        except Exception:
+            pass
+        else:
+            raise AssertionError(('source accepted invalid test', state))
+        try:
+            kernel.encode([state])
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError(('native accepted invalid test', state))
+    for malformed in (None, {}, 3, 'bad'):
+        try:
+            backend.call(packet([711, kernel.handle], malformed))
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError(('native accepted malformed array', malformed))
+    compare([expected[0]], kernel.encode([{}]), ('after rejection',))
+    kernel.close()
+    return len(states) + len(invalid)
+
+
+def equipment_config(equipment):
+    return dict((name, getattr(equipment, name))
+                for name in equipment.__slots__)
+
+
+def equipment_cases(backend, rt, runtime, rng, count):
+    source_id = next(iter(runtime.states))
+    equipment = copy.deepcopy(runtime._equipment_states[source_id])
+    gun, ammo = runtime._gun_states[source_id], runtime._ammo_states[source_id]
+    state = bot_config({'id': 1}, gun, ammo, rt.burst_mechanics.BurstClock())
+    state['equipment'] = [equipment_config(e) for e in equipment]
+    kernel = Kernel(backend, rt.bot_state_codec, [state])
+    actions, expected = [], []
+    now = 0.0
+    for frame in range(count):
+        now += rng.choice((0, .01, .1, .2, 20, 93))
+        critical = dict(fire=bool(frame % 4),
+                        devices=[dict(name='engineHealth', state='critical')]
+                        if frame % 3 else [],
+                        destroyed=['leftTrackHealth'] if frame % 4 else [],
+                        crew_ko=['gunner1'] if frame % 5 else [])
+        for slot, e in enumerate(equipment):
+            method = 'ready' if frame % 5 == 0 else 'poll_bot'
+            kwargs = dict(now=now)
+            if method == 'poll_bot':
+                kwargs.update(critical=critical, stunned=bool(frame % 3))
+            result = getattr(e, method)(**kwargs)
+            action = dict(kwargs, slot=slot, method=method)
+            actions.append(action)
+            expected.append(plain(dict(
+                result=result, states=[equipment_config(v) for v in equipment],
+                wires=[v.trusted_snapshot(now) for v in equipment],
+                passives=rt.equipment_mechanics.passive_effects(equipment))))
+    compare(expected, kernel.equipment_actions(1, actions), ('equipment',))
+    inputs = []
+    for digits in range(7):
+        scale = 10 ** digits
+        inputs.extend((value, digits) for value in
+                      (0, -0.0, .125, -.125, 2.675, -2.675, .035, -.035))
+        for i in range(count):
+            inputs.append((rng.uniform(-10000, 10000), digits))
+            inputs.append(((rng.randrange(-10000, 10000) + .5) / scale, digits))
+    import sys
+    if sys.version_info[0] == 2:
+        compare([round(v, digits) for v, digits in inputs],
+                kernel.round(inputs), ('decimal rounding',))
+    kernel.close()
+    return len(actions), len(inputs)
+
+
+def health_cases(backend, rt, runtime, rng, count):
+    bot_id = next(iter(runtime.states))
+    original = copy.deepcopy(runtime.states[bot_id])
+    descriptor = copy.deepcopy(runtime._descriptors[bot_id])
+    descriptor.engine = dict(maxHealth=105, maxRegenHealth=52)
+    descriptor.fuelTank = dict(maxHealth=100, maxRegenHealth=40)
+    descriptor.miscAttrs = {}
+    runtime._descriptors[bot_id] = descriptor
+    original_equipment = copy.deepcopy(runtime._equipment_states[bot_id])
+    checks = 0
+    for mode in ('repair', 'fire', 'drowning', 'overturn', 'kits'):
+        state = copy.deepcopy(original)
+        state['critical'] = dict(devices=[dict(
+            name=name, hp=0.0,
+            max_hp=float(rt.device_damage.device_max_hp(descriptor, name)),
+            state='destroyed') for name in ('engineHealth', 'leftTrackHealth',
+                                            'fuelTankHealth')],
+            destroyed=['engineHealth', 'leftTrackHealth', 'fuelTankHealth'],
+            crew_ko=['gunner1'], fire=mode == 'fire', events=[],
+            ammo_rack_death=False)
+        state['combat_fire_elapsed'] = 0.0
+        state['combat_fire_timer'] = 0.0
+        state['stun_end_server_time_ms'] = 115000 if mode == 'kits' else 0
+        state['_stun_until_equipment_time'] = 15.0 if mode == 'kits' else 0.0
+        runtime.states[bot_id] = state
+        runtime._combat_sync.pop(bot_id, None)
+        runtime._equipment_wire_cache.pop(bot_id, None)
+        runtime._equipment_states[bot_id] = (
+            copy.deepcopy(original_equipment) if mode == 'kits' else [])
+        runtime._equipment_passives[bot_id] = rt.equipment_mechanics.passive_effects(
+            runtime._equipment_states[bot_id])
+        runtime._repair_factors.pop(bot_id, None)
+        runtime._friendly_repositions[bot_id] = {'test': True}
+        runtime._turn_speeds[bot_id] = .3
+        config = bot_config(state, runtime._gun_states[bot_id],
+                            runtime._ammo_states[bot_id], rt.burst_mechanics.BurstClock())
+        config.update(critical_config=critical_config(rt, runtime, bot_id),
+                      config=health_config(rt, descriptor),
+                      equipment=[equipment_config(e) for e in
+                                 runtime._equipment_states[bot_id]],
+                      turn_speed=.3)
+        kernel = Kernel(backend, rt.bot_state_codec, [config])
+        actions, expected = [], []
+        elapsed = 0.0
+
+        def act(action):
+            method = action['method']
+            runtime._equipment_now = action.get('equipment_now', elapsed)
+            if method == 'set':
+                state.update(action['state'])
+                result = None
+            elif method == 'critical':
+                result = runtime._advance_bot_critical(
+                    state, action['dt'], action['now'])
+            elif method == 'publish':
+                result = runtime._mark_combat_publication(state)
+            elif method == 'drowning':
+                runtime._water_depth_probe = lambda position: action['depth']
+                result = runtime._advance_bot_drowning(state, action['dt'])
+            elif method == 'overturn':
+                result = runtime._advance_bot_overturn(state, action['dt'])
+            actions.append(action)
+            expected.append(plain(dict(
+                result=result, state=state, sync=runtime._combat_sync.get(bot_id),
+                turn_speed=runtime._turn_speeds.get(bot_id, 0),
+                clear_reposition=bot_id not in runtime._friendly_repositions)))
+
+        for frame in range(count):
+            dt = rng.choice((0, .01, 1.0 / 15, .15, .37, 1.13))
+            elapsed += dt
+            if mode == 'overturn':
+                act(dict(method='set', state=dict(pitch=1.9, roll=.5)))
+                act(dict(method='overturn', dt=dt))
+            elif mode == 'drowning':
+                act(dict(method='drowning', dt=dt, depth=3.0 if frame > 4 else -.1))
+            else:
+                act(dict(method='critical', dt=dt, now=100 + elapsed,
+                         equipment_now=elapsed))
+            if frame % 7 == 0:
+                act(dict(method='publish'))
+        compare(expected, kernel.health_actions(bot_id, actions), ('health', mode))
+        checks += len(actions)
+        kernel.close()
+    return checks
+
+
+def boundary_cases(backend, rt):
+    """Exercise caller-owned byte output and recovery after rejected commands."""
+    kernel = Kernel(backend, rt.bot_state_codec, [])
+    checks = 0
+    try:
+        size = int(backend.call([724, kernel.handle])[0])
+        expected = kernel.output(size)
+        for width in (2, (size + 7) // 8 + 1):
+            guard = 987654321.125
+            values = array('d', [guard] + [719, kernel.handle] +
+                           [0] * (width - 2) + [guard])
+            address = values.buffer_info()[0] + values.itemsize
+            status = backend.module.dispatch(int(address & 0xffff), int(address >> 16), width)
+            assert values[0] == values[-1] == guard
+            if width == 2:
+                assert status != 0 and values[1:3] == array('d', [719, kernel.handle])
+            else:
+                assert status == 0 and int(values[1]) == size
+                payload = values[2:-1]
+                raw = payload.tobytes() if hasattr(payload, 'tobytes') else payload.tostring()
+                compare(expected, json.loads(raw[:size].decode('utf-8')), ('packed output',))
+            checks += 1
+        invalid = ([724], [724, float('nan')], [724, float('inf')],
+                   [724, kernel.handle, 1], [726, kernel.handle],
+                   [723, kernel.handle, 2, 123, 125],
+                   [711, kernel.handle, 2, 91], [711, kernel.handle, 1, 256],
+                   [700, 2, 123, 125], [700, -1])
+        for command in invalid:
+            try:
+                backend.call(command)
+            except RuntimeError:
+                checks += 1
+            else:
+                raise AssertionError(('accepted invalid kernel boundary', command))
+            compare(expected, kernel.output(size), ('recovery after rejection',))
+    finally:
+        identity = kernel.handle
+        kernel.close()
+    kernel.close()
+    try:
+        backend.call([724, identity])
+    except RuntimeError:
+        checks += 1
+    else:
+        raise AssertionError('retired kernel owner remained accessible')
+    return checks
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--module', required=True)
+    parser.add_argument('--fixture', required=True)
+    parser.add_argument('--cases', type=int, default=300)
+    args = parser.parse_args()
+    with redirected():
+        fixture = load_fixture(args.fixture)
+        runtime, unused_ground = fixture['make_runtime'](
+            Path(ROOT), '59_asia_great_wall', 'combat')
+    rt = fixture['fixtures']._load()
+    backend = Backend(args.module)
+    try:
+        rng = random.Random(7151327)
+        weapons = weapon_cases(backend, rt, runtime, rng, args.cases)
+        rows = codec_cases(backend, rt, runtime, rng, args.cases)
+        equipment, decimals = equipment_cases(backend, rt, runtime, rng, args.cases)
+        health = health_cases(backend, rt, runtime, rng, args.cases)
+        boundaries = boundary_cases(backend, rt)
+        print('Exact owned kernel state: %d weapon transitions, %d wire/invalid rows, %d equipment transitions, %d decimal cases, %d health/publication transitions.' % (weapons, rows, equipment, decimals, health))
+        print('Packed output, malformed commands and owner retirement: %d checks.' % boundaries)
+    finally:
+        backend.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/ffi_experiment/check_kernel_update.py
+++ b/tools/ffi_experiment/check_kernel_update.py
@@ -12,7 +12,7 @@ from navigation_adapter import Backend
 from portable_workload import load_fixture, Path, ROOT, redirected, patch_dict
 
 
-def run(backend, fixture, map_name, scenario, frames, siege=False, human=False, cover=False, fixture_source=None, orders=False):
+def run(backend, fixture, map_name, scenario, frames, siege=False, human=False, cover=False, fixture_source=None, orders=False, native_world=False):
     with redirected():
         random.seed(17)
         source, source_ground = fixture['make_runtime'](Path(ROOT), map_name, scenario)
@@ -70,7 +70,8 @@ def run(backend, fixture, map_name, scenario, frames, siege=False, human=False, 
                     return probe
                 source.cover_probe = cover_probe(cover_calls[0])
                 native.cover_probe = cover_probe(cover_calls[1])
-            kernel = KernelBackend(backend, native, rt)
+            kernel = KernelBackend(backend, native, rt,
+                                   world_owner=native._ffi_world_owner if native_world else None)
             try:
                 enabled_seen = False
                 for frame in range(frames):
@@ -108,6 +109,11 @@ def run(backend, fixture, map_name, scenario, frames, siege=False, human=False, 
                             json.dump(dump, stream, default=repr, indent=2)
                         raise
                     compare(plain(source_queries), plain(native_queries), (map_name, scenario, frame, 'queries'))
+                    if native_world:
+                        compare(source._ffi_world_owner._bot_motion_kinds,
+                                native._ffi_world_owner._bot_motion_kinds,
+                                (map_name, scenario, frame, 'world_kinds'))
+                        assert kernel.engine.world.context is None
                     compare(source._last_update_control_steps, native._last_update_control_steps,
                             (map_name, scenario, frame, 'control_steps'))
                     compare(source._last_update_max_control_step, native._last_update_max_control_step,
@@ -142,7 +148,28 @@ def run(backend, fixture, map_name, scenario, frames, siege=False, human=False, 
                     assert len(kernel.engine.tokens) < 30, "Retired cover receipts leaked"
                 if siege and frames >= 30:
                     assert enabled_seen, "Siege fixture never completed its transition"
+                if native_world:
+                    class WorldFailure(Exception):
+                        pass
+                    original_query = kernel.engine.world.query
+                    def fail_world(*unused):
+                        raise WorldFailure('injected owned world leaf failure')
+                    kernel.engine.world.query = fail_world
+                    failed = False
+                    try:
+                        for retry in range(30):
+                            try:
+                                with patch_dict(sys.modules, native_env):
+                                    kernel.update(.13, now + (retry + 1) * .13, players)
+                            except WorldFailure:
+                                failed = True
+                                assert kernel.engine.world.context is None
+                                break
+                        assert failed, 'World failure fixture issued no collision query'
+                    finally:
+                        kernel.engine.world.query = original_query
             finally:
+                kernel.close()
                 kernel.close()
     return frames
 
@@ -156,11 +183,12 @@ def main():
     parser.add_argument('--human', action='store_true')
     parser.add_argument('--siege', action='store_true')
     parser.add_argument('--orders', action='store_true')
+    parser.add_argument('--native-world', action='store_true')
     parser.add_argument('--map', default='59_asia_great_wall')
     parser.add_argument('--scenario', default='combat')
     args = parser.parse_args()
     fixture = load_fixture(args.fixture)
-    count = run(Backend(args.module), fixture, args.map, args.scenario, args.frames, args.siege, args.human, args.cover, args.fixture, args.orders)
+    count = run(Backend(args.module), fixture, args.map, args.scenario, args.frames, args.siege, args.human, args.cover, args.fixture, args.orders, args.native_world)
     print('Native whole Bot update parity: %d complete callbacks.' % count)
 
 

--- a/tools/ffi_experiment/check_kernel_update.py
+++ b/tools/ffi_experiment/check_kernel_update.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python
+"""Compare the complete owned Bot update with the unchanged Python update."""
+from __future__ import print_function
+import argparse
+import copy
+import json
+import random
+import sys
+from check_kernel_state import compare, plain
+from kernel_adapter import KernelBackend
+from navigation_adapter import Backend
+from portable_workload import load_fixture, Path, ROOT, redirected, patch_dict
+
+
+def run(backend, fixture, map_name, scenario, frames, siege=False, human=False, cover=False, fixture_source=None, orders=False):
+    with redirected():
+        random.seed(17)
+        source, source_ground = fixture['make_runtime'](Path(ROOT), map_name, scenario)
+        random.seed(17)
+        native, native_ground = fixture['make_runtime'](Path(ROOT), map_name, scenario)
+    rt = fixture['fixtures']._load()
+    player = None
+    if human:
+        with open(fixture_source) as stream:
+            body = json.load(stream)['_effective_params_snapshot']
+        scope = {}
+        eval(compile(body, 'human_fixture', 'exec'), scope)
+        states = list(source.states.values())
+        player = dict(id=1, team=1, vehicle=states[0]['vehicle'],
+                      x=sum(state['x'] for state in states) / len(states),
+                      y=states[0]['y'], z=sum(state['z'] for state in states) / len(states),
+                      yaw=0, speed=0, alive=True, health=1000, max_health=1000,
+                      fire_seq=0, critical={}, effective_params=scope['_effective_params_snapshot']())
+    if siege:
+        for runtime in (source, native):
+            for identity in sorted(runtime.states)[:3]:
+                travel = runtime._descriptors[identity]
+                travel.type = dict(name='sweden:S11_Strv_103B')
+                enabled = copy.deepcopy(travel)
+                enabled.gun.shotDispersionAngle = .012
+                enabled.gun.aimingTime = .9
+                enabled.gun.reloadTime = .8
+                enabled.physics['speedLimits'] = (10.0 / 3.6, 5.0 / 3.6)
+                runtime._descriptor_pairs[identity] = (travel, enabled)
+                runtime.states[identity]['vehicle'] = 'sweden:S11_Strv_103B'
+    with fixture['combat_native_queries'](source, source_ground) as source_queries:
+        source_env = dict((name, sys.modules[name]) for name in ('AreaDestructibles', 'BigWorld', 'Math'))
+        with fixture['combat_native_queries'](native, native_ground) as native_queries:
+            native_env = dict((name, sys.modules[name]) for name in source_env)
+            tapes = [[], []]
+            for index, runtime in enumerate((source, native)):
+                for name in ('direction_probe', 'world_receipt_probe'):
+                    original = getattr(runtime, name)
+                    if not callable(original):
+                        continue
+                    def wrap(original, name, tape):
+                        def probe(*args, **kwargs):
+                            tape.append((name, args[:3], args[4:], kwargs))
+                            return original(*args, **kwargs)
+                        return probe
+                    setattr(runtime, name, wrap(original, name, tapes[index]))
+            cover_calls = [[], []]
+            if cover:
+                def cover_probe(tape):
+                    def probe(source, target, route, allies, clear):
+                        tape.append((source['id'], target['network_id'], rt._position(source),
+                                     target['position'], route, allies))
+                        return [dict(position=route, supported=clear(rt._position(source), route),
+                                     target_id=target['network_id'])]
+                    return probe
+                source.cover_probe = cover_probe(cover_calls[0])
+                native.cover_probe = cover_probe(cover_calls[1])
+            kernel = KernelBackend(backend, native, rt)
+            try:
+                enabled_seen = False
+                for frame in range(frames):
+                    if orders and frame % 13 == 5:
+                        message = dict(bot_order_revision=source._order_revision + 1,
+                                       bot_orders=[dict(copy.deepcopy(order), id=identity)
+                                                   for identity, order in source._server_orders.items()])
+                        for order in message['bot_orders'][:5]:
+                            order['route_id'] = 'kernel-change-%d' % frame
+                            order['fire_allowed'] = frame % 2 == 0
+                            order['throttle_override'] = .35 if frame % 2 else .8
+                        assert source._apply_orders(message)
+                        assert native._apply_orders(message)
+                    dt = (1.0 / 30, 1.0 / 30, 1.0 / 30, .27, .013)[frame % 5]
+                    now = 100 + (frame + 1) * .13
+                    players = []
+                    if player is not None:
+                        players = [dict(player, x=player['x'] + frame * .7,
+                                        alive=frame % 19 not in (8, 9, 10),
+                                        fire_seq=frame // 5, speed=3 if frame % 7 else 0)]
+                        source._camera_position = native._camera_position = (
+                            player['x'] + (0, 400, 900)[frame % 3], player['y'], player['z'])
+                    with redirected():
+                        with patch_dict(sys.modules, source_env):
+                            expected = source.update(dt, now, players)
+                        with patch_dict(sys.modules, native_env):
+                            actual = kernel.update(dt, now, players)
+                    try:
+                        compare(plain(expected), plain(actual), (map_name, scenario, frame, 'messages'))
+                    except AssertionError:
+                        dump = dict(expected=expected, actual=actual, native=kernel.snapshot(),
+                                    states=source.states, source_queries=source_queries,
+                                    native_queries=native_queries, decisions=source._decision_cache)
+                        with open('/tmp/wot-kernel-update-difference.json', 'w') as stream:
+                            json.dump(dump, stream, default=repr, indent=2)
+                        raise
+                    compare(plain(source_queries), plain(native_queries), (map_name, scenario, frame, 'queries'))
+                    compare(source._last_update_control_steps, native._last_update_control_steps,
+                            (map_name, scenario, frame, 'control_steps'))
+                    compare(source._last_update_max_control_step, native._last_update_max_control_step,
+                            (map_name, scenario, frame, 'maximum_step'))
+                    compare(plain(cover_calls[0]), plain(cover_calls[1]), (map_name, scenario, frame, 'cover_leaves'))
+                    compare(plain(tapes[0]), plain(tapes[1]), (map_name, scenario, frame, 'motion_leaves'))
+                    compare(plain(source.probe_totals()), plain(kernel.probes()),
+                            (map_name, scenario, frame, 'probes'))
+                    compare(source._decision_counts, kernel.counters()['decisions'],
+                            (map_name, scenario, frame, 'decisions'))
+                    compare(source.diagnostic_totals(), kernel.diagnostics(),
+                            (map_name, scenario, frame, 'diagnostics'))
+                    expected_bots = {}
+                    for identity, state in source.states.items():
+                        clean = dict((key, value) for key, value in state.items()
+                                     if key not in ('_gun_pitch_limit_cache', '_motion_stall_pending'))
+                        expected_bots[str(identity)] = dict(state=clean, gun=source._gun_states[identity].__dict__,
+                            ammo=source._ammo_states[identity].__dict__, burst=source._burst_states[identity].__dict__)
+                    snapshot = kernel.snapshot()
+                    enabled_seen = enabled_seen or any(state.get("siege_state") == 2 for state in source.states.values())
+                    # Static producer fields remain on their Python descriptors;
+                    # the focused weapon tests compare their full clock schema.
+                    for identity in expected_bots:
+                        compare(plain(expected_bots[identity]['state']), snapshot['bots'][identity]['state'],
+                                (map_name, scenario, frame, identity, 'state'))
+                    for message in expected:
+                        for launch in message.get('launches', ()):
+                            assert source.ack_projectile_launch(launch['id'], launch['fire_seq'])
+                            assert kernel.ack(launch['id'], launch['fire_seq'])
+                if cover and frames >= 30:
+                    assert cover_calls[0], "Cover fixture never serviced a job"
+                    assert len(kernel.engine.tokens) < 30, "Retired cover receipts leaked"
+                if siege and frames >= 30:
+                    assert enabled_seen, "Siege fixture never completed its transition"
+            finally:
+                kernel.close()
+    return frames
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--module', required=True)
+    parser.add_argument('--fixture', required=True)
+    parser.add_argument('--frames', type=int, default=30)
+    parser.add_argument('--cover', action='store_true')
+    parser.add_argument('--human', action='store_true')
+    parser.add_argument('--siege', action='store_true')
+    parser.add_argument('--orders', action='store_true')
+    parser.add_argument('--map', default='59_asia_great_wall')
+    parser.add_argument('--scenario', default='combat')
+    args = parser.parse_args()
+    fixture = load_fixture(args.fixture)
+    count = run(Backend(args.module), fixture, args.map, args.scenario, args.frames, args.siege, args.human, args.cover, args.fixture, args.orders)
+    print('Native whole Bot update parity: %d complete callbacks.' % count)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/ffi_experiment/check_kernel_world.py
+++ b/tools/ffi_experiment/check_kernel_world.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python
+"""Compare native collision arbitration with the unchanged battle resolver.
+
+The source executes its real sweep and resolver. Scripted leaves cover return
+contracts and failures; populated catalog scenes execute real contact, commit,
+publication, pending-skin and filter code against deterministic native fakes.
+"""
+from __future__ import print_function
+import argparse
+import contextlib
+import copy
+import itertools
+import math
+import random
+import sys
+
+from check_kernel_state import compare, plain
+from kernel_adapter import Kernel, bot_config, ENGINE_FIELDS, motion_config
+from kernel_engine import EngineLeaves
+from kernel_world import WorldLeaves, descriptor_profile, _STATUSES
+from navigation_adapter import Backend
+from portable_workload import load_fixture, Path, ROOT, Namespace, patch_dict, redirected
+
+
+@contextlib.contextmanager
+def replaced(owner, **values):
+    old = dict((key, getattr(owner, key)) for key in values)
+    for key, value in values.items():
+        setattr(owner, key, value)
+    try:
+        yield
+    finally:
+        for key, value in old.items():
+            setattr(owner, key, value)
+
+
+def point(value):
+    return (value.x, value.y, value.z)
+
+
+class Counts(object):
+    def __init__(self):
+        self.values = {}
+
+    def count(self, name):
+        self.values[name] = self.values.get(name, 0) + 1
+
+
+class Audit(object):
+    def __init__(self, backend, fixture):
+        from gui.mods.offline_lan_0922.battle_runtime import BattleRuntime
+        from gui.mods.offline_lan_0922 import world_collision
+        self.world, self.fixture, self.backend = world_collision, fixture, backend
+        with redirected():
+            self.runtime, unused_ground = fixture['make_runtime'](Path(ROOT), '59_asia_great_wall', 'combat')
+        self.rt, self.vector = fixture['fixtures']._load(), fixture['_Vector']
+        self.identity = sorted(self.runtime.states)[0]
+        self.base_state = dict(self.runtime.states[self.identity])
+        self.descriptor = self.runtime._descriptors[self.identity]
+        self.descriptor.physics['weight'] = 40000.0
+        self.owner = BattleRuntime.__new__(BattleRuntime)
+        self.owner.__dict__.update(
+            _bots=self.runtime, _avatar=Namespace(spaceID=1),
+            _vector=lambda value: self.vector(*value), _bot_motion_kinds={},
+            _combat_diagnostics=Counts())
+        self.engine = EngineLeaves(self.rt, self.runtime)
+        self.engine.owned = True
+        self.rows = 0
+        self.outcomes = {}
+
+    def kernel(self):
+        identity, runtime = self.identity, self.runtime
+        value = bot_config(self.base_state, runtime._gun_states[identity],
+                           runtime._ammo_states[identity], runtime._burst_states[identity])
+        value['config'] = dict(motion=dict(physics=runtime._physics_params_for(identity),
+                                         world=descriptor_profile(self.descriptor)))
+        return Kernel(self.backend, self.rt.bot_state_codec, [value],
+                      engine=dict(fields=ENGINE_FIELDS), motion=motion_config(self.rt, runtime))
+
+    def state(self, case):
+        return dict(self.base_state, x=0, y=0, z=0, yaw=case.get('yaw', 0),
+                    speed=case.get('speed', 4), airborne=case.get('airborne', False),
+                    movement_dir=case.get('drive', 1), rotation_dir=case.get('turn', 0),
+                    terrain_pitch=case.get('pitch', 0), roll=case.get('roll', 0))
+
+    def run(self, kernel, case, native):
+        state, owner, runtime = self.state(case), self.owner, self.runtime
+        runtime.states[self.identity] = state
+        runtime._turn_speeds[self.identity] = case.get('turn_speed', 0)
+        runtime.motion_world_corridor_reusable = lambda *unused: case.get('reuse', False)
+        owner._bot_motion_kinds = {self.identity: 'previous'}
+        owner._combat_diagnostics = Counts()
+        motion_yaw = case.get('motion_yaw')
+        commit = case.get('commit', True) if motion_yaw is not None else True
+        position = case.get('position', (0, 0, 0))
+        if native:
+            query = [615, self.identity] + list(position) + [
+                motion_yaw if motion_yaw is not None else state['yaw'],
+                state['speed'], case.get('dt', .04), 10.0,
+                int(motion_yaw is not None), int(commit)] + [0] * 9
+            query += [int(case.get('reuse', False)), 0]
+            assert len(query) == 22
+            self.engine.world = WorldLeaves(owner, self.engine)
+            try:
+                rows = kernel.motion_actions([
+                    dict(method='set', id=self.identity, state=state,
+                         turn_speed=case.get('turn_speed', 0)),
+                    dict(method='world', id=self.identity, query=query)], self.engine)
+                result = _STATUSES[rows[-1]['result']]
+                assert self.engine.world.context is None
+            except Exception as error:
+                result = ('error', type(error).__name__)
+            finally:
+                self.engine.world.clear()
+        else:
+            try:
+                result = owner._resolve_bot_motion(
+                    self.identity, position, state['yaw'], state['speed'], self.descriptor,
+                    case.get('dt', .04), 10.0, commit,
+                    motion_yaw=(motion_yaw + (math.pi if state['speed'] < 0 else 0)
+                                if motion_yaw is not None else None))
+            except Exception as error:
+                result = ('error', type(error).__name__)
+        return (result, dict(owner._bot_motion_kinds), dict(owner._combat_diagnostics.values))
+
+    def scripted(self, kernel, case, native):
+        tape, v = [], self.vector
+        fault = case.get('fault')
+
+        def note(kind, *values):
+            tape.append((kind,) + values)
+            if kind == fault:
+                raise RuntimeError('injected ' + kind)
+
+        def catalog_call(kind, *args, **kwargs):
+            position, yaw, speed, descriptor = args[:4]
+            note(kind, point(position), yaw, speed, args[4:], kwargs)
+            if case.get('retire_catalog') and kind == 'catalog':
+                self.runtime.round_id += 1
+            return case.get(kind, False if kind in ('guard', 'pending') else dict(status='clear'))
+
+        self.owner._destructibles = None if case.get('no_catalog') else Namespace(
+            _catalog_hull_contact=lambda *a, **kw: catalog_call('guard', *a, **kw),
+            _catalog_pending_at_hull=lambda *a, **kw: catalog_call('pending', *a, **kw),
+            _catalog_motion_blocked=lambda space, *a, **kw: catalog_call('catalog', *a, **kw))
+        filter_token = object()
+
+        def prepare(start, end):
+            note('prepare', point(start), point(end))
+            return filter_token if case.get('filter') else None
+
+        def collide(space, start, end, mask, *filters):
+            note('ray', space, point(start), point(end), mask, bool(filters))
+            if abs(start.x - end.x) < 1e-9 and abs(start.z - end.z) < 1e-9:
+                if case.get('invalid_ground'):
+                    return v(start.x, float('nan'), start.z), v(0, 1, 0), 0
+                height = (.496 if start.x < -294 else .384) if case.get('power_rounding') else 0
+                return (v(start.x, height, start.z), v(0, 1, 0), 0) if min(start.y, end.y) <= height <= max(start.y, end.y) else None
+            if case.get('retire_round') and start.y == 1.1:
+                self.runtime.round_id += 1
+            if case.get('upper_failure') and start.y == 1.1:
+                raise RuntimeError('injected first upper ray failure')
+            if case.get('invalid_upper') and start.y == 1.1:
+                return v(float('nan'), start.y, start.z), v(0, 0, -1), 75
+            if case.get('wall'):
+                normal = object() if case.get('bad_normal') else v(0, 0, -1)
+                return (v((start.x + end.x) * .5, (start.y + end.y) * .5,
+                          (start.z + end.z) * .5), normal, 75)
+            return None
+
+        def destroy(space, start, end, hit, yaw, speed, descriptor, crush,
+                    allow_kinetic, kinetic_speed, commit, collision_filter):
+            note('destroy', point(start), point(end), point(hit[0]), yaw, speed,
+                 crush[0], allow_kinetic, kinetic_speed, commit,
+                 collision_filter is filter_token)
+            result = case.get('destroy', False)
+            if result is True:
+                crush[0] = True
+            return result
+
+        bigworld, math_module = Namespace(wg_collideSegment=collide), Namespace(Vector3=v)
+        self.owner._runtime = Namespace(bigworld=bigworld, math=math_module)
+        with patch_dict(sys.modules, dict(BigWorld=bigworld, Math=math_module)):
+            with replaced(self.world, prepare_horizontal_collision_filter=prepare,
+                          _destroy_and_recast=destroy):
+                result = self.run(kernel, case, native)
+        return result, tape
+
+    def check_scripted(self, kernel, case):
+        expected = self.scripted(kernel, case, False)
+        actual = self.scripted(kernel, case, True)
+        compare(plain(expected), plain(actual), ('world', self.rows, case))
+        self.rows += 1
+        key = str(expected[0][0])
+        self.outcomes[key] = self.outcomes.get(key, 0) + 1
+
+    def contracts(self, kernel):
+        rounding = dict(position=(-295.2507744825458, .496, 384.6935827796212),
+                        yaw=2.1156409658631405, speed=3.3158922348808404, dt=.07,
+                        pitch=.02058014125132504, roll=.014903167058722107, power_rounding=True)
+        self.check_scripted(kernel, rounding)
+        unused_result, tape = self.scripted(kernel, rounding, False)
+        first = next(row for row in tape if row[0] == 'ray' and row[2][0] != row[3][0])
+        assert first[3][1] == .9719008512196334
+        for speed, drive, airborne, turn, reuse, wall in itertools.product(
+                (-4, 0, 4), (-1, 0, 1), (False, True), (0, 1), (False, True), (False, True)):
+            self.check_scripted(kernel, dict(speed=speed, drive=drive, airborne=airborne,
+                                            turn=turn, reuse=reuse, wall=wall, filter=True))
+        details = [False, True, 'clear', 'crushed', 'soft', 'hard', 'approach',
+                   dict(status='crushed', accepted_now=True, used_kinetic_speed=True,
+                        token=((22, 37, None),), kinds='fragile'),
+                   dict(status='clear', accepted_now=True),
+                   dict(status='soft', accepted_now=True),
+                   dict(status='approach', accepted_now=True),
+                   dict(status='crushed', used_kinetic_speed=True),
+                   dict(status='crushed', accepted_now=True, used_kinetic_speed=True),
+                   dict(status='pending'), None, 17]
+        for detail, destroyed, wall in itertools.product(details, (False, True, 'kinetic'), (False, True)):
+            self.check_scripted(kernel, dict(catalog=detail, destroy=destroyed, wall=wall))
+        for phase in ('guard', 'prepare', 'ray', 'destroy', 'pending', 'catalog'):
+            self.check_scripted(kernel, dict(fault=phase, wall=phase in ('destroy', 'pending'),
+                                            reuse=phase == 'guard'))
+            self.check_scripted(kernel, {}) # Same native owner works after failure.
+        rng = random.Random(7721513)
+        for index in range(200):
+            self.check_scripted(kernel, dict(
+                speed=rng.choice((-8, -.01, 0, .01, 10)), drive=rng.choice((-1, 0, 1)),
+                yaw=rng.uniform(-3, 3), pitch=rng.choice((0, -.17, .12)),
+                roll=rng.choice((0, -.08, .07)), turn_speed=rng.choice((0, .01, .010001)),
+                motion_yaw=rng.uniform(-3, 3) if index % 2 else None,
+                commit=index % 3 != 0, dt=rng.choice((.001, .04, .27)),
+                reuse=index % 4 == 0, guard=index % 3 == 0, pending=index % 5 == 0,
+                no_catalog=index % 7 == 0, wall=index % 2 == 0,
+                destroy=rng.choice((False, True, 'kinetic')), bad_normal=index % 3 == 0))
+        # Compare error barriers with the existing scalar native reader. An
+        # invalid first upper answer must not issue the second paired ray.
+        from world_adapter import SyncWorldBackend
+        scalar = SyncWorldBackend(self.backend)
+        try:
+            for name in ('upper_failure', 'invalid_upper', 'invalid_ground'):
+                case = {name: True, 'pitch': .1 if name == 'invalid_ground' else 0}
+                self.check_scripted(kernel, case)
+                result, tape = self.scripted(kernel, case, True)
+                assert result[0] == ('error', 'RuntimeError')
+                assert not any(row[0] == 'ray' and row[2][1] == 1.6 for row in tape)
+        finally:
+            scalar.close()
+
+    def lifetimes(self, kernel):
+        round_id = self.runtime.round_id
+        try:
+            result, tape = self.scripted(kernel, dict(retire_round=True), True)
+            assert result[0] == ('error', 'RuntimeError')
+            assert self.engine.world.context is None
+            assert not any(row[0] == 'ray' and row[2][1] == 1.6 for row in tape)
+        finally:
+            self.runtime.round_id = round_id
+        try:
+            result, unused_tape = self.scripted(kernel, dict(retire_catalog=True), True)
+            assert result[0] == ('error', 'RuntimeError')
+            assert self.engine.world.context is None
+        finally:
+            self.runtime.round_id = round_id
+        self.check_scripted(kernel, {})
+        from kernel_adapter import KernelBackend
+        navigator, driver = self.runtime.navigator, self.runtime.adapter.driver
+        wrong_owner = copy.copy(self.owner)
+        wrong_owner._bots = object()
+        try:
+            KernelBackend(self.backend, self.runtime, self.rt, world_owner=wrong_owner)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError('Mismatched battle owner was admitted')
+        assert self.runtime.navigator is navigator
+        assert self.runtime.adapter.driver is driver
+        self.check_scripted(kernel, {})
+
+    def populated(self, kernel, case, native):
+        sensor, v = self.fixture['destructibles_sensor'], self.vector
+        kind = case.get('kind', 'fragile')
+        filename = 'content/GatesAndFences/ffi/normal/lod0/fence.model'
+        materials = (73, 74) if kind == 'structure' else (None,)
+        sensor.set_catalog(self.fixture['_catalog']({filename: dict(
+            kind=kind, boxes=[[-.25, -.2, -.5, .25, 1.5, .5, mat] for mat in materials])}))
+        record = sensor._destructible_catalog['resources'][filename.lower()]
+        instances, bins = {}, {}
+        for identity, x in ((37, -.2), (38, .2)):
+            matrix = self.fixture['_ItemMatrix'](v(x, 0, case.get('obstacle_z', 3.5)))
+            instance = dict(filename=filename.lower(), kind=kind, item_scale=1.0,
+                            boxes=sensor._world_catalog_boxes(record, matrix, v(), Namespace(Vector3=v)))
+            instances[(22, identity)] = instance
+            sensor._index_catalog_instance_1513(bins, (22, identity), instance)
+        sensor.g_offh_destr_instances = instances
+        sensor.g_offh_destr_contact_bins = bins
+        destroyed, events, tape = set(), [], []
+
+        def destroy(chunk, identity, material, position):
+            tape.append(('destroy', chunk, identity, material, point(position)))
+            destroyed.add((chunk, identity, material))
+            return True
+
+        authority = Namespace(
+            is_destroyed=lambda chunk, item, mat=None: (chunk, item, mat) in destroyed,
+            destroyed_keys=lambda chunk: set((item, mat) for cid, item, mat in destroyed if cid == chunk),
+            destroy_fragile=lambda space, chunk, item, position, shot: destroy(chunk, item, None, position),
+            destroy_module=lambda space, chunk, item, mat, position, shot: destroy(chunk, item, mat, position))
+        area = Namespace(
+            DESTR_TYPE_TREE=1, DESTR_TYPE_FALLING_ATOM=2, DESTR_TYPE_FRAGILE=3,
+            DESTR_TYPE_STRUCTURE=4, DESTRUCTIBLE_HIDING_DELAY=.2,
+            g_destructiblesManager=object(),
+            g_cache=Namespace(unitVehicleMass=10000.0, getDescByFilename=lambda name: dict(
+                type=4 if kind == 'structure' else 3, health=5, kineticDamageCorrection=1.0,
+                modules=dict((mat, dict(health=5)) for mat in materials))))
+
+        def collide(space, start, end, mask, *filters):
+            tested = tuple((item, mat, collision_filter(75 if mat is None else mat, 0, item, 22))
+                           for collision_filter in filters for item in (37, 38) for mat in materials)
+            tape.append(('ray', point(start), point(end), tested))
+            if abs(start.x - end.x) < 1e-9 and abs(start.z - end.z) < 1e-9:
+                return (v(start.x, 0, start.z), v(0, 1, 0), 0) if min(start.y, end.y) <= 0 <= max(start.y, end.y) else None
+            return None
+
+        bigworld = Namespace(wg_collideSegment=collide, time=lambda: 10.0)
+        math_module = Namespace(Vector3=v)
+        cache = Namespace(scaledDestructibleHealth=lambda scale, health: scale * health)
+        self.owner._runtime = Namespace(bigworld=bigworld, math=math_module)
+        self.owner._destructibles = sensor
+        old_sink = sensor._event_sink
+        sensor.set_event_sink(lambda event: events.append(copy.deepcopy(event)) or True)
+        try:
+            with patch_dict(sys.modules, dict(BigWorld=bigworld, Math=math_module,
+                                              AreaDestructibles=area, DestructiblesCache=cache)):
+                with replaced(sensor, _get_destr_authority=lambda: authority):
+                    results = [self.run(kernel, case, native), self.run(kernel, case, native)]
+                    pending = sorted(sensor.__dict__.get('g_offh_destr_pending', {}).items())
+                    published = sensor.__dict__.get('g_offh_tree_state', {}).get('publish_pending', {})
+                    assert not published
+            return results, sorted(destroyed), events, tape, pending
+        finally:
+            sensor.set_event_sink(old_sink)
+            sensor.set_catalog(None)
+
+    def catalogs(self, kernel):
+        for kind in ('fragile', 'structure'):
+            cases = [dict(speed=20), dict(speed=.01), dict(speed=.01, drive=0),
+                     dict(speed=20, motion_yaw=0, commit=False), dict(airborne=True),
+                     dict(speed=.01, obstacle_z=7), dict(speed=-20, drive=-1, obstacle_z=-3.5)]
+            for case in cases:
+                case['kind'] = kind
+                expected = self.populated(kernel, case, False)
+                actual = self.populated(kernel, case, True)
+                compare(plain(expected), plain(actual), ('populated', case))
+                if (case.get('speed', 0) > 0 and case.get('drive', 1) and
+                        case.get('commit', True) and case.get('obstacle_z', 3.5) == 3.5):
+                    assert len(expected[1]) == (4 if kind == 'structure' else 2), expected[:3]
+                    assert expected[2], 'Native destruction had no canonical publication'
+                self.rows += 1
+
+    def profiles(self):
+        original = self.descriptor
+        try:
+            for forward, backward, width in ((3.0, 1.5, 2.1), (18.0, 9.0, 1.2)):
+                self.descriptor = copy.deepcopy(original)
+                self.descriptor.physics['speedLimits'] = (forward, backward)
+                self.descriptor.hull.hitTester.bbox = ((-width, -.2, -4.1), (width, 1.4, 3.8), None)
+                self.runtime._descriptors[self.identity] = self.descriptor
+                kernel = self.kernel()
+                try:
+                    for speed, motion in itertools.product((-4, 4), (None, .25)):
+                        self.check_scripted(kernel, dict(speed=speed, drive=-1 if speed < 0 else 1,
+                                                        motion_yaw=motion, wall=True, destroy='kinetic',
+                                                        catalog=dict(status='crushed', accepted_now=True,
+                                                                     used_kinetic_speed=True, token=(1,))))
+                finally:
+                    kernel.close()
+        finally:
+            self.descriptor = original
+            self.runtime._descriptors[self.identity] = original
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--module', required=True)
+    parser.add_argument('--fixture', required=True)
+    args = parser.parse_args()
+    fixture = load_fixture(args.fixture)
+    backend = Backend(args.module)
+    audit = Audit(backend, fixture)
+    kernel = audit.kernel()
+    try:
+        audit.contracts(kernel)
+        audit.catalogs(kernel)
+        audit.lifetimes(kernel)
+        audit.profiles()
+    finally:
+        kernel.close()
+        backend.close()
+    print('Native world resolver parity: %d cases; outcomes=%r' % (audit.rows, audit.outcomes))
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/ffi_experiment/check_motion_flow.py
+++ b/tools/ffi_experiment/check_motion_flow.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python
+"""Differential preparation/integration with callback-visible state and caches."""
+from __future__ import print_function
+import argparse
+import copy
+import inspect
+import random
+import textwrap
+
+from navigation_adapter import Backend
+from driver_adapter import DriverBackend
+from navigation_flow_adapter import NavigationFlowBackend
+from motion_adapter import MotionFlowBackend
+from portable_workload import load_fixture, Path, ROOT, redirected
+
+
+def equivalent(first, second):
+    if isinstance(first, dict) and isinstance(second, dict):
+        return set(first) == set(second) and all(equivalent(first[key], second[key]) for key in first)
+    if isinstance(first, (tuple, list)) and isinstance(second, (tuple, list)):
+        return len(first) == len(second) and all(equivalent(a, b) for a, b in zip(first, second))
+    return first == second
+
+
+def reference(module):
+    source = open(inspect.getsourcefile(module.BotRuntime), 'rb').read().decode('utf-8')
+    start = source.index("            throttle = max(-1.0, min(1.0, command['throttle']))", source.index('    def _update_once('))
+    end = source.index("            if diagnostic is not None:\n                diagnostic.phase('bot.aim_fire')", start)
+    header = '''def original_step(self, state, command, target, descriptor, position, step, now,
+        decision_due, refresh_control, siege_motion_locked, tick_siege_yaw,
+        siege_locked_poses, attempted_yaws, baked_shallow_escape, diagnostic):
+    controlled_shallow = getattr(self.navigator, 'controlled_shallow_step', None)
+    controlled_shallow_commit = getattr(self.navigator, 'controlled_shallow_commit_step', None)
+'''
+    code = header + '\n'.join('    ' + line for line in textwrap.dedent(source[start:end]).splitlines()) + '\n    return destroyed_devices\n'
+    scope = dict(module.__dict__)
+    eval(compile(code, '<source-motion-block>', 'exec'), scope)
+    return scope['original_step']
+
+
+def run(args):
+    fixtures = load_fixture(args.fixture)
+    module = fixtures['fixtures']._load()
+    from gui.mods.offline_lan_0922.ai import navigation
+    first, unused = fixtures['make_runtime'](Path(ROOT), '59_asia_great_wall', 'combat')
+    second, unused = fixtures['make_runtime'](Path(ROOT), '59_asia_great_wall', 'combat')
+    backend = Backend(args.module)
+    driver = DriverBackend(backend, second, True)
+    nav = NavigationFlowBackend(backend, second, navigation)
+    motion = MotionFlowBackend(backend, second, module)
+    navigation_events = []
+    publish_event = second.navigator._publish_event
+    def observe_navigation(packet=None):
+        if packet is not None:
+            navigation_events.append(int(packet[0]))
+        return publish_event(packet)
+    second.navigator._publish_event = observe_navigation
+    original = reference(module)
+    initial = copy.deepcopy(first.states[11])
+    rng = random.Random(6261513)
+    query_count = 0
+    try:
+        for case in range(args.cases):
+            state = copy.deepcopy(initial)
+            state.update(speed=rng.choice((0.0, 0.02, 0.1, 4.0, -3.0)),
+                         yaw=rng.uniform(-3.14, 3.14), airborne=bool(case % 11 == 0),
+                         grounded_once=bool(case % 7), _water_depth=rng.choice((-1.0, 0.0, 0.7, 1.1)))
+            if case % 9 == 0:
+                state['destructible_contact_speed'] = rng.uniform(-4, 4)
+            state['_motion_stall_pending'] = {}
+            command = dict(throttle=rng.choice((-1.0, 0.0, 0.3, 1.0)),
+                turn=rng.choice((-0.8, 0.0, 0.0, 0.4)), movement_intent=bool(case % 4),
+                move_position=(state['x'] + 3, state['y'], state['z'] + 10),
+                aim_position=(state['x'] + 20, state['y'], state['z'] - 2),
+                recovery_mode=rng.choice(('drive', 'avoid', 'blocked', 'reverse_turn', 'pivot_recovery', 'arrived')),
+                combat_mode='engage', fire_allowed=True)
+            now, dt = 100.0 + case * 0.05, rng.choice((0.01, 0.05, 0.1, 0.2))
+            probe_kind = rng.randrange(10)
+            receipt_kind = rng.randrange(5)
+            resolver_kind = rng.randrange(5)
+            turnspeed = rng.choice((0.0, 0.0, 0.2, -0.5))
+            probes = [None, False, {}, {'clear': True}, {'clear': False, 'collision': True},
+                      {'clear': False, 'water': True}, {'clear': True, 'slope': 0.4},
+                      {'clear': True, 'slope': -0.03}, {'clear': True, 'deferred': True},
+                      {'clear': True, '_world_receipt_pending': True}]
+            receipt = [None, False, 'deferred', {}, dict(origin=module._position(state),
+                       yaw=state['yaw'], direction=1, leading=3.5, distance=30)][receipt_kind]
+            cached = None
+            if case % 3:
+                cached = dict(result=copy.deepcopy(probes[(probe_kind + 3) % 10]),
+                    position=module._position(state), yaw=state['yaw'], maximum_distance=None,
+                    probe_distance=15.0, probe_leading=3.5, deadline=now + (0.1 if case % 2 else -0.1))
+                if case % 5 == 0 and isinstance(cached['result'], dict):
+                    cached['result']['world_receipt'] = copy.deepcopy(receipt)
+            outputs, tapes = [], []
+            for runtime, native in ((first, False), (second, True)):
+                runtime.states[11] = current = copy.deepcopy(state)
+                current_command = copy.deepcopy(command)
+                runtime._motion_probe_cache.clear()
+                if cached is not None:
+                    runtime._motion_probe_cache[11] = copy.deepcopy(cached)
+                runtime._hard_contact_grinds = {11: case % 5} if case % 2 else {}
+                runtime._turn_speeds[11] = turnspeed
+                runtime._decision_cache = {11: {'test': case}}
+                if case % 29 == 0:
+                    navigator = runtime.navigator
+                    navigator.search_max_expansions = 1
+                    navigator.begin_frame(0.1)
+                    navigator.tick(now)
+                    navigator.next_target(11, module._position(current),
+                        (current['x'] + 100, current['y'], current['z'] + 100),
+                        ('local', 11, 'motion_cancellation', case), now)
+                    navigator.end_frame()
+                tape = []
+                def record(kind, args):
+                    tape.append((kind, copy.deepcopy(args), copy.deepcopy(current),
+                                 copy.deepcopy(runtime._motion_probe_cache),
+                                 copy.deepcopy(runtime._hard_contact_grinds)))
+                def direction(*values):
+                    record('direction', values[:3] + values[4:])
+                    if case % 137 == 1:
+                        raise RuntimeError('injected motion query failure')
+                    return copy.deepcopy(probes[probe_kind])
+                def exact(*values):
+                    record('receipt', values[:4] + values[5:])
+                    return copy.deepcopy(receipt)
+                def resolver(*values, **kwargs):
+                    record('resolver', (values[:4] + values[5:], kwargs))
+                    # A passive query cannot return the active-crush cap.
+                    kind = resolver_kind if len(values) == 7 else (resolver_kind if resolver_kind != 3 else 4)
+                    return ('clear', 'crushed', 'soft', 'cap_crushed', 'hard')[kind]
+                def report(*values):
+                    record('report', values)
+                def log_flip(*values):
+                    record('flip', values[1:])
+                def log_stall(*values):
+                    record('stall', values[1:])
+                runtime._probe_direction = direction
+                runtime._probe_world_receipt = exact
+                runtime.motion_resolver = resolver if case % 4 else None
+                runtime.motion_report = report
+                runtime._log_direction_flip = log_flip
+                runtime._log_motion_stall = log_stall
+                poses, yaws = {}, {}
+                callargs = (current, current_command, {'position': command['aim_position']} if case % 2 else None,
+                    runtime._descriptors[11], module._position(current), dt, now, bool(case % 2),
+                    bool(case % 3), bool(case % 19 == 0), current['yaw'], poses, yaws, bool(case % 13 == 0), None)
+                try:
+                    result = motion.step(*callargs) if native else original(runtime, *callargs)
+                    error = None
+                except (AttributeError, TypeError, RuntimeError) as exc:
+                    error = (type(exc).__name__, str(exc))
+                    result = None
+                outputs.append((error, result, current, current_command, runtime._motion_probe_cache,
+                    runtime._hard_contact_grinds, runtime._turn_speeds[11], runtime._decision_cache, poses, yaws))
+                tapes.append(tape)
+            if outputs[0] != outputs[1] or tapes[0] != tapes[1]:
+                for index, (a, b) in enumerate(zip(outputs[0], outputs[1])):
+                    if a != b:
+                        print('State mismatch', case, index, repr(a), repr(b))
+                for index, (a, b) in enumerate(zip(tapes[0], tapes[1])):
+                    if a != b:
+
+                        for field, (aa, bb) in enumerate(zip(a, b)):
+                            if aa != bb:
+                                print('Callback mismatch', case, index, field, repr(aa), repr(bb))
+                        break
+                print('Callback lengths', len(tapes[0]), len(tapes[1]))
+                raise AssertionError('motion case %d' % case)
+            if len(motion.objects.get(11, {})) > 3:
+                raise AssertionError(('unbounded opaque cache', case, len(motion.objects[11])))
+            query_count += len(tapes[0])
+        for name, actual in second.navigator.dump_state().items():
+            expected = (first.navigator.grid._failed_edges if name == 'grid_failed_edges'
+                        else getattr(first.navigator, name))
+            if name == 'searches':
+                def searches(values):
+                    return dict((key, (value.last_frame, value.hull_revision, value.done))
+                                for key, value in values.items())
+                expected, actual = searches(expected), searches(actual)
+            if not equivalent(expected, actual):
+                raise AssertionError(('navigation after motion', name, expected, actual))
+        if args.cases >= 1000 and 504 not in navigation_events:
+            raise AssertionError('motion never exercised pending-search retirement')
+        return query_count, len(navigation_events)
+    finally:
+        motion.close()
+        nav.close()
+        driver.close()
+        backend.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--module', required=True)
+    parser.add_argument('--fixture', required=True)
+    parser.add_argument('--cases', type=int, default=2000)
+    args = parser.parse_args()
+    count, retirements = run(args)
+    print('Exact motion flow: %d cases, %d ordered callback/state observations, %d navigation retirements.' %
+          (args.cases, count, retirements))
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/ffi_experiment/check_motion_physics.py
+++ b/tools/ffi_experiment/check_motion_physics.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+"""Exact copied-physics behavior across descriptors, terrain, slopes and tuning."""
+from __future__ import print_function
+
+import argparse
+import random
+
+from navigation_adapter import Backend
+from portable_workload import load_fixture
+from motion_adapter import Physics, CONSTANTS
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--module', required=True)
+    parser.add_argument('--fixture', required=True)
+    parser.add_argument('--cases', type=int, default=10000)
+    args = parser.parse_args()
+    fixtures = load_fixture(args.fixture)
+    rt = fixtures['fixtures']._load()
+    module = rt.vehicle_physics
+    backend = Backend(args.module)
+    rng = random.Random(62771513)
+    saved = dict((name, getattr(module, name)) for name in CONSTANTS)
+    checks = 0
+    try:
+        for variant in range(3):
+            if variant:
+                for name in module._TUNABLE.values():
+                    if name in saved:
+                        setattr(module, name, saved[name] * rng.uniform(0.75, 1.25))
+                module.GRAVITY = module.G * module.GRAVITY_FACTOR
+            physics = Physics(backend, module)
+            params = dict(mass=14000.0 + variant * 22000, powerW=440000.0,
+                          nativePowerRatio=0.7 + variant * 0.15, specificFriction=0.6867,
+                          brakeDecel=module.COHESION * module.GRAVITY, speedFwd=16.0,
+                          speedBwd=6.0, rotSpd=0.6, terrainResist=(1.0, 1.3, 2.1))
+            rows = [[] for unused in range(5)]
+            expected = [[] for unused in range(5)]
+            for index in range(args.cases):
+                v = rng.choice((0.0, rng.uniform(-20, 25)))
+                throttle = rng.choice((-1.0, 0.0, 0.3, 1.0))
+                steering, airborne, handbrake = (bool(rng.randrange(2)) for unused in range(3))
+                pitch, dt, terrain = rng.uniform(-1.2, 1.2), rng.choice((0.01, 1.0/60, 0.05, 0.2)), rng.randrange(3)
+                args0 = (v, throttle, steering, pitch, dt, airborne, terrain, handbrake)
+                rows[0].append(args0)
+                expected[0].append(module.longitudinal_step(params, *args0))
+                args1 = (rng.uniform(-1, 1), rng.uniform(-1, 1), v, dt, terrain, throttle)
+                rows[1].append(args1)
+                expected[1].append(module.traverse_step(params, *args1))
+                yaw, slide = rng.uniform(-4, 4), bool(index % 2)
+                rows[2].append((v, dt, steering, slide, yaw))
+                expected[2].append(module.hard_contact_step(v, dt, steering, yaw if slide else None))
+                rows[3].append((v, pitch, dt))
+                expected[3].append(module.ground_follow_gap(v, pitch, dt))
+                current, tangent = rng.uniform(0, 12), rng.uniform(0, 2.0)
+                rows[4].append((current, tangent, dt))
+                expected[4].append(module.slope_slide_speed(current, tangent, dt))
+            for kind in range(5):
+                actual = physics.batch(params, kind, rows[kind])
+                for index, (first, second) in enumerate(zip(expected[kind], actual)):
+                    if first != second:
+                        raise AssertionError((variant, kind, index, rows[kind][index], first, second))
+                    checks += 1
+        print('Exact copied physics: %d results across descriptor, slope, braking, terrain, airborne and tuning variants.' % checks)
+    finally:
+        for name, value in saved.items():
+            setattr(module, name, value)
+        backend.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/ffi_experiment/check_motion_vertical.py
+++ b/tools/ffi_experiment/check_motion_vertical.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python
+"""Compare complete legacy ground/ballistic updates and native query order."""
+from __future__ import print_function
+import argparse
+import copy
+import random
+from navigation_adapter import Backend
+from driver_adapter import DriverBackend
+from navigation_flow_adapter import NavigationFlowBackend
+from motion_adapter import MotionFlowBackend
+from portable_workload import load_fixture, Path, ROOT
+
+
+def first_difference(a, b, path=''):
+    if type(a) != type(b):
+        # Python exposes the same numeric value for int/float spellings.
+        if isinstance(a, (int, float)) and isinstance(b, (int, float)) and a == b:
+            return None
+        return (path, a, b)
+    if isinstance(a, dict):
+        if set(a) != set(b):
+            return (path + '.keys', set(a), set(b))
+        pairs = ((a[k], b[k], path + '.' + str(k)) for k in sorted(a))
+    elif isinstance(a, (tuple, list)):
+        if len(a) != len(b):
+            return (path + '.length', len(a), len(b))
+        pairs = ((x, y, path + '[%d]' % i) for i, (x, y) in enumerate(zip(a, b)))
+    else:
+        return None if a == b else (path, a, b)
+    for x, y, p in pairs:
+        diff = first_difference(x, y, p)
+        if diff is not None:
+            return diff
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--module', required=True)
+    parser.add_argument('--fixture', required=True)
+    parser.add_argument('--cases', type=int, default=3000)
+    args = parser.parse_args()
+    fixtures = load_fixture(args.fixture)
+    module = fixtures['fixtures']._load()
+    from gui.mods.offline_lan_0922.ai import navigation
+    first, unused = fixtures['make_runtime'](Path(ROOT), '59_asia_great_wall', 'combat')
+    second, unused = fixtures['make_runtime'](Path(ROOT), '59_asia_great_wall', 'combat')
+    backend = Backend(args.module)
+    driver = DriverBackend(backend, second, True)
+    nav = NavigationFlowBackend(backend, second, navigation)
+    motion = MotionFlowBackend(backend, second, module)
+    initial = copy.deepcopy(first.states[11])
+    rng = random.Random(627001513)
+    checks = queries = 0
+    try:
+        for case in range(args.cases):
+            state = copy.deepcopy(initial)
+            state.update(speed=rng.uniform(-9, 20), vertical_speed=rng.uniform(-30, 15),
+                         yaw=rng.uniform(-3.14, 3.14), airborne=bool(case % 3),
+                         grounded_once=bool(case % 5), last_drive_pitch=rng.uniform(-0.7, 0.7),
+                         air_lateral_x=rng.uniform(-3, 3), air_lateral_z=rng.uniform(-3, 3))
+            state['_motion_stall_pending'] = {}
+            step = rng.choice((0.01, 1.0/30, 0.05, 0.1, 0.2))
+            tick = None if case % 7 == 0 else (state['x'] + rng.uniform(-5, 5), state['y'] - rng.uniform(0, 3), state['z'] + rng.uniform(-5, 5))
+            support_kind = case % 6
+            rise, dx, dz = rng.uniform(-3, 4), rng.uniform(-0.8, 0.8), rng.uniform(-0.8, 0.8)
+            outputs = []
+            for runtime in (first, second):
+                current = copy.deepcopy(state)
+                runtime.states[11] = current
+                tape = []
+                runtime._turn_speeds[11] = 0.2
+                runtime._motion_probe_cache = {11: {'test': 1}}
+                runtime._decision_cache = {11: {'test': 2}}
+                def probe(x, z, hint):
+                    tape.append(('ground', (x, z, hint), copy.deepcopy(current)))
+                    if support_kind == 0 or support_kind == 1 and x == state['x'] and z == state['z']:
+                        return None
+                    if support_kind == 2 and len(tape) % 2:
+                        return None
+                    return state['y'] + rise + (x-state['x']) * dx + (z-state['z']) * dz
+                runtime._physics_ground_probe = probe
+                result = runtime._update_vertical_motion(current, step, tick, state['yaw'] + 0.2)
+                outputs.append((result, current, tape, runtime._turn_speeds[11],
+                                runtime._decision_cache, runtime._motion_probe_cache))
+            diff = first_difference(outputs[0], outputs[1])
+            if diff:
+                raise AssertionError(('vertical', case, diff))
+            queries += len(outputs[0][2]); checks += 1
+            # The complete four-point pose sampler also covers absent edge
+            # support, marker reuse, large tilts and prior suspension offset.
+            state['airborne'] = False
+            state['grounded_once'] = True
+            outputs = []
+            for runtime in (first, second):
+                current = copy.deepcopy(state)
+                current['pose_sample'] = (state['x'], state['z'], state['yaw']) if case % 4 == 0 else None
+                tape = []
+                def probe(x, z, hint):
+                    tape.append((x, z, hint))
+                    return None if support_kind == 0 else state['y'] + rise + (x-state['x']) * dx + (z-state['z']) * dz
+                runtime._physics_ground_probe = probe
+                result = runtime._update_slope_pose(current)
+                outputs.append((result, current, tape))
+            diff = first_difference(outputs[0], outputs[1])
+            if diff:
+                raise AssertionError(('slope', case, diff))
+            queries += len(outputs[0][2]); checks += 1
+            # Contact impulses observe the reduced forward speed before the
+            # native nudge gate, then publish decay and the admitted endpoint.
+            outputs = []
+            impulse = dict(delta_velocity=(rng.uniform(-4, 4), rng.uniform(-4, 4)),
+                           correction=(rng.uniform(-1, 1), rng.uniform(-1, 1)))
+            for runtime in (first, second):
+                current = copy.deepcopy(state)
+                tape = []
+                def clear(*values):
+                    tape.append((values, copy.deepcopy(current)))
+                    return bool(case % 3)
+                runtime._clear = clear
+                runtime._apply_tank_contact_response(current, impulse, step, bool(case % 4), bool(case % 5))
+                outputs.append((current, tape))
+            diff = first_difference(outputs[0], outputs[1])
+            if diff:
+                raise AssertionError(('contact impulse', case, diff))
+            queries += len(outputs[0][1]); checks += 1
+            # Check every side/corner of the baked bounds and hazardous cells.
+            outputs = []
+            current_position = (state['x'] + rng.uniform(-1000, 1000), state['y'], state['z'] + rng.uniform(-1000, 1000))
+            for runtime in (first, second):
+                current = copy.deepcopy(state)
+                current['x'], current['y'], current['z'] = current_position
+                runtime._decision_cache = {11: 'command'}
+                runtime._motion_probe_cache = {11: 'proof'}
+                result = runtime._guard_realised_pose(current, module._position(state), bool(case % 2), state['yaw'])
+                outputs.append((result, current, runtime._decision_cache, runtime._motion_probe_cache))
+            diff = first_difference(outputs[0], outputs[1])
+            if diff:
+                raise AssertionError(('final guard', case, diff))
+            checks += 1
+            params = first._physics_params_for(11)
+            for pitch in (-0.7, 0.0, 0.7):
+                source = dict(id=11, speed=state['speed'], last_drive_pitch=pitch)
+                command = dict(turn=0.5 if case % 2 else 0.0)
+                expected = first._cached_traffic_stopping_distance(source, command, params)
+                actual = second._cached_traffic_stopping_distance(source, command, params)
+                if expected != actual:
+                    raise AssertionError(('stopping', case, expected, actual))
+                checks += 1
+        print('Exact vertical/slope/coast flow: %d checks and %d native-ground query observations.' % (checks, queries))
+    finally:
+        motion.close(); nav.close(); driver.close(); backend.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/ffi_experiment/check_navigation_flow.py
+++ b/tools/ffi_experiment/check_navigation_flow.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python
+"""Compare complete navigation transitions, queue timing and persistent state."""
+from __future__ import print_function
+
+import argparse
+import random
+
+from check_parity import nav, random_graph, ground_for
+from navigation_adapter import Backend
+from navigation_flow_adapter import NativeNavigator
+
+
+def difference(a, b, path='root'):
+    if isinstance(a, dict) and isinstance(b, dict):
+        if set(a) != set(b):
+            return path, 'keys', sorted(repr(key) for key in set(a) - set(b)), sorted(repr(key) for key in set(b) - set(a))
+        for key in sorted(a, key=repr):
+            found = difference(a[key], b[key], path + '[' + repr(key) + ']')
+            if found:
+                return found
+    elif isinstance(a, (list, tuple)) and isinstance(b, (list, tuple)):
+        if len(a) != len(b):
+            return path, 'length', len(a), len(b)
+        for i, (first, second) in enumerate(zip(a, b)):
+            found = difference(first, second, path + '[%s]' % i)
+            if found:
+                return found
+    elif a != b:
+        return path, a, b
+    return None
+
+
+def reference_state(original):
+    names = ('paths', 'path_times', 'path_hull_revisions', 'search_times', 'bot_states',
+             'bot_failed_edges', 'bot_macro_edges', 'bot_direct_progress',
+             'search_frame_time', 'housekeeping_time', 'search_next_key', 'search_credit',
+             'search_frame_serial', 'search_processed_frame', 'search_frame_budget',
+             'search_frame_open', 'search_auto_time', 'search_max_expansions',
+             'search_completed', 'search_failed', 'search_now', 'fallback_totals',
+             'fallback_recovered', 'fallback_modes')
+    result = dict((name, getattr(original, name)) for name in names)
+    result['searches'] = dict((key, dict(last_frame=search.last_frame,
+                                        hull_revision=search.hull_revision, done=search.done))
+                              for key, search in original.searches.items())
+    result['grid_failed_edges'] = original.grid._failed_edges
+    return result
+
+
+def native_state(native):
+    result = dict(native.dump_state())
+    result['searches'] = dict((key, dict(last_frame=search.last_frame,
+                                        hull_revision=search.hull_revision, done=search.done))
+                              for key, search in result['searches'].items())
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--module', required=True)
+    parser.add_argument('--cases', type=int, default=12)
+    parser.add_argument('--frames', type=int, default=80)
+    args = parser.parse_args()
+    backend = Backend(args.module)
+    operations = 0
+    try:
+        for seed in range(args.cases):
+            rng = random.Random(seed + 7513)
+            graph = random_graph(rng, 21, 17)
+            reference = nav.TerrainNavigator(ground_for(graph), baked_graph=graph)
+            shell = nav.TerrainNavigator(ground_for(graph), baked_graph=graph)
+            native = NativeNavigator(backend, shell, nav)
+            reference.search_max_expansions = native.search_max_expansions = (8, 32, 128, 4096)[seed % 4]
+            positions, goals = {}, {}
+            for bot in range(1, 9):
+                positions[bot] = reference.grid.point_for((rng.randrange(21), rng.randrange(17)), 0)
+                goals[bot] = reference.grid.point_for((rng.randrange(21), rng.randrange(17)), 0)
+            now = 0.0
+            for frame in range(args.frames):
+                elapsed = (0.03, 0.1, 0.23, 0.5)[frame % 4]
+                now += elapsed
+                for owner in (reference, native):
+                    owner.begin_frame(elapsed)
+                    owner.tick(now)
+                if frame in (20, 40, 60):
+                    hulls = [(5, -1.0, 5.0, 0.8, 3.5, 1.7)] if frame != 40 else []
+                    reference.grid.set_static_hulls(hulls)
+                    native.grid.set_static_hulls(hulls)
+                for bot in range(1, 9):
+                    current, goal = positions[bot], goals[bot]
+                    key = ('route', bot % 2 + 1, 'test_lane', frame // 23) if bot < 5 else ('local', bot, 'combat', frame // 29)
+                    movement = not (frame % 11 == 0)
+                    anchor = current if bot % 3 == 0 else None
+                    if frame % 3 == 0:
+                        direct = (((current[0]-goal[0])**2 + (current[2]-goal[2])**2)**0.5 <= 15.0 and
+                                  not reference.bot_segment_penalized(bot, current, goal, now) and
+                                  reference.grid.dry_segment_clear(current, goal, now))
+                        if direct:
+                            expected = tuple(reference.observe_direct_target(bot, current, goal, key, now, movement) or goal)
+                        else:
+                            expected = reference.next_target(bot, current, goal, key, now, anchor, None, 20.0, movement)
+                        stop = bool(bot % 2)
+                        expected_stop = stop and ((direct and expected == tuple(goal)) or
+                                                 (not direct and reference.target_is_terminal(bot)))
+                        actual, actual_stop = native.motion_target(bot, current, goal, key, now, anchor, 20.0, movement, stop)
+                        if expected_stop != actual_stop:
+                            raise AssertionError((seed, frame, bot, 'terminal target', expected_stop, actual_stop))
+                    else:
+                        expected = reference.next_target(bot, current, goal, key, now,
+                                                         anchor, None, 20.0, movement)
+                        actual = native.next_target(bot, current, goal, key, now,
+                                                    anchor, None, 20.0, movement)
+                    if expected != actual:
+                        raise AssertionError((seed, frame, bot, 'target', expected, actual))
+                    operations += 1
+                    for name, values in (
+                        ('report_blocked_step', (bot, current, actual, now)),
+                        ('bot_segment_penalized', (bot, current, goal, now)),
+                        ('controlled_shallow_step', (bot, current, frame * 0.17)),
+                        ('controlled_shallow_committed', (bot, current, frame * 0.17)),
+                        ('target_is_terminal', (bot,)),
+                    ):
+                        expected_value = getattr(reference, name)(*values)
+                        actual_value = getattr(native, name)(*values)
+                        if expected_value != actual_value:
+                            raise AssertionError((seed, frame, bot, name, expected_value, actual_value))
+                        operations += 1
+                    # Some hulls remain stationary to exercise stall and
+                    # repeated-blocked transitions; others consume the route.
+                    if bot % 3 and movement:
+                        positions[bot] = tuple(current[i] + (actual[i] - current[i]) * 0.14 for i in range(3))
+                for owner in (reference, native):
+                    owner.end_frame()
+                active_keys = set(native.paths) | set(native.searches)
+                if native.search_next_key is not None:
+                    active_keys.add(native.search_next_key)
+                if set(native._native_keys.values()) != active_keys:
+                    raise AssertionError(('retired navigation cache identities', seed, frame, set(native._native_keys.values()) - active_keys))
+                found = difference(reference_state(reference), native_state(native))
+                if found:
+                    raise AssertionError((seed, frame, found))
+                expected = reference.fallback_diagnostics(range(1, 9), now)
+                actual = native.fallback_diagnostics(range(1, 9), now)
+                if expected != actual:
+                    raise AssertionError((seed, frame, 'diagnostics', difference(expected, actual)))
+            # A direct route has its own progress lease. Keep the request and
+            # pose fixed long enough to select and expire a real safe escape.
+            for frame in range(100):
+                now += 0.5
+                current, goal = positions[1], goals[1]
+                key = ('local', 91, 'direct_test')
+                expected = reference.observe_direct_target(91, current, goal, key, now, frame % 41 != 0)
+                actual = native.observe_direct_target(91, current, goal, key, now, frame % 41 != 0)
+                if expected != actual:
+                    raise AssertionError((seed, frame, 'direct', expected, actual))
+                active_keys = set(native.paths) | set(native.searches)
+                if native.search_next_key is not None:
+                    active_keys.add(native.search_next_key)
+                if set(native._native_keys.values()) != active_keys:
+                    raise AssertionError(('retired navigation cache identities', seed, frame, set(native._native_keys.values()) - active_keys))
+                found = difference(reference_state(reference), native_state(native))
+                if found:
+                    raise AssertionError((seed, frame, 'direct_state', found))
+            native.close()
+        print('Exact native navigation: %d operations and %d complete frame-state comparisons.' %
+              (operations, args.cases * (args.frames + 100)))
+    finally:
+        backend.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/ffi_experiment/check_navigation_grid.py
+++ b/tools/ffi_experiment/check_navigation_grid.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+"""Differential native navigation guards, hazards, smoothing and recovery."""
+from __future__ import print_function
+
+import argparse
+import random
+
+from check_parity import nav, random_graph, ground_for
+from navigation_adapter import Backend
+from navigation_flow_adapter import NativeGrid
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--module', required=True)
+    parser.add_argument('--cases', type=int, default=150)
+    args = parser.parse_args()
+    backend = Backend(args.module)
+    checks = 0
+    try:
+        for seed in range(args.cases):
+            rng = random.Random(seed)
+            graph = random_graph(rng)
+            original = nav.TerrainGrid(ground_for(graph), baked_graph=graph)
+            original.bounds = (-20.0, -25.0, 27.0, 21.0) if seed % 2 else None
+            original._failed_edges = {((0, 0), (1, 0)): (2.0, 240.0)}
+            original._static_hull_edges = {((1, 1), (2, 1)): 240.0}
+            native = NativeGrid(backend, original, nav)
+            def check(name, *values):
+                expected = getattr(original, name)(*values)
+                actual = getattr(native, name)(*values)
+                if expected != actual:
+                    raise AssertionError((seed, name, values, expected, actual))
+            for unused in range(20):
+                points = [original.point_for((rng.randrange(-2, 15), rng.randrange(-2, 13)),
+                                             rng.uniform(-2.0, 2.0)) for i in range(5)]
+                a, b = points[:2]
+                yaw, now = rng.uniform(-3.14, 3.14), rng.choice((0.0, 1.0, 2.0, 5.0))
+                # Time advances independently in each owner's failure map.
+                for name, values in (
+                    ('_ground', (a[0], a[2], a[1])),
+                    ('segment_clear', (a, b)),
+                    ('dry_segment_clear', (a, b, now)),
+                    ('segment_has_baked_hazard', (a, b, 4)),
+                    ('segment_has_motion_hazard', (a, b, 3)),
+                    ('point_has_baked_hazard', (a, 7)),
+                    ('baked_hazard_near', (a, 2)),
+                    ('near_baked_navigation', (a, 2)),
+                    ('hull_pose_clear', (a, yaw, 3.5, 1.7)),
+                    ('local_corridor', (a,)),
+                    ('segment_penalty', (a, b, now)),
+                    ('_baked_segment_cells', (a, b, True)),
+                    ('_baked_segment_cells', (a, b, False)),
+                    ('baked_hazard_cells', (a, b, 4)),
+                    ('_smooth', (tuple(points), now, bool(seed % 2), original._static_hull_edges)),
+                    ('safe_local_target', (a, b, now, points[2:], -1.0, None, 0.4)),
+                    ('path_has_edge_penalty', (points, original._static_hull_edges)),
+                    ('_baked_clearance_exposure', (points,)),
+                    ('shortcut_preserves_climb_approach', (points, 0, 4)),
+                    ('live_shortcut_preserves_climb_approach', (a, points, 1, 4)),
+                    ('shortcut_preserves_baked_clearance', (points, 0, 4)),
+                    ('path_has_penalty', (points, now)),
+                    ('path_crosses_static_hull', (points,)),
+                    ('_edge_keys_for_segment', (a, b)),
+                    ('_baked_corridor', (a, b)),
+                ):
+                    check(name, *values)
+                    checks += 1
+            native.close()
+        print('Exact native baked geometry/recovery results: %d checks across %d maps.' % (checks, args.cases))
+    finally:
+        backend.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/ffi_experiment/check_parity.py
+++ b/tools/ffi_experiment/check_parity.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python
+"""Differential A* checks, runnable unchanged on CPython 2.7 and 3.
+
+Checks exact completed paths, paid-step completion timing, and live penalty
+expiry across synthetic disconnected/risk-weighted graphs and shipped maps.
+No approximation tolerance or changed expansion budget is accepted.
+"""
+from __future__ import print_function
+import argparse
+import json
+import math
+import os
+import random
+import sys
+import types
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+CLIENT = os.path.join(ROOT, 'src', 'res', 'scripts', 'client', 'gui', 'mods', 'offline_lan_0922')
+for name, path in [('gui', CLIENT), ('gui.mods', CLIENT),
+                   ('gui.mods.offline_lan_0922', CLIENT),
+                   ('gui.mods.offline_lan_0922.ai', os.path.join(CLIENT, 'ai'))]:
+    module = types.ModuleType(name)
+    module.__path__ = [path]
+    sys.modules[name] = module
+from gui.mods.offline_lan_0922.ai import navigation as nav
+from navigation_adapter import Backend
+
+
+def ground_for(graph):
+    def ground(x, z, unused_hint=0.0):
+        ix = int(math.floor((x - graph['origin'][0]) / graph['cell_size'] + 0.5))
+        iz = int(math.floor((z - graph['origin'][1]) / graph['cell_size'] + 0.5))
+        if 0 <= ix < graph['width'] and 0 <= iz < graph['height']:
+            height = graph['heights_mm'][iz * graph['width'] + ix]
+            return None if height is None else float(height) / 1000.0
+        return None
+    return ground
+
+
+def random_graph(rng, width=13, height=11):
+    heights = [None if rng.random() < 0.18 else rng.randrange(-1000, 1001)
+               for unused in range(width * height)]
+    return dict(format=nav.BAKED_FORMAT_NAME, version=nav.BAKED_FORMAT_VERSION,
+                width=width, height=height, origin=[-17.0, -23.0], cell_size=4.0,
+                heights_mm=heights, links=[rng.randrange(256) for unused in heights],
+                hazards=[rng.choice((0, 0, 0, 1, 2, 4, 4)) for unused in heights],
+                bake={'max_grade': 0.3})
+
+
+def check(backend, graph, seed, maximum=1600):
+    rng = random.Random(seed)
+    ground = ground_for(graph)
+    grids = [nav.TerrainGrid(ground, baked_graph=graph) for unused in range(2)]
+    points = []
+    for unused in range(2):
+        x = rng.randrange(-2, graph['width'] + 2)
+        z = rng.randrange(-2, graph['height'] + 2)
+        points.append(grids[0].point_for((x, z), 0.0))
+    avoid = [grids[0].point_for((rng.randrange(graph['width']), rng.randrange(graph['height'])), 0)
+             for unused in range(seed % 4)]
+    local = [{}, {}]
+    hard = [set(), set()]
+    for grid in grids:
+        grid._failed_edges[((0, 0), (1, 0))] = (2.0 if seed % 2 else 10.0, 240.0)
+        grid._static_hull_edges[((1, 1), (2, 1))] = 240.0
+    params = (points[0], points[1], avoid, maximum, 5.0, seed % 2 == 0)
+    reference = backend.original_begin(grids[0], *(params + (local[0], hard[0])))
+    candidate = grids[1].begin_plan(*(params + (local[1], hard[1])))
+    step_count = 0
+    while not reference.done:
+        budget = (1, 3, 11, 2)[step_count % 4]
+        if step_count == 2:
+            for index in (0, 1):
+                local[index][((2, 2), (3, 2))] = 120.0
+                hard[index].add(((3, 3), (4, 3)))
+                grids[index]._static_hull_edges[((4, 4), (5, 4))] = 480.0
+        reference.step(budget)
+        candidate.step(budget)
+        if reference.done != candidate.done:
+            raise AssertionError('completion frame differs seed=%s step=%s' % (seed, step_count))
+        if grids[0]._failed_edges != grids[1]._failed_edges:
+            raise AssertionError('failure expiry differs seed=%s step=%s' % (seed, step_count))
+        if reference.result != candidate.result:
+            raise AssertionError('path differs seed=%s step=%s\n%r\n%r' %
+                                 (seed, step_count, reference.result, candidate.result))
+        step_count += 1
+        if step_count > 200000:
+            raise AssertionError('search did not terminate')
+    return step_count
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--module', required=True)
+    parser.add_argument('--random-cases', type=int, default=200)
+    args = parser.parse_args()
+    original_begin = nav.TerrainGrid.__dict__['begin_plan']
+    original_advance = nav.TerrainNavigator.__dict__['_advance_searches']
+    backend = Backend(args.module).install(nav)
+    cases = steps = 0
+    try:
+        for seed in range(args.random_cases):
+            graph = random_graph(random.Random(seed))
+            maximum = (0, 1, 2, 15, 30, 100, 1600)[seed % 7]
+            steps += check(backend, graph, seed, maximum)
+            cases += 1
+        for map_name in ('01_karelia', '05_prohorovka', '59_asia_great_wall'):
+            with open(os.path.join(ROOT, 'navgraphs', map_name + '.json')) as stream:
+                graph = json.load(stream)
+            for seed in range(12):
+                steps += check(backend, graph, seed + 500, (30, 1600, 2500)[seed % 3])
+                cases += 1
+        # Cancel after allocation and repeat cleanup.
+        grid = nav.TerrainGrid(lambda *unused: 0.0, baked_graph=random_graph(random.Random(3)))
+        cancelled = grid.begin_plan((0, 0, 0), (4, 0, 4))
+        cancelled.ensure_started()
+        cancelled.close()
+        cancelled.close()
+        for invalid in ([99], [3, 999999, 0, 0, 1, 0, 0], [5, 1, 1, 0, 0, 0, 0, 0, 999999]):
+            try:
+                backend.call(invalid)
+            except RuntimeError:
+                pass
+            else:
+                raise AssertionError('invalid command was accepted')
+    finally:
+        backend.close()
+        backend.close()
+    assert nav.TerrainGrid.__dict__['begin_plan'] is original_begin
+    assert nav.TerrainNavigator.__dict__['_advance_searches'] is original_advance
+    print(json.dumps({'cases': cases, 'paid_batches': steps,
+                      'exact_path_and_completion_parity': True,
+                      'python': sys.version}, sort_keys=True))
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/ffi_experiment/check_perception_parity.py
+++ b/tools/ffi_experiment/check_perception_parity.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+"""Differential visibility fairness, fire edges, memory and phase tests."""
+from __future__ import print_function
+import argparse
+import random
+
+from check_core_parity import equal
+from navigation_adapter import Backend
+from perception_adapter import PerceptionBackend
+from portable_workload import load_fixture, Path, ROOT, redirected
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--module', required=True)
+    parser.add_argument('--fixture', required=True)
+    args = parser.parse_args()
+    fixture = load_fixture(args.fixture)
+    rt = fixture['fixtures']._load()
+    backend = Backend(args.module)
+    with redirected():
+        random.seed(17)
+        first, unused = fixture['make_runtime'](Path(ROOT), '59_asia_great_wall', 'combat')
+        random.seed(17)
+        second, unused = fixture['make_runtime'](Path(ROOT), '59_asia_great_wall', 'combat')
+    for runtime in (first, second):
+        runtime.states = dict((key, value) for key, value in runtime.states.items()
+                              if key in (11, 12, 13, 26, 27, 28))
+    # One guaranteed two-pair native budget forces priority changes and debt.
+    old_budget = rt.MAX_VISIBILITY_PROBES_PER_FRAME
+    rt.MAX_VISIBILITY_PROBES_PER_FRAME = 2
+    native = PerceptionBackend(backend, second, rt)
+    total = 0
+    try:
+        for frame in range(180):
+            now = 100.0 + frame * 0.13
+            logs = [[], []]
+            players = [[fixture['wire_player'](
+                1, team=1, vehicle='ussr:R11_MS-1', alive=True,
+                x=0.0, y=0.0, z=120.0, speed=0.0, fire_seq=frame // 9),
+                fixture['wire_player'](
+                2, team=2, vehicle='ussr:R11_MS-1', alive=True,
+                x=30.0, y=0.0, z=370.0, speed=3.0, fire_seq=frame // 5)]
+                for unused in range(2)]
+            for side, runtime in enumerate((first, second)):
+                def probe(source, target, fired=False, side=side):
+                    logs[side].append((source.get('kind', 'bot'), source['id'],
+                                       target['kind'], target['network_id'],
+                                       tuple(target['position']), fired))
+                    if frame % 13 == 0:
+                        raise RuntimeError('deterministic unavailable LOS')
+                    return dict(line_of_sight=frame < 40 or frame > 140,
+                                foliage_bonus=0.1 if frame % 3 else 0.0)
+                runtime.visibility_probe = probe
+                for index, key in enumerate(sorted(runtime.states)):
+                    s = runtime.states[key]
+                    s.update(x=float(index % 3) * 30.0, y=float(index),
+                             z=100.0 if index < 3 else (140.0 if frame % 9 == 0 else 390.0),
+                             speed=0.0 if frame % 4 else 3.0,
+                             fire_seq=frame // 7 if frame < 90 else (frame - 90) // 11,
+                             alive=not (key == 28 and 60 <= frame < 70))
+                    if frame % 5:
+                        runtime._server_orders[key]['target_id'] = 26 if key < 26 else 11
+                runtime._begin_visibility_frame()
+                runtime._prepare_visibility_frame(players[side], now, frame % 2 == 0)
+            ticks = [{}, {}]
+            teams = [{}, {}]
+            if frame % 2 == 0:
+                observations = [{}, {}]
+                for side, runtime in enumerate((first, second)):
+                    runtime._append_human_observations(
+                        players[side], now, observations[side], teams[side], ticks[side])
+                equal(observations[1], observations[0], 'human priority observations')
+            processed = set()
+            for key in sorted(first.states):
+                results = []
+                for side, runtime in enumerate((first, second)):
+                    results.append(runtime._contacts_for(runtime.states[key], players[side], now,
+                                                         teams[side], ticks[side], processed))
+                equal(results[1], results[0], 'contacts frame=%d source=%d' % (frame, key))
+                equal(teams[1], teams[0], 'shared team flags')
+                # The next observer must see this post-motion pose, including
+                # missing optional articulation in a newly remembered sample.
+                for runtime in (first, second):
+                    runtime.states[key]['x'] += 2.5
+                    if frame % 6 == 0:
+                        runtime.states[key].pop('velocity', None)
+                processed.add(key)
+                total += 1
+            for runtime in (first, second):
+                runtime._finish_visibility_frame()
+            equal(logs[1], logs[0], 'visibility query sequence frame %d' % frame)
+            equal(second._visible_target_poses, first._visible_target_poses, 'remembered poses')
+            equal(second.diagnostic_totals(), first.diagnostic_totals(), 'fair scheduler counters')
+            for key in ((1, 'bot', 26), (2, 'bot', 11)):
+                equal(second._team_spot_time_left(key, now), first._team_spot_time_left(key, now), 'memory expiry')
+            if frame == 95:
+                # Same lifecycle identity replacement performed by battle
+                # reset; the next native frame must retire all old state.
+                for runtime in (first, second):
+                    runtime._visibility_cache = {}
+                    runtime._visibility_fire = {}
+                    runtime._visibility_waiting = []
+                    runtime._visibility_frame = None
+                    runtime._spot_until = {}
+                    runtime._visible_target_poses = {}
+                    runtime._reset_visibility_diagnostics()
+        # Human observers use the same cache/fair budget via the singleton
+        # entry point; test their identity separately without an engine model.
+        source = dict(kind='human', id=1, team=1, x=0.0, y=0.0, z=0.0)
+        target = dict(kind='bot', id=26, network_id=26, team=2,
+                      position=(40.0, 100.0, 0.0), fire_seq=0)
+        equal(second._visible(source, target, 200.0), first._visible(source, target, 200.0), 'human proximity')
+        equal(second._visible(source, target, 200.1), first._visible(source, target, 200.1), 'human cache')
+        for runtime in (first, second):
+            runtime._renew_team_spot((1, 'bot', 26), 200.0, 12.0)
+        for now in (200.0, 210.0, 211.9, 212.0):
+            equal(second._team_spot_time_left((1, 'bot', 26), now),
+                  first._team_spot_time_left((1, 'bot', 26), now), 'designated lease')
+        print('Exact perception parity: %d Bot contact batches plus 180 human observer slices; fair debt, human/selected/fire priorities, fire/reset edges, motion phases, hidden memory, probe failure and human cache/lease.' % total)
+    finally:
+        native.close()
+        rt.MAX_VISIBILITY_PROBES_PER_FRAME = old_budget
+        backend.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/ffi_experiment/check_query_bridge.py
+++ b/tools/ffi_experiment/check_query_bridge.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+"""Check synchronous callback failures, non-reentrancy and result ownership."""
+from __future__ import print_function
+
+import argparse
+import threading
+from array import array
+
+from navigation_adapter import Backend
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--module', required=True)
+    args = parser.parse_args()
+    backend = Backend(args.module)
+    query = array('d', [0.0] * 16)
+    command = [405, 0, 0, 0, 0, 1, 1.7, 3.5, 3.5, 0, 0.1, 0, 0, 0, 0]
+    counts = [0, 0]
+    nested_counts = [0]
+    nested_packet = array('d', [0.0] * 16)
+
+    def nested():
+        nested_counts[0] += 1
+        nested_packet[:8] = array('d', [0.0] * 8)
+
+    class Result(object):
+        def __del__(self):
+            counts[1] += 1
+
+    def complete():
+        counts[0] += 1
+        if counts[0] == 1:
+            try:
+                backend.call_sync(command, query, nested)
+            except RuntimeError as exc:
+                assert 'status=18' in str(exc)
+            else:
+                raise AssertionError('aliased nested query buffer was admitted')
+            failures = []
+            def other_thread():
+                try:
+                    backend.call(command)
+                except RuntimeError as exc:
+                    failures.append('status=18' in str(exc))
+            thread = threading.Thread(target=other_thread)
+            thread.start()
+            thread.join()
+            assert failures == [True], failures
+            backend.call_sync(command, nested_packet, nested)
+        # Callback entry must not permit a reset of its active native owner.
+        try:
+            backend.call([0])
+        except RuntimeError as exc:
+            assert 'status=18' in str(exc)
+        else:
+            raise AssertionError('nested reset was admitted')
+        query[:8] = array('d', [0.0] * 8)
+        return Result()
+
+    class EngineFailure(Exception):
+        pass
+
+    def fail():
+        raise EngineFailure('original engine failure')
+
+    try:
+        alias = array('d', command + [0.0])
+        try:
+            backend.call_sync(alias, alias, fail)
+        except RuntimeError as exc:
+            assert 'status=18' in str(exc)
+        else:
+            raise AssertionError('overlapping owned buffers were admitted')
+        for unused in range(20):
+            try:
+                backend.call_sync(command, query, fail)
+            except EngineFailure as exc:
+                assert str(exc) == 'original engine failure'
+            else:
+                raise AssertionError('callback exception was lost')
+            # Failure releases the borrowed provider, allowing the next call.
+            backend.call_sync(command, query, complete)
+        assert counts[0] == 200 and counts[0] == counts[1], counts
+        assert nested_counts[0] == 10, nested_counts
+        backend.call([0])
+        print('Callback exception identity, reset rejection, cleanup and %d result releases passed.' % counts[1])
+    finally:
+        backend.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/ffi_experiment/check_world_parity.py
+++ b/tools/ffi_experiment/check_world_parity.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Exercise native world sweep requests against existing physical scenarios."""
+import argparse
+import sys
+import unittest
+from pathlib import Path
+
+from navigation_adapter import Backend
+from world_adapter import WorldBackend
+from world_trace import Recorder
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--module', required=True)
+    args = parser.parse_args()
+    sys.path.insert(0,str(Path(__file__).resolve().parents[2]/'tests'))
+    import test_port_0922_world_collision as tests
+    backend = Backend(args.module)
+    shadow = Recorder(backend)
+    # This one source test replaces the entire ground-profile computation
+    # with invented heights, so its native leaf tape is intentionally absent.
+    # Keep its original assertion. Other physical scenes still exercise
+    # diagonal sweeps, pitched lanes, terrain profiles and exact-top checks.
+    replaced = 'test_diagonal_drivable_profile_samples_the_hit_corner_segment'
+    names = unittest.defaultTestLoader.getTestCaseNames(tests.WorldCollisionTests)
+    try:
+        suite = unittest.TestSuite(tests.WorldCollisionTests(name) for name in names if name != replaced)
+        result = unittest.TextTestRunner(verbosity=1).run(suite)
+        count = len(shadow.traces)
+        shadow.close()
+        source_result = unittest.TextTestRunner(verbosity=1).run(
+            unittest.TestSuite([tests.WorldCollisionTests(replaced)]))
+        native = WorldBackend(backend)
+        try:
+            live_result = unittest.TextTestRunner(verbosity=1).run(
+                unittest.TestSuite(tests.WorldCollisionTests(name) for name in names if name != replaced))
+        finally:
+            native.close()
+        if not (result.wasSuccessful() and source_result.wasSuccessful() and live_result.wasSuccessful()):
+            raise SystemExit(1)
+        print('Exact native query/result traces: %d; %d physical tests pass both shadow and live adapters; one internal-helper mock remains a source-only test.' % (count,len(names)-1))
+    finally:
+        shadow.close()
+        backend.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/ffi_experiment/check_world_parity.py
+++ b/tools/ffi_experiment/check_world_parity.py
@@ -6,13 +6,14 @@ import unittest
 from pathlib import Path
 
 from navigation_adapter import Backend
-from world_adapter import WorldBackend
+from world_adapter import WorldBackend, SyncWorldBackend
 from world_trace import Recorder
 
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('--module', required=True)
+    parser.add_argument('--sync', action='store_true')
     args = parser.parse_args()
     sys.path.insert(0,str(Path(__file__).resolve().parents[2]/'tests'))
     import test_port_0922_world_collision as tests
@@ -31,7 +32,7 @@ def main():
         shadow.close()
         source_result = unittest.TextTestRunner(verbosity=1).run(
             unittest.TestSuite([tests.WorldCollisionTests(replaced)]))
-        native = WorldBackend(backend)
+        native = (SyncWorldBackend if args.sync else WorldBackend)(backend)
         try:
             live_result = unittest.TextTestRunner(verbosity=1).run(
                 unittest.TestSuite(tests.WorldCollisionTests(name) for name in names if name != replaced))

--- a/tools/ffi_experiment/combat_adapter.py
+++ b/tools/ffi_experiment/combat_adapter.py
@@ -1,0 +1,170 @@
+"""Opt-in complete numerical aiming experiment; Python owns engine seams.
+
+Profiles are transferred per descriptor identity. Numeric state is sampled at
+the original synchronous call site, after the exact muzzle/part queries. No
+query, firing intent, projectile event, or actor-order barrier is coalesced.
+"""
+from __future__ import print_function
+
+import math
+
+
+class CombatBackend(object):
+    def __init__(self, backend, runtime_module):
+        self.backend = backend
+        self.runtime = runtime_module
+        self.profiles = {}
+        self.originals = []
+        self.closed = False
+
+    def install(self):
+        cls = self.runtime.BotRuntime
+        owner = self
+
+        def ballistic(runtime, state, target, descriptor, shell_index):
+            return owner.ballistic(runtime, state, target, descriptor, shell_index)
+
+        def aim(runtime, state, command, target, step):
+            return owner.aim(runtime, state, command, target, step)
+
+        for name, replacement in (('_local_ballistic_solution', ballistic),
+                                  ('_update_gun_aim', aim)):
+            self.originals.append((cls, name, cls.__dict__[name], replacement))
+            setattr(cls, name, replacement)
+        return self
+
+    def close(self):
+        if self.closed:
+            return
+        for cls, name, original, replacement in reversed(self.originals):
+            if cls.__dict__.get(name) is replacement:
+                setattr(cls, name, original)
+        self.profiles.clear()
+        self.closed = True
+
+    def profile(self, descriptor):
+        cached = self.profiles.get(id(descriptor))
+        if cached is not None and cached[0] is descriptor:
+            return cached[1]
+        rt = self.runtime
+        gun = rt._value(descriptor, 'gun', {}) or {}
+        limits = rt._value(gun, 'pitchLimits')
+        kind, low, high = 0, 0.0, 0.0
+        curves = []
+        if isinstance(limits, dict) and all(name in limits for name in ('minPitch', 'maxPitch')):
+            try:
+                for name in ('minPitch', 'maxPitch'):
+                    points = rt.gun_pitch_limits._curve_points(limits[name])
+                    curves.append(len(points))
+                    for point in points:
+                        curves.extend(point)
+                kind = 2
+            except ValueError:
+                curves = []
+        else:
+            pair = rt._gun_pitch_limits(descriptor)
+            if pair is not None:
+                kind, low, high = 1, pair[0], pair[1]
+        yaw = rt.ai_driver.gun_yaw_limits(descriptor)
+        static_pitch = rt.BotRuntime._static_gun_value(descriptor, 'staticPitch')
+        static_yaw = rt.BotRuntime._static_gun_value(descriptor, 'staticTurretYaw')
+        try:
+            hydraulic = rt.hull_aiming.pitch_params(descriptor)
+        except ValueError:
+            hydraulic = None
+        hp = hydraulic or {}
+        packet = [100, kind, low, high, yaw[0], yaw[1], int(yaw[2]),
+                  int(static_pitch is not None), static_pitch or 0.0,
+                  int(static_yaw is not None), static_yaw or 0.0,
+                  int(hydraulic is not None), int(bool(hp.get('isAvailable'))),
+                  int(bool(hp.get('isEnabled'))), hp.get('minimum', 0.0),
+                  hp.get('maximum', 0.0), hp.get('speed', 0.0)] + curves
+        handle = int(self.backend.call(packet)[0])
+        self.profiles[id(descriptor)] = (descriptor, handle)
+        return handle
+
+    def pose(self, state):
+        rt = self.runtime
+        unused_devices, destroyed, unused_crew, unused_yellow = rt._critical_parts(state)
+        return [state.get('yaw', 0.0), state.get('pitch', 0.0),
+                state.get('roll', 0.0), rt.BotRuntime._terrain_pitch(state),
+                rt._number(state.get('suspension_pitch')),
+                state.get('turret_yaw', 0.0), state.get('gun_pitch', 0.0),
+                state.get('aim_yaw', state.get('yaw', 0.0)),
+                int(int(state.get('movement_dir', 0)) != 0),
+                int('engineHealth' in destroyed),
+                int(bool(destroyed.intersection(('leftTrackHealth', 'rightTrackHealth')))),
+                int(bool(state.get('_overturned', False))),
+                int(state.get('siege_state', rt.siege_mechanics.DISABLED))]
+
+    def ballistic(self, runtime, state, target, descriptor, shell_index):
+        rt = self.runtime
+        physical = rt._shot_ballistics(descriptor, shell_index)
+        if target is None or physical is None:
+            return None
+        speed, gravity, maximum = physical
+        start = runtime._exact_shot_origin(state, descriptor, shell_index)
+        if start is None:
+            return None
+        aim_token = None
+        if callable(runtime.direct_aim_point_probe):
+            selected = runtime.direct_aim_point_probe(state, target)
+            if not isinstance(selected, dict):
+                return None
+            try:
+                position = rt._water_sensor_vector(selected['aim_position'], 3, 'bot aim point')
+                aim_token = selected['aim_token']
+            except (KeyError, TypeError, ValueError):
+                return None
+        else:
+            raw = rt._point(target.get('position'), rt._position(target))
+            position = (raw[0], raw[1] + 1.0, raw[2])
+        packet = self.backend.call(
+            [101, self.profile(descriptor)] + self.pose(state) + list(start) +
+            list(position) + list(runtime._target_velocity(target)) +
+            [speed, gravity, -math.pi * 0.5, math.pi * 0.5, 0, 20.0, maximum] + [0] * 7)
+        result = packet[-7:]
+        if not result[0]:
+            return None
+        return dict(aim_position=tuple(result[1:4]), yaw=result[6], pitch=result[4],
+                    flight_time=result[5], arc='low', _origin=start, _aim_token=aim_token)
+
+    def aim(self, runtime, state, command, target, step):
+        rt = self.runtime
+        descriptor = runtime._descriptors.get(state['id'], {})
+        solution = command.get('_ballistic_solution')
+        if target is None and not isinstance(solution, dict):
+            desired_yaw = state.get('aim_yaw', state.get('yaw', 0.0))
+            world_pitch, horizontal = 0.0, 0.0
+        else:
+            fallback = target.get('position') if target is not None else rt._position(state)
+            position = rt._point(solution.get('aim_position') if isinstance(solution, dict)
+                                 else command.get('aim_position'), fallback)
+            origin = solution.get('_origin') if isinstance(solution, dict) else None
+            if not (isinstance(origin, (list, tuple)) and len(origin) == 3):
+                origin = runtime._exact_shot_origin(state, descriptor, state.get('shell_index', 0))
+            if origin is None:
+                state['gun_aligned'] = False
+                return state.get('aim_yaw', 0.0), 0.0
+            dx, dz = position[0] - origin[0], position[2] - origin[2]
+            horizontal = math.sqrt(dx * dx + dz * dz)
+            desired_yaw = (solution.get('yaw', 0.0) if isinstance(solution, dict)
+                           else math.atan2(dx, dz) if horizontal > 0.1 else state.get('yaw', 0.0))
+            world_pitch = (solution.get('pitch', 0.0) if isinstance(solution, dict)
+                           else -math.atan2((position[1] + 1.0) - origin[1], max(0.5, horizontal)))
+        gun_state = runtime._gun_states.get(state['id'])
+        modifiers = gun_state.loadout if gun_state is not None else {}
+        turret = rt._value(descriptor, 'turret', {}) or {}
+        gun = rt._value(descriptor, 'gun', {}) or {}
+        turret_speed = (rt._rotation_speed(turret, 0.5) *
+                        max(0.0, modifiers.get('crew_factor', 1.0)) *
+                        rt._critical_factor(state, descriptor, 'turret_speed'))
+        gun_speed = rt._rotation_speed(gun, 0.35) * max(0.0, modifiers.get('gun_rotation_factor', 1.0))
+        result = self.backend.call(
+            [102, self.profile(descriptor)] + self.pose(state) +
+            [desired_yaw, world_pitch, step, int(target is not None), turret_speed, gun_speed] + [0] * 8)[-8:]
+        for index, key in enumerate(('terrain_pitch', 'suspension_pitch', 'pitch',
+                                     'turret_yaw', 'gun_pitch', 'desired_gun_pitch', 'aim_yaw')):
+            state[key] = result[index]
+        state['gun_aligned'] = bool(result[7])
+        return desired_yaw, horizontal

--- a/tools/ffi_experiment/combat_core.cpp
+++ b/tools/ffi_experiment/combat_core.cpp
@@ -1,0 +1,269 @@
+// Experimental numeric Bot aiming owner; no Python or engine objects.
+#include "combat_core.h"
+#include <algorithm>
+#include <cmath>
+#include <map>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+const double PI = 3.14159265358979323846;
+struct Reader {
+    double *b; int n, i;
+    Reader(double *p, int count) : b(p), n(count), i(1) {}
+    double next() {
+        if (i >= n || !std::isfinite(b[i])) throw std::invalid_argument("combat buffer");
+        return b[i++];
+    }
+    int integer() {
+        double v = next();
+        if (v < -1000000 || v > 1000000 || v != std::floor(v))
+            throw std::invalid_argument("combat integer");
+        return static_cast<int>(v);
+    }
+    void end() { if (i != n) throw std::invalid_argument("combat width"); }
+};
+double clamp(double v, double low, double high) { return std::max(low, std::min(high, v)); }
+double wrap(double v) {
+    while (v > PI) v -= 2.0 * PI;
+    while (v < -PI) v += 2.0 * PI;
+    return v;
+}
+struct Vec {
+    double x, y, z;
+    Vec(double a=0, double b=0, double c=0) : x(a), y(b), z(c) {}
+};
+Vec vector(Reader &r) { double x=r.next(), y=r.next(), z=r.next(); return Vec(x,y,z); }
+Vec rx(Vec v, double a) { double s=std::sin(a),c=std::cos(a); return Vec(v.x,c*v.y-s*v.z,s*v.y+c*v.z); }
+Vec ry(Vec v, double a) { double s=std::sin(a),c=std::cos(a); return Vec(c*v.x+s*v.z,v.y,-s*v.x+c*v.z); }
+Vec rz(Vec v, double a) { double s=std::sin(a),c=std::cos(a); return Vec(c*v.x-s*v.y,s*v.x+c*v.y,v.z); }
+Vec barrel(double yaw,double pitch) { double h=std::cos(pitch); return Vec(std::sin(yaw)*h,-std::sin(pitch),std::cos(yaw)*h); }
+typedef std::pair<double,double> Pair;
+Pair local_angles(Vec d,double yaw,double pitch,double roll) {
+    Vec v=rz(rx(ry(d,-yaw),-pitch),-roll);
+    double length=std::sqrt((0.0+v.x*v.x)+v.y*v.y+v.z*v.z);
+    if(length<=1e-12) throw std::invalid_argument("zero direction");
+    v.x/=length; v.y/=length; v.z/=length;
+    return Pair(std::atan2(v.x,v.z),-std::atan2(v.y,std::max(1e-12,std::sqrt(v.x*v.x+v.z*v.z))));
+}
+std::vector<Pair> roots(Vec s,Vec t,double speed,double gravity,double minimum,double maximum) {
+    std::vector<Pair> result;
+    double g=std::abs(gravity);
+    if(speed<=1.0 || g<=0.01) return result;
+    double dx=t.x-s.x,dz=t.z-s.z,h=std::sqrt(dx*dx+dz*dz);
+    if(h<=0.1) return result;
+    double dy=t.y-s.y, ss=speed*speed;
+    double disc=ss*ss-g*(g*h*h+2.0*dy*ss);
+    if(disc<0.0) return result;
+    double root=std::sqrt(std::max(0.0,disc));
+    double ns[]={ss-root,ss+root};
+    for(double numerator:ns) {
+        double elevation=std::atan(numerator/(g*h)),pitch=-elevation;
+        if(pitch<minimum-0.0001 || pitch>maximum+0.0001) continue;
+        double hs=speed*std::cos(elevation);
+        if(hs<=0.01) continue;
+        double time=h/hs;
+        if(time<=0.0 || time>20.0) continue;
+        if(result.empty() || std::abs(pitch-result.back().first)>0.00001) result.push_back(Pair(pitch,time));
+    }
+    std::stable_sort(result.begin(),result.end(),[](Pair a,Pair b){return a.second<b.second;});
+    return result;
+}
+bool intercept(Vec s,Vec t,Vec velocity,double speed,double gravity,double minimum,double maximum,
+               bool high,double max_time,Vec &aim,Pair &solution) {
+    aim=t; max_time=std::max(0.0,max_time);
+    for(int i=0;i<5;++i) {
+        std::vector<Pair> values=roots(s,aim,speed,gravity,minimum,maximum);
+        if(values.empty()) return false;
+        solution=high?values.back():values.front();
+        if(max_time && solution.second>max_time+1e-9) return false;
+        if(i<4) aim=Vec(t.x+velocity.x*solution.second,t.y+velocity.y*solution.second,t.z+velocity.z*solution.second);
+    }
+    return true;
+}
+float f32(double v) {
+    float f=static_cast<float>(v);
+    if(!std::isfinite(f)) throw std::invalid_argument("float32 overflow");
+    return f;
+}
+float add(float a,float b) {return f32(static_cast<double>(a)+b);}
+float sub(float a,float b) {return f32(static_cast<double>(a)-b);}
+float mul(float a,float b) {return f32(static_cast<double>(a)*b);}
+float divide(float a,float b) {
+    if(b==0) throw std::invalid_argument("duplicate curve node");
+    return f32(static_cast<double>(a)/b);
+}
+struct Profile {
+    int pitch_kind;
+    Pair pitch, yaw;
+    std::vector<Pair> low,high;
+    bool limited, has_static_pitch,has_static_yaw,has_hydraulic,available,enabled;
+    double static_pitch,static_yaw,minimum,maximum,speed;
+};
+std::map<int,Profile> profiles;
+int next_profile=1;
+float sample(float yaw,const std::vector<Pair> &points) {
+    size_t low=0,high=points.size()-1;
+    while(high-low>1) {
+        size_t middle=(low+high)/2;
+        if(yaw>points[middle].first) low=middle; else high=middle;
+    }
+    float span=sub(points[high].first,points[low].first);
+    float fraction=divide(sub(yaw,points[low].first),span);
+    return add(mul(points[low].second,sub(1.0f,fraction)),mul(points[high].second,fraction));
+}
+struct Pose {
+    double yaw,pitch,roll,terrain,correction,turret,gun,aim;
+    bool moving,engine,tracks,overturned; int siege;
+};
+bool switching(const Pose &s) { return s.siege==1 || s.siege==3; }
+bool limits(const Profile &p,const Pose &s,double yaw,Pair &result) {
+    if(p.has_static_pitch && (s.engine || s.overturned || switching(s))) {
+        result=Pair(p.static_pitch,p.static_pitch); return true;
+    }
+    if(!p.pitch_kind) return false;
+    if(p.pitch_kind==1) {result=p.pitch;return true;}
+    float y=f32(yaw); if(y<0.0f) y=add(y,f32(2.0*PI));
+    result=Pair(sample(y,p.low),sample(y,p.high)); return true;
+}
+bool active(const Profile &p,const Pose &s) {return p.has_hydraulic && p.available && p.enabled && s.siege==2;}
+int status(const Profile &p,const Pose &s,Vec d,double correction) {
+    Pair a=local_angles(d,s.yaw,s.terrain+correction,s.roll),l;
+    if(!limits(p,s,a.first,l)) return 2;
+    if(l.first>l.second) throw std::invalid_argument("inverted pitch limits");
+    return a.second<l.first-1e-8?-1:(a.second>l.second+1e-8?1:0);
+}
+Pair correction(const Profile &p,const Pose &s,double yaw,double pitch) {
+    Vec d=barrel(yaw,pitch);
+    double neutral=clamp(0.0,p.minimum,p.maximum);
+    int a=status(p,s,d,neutral);
+    if(a==2) return Pair(neutral,0);
+    if(a==0) return Pair(neutral,1);
+    double edge=a<0?p.minimum:p.maximum;
+    int b=status(p,s,d,edge);
+    if(b==2 || (a<0 && b<0) || (a>0 && b>0)) return Pair(edge,0);
+    double blocked=neutral,feasible=edge;
+    for(int i=0;i<48;++i) {
+        double candidate=(blocked+feasible)*0.5;
+        int c=status(p,s,d,candidate);
+        if(c==2) return Pair(edge,0);
+        if(c==a) blocked=candidate; else feasible=candidate;
+    }
+    return Pair(feasible,1);
+}
+bool reachable(const Profile &p,const Pose &s,double yaw,double pitch) {
+    if(active(p,s)) return correction(p,s,yaw,pitch).second!=0.0;
+    Pair a=local_angles(barrel(yaw,pitch),s.yaw,s.pitch,s.roll),l;
+    return limits(p,s,a.first,l) && l.first-0.0001<=a.second && a.second<=l.second+0.0001;
+}
+double slew(double current,double desired,double speed,double dt) {
+    double step=std::max(0.0,speed)*std::max(0.0,dt),diff=desired-current;
+    if(diff>step) return current+step;
+    if(diff<-step) return current-step;
+    return desired;
+}
+double gun_step(double current,double desired,const Profile &p,double speed,double dt,double rotation,Pair l) {
+    dt=std::max(0.0,dt);speed=std::max(0.0,speed);
+    if(speed==0.0) return current;
+    if(l.first>l.second) throw std::invalid_argument("inverted gun limits");
+    double bounded=clamp(desired,l.first,l.second);
+    if(std::abs(current-desired)<1e-6) return bounded;
+    double diff=bounded-current,step=speed*dt;
+    if(p.has_static_pitch) {
+        if(diff*(current-p.static_pitch)<0.0) step*=2.0;
+        rotation=std::max(0.0,rotation);
+        if(rotation>0.0) step=std::min(step,(std::abs(diff)/rotation)*dt);
+    }
+    if(diff>step) return current+step;
+    if(diff<-step) return current-step;
+    return bounded;
+}
+Pose pose(Reader &r) {
+    Pose s;
+    s.yaw=r.next();s.pitch=r.next();s.roll=r.next();s.terrain=r.next();
+    s.correction=r.next();s.turret=r.next();s.gun=r.next();s.aim=r.next();
+    s.moving=r.integer()!=0;s.engine=r.integer()!=0;s.tracks=r.integer()!=0;
+    s.overturned=r.integer()!=0;s.siege=r.integer();
+    return s;
+}
+Profile &profile(Reader &r) {
+    auto it=profiles.find(r.integer());
+    if(it==profiles.end()) throw std::invalid_argument("unknown aiming profile");
+    return it->second;
+}
+void read_curve(Reader &r,std::vector<Pair> &v) {
+    int count=r.integer();
+    if(count<2 || count>10000) throw std::invalid_argument("curve size");
+    for(int i=0;i<count;++i) {double x=f32(r.next()),y=f32(r.next());v.push_back(Pair(x,y));}
+}
+}
+void offline_combat_reset() {profiles.clear();}
+int offline_combat_dispatch(double *b,int n) {
+    Reader r(b,n);int op=static_cast<int>(b[0]);
+    if(op==100) {
+        Profile p;
+        p.pitch_kind=r.integer();p.pitch.first=r.next();p.pitch.second=r.next();
+        if(p.pitch_kind<0 || p.pitch_kind>2) throw std::invalid_argument("pitch kind");
+        p.yaw.first=r.next();p.yaw.second=r.next();p.limited=r.integer()!=0;
+        p.has_static_pitch=r.integer()!=0;p.static_pitch=r.next();
+        p.has_static_yaw=r.integer()!=0;p.static_yaw=r.next();
+        p.has_hydraulic=r.integer()!=0;p.available=r.integer()!=0;p.enabled=r.integer()!=0;
+        p.minimum=r.next();p.maximum=r.next();p.speed=r.next();
+        if(p.has_hydraulic && (p.minimum>p.maximum || p.speed<0)) throw std::invalid_argument("hydraulic params");
+        if(p.pitch_kind==2) {read_curve(r,p.low);read_curve(r,p.high);}
+        r.end();int id=next_profile++;profiles[id]=p;b[0]=id;return 0;
+    }
+    if(op==101 || op==103) {
+        // 101: one complete low-arc + physical gun reach calculation.
+        // 103: standalone intercept parity, including high-arc selection.
+        Profile *p=nullptr;Pose s={};
+        if(op==101) {p=&profile(r);s=pose(r);}
+        Vec start=vector(r),target=vector(r),velocity=vector(r);
+        double speed=r.next(),gravity=r.next(),minimum=r.next(),maximum=r.next();
+        bool high=r.integer()!=0;double max_time=r.next(),max_distance=r.next();
+        int out=r.i;if(n!=out+7) throw std::invalid_argument("intercept output width");
+        Vec aim;Pair solution;
+        bool valid=intercept(start,target,velocity,speed,gravity,minimum,maximum,high,max_time,aim,solution);
+        double yaw=0;
+        if(valid) {
+            yaw=std::atan2(aim.x-start.x,aim.z-start.z);
+            if(op==101 && (speed*solution.second>max_distance+1e-6 || !reachable(*p,s,yaw,solution.first))) valid=false;
+        }
+        b[out]=valid;
+        if(valid) {b[out+1]=aim.x;b[out+2]=aim.y;b[out+3]=aim.z;b[out+4]=solution.first;b[out+5]=solution.second;b[out+6]=yaw;}
+        return 0;
+    }
+    if(op==102) {
+        Profile &p=profile(r);Pose s=pose(r);
+        double desired_yaw=r.next(),world_pitch=r.next(),dt=r.next();
+        bool target=r.integer()!=0;
+        double turret_speed=r.next(),gun_speed=r.next();
+        int out=r.i;if(n!=out+8) throw std::invalid_argument("gun output width");
+        double desired_correction=active(p,s)?correction(p,s,desired_yaw,world_pitch).first:0.0;
+        s.correction=p.has_hydraulic?slew(clamp(s.correction,p.minimum,p.maximum),desired_correction,p.speed,dt):0.0;
+        s.pitch=s.terrain+s.correction;
+        Pair local=local_angles(barrel(desired_yaw,world_pitch),s.yaw,s.pitch,s.roll);
+        Pair yaw=p.yaw;
+        bool limited=p.limited;
+        if(p.has_static_yaw && (s.engine || s.tracks || s.overturned || s.moving || switching(s))) {
+            yaw=Pair(p.static_yaw,p.static_yaw);limited=true;
+        }
+        double relative=limited?clamp(local.first,yaw.first,yaw.second):local.first;
+        double step=turret_speed*dt;
+        s.turret=wrap(s.turret+clamp(wrap(relative-s.turret),-step,step));
+        if(limited) s.turret=clamp(s.turret,yaw.first,yaw.second);
+        double rotation=turret_speed>0.0?std::abs(s.turret-local.first)/turret_speed:0.0;
+        Pair pitch;bool has_limits=limits(p,s,s.turret,pitch);
+        double desired=has_limits?clamp(local.second,pitch.first,pitch.second):s.gun;
+        if(has_limits) s.gun=gun_step(s.gun,local.second,p,gun_speed,dt,rotation,pitch);
+        Vec d;
+        if(std::abs(s.pitch)<=1e-12 && std::abs(s.roll)<=1e-12) d=barrel(wrap(s.yaw+s.turret),s.gun);
+        else d=ry(rx(rz(barrel(s.turret,s.gun),s.roll),s.pitch),s.yaw);
+        s.aim=std::atan2(d.x,d.z);
+        bool aligned=has_limits && target && std::abs(wrap(local.first-s.turret))<=0.06 && std::abs(local.second-s.gun)<=0.04;
+        b[out]=s.terrain;b[out+1]=s.correction;b[out+2]=s.pitch;b[out+3]=s.turret;
+        b[out+4]=s.gun;b[out+5]=desired;b[out+6]=s.aim;b[out+7]=aligned;
+        return 0;
+    }
+    throw std::invalid_argument("combat opcode");
+}

--- a/tools/ffi_experiment/combat_core.cpp
+++ b/tools/ffi_experiment/combat_core.cpp
@@ -265,5 +265,9 @@ int offline_combat_dispatch(double *b,int n) {
         b[out+4]=s.gun;b[out+5]=desired;b[out+6]=s.aim;b[out+7]=aligned;
         return 0;
     }
+    if(op==104) {
+        Profile &p=profile(r);Pose s=pose(r);double yaw=r.next(),pitch=r.next();r.end();
+        b[0]=reachable(p,s,yaw,pitch);return 0;
+    }
     throw std::invalid_argument("combat opcode");
 }

--- a/tools/ffi_experiment/combat_core.h
+++ b/tools/ffi_experiment/combat_core.h
@@ -1,0 +1,5 @@
+#ifndef OFFLINE_COMBAT_CORE_H
+#define OFFLINE_COMBAT_CORE_H
+int offline_combat_dispatch(double *buffer, int count);
+void offline_combat_reset();
+#endif

--- a/tools/ffi_experiment/compare_runs.py
+++ b/tools/ffi_experiment/compare_runs.py
@@ -32,6 +32,8 @@ def main():
                         help='also measure native A* without the extra components')
     parser.add_argument('--stage-timing', action='store_true')
     parser.add_argument('--components', default='')
+    parser.add_argument('--control-components', default='',
+                        help='also run a native variant with this component subset')
     args = parser.parse_args()
     if args.include_astar_control and not args.components:
         parser.error('--include-astar-control requires --components')
@@ -39,6 +41,8 @@ def main():
     backends = ['python', 'native'] + (['native-step'] if args.include_step else [])
     if args.include_astar_control:
         backends.append('native-astar')
+    if args.control_components:
+        backends.append('native-control')
     reference = None
     waiting = []
     records = []
@@ -49,13 +53,15 @@ def main():
             output = args.output / ('%02d-%s.json' % (repeat, backend))
             command = [args.python, str(HERE / 'portable_workload.py'),
                        '--fixture', args.fixture, '--backend',
-                       'native' if backend == 'native-astar' else backend,
+                       'native' if backend in ('native-astar', 'native-control') else backend,
                        '--module', args.module, '--map', args.map,
                        '--scenario', args.scenario, '--seconds', str(args.seconds),
                        '--fps', str(args.fps), '--output', str(output)]
             if args.stage_timing:
                 command.append('--stage-timing')
-            if backend not in ('python', 'native-astar') and args.components:
+            if backend == 'native-control':
+                command.extend(('--components', args.control_components))
+            elif backend not in ('python', 'native-astar') and args.components:
                 command.extend(('--components', args.components))
             result = subprocess.run(command, env=env, capture_output=True, text=True)
             if result.returncode:

--- a/tools/ffi_experiment/compare_runs.py
+++ b/tools/ffi_experiment/compare_runs.py
@@ -28,10 +28,17 @@ def main():
     parser.add_argument('--seconds', type=float, default=30)
     parser.add_argument('--fps', type=float, default=15)
     parser.add_argument('--include-step', action='store_true')
+    parser.add_argument('--include-astar-control', action='store_true',
+                        help='also measure native A* without the extra components')
     parser.add_argument('--stage-timing', action='store_true')
+    parser.add_argument('--components', default='')
     args = parser.parse_args()
+    if args.include_astar_control and not args.components:
+        parser.error('--include-astar-control requires --components')
     args.output.mkdir(parents=True, exist_ok=False)
     backends = ['python', 'native'] + (['native-step'] if args.include_step else [])
+    if args.include_astar_control:
+        backends.append('native-astar')
     reference = None
     waiting = []
     records = []
@@ -41,16 +48,20 @@ def main():
         for backend in order:
             output = args.output / ('%02d-%s.json' % (repeat, backend))
             command = [args.python, str(HERE / 'portable_workload.py'),
-                       '--fixture', args.fixture, '--backend', backend,
+                       '--fixture', args.fixture, '--backend',
+                       'native' if backend == 'native-astar' else backend,
                        '--module', args.module, '--map', args.map,
                        '--scenario', args.scenario, '--seconds', str(args.seconds),
                        '--fps', str(args.fps), '--output', str(output)]
             if args.stage_timing:
                 command.append('--stage-timing')
+            if backend not in ('python', 'native-astar') and args.components:
+                command.extend(('--components', args.components))
             result = subprocess.run(command, env=env, capture_output=True, text=True)
             if result.returncode:
                 raise RuntimeError(result.stdout + result.stderr)
             report = json.loads(output.read_text())
+            report['backend'] = backend
             snapshot = report.pop('snapshot')
             if backend == 'python' and reference is None:
                 reference = snapshot

--- a/tools/ffi_experiment/compare_runs.py
+++ b/tools/ffi_experiment/compare_runs.py
@@ -31,6 +31,8 @@ def main():
     parser.add_argument('--include-astar-control', action='store_true',
                         help='also measure native A* without the extra components')
     parser.add_argument('--stage-timing', action='store_true')
+    parser.add_argument('--profile-module',
+                        help='also compare a host --profile build with observation off and on')
     parser.add_argument('--components', default='')
     parser.add_argument('--control-components', default='',
                         help='also run a native variant with this component subset')
@@ -42,12 +44,16 @@ def main():
         parser.error('--control-module/--control-runner require --control-components')
     if args.include_astar_control and not args.components:
         parser.error('--include-astar-control requires --components')
+    if args.profile_module and not args.components:
+        parser.error('--profile-module requires --components')
     args.output.mkdir(parents=True, exist_ok=False)
     backends = ['python', 'native'] + (['native-step'] if args.include_step else [])
     if args.include_astar_control:
         backends.append('native-astar')
     if args.control_components:
         backends.append('native-control')
+    if args.profile_module:
+        backends.extend(('native-profile-off', 'native-profile-on'))
     reference = None
     waiting = []
     records = []
@@ -60,14 +66,19 @@ def main():
                       else HERE / 'portable_workload.py')
             module = (args.control_module if backend == 'native-control' and args.control_module
                       else args.module)
+            if backend.startswith('native-profile-'):
+                module = args.profile_module
             command = [args.python, str(runner),
                        '--fixture', args.fixture, '--backend',
-                       'native' if backend in ('native-astar', 'native-control') else backend,
+                       'native' if backend in ('native-astar', 'native-control',
+                                               'native-profile-off', 'native-profile-on') else backend,
                        '--module', module, '--map', args.map,
                        '--scenario', args.scenario, '--seconds', str(args.seconds),
                        '--fps', str(args.fps), '--output', str(output)]
             if args.stage_timing:
                 command.append('--stage-timing')
+            if backend == 'native-profile-on':
+                command.append('--boundary-profile')
             if backend == 'native-control':
                 command.extend(('--components', args.control_components))
             elif backend not in ('python', 'native-astar') and args.components:
@@ -117,6 +128,22 @@ def main():
                   limitations=['Linux host CPU timings, not #1513 Windows frame pacing',
                                'Synthetic 29-Bot scene and deterministic native-query fakes',
                                'Projectile launches acknowledged; terminals are not simulated'])
+    if args.profile_module:
+        zones = ('native_core', 'python_callbacks', 'callback_bridge', 'python_outer')
+        observed = [row['boundary_profile'] for row in records if row['backend'] == 'native-profile-on']
+        means = {zone: statistics.mean(row[zone] for row in observed) for zone in zones}
+        total = sum(means.values())
+        plain = summaries['native']['median_cpu_seconds']
+        off = summaries['native-profile-off']['median_cpu_seconds']
+        on = summaries['native-profile-on']['median_cpu_seconds']
+        result['boundary_attribution'] = dict(
+            mean_cpu_seconds=means,
+            percent={zone: 100 * value / total for zone, value in means.items()},
+            observer_enabled_delta_percent=100 * (on / off - 1),
+            observer_compiled_delta_percent=100 * (off / plain - 1),
+            note='Observed ownership zones include clock overhead; they are not irreducible costs. '
+                 'Python zones include builtins and native-query fakes. Callback rows are inclusive '
+                 'and can overlap when callbacks nest; only zones form a partition.')
     (args.output / 'summary.json').write_text(json.dumps(result, indent=2, sort_keys=True))
     print(json.dumps(summaries, indent=2, sort_keys=True), flush=True)
 

--- a/tools/ffi_experiment/compare_runs.py
+++ b/tools/ffi_experiment/compare_runs.py
@@ -34,7 +34,12 @@ def main():
     parser.add_argument('--components', default='')
     parser.add_argument('--control-components', default='',
                         help='also run a native variant with this component subset')
+    parser.add_argument('--control-module', help='frozen module for native-control')
+    parser.add_argument('--control-runner', type=Path,
+                        help='frozen portable_workload.py, including its adapters and source root')
     args = parser.parse_args()
+    if (args.control_module or args.control_runner) and not args.control_components:
+        parser.error('--control-module/--control-runner require --control-components')
     if args.include_astar_control and not args.components:
         parser.error('--include-astar-control requires --components')
     args.output.mkdir(parents=True, exist_ok=False)
@@ -51,10 +56,14 @@ def main():
         order = backends[repeat % len(backends):] + backends[:repeat % len(backends)]
         for backend in order:
             output = args.output / ('%02d-%s.json' % (repeat, backend))
-            command = [args.python, str(HERE / 'portable_workload.py'),
+            runner = (args.control_runner if backend == 'native-control' and args.control_runner
+                      else HERE / 'portable_workload.py')
+            module = (args.control_module if backend == 'native-control' and args.control_module
+                      else args.module)
+            command = [args.python, str(runner),
                        '--fixture', args.fixture, '--backend',
                        'native' if backend in ('native-astar', 'native-control') else backend,
-                       '--module', args.module, '--map', args.map,
+                       '--module', module, '--map', args.map,
                        '--scenario', args.scenario, '--seconds', str(args.seconds),
                        '--fps', str(args.fps), '--output', str(output)]
             if args.stage_timing:
@@ -68,6 +77,8 @@ def main():
                 raise RuntimeError(result.stdout + result.stderr)
             report = json.loads(output.read_text())
             report['backend'] = backend
+            report['runner'] = str(runner.resolve())
+            report['module'] = str(Path(module).resolve()) if backend != 'python' else None
             snapshot = report.pop('snapshot')
             if backend == 'python' and reference is None:
                 reference = snapshot

--- a/tools/ffi_experiment/compare_runs.py
+++ b/tools/ffi_experiment/compare_runs.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Run sequential, rotating-order workload comparisons and check all outputs.
+
+Every run has its own process and is compared with the unmodified Python
+implementation's complete snapshot. Timing excludes process/fixture startup;
+native map transfer is reported separately and included in the cold total.
+"""
+import argparse
+import json
+import os
+from pathlib import Path
+import statistics
+import subprocess
+import sys
+
+HERE = Path(__file__).resolve().parent
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--python', required=True)
+    parser.add_argument('--module', required=True)
+    parser.add_argument('--fixture', required=True)
+    parser.add_argument('--output', type=Path, required=True)
+    parser.add_argument('--rounds', type=int, default=7)
+    parser.add_argument('--map', default='59_asia_great_wall')
+    parser.add_argument('--scenario', default='combat')
+    parser.add_argument('--seconds', type=float, default=30)
+    parser.add_argument('--fps', type=float, default=15)
+    parser.add_argument('--include-step', action='store_true')
+    parser.add_argument('--stage-timing', action='store_true')
+    args = parser.parse_args()
+    args.output.mkdir(parents=True, exist_ok=False)
+    backends = ['python', 'native'] + (['native-step'] if args.include_step else [])
+    reference = None
+    waiting = []
+    records = []
+    env = dict(os.environ, PYTHONDONTWRITEBYTECODE='1')
+    for repeat in range(args.rounds):
+        order = backends[repeat % len(backends):] + backends[:repeat % len(backends)]
+        for backend in order:
+            output = args.output / ('%02d-%s.json' % (repeat, backend))
+            command = [args.python, str(HERE / 'portable_workload.py'),
+                       '--fixture', args.fixture, '--backend', backend,
+                       '--module', args.module, '--map', args.map,
+                       '--scenario', args.scenario, '--seconds', str(args.seconds),
+                       '--fps', str(args.fps), '--output', str(output)]
+            if args.stage_timing:
+                command.append('--stage-timing')
+            result = subprocess.run(command, env=env, capture_output=True, text=True)
+            if result.returncode:
+                raise RuntimeError(result.stdout + result.stderr)
+            report = json.loads(output.read_text())
+            snapshot = report.pop('snapshot')
+            if backend == 'python' and reference is None:
+                reference = snapshot
+                for previous in waiting:
+                    if previous != reference:
+                        raise RuntimeError('pre-reference candidate changed behavior')
+                waiting.clear()
+            if reference is None:
+                waiting.append(snapshot)
+            elif snapshot != reference:
+                for key in reference:
+                    if snapshot[key] != reference[key]:
+                        raise RuntimeError('%s changed %s' % (output.name, key))
+                raise RuntimeError('%s changed snapshot keys' % output.name)
+            report['round'] = repeat
+            report['order'] = order.index(backend)
+            report['cold_cpu_seconds'] = report['cpu_seconds'] + report['initialization_cpu_seconds']
+            records.append(report)
+            print('%02d %-11s cpu=%.6f init=%.6f parity=equal' % (
+                repeat, backend, report['cpu_seconds'], report['initialization_cpu_seconds']), flush=True)
+    summaries = {}
+    for backend in backends:
+        rows = [row for row in records if row['backend'] == backend]
+        summaries[backend] = {
+            'median_cpu_seconds': statistics.median(row['cpu_seconds'] for row in rows),
+            'min_cpu_seconds': min(row['cpu_seconds'] for row in rows),
+            'max_cpu_seconds': max(row['cpu_seconds'] for row in rows),
+            'median_cold_cpu_seconds': statistics.median(row['cold_cpu_seconds'] for row in rows),
+            'median_initialization_cpu_seconds': statistics.median(row['initialization_cpu_seconds'] for row in rows),
+        }
+    original = summaries['python']['median_cpu_seconds']
+    for backend in backends:
+        summaries[backend]['cpu_reduction_percent'] = 100 * (1 - summaries[backend]['median_cpu_seconds'] / original)
+    result = dict(records=records, summary=summaries, snapshot_parity=True,
+                  reference='unmodified production Python code',
+                  limitations=['Linux host CPU timings, not #1513 Windows frame pacing',
+                               'Synthetic 29-Bot scene and deterministic native-query fakes',
+                               'Projectile launches acknowledged; terminals are not simulated'])
+    (args.output / 'summary.json').write_text(json.dumps(result, indent=2, sort_keys=True))
+    print(json.dumps(summaries, indent=2, sort_keys=True), flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/ffi_experiment/driver_adapter.py
+++ b/tools/ffi_experiment/driver_adapter.py
@@ -1,14 +1,15 @@
 """One persistent native LocalDriver with synchronous engine-query yields."""
 from __future__ import print_function
+from array import array
 
 MODES = ('arrived', 'blocked', 'pivot_recovery', 'reverse_turn', 'avoid', 'drive')
 
 
 class DriverBackend(object):
-    def __init__(self, backend, runtime):
+    def __init__(self, backend, runtime, synchronous=False):
         self.backend, self.runtime = backend, runtime
         self.original = runtime.adapter.driver
-        self.driver = NativeDriver(backend, self.original)
+        self.driver = NativeDriver(backend, self.original, synchronous, runtime)
         runtime.adapter.driver = self.driver
 
     def close(self):
@@ -17,7 +18,7 @@ class DriverBackend(object):
 
 
 class NativeDriver(object):
-    def __init__(self, backend, original):
+    def __init__(self, backend, original, synchronous=False, runtime=None):
         self.backend, self.original = backend, original
         self.stuck_seconds = original.stuck_seconds
         self.recovery_seconds = original.recovery_seconds
@@ -28,6 +29,14 @@ class NativeDriver(object):
         # state lives in C++; dump_state is explicit diagnostic output.
         self.states = {}
         self.queries = 0
+        self.synchronous = synchronous
+        self.runtime = runtime
+        self.bake_admitted = False
+        if runtime is not None:
+            bake = (runtime.baked_graph or {}).get('bake') or {}
+            radii = bake.get('edge_clearance_radii') or ()
+            self.bake_admitted = (float(bake.get('vehicle_half_width', 0.0)) >= 2.15 and
+                                  max([float(value) for value in radii] or [0.0]) >= 3.0)
 
     def __getattr__(self, name):
         return getattr(self.original, name)
@@ -85,7 +94,30 @@ class NativeDriver(object):
                    horizon, int(pose_clear is not None), round(float(target[0]), 2),
                    round(float(target[2]), 2), len(rows) // 9] + rows + [0] * 7)
         try:
-            result = self.backend.call(packet)[-7:]
+            if self.synchronous:
+                navigator = getattr(self.runtime, 'navigator', None)
+                nav_handle = getattr(navigator, 'handle', None)
+                state = self.runtime.states.get(bot_id, {}) if self.runtime is not None else {}
+                packet[0] = 208
+                packet[-7:-7] = [nav_handle or 0, int(state.get('_water_depth', -1.0) > 0.90),
+                                 int(self.bake_admitted)]
+                query_packet = array('d', [0.0] * 16)
+
+                def query():
+                    kind, query_yaw, distance = int(query_packet[0]), query_packet[1], query_packet[2]
+                    self.queries += 1
+                    if kind == 1:
+                        answer = self.original._clear(direction_clear, query_yaw,
+                                                      None if distance < 0 else distance)
+                    elif kind == 2:
+                        answer = self.original._pose_fits(pose_clear, query_yaw)
+                    else:
+                        raise RuntimeError('unknown synchronous driver query')
+                    query_packet[0] = int(answer)
+
+                result = self.backend.call_sync(packet, query_packet, query)[-7:]
+            else:
+                result = self.backend.call(packet)[-7:]
             while result[0]:
                 kind, query_yaw, distance = int(result[0]), result[1], result[2]
                 self.queries += 1

--- a/tools/ffi_experiment/driver_adapter.py
+++ b/tools/ffi_experiment/driver_adapter.py
@@ -1,0 +1,142 @@
+"""One persistent native LocalDriver with synchronous engine-query yields."""
+from __future__ import print_function
+
+MODES = ('arrived', 'blocked', 'pivot_recovery', 'reverse_turn', 'avoid', 'drive')
+
+
+class DriverBackend(object):
+    def __init__(self, backend, runtime):
+        self.backend, self.runtime = backend, runtime
+        self.original = runtime.adapter.driver
+        self.driver = NativeDriver(backend, self.original)
+        runtime.adapter.driver = self.driver
+
+    def close(self):
+        if self.runtime.adapter.driver is self.driver:
+            self.runtime.adapter.driver = self.original
+
+
+class NativeDriver(object):
+    def __init__(self, backend, original):
+        self.backend, self.original = backend, original
+        self.stuck_seconds = original.stuck_seconds
+        self.recovery_seconds = original.recovery_seconds
+        self.failure_ttl = original.failure_ttl
+        self.handle = int(backend.call([200, self.stuck_seconds,
+                                       self.recovery_seconds, self.failure_ttl])[0])
+        # The route observer reads only traffic_waiting. All other driver
+        # state lives in C++; dump_state is explicit diagnostic output.
+        self.states = {}
+        self.queries = 0
+
+    def __getattr__(self, name):
+        return getattr(self.original, name)
+
+    def forget(self, bot_id):
+        self.backend.call([203, self.handle, bot_id])
+        self.states.pop(bot_id, None)
+
+    def wait_for_traffic(self, bot_id, elapsed=None):
+        result = bool(self.backend.call([204, self.handle, bot_id,
+                                        int(elapsed is not None), elapsed or 0.0])[0])
+        if result:
+            self.states[bot_id]['traffic_waiting'] = True
+        return result
+
+    def remember_failure(self, bot_id, yaw, ttl=None):
+        self.backend.call([205, self.handle, bot_id, yaw, int(ttl is not None), ttl or 0.0])
+
+    def drive(self, bot_id, team_slot, position, yaw, speed, dt, target,
+              neighbours, direction_clear, velocity=None,
+              half_length=3.5, half_width=1.7, movement_intent=True,
+              stopping_distance=None, stop_at_target=True,
+              decision_horizon=0.0, pose_clear=None):
+        own_length, own_width = max(0.5, float(half_length)), max(0.3, float(half_width))
+        rows = []
+        for raw in neighbours or ():
+            point = self.original._neighbour_position(raw)
+            if point is None:
+                continue
+            try:
+                values = [float(point[0]), float(point[1]), float(point[2])]
+                if isinstance(raw, dict):
+                    values.extend((float(raw.get('yaw', 0.0) or 0.0),
+                                   float(raw.get('half_length', own_length) or own_length),
+                                   float(raw.get('half_width', own_width) or own_width),
+                                   int(raw.get('id') is not None), raw.get('id') or 0,
+                                   int(bool(raw.get('alive', True)))))
+                else:
+                    values.extend((0.0, own_length, own_width, 0, 0, 1))
+                rows.extend(values)
+            except (TypeError, ValueError, IndexError, OverflowError):
+                # Runtime neighbours are already admitted plain numeric data.
+                # Fail explicitly rather than silently change malformed-input
+                # behavior of the differently guarded source geometry loops.
+                raise ValueError('native driver requires normalized neighbours')
+        try:
+            stopping = max(0.0, float(stopping_distance)) if stopping_distance is not None else 0.0
+            horizon = max(0.0, float(decision_horizon))
+        except (TypeError, ValueError, OverflowError):
+            stopping, horizon = 0.0, 0.0
+        packet = ([201, self.handle, bot_id, int(team_slot)] + list(position) +
+                  [yaw, speed, dt] + list(target) +
+                  [half_length, half_width, int(bool(movement_intent)),
+                   int(stopping_distance is not None), stopping, int(bool(stop_at_target)),
+                   horizon, int(pose_clear is not None), round(float(target[0]), 2),
+                   round(float(target[2]), 2), len(rows) // 9] + rows + [0] * 7)
+        try:
+            result = self.backend.call(packet)[-7:]
+            while result[0]:
+                kind, query_yaw, distance = int(result[0]), result[1], result[2]
+                self.queries += 1
+                if kind == 1:
+                    answer = self.original._clear(direction_clear, query_yaw,
+                                                  None if distance < 0 else distance)
+                elif kind == 2:
+                    answer = self.original._pose_fits(pose_clear, query_yaw)
+                else:
+                    raise RuntimeError('unknown native driver query')
+                result = self.backend.call([202, self.handle, int(answer)] + [0] * 7)[-7:]
+        except Exception:
+            self.backend.call([207, self.handle])
+            raise
+        self.states.setdefault(bot_id, {}).pop('traffic_waiting', None)
+        output = dict(throttle=result[1], turn=result[2], target_yaw=result[3],
+                      recovery_mode=MODES[int(result[4])])
+        if result[5]:
+            output['reverse_blocked_by'] = True if result[5] == 1 else int(result[6])
+        return output
+
+    def dump_state(self, bot_id):
+        values = self.backend.call([206, self.handle, bot_id] + [0] * 97)
+        if not values[0]:
+            return None
+        it = iter(values[1:])
+        state = dict(team_slot=int(next(it)), last_position=(next(it), next(it)),
+                     stuck_time=next(it), recovery_time=next(it),
+                     recovery_count=int(next(it)), recovery_side=next(it))
+        def optional():
+            present, value = next(it), next(it)
+            return value if present else None
+        state['steering_yaw'] = optional()
+        state['steering_reason'] = 'obstacle' if next(it) else 'route'
+        for key in ('steering_age', 'plan_age', 'recovery_timing_phase', 'clock',
+                    'escape_side', 'escape_side_until'):
+            state[key] = next(it)
+        for key in ('last_desired_yaw', 'heading_progress_yaw', 'best_heading_error'):
+            state[key] = optional()
+        present, waiting = next(it), next(it)
+        if present:
+            state['traffic_waiting'] = bool(waiting)
+        state['traffic_wait_time'], state['last_step'] = next(it), next(it)
+        braking, x, z = next(it), next(it), next(it)
+        state['braking_target'] = (x, z) if braking else None
+        clear_yaw = optional()
+        if clear_yaw is not None:
+            state['last_clear_yaw'] = clear_yaw
+        failed = {}
+        for unused in range(int(next(it))):
+            key, expires = int(next(it)), next(it)
+            failed[key] = expires
+        state['failed_yaws'] = failed
+        return state

--- a/tools/ffi_experiment/driver_core.cpp
+++ b/tools/ffi_experiment/driver_core.cpp
@@ -1,6 +1,8 @@
 // Full LocalDriver state machine. Query answers resume the same operation;
 // replay is confined to native calculations and never repeats an engine call.
 #include "driver_core.h"
+#include "navigation_flow.h"
+#include "query_bridge.h"
 #include <algorithm>
 #include <cmath>
 #include <map>
@@ -49,8 +51,20 @@ struct Result {
 // Modes: arrived, blocked, pivot_recovery, reverse_turn, avoid, drive.
 struct Pending {
     bool active;Input in;State initial;std::vector<bool> answers;size_t cursor;
+    bool synchronous=false,wet_escape=false,bake_admitted=false;int navigation=0;
     Pending():active(false),cursor(0){}
     bool query(int kind,double yaw,double distance=-1){
+        if(synchronous){
+            if(navigation){
+                int result=offline_navigation_local_query(navigation,in.bot,kind,in.pos.x,in.pos.y,in.pos.z,
+                    yaw,in.length,in.width,wet_escape,bake_admitted,distance>=0,distance);
+                if(result!=2)return result!=0;
+            }
+            double packet[16]={static_cast<double>(kind),yaw,distance};
+            if(offline_query(packet,16))throw std::runtime_error("driver engine callback");
+            if(packet[0]!=0&&packet[0]!=1)throw std::invalid_argument("driver callback verdict");
+            ++cursor;return packet[0]!=0;
+        }
         if(cursor==answers.size()) throw Query{kind,yaw,distance};
         return answers[cursor++];
     }
@@ -225,6 +239,16 @@ void resume(Driver &d,double *b,int out){
 void optional(double *b,int &i,Optional v){b[i++]=v.present;b[i++]=v.value;}
 }
 void offline_driver_reset(){drivers.clear();}
+void offline_driver_remember(int id,int bot,double yaw,bool has_ttl,double ttl){
+    auto found=drivers.find(id);if(found==drivers.end())throw std::invalid_argument("unknown driver");
+    Driver &d=found->second;if(d.pending.active)throw std::invalid_argument("driver mutation during query");
+    auto it=d.states.find(bot);if(it==d.states.end())return;
+    State &s=it->second;ttl=std::max(0.1,has_ttl?ttl:d.failure_ttl);
+    s.failed[yaw_key(yaw)]=s.clock+ttl;
+    double offset=s.desired.present?angle(yaw,s.desired.value):0.0;
+    s.escape=std::abs(offset)>=0.10?(offset>0?1.0:-1.0):fallback(s);
+    s.escape_until=s.clock+std::min(2.0,std::max(0.8,ttl));s.steering.clear();s.plan_age=999;
+}
 int offline_driver_dispatch(double *b,int n){
     Reader r(b,n);int op=static_cast<int>(b[0]);
     if(op==200){
@@ -232,7 +256,7 @@ int offline_driver_dispatch(double *b,int n){
         int id=next_driver++;drivers[id]=d;b[0]=id;return 0;
     }
     Driver &d=owner(r);
-    if(op==201){
+    if(op==201||op==208){
         if(d.pending.active)throw std::invalid_argument("reentrant driver start");
         Input in;in.bot=r.integer();in.slot=r.integer();if(in.slot<0 || in.slot>=15)throw std::invalid_argument("team slot");
         in.pos=vec(r);in.yaw=r.next();in.speed=r.next();in.dt=r.next();in.target=vec(r);
@@ -242,13 +266,17 @@ int offline_driver_dispatch(double *b,int n){
         for(int i=0;i<count;++i){
             Neighbour v;v.pos=vec(r);v.yaw=r.next();v.length=r.next();v.width=r.next();v.has_id=r.integer()!=0;v.id=r.next();v.alive=r.integer()!=0;in.neighbours.push_back(v);
         }
+        int navigation=0;bool wet=false,admitted=false;
+        if(op==208){navigation=r.integer();wet=r.integer()!=0;admitted=r.integer()!=0;}
         int out=r.i;if(n!=out+7)throw std::invalid_argument("driver result width");
         auto it=d.states.find(in.bot);
         if(it==d.states.end()){
             State s;s.slot=in.slot;s.last=Vec(in.pos.x,0,in.pos.z);s.phase=(((in.slot*7)%15)+0.5)/15.0;it=d.states.insert(std::make_pair(in.bot,s)).first;
         }else if(it->second.slot!=in.slot)throw std::invalid_argument("changed team slot");
         d.pending.in=in;d.pending.initial=it->second;d.pending.answers.clear();d.pending.active=true;
-        resume(d,b,out);return 0;
+        d.pending.synchronous=op==208;d.pending.navigation=navigation;d.pending.wet_escape=wet;d.pending.bake_admitted=admitted;
+        try{resume(d,b,out);}catch(...){d.pending.active=false;throw;}
+        return 0;
     }
     if(op==202){
         if(!d.pending.active)throw std::invalid_argument("driver is not pending");

--- a/tools/ffi_experiment/driver_core.cpp
+++ b/tools/ffi_experiment/driver_core.cpp
@@ -15,6 +15,7 @@ struct Reader {
     double *b;int n,i;
     Reader(double *v,int size):b(v),n(size),i(1){}
     double next(){if(i>=n || !std::isfinite(b[i])) throw std::invalid_argument("driver buffer");return b[i++];}
+    double stopping(){if(i>=n||std::isnan(b[i])||b[i]<0)throw std::invalid_argument("driver stopping distance");return b[i++];}
     int integer(){double v=next();if(v!=std::floor(v)||std::abs(v)>1000000000) throw std::invalid_argument("driver int");return static_cast<int>(v);}
     void end(){if(i!=n) throw std::invalid_argument("driver width");}
 };
@@ -239,6 +240,10 @@ void resume(Driver &d,double *b,int out){
 void optional(double *b,int &i,Optional v){b[i++]=v.present;b[i++]=v.value;}
 }
 void offline_driver_reset(){drivers.clear();}
+bool offline_driver_waiting(int id,int bot){
+    auto found=drivers.find(id);if(found==drivers.end())return false;
+    auto state=found->second.states.find(bot);return state!=found->second.states.end()&&state->second.traffic_present&&state->second.traffic;
+}
 void offline_driver_remember(int id,int bot,double yaw,bool has_ttl,double ttl){
     auto found=drivers.find(id);if(found==drivers.end())throw std::invalid_argument("unknown driver");
     Driver &d=found->second;if(d.pending.active)throw std::invalid_argument("driver mutation during query");
@@ -261,7 +266,7 @@ int offline_driver_dispatch(double *b,int n){
         Input in;in.bot=r.integer();in.slot=r.integer();if(in.slot<0 || in.slot>=15)throw std::invalid_argument("team slot");
         in.pos=vec(r);in.yaw=r.next();in.speed=r.next();in.dt=r.next();in.target=vec(r);
         in.length=r.next();in.width=r.next();in.moving=r.integer()!=0;in.has_stopping=r.integer()!=0;
-        in.stopping=r.next();in.stop=r.integer()!=0;in.horizon=r.next();in.pose=r.integer()!=0;in.key_x=r.next();in.key_z=r.next();
+        in.stopping=r.stopping();in.stop=r.integer()!=0;in.horizon=r.next();in.pose=r.integer()!=0;in.key_x=r.next();in.key_z=r.next();
         int count=r.integer();if(count<0 || count>10000)throw std::invalid_argument("neighbour count");
         for(int i=0;i<count;++i){
             Neighbour v;v.pos=vec(r);v.yaw=r.next();v.length=r.next();v.width=r.next();v.has_id=r.integer()!=0;v.id=r.next();v.alive=r.integer()!=0;in.neighbours.push_back(v);

--- a/tools/ffi_experiment/driver_core.cpp
+++ b/tools/ffi_experiment/driver_core.cpp
@@ -1,0 +1,293 @@
+// Full LocalDriver state machine. Query answers resume the same operation;
+// replay is confined to native calculations and never repeats an engine call.
+#include "driver_core.h"
+#include <algorithm>
+#include <cmath>
+#include <map>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+const double PI=3.14159265358979323846;
+struct Reader {
+    double *b;int n,i;
+    Reader(double *v,int size):b(v),n(size),i(1){}
+    double next(){if(i>=n || !std::isfinite(b[i])) throw std::invalid_argument("driver buffer");return b[i++];}
+    int integer(){double v=next();if(v!=std::floor(v)||std::abs(v)>1000000000) throw std::invalid_argument("driver int");return static_cast<int>(v);}
+    void end(){if(i!=n) throw std::invalid_argument("driver width");}
+};
+double clamp(double v,double a,double b){return std::max(a,std::min(b,v));}
+double angle(double a,double b){double v=a-b;while(v>PI)v-=2*PI;while(v<-PI)v+=2*PI;return v;}
+struct Vec {double x,y,z;Vec(double a=0,double b=0,double c=0):x(a),y(b),z(c){}};
+Vec vec(Reader &r){double a=r.next(),b=r.next(),c=r.next();return Vec(a,b,c);}
+double distance(Vec a,Vec b){double x=a.x-b.x,z=a.z-b.z;return std::sqrt(x*x+z*z);}
+struct Optional {
+    bool present;double value;
+    Optional():present(false),value(0){}
+    void set(double v){present=true;value=v;}
+    void clear(){present=false;}
+};
+struct State {
+    int slot,count;Vec last;double stuck,recovery,side,steering_age,plan_age,phase,clock,escape,escape_until,wait,last_step;
+    Optional steering,desired,progress,best,clear_yaw;
+    bool obstacle,traffic,traffic_present,braking;double brake_x,brake_z;
+    std::map<int,double> failed;
+    State():slot(0),count(0),stuck(0),recovery(0),side(0),steering_age(999),plan_age(999),phase(0),clock(0),escape(0),escape_until(0),wait(0),last_step(0),obstacle(false),traffic(false),traffic_present(true),braking(false),brake_x(0),brake_z(0){}
+};
+struct Neighbour {Vec pos;double yaw,length,width,id;bool has_id,alive;};
+struct Input {
+    int bot,slot;Vec pos,target;double yaw,speed,dt,length,width,stopping,horizon,key_x,key_z;
+    bool moving,has_stopping,stop,pose;
+    std::vector<Neighbour> neighbours;
+};
+// 0=done, 1=direction query (distance -1 means unbounded), 2=pose query.
+struct Query {int kind;double yaw,distance;};
+struct Result {
+    double throttle,turn,yaw,blocker;int mode,blocker_kind;
+    Result(double a,double b,double c,int d):throttle(a),turn(b),yaw(c),blocker(0),mode(d),blocker_kind(0){}
+};
+// Modes: arrived, blocked, pivot_recovery, reverse_turn, avoid, drive.
+struct Pending {
+    bool active;Input in;State initial;std::vector<bool> answers;size_t cursor;
+    Pending():active(false),cursor(0){}
+    bool query(int kind,double yaw,double distance=-1){
+        if(cursor==answers.size()) throw Query{kind,yaw,distance};
+        return answers[cursor++];
+    }
+};
+struct Driver {
+    double stuck_seconds,recovery_seconds,failure_ttl;
+    std::map<int,State> states;Pending pending;
+};
+std::map<int,Driver> drivers;int next_driver=1;
+int yaw_key(double yaw){
+    double turn=PI*2.0,from=std::fmod(yaw+PI,turn);if(from<0)from+=turn;
+    return static_cast<int>(std::floor(from*24/turn+0.5))%24;
+}
+double fallback(const State &s){return (s.slot+s.count)&1?1.0:-1.0;}
+double penalty(State &s,double yaw,double ttl){
+    int key=yaw_key(yaw);auto it=s.failed.find(key);if(it==s.failed.end())return 0;
+    if(it->second<=s.clock){s.failed.erase(it);return 0;}
+    return 3.0+(it->second-s.clock)/ttl;
+}
+bool overlap(Vec a,double ay,double al,double aw,Vec b,double by,double bl,double bw){
+    double af[]={std::sin(ay),std::cos(ay)},as[]={std::cos(ay),-std::sin(ay)};
+    double bf[]={std::sin(by),std::cos(by)},bs[]={std::cos(by),-std::sin(by)};
+    const double *axes[]={af,as,bf,bs};double dx=b.x-a.x,dz=b.z-a.z;
+    for(const double *axis:axes){
+        double d=std::abs(dx*axis[0]+dz*axis[1]);
+        double ra=std::abs(af[0]*axis[0]+af[1]*axis[1])*al+std::abs(as[0]*axis[0]+as[1]*axis[1])*aw;
+        double rb=std::abs(bf[0]*axis[0]+bf[1]*axis[1])*bl+std::abs(bs[0]*axis[0]+bs[1]*axis[1])*bw;
+        if(d>ra+rb)return false;
+    }
+    return true;
+}
+bool static_ahead(const Input &in,double yaw,double length,double width){
+    double reach=length*1.6;
+    Vec sweep(in.pos.x+std::sin(yaw)*reach*0.5,in.pos.y,in.pos.z+std::cos(yaw)*reach*0.5);
+    for(const auto &n:in.neighbours){
+        if(n.alive || std::abs(n.pos.y-in.pos.y)>5.0)continue;
+        if(overlap(sweep,yaw,length+reach*0.5,width,n.pos,n.yaw,n.length,n.width))return true;
+    }
+    return false;
+}
+int reverse_blocker(const Input &in,double length,double width,double &id){
+    double reach=length*1.6;
+    Vec sweep(in.pos.x-std::sin(in.yaw)*reach*0.5,in.pos.y,in.pos.z-std::cos(in.yaw)*reach*0.5);
+    for(const auto &n:in.neighbours){
+        if(std::abs(n.pos.y-in.pos.y)>5.0)continue;
+        if(overlap(sweep,in.yaw,length+reach*0.5,width,n.pos,n.yaw,n.length,n.width)){
+            id=n.has_id?n.id:1.0;return n.has_id?2:1;
+        }
+    }
+    return 0;
+}
+int occupancy(const Input &in,double direction,double length,double width){
+    int occupied=0;
+    for(const auto &n:in.neighbours){
+        if(std::abs(n.pos.y-in.pos.y)>5.0)continue;
+        for(int i=1;i<=4;++i){
+            double yaw=in.yaw+direction*0.85*(i*0.25);
+            if(overlap(in.pos,yaw,length,width,n.pos,n.yaw,n.length,n.width))++occupied;
+        }
+    }
+    return occupied;
+}
+double select_side(const State &s,const Input &in,double length,double width){
+    int negative=occupancy(in,-1.0,length,width),positive=occupancy(in,1.0,length,width);
+    return negative<positive?-1.0:(positive<negative?1.0:fallback(s));
+}
+bool pivot_fits(Pending &job,double direction){
+    if(!job.in.pose)return true;
+    for(int i=1;i<=4;++i)if(!job.query(2,job.in.yaw+direction*0.85*(i*0.25)))return false;
+    return true;
+}
+Optional choose(State &s,Driver &d,double desired,double length,double width){
+    const double offsets[]={0.0,0.42,-0.42,0.78,-0.78,1.18,-1.18,1.55,-1.55};
+    std::vector<std::pair<double,double> > candidates;
+    for(double offset:offsets){
+        double candidate=desired+offset,score=std::abs(offset)+penalty(s,candidate,d.failure_ttl);
+        if(s.escape_until>s.clock && offset*s.escape<-0.01)score+=1.25;
+        candidates.push_back(std::make_pair(score,candidate));
+    }
+    std::stable_sort(candidates.begin(),candidates.end(),[](std::pair<double,double>a,std::pair<double,double>b){return a.first<b.first;});
+    Optional result;
+    for(auto item:candidates){
+        if(d.pending.query(1,item.second) && !static_ahead(d.pending.in,item.second,length,width)){
+            s.obstacle=std::abs(angle(item.second,desired))>0.05;result.set(item.second);return result;
+        }
+    }
+    return result;
+}
+Result drive(Driver &d,State &s){
+    Pending &job=d.pending;const Input &in=job.in;
+    double step=std::max(0.0,in.dt);
+    if(!s.traffic)s.wait=0;
+    s.traffic=false;s.traffic_present=false;s.last_step=step;s.clock+=step;
+    for(auto it=s.failed.begin();it!=s.failed.end();){if(it->second<=s.clock)it=s.failed.erase(it);else ++it;}
+    s.steering_age+=step;s.plan_age+=step;
+    double desired=std::atan2(in.target.x-in.pos.x,in.target.z-in.pos.z);
+    double error=std::abs(angle(desired,in.yaw));s.desired.set(desired);
+    double target_distance=distance(in.pos,in.target);
+    if(!in.moving || target_distance<=1.5){
+        s.stuck=0;s.recovery=0;s.side=0;s.steering.clear();s.progress.clear();s.braking=false;
+        if(in.moving)s.last=Vec(in.pos.x,0,in.pos.z);
+        return Result(0,0,in.yaw,0);
+    }
+    double length=std::max(0.5,in.length),width=std::max(0.3,in.width);
+    double displacement=distance(in.pos,s.last);bool progress=false;
+    if(displacement>=0.08 || !s.progress.present || std::abs(angle(desired,s.progress.value))>0.12){
+        s.progress.set(desired);s.best.set(error);
+    }else{
+        double pe=std::abs(angle(s.progress.value,in.yaw));
+        if(pe+0.002<s.best.value){s.best.set(pe);progress=true;}
+    }
+    if(displacement>=0.08){s.last=Vec(in.pos.x,0,in.pos.z);s.stuck=0;}
+    else if(progress)s.stuck=std::max(0.0,s.stuck-step);
+    else s.stuck+=step;
+    double threshold=d.stuck_seconds+s.phase*0.42;
+    if(s.recovery>0){
+        s.recovery=std::max(0.0,s.recovery-step);
+        if(s.recovery==0){++s.count;s.side=0;s.stuck=0;s.progress.clear();}
+    }else if(s.stuck>=threshold){
+        if(s.clear_yaw.present)s.failed[yaw_key(s.clear_yaw.value)]=s.clock+d.failure_ttl;
+        s.recovery=d.recovery_seconds+s.phase*0.28;s.side=select_side(s,in,length,width);
+    }
+    if(s.recovery>0){
+        double direction=s.side;
+        if(direction!=-1 && direction!=1)s.side=direction=select_side(s,in,length,width);
+        double recovery_yaw=in.yaw+direction*0.85,reach=length*1.6;
+        bool clear=job.query(1,in.yaw+PI,reach);double blocker=0;
+        int blocked=clear?reverse_blocker(in,length,width,blocker):0;
+        if(!clear || blocked){
+            if(!pivot_fits(job,direction)){
+                if(pivot_fits(job,-direction)){s.side=direction=-direction;recovery_yaw=in.yaw+direction*0.85;}
+                else{Result r(0,0,in.yaw,1);r.blocker_kind=blocked;r.blocker=blocker;return r;}
+            }
+            return Result(0,direction,recovery_yaw,2);
+        }
+        double turn=-direction,target=recovery_yaw;
+        for(int i=1;i<=4;++i){
+            if(!job.query(1,in.yaw+PI+direction*0.85*(i*0.25),reach)){turn=0;target=in.yaw;break;}
+        }
+        return Result(-0.72,turn,target,3);
+    }
+    Optional chosen;
+    double hold=s.obstacle?1.20:0.35;
+    if(s.steering.present && s.plan_age<hold && std::abs(angle(desired,s.steering.value))<2.15 &&
+       penalty(s,s.steering.value,d.failure_ttl)<=0 && job.query(1,s.steering.value) &&
+       !static_ahead(in,s.steering.value,length,width))chosen=s.steering;
+    if(!chosen.present){chosen=choose(s,d,desired,length,width);s.plan_age=0;}
+    if(!chosen.present){s.stuck=std::max(s.stuck,threshold);return Result(0,0,in.yaw,1);}
+    s.clear_yaw=chosen;
+    if(!s.steering.present || std::abs(angle(chosen.value,s.steering.value))>0.04){s.steering=chosen;s.steering_age=0;}
+    double delta=angle(chosen.value,in.yaw),turn=clamp(delta/0.58,-1,1),throttle=1;
+    double grade=(in.target.y-in.pos.y)/std::max(0.1,target_distance);
+    if(grade>0.10 && std::abs(delta)>0.30 && !s.obstacle)throttle=0;
+    else if(std::abs(delta)>PI*0.5 || (!s.obstacle && error>PI*0.5))throttle=0;
+    if(in.stop && !s.obstacle && in.has_stopping){
+        double braking=std::max(0.0,in.stopping),reaction=std::abs(in.speed)*std::max(0.0,in.horizon);
+        if(s.braking && (s.brake_x!=in.key_x || s.brake_z!=in.key_z))s.braking=false;
+        if(target_distance<=1.5+braking+reaction){s.braking=true;s.brake_x=in.key_x;s.brake_z=in.key_z;}
+        if(s.braking){if(std::abs(in.speed)<=0.35 && target_distance>2.0)s.braking=false;else throttle=0;}
+    }else if(!in.stop)s.braking=false;
+    return Result(throttle,turn,chosen.value,s.obstacle?4:5);
+}
+Driver &owner(Reader &r){auto it=drivers.find(r.integer());if(it==drivers.end())throw std::invalid_argument("unknown driver");return it->second;}
+void resume(Driver &d,double *b,int out){
+    State state=d.pending.initial;d.pending.cursor=0;
+    try{
+        Result r=drive(d,state);
+        d.states[d.pending.in.bot]=state;d.pending.active=false;
+        b[out]=0;b[out+1]=r.throttle;b[out+2]=r.turn;b[out+3]=r.yaw;b[out+4]=r.mode;b[out+5]=r.blocker_kind;b[out+6]=r.blocker;
+    }catch(const Query &q){b[out]=q.kind;b[out+1]=q.yaw;b[out+2]=q.distance;}
+}
+void optional(double *b,int &i,Optional v){b[i++]=v.present;b[i++]=v.value;}
+}
+void offline_driver_reset(){drivers.clear();}
+int offline_driver_dispatch(double *b,int n){
+    Reader r(b,n);int op=static_cast<int>(b[0]);
+    if(op==200){
+        Driver d;d.stuck_seconds=std::max(0.4,r.next());d.recovery_seconds=std::max(0.25,r.next());d.failure_ttl=std::max(0.25,r.next());r.end();
+        int id=next_driver++;drivers[id]=d;b[0]=id;return 0;
+    }
+    Driver &d=owner(r);
+    if(op==201){
+        if(d.pending.active)throw std::invalid_argument("reentrant driver start");
+        Input in;in.bot=r.integer();in.slot=r.integer();if(in.slot<0 || in.slot>=15)throw std::invalid_argument("team slot");
+        in.pos=vec(r);in.yaw=r.next();in.speed=r.next();in.dt=r.next();in.target=vec(r);
+        in.length=r.next();in.width=r.next();in.moving=r.integer()!=0;in.has_stopping=r.integer()!=0;
+        in.stopping=r.next();in.stop=r.integer()!=0;in.horizon=r.next();in.pose=r.integer()!=0;in.key_x=r.next();in.key_z=r.next();
+        int count=r.integer();if(count<0 || count>10000)throw std::invalid_argument("neighbour count");
+        for(int i=0;i<count;++i){
+            Neighbour v;v.pos=vec(r);v.yaw=r.next();v.length=r.next();v.width=r.next();v.has_id=r.integer()!=0;v.id=r.next();v.alive=r.integer()!=0;in.neighbours.push_back(v);
+        }
+        int out=r.i;if(n!=out+7)throw std::invalid_argument("driver result width");
+        auto it=d.states.find(in.bot);
+        if(it==d.states.end()){
+            State s;s.slot=in.slot;s.last=Vec(in.pos.x,0,in.pos.z);s.phase=(((in.slot*7)%15)+0.5)/15.0;it=d.states.insert(std::make_pair(in.bot,s)).first;
+        }else if(it->second.slot!=in.slot)throw std::invalid_argument("changed team slot");
+        d.pending.in=in;d.pending.initial=it->second;d.pending.answers.clear();d.pending.active=true;
+        resume(d,b,out);return 0;
+    }
+    if(op==202){
+        if(!d.pending.active)throw std::invalid_argument("driver is not pending");
+        bool answer=r.integer()!=0;int out=r.i;if(n!=out+7)throw std::invalid_argument("driver resume width");
+        d.pending.answers.push_back(answer);resume(d,b,out);return 0;
+    }
+    if(op==207){r.end();d.pending.active=false;return 0;}
+    if(d.pending.active)throw std::invalid_argument("driver mutation during query");
+    int bot=r.integer();auto it=d.states.find(bot);
+    if(op==203){r.end();d.states.erase(bot);return 0;}
+    if(op==204){
+        bool has_elapsed=r.integer()!=0;double elapsed=r.next();r.end();b[0]=it!=d.states.end();
+        if(it!=d.states.end()){
+            State &s=it->second;s.traffic=true;s.traffic_present=true;s.wait+=std::max(0.0,has_elapsed?elapsed:s.last_step);
+            if(s.wait<=1.5){s.stuck=0;s.recovery=0;s.side=0;}
+        }
+        return 0;
+    }
+    if(op==205){
+        double yaw=r.next();bool has_ttl=r.integer()!=0;double ttl=r.next();r.end();
+        if(it!=d.states.end()){
+            State &s=it->second;ttl=std::max(0.1,has_ttl?ttl:d.failure_ttl);
+            s.failed[yaw_key(yaw)]=s.clock+ttl;
+            double offset=s.desired.present?angle(yaw,s.desired.value):0.0;
+            s.escape=std::abs(offset)>=0.10?(offset>0?1.0:-1.0):fallback(s);
+            s.escape_until=s.clock+std::min(2.0,std::max(0.8,ttl));s.steering.clear();s.plan_age=999;
+        }
+        return 0;
+    }
+    if(op==206){
+        if(n!=100)throw std::invalid_argument("driver dump width");
+        b[0]=it!=d.states.end();if(it==d.states.end())return 0;
+        State &s=it->second;int i=1;
+        b[i++]=s.slot;b[i++]=s.last.x;b[i++]=s.last.z;b[i++]=s.stuck;b[i++]=s.recovery;b[i++]=s.count;b[i++]=s.side;
+        optional(b,i,s.steering);b[i++]=s.obstacle;b[i++]=s.steering_age;b[i++]=s.plan_age;b[i++]=s.phase;b[i++]=s.clock;
+        b[i++]=s.escape;b[i++]=s.escape_until;optional(b,i,s.desired);optional(b,i,s.progress);optional(b,i,s.best);
+        b[i++]=s.traffic_present;b[i++]=s.traffic;b[i++]=s.wait;b[i++]=s.last_step;b[i++]=s.braking;b[i++]=s.brake_x;b[i++]=s.brake_z;
+        optional(b,i,s.clear_yaw);b[i++]=s.failed.size();for(auto edge:s.failed){b[i++]=edge.first;b[i++]=edge.second;}
+        return 0;
+    }
+    throw std::invalid_argument("driver opcode");
+}

--- a/tools/ffi_experiment/driver_core.h
+++ b/tools/ffi_experiment/driver_core.h
@@ -1,0 +1,5 @@
+#ifndef OFFLINE_DRIVER_CORE_H
+#define OFFLINE_DRIVER_CORE_H
+int offline_driver_dispatch(double *buffer, int count);
+void offline_driver_reset();
+#endif

--- a/tools/ffi_experiment/driver_core.h
+++ b/tools/ffi_experiment/driver_core.h
@@ -3,4 +3,5 @@
 int offline_driver_dispatch(double *buffer, int count);
 void offline_driver_reset();
 void offline_driver_remember(int owner,int bot,double yaw,bool has_ttl,double ttl);
+bool offline_driver_waiting(int owner,int bot);
 #endif

--- a/tools/ffi_experiment/driver_core.h
+++ b/tools/ffi_experiment/driver_core.h
@@ -2,4 +2,5 @@
 #define OFFLINE_DRIVER_CORE_H
 int offline_driver_dispatch(double *buffer, int count);
 void offline_driver_reset();
+void offline_driver_remember(int owner,int bot,double yaw,bool has_ttl,double ttl);
 #endif

--- a/tools/ffi_experiment/export_fixture.py
+++ b/tools/ffi_experiment/export_fixture.py
@@ -31,7 +31,8 @@ def main():
     parser.add_argument('output', type=Path)
     args = parser.parse_args()
     bodies = select('tests/test_port_0922_bot_runtime.py', (
-        '_Strict1513Component', '_HitTester1513', '_combat_descriptor', '_bot_equipment_contracts'))
+        '_Strict1513Component', '_HitTester1513', '_combat_descriptor', '_bot_equipment_contracts',
+        '_effective_params_snapshot'))
     bodies.update(select('tests/test_port_0922_destructibles.py', (
         '_Vector', '_Manager', '_catalog', '_empty_catalog_scan_fixture')))
     bodies.update(select('tools/benchmark_bot_workload.py', ('make_runtime', 'combat_native_queries')))

--- a/tools/ffi_experiment/export_fixture.py
+++ b/tools/ffi_experiment/export_fixture.py
@@ -34,7 +34,7 @@ def main():
         '_Strict1513Component', '_HitTester1513', '_combat_descriptor', '_bot_equipment_contracts',
         '_effective_params_snapshot'))
     bodies.update(select('tests/test_port_0922_destructibles.py', (
-        '_Vector', '_Manager', '_catalog', '_empty_catalog_scan_fixture')))
+        '_Vector', '_Manager', '_ItemMatrix', '_catalog', '_empty_catalog_scan_fixture')))
     bodies.update(select('tools/benchmark_bot_workload.py', ('make_runtime', 'combat_native_queries')))
     bodies['crew_factors_module'] = (ROOT / 'tests/effective_params_fixture.py').read_text()
     bodies['make_runtime'] = bodies['make_runtime'].replace(
@@ -50,6 +50,12 @@ def main():
         '        def __init__(self, **values):\n'
         '            self.__dict__.update(values)\n'
         '    holder = Holder(')
+    # Expose the existing owner to the explicit native resolver experiment.
+    # Source/control runners keep the original resolver and native-query laws.
+    bodies['combat_native_queries'] = bodies['combat_native_queries'].replace(
+        '    runtime.motion_resolver = lambda',
+        '    runtime._ffi_world_owner = holder\n'
+        '    runtime.motion_resolver = lambda')
     args.output.write_text(json.dumps(bodies, sort_keys=True))
 
 

--- a/tools/ffi_experiment/export_fixture.py
+++ b/tools/ffi_experiment/export_fixture.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Extract existing workload fixtures for the Python 2 measurement runner.
+
+The production client source is not translated. Only Python-3-only test-module
+imports are replaced with a small portable harness. Selected fixture bodies
+remain independently inspectable in the output JSON; the native-query holder
+also gains its required receiver type for Python 2 unbound methods.
+"""
+import argparse
+import ast
+import json
+from pathlib import Path
+import textwrap
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def select(path, names):
+    source = (ROOT / path).read_text()
+    found = {}
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, (ast.ClassDef, ast.FunctionDef)) and node.name in names:
+            found[node.name] = textwrap.dedent(ast.get_source_segment(source, node))
+    if set(found) != set(names):
+        raise RuntimeError('fixture selection does not match %s' % path)
+    return found
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('output', type=Path)
+    args = parser.parse_args()
+    bodies = select('tests/test_port_0922_bot_runtime.py', (
+        '_Strict1513Component', '_HitTester1513', '_combat_descriptor', '_bot_equipment_contracts'))
+    bodies.update(select('tests/test_port_0922_destructibles.py', (
+        '_Vector', '_Manager', '_catalog', '_empty_catalog_scan_fixture')))
+    bodies.update(select('tools/benchmark_bot_workload.py', ('make_runtime', 'combat_native_queries')))
+    bodies['crew_factors_module'] = (ROOT / 'tests/effective_params_fixture.py').read_text()
+    bodies['make_runtime'] = bodies['make_runtime'].replace(
+        '    import test_port_0922_bot_runtime as fixtures\n', '').replace(
+        '    from effective_params_fixture import bot_default_crew_factors\n', '')
+    bodies['combat_native_queries'] = '@contextlib.contextmanager\n' + bodies['combat_native_queries'].replace(
+        '    import test_port_0922_destructibles as fixtures\n', '')
+    # Python 2 checks an unbound method's receiver type. Preserve the fixture's
+    # exact attributes while giving its holder the required BattleRuntime base.
+    bodies['combat_native_queries'] = bodies['combat_native_queries'].replace(
+        '    holder = types.SimpleNamespace(',
+        '    class Holder(BattleRuntime):\n'
+        '        def __init__(self, **values):\n'
+        '            self.__dict__.update(values)\n'
+        '    holder = Holder(')
+    args.output.write_text(json.dumps(bodies, sort_keys=True))
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/ffi_experiment/host_profile.h
+++ b/tools/ffi_experiment/host_profile.h
@@ -1,0 +1,89 @@
+/* Optional Linux-host CPU attribution. Never compiled into the #1513 bridge.
+ * Zones partition one thread's synchronous loop, including nested dispatches.
+ * Python zones include their ordinary builtin/native callees and test fakes;
+ * they are ownership boundaries, not Python bytecode instruction timings. */
+#ifndef OFFLINE_HOST_PROFILE_H
+#define OFFLINE_HOST_PROFILE_H
+#include <time.h>
+
+enum { PROFILE_OUTER, PROFILE_CORE, PROFILE_BRIDGE, PROFILE_CALLBACK, PROFILE_ZONES };
+enum { PROFILE_ROWS = 804 };
+static struct {
+    int enabled, zone;
+    double last, seconds[PROFILE_ZONES], callbacks[PROFILE_ROWS];
+    unsigned long calls[PROFILE_ROWS], transitions;
+} host_profile;
+
+static double profile_clock(void)
+{
+    struct timespec value;
+    clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &value);
+    return (double)value.tv_sec + (double)value.tv_nsec * 1e-9;
+}
+static void profile_zone(int zone)
+{
+    if (host_profile.enabled) {
+        double now = profile_clock();
+        host_profile.seconds[host_profile.zone] += now - host_profile.last;
+        host_profile.last = now;
+        host_profile.zone = zone;
+        ++host_profile.transitions;
+    }
+}
+static int profile_key(const double *packet, int count)
+{
+    double opcode = packet[0];
+    int key = opcode >= 0 && opcode < 800 ? (int)opcode : 0;
+    if (key == 772 && count > 1 && packet[1] >= 0 && packet[1] < 4)
+        key = 800 + (int)packet[1];
+    return key;
+}
+static PyObject *profile_start(PyObject *self, PyObject *args)
+{
+    (void)self;
+    if (!PyArg_ParseTuple(args, "")) return NULL;
+    if (offline_query_active() || host_profile.enabled) {
+        PyErr_SetString(PyExc_RuntimeError, "host profile owner is active");
+        return NULL;
+    }
+    memset(&host_profile, 0, sizeof(host_profile));
+    host_profile.last = profile_clock();
+    host_profile.enabled = 1;
+    Py_RETURN_NONE;
+}
+static PyObject *profile_stop(PyObject *self, PyObject *args)
+{
+    PyObject *rows, *result;
+    int key;
+    (void)self;
+    if (!PyArg_ParseTuple(args, "")) return NULL;
+    if (offline_query_active() || !host_profile.enabled) {
+        PyErr_SetString(PyExc_RuntimeError, "host profile has no idle owner");
+        return NULL;
+    }
+    profile_zone(PROFILE_OUTER);
+    host_profile.enabled = 0;
+    rows = PyList_New(0);
+    if (!rows) return NULL;
+    for (key = 0; key < PROFILE_ROWS; ++key) {
+        PyObject *row;
+        int status;
+        if (!host_profile.calls[key]) continue;
+        row = Py_BuildValue("{s:i,s:k,s:d}", "key", key,
+                           "calls", host_profile.calls[key],
+                           "inclusive_cpu_seconds", host_profile.callbacks[key]);
+        if (!row) { Py_DECREF(rows); return NULL; }
+        status = PyList_Append(rows, row);
+        Py_DECREF(row);
+        if (status) { Py_DECREF(rows); return NULL; }
+    }
+    result = Py_BuildValue("{s:d,s:d,s:d,s:d,s:k,s:O}",
+                          "python_outer", host_profile.seconds[PROFILE_OUTER],
+                          "native_core", host_profile.seconds[PROFILE_CORE],
+                          "callback_bridge", host_profile.seconds[PROFILE_BRIDGE],
+                          "python_callbacks", host_profile.seconds[PROFILE_CALLBACK],
+                          "clock_transitions", host_profile.transitions, "callbacks", rows);
+    Py_DECREF(rows);
+    return result;
+}
+#endif

--- a/tools/ffi_experiment/kernel_adapter.py
+++ b/tools/ffi_experiment/kernel_adapter.py
@@ -321,7 +321,16 @@ def simulation_config(rt, runtime):
 
 class KernelBackend(object):
     """One native update call owns all mutable Bot simulation phases."""
-    def __init__(self, backend, runtime, rt):
+    def __init__(self, backend, runtime, rt, world_owner=None):
+        self.runtime, self.parts, self.kernel, self.engine = runtime, [], None, None
+        self.originals = {}
+        try:
+            self._initialize(backend, runtime, rt, world_owner)
+        except Exception:
+            self.close()
+            raise
+
+    def _initialize(self, backend, runtime, rt, world_owner):
         from combat_adapter import CombatBackend
         from driver_adapter import DriverBackend
         from navigation_flow_adapter import NavigationFlowBackend
@@ -330,8 +339,8 @@ class KernelBackend(object):
         if runtime.native_motion or runtime._suspension_ground_probe is not None:
             raise ValueError('Owned kernel experiment requires the copied vertical controller')
         self.backend, self.runtime, self.module = backend, runtime, rt
-        self.parts = [NavigationFlowBackend(backend, runtime, navigation),
-                      DriverBackend(backend, runtime, True)]
+        self.parts.append(NavigationFlowBackend(backend, runtime, navigation))
+        self.parts.append(DriverBackend(backend, runtime, True))
         combat = CombatBackend(backend, rt)
         self.parts.append(combat)
         bots = []
@@ -353,9 +362,13 @@ class KernelBackend(object):
                                 vision=runtime._vision_ranges.get(identity)),
                 motion=dict(physics=runtime._physics_params_for(identity),
                             yaw_limits=rt.ai_driver.gun_yaw_limits(descriptor)))
+            if world_owner is not None:
+                from kernel_world import descriptor_profile
+                value['config']['motion']['world'] = descriptor_profile(descriptor)
             pair = runtime._descriptor_pairs.get(identity)
             if pair is not None and pair[1] is not None:
-                value['config']['siege_modes'] = [descriptor_mode(rt, runtime, identity, mode, combat)
+                value['config']['siege_modes'] = [descriptor_mode(rt, runtime, identity, mode, combat,
+                                                                 world_owner is not None)
                                                   for mode in (0, 2)]
                 value['config']['siege_params'] = rt.siege_mechanics.params(pair[0])
             bots.append(value)
@@ -371,6 +384,9 @@ class KernelBackend(object):
             simulation=simulation_config(rt, runtime))
         self.engine = EngineLeaves(rt, runtime)
         self.engine.owned = True
+        if world_owner is not None:
+            from kernel_world import WorldLeaves
+            self.engine.world = WorldLeaves(world_owner, self.engine)
         self.originals = {}
         self.order_revision = runtime._order_revision
         self.query = array('d', [0]) * 32768
@@ -390,7 +406,11 @@ class KernelBackend(object):
             inputs['orders'] = [[identity, dict(order, _kernel_token=self.runtime._server_order_tokens.get(identity, 0))]
                                 for identity, order in self.runtime._server_orders.items()]
         command = packet([723, self.kernel.handle], self.engine.prepare(inputs))
-        result = self.backend.call_sync(command, self.query, lambda: self.engine(self.query))
+        try:
+            result = self.backend.call_sync(command, self.query, lambda: self.engine(self.query))
+        finally:
+            if self.engine.world is not None:
+                self.engine.world.clear()
         output = self.kernel.output(result[0])
         self.order_revision = self.runtime._order_revision
         messages = output['messages']
@@ -443,13 +463,19 @@ class KernelBackend(object):
     def close(self):
         for name, original in self.originals.items():
             setattr(self.runtime, name, original)
-        self.engine.actor_cache.clear()
-        self.kernel.close()
+        self.originals.clear()
+        if self.engine is not None:
+            self.engine.actor_cache.clear()
+            if self.engine.world is not None:
+                self.engine.world.clear()
+        if self.kernel is not None:
+            self.kernel.close()
         for part in reversed(self.parts):
             part.close()
+        self.parts = []
 
 
-def descriptor_mode(rt, runtime, identity, mode, combat):
+def descriptor_mode(rt, runtime, identity, mode, combat, native_world=False):
     """Read both immutable stock descriptor modes once at owner construction."""
     import copy
     shadow = copy.copy(runtime)
@@ -466,7 +492,7 @@ def descriptor_mode(rt, runtime, identity, mode, combat):
     descriptor = shadow._descriptors[identity]
     target = dict(state, kind='bot', network_id=identity)
     names = ('move_speed', 'view_range', 'half_length', 'half_width', 'collision_shape', 'mass', 'ram_profile')
-    return dict(gun=shadow._gun_states[identity].__dict__,
+    result = dict(gun=shadow._gun_states[identity].__dict__,
                 critical=critical_config(rt, shadow, identity),
                 health=health_config(rt, descriptor),
                 state=dict((name, state[name]) for name in names),
@@ -476,3 +502,7 @@ def descriptor_mode(rt, runtime, identity, mode, combat):
                 motion=dict(physics=shadow._physics_params_for(identity),
                             yaw_limits=rt.ai_driver.gun_yaw_limits(descriptor),
                             siege_limit=rt.siege_mechanics.enabled_speed_limit(descriptor)))
+    if native_world:
+        from kernel_world import descriptor_profile
+        result['motion']['world'] = descriptor_profile(descriptor)
+    return result

--- a/tools/ffi_experiment/kernel_adapter.py
+++ b/tools/ffi_experiment/kernel_adapter.py
@@ -1,0 +1,477 @@
+"""Owned native Bot state with JSON only at configuration/publication edges."""
+from __future__ import print_function
+
+from array import array
+import json
+
+
+def packet(prefix, value):
+    payload = json.dumps(value, separators=(',', ':'), allow_nan=False)
+    if not isinstance(payload, bytes):
+        payload = payload.encode('utf-8')
+    result = array('d', prefix)
+    result.append(len(payload))
+    result.extend(bytearray(payload))
+    return result
+
+
+def codec_config(codec):
+    return dict(scalars=codec.SCALARS, clamps=codec.CLAMPS,
+                groups=codec.OPTIONAL_GROUPS, devices=codec.DEVICE_NAMES,
+                crew=codec.CREW_NAMES, device_states=codec.DEVICE_STATES)
+
+
+def bot_config(state, gun, ammo, burst):
+    return dict(state=state, gun=gun.__dict__, ammo=ammo.__dict__,
+                burst=burst.__dict__)
+
+
+def critical_config(rt, runtime, bot_id):
+    descriptor = runtime._descriptors[bot_id]
+    return descriptor_critical_config(rt, descriptor,
+                                     runtime._bot_repair_factor(bot_id, descriptor))
+
+
+def descriptor_critical_config(rt, descriptor, factor=1.0):
+    damage = rt.device_damage
+    return dict(devices=[dict(
+        name=name, maximum=damage.device_max_hp(descriptor, name),
+        cap=damage.device_regen_hp(descriptor, name),
+        seconds=damage.repair_seconds(name, descriptor, 100.0, False, factor),
+        no_fire_repair=name in damage.NO_REPAIR_PROGRESS_DEVICES)
+        for name in rt.bot_state_codec.DEVICE_NAMES],
+        roster=rt._descriptor_crew_roster(descriptor),
+        fire_duration=damage.FIRE_DURATION_SECONDS,
+        fire_fraction=damage.FIRE_DAMAGE_FRACTION_PER_SEC,
+        critical_fraction=damage.CRITICAL_HP_FRACTION)
+
+
+def player_config(rt, runtime, raw):
+    rt._player_effective_params(raw)
+    profile = runtime._player_vehicle_profile(raw)
+    descriptor = profile['descriptor']
+    result = dict(raw)
+    result['_kernel'] = dict(
+        class_tag=profile['class_tag'], armor=profile['armor'],
+        base_view=rt._value(rt._value(descriptor, 'turret', {}),
+                            'circularVisionRadius', 330.0),
+        view_misc=rt._value(rt._value(descriptor, 'miscAttrs', {}),
+                            'circularVisionRadiusFactor', 1.0),
+        critical_config=descriptor_critical_config(rt, descriptor))
+    return result
+
+
+def health_config(rt, descriptor):
+    names = (
+        'BOT_DROWNING_PROBE_SECONDS', 'BOT_DROWNING_SECONDS',
+        'BOT_DROWNING_DEATH_REASON', 'BOT_OVERTURN_IGNORE_SECONDS',
+        'BOT_OVERTURN_WARNING_COSINE', 'BOT_OVERTURN_DANGER_COSINE',
+        'BOT_OVERTURN_DEATH_SECONDS', 'BOT_OVERTURN_DEATH_REASON')
+    result = dict((name, getattr(rt, name)) for name in names)
+    result['water_offset'] = rt._water_sensor_geometry(descriptor)[0]
+    return result
+
+
+def factor_config(rt):
+    damage = rt.device_damage
+    names = rt.bot_state_codec.CREW_NAMES
+    rows = {}
+    for stat in ('reload', 'aim_time', 'dispersion', 'turret_speed',
+                 'mobility', 'vision', 'signal'):
+        rows[stat] = [damage.crew_stat_factor(
+            [name for index, name in enumerate(names) if mask & (1 << index)],
+            stat) for mask in range(1 << len(names))]
+    return dict(crew_names=names, crew_rows=rows,
+                module_specs=damage._MODULE_STAT_SPEC,
+                minimum_vision=damage.MIN_VISION_FACTOR)
+
+
+def perception_config(rt, runtime):
+    return dict(
+        ttl=rt.VISIBILITY_SAMPLE_SECONDS,
+        shot_seconds=rt.spotting.SHOT_CAMOUFLAGE_SECONDS,
+        proximity=rt.spotting.PROXIMITY_SPOT_DISTANCE,
+        maximum=rt.spotting.MAX_SPOT_DISTANCE,
+        memory=rt.spotting.SPOT_MEMORY_SECONDS,
+        designated=rt.spotting.DESIGNATED_SPOT_MEMORY_SECONDS,
+        budget=rt.MAX_VISIBILITY_PROBES_PER_FRAME,
+        moving_epsilon=rt.spotting.MOVING_SPEED_EPSILON,
+        human_base=rt.HUMAN_TARGET_ID_BASE,
+        last_effort=rt.spotting.LAST_EFFORT_SECONDS,
+        pose_fields=rt._TARGET_POSE_FIELDS,
+        bot_fields=rt._TARGET_DYNAMIC_FIELDS + rt._BOT_TARGET_STATIC_FIELDS,
+        human_fields=rt._TARGET_DYNAMIC_FIELDS + rt._HUMAN_TARGET_STATIC_FIELDS,
+        factors=factor_config(rt))
+
+
+ENGINE_FIELDS = (
+    'id team x y z yaw pitch roll aim_yaw turret_yaw gun_pitch speed '
+    'fire_seq shell_index alive health max_health half_length half_width '
+    'vertical_speed airborne grounded_once movement_dir rotation_dir '
+    'siege_state siege_time_left_ms siege_transition_total_ms '
+    'hull_aiming gun_aligned skill_rating _drowning _overturned '
+    'combat_fire_elapsed combat_fire_timer stun_end_server_time_ms '
+    'terrain_pitch suspension_pitch _kernel_turn_speed'
+).split()
+
+
+def lane_config(rt, runtime):
+    return dict(phases=rt.SHOT_LANE_PHASES, refresh=rt.SHOT_LANE_REFRESH_SECONDS,
+                seconds=rt.SHOT_LANE_SECONDS, distance=rt.SHOT_LANE_QUERY_DISTANCE,
+                spg_distance=rt.SPG_SHOT_LANE_QUERY_DISTANCE,
+                control=runtime._control_seconds,
+                has_incoming=callable(runtime.incoming_lane_probe))
+
+
+def motion_config(rt, runtime):
+    from motion_adapter import CONSTANTS
+    return dict(tuning=dict((name, getattr(rt.vehicle_physics, name)) for name in CONSTANTS),
+                factors=factor_config(rt), probe_seconds=rt.MOTION_PROBE_SECONDS,
+                navigation=getattr(runtime.navigator, 'handle', 0),
+                driver=getattr(runtime.adapter.driver, 'handle', 0),
+                receipt_budget=rt.MAX_WORLD_RECEIPTS_PER_FRAME,
+                has_receipt=callable(runtime.world_receipt_probe),
+                has_resolver=callable(runtime.motion_resolver),
+                has_report=callable(runtime.motion_report),
+                bake_admitted=getattr(runtime.adapter.driver, 'bake_admitted', False),
+                siege_enabled=rt.siege_mechanics.ENABLED,
+                slope_metres=rt.SLOPE_SAMPLE_METRES,
+                slope_radians=rt.SLOPE_SAMPLE_RADIANS)
+
+
+def gunner_config(rt, runtime, bot_id):
+    result = dict(rt.bot_gunnery.rating_parameters(runtime.bot_rating(bot_id)))
+    result.update(epoch_seconds=rt.bot_gunnery.AIM_BIAS_SECONDS,
+                  maximum_offset=rt.bot_gunnery.MAX_AIM_OFFSET_METRES,
+                  vertical_share=rt.bot_gunnery.VERTICAL_BIAS_SHARE)
+    return result
+
+
+def aim_config(rt, runtime):
+    return dict(factors=factor_config(rt), maximum_time=rt.ballistics.PROJECTILE_MAX_FLIGHT_SECONDS,
+                action_seconds=rt.LOCAL_ACTION_SECONDS, intent_seconds=rt.ARTILLERY_INTENT_SECONDS,
+                total_seconds=rt.ARTILLERY_TOTAL_PROOF_SECONDS,
+                reproof_seconds=rt.ARTILLERY_REPROOF_SECONDS,
+                staleness_metres=rt.ARTILLERY_AIM_STALENESS_METRES,
+                has_part=callable(runtime.direct_aim_point_probe),
+                has_solution=callable(runtime.ballistic_solution_probe),
+                has_launch=callable(runtime.artillery_launch_probe),
+                has_cancel=callable(runtime.artillery_launch_cancel))
+
+
+def aim_profile(rt, runtime, bot_id, combat):
+    descriptor = runtime._descriptors[bot_id]
+    gun = runtime._gun_states[bot_id]
+    return dict(handle=combat.profile(descriptor),
+                shells=[rt._shot_ballistics(descriptor, index) for index in range(gun.shell_count)],
+                turret_speed=rt._rotation_speed(rt._value(descriptor, 'turret', {}) or {}, .5) *
+                             max(0.0, gun.loadout.get('crew_factor', 1)),
+                gun_speed=rt._rotation_speed(rt._value(descriptor, 'gun', {}) or {}, .35) *
+                          max(0.0, gun.loadout.get('gun_rotation_factor', 1)))
+
+
+def driver_config(rt, runtime):
+    return dict(driver=runtime.adapter.driver.handle,
+                navigation=getattr(runtime.navigator, 'handle', 0),
+                bake_admitted=runtime.adapter.driver.bake_admitted,
+                lookahead=rt.BAKED_MOTION_LOOKAHEAD_SECONDS,
+                publication_seconds=rt.PUBLICATION_SECONDS,
+                speed_epsilon=rt.TRAFFIC_DIRECTION_SPEED_EPSILON)
+
+
+class Kernel(object):
+    def __init__(self, backend, codec, bots, **configuration):
+        self.backend = backend
+        configuration.update(codec=codec_config(codec), bots=bots)
+        self.handle = int(backend.call(packet(
+            [700], configuration))[0])
+
+    def output(self, size):
+        size = int(size)
+        values = self.backend.call(array('d', [719, self.handle]) +
+                                   array('d', [0]) * max(0, (size + 7) // 8 - 1))
+        raw = values.tostring() if hasattr(values, 'tostring') else values.tobytes()
+        return json.loads(raw[8:8 + size].decode('utf-8'))
+
+    def weapon_actions(self, bot_id, actions):
+        result = self.backend.call(packet([710, self.handle, bot_id], actions))
+        return self.output(result[0])
+
+    def encode(self, states):
+        result = self.backend.call(packet([711, self.handle], states))
+        return self.output(result[0])
+
+    def equipment_actions(self, bot_id, actions):
+        result = self.backend.call(packet([712, self.handle, bot_id], actions))
+        return self.output(result[0])
+
+    def round(self, inputs):
+        result = self.backend.call(packet([713, self.handle], inputs))
+        return self.output(result[0])
+
+    def gunnery_actions(self, bot_id, actions):
+        result = self.backend.call(packet([716, self.handle, bot_id], actions))
+        return self.output(result[0])
+
+    def launch_actions(self, bot_id, actions):
+        result = self.backend.call(packet([717, self.handle, bot_id], actions))
+        return self.output(result[0])
+
+    def motion_actions(self, actions, callback):
+        query = array('d', [0]) * 256
+        result = self.backend.call_sync(packet([718, self.handle], actions), query,
+                                        lambda: callback(query))
+        return self.output(result[0])
+
+    def aim_actions(self, actions, callback):
+        query = array('d', [0]) * 256
+        result = self.backend.call_sync(packet([720, self.handle], callback.prepare(actions)), query,
+                                        lambda: callback(query))
+        return callback.resolve(self.output(result[0]))
+
+    def driver_actions(self, actions, callback):
+        query = array('d', [0]) * 32768
+        result = self.backend.call_sync(packet([721, self.handle], actions), query,
+                                        lambda: callback(query))
+        return self.output(result[0])
+
+    def contact_actions(self, actions, callback):
+        query = array('d', [0]) * 256
+        result = self.backend.call_sync(packet([722, self.handle], actions), query,
+                                        lambda: callback(query))
+        return self.output(result[0])
+
+    def health_actions(self, bot_id, actions):
+        result = self.backend.call(packet([714, self.handle, bot_id], actions))
+        return self.output(result[0])
+
+    def perception_actions(self, actions, visibility, engine=None):
+        query = array('d', [0]) * 256
+
+        def callback():
+            if int(query[0]) in (751, 752) and engine is not None:
+                return engine(query)
+            if int(query[0]) != 750:
+                raise RuntimeError('unknown kernel perception query')
+            source_kind, source_id, target_kind, target_id = (
+                int(v) for v in query[1:5])
+            source = dict(kind='human' if source_kind else 'bot',
+                          id=source_id, network_id=source_id,
+                          x=query[6], y=query[7], z=query[8])
+            target = dict(kind='human' if target_kind else 'bot',
+                          id=target_id, network_id=target_id,
+                          x=query[9], y=query[10], z=query[11],
+                          position=tuple(query[9:12]))
+            try:
+                try:
+                    result = visibility(source, target, bool(query[5]))
+                except TypeError:
+                    result = visibility(source, target)
+            except Exception:
+                result = False
+            query[0] = bool(result.get('line_of_sight', False)) if isinstance(result, dict) else bool(result)
+            query[1] = float(result.get('foliage_bonus', 0)) if isinstance(result, dict) else 0
+            return 0
+
+        result = self.backend.call_sync(packet([715, self.handle], actions), query, callback)
+        return self.output(result[0])
+
+    def close(self):
+        if self.handle:
+            self.backend.call([705, self.handle])
+            self.handle = 0
+
+
+def simulation_config(rt, runtime):
+    from gui.mods.offline_lan_0922.ai import navigation
+    import sys
+    return dict(
+        debug=runtime.debug_logging, native_motion=runtime.native_motion,
+        camera=runtime._camera_position, accumulator=runtime._accumulator,
+        next_publication=runtime._next_publication,
+        next_observation=runtime._next_observation,
+        next_lane=runtime._next_shot_lane_refresh,
+        next_cover=runtime._next_cover_refresh, equipment_now=runtime._equipment_now,
+        sample=runtime._sample_time_us, edge_sample=runtime._edge_sample_time_us,
+        edge_revision=runtime._edge_revision, control=runtime._control_seconds,
+        maximum_step=rt.MAX_CONTROL_ELAPSED_SECONDS,
+        decision_seconds=rt.DECISION_SECONDS, decision_tiers=rt.DECISION_TIER_FACTOR,
+        near=rt.DETAIL_NEAR_METRES, far=rt.DETAIL_FAR_METRES,
+        observation_seconds=rt.OBSERVATION_SECONDS,
+        lane_seconds=rt.SHOT_LANE_REFRESH_SECONDS,
+        final_lane_budget=rt.MAX_SHOT_LANE_PAIRS_PER_FRAME,
+        lane_budget=rt.MAX_WORKER_SHOT_LANE_PAIRS_PER_FRAME,
+        cover_seconds=rt.COVER_REFRESH_SECONDS, cover_jobs=rt.COVER_JOBS_PER_OBSERVATION,
+        cover_window=rt.COVER_JOB_WINDOW_SECONDS,
+        has_cover=callable(runtime.cover_probe), has_water=callable(runtime._water_depth_probe),
+        has_destructible=callable(runtime.destructible_body_scan),
+        destructible_speed=rt.DESTRUCTIBLE_SCAN_MIN_SPEED,
+        human_base=rt.HUMAN_TARGET_ID_BASE, py2=sys.version_info[0] == 2,
+        arrival=rt.ai_driver.WAYPOINT_ARRIVAL_RADIUS,
+        contact_slop=rt.tank_collision.POSITION_SLOP,
+        reposition_seconds=rt.FRIENDLY_REPOSITION_SECONDS,
+        hull_penalty=navigation.STATIC_HULL_EDGE_PENALTY,
+        slope_budget=rt.MAX_SLOPE_POSE_SAMPLES_PER_FRAME,
+        siege_long=rt.SIEGE_LONG_TRAVEL_METRES,
+        siege_enable_debounce=rt.SIEGE_ENABLE_DEBOUNCE_SECONDS,
+        siege_disable_debounce=rt.SIEGE_DISABLE_DEBOUNCE_SECONDS,
+        edge_fields=rt._PUBLICATION_EDGE_SCALAR_FIELDS,
+        suspension_failures=runtime._suspension_param_failures)
+
+
+class KernelBackend(object):
+    """One native update call owns all mutable Bot simulation phases."""
+    def __init__(self, backend, runtime, rt):
+        from combat_adapter import CombatBackend
+        from driver_adapter import DriverBackend
+        from navigation_flow_adapter import NavigationFlowBackend
+        from kernel_engine import EngineLeaves
+        from gui.mods.offline_lan_0922.ai import navigation
+        if runtime.native_motion or runtime._suspension_ground_probe is not None:
+            raise ValueError('Owned kernel experiment requires the copied vertical controller')
+        self.backend, self.runtime, self.module = backend, runtime, rt
+        self.parts = [NavigationFlowBackend(backend, runtime, navigation),
+                      DriverBackend(backend, runtime, True)]
+        combat = CombatBackend(backend, rt)
+        self.parts.append(combat)
+        bots = []
+        for identity, state in runtime.states.items():
+            descriptor = runtime._descriptors[identity]
+            value = bot_config(state, runtime._gun_states[identity],
+                               runtime._ammo_states[identity], runtime._burst_states[identity])
+            target = dict(state, kind='bot', network_id=identity)
+            value.update(critical_config=critical_config(rt, runtime, identity),
+                         equipment=[dict((name, getattr(item, name)) for name in item.__slots__)
+                                    for item in runtime._equipment_states.get(identity, ())],
+                         sync=runtime._combat_sync.get(identity),
+                         turn_speed=runtime._turn_speeds.get(identity, 0))
+            value['config'] = health_config(rt, descriptor)
+            value['config'].update(
+                gunnery=gunner_config(rt, runtime, identity),
+                aim=aim_profile(rt, runtime, identity, combat),
+                perception=dict(profile=runtime._spotting_profile(target),
+                                vision=runtime._vision_ranges.get(identity)),
+                motion=dict(physics=runtime._physics_params_for(identity),
+                            yaw_limits=rt.ai_driver.gun_yaw_limits(descriptor)))
+            pair = runtime._descriptor_pairs.get(identity)
+            if pair is not None and pair[1] is not None:
+                value['config']['siege_modes'] = [descriptor_mode(rt, runtime, identity, mode, combat)
+                                                  for mode in (0, 2)]
+                value['config']['siege_params'] = rt.siege_mechanics.params(pair[0])
+            bots.append(value)
+        orders = [[identity, dict(order, _kernel_token=runtime._server_order_tokens.get(identity, 0))]
+                  for identity, order in runtime._server_orders.items()]
+        self.kernel = Kernel(backend, rt.bot_state_codec, bots, round_id=runtime.round_id,
+            engine=dict(fields=ENGINE_FIELDS), perception=perception_config(rt, runtime),
+            lanes=lane_config(rt, runtime), motion=motion_config(rt, runtime),
+            aim=aim_config(rt, runtime), driver=driver_config(rt, runtime), orders=orders,
+            contacts=dict(human_base=rt.HUMAN_TARGET_ID_BASE,
+                          has_armor=callable(runtime.ram_contact_probe),
+                          py2=simulation_config(rt, runtime)['py2'], sequence=runtime._ram_seq),
+            simulation=simulation_config(rt, runtime))
+        self.engine = EngineLeaves(rt, runtime)
+        self.engine.owned = True
+        self.originals = {}
+        self.order_revision = runtime._order_revision
+        self.query = array('d', [0]) * 32768
+
+    def update(self, dt, now, players=None, neighbours=None):
+        self.engine.actor_cache.clear()
+        supplied = []
+        for raw in players or ():
+            value = player_config(self.module, self.runtime, raw)
+            value['_kernel']['collision'] = self.runtime._player_collision_profile(raw)
+            supplied.append(value)
+        self.engine.players = dict((item['id'], item) for item in players or ())
+        inputs = dict(
+            dt=dt, now=now, players=supplied, neighbours=neighbours or (),
+            camera=self.runtime._camera_position)
+        if self.runtime._order_revision != self.order_revision:
+            inputs['orders'] = [[identity, dict(order, _kernel_token=self.runtime._server_order_tokens.get(identity, 0))]
+                                for identity, order in self.runtime._server_orders.items()]
+        command = packet([723, self.kernel.handle], self.engine.prepare(inputs))
+        result = self.backend.call_sync(command, self.query, lambda: self.engine(self.query))
+        output = self.kernel.output(result[0])
+        self.order_revision = self.runtime._order_revision
+        messages = output['messages']
+        for message in messages:
+            for key in ('launches', 'affordances'):
+                if key in message:
+                    message[key] = self.engine.resolve(message[key])
+        for row in output['logs']:
+            print('[%s] %s' % (str(row['kind']), json.dumps(row['payload'], sort_keys=True, separators=(',', ':'))))
+        self.engine.retain(output['tokens'])
+        self.runtime._sample_time_us = output['sample']
+        self.runtime._equipment_now = output['equipment_now']
+        self.runtime._last_update_control_steps = output['steps']
+        self.runtime._last_update_max_control_step = output['maximum_step']
+        self.runtime.navigator._snapshot = None
+        self.runtime.navigator._progress = None
+        return messages
+
+    def counters(self):
+        result = self.backend.call([726, self.kernel.handle])
+        output = self.kernel.output(result[0])
+        output['decisions'] = dict((int(key), value) for key, value in output['decisions'].items())
+        return output
+
+    def probes(self):
+        counts = self.counters()
+        values = counts['motion_probes']
+        values[0] = self.engine.calls.get(767, 0)
+        values[1] = counts['lane_probes']
+        values[2] = counts['cover_probes']
+        return tuple(values)
+
+    def diagnostics(self):
+        return self.counters()['diagnostics']
+
+    def install(self):
+        for name, replacement in (('update', self.update), ('ack_projectile_launch', self.ack),
+                                  ('probe_totals', self.probes), ('diagnostic_totals', self.diagnostics)):
+            self.originals[name] = getattr(self.runtime, name)
+            setattr(self.runtime, name, replacement)
+        return self
+
+    def snapshot(self):
+        result = self.backend.call([724, self.kernel.handle])
+        return self.engine.resolve(self.kernel.output(result[0]))
+
+    def ack(self, identity, sequence):
+        return bool(self.backend.call([725, self.kernel.handle, identity, sequence])[0])
+
+    def close(self):
+        for name, original in self.originals.items():
+            setattr(self.runtime, name, original)
+        self.kernel.close()
+        for part in reversed(self.parts):
+            part.close()
+
+
+def descriptor_mode(rt, runtime, identity, mode, combat):
+    """Read both immutable stock descriptor modes once at owner construction."""
+    import copy
+    shadow = copy.copy(runtime)
+    for name in ('_descriptors', '_physics_params', '_suspension_params', '_gun_yaw_limits',
+                 '_gun_states', '_repair_factors', '_vision_ranges', '_spotting_profiles',
+                 '_motion_probe_cache', '_traffic_stopping_cache', '_artillery_intents',
+                 '_artillery_reproofs'):
+        setattr(shadow, name, dict(getattr(runtime, name)))
+    shadow._gun_states[identity] = copy.deepcopy(runtime._gun_states[identity])
+    shadow._traffic_coordinator = copy.deepcopy(runtime._traffic_coordinator)
+    shadow.artillery_launch_cancel = None
+    state = copy.deepcopy(runtime.states[identity])
+    shadow._install_bot_descriptor(identity, state, mode)
+    descriptor = shadow._descriptors[identity]
+    target = dict(state, kind='bot', network_id=identity)
+    names = ('move_speed', 'view_range', 'half_length', 'half_width', 'collision_shape', 'mass', 'ram_profile')
+    return dict(gun=shadow._gun_states[identity].__dict__,
+                critical=critical_config(rt, shadow, identity),
+                health=health_config(rt, descriptor),
+                state=dict((name, state[name]) for name in names),
+                aim=aim_profile(rt, shadow, identity, combat),
+                perception=dict(profile=shadow._spotting_profile(target),
+                                vision=shadow._vision_ranges.get(identity)),
+                motion=dict(physics=shadow._physics_params_for(identity),
+                            yaw_limits=rt.ai_driver.gun_yaw_limits(descriptor),
+                            siege_limit=rt.siege_mechanics.enabled_speed_limit(descriptor)))

--- a/tools/ffi_experiment/kernel_adapter.py
+++ b/tools/ffi_experiment/kernel_adapter.py
@@ -443,6 +443,7 @@ class KernelBackend(object):
     def close(self):
         for name, original in self.originals.items():
             setattr(self.runtime, name, original)
+        self.engine.actor_cache.clear()
         self.kernel.close()
         for part in reversed(self.parts):
             part.close()

--- a/tools/ffi_experiment/kernel_aim.h
+++ b/tools/ffi_experiment/kernel_aim.h
@@ -1,0 +1,552 @@
+#ifndef OFFLINE_EXPERIMENT_KERNEL_AIM_H
+#define OFFLINE_EXPERIMENT_KERNEL_AIM_H
+#include "kernel_gunnery.h"
+#include "kernel_engine.h"
+#include "kernel_factors.h"
+#include "combat_core.h"
+
+namespace offline_kernel {
+inline double cache_deadline(double now, int id, double interval, int salt, bool initial) {
+    interval = std::max(.001, interval);
+    double result = now + interval;
+    return initial ? result + ((std::abs(id) * 17 + salt * 11) % 29) / 29.0 * interval : result;
+}
+inline Value engine_token(double token) {
+    if (token == 0)
+        return Value();
+    if (token < 0 || token != std::floor(token) || token > 9007199254740991.0)
+        throw std::invalid_argument("kernel engine token");
+    Value v = Value::object();
+    v["_engine_token"] = Value(static_cast<int64_t>(token));
+    return v;
+}
+inline double engine_token_id(const Value &v) { return field(v, "_engine_token"); }
+inline double angle_delta(double v) {
+    while (v > 3.141592653589793)
+        v -= 6.283185307179586;
+    while (v < -3.141592653589793)
+        v += 6.283185307179586;
+    return v;
+}
+struct Aim {
+    struct Cached {
+        Value signature, solution;
+        double deadline;
+    };
+    Value config;
+    Engine &engine;
+    Factors factors;
+    std::map<int, Gunnery> &gunners;
+    std::map<int, Cached> cache;
+    std::map<int, Value> intents, reproofs;
+    int round;
+    Aim(const Value &v, Engine &e, std::map<int, Gunnery> &g, int round)
+        : config(v), engine(e), factors(v.get("factors")), gunners(g), round(round) {}
+    static const Value &profile(const Bot &bot) { return bot.config.get("aim"); }
+    static Value physical(const Bot &bot, int shell) {
+        const Value &shells = profile(bot).get("shells");
+        return shell >= 0 && shell < static_cast<int>(shells.size()) ? shells[shell] : Value();
+    }
+    static void pose(std::vector<double> &out, const Value &s) {
+        std::set<std::string> destroyed = names(s.get("critical").get("destroyed"));
+        for (const char *name : {"yaw", "pitch", "roll"})
+            out.push_back(field(s, name));
+        out.push_back(field(s, "terrain_pitch", field(s, "pitch") - field(s, "suspension_pitch")));
+        for (const char *name : {"suspension_pitch", "turret_yaw", "gun_pitch"})
+            out.push_back(field(s, name));
+        out.push_back(field(s, "aim_yaw", field(s, "yaw")));
+        out.push_back(integer(s, "movement_dir") != 0);
+        out.push_back(destroyed.count("engineHealth"));
+        out.push_back(destroyed.count("leftTrackHealth") || destroyed.count("rightTrackHealth"));
+        out.push_back(flag(s, "_overturned"));
+        out.push_back(integer(s, "siege_state"));
+    }
+    static void point(std::vector<double> &out, const Value &v) {
+        for (size_t i = 0; i < 3; ++i)
+            out.push_back(v[i].number());
+    }
+    static Value solution(const double *result, const std::string &arc) {
+        if (result[0] == 0)
+            return Value();
+        Value v = Value::object();
+        v["aim_position"] = vector3(result[1], result[2], result[3]);
+        v["pitch"] = Value(result[4]);
+        v["flight_time"] = Value(result[5]);
+        v["yaw"] = Value(result[6]);
+        v["arc"] = Value(arc);
+        return v;
+    }
+    Value origin(const Bot &bot, int shell, int seq, double yaw, double pitch, double time) {
+        auto result =
+            engine.query(761, bot.state, Value::object(),
+                         {static_cast<double>(shell), static_cast<double>(seq), yaw, pitch, time});
+        return result[0] != 0 ? vector3(result[1], result[2], result[3]) : Value();
+    }
+    Value exact_origin(const Bot &bot, int shell) {
+        Value d = world_barrel(bot.state);
+        double horizontal =
+            std::sqrt(d[0].number() * d[0].number() + d[2].number() * d[2].number());
+        return origin(bot, shell, integer(bot.state, "fire_seq") + 1,
+                      std::atan2(d[0].number(), d[2].number()),
+                      -std::atan2(d[1].number(), std::max(1e-12, horizontal)), 0);
+    }
+    Value part(const Bot &bot, const Value &target) {
+        auto result = engine.query(762, bot.state, target);
+        if (result[0] == 0)
+            return Value();
+        Value v = Value::object();
+        v["aim_position"] = vector3(result[1], result[2], result[3]);
+        v["aim_token"] = engine_token(result[4]);
+        return v;
+    }
+    bool reachable(const Bot &bot, double yaw, double pitch) {
+        std::vector<double> packet = {104, field(profile(bot), "handle")};
+        pose(packet, bot.state);
+        packet.push_back(yaw);
+        packet.push_back(pitch);
+        offline_combat_dispatch(packet.data(), packet.size());
+        return packet[0] != 0;
+    }
+    Value intercept(const Bot &bot, const Value &start, const Value &target, const Value &speed,
+                    const Value &shell, bool high) {
+        std::vector<double> packet = {101, field(profile(bot), "handle")};
+        pose(packet, bot.state);
+        point(packet, start);
+        point(packet, target);
+        point(packet, speed);
+        packet.insert(packet.end(), {shell[0].number(), shell[1].number(), -1.5707963267948966,
+                                     1.5707963267948966, static_cast<double>(high),
+                                     field(config, "maximum_time"), shell[2].number()});
+        size_t offset = packet.size();
+        packet.resize(offset + 7, 0);
+        offline_combat_dispatch(packet.data(), packet.size());
+        return solution(packet.data() + offset, high ? "high" : "low");
+    }
+    Value local(const Bot &bot, const Value &target, int shell) {
+        Value physics = physical(bot, shell);
+        if (target.kind == Value::Null || physics.kind == Value::Null)
+            return Value();
+        Value start = exact_origin(bot, shell);
+        if (start.kind == Value::Null)
+            return Value();
+        Value aim, token;
+        if (flag(config, "has_part")) {
+            Value selected = part(bot, target);
+            if (selected.kind == Value::Null)
+                return Value();
+            aim = selected.get("aim_position");
+            token = selected.get("aim_token");
+        } else {
+            aim = target_position(target).copy();
+            aim[1] = Value(aim[1].number() + 1);
+        }
+        Value result = intercept(bot, start, aim, velocity(target), physics, false);
+        if (result.kind != Value::Null) {
+            result["_origin"] = start;
+            result["_aim_token"] = token;
+        }
+        return result;
+    }
+    Value signature(const Bot &bot, const Value &target, int shell) {
+        Value v = Value::array();
+        v.append(Value(target.get("kind").text()));
+        v.append(target.has("network_id") ? target.get("network_id") : target.get("id"));
+        v.append(Value(flag(target, "alive", true)));
+        v.append(Value(shell));
+        v.append(profile(bot).get("handle"));
+        v.append(Value(integer(bot.state, "siege_state")));
+        v.append(Value(integer(bot.state, "fire_seq")));
+        return v;
+    }
+    std::pair<Value, bool> cadenced(Bot &bot, const Value &target, int shell, double now,
+                                    bool refresh, bool force = false) {
+        int id = integer(bot.state, "id");
+        Value key = signature(bot, target, shell);
+        auto at = cache.find(id);
+        bool fresh = force || at == cache.end() || at->second.signature != key ||
+                     (refresh && now + 1e-9 >= at->second.deadline);
+        if (!fresh)
+            return {at->second.solution, false};
+        Value aimed = gunners.at(id).aimed(bot.state, target, now, round, bot.gun);
+        Value result = bot.state.get("profile").get("class_tag").text() == "SPG"
+                           ? artillery(bot, aimed, shell, now)
+                           : local(bot, aimed, shell);
+        cache[id] =
+            Cached{key, result,
+                   cache_deadline(now, id, field(config, "action_seconds"), 13, at == cache.end())};
+        return {result, true};
+    }
+    Value slew(Bot &bot, const Value &command, const Value &target, double dt) {
+        Value &s = bot.state;
+        const Value &solution = command.get("_ballistic_solution");
+        double desired = field(s, "aim_yaw", field(s, "yaw")), pitch = 0, horizontal = 0;
+        if (target.kind != Value::Null || solution.kind == Value::Object) {
+            Value fallback = target.kind != Value::Null ? target_position(target) : position(s),
+                  aim = solution.kind == Value::Object ? solution.get("aim_position")
+                                                       : command.get("aim_position");
+            if (aim.kind != Value::Array || aim.size() != 3)
+                aim = fallback;
+            Value origin = solution.get("_origin");
+            if (origin.kind != Value::Array || origin.size() != 3)
+                origin = exact_origin(bot, integer(s, "shell_index"));
+            if (origin.kind == Value::Null) {
+                s["gun_aligned"] = Value(false);
+                Value result = Value::array();
+                result.append(Value(field(s, "aim_yaw")));
+                result.append(Value(0.0));
+                return result;
+            }
+            double dx = aim[0].number() - origin[0].number(),
+                   dz = aim[2].number() - origin[2].number();
+            horizontal = std::sqrt(dx * dx + dz * dz);
+            desired = solution.kind == Value::Object ? field(solution, "yaw")
+                      : horizontal > .1              ? std::atan2(dx, dz)
+                                                     : field(s, "yaw");
+            pitch = solution.kind == Value::Object
+                        ? field(solution, "pitch")
+                        : -std::atan2((aim[1].number() + 1) - origin[1].number(),
+                                      std::max(.5, horizontal));
+        }
+        std::vector<double> packet = {102, field(profile(bot), "handle")};
+        pose(packet, s);
+        packet.insert(
+            packet.end(),
+            {desired, pitch, dt, static_cast<double>(target.kind != Value::Null),
+             field(profile(bot), "turret_speed") * factors.stat(s, *bot.critical, "turret_speed"),
+             field(profile(bot), "gun_speed")});
+        size_t offset = packet.size();
+        packet.resize(offset + 8, 0);
+        offline_combat_dispatch(packet.data(), packet.size());
+        const char *names[] = {"terrain_pitch", "suspension_pitch",  "pitch",  "turret_yaw",
+                               "gun_pitch",     "desired_gun_pitch", "aim_yaw"};
+        for (size_t i = 0; i < 7; ++i)
+            s[names[i]] = Value(packet[offset + i]);
+        s["gun_aligned"] = Value(packet[offset + 7] != 0);
+        Value result = Value::array();
+        result.append(Value(desired));
+        result.append(Value(horizontal));
+        return result;
+    }
+    bool direct_matches(const Bot &bot, const Value &target, const Value &solution) {
+        if (!flag(config, "has_part"))
+            return true;
+        Value selected = part(bot, target);
+        bool matches = selected.kind == Value::Object && solution.kind == Value::Object &&
+                       selected.get("aim_token") == solution.get("_aim_token");
+        if (!matches)
+            cache.erase(integer(bot.state, "id"));
+        return matches;
+    }
+    Value preview(const Bot &bot, int shell, const Value &solution, const Subshot *edge = nullptr) {
+        double time = field(solution, "flight_time", -1);
+        if (solution.kind != Value::Object && edge) {
+            Value p = physical(bot, shell);
+            if (p.kind == Value::Null)
+                return Value();
+            double speed = p[0].number(), maximum = p[2].number();
+            if (speed > 0 && maximum > 0)
+                time = std::min(field(config, "maximum_time"), maximum / speed);
+        }
+        if (!std::isfinite(time) || time <= 0 || time > field(config, "maximum_time"))
+            return Value();
+        int seq = integer(bot.state, "fire_seq") + 1, group = seq, index = 0;
+        if (edge) {
+            seq = edge->seq;
+            group = edge->group;
+            index = edge->index;
+            if (seq != integer(bot.state, "fire_seq") + 1)
+                return Value();
+        }
+        Value angles = dispersed(
+            integer(bot.state, "id"), round, seq, field(bot.state, "aim_yaw"),
+            field(bot.state, "gun_pitch"),
+            std::max(bot.gun.dispersion,
+                     bot.gun.fully_aimed * factors.stat(bot.state, *bot.critical, "dispersion")),
+            index, group, dispersal_base(bot.state));
+        Value start = origin(bot, shell, seq, angles[0].number(), angles[1].number(), time);
+        if (start.kind == Value::Null)
+            return Value();
+        Value result = Value::object();
+        result["fire_seq"] = Value(seq);
+        result["shell_index"] = Value(shell);
+        result["shot_yaw"] = angles[0];
+        result["shot_pitch"] = angles[1];
+        result["flight_time"] = Value(time);
+        result["origin"] = start;
+        return result;
+    }
+    static Value target_identity(const Value &target) {
+        if (target.kind != Value::Object || (!target.has("network_id") && !target.has("id")))
+            return Value();
+        Value id = target.has("network_id") ? target.get("network_id") : target.get("id");
+        if (id.kind == Value::Null)
+            return Value();
+        Value v = Value::array();
+        v.append(Value(target.get("kind").text()));
+        v.append(Value(id.exact()));
+        return v;
+    }
+    static Value source_pose(const Value &s) {
+        Value v = Value::array();
+        for (const char *name : {"x", "y", "z", "yaw", "pitch", "roll", "turret_yaw", "gun_pitch"})
+            v.append(Value(field(s, name)));
+        return v;
+    }
+    bool cancel(Bot &bot, bool preserve = false) {
+        int id = integer(bot.state, "id");
+        bool had = intents.erase(id) > 0, proof = reproofs.count(id) > 0;
+        if (!preserve)
+            reproofs.erase(id);
+        if (had && flag(config, "has_cancel"))
+            engine.query(766, bot.state, Value::object());
+        return had || proof;
+    }
+    Value active_reproof(Bot &bot, const Value &target, int shell, double now) {
+        int id = integer(bot.state, "id");
+        auto at = reproofs.find(id);
+        if (at == reproofs.end())
+            return Value();
+        Value proof = at->second, pose = source_pose(bot.state);
+        const Value &before = proof.get("source_pose");
+        double moved = 0;
+        bool turned = false;
+        for (size_t i = 0; i < 3; ++i) {
+            double d = pose[i].number() - before[i].number();
+            moved += d * d;
+        }
+        moved = std::sqrt(moved);
+        for (size_t i = 3; i < std::min(pose.size(), before.size()); ++i)
+            turned = turned || std::abs(angle_delta(pose[i].number() - before[i].number())) > .001;
+        bool invalid = target.kind != Value::Object || !flag(target, "alive", true) ||
+                       (target.has("health") && field(target, "health") <= 0) ||
+                       target_identity(target) != proof.get("target_identity") ||
+                       shell != integer(proof, "shell_index") ||
+                       integer(bot.state, "fire_seq") + 1 != integer(proof, "fire_seq") ||
+                       physical(bot, shell) != proof.get("physical") || moved > .05 || turned;
+        if (invalid || now > field(proof, "deadline") + 1e-9) {
+            cancel(bot);
+            return Value();
+        }
+        return proof;
+    }
+    Value active_intent(Bot &bot, const Value &target, int shell, double now) {
+        auto at = intents.find(integer(bot.state, "id"));
+        if (at == intents.end())
+            return Value();
+        Value intent = at->second;
+        return active_reproof(bot, target, shell, now).kind == Value::Null ? Value() : intent;
+    }
+    static bool aligned(const Bot &bot, const Value &solution) {
+        if (!flag(bot.state, "gun_aligned") || solution.kind != Value::Object)
+            return false;
+        Value d = world_barrel(bot.state);
+        double yaw = std::atan2(d[0].number(), d[2].number()),
+               pitch = -std::atan2(d[1].number(),
+                                   std::max(1e-12, std::sqrt(d[0].number() * d[0].number() +
+                                                             d[2].number() * d[2].number())));
+        return std::abs(angle_delta(field(solution, "yaw") - yaw)) <= 1e-7 &&
+               std::abs(field(solution, "pitch") - pitch) <= 1e-7;
+    }
+    Value create_intent(Bot &bot, const Value &target, int shell, const Value &solution,
+                        double now) {
+        Value physics = physical(bot, shell), identity = target_identity(target);
+        if (physics.kind == Value::Null || identity.kind == Value::Null ||
+            !flag(target, "alive", true) ||
+            (target.has("health") && field(target, "health") <= 0) ||
+            std::abs(field(bot.state, "speed")) > .05 || !aligned(bot, solution))
+            return Value();
+        int id = integer(bot.state, "id"), seq = integer(bot.state, "fire_seq") + 1;
+        Value proof = active_reproof(bot, target, shell, now);
+        if (proof.kind == Value::Null) {
+            proof = Value::object();
+            Value source = Value::object();
+            source["id"] = Value(id);
+            proof["source"] = source;
+            proof["source_pose"] = source_pose(bot.state);
+            proof["target_identity"] = identity;
+            proof["shell_index"] = Value(shell);
+            proof["fire_seq"] = Value(seq);
+            proof["physical"] = physics;
+            proof["proof_latency"] = Value(0.0);
+            proof["attempts"] = Value(0);
+            proof["created"] = Value(now);
+            proof["deadline"] = Value(now + field(config, "intent_seconds"));
+            proof["absolute_deadline"] = Value(now + field(config, "total_seconds"));
+            reproofs[id] = proof;
+        } else if (integer(proof, "attempts"))
+            proof["deadline"] =
+                Value(std::min(field(proof, "absolute_deadline", field(proof, "deadline")),
+                               now + field(config, "reproof_seconds")));
+        Value angles = dispersed(
+            id, round, seq, field(bot.state, "aim_yaw"), field(bot.state, "gun_pitch"),
+            std::max(bot.gun.dispersion,
+                     bot.gun.fully_aimed * factors.stat(bot.state, *bot.critical, "dispersion")),
+            0, seq, dispersal_base(bot.state));
+        Value frozen = solution.copy();
+        proof["hold_solution"] = frozen.copy();
+        Value intent = Value::object();
+        for (const char *name : {"source", "source_pose", "target_identity", "shell_index",
+                                 "fire_seq", "physical", "deadline"})
+            intent[name] = proof.get(name);
+        intent["solution"] = frozen;
+        intent["shot_yaw"] = angles[0];
+        intent["shot_pitch"] = angles[1];
+        intent["created"] = Value(now);
+        intents[id] = intent;
+        return intent;
+    }
+    Value reproof_solution(Bot &bot, const Value &target, int shell, const Value &proof) {
+        Value physics = physical(bot, shell);
+        if (physics.kind == Value::Null || target.kind != Value::Object)
+            return Value();
+        Value start = exact_origin(bot, shell);
+        if (start.kind == Value::Null)
+            return Value();
+        Value aim = target_position(target).copy(), v = velocity(target);
+        aim[1] = Value(aim[1].number() + 1);
+        double latency = std::max(0.0, field(proof, "proof_latency"));
+        for (size_t i = 0; i < 3; ++i)
+            aim[i] = Value(aim[i].number() + v[i].number() * latency);
+        std::string arc = proof.get("arc").text();
+        if (arc != "low" && arc != "high")
+            return Value();
+        return intercept(bot, start, aim, v, physics, arc == "high");
+    }
+    Value artillery(Bot &bot, const Value &target, int shell, double now) {
+        Value intent = active_intent(bot, target, shell, now);
+        if (intent.kind != Value::Null)
+            return intent.get("solution").copy();
+        Value proof = active_reproof(bot, target, shell, now);
+        if (proof.kind != Value::Null && integer(proof, "attempts"))
+            return reproof_solution(bot, target, shell, proof);
+        if (!flag(config, "has_solution"))
+            return Value();
+        auto answer = engine.query(763, bot.state, target, {static_cast<double>(shell), now});
+        if (answer[0] == 0 || answer[5] <= 0 || answer[5] > field(config, "maximum_time") ||
+            !reachable(bot, answer[6], answer[4]))
+            return Value();
+        Value result = solution(answer.data(), answer[7] == 1 ? "high" : "low");
+        result["_engine_payload"] = engine_token(answer[8]);
+        return result;
+    }
+    Value validated_receipt(const Bot &bot, int shell, int seq, double yaw, double pitch,
+                            double time, const std::array<double, 256> &r) {
+        Value physics = physical(bot, shell);
+        if (r[0] == 0 || physics.kind == Value::Null)
+            return Value();
+        for (size_t i = 1; i < 16; ++i)
+            if (!std::isfinite(r[i]))
+                return Value();
+        int max_ms = static_cast<int>(r[11]);
+        if (static_cast<int>(r[12]) != seq || static_cast<int>(r[13]) != shell || r[7] != yaw ||
+            r[8] != pitch || r[14] != time || max_ms <= 0 || max_ms > 20000 ||
+            r[9] != physics[1].number() || r[10] != physics[2].number())
+            return Value();
+        double speed = physics[0].number(), horizontal = std::cos(pitch);
+        std::array<double, 3> velocity = {{std::sin(yaw) * horizontal * speed,
+                                           std::sin(pitch) * speed,
+                                           std::cos(yaw) * horizontal * speed}};
+        for (size_t i = 0; i < 3; ++i)
+            if (std::abs(r[4 + i] - velocity[i]) > 1e-7)
+                return Value();
+        Value result = Value::object();
+        result["origin"] = vector3(r[1], r[2], r[3]);
+        result["velocity"] = vector3(r[4], r[5], r[6]);
+        result["shot_yaw"] = Value(r[7]);
+        result["shot_pitch"] = Value(r[8]);
+        result["gravity"] = Value(r[9]);
+        result["max_distance"] = Value(r[10]);
+        result["max_time_ms"] = Value(max_ms);
+        result["fire_seq"] = Value(seq);
+        result["shell_index"] = Value(shell);
+        result["flight_time"] = Value(r[14]);
+        result["proof_key"] = engine_token(r[15]);
+        result["_engine_payload"] = engine_token(r[16]);
+        return result;
+    }
+    bool reject_stale(Bot &bot, const Value &target, int shell, const Value &intent,
+                      const Value &receipt, double now) {
+        const Value &solution = intent.get("solution"), &intended = solution.get("aim_position");
+        if (intended.kind != Value::Array || intended.size() != 3) {
+            cancel(bot);
+            return true;
+        }
+        Value p = target_position(target), v = velocity(target);
+        double error = 0, time = field(receipt, "flight_time");
+        for (size_t i = 0; i < 3; ++i) {
+            double projected = p[i].number() + (i == 1 ? 1 : 0) + v[i].number() * time,
+                   d = projected - intended[i].number();
+            if (!std::isfinite(d)) {
+                cancel(bot);
+                return true;
+            }
+            error += d * d;
+        }
+        error = std::sqrt(error);
+        if (error <= field(config, "staleness_metres") + 1e-9)
+            return false;
+        Value proof = active_reproof(bot, target, shell, now);
+        if (proof.kind == Value::Null) {
+            cancel(bot);
+            return true;
+        }
+        double latency = std::max(0.0, now - field(intent, "created"));
+        proof["proof_latency"] = Value(latency);
+        proof["attempts"] = Value(integer(proof, "attempts") + 1);
+        proof["deadline"] =
+            Value(std::min(field(proof, "absolute_deadline", field(proof, "deadline")),
+                           now + field(config, "reproof_seconds")));
+        proof["last_proof_latency"] = Value(latency);
+        proof["last_aim_staleness"] = Value(error);
+        proof["arc"] = Value(solution.get("arc").text());
+        cancel(bot, true);
+        return true;
+    }
+    Value launch_receipt(Bot &bot, const Value &target, int shell, const Value &solution,
+                         double now) {
+        if (!flag(config, "has_launch"))
+            return Value();
+        Value intent = active_intent(bot, target, shell, now);
+        if (intent.kind == Value::Null)
+            intent = create_intent(bot, target, shell, solution, now);
+        if (intent.kind == Value::Null || !aligned(bot, intent.get("solution")))
+            return Value();
+        int seq = integer(intent, "fire_seq");
+        double yaw = field(intent, "shot_yaw"), pitch = field(intent, "shot_pitch"),
+               time = field(intent.get("solution"), "flight_time");
+        auto answer = engine.query(
+            764, bot.state, target,
+            {static_cast<double>(shell), static_cast<double>(seq), yaw, pitch, time, now});
+        Value receipt = validated_receipt(bot, shell, seq, yaw, pitch, time, answer);
+        return receipt.kind == Value::Null || reject_stale(bot, target, shell, intent, receipt, now)
+                   ? Value()
+                   : receipt;
+    }
+    Value friendly(Bot &bot, const Value &target, int shell, const Value &launch, bool artillery) {
+        std::vector<double> args = {static_cast<double>(artillery), static_cast<double>(shell),
+                                    field(launch, "fire_seq"),      field(launch, "shot_yaw"),
+                                    field(launch, "shot_pitch"),    field(launch, "flight_time")};
+        point(args, launch.get("origin"));
+        if (artillery) {
+            point(args, launch.get("velocity"));
+            args.push_back(field(launch, "gravity"));
+            args.push_back(field(launch, "max_distance"));
+            args.push_back(field(launch, "max_time_ms"));
+            args.push_back(engine_token_id(launch.get("proof_key")));
+            args.push_back(engine_token_id(launch.get("_engine_payload")));
+        }
+        auto answer = engine.query(765, bot.state, target, args);
+        Value result = Value::object();
+        result["clear"] = Value(answer[0] != 0);
+        if (answer[1] != 0) {
+            result["blocker_kind"] = Value(answer[2] == 1 ? "player" : "bot");
+            result["blocker_id"] = Value(static_cast<int>(answer[3]));
+            result["blocker_team"] = Value(static_cast<int>(answer[4]));
+            result["blocker_position"] = vector3(answer[5], answer[6], answer[7]);
+            result["blocker_radius"] = Value(answer[8]);
+        }
+        return result;
+    }
+};
+} // namespace offline_kernel
+#endif

--- a/tools/ffi_experiment/kernel_aim.h
+++ b/tools/ffi_experiment/kernel_aim.h
@@ -48,18 +48,19 @@ struct Aim {
         return shell >= 0 && shell < static_cast<int>(shells.size()) ? shells[shell] : Value();
     }
     static void pose(std::vector<double> &out, const Value &s) {
-        std::set<std::string> destroyed = names(s.get("critical").get("destroyed"));
+        std::set<std::string> destroyed = names(s.get(sf::critical).get("destroyed"));
         for (const char *name : {"yaw", "pitch", "roll"})
             out.push_back(field(s, name));
-        out.push_back(field(s, "terrain_pitch", field(s, "pitch") - field(s, "suspension_pitch")));
+        out.push_back(
+            field(s, sf::terrain_pitch, field(s, sf::pitch) - field(s, sf::suspension_pitch)));
         for (const char *name : {"suspension_pitch", "turret_yaw", "gun_pitch"})
             out.push_back(field(s, name));
-        out.push_back(field(s, "aim_yaw", field(s, "yaw")));
-        out.push_back(integer(s, "movement_dir") != 0);
+        out.push_back(field(s, sf::aim_yaw, field(s, sf::yaw)));
+        out.push_back(integer(s, sf::movement_dir) != 0);
         out.push_back(destroyed.count("engineHealth"));
         out.push_back(destroyed.count("leftTrackHealth") || destroyed.count("rightTrackHealth"));
-        out.push_back(flag(s, "_overturned"));
-        out.push_back(integer(s, "siege_state"));
+        out.push_back(flag(s, sf::_overturned));
+        out.push_back(integer(s, sf::siege_state));
     }
     static void point(std::vector<double> &out, const Value &v) {
         for (size_t i = 0; i < 3; ++i)
@@ -70,9 +71,9 @@ struct Aim {
             return Value();
         Value v = Value::object();
         v["aim_position"] = vector3(result[1], result[2], result[3]);
-        v["pitch"] = Value(result[4]);
+        v[sf::pitch] = Value(result[4]);
         v["flight_time"] = Value(result[5]);
-        v["yaw"] = Value(result[6]);
+        v[sf::yaw] = Value(result[6]);
         v["arc"] = Value(arc);
         return v;
     }
@@ -86,7 +87,7 @@ struct Aim {
         Value d = world_barrel(bot.state);
         double horizontal =
             std::sqrt(d[0].number() * d[0].number() + d[2].number() * d[2].number());
-        return origin(bot, shell, integer(bot.state, "fire_seq") + 1,
+        return origin(bot, shell, integer(bot.state, sf::fire_seq) + 1,
                       std::atan2(d[0].number(), d[2].number()),
                       -std::atan2(d[1].number(), std::max(1e-12, horizontal)), 0);
     }
@@ -149,18 +150,18 @@ struct Aim {
     }
     Value signature(const Bot &bot, const Value &target, int shell) {
         Value v = Value::array();
-        v.append(Value(target.get("kind").text()));
-        v.append(target.has("network_id") ? target.get("network_id") : target.get("id"));
-        v.append(Value(flag(target, "alive", true)));
+        v.append(Value(target.get(sf::kind).text()));
+        v.append(target.has(sf::network_id) ? target.get(sf::network_id) : target.get(sf::id));
+        v.append(Value(flag(target, sf::alive, true)));
         v.append(Value(shell));
         v.append(profile(bot).get("handle"));
-        v.append(Value(integer(bot.state, "siege_state")));
-        v.append(Value(integer(bot.state, "fire_seq")));
+        v.append(Value(integer(bot.state, sf::siege_state)));
+        v.append(Value(integer(bot.state, sf::fire_seq)));
         return v;
     }
     std::pair<Value, bool> cadenced(Bot &bot, const Value &target, int shell, double now,
                                     bool refresh, bool force = false) {
-        int id = integer(bot.state, "id");
+        int id = integer(bot.state, sf::id);
         Value key = signature(bot, target, shell);
         auto at = cache.find(id);
         bool fresh = force || at == cache.end() || at->second.signature != key ||
@@ -168,7 +169,7 @@ struct Aim {
         if (!fresh)
             return {at->second.solution, false};
         Value aimed = gunners.at(id).aimed(bot.state, target, now, round, bot.gun);
-        Value result = bot.state.get("profile").get("class_tag").text() == "SPG"
+        Value result = bot.state.get(sf::profile).get(sf::class_tag).text() == "SPG"
                            ? artillery(bot, aimed, shell, now)
                            : local(bot, aimed, shell);
         cache[id] =
@@ -179,7 +180,7 @@ struct Aim {
     Value slew(Bot &bot, const Value &command, const Value &target, double dt) {
         Value &s = bot.state;
         const Value &solution = command.get("_ballistic_solution");
-        double desired = field(s, "aim_yaw", field(s, "yaw")), pitch = 0, horizontal = 0;
+        double desired = field(s, sf::aim_yaw, field(s, sf::yaw)), pitch = 0, horizontal = 0;
         if (target.kind != Value::Null || solution.kind == Value::Object) {
             Value fallback = target.kind != Value::Null ? target_position(target) : position(s),
                   aim = solution.kind == Value::Object ? solution.get("aim_position")
@@ -188,22 +189,22 @@ struct Aim {
                 aim = fallback;
             Value origin = solution.get("_origin");
             if (origin.kind != Value::Array || origin.size() != 3)
-                origin = exact_origin(bot, integer(s, "shell_index"));
+                origin = exact_origin(bot, integer(s, sf::shell_index));
             if (origin.kind == Value::Null) {
-                s["gun_aligned"] = Value(false);
+                s[sf::gun_aligned] = Value(false);
                 Value result = Value::array();
-                result.append(Value(field(s, "aim_yaw")));
+                result.append(Value(field(s, sf::aim_yaw)));
                 result.append(Value(0.0));
                 return result;
             }
             double dx = aim[0].number() - origin[0].number(),
                    dz = aim[2].number() - origin[2].number();
             horizontal = std::sqrt(dx * dx + dz * dz);
-            desired = solution.kind == Value::Object ? field(solution, "yaw")
+            desired = solution.kind == Value::Object ? field(solution, sf::yaw)
                       : horizontal > .1              ? std::atan2(dx, dz)
-                                                     : field(s, "yaw");
+                                                     : field(s, sf::yaw);
             pitch = solution.kind == Value::Object
-                        ? field(solution, "pitch")
+                        ? field(solution, sf::pitch)
                         : -std::atan2((aim[1].number() + 1) - origin[1].number(),
                                       std::max(.5, horizontal));
         }
@@ -221,7 +222,7 @@ struct Aim {
                                "gun_pitch",     "desired_gun_pitch", "aim_yaw"};
         for (size_t i = 0; i < 7; ++i)
             s[names[i]] = Value(packet[offset + i]);
-        s["gun_aligned"] = Value(packet[offset + 7] != 0);
+        s[sf::gun_aligned] = Value(packet[offset + 7] != 0);
         Value result = Value::array();
         result.append(Value(desired));
         result.append(Value(horizontal));
@@ -234,7 +235,7 @@ struct Aim {
         bool matches = selected.kind == Value::Object && solution.kind == Value::Object &&
                        selected.get("aim_token") == solution.get("_aim_token");
         if (!matches)
-            cache.erase(integer(bot.state, "id"));
+            cache.erase(integer(bot.state, sf::id));
         return matches;
     }
     Value preview(const Bot &bot, int shell, const Value &solution, const Subshot *edge = nullptr) {
@@ -249,17 +250,17 @@ struct Aim {
         }
         if (!std::isfinite(time) || time <= 0 || time > field(config, "maximum_time"))
             return Value();
-        int seq = integer(bot.state, "fire_seq") + 1, group = seq, index = 0;
+        int seq = integer(bot.state, sf::fire_seq) + 1, group = seq, index = 0;
         if (edge) {
             seq = edge->seq;
             group = edge->group;
             index = edge->index;
-            if (seq != integer(bot.state, "fire_seq") + 1)
+            if (seq != integer(bot.state, sf::fire_seq) + 1)
                 return Value();
         }
         Value angles = dispersed(
-            integer(bot.state, "id"), round, seq, field(bot.state, "aim_yaw"),
-            field(bot.state, "gun_pitch"),
+            integer(bot.state, sf::id), round, seq, field(bot.state, sf::aim_yaw),
+            field(bot.state, sf::gun_pitch),
             std::max(bot.gun.dispersion,
                      bot.gun.fully_aimed * factors.stat(bot.state, *bot.critical, "dispersion")),
             index, group, dispersal_base(bot.state));
@@ -267,22 +268,22 @@ struct Aim {
         if (start.kind == Value::Null)
             return Value();
         Value result = Value::object();
-        result["fire_seq"] = Value(seq);
-        result["shell_index"] = Value(shell);
-        result["shot_yaw"] = angles[0];
-        result["shot_pitch"] = angles[1];
+        result[sf::fire_seq] = Value(seq);
+        result[sf::shell_index] = Value(shell);
+        result[sf::shot_yaw] = angles[0];
+        result[sf::shot_pitch] = angles[1];
         result["flight_time"] = Value(time);
         result["origin"] = start;
         return result;
     }
     static Value target_identity(const Value &target) {
-        if (target.kind != Value::Object || (!target.has("network_id") && !target.has("id")))
+        if (target.kind != Value::Object || (!target.has(sf::network_id) && !target.has(sf::id)))
             return Value();
-        Value id = target.has("network_id") ? target.get("network_id") : target.get("id");
+        Value id = target.has(sf::network_id) ? target.get(sf::network_id) : target.get(sf::id);
         if (id.kind == Value::Null)
             return Value();
         Value v = Value::array();
-        v.append(Value(target.get("kind").text()));
+        v.append(Value(target.get(sf::kind).text()));
         v.append(Value(id.exact()));
         return v;
     }
@@ -293,7 +294,7 @@ struct Aim {
         return v;
     }
     bool cancel(Bot &bot, bool preserve = false) {
-        int id = integer(bot.state, "id");
+        int id = integer(bot.state, sf::id);
         bool had = intents.erase(id) > 0, proof = reproofs.count(id) > 0;
         if (!preserve)
             reproofs.erase(id);
@@ -302,7 +303,7 @@ struct Aim {
         return had || proof;
     }
     Value active_reproof(Bot &bot, const Value &target, int shell, double now) {
-        int id = integer(bot.state, "id");
+        int id = integer(bot.state, sf::id);
         auto at = reproofs.find(id);
         if (at == reproofs.end())
             return Value();
@@ -317,11 +318,11 @@ struct Aim {
         moved = std::sqrt(moved);
         for (size_t i = 3; i < std::min(pose.size(), before.size()); ++i)
             turned = turned || std::abs(angle_delta(pose[i].number() - before[i].number())) > .001;
-        bool invalid = target.kind != Value::Object || !flag(target, "alive", true) ||
-                       (target.has("health") && field(target, "health") <= 0) ||
+        bool invalid = target.kind != Value::Object || !flag(target, sf::alive, true) ||
+                       (target.has(sf::health) && field(target, sf::health) <= 0) ||
                        target_identity(target) != proof.get("target_identity") ||
-                       shell != integer(proof, "shell_index") ||
-                       integer(bot.state, "fire_seq") + 1 != integer(proof, "fire_seq") ||
+                       shell != integer(proof, sf::shell_index) ||
+                       integer(bot.state, sf::fire_seq) + 1 != integer(proof, sf::fire_seq) ||
                        physical(bot, shell) != proof.get("physical") || moved > .05 || turned;
         if (invalid || now > field(proof, "deadline") + 1e-9) {
             cancel(bot);
@@ -330,42 +331,42 @@ struct Aim {
         return proof;
     }
     Value active_intent(Bot &bot, const Value &target, int shell, double now) {
-        auto at = intents.find(integer(bot.state, "id"));
+        auto at = intents.find(integer(bot.state, sf::id));
         if (at == intents.end())
             return Value();
         Value intent = at->second;
         return active_reproof(bot, target, shell, now).kind == Value::Null ? Value() : intent;
     }
     static bool aligned(const Bot &bot, const Value &solution) {
-        if (!flag(bot.state, "gun_aligned") || solution.kind != Value::Object)
+        if (!flag(bot.state, sf::gun_aligned) || solution.kind != Value::Object)
             return false;
         Value d = world_barrel(bot.state);
         double yaw = std::atan2(d[0].number(), d[2].number()),
                pitch = -std::atan2(d[1].number(),
                                    std::max(1e-12, std::sqrt(d[0].number() * d[0].number() +
                                                              d[2].number() * d[2].number())));
-        return std::abs(angle_delta(field(solution, "yaw") - yaw)) <= 1e-7 &&
-               std::abs(field(solution, "pitch") - pitch) <= 1e-7;
+        return std::abs(angle_delta(field(solution, sf::yaw) - yaw)) <= 1e-7 &&
+               std::abs(field(solution, sf::pitch) - pitch) <= 1e-7;
     }
     Value create_intent(Bot &bot, const Value &target, int shell, const Value &solution,
                         double now) {
         Value physics = physical(bot, shell), identity = target_identity(target);
         if (physics.kind == Value::Null || identity.kind == Value::Null ||
-            !flag(target, "alive", true) ||
-            (target.has("health") && field(target, "health") <= 0) ||
-            std::abs(field(bot.state, "speed")) > .05 || !aligned(bot, solution))
+            !flag(target, sf::alive, true) ||
+            (target.has(sf::health) && field(target, sf::health) <= 0) ||
+            std::abs(field(bot.state, sf::speed)) > .05 || !aligned(bot, solution))
             return Value();
-        int id = integer(bot.state, "id"), seq = integer(bot.state, "fire_seq") + 1;
+        int id = integer(bot.state, sf::id), seq = integer(bot.state, sf::fire_seq) + 1;
         Value proof = active_reproof(bot, target, shell, now);
         if (proof.kind == Value::Null) {
             proof = Value::object();
             Value source = Value::object();
-            source["id"] = Value(id);
+            source[sf::id] = Value(id);
             proof["source"] = source;
             proof["source_pose"] = source_pose(bot.state);
             proof["target_identity"] = identity;
-            proof["shell_index"] = Value(shell);
-            proof["fire_seq"] = Value(seq);
+            proof[sf::shell_index] = Value(shell);
+            proof[sf::fire_seq] = Value(seq);
             proof["physical"] = physics;
             proof["proof_latency"] = Value(0.0);
             proof["attempts"] = Value(0);
@@ -378,7 +379,7 @@ struct Aim {
                 Value(std::min(field(proof, "absolute_deadline", field(proof, "deadline")),
                                now + field(config, "reproof_seconds")));
         Value angles = dispersed(
-            id, round, seq, field(bot.state, "aim_yaw"), field(bot.state, "gun_pitch"),
+            id, round, seq, field(bot.state, sf::aim_yaw), field(bot.state, sf::gun_pitch),
             std::max(bot.gun.dispersion,
                      bot.gun.fully_aimed * factors.stat(bot.state, *bot.critical, "dispersion")),
             0, seq, dispersal_base(bot.state));
@@ -389,8 +390,8 @@ struct Aim {
                                  "fire_seq", "physical", "deadline"})
             intent[name] = proof.get(name);
         intent["solution"] = frozen;
-        intent["shot_yaw"] = angles[0];
-        intent["shot_pitch"] = angles[1];
+        intent[sf::shot_yaw] = angles[0];
+        intent[sf::shot_pitch] = angles[1];
         intent["created"] = Value(now);
         intents[id] = intent;
         return intent;
@@ -451,14 +452,14 @@ struct Aim {
                 return Value();
         Value result = Value::object();
         result["origin"] = vector3(r[1], r[2], r[3]);
-        result["velocity"] = vector3(r[4], r[5], r[6]);
-        result["shot_yaw"] = Value(r[7]);
-        result["shot_pitch"] = Value(r[8]);
+        result[sf::velocity] = vector3(r[4], r[5], r[6]);
+        result[sf::shot_yaw] = Value(r[7]);
+        result[sf::shot_pitch] = Value(r[8]);
         result["gravity"] = Value(r[9]);
         result["max_distance"] = Value(r[10]);
         result["max_time_ms"] = Value(max_ms);
-        result["fire_seq"] = Value(seq);
-        result["shell_index"] = Value(shell);
+        result[sf::fire_seq] = Value(seq);
+        result[sf::shell_index] = Value(shell);
         result["flight_time"] = Value(r[14]);
         result["proof_key"] = engine_token(r[15]);
         result["_engine_payload"] = engine_token(r[16]);
@@ -511,8 +512,8 @@ struct Aim {
             intent = create_intent(bot, target, shell, solution, now);
         if (intent.kind == Value::Null || !aligned(bot, intent.get("solution")))
             return Value();
-        int seq = integer(intent, "fire_seq");
-        double yaw = field(intent, "shot_yaw"), pitch = field(intent, "shot_pitch"),
+        int seq = integer(intent, sf::fire_seq);
+        double yaw = field(intent, sf::shot_yaw), pitch = field(intent, sf::shot_pitch),
                time = field(intent.get("solution"), "flight_time");
         auto answer = engine.query(
             764, bot.state, target,
@@ -524,11 +525,11 @@ struct Aim {
     }
     Value friendly(Bot &bot, const Value &target, int shell, const Value &launch, bool artillery) {
         std::vector<double> args = {static_cast<double>(artillery), static_cast<double>(shell),
-                                    field(launch, "fire_seq"),      field(launch, "shot_yaw"),
-                                    field(launch, "shot_pitch"),    field(launch, "flight_time")};
+                                    field(launch, sf::fire_seq),    field(launch, sf::shot_yaw),
+                                    field(launch, sf::shot_pitch),  field(launch, "flight_time")};
         point(args, launch.get("origin"));
         if (artillery) {
-            point(args, launch.get("velocity"));
+            point(args, launch.get(sf::velocity));
             args.push_back(field(launch, "gravity"));
             args.push_back(field(launch, "max_distance"));
             args.push_back(field(launch, "max_time_ms"));

--- a/tools/ffi_experiment/kernel_bot.h
+++ b/tools/ffi_experiment/kernel_bot.h
@@ -1,0 +1,354 @@
+#ifndef OFFLINE_EXPERIMENT_KERNEL_BOT_H
+#define OFFLINE_EXPERIMENT_KERNEL_BOT_H
+#include "kernel_weapon.h"
+#include "kernel_critical.h"
+
+namespace offline_kernel {
+inline Value canonical_critical(const Value &payload) {
+    if (payload.kind != Value::Object || !payload.truth())
+        return Value::object();
+    Value result = Value::object(), records = Value::array();
+    const Value &devices = payload.get("devices");
+    if (devices.kind != Value::Null)
+        for (const Value &v : elements(devices)) {
+            Value row = Value::object();
+            double maximum = std::max(1.0, rounded(field(v, "max_hp"), 3));
+            row["name"] = v.get("name");
+            row["hp"] = Value(clamp(rounded(field(v, "hp"), 3), 0, maximum));
+            row["max_hp"] = Value(maximum);
+            row["state"] = v.get("state");
+            records.append(row);
+        }
+    std::sort(
+        records.data->array.begin(), records.data->array.end(),
+        [](const Value &a, const Value &b) { return a.get("name").text() < b.get("name").text(); });
+    result["devices"] = records;
+    result["destroyed"] = name_array(names(payload.get("destroyed")));
+    result["crew_ko"] = name_array(names(payload.get("crew_ko")));
+    result["fire"] = Value(flag(payload, "fire"));
+    result["ammo_rack_death"] = Value(flag(payload, "ammo_rack_death"));
+    result["events"] = Value::array();
+    if (payload.get("crew_roster").truth())
+        result["crew_roster"] = payload.get("crew_roster");
+    return result;
+}
+inline Value combat_record(const Value &state) {
+    Value v = Value::object();
+    v["health"] = Value(std::max(0, integer(state, "health")));
+    v["alive"] = Value(flag(state, "alive"));
+    v["critical"] = canonical_critical(state.get("critical"));
+    v["combat_fire_elapsed"] = Value(rounded(field(state, "combat_fire_elapsed"), 6));
+    v["combat_fire_timer"] = Value(rounded(field(state, "combat_fire_timer"), 6));
+    v["stun_end_server_time_ms"] = Value(std::max(0, integer(state, "stun_end_server_time_ms")));
+    return v;
+}
+struct Bot {
+    Value state, sync, config;
+    Gun gun;
+    Ammo ammo;
+    Burst burst;
+    std::vector<Equipment> equipment;
+    std::unique_ptr<CriticalConfig> critical;
+    double turn_speed = 0;
+    bool clear_reposition = false;
+    explicit Bot(const Value &v)
+        : state(v.get("state")), sync(v.get("sync")), config(v.get("config")) {
+        gun.load(v.get("gun"));
+        ammo.load(v.get("ammo"));
+        burst.load(v.get("burst"));
+        if (v.has("equipment"))
+            for (const Value &item : elements(v.get("equipment")))
+                equipment.emplace_back(item);
+        if (v.has("critical_config"))
+            critical.reset(new CriticalConfig(v.get("critical_config")));
+        turn_speed = field(v, "turn_speed");
+    }
+    void publish_weapon() {
+        state["shell_index"] = Value(ammo.loaded);
+        state["next_shell_index"] = Value(ammo.next);
+        state["ammo_reload_pending"] = Value(ammo.reload_pending);
+        Value quantities = Value::array();
+        for (int q : ammo.quantities)
+            quantities.append(Value(q));
+        state["ammo_remaining"] = quantities;
+        state["clip"] = Value(gun.clip);
+        state["clip_size"] = Value(gun.clip_size);
+        state["reload_time"] = Value(gun.remaining(gun.reload_factor));
+        state["reload_duration"] = Value(gun.duration(gun.reload_factor));
+        state["burst_active"] = Value(burst.active);
+        state["burst_group_seq"] = Value(burst.group);
+        state["burst_count"] = Value(burst.count);
+        state["burst_next_index"] = Value(burst.next);
+        state["burst_shell_index"] = Value(burst.shell);
+        state["burst_interval"] = Value(rounded(burst.interval, 6));
+        state["burst_time_left"] = Value(rounded(std::max(0.0, burst.left), 6));
+    }
+    Value equipment_wire(double now) const {
+        Value rows = Value::array();
+        for (const Equipment &e : equipment)
+            rows.append(e.wire(now));
+        return rows;
+    }
+    Value snapshot() const {
+        Value v = Value::object();
+        v["state"] = state.clone();
+        v["gun"] = gun.snapshot();
+        v["ammo"] = ammo.snapshot();
+        v["burst"] = burst.snapshot();
+        return v;
+    }
+    bool stunned(double equipment_now) const {
+        return flag(state, "alive") &&
+               field(state, "_stun_until_equipment_time") > equipment_now + 1e-9;
+    }
+    void ensure_sync() {
+        if (sync.kind == Value::Null) {
+            Value signature = combat_signature(state);
+            sync = Value::object();
+            sync["server_signature"] = signature;
+            sync["server_combat"] = combat_record(state);
+            sync["published_signature"] = signature;
+            sync["pending"] = Value::array();
+            sync["next_seq"] = Value(std::max(0, integer(state, "combat_ack_seq")));
+            sync["acked_seq"] = sync.get("next_seq");
+            sync["combat_revision"] = Value(std::max(0, integer(state, "combat_revision")));
+            sync["base_revision"] = Value(std::max(0, integer(state, "combat_base_revision")));
+            sync["server_tick"] = Value(-1);
+            sync["unpublished_steps"] = Value::array();
+            sync["authority_handoff_pending"] = Value(false);
+        }
+        state["combat_revision"] = sync.get("combat_revision");
+        state["combat_base_revision"] = sync.get("base_revision");
+        state["combat_ack_seq"] = sync.get("acked_seq");
+        state["combat_seq"] = sync.get("next_seq");
+    }
+    bool mark_combat() {
+        ensure_sync();
+        Value signature = combat_signature(state);
+        if (signature == sync.get("published_signature"))
+            return false;
+        int seq = integer(sync, "next_seq") + 1;
+        sync["next_seq"] = Value(seq);
+        Value pending = Value::object();
+        pending["seq"] = Value(seq);
+        pending["signature"] = signature;
+        pending["combat"] = combat_record(state);
+        pending["steps"] = sync.get("unpublished_steps").copy();
+        sync["pending"].append(pending);
+        sync["unpublished_steps"] = Value::array();
+        sync["published_signature"] = signature;
+        state["combat_seq"] = Value(seq);
+        return true;
+    }
+    bool apply_effect(const Value &effect, double equipment_now, bool strict) {
+        if (!critical)
+            throw std::invalid_argument("kernel critical configuration absent");
+        Critical shadow(state.get("critical"), *critical);
+        bool clear_stun = flag(effect, "clearStun"), stun_cleared = false;
+        int base = integer(effect, "stunBaseEndServerTimeMs");
+        if (clear_stun && base <= 0) {
+            if (strict)
+                throw std::invalid_argument("kernel stun base");
+            return false;
+        }
+        bool changed = shadow.effect(effect);
+        if (!changed && !clear_stun) {
+            if (strict)
+                throw std::runtime_error("kernel equipment effect declined");
+            return false;
+        }
+        if (changed)
+            state["critical"] = shadow.payload();
+        if (effect.get("action").text() == "extinguish_fire") {
+            state["combat_fire_elapsed"] = Value(0.0);
+            state["combat_fire_timer"] = Value(0.0);
+        }
+        if (clear_stun && integer(state, "stun_end_server_time_ms") == base) {
+            state["stun_end_server_time_ms"] = Value(0);
+            state["_stun_until_equipment_time"] = Value(equipment_now);
+            stun_cleared = true;
+        }
+        return changed || stun_cleared;
+    }
+    Value poll_equipment(double equipment_now) {
+        Value effects = Value::array();
+        for (Equipment &e : equipment) {
+            Value effect = e.poll_bot(equipment_now, state.get("critical"), stunned(equipment_now));
+            if (effect.kind == Value::Null)
+                continue;
+            if (flag(effect, "clearStun"))
+                effect["stunBaseEndServerTimeMs"] =
+                    Value(integer(state, "stun_end_server_time_ms"));
+            apply_effect(effect, equipment_now, true);
+            effects.append(effect);
+        }
+        state["equipment_states"] = equipment_wire(equipment_now);
+        return effects;
+    }
+    void death(int reason, int display) {
+        state["health"] = Value(0);
+        state["alive"] = Value(false);
+        state["display_health"] = Value(display);
+        state["death_reason"] = Value(reason);
+        state["speed"] = Value(0.0);
+        state["movement_dir"] = Value(0);
+        state["rotation_dir"] = Value(0);
+        state["target_kind"] = Value();
+        state["target_id"] = Value();
+        clear_reposition = true;
+    }
+    bool advance_critical(double dt, double now, double equipment_now, bool record = true,
+                          bool advance_fire = true, const Value &supplied_effects = Value()) {
+        const Value payload = state.get("critical");
+        if (!payload.truth() && !stunned(equipment_now))
+            return false;
+        if (!critical)
+            throw std::invalid_argument("kernel critical configuration absent");
+        Value before = combat_signature(state);
+        bool was_fire = flag(payload, "fire");
+        ensure_sync();
+        Value effects;
+        if (supplied_effects.kind == Value::Null)
+            effects = record ? poll_equipment(equipment_now) : Value::array();
+        else {
+            effects = supplied_effects;
+            for (const Value &effect : elements(effects))
+                apply_effect(effect, equipment_now, false);
+        }
+        double elapsed =
+            rounded(clamp(field(state, "combat_fire_elapsed"), 0, critical->fire_duration), 6);
+        double timer = rounded(clamp(field(state, "combat_fire_timer"), 0, .999999), 6);
+        Critical shadow(state.get("critical"), *critical);
+        bool repaired = shadow.repair(dt, integer(state, "health"));
+        Value repair_payload = repaired ? shadow.payload() : Value();
+        Value prefire = shadow.identity();
+        int damage = 0;
+        if (advance_fire) {
+            double started =
+                was_fire ? now - std::min(critical->fire_duration, elapsed + dt) : now - dt;
+            damage = shadow.burn(
+                dt, now, started, timer, integer(state, "health"),
+                std::max(1, integer(state, "max_health", std::max(1, integer(state, "health")))));
+        }
+        Value fire_payload = prefire != shadow.identity() ? shadow.payload() : Value();
+        if (was_fire && advance_fire && shadow.fire) {
+            state["combat_fire_elapsed"] =
+                Value(rounded(std::min(critical->fire_duration, elapsed + dt), 6));
+            state["combat_fire_timer"] = Value(rounded(clamp(timer, 0, .999999), 6));
+        } else if (!shadow.fire) {
+            state["combat_fire_elapsed"] = Value(0.0);
+            state["combat_fire_timer"] = Value(0.0);
+        }
+        if (fire_payload.kind != Value::Null)
+            state["critical"] = fire_payload;
+        else if (repair_payload.kind != Value::Null)
+            state["critical"] = repair_payload;
+        if (damage > 0) {
+            int health = std::max(0, integer(state, "health") - damage);
+            state["health"] = Value(health);
+            state["alive"] = Value(health > 0);
+            state["display_health"] = Value(health);
+            if (health <= 0) {
+                Critical terminal(state.get("critical"), *critical);
+                state["critical"] = terminal.terminal();
+                state["combat_fire_elapsed"] = Value(0.0);
+                state["combat_fire_timer"] = Value(0.0);
+                death(1, 0);
+            }
+        }
+        bool changed = combat_signature(state) != before;
+        if (record &&
+            (changed || was_fire || flag(state.get("critical"), "fire") || effects.truth())) {
+            Value step = Value::array();
+            step.append(Value(dt));
+            step.append(Value(now));
+            step.append(Value(was_fire));
+            step.append(effects);
+            sync["unpublished_steps"].append(step);
+        }
+        return changed;
+    }
+    bool drowning_due(double step) const {
+        return flag(state, "alive") && field(state, "health") > 0 && step > 0 &&
+               field(state, "_drown_check") + step >= field(config, "BOT_DROWNING_PROBE_SECONDS");
+    }
+    bool advance_drowning(double step, double depth) {
+        if (!flag(state, "alive") || field(state, "health") <= 0 || step <= 0)
+            return false;
+        double check = field(state, "_drown_check") + step;
+        state["_drown_check"] = Value(check);
+        if (check < field(config, "BOT_DROWNING_PROBE_SECONDS"))
+            return false;
+        state["_drown_check"] = Value(0.0);
+        state["_water_depth"] = Value(depth);
+        int level = 0;
+        if (depth >= 0) {
+            const Value &offset = config.get("water_offset");
+            double pitch = field(state, "pitch"), roll = field(state, "roll");
+            double rolled =
+                std::sin(roll) * offset[0].number() + std::cos(roll) * offset[1].number();
+            double height = std::cos(pitch) * rolled - std::sin(pitch) * offset[2].number();
+            level = depth > height ? 2 : 1;
+        }
+        if (level != 2) {
+            state["_drown_time"] = Value(0.0);
+            state["_drowning"] = Value(false);
+            return false;
+        }
+        state["_drowning"] = Value(true);
+        double elapsed = field(state, "_drown_time") + check;
+        state["_drown_time"] = Value(elapsed);
+        if (elapsed <= field(config, "BOT_DROWNING_SECONDS"))
+            return false;
+        int display = std::max(0, integer(state, "health"));
+        Critical terminal(state.get("critical"), *critical);
+        state["critical"] = terminal.terminal();
+        death(integer(config, "BOT_DROWNING_DEATH_REASON"), display);
+        state["_drowned"] = Value(true);
+        state["_drown_time"] = config.get("BOT_DROWNING_SECONDS");
+        state["_drowning"] = Value(false);
+        return true;
+    }
+    bool advance_overturn(double step) {
+        if (!flag(state, "alive") || field(state, "health") <= 0 || step <= 0)
+            return false;
+        double up = clamp(std::cos(field(state, "pitch")) * std::cos(field(state, "roll")), -1, 1);
+        int level = up <= field(config, "BOT_OVERTURN_DANGER_COSINE")    ? 2
+                    : up <= field(config, "BOT_OVERTURN_WARNING_COSINE") ? 1
+                                                                         : 0;
+        if (!level) {
+            state["_overturn_check"] = Value(0.0);
+            state["_overturn_time"] = Value(0.0);
+            state["_overturn_level"] = Value(0);
+            state["_overturned"] = Value(false);
+            return false;
+        }
+        double check = field(state, "_overturn_check") + step;
+        state["_overturn_check"] = Value(check);
+        if (check + .000001 < field(config, "BOT_OVERTURN_IGNORE_SECONDS"))
+            return false;
+        if (level != integer(state, "_overturn_level")) {
+            state["_overturn_level"] = Value(level);
+            state["_overturn_time"] = Value(0.0);
+        }
+        state["_overturned"] = Value(level == 2);
+        if (level != 2) {
+            state["_overturn_time"] = Value(0.0);
+            return false;
+        }
+        state["movement_dir"] = Value(0);
+        state["rotation_dir"] = Value(0);
+        turn_speed = 0;
+        double elapsed = field(state, "_overturn_time") + step;
+        state["_overturn_time"] = Value(elapsed);
+        if (elapsed + .000001 < field(config, "BOT_OVERTURN_DEATH_SECONDS"))
+            return false;
+        Critical terminal(state.get("critical"), *critical);
+        state["critical"] = terminal.terminal();
+        death(integer(config, "BOT_OVERTURN_DEATH_REASON"), 0);
+        state["_overturn_time"] = config.get("BOT_OVERTURN_DEATH_SECONDS");
+        return true;
+    }
+};
+} // namespace offline_kernel
+#endif

--- a/tools/ffi_experiment/kernel_bot.h
+++ b/tools/ffi_experiment/kernel_bot.h
@@ -13,15 +13,16 @@ inline Value canonical_critical(const Value &payload) {
         for (const Value &v : elements(devices)) {
             Value row = Value::object();
             double maximum = std::max(1.0, rounded(field(v, "max_hp"), 3));
-            row["name"] = v.get("name");
+            row[sf::name] = v.get(sf::name);
             row["hp"] = Value(clamp(rounded(field(v, "hp"), 3), 0, maximum));
             row["max_hp"] = Value(maximum);
             row["state"] = v.get("state");
             records.append(row);
         }
-    std::sort(
-        records.data->array.begin(), records.data->array.end(),
-        [](const Value &a, const Value &b) { return a.get("name").text() < b.get("name").text(); });
+    std::sort(records.data->array.begin(), records.data->array.end(),
+              [](const Value &a, const Value &b) {
+                  return a.get(sf::name).text() < b.get(sf::name).text();
+              });
     result["devices"] = records;
     result["destroyed"] = name_array(names(payload.get("destroyed")));
     result["crew_ko"] = name_array(names(payload.get("crew_ko")));
@@ -34,12 +35,13 @@ inline Value canonical_critical(const Value &payload) {
 }
 inline Value combat_record(const Value &state) {
     Value v = Value::object();
-    v["health"] = Value(std::max(0, integer(state, "health")));
-    v["alive"] = Value(flag(state, "alive"));
-    v["critical"] = canonical_critical(state.get("critical"));
-    v["combat_fire_elapsed"] = Value(rounded(field(state, "combat_fire_elapsed"), 6));
-    v["combat_fire_timer"] = Value(rounded(field(state, "combat_fire_timer"), 6));
-    v["stun_end_server_time_ms"] = Value(std::max(0, integer(state, "stun_end_server_time_ms")));
+    v[sf::health] = Value(std::max(0, integer(state, sf::health)));
+    v[sf::alive] = Value(flag(state, sf::alive));
+    v[sf::critical] = canonical_critical(state.get(sf::critical));
+    v[sf::combat_fire_elapsed] = Value(rounded(field(state, sf::combat_fire_elapsed), 6));
+    v[sf::combat_fire_timer] = Value(rounded(field(state, sf::combat_fire_timer), 6));
+    v[sf::stun_end_server_time_ms] =
+        Value(std::max(0, integer(state, sf::stun_end_server_time_ms)));
     return v;
 }
 struct Bot {
@@ -52,7 +54,7 @@ struct Bot {
     double turn_speed = 0;
     bool clear_reposition = false;
     explicit Bot(const Value &v)
-        : state(v.get("state")), sync(v.get("sync")), config(v.get("config")) {
+        : state(v.get("state").as_record()), sync(v.get("sync")), config(v.get("config")) {
         gun.load(v.get("gun"));
         ammo.load(v.get("ammo"));
         burst.load(v.get("burst"));
@@ -64,24 +66,24 @@ struct Bot {
         turn_speed = field(v, "turn_speed");
     }
     void publish_weapon() {
-        state["shell_index"] = Value(ammo.loaded);
-        state["next_shell_index"] = Value(ammo.next);
-        state["ammo_reload_pending"] = Value(ammo.reload_pending);
+        state[sf::shell_index] = Value(ammo.loaded);
+        state[sf::next_shell_index] = Value(ammo.next);
+        state[sf::ammo_reload_pending] = Value(ammo.reload_pending);
         Value quantities = Value::array();
         for (int q : ammo.quantities)
             quantities.append(Value(q));
-        state["ammo_remaining"] = quantities;
-        state["clip"] = Value(gun.clip);
-        state["clip_size"] = Value(gun.clip_size);
-        state["reload_time"] = Value(gun.remaining(gun.reload_factor));
-        state["reload_duration"] = Value(gun.duration(gun.reload_factor));
-        state["burst_active"] = Value(burst.active);
-        state["burst_group_seq"] = Value(burst.group);
-        state["burst_count"] = Value(burst.count);
-        state["burst_next_index"] = Value(burst.next);
-        state["burst_shell_index"] = Value(burst.shell);
-        state["burst_interval"] = Value(rounded(burst.interval, 6));
-        state["burst_time_left"] = Value(rounded(std::max(0.0, burst.left), 6));
+        state[sf::ammo_remaining] = quantities;
+        state[sf::clip] = Value(gun.clip);
+        state[sf::clip_size] = Value(gun.clip_size);
+        state[sf::reload_time] = Value(gun.remaining(gun.reload_factor));
+        state[sf::reload_duration] = Value(gun.duration(gun.reload_factor));
+        state[sf::burst_active] = Value(burst.active);
+        state[sf::burst_group_seq] = Value(burst.group);
+        state[sf::burst_count] = Value(burst.count);
+        state[sf::burst_next_index] = Value(burst.next);
+        state[sf::burst_shell_index] = Value(burst.shell);
+        state[sf::burst_interval] = Value(rounded(burst.interval, 6));
+        state[sf::burst_time_left] = Value(rounded(std::max(0.0, burst.left), 6));
     }
     Value equipment_wire(double now) const {
         Value rows = Value::array();
@@ -98,8 +100,8 @@ struct Bot {
         return v;
     }
     bool stunned(double equipment_now) const {
-        return flag(state, "alive") &&
-               field(state, "_stun_until_equipment_time") > equipment_now + 1e-9;
+        return flag(state, sf::alive) &&
+               field(state, sf::_stun_until_equipment_time) > equipment_now + 1e-9;
     }
     void ensure_sync() {
         if (sync.kind == Value::Null) {
@@ -109,18 +111,18 @@ struct Bot {
             sync["server_combat"] = combat_record(state);
             sync["published_signature"] = signature;
             sync["pending"] = Value::array();
-            sync["next_seq"] = Value(std::max(0, integer(state, "combat_ack_seq")));
+            sync["next_seq"] = Value(std::max(0, integer(state, sf::combat_ack_seq)));
             sync["acked_seq"] = sync.get("next_seq");
-            sync["combat_revision"] = Value(std::max(0, integer(state, "combat_revision")));
-            sync["base_revision"] = Value(std::max(0, integer(state, "combat_base_revision")));
+            sync[sf::combat_revision] = Value(std::max(0, integer(state, sf::combat_revision)));
+            sync["base_revision"] = Value(std::max(0, integer(state, sf::combat_base_revision)));
             sync["server_tick"] = Value(-1);
             sync["unpublished_steps"] = Value::array();
             sync["authority_handoff_pending"] = Value(false);
         }
-        state["combat_revision"] = sync.get("combat_revision");
-        state["combat_base_revision"] = sync.get("base_revision");
-        state["combat_ack_seq"] = sync.get("acked_seq");
-        state["combat_seq"] = sync.get("next_seq");
+        state[sf::combat_revision] = sync.get(sf::combat_revision);
+        state[sf::combat_base_revision] = sync.get("base_revision");
+        state[sf::combat_ack_seq] = sync.get("acked_seq");
+        state[sf::combat_seq] = sync.get("next_seq");
     }
     bool mark_combat() {
         ensure_sync();
@@ -137,13 +139,13 @@ struct Bot {
         sync["pending"].append(pending);
         sync["unpublished_steps"] = Value::array();
         sync["published_signature"] = signature;
-        state["combat_seq"] = Value(seq);
+        state[sf::combat_seq] = Value(seq);
         return true;
     }
     bool apply_effect(const Value &effect, double equipment_now, bool strict) {
         if (!critical)
             throw std::invalid_argument("kernel critical configuration absent");
-        Critical shadow(state.get("critical"), *critical);
+        Critical shadow(state.get(sf::critical), *critical);
         bool clear_stun = flag(effect, "clearStun"), stun_cleared = false;
         int base = integer(effect, "stunBaseEndServerTimeMs");
         if (clear_stun && base <= 0) {
@@ -158,14 +160,14 @@ struct Bot {
             return false;
         }
         if (changed)
-            state["critical"] = shadow.payload();
+            state[sf::critical] = shadow.payload();
         if (effect.get("action").text() == "extinguish_fire") {
-            state["combat_fire_elapsed"] = Value(0.0);
-            state["combat_fire_timer"] = Value(0.0);
+            state[sf::combat_fire_elapsed] = Value(0.0);
+            state[sf::combat_fire_timer] = Value(0.0);
         }
-        if (clear_stun && integer(state, "stun_end_server_time_ms") == base) {
-            state["stun_end_server_time_ms"] = Value(0);
-            state["_stun_until_equipment_time"] = Value(equipment_now);
+        if (clear_stun && integer(state, sf::stun_end_server_time_ms) == base) {
+            state[sf::stun_end_server_time_ms] = Value(0);
+            state[sf::_stun_until_equipment_time] = Value(equipment_now);
             stun_cleared = true;
         }
         return changed || stun_cleared;
@@ -173,33 +175,34 @@ struct Bot {
     Value poll_equipment(double equipment_now) {
         Value effects = Value::array();
         for (Equipment &e : equipment) {
-            Value effect = e.poll_bot(equipment_now, state.get("critical"), stunned(equipment_now));
+            Value effect =
+                e.poll_bot(equipment_now, state.get(sf::critical), stunned(equipment_now));
             if (effect.kind == Value::Null)
                 continue;
             if (flag(effect, "clearStun"))
                 effect["stunBaseEndServerTimeMs"] =
-                    Value(integer(state, "stun_end_server_time_ms"));
+                    Value(integer(state, sf::stun_end_server_time_ms));
             apply_effect(effect, equipment_now, true);
             effects.append(effect);
         }
-        state["equipment_states"] = equipment_wire(equipment_now);
+        state[sf::equipment_states] = equipment_wire(equipment_now);
         return effects;
     }
     void death(int reason, int display) {
-        state["health"] = Value(0);
-        state["alive"] = Value(false);
-        state["display_health"] = Value(display);
-        state["death_reason"] = Value(reason);
-        state["speed"] = Value(0.0);
-        state["movement_dir"] = Value(0);
-        state["rotation_dir"] = Value(0);
-        state["target_kind"] = Value();
-        state["target_id"] = Value();
+        state[sf::health] = Value(0);
+        state[sf::alive] = Value(false);
+        state[sf::display_health] = Value(display);
+        state[sf::death_reason] = Value(reason);
+        state[sf::speed] = Value(0.0);
+        state[sf::movement_dir] = Value(0);
+        state[sf::rotation_dir] = Value(0);
+        state[sf::target_kind] = Value();
+        state[sf::target_id] = Value();
         clear_reposition = true;
     }
     bool advance_critical(double dt, double now, double equipment_now, bool record = true,
                           bool advance_fire = true, const Value &supplied_effects = Value()) {
-        const Value payload = state.get("critical");
+        const Value payload = state.get(sf::critical);
         if (!payload.truth() && !stunned(equipment_now))
             return false;
         if (!critical)
@@ -216,49 +219,49 @@ struct Bot {
                 apply_effect(effect, equipment_now, false);
         }
         double elapsed =
-            rounded(clamp(field(state, "combat_fire_elapsed"), 0, critical->fire_duration), 6);
-        double timer = rounded(clamp(field(state, "combat_fire_timer"), 0, .999999), 6);
-        Critical shadow(state.get("critical"), *critical);
-        bool repaired = shadow.repair(dt, integer(state, "health"));
+            rounded(clamp(field(state, sf::combat_fire_elapsed), 0, critical->fire_duration), 6);
+        double timer = rounded(clamp(field(state, sf::combat_fire_timer), 0, .999999), 6);
+        Critical shadow(state.get(sf::critical), *critical);
+        bool repaired = shadow.repair(dt, integer(state, sf::health));
         Value repair_payload = repaired ? shadow.payload() : Value();
         Value prefire = shadow.identity();
         int damage = 0;
         if (advance_fire) {
             double started =
                 was_fire ? now - std::min(critical->fire_duration, elapsed + dt) : now - dt;
-            damage = shadow.burn(
-                dt, now, started, timer, integer(state, "health"),
-                std::max(1, integer(state, "max_health", std::max(1, integer(state, "health")))));
+            damage = shadow.burn(dt, now, started, timer, integer(state, sf::health),
+                                 std::max(1, integer(state, sf::max_health,
+                                                     std::max(1, integer(state, sf::health)))));
         }
         Value fire_payload = prefire != shadow.identity() ? shadow.payload() : Value();
         if (was_fire && advance_fire && shadow.fire) {
-            state["combat_fire_elapsed"] =
+            state[sf::combat_fire_elapsed] =
                 Value(rounded(std::min(critical->fire_duration, elapsed + dt), 6));
-            state["combat_fire_timer"] = Value(rounded(clamp(timer, 0, .999999), 6));
+            state[sf::combat_fire_timer] = Value(rounded(clamp(timer, 0, .999999), 6));
         } else if (!shadow.fire) {
-            state["combat_fire_elapsed"] = Value(0.0);
-            state["combat_fire_timer"] = Value(0.0);
+            state[sf::combat_fire_elapsed] = Value(0.0);
+            state[sf::combat_fire_timer] = Value(0.0);
         }
         if (fire_payload.kind != Value::Null)
-            state["critical"] = fire_payload;
+            state[sf::critical] = fire_payload;
         else if (repair_payload.kind != Value::Null)
-            state["critical"] = repair_payload;
+            state[sf::critical] = repair_payload;
         if (damage > 0) {
-            int health = std::max(0, integer(state, "health") - damage);
-            state["health"] = Value(health);
-            state["alive"] = Value(health > 0);
-            state["display_health"] = Value(health);
+            int health = std::max(0, integer(state, sf::health) - damage);
+            state[sf::health] = Value(health);
+            state[sf::alive] = Value(health > 0);
+            state[sf::display_health] = Value(health);
             if (health <= 0) {
-                Critical terminal(state.get("critical"), *critical);
-                state["critical"] = terminal.terminal();
-                state["combat_fire_elapsed"] = Value(0.0);
-                state["combat_fire_timer"] = Value(0.0);
+                Critical terminal(state.get(sf::critical), *critical);
+                state[sf::critical] = terminal.terminal();
+                state[sf::combat_fire_elapsed] = Value(0.0);
+                state[sf::combat_fire_timer] = Value(0.0);
                 death(1, 0);
             }
         }
         bool changed = combat_signature(state) != before;
         if (record &&
-            (changed || was_fire || flag(state.get("critical"), "fire") || effects.truth())) {
+            (changed || was_fire || flag(state.get(sf::critical), "fire") || effects.truth())) {
             Value step = Value::array();
             step.append(Value(dt));
             step.append(Value(now));
@@ -269,84 +272,85 @@ struct Bot {
         return changed;
     }
     bool drowning_due(double step) const {
-        return flag(state, "alive") && field(state, "health") > 0 && step > 0 &&
-               field(state, "_drown_check") + step >= field(config, "BOT_DROWNING_PROBE_SECONDS");
+        return flag(state, sf::alive) && field(state, sf::health) > 0 && step > 0 &&
+               field(state, sf::_drown_check) + step >= field(config, "BOT_DROWNING_PROBE_SECONDS");
     }
     bool advance_drowning(double step, double depth) {
-        if (!flag(state, "alive") || field(state, "health") <= 0 || step <= 0)
+        if (!flag(state, sf::alive) || field(state, sf::health) <= 0 || step <= 0)
             return false;
-        double check = field(state, "_drown_check") + step;
-        state["_drown_check"] = Value(check);
+        double check = field(state, sf::_drown_check) + step;
+        state[sf::_drown_check] = Value(check);
         if (check < field(config, "BOT_DROWNING_PROBE_SECONDS"))
             return false;
-        state["_drown_check"] = Value(0.0);
-        state["_water_depth"] = Value(depth);
+        state[sf::_drown_check] = Value(0.0);
+        state[sf::_water_depth] = Value(depth);
         int level = 0;
         if (depth >= 0) {
             const Value &offset = config.get("water_offset");
-            double pitch = field(state, "pitch"), roll = field(state, "roll");
+            double pitch = field(state, sf::pitch), roll = field(state, sf::roll);
             double rolled =
                 std::sin(roll) * offset[0].number() + std::cos(roll) * offset[1].number();
             double height = std::cos(pitch) * rolled - std::sin(pitch) * offset[2].number();
             level = depth > height ? 2 : 1;
         }
         if (level != 2) {
-            state["_drown_time"] = Value(0.0);
-            state["_drowning"] = Value(false);
+            state[sf::_drown_time] = Value(0.0);
+            state[sf::_drowning] = Value(false);
             return false;
         }
-        state["_drowning"] = Value(true);
-        double elapsed = field(state, "_drown_time") + check;
-        state["_drown_time"] = Value(elapsed);
+        state[sf::_drowning] = Value(true);
+        double elapsed = field(state, sf::_drown_time) + check;
+        state[sf::_drown_time] = Value(elapsed);
         if (elapsed <= field(config, "BOT_DROWNING_SECONDS"))
             return false;
-        int display = std::max(0, integer(state, "health"));
-        Critical terminal(state.get("critical"), *critical);
-        state["critical"] = terminal.terminal();
+        int display = std::max(0, integer(state, sf::health));
+        Critical terminal(state.get(sf::critical), *critical);
+        state[sf::critical] = terminal.terminal();
         death(integer(config, "BOT_DROWNING_DEATH_REASON"), display);
-        state["_drowned"] = Value(true);
-        state["_drown_time"] = config.get("BOT_DROWNING_SECONDS");
-        state["_drowning"] = Value(false);
+        state[sf::_drowned] = Value(true);
+        state[sf::_drown_time] = config.get("BOT_DROWNING_SECONDS");
+        state[sf::_drowning] = Value(false);
         return true;
     }
     bool advance_overturn(double step) {
-        if (!flag(state, "alive") || field(state, "health") <= 0 || step <= 0)
+        if (!flag(state, sf::alive) || field(state, sf::health) <= 0 || step <= 0)
             return false;
-        double up = clamp(std::cos(field(state, "pitch")) * std::cos(field(state, "roll")), -1, 1);
+        double up =
+            clamp(std::cos(field(state, sf::pitch)) * std::cos(field(state, sf::roll)), -1, 1);
         int level = up <= field(config, "BOT_OVERTURN_DANGER_COSINE")    ? 2
                     : up <= field(config, "BOT_OVERTURN_WARNING_COSINE") ? 1
                                                                          : 0;
         if (!level) {
-            state["_overturn_check"] = Value(0.0);
-            state["_overturn_time"] = Value(0.0);
-            state["_overturn_level"] = Value(0);
-            state["_overturned"] = Value(false);
+            state[sf::_overturn_check] = Value(0.0);
+            state[sf::_overturn_time] = Value(0.0);
+            state[sf::_overturn_level] = Value(0);
+            state[sf::_overturned] = Value(false);
             return false;
         }
-        double check = field(state, "_overturn_check") + step;
-        state["_overturn_check"] = Value(check);
+        double check = field(state, sf::_overturn_check) + step;
+        state[sf::_overturn_check] = Value(check);
         if (check + .000001 < field(config, "BOT_OVERTURN_IGNORE_SECONDS"))
             return false;
-        if (level != integer(state, "_overturn_level")) {
-            state["_overturn_level"] = Value(level);
-            state["_overturn_time"] = Value(0.0);
+        if (level != integer(state, sf::_overturn_level)) {
+            state[sf::_overturn_level] = Value(level);
+            state[sf::_overturn_time] = Value(0.0);
         }
-        state["_overturned"] = Value(level == 2);
+        state[sf::_overturned] = Value(level == 2);
         if (level != 2) {
-            state["_overturn_time"] = Value(0.0);
+            state[sf::_overturn_time] = Value(0.0);
             return false;
         }
-        state["movement_dir"] = Value(0);
-        state["rotation_dir"] = Value(0);
+        state[sf::movement_dir] = Value(0);
+        state[sf::rotation_dir] = Value(0);
         turn_speed = 0;
-        double elapsed = field(state, "_overturn_time") + step;
-        state["_overturn_time"] = Value(elapsed);
+        double elapsed = field(state, sf::_overturn_time) + step;
+        state[sf::_overturn_time] = Value(elapsed);
         if (elapsed + .000001 < field(config, "BOT_OVERTURN_DEATH_SECONDS"))
             return false;
-        Critical terminal(state.get("critical"), *critical);
-        state["critical"] = terminal.terminal();
+        Critical terminal(state.get(sf::critical), *critical);
+        state[sf::critical] = terminal.terminal();
         death(integer(config, "BOT_OVERTURN_DEATH_REASON"), 0);
-        state["_overturn_time"] = config.get("BOT_OVERTURN_DEATH_SECONDS");
+        state[sf::_overturn_time] = config.get("BOT_OVERTURN_DEATH_SECONDS");
         return true;
     }
 };

--- a/tools/ffi_experiment/kernel_codec.h
+++ b/tools/ffi_experiment/kernel_codec.h
@@ -1,0 +1,225 @@
+#ifndef OFFLINE_EXPERIMENT_KERNEL_CODEC_H
+#define OFFLINE_EXPERIMENT_KERNEL_CODEC_H
+#include "kernel_value.h"
+#include <array>
+
+namespace offline_kernel {
+struct Codec {
+    struct Column {
+        std::string name;
+        int scale;
+        bool bounded;
+        double minimum, maximum;
+    };
+    struct Group {
+        int flag;
+        std::vector<std::string> names;
+    };
+    std::vector<Column> columns;
+    std::vector<Group> groups;
+    std::vector<std::string> devices, crew, device_states;
+    explicit Codec(const Value &config) {
+        for (const Value &raw : elements(config.get("scalars"))) {
+            Column c;
+            c.name = raw[0].text();
+            c.scale = static_cast<int>(raw[1].exact());
+            const Value &bounds = config.get("clamps").get(c.name);
+            c.bounded = bounds.kind == Value::Array;
+            c.minimum = c.bounded ? bounds[0].number() : 0;
+            c.maximum = c.bounded ? bounds[1].number() : 0;
+            columns.push_back(c);
+        }
+        for (const Value &raw : elements(config.get("groups"))) {
+            Group g;
+            g.flag = static_cast<int>(raw[0].exact());
+            for (const Value &name : elements(raw[1]))
+                g.names.push_back(name.text());
+            groups.push_back(g);
+        }
+        for (const Value &raw : elements(config.get("devices")))
+            devices.push_back(raw.text());
+        for (const Value &raw : elements(config.get("crew")))
+            crew.push_back(raw.text());
+        for (const Value &raw : elements(config.get("device_states")))
+            device_states.push_back(raw.text());
+        if (columns.size() != 37 || groups.size() != 4 || devices.size() != 9 || crew.size() != 8 ||
+            device_states.size() != 3)
+            throw std::invalid_argument("kernel codec producer");
+    }
+    static int64_t fixed(double value, int scale, bool bounded = false, double minimum = 0,
+                         double maximum = 0) {
+        if (!std::isfinite(value))
+            throw std::invalid_argument("bot state column is not finite");
+        if (bounded)
+            value = clamp(value, minimum, maximum);
+        double scaled = value * scale;
+        if (std::abs(scaled) > 9007199254740991.0)
+            throw std::invalid_argument("kernel wire numeric range");
+        return scaled >= 0 ? static_cast<int64_t>(std::floor(scaled + 0.5))
+                           : -static_cast<int64_t>(std::floor(-scaled + 0.5));
+    }
+    static int index(const std::vector<std::string> &names, const std::string &name,
+                     const char *error) {
+        auto at = std::find(names.begin(), names.end(), name);
+        if (at == names.end())
+            throw std::invalid_argument(error);
+        return static_cast<int>(at - names.begin());
+    }
+    int crew_mask(const Value &names) const {
+        int mask = 0;
+        if (names.truth()) {
+            if (names.kind != Value::Array)
+                throw std::invalid_argument("kernel crew list");
+            for (const Value &name : names.data->array)
+                mask |= 1 << index(crew, name.text(), "unknown crew member");
+        }
+        return mask;
+    }
+    static int64_t exact(const Value &v) {
+        if (v.kind == Value::Integer)
+            return v.integer;
+        if (v.kind == Value::Real && std::isfinite(v.real) &&
+            std::abs(v.real) <= 9007199254740991.0)
+            return static_cast<int64_t>(v.real);
+        if (v.kind == Value::String) {
+            const std::string &s = v.data->string;
+            char *end = nullptr;
+            long long n = std::strtoll(s.c_str(), &end, 10);
+            if (end != s.c_str()) {
+                while (*end == ' ' || *end == '\t' || *end == '\n' || *end == '\r')
+                    ++end;
+                if (!*end)
+                    return n;
+            }
+        }
+        throw std::invalid_argument("invalid integer column");
+    }
+    static double numeric(const Value &v) {
+        double n = v.number(std::numeric_limits<double>::quiet_NaN());
+        if (!std::isfinite(n))
+            throw std::invalid_argument("invalid real column");
+        return n;
+    }
+    Value row(const Value &state) const {
+        if (state.kind != Value::Object)
+            throw std::invalid_argument("bot state must be a mapping");
+        const Value &critical = state.get("critical"), &equipment = state.get("equipment_states"),
+                    &ammo = state.get("ammo_remaining");
+        bool shot = state.has("shot_yaw");
+        if (shot != state.has("shot_pitch"))
+            throw std::invalid_argument("bot shot angles must be an atomic pair");
+        int flags = 0;
+        if (flag(state, "alive", true))
+            flags |= 1;
+        if (flag(state, "world_pose", true))
+            flags |= 2;
+        if (flag(state, "ammo_reload_pending"))
+            flags |= 4;
+        if (flag(state, "burst_active"))
+            flags |= 8;
+        if (critical.kind == Value::Object) {
+            flags |= 128;
+            if (flag(critical, "fire"))
+                flags |= 16;
+            if (flag(critical, "ammo_rack_death"))
+                flags |= 32;
+        }
+        if (equipment.kind != Value::Null)
+            flags |= 256;
+        if (shot)
+            flags |= 64;
+        for (const Group &g : groups) {
+            size_t count = 0;
+            for (const std::string &name : g.names)
+                if (state.has(name))
+                    ++count;
+            if (count == g.names.size())
+                flags |= g.flag;
+            else if (count)
+                throw std::invalid_argument("bot state group is incomplete");
+        }
+        double movement = field(state, "movement_dir"), rotation = field(state, "rotation_dir");
+        if (movement > 0.01)
+            flags |= 1024;
+        else if (movement < -.01)
+            flags |= 2048;
+        if (rotation > 0.01)
+            flags |= 4096;
+        else if (rotation < -.01)
+            flags |= 8192;
+        Value out = Value::array();
+        for (const Column &c : columns) {
+            if (c.name == "_flags") {
+                out.append(Value(flags));
+                continue;
+            }
+            if (c.name == "shot_yaw" || c.name == "shot_pitch") {
+                if (!shot) {
+                    out.append(Value(0));
+                    continue;
+                }
+                double value = numeric(state.get(c.name));
+                if (c.name == "shot_yaw") {
+                    const double pi = 3.14159265358979323846;
+                    value = std::fmod(value + pi, 2 * pi);
+                    if (value < 0)
+                        value += 2 * pi;
+                    value -= pi;
+                }
+                out.append(Value(fixed(value, c.scale, c.bounded, c.minimum, c.maximum)));
+                continue;
+            }
+            const Value v = state.has(c.name) ? state.get(c.name) : Value(0);
+            out.append(Value(c.scale ? fixed(numeric(v), c.scale, c.bounded, c.minimum, c.maximum)
+                                     : exact(v)));
+        }
+        if (flags & 512) {
+            if (ammo.kind != Value::Array || ammo.size() > 5)
+                throw std::invalid_argument("bot carries too many shell types");
+            out.append(Value(static_cast<int>(ammo.size())));
+            for (const Value &v : ammo.data->array)
+                out.append(Value(exact(v)));
+        }
+        if (critical.kind == Value::Object) {
+            std::vector<std::array<int64_t, 4>> records;
+            const Value &values = critical.get("devices");
+            if (values.truth()) {
+                if (values.kind != Value::Array)
+                    throw std::invalid_argument("kernel device list");
+                for (const Value &v : values.data->array)
+                    records.push_back(std::array<int64_t, 4>{
+                        {index(devices, v.get("name").text(), "unknown critical device"),
+                         fixed(field(v, "hp"), 1000), fixed(field(v, "max_hp", 1), 1000),
+                         index(device_states, v.get("state").text("normal"),
+                               "unknown critical device state")}});
+            }
+            std::sort(records.begin(), records.end());
+            out.append(Value(static_cast<int>(records.size())));
+            for (const auto &v : records)
+                for (int64_t n : v)
+                    out.append(Value(n));
+            out.append(Value(crew_mask(critical.get("crew_ko"))));
+            const Value &roster = critical.get("crew_roster");
+            out.append(Value(roster.kind == Value::Null ? -1 : crew_mask(roster)));
+        }
+        if (equipment.kind != Value::Null) {
+            if (equipment.kind != Value::Array || equipment.size() > 3)
+                throw std::invalid_argument("bot carries too many consumables");
+            out.append(Value(static_cast<int>(equipment.size())));
+            for (const Value &v : equipment.data->array) {
+                if (v.kind != Value::Object)
+                    throw std::invalid_argument("kernel equipment record");
+                out.append(Value(exact(v.has("usesLeft") ? v.get("usesLeft") : Value(0))));
+                out.append(Value(fixed(field(v, "cooldownTimeLeft"), 1000000)));
+                out.append(Value(flag(v, "active") ? 1 : 0));
+                for (const char *name : {"autoPendingElapsed", "aiPendingElapsed"})
+                    out.append(Value(v.get(name).kind == Value::Null
+                                         ? int64_t(-1)
+                                         : fixed(field(v, name), 1000000)));
+            }
+        }
+        return out;
+    }
+};
+} // namespace offline_kernel
+#endif

--- a/tools/ffi_experiment/kernel_codec.h
+++ b/tools/ffi_experiment/kernel_codec.h
@@ -7,7 +7,7 @@ namespace offline_kernel {
 struct Codec {
     struct Column {
         std::string name;
-        int scale;
+        int scale, slot;
         bool bounded;
         double minimum, maximum;
     };
@@ -22,6 +22,7 @@ struct Codec {
         for (const Value &raw : elements(config.get("scalars"))) {
             Column c;
             c.name = raw[0].text();
+            c.slot = field_slot(c.name);
             c.scale = static_cast<int>(raw[1].exact());
             const Value &bounds = config.get("clamps").get(c.name);
             c.bounded = bounds.kind == Value::Array;
@@ -103,19 +104,20 @@ struct Codec {
     Value row(const Value &state) const {
         if (state.kind != Value::Object)
             throw std::invalid_argument("bot state must be a mapping");
-        const Value &critical = state.get("critical"), &equipment = state.get("equipment_states"),
-                    &ammo = state.get("ammo_remaining");
-        bool shot = state.has("shot_yaw");
-        if (shot != state.has("shot_pitch"))
+        const Value &critical = state.get(sf::critical),
+                    &equipment = state.get(sf::equipment_states),
+                    &ammo = state.get(sf::ammo_remaining);
+        bool shot = state.has(sf::shot_yaw);
+        if (shot != state.has(sf::shot_pitch))
             throw std::invalid_argument("bot shot angles must be an atomic pair");
         int flags = 0;
-        if (flag(state, "alive", true))
+        if (flag(state, sf::alive, true))
             flags |= 1;
-        if (flag(state, "world_pose", true))
+        if (flag(state, sf::world_pose, true))
             flags |= 2;
-        if (flag(state, "ammo_reload_pending"))
+        if (flag(state, sf::ammo_reload_pending))
             flags |= 4;
-        if (flag(state, "burst_active"))
+        if (flag(state, sf::burst_active))
             flags |= 8;
         if (critical.kind == Value::Object) {
             flags |= 128;
@@ -138,7 +140,7 @@ struct Codec {
             else if (count)
                 throw std::invalid_argument("bot state group is incomplete");
         }
-        double movement = field(state, "movement_dir"), rotation = field(state, "rotation_dir");
+        double movement = field(state, sf::movement_dir), rotation = field(state, sf::rotation_dir);
         if (movement > 0.01)
             flags |= 1024;
         else if (movement < -.01)
@@ -158,7 +160,7 @@ struct Codec {
                     out.append(Value(0));
                     continue;
                 }
-                double value = numeric(state.get(c.name));
+                double value = numeric(state.get(Field{c.slot, c.name.c_str(), c.name.size()}));
                 if (c.name == "shot_yaw") {
                     const double pi = 3.14159265358979323846;
                     value = std::fmod(value + pi, 2 * pi);
@@ -169,7 +171,9 @@ struct Codec {
                 out.append(Value(fixed(value, c.scale, c.bounded, c.minimum, c.maximum)));
                 continue;
             }
-            const Value v = state.has(c.name) ? state.get(c.name) : Value(0);
+            const Value v = state.has(Field{c.slot, c.name.c_str(), c.name.size()})
+                                ? state.get(Field{c.slot, c.name.c_str(), c.name.size()})
+                                : Value(0);
             out.append(Value(c.scale ? fixed(numeric(v), c.scale, c.bounded, c.minimum, c.maximum)
                                      : exact(v)));
         }
@@ -188,7 +192,7 @@ struct Codec {
                     throw std::invalid_argument("kernel device list");
                 for (const Value &v : values.data->array)
                     records.push_back(std::array<int64_t, 4>{
-                        {index(devices, v.get("name").text(), "unknown critical device"),
+                        {index(devices, v.get(sf::name).text(), "unknown critical device"),
                          fixed(field(v, "hp"), 1000), fixed(field(v, "max_hp", 1), 1000),
                          index(device_states, v.get("state").text("normal"),
                                "unknown critical device state")}});

--- a/tools/ffi_experiment/kernel_codec.h
+++ b/tools/ffi_experiment/kernel_codec.h
@@ -13,7 +13,11 @@ struct Codec {
     };
     struct Group {
         int flag;
-        std::vector<std::string> names;
+        struct Name {
+            std::string text;
+            int slot;
+        };
+        std::vector<Name> names;
     };
     std::vector<Column> columns;
     std::vector<Group> groups;
@@ -34,7 +38,7 @@ struct Codec {
             Group g;
             g.flag = static_cast<int>(raw[0].exact());
             for (const Value &name : elements(raw[1]))
-                g.names.push_back(name.text());
+                g.names.push_back(Group::Name{name.text(), field_slot(name.text())});
             groups.push_back(g);
         }
         for (const Value &raw : elements(config.get("devices")))
@@ -132,8 +136,8 @@ struct Codec {
             flags |= 64;
         for (const Group &g : groups) {
             size_t count = 0;
-            for (const std::string &name : g.names)
-                if (state.has(name))
+            for (const Group::Name &name : g.names)
+                if (state.has(Field{name.slot, name.text.c_str(), name.text.size()}))
                     ++count;
             if (count == g.names.size())
                 flags |= g.flag;
@@ -149,7 +153,16 @@ struct Codec {
             flags |= 4096;
         else if (rotation < -.01)
             flags |= 8192;
-        Value out = Value::array();
+        // Reserve the fixed columns and exact optional payload widths. Invalid
+        // nested values are still rejected by the same checks below.
+        size_t width = columns.size();
+        if (flags & 512)
+            width += 1 + ammo.size();
+        if (critical.kind == Value::Object)
+            width += 3 + 4 * critical.get("devices").size();
+        if (equipment.kind != Value::Null)
+            width += 1 + 5 * equipment.size();
+        Value out = Value::array(width);
         for (const Column &c : columns) {
             if (c.name == "_flags") {
                 out.append(Value(flags));

--- a/tools/ffi_experiment/kernel_contacts.h
+++ b/tools/ffi_experiment/kernel_contacts.h
@@ -10,12 +10,12 @@ struct TankBody {
     double x, y, z, yaw, pitch, roll, mass, vx, vy, vz;
     std::array<double, 4> shape;
     explicit TankBody(const Value &v)
-        : raw(v), id(integer(v, "id", -1)), team(integer(v, "team")), alive(flag(v, "alive", true)),
-          impulse(flag(v, "impulse", true)), has_y(v.get("y").kind != Value::Null),
-          x(field(v, "x")), y(field(v, "y")), z(field(v, "z")), yaw(field(v, "yaw")),
-          pitch(field(v, "pitch")), roll(field(v, "roll")),
-          mass(std::max(1.0, field(v, "mass", 1))), vx(field(v, "vx")), vy(field(v, "vy")),
-          vz(field(v, "vz")) {
+        : raw(v), id(integer(v, sf::id, -1)), team(integer(v, sf::team)),
+          alive(flag(v, sf::alive, true)), impulse(flag(v, "impulse", true)),
+          has_y(v.get(sf::y).kind != Value::Null), x(field(v, sf::x)), y(field(v, sf::y)),
+          z(field(v, sf::z)), yaw(field(v, sf::yaw)), pitch(field(v, sf::pitch)),
+          roll(field(v, sf::roll)), mass(std::max(1.0, field(v, sf::mass, 1))), vx(field(v, "vx")),
+          vy(field(v, "vy")), vz(field(v, "vz")) {
         const Value &s = v.get("shape");
         if (s.kind != Value::Array || s.size() != 4)
             throw std::invalid_argument("kernel tank shape producer");
@@ -173,12 +173,12 @@ struct TankContacts {
     static offline_nav::Optional<Contact> ram_inputs(const TankBody &body,
                                                      const Value &provided = Value()) {
         const Value &armor =
-            provided.kind != Value::Null ? provided : body.raw.get("contact_armor");
+            provided.kind != Value::Null ? provided : body.raw.get(sf::contact_armor);
         if (armor.kind == Value::Null)
             return {};
         double nominal = armor.number(-1),
-               spall = field(body.raw.get("ram_profile"), "spall_coefficient", 1),
-               bonus = field(body.raw.get("ram_profile"), "ramming_bonus");
+               spall = field(body.raw.get(sf::ram_profile), "spall_coefficient", 1),
+               bonus = field(body.raw.get(sf::ram_profile), "ramming_bonus");
         if (nominal < 0 || !std::isfinite(nominal) || spall < 1 || !std::isfinite(spall) ||
             bonus < 0 || bonus > .15 || !std::isfinite(bonus))
             throw std::runtime_error("kernel contact armor producer");
@@ -186,11 +186,11 @@ struct TankContacts {
     }
     static void encode_body(std::vector<double> &args, const TankBody &b) {
         args.insert(args.end(), {static_cast<double>(b.id),
-                                 static_cast<double>(b.raw.get("kind").text() == "player"),
+                                 static_cast<double>(b.raw.get(sf::kind).text() == "player"),
                                  static_cast<double>(b.impulse), b.mass, b.vx, b.vy, b.vz});
         args.insert(args.end(), b.shape.begin(), b.shape.end());
-        args.push_back(field(b.raw.get("ram_profile"), "spall_coefficient", 1));
-        args.push_back(field(b.raw.get("ram_profile"), "ramming_bonus"));
+        args.push_back(field(b.raw.get(sf::ram_profile), "spall_coefficient", 1));
+        args.push_back(field(b.raw.get(sf::ram_profile), "ramming_bonus"));
     }
     Value armor_probe(const TankBody &a, const TankBody &b, Contact contact) {
         Pair pair(std::min(a.id, b.id), std::max(a.id, b.id));
@@ -288,8 +288,8 @@ struct TankContacts {
             event["pair"] = tuple_value({Value(pair.first), Value(pair.second)});
             event["self_id"] = Value(own.id);
             event["other_id"] = Value(other.id);
-            event["self_vehicle"] = Value(own.raw.get("vehicle").text());
-            event["other_vehicle"] = Value(other.raw.get("vehicle").text());
+            event["self_vehicle"] = Value(own.raw.get(sf::vehicle).text());
+            event["other_vehicle"] = Value(other.raw.get(sf::vehicle).text());
             event["mass_self"] = Value(own.mass);
             event["mass_other"] = Value(other.mass);
             event["velocity_self"] = array(own.velocity());
@@ -325,41 +325,47 @@ struct TankContacts {
     void apply(Bot &bot, const Response &result, double step, bool advance = true,
                bool correct = true) {
         Value &s = bot.state;
-        double yaw = field(s, "yaw"), speed = field(s, "speed"),
+        double yaw = field(s, sf::yaw), speed = field(s, sf::speed),
                forward = result.delta[0] * std::sin(yaw) + result.delta[1] * std::cos(yaw),
                applied = 0;
         if (forward * speed < 0) {
             applied = std::abs(forward) >= std::abs(speed) ? -speed : forward;
-            s["speed"] = Value(speed + applied);
+            s[sf::speed] = Value(speed + applied);
         }
-        double px = field(s, "push_x") + result.delta[0] - applied * std::sin(yaw),
-               pz = field(s, "push_z") + result.delta[1] - applied * std::cos(yaw),
+        double px = field(s, sf::push_x) + result.delta[0] - applied * std::sin(yaw),
+               pz = field(s, sf::push_z) + result.delta[1] - applied * std::cos(yaw),
                mx = (correct ? result.correction[0] : 0) + (advance ? px * step : 0),
                mz = (correct ? result.correction[1] : 0) + (advance ? pz * step : 0),
                distance = std::sqrt(mx * mx + mz * mz);
         if (distance > .0001) {
             double direction = std::atan2(mx, mz), velocity = distance / std::max(step, 1.0 / 120),
-                   relative = direction - yaw, length = std::max(.5, field(s, "half_length", 3.5)),
-                   width = std::max(.3, field(s, "half_width", 1.7)),
+                   relative = direction - yaw,
+                   length = std::max(.5, field(s, sf::half_length, 3.5)),
+                   width = std::max(.3, field(s, sf::half_width, 1.7)),
                    support =
                        length * std::abs(std::cos(relative)) + width * std::abs(std::sin(relative)),
                    half_width =
                        length * std::abs(std::sin(relative)) + width * std::abs(std::cos(relative));
-            double packet[128] = {635,           static_cast<double>(integer(s, "id")),
-                                  field(s, "x"), field(s, "y"),
-                                  field(s, "z"), direction,
-                                  velocity,      std::max(1.0, distance + support),
-                                  half_width,    field(s, "speed")};
+            double packet[128] = {635,
+                                  static_cast<double>(integer(s, sf::id)),
+                                  field(s, sf::x),
+                                  field(s, sf::y),
+                                  field(s, sf::z),
+                                  direction,
+                                  velocity,
+                                  std::max(1.0, distance + support),
+                                  half_width,
+                                  field(s, sf::speed)};
             motion.engine_event(packet, 128, s);
             if (!packet[0]) {
                 mx = mz = px = pz = 0;
             }
         }
-        s["x"] = Value(field(s, "x") + mx);
-        s["z"] = Value(field(s, "z") + mz);
+        s[sf::x] = Value(field(s, sf::x) + mx);
+        s[sf::z] = Value(field(s, sf::z) + mz);
         double decay = advance ? std::pow(.90, std::max(0.0, step) * 60) : 1;
-        s["push_x"] = Value(px * decay);
-        s["push_z"] = Value(pz * decay);
+        s[sf::push_x] = Value(px * decay);
+        s[sf::push_z] = Value(pz * decay);
     }
     Value report(int id, int other, int self_damage, int other_damage, int player = 0,
                  int seq = 0) {
@@ -367,8 +373,8 @@ struct TankContacts {
         int base = integer(config, "human_base");
         v["type"] = Value("bot_ram");
         v["bot_id"] = Value(id);
-        v["target_kind"] = Value(other >= base ? "human" : "bot");
-        v["target_id"] = Value(other >= base ? other - base : other);
+        v[sf::target_kind] = Value(other >= base ? "human" : "bot");
+        v[sf::target_id] = Value(other >= base ? other - base : other);
         v["ram_seq"] = Value(++sequence);
         v["damage_to_bot"] = Value(self_damage);
         v["damage_to_target"] = Value(other_damage);
@@ -390,28 +396,28 @@ struct TankContacts {
         return true;
     }
     static Value body(const Value &s, bool human, int base, const Value &collision) {
-        int id = integer(s, "id");
+        int id = integer(s, sf::id);
         Value result = Value::object();
-        result["id"] = Value(id + (human ? base : 0));
-        result["network_id"] = Value(id);
-        result["kind"] = Value(human ? "player" : "bot");
-        result["alive"] = Value(flag(s, "alive", true));
-        result["team"] = Value(integer(s, "team"));
-        result["vehicle"] = Value(s.get("vehicle").text());
+        result[sf::id] = Value(id + (human ? base : 0));
+        result[sf::network_id] = Value(id);
+        result[sf::kind] = Value(human ? "player" : "bot");
+        result[sf::alive] = Value(flag(s, sf::alive, true));
+        result[sf::team] = Value(integer(s, sf::team));
+        result[sf::vehicle] = Value(s.get(sf::vehicle).text());
         if (human)
             result["impulse"] = Value(false);
         for (const char *key : {"x", "y", "z", "yaw"})
             result[key] = Value(field(s, key));
-        result["mass"] = Value(human ? field(collision, "mass") : field(s, "mass", 25000));
-        result["shape"] = human ? collision.get("shape") : s.get("collision_shape");
-        result["ram_profile"] = human ? collision.get("ram_profile") : s.get("ram_profile");
-        double speed = flag(s, "alive", true) ? field(s, "speed") : 0, yaw = field(s, "yaw");
-        result["vx"] = Value(std::sin(yaw) * speed + (human ? 0 : field(s, "push_x")));
-        result["vz"] = Value(std::cos(yaw) * speed + (human ? 0 : field(s, "push_z")));
+        result[sf::mass] = Value(human ? field(collision, sf::mass) : field(s, sf::mass, 25000));
+        result["shape"] = human ? collision.get("shape") : s.get(sf::collision_shape);
+        result[sf::ram_profile] = human ? collision.get(sf::ram_profile) : s.get(sf::ram_profile);
+        double speed = flag(s, sf::alive, true) ? field(s, sf::speed) : 0, yaw = field(s, sf::yaw);
+        result["vx"] = Value(std::sin(yaw) * speed + (human ? 0 : field(s, sf::push_x)));
+        result["vz"] = Value(std::cos(yaw) * speed + (human ? 0 : field(s, sf::push_z)));
         if (!human) {
-            result["vy"] = Value(field(s, "ram_vy", field(s, "vertical_speed")));
-            result["pitch"] = Value(field(s, "pitch"));
-            result["roll"] = Value(field(s, "roll"));
+            result["vy"] = Value(field(s, sf::ram_vy, field(s, sf::vertical_speed)));
+            result[sf::pitch] = Value(field(s, sf::pitch));
+            result[sf::roll] = Value(field(s, sf::roll));
         }
         return result;
     }
@@ -420,18 +426,18 @@ struct TankContacts {
         std::map<int, std::vector<Value>> entries;
         int base = integer(config, "human_base");
         for (const Value &raw : elements(players)) {
-            if (raw.kind != Value::Object || !raw.has("id"))
+            if (raw.kind != Value::Object || !raw.has(sf::id))
                 continue;
-            int id = integer(raw, "id"), resolved = integer(raw, "ram_contact_resolved_seq");
+            int id = integer(raw, sf::id), resolved = integer(raw, sf::ram_contact_resolved_seq);
             if (resolved > 0)
                 ack(id, resolved);
-            if (raw.get("ram_contacts").kind == Value::Array) {
-                for (const Value &receipt : elements(raw.get("ram_contacts"))) {
+            if (raw.get(sf::ram_contacts).kind == Value::Array) {
+                for (const Value &receipt : elements(raw.get(sf::ram_contacts))) {
                     if (receipt.kind != Value::Object)
                         continue;
                     Value row = raw.copy();
-                    row["ram_contact"] = receipt;
-                    row["_ram_contact_bot_state"] = receipt.get("_ram_contact_bot_state");
+                    row[sf::ram_contact] = receipt;
+                    row[sf::_ram_contact_bot_state] = receipt.get(sf::_ram_contact_bot_state);
                     entries[id].push_back(row);
                 }
             } else
@@ -442,12 +448,12 @@ struct TankContacts {
             int player = group.first;
             auto &rows = group.second;
             std::stable_sort(rows.begin(), rows.end(), [](const Value &a, const Value &b) {
-                return integer(a.get("ram_contact"), "seq", 2147483647) <
-                       integer(b.get("ram_contact"), "seq", 2147483647);
+                return integer(a.get(sf::ram_contact), "seq", 2147483647) <
+                       integer(b.get(sf::ram_contact), "seq", 2147483647);
             });
             for (const Value &raw : rows) {
-                const Value &r = raw.get("ram_contact"),
-                            &historical = raw.get("_ram_contact_bot_state");
+                const Value &r = raw.get(sf::ram_contact),
+                            &historical = raw.get(sf::_ram_contact_bot_state);
                 if (r.kind != Value::Object || r.get("seq").kind == Value::Null ||
                     r.get("bot_id").kind == Value::Null)
                     continue;
@@ -468,7 +474,7 @@ struct TankContacts {
                 Bot &current = *bots.at(id);
                 Value receipt_reports = Value::array();
                 bool valid =
-                    flag(current.state, "alive", true) && integer(historical, "id", -1) == id;
+                    flag(current.state, sf::alive, true) && integer(historical, sf::id, -1) == id;
                 for (const char *name : {"x", "y", "z", "yaw", "vx", "vy", "vz", "bot_vx", "bot_vy",
                                          "bot_vz", "presentation_time_us", "contact_x", "contact_y",
                                          "contact_z", "contact_armor_player", "contact_armor_bot",
@@ -477,14 +483,14 @@ struct TankContacts {
                         valid && r.get(name).kind != Value::Null && std::isfinite(field(r, name));
                 if (valid) {
                     Value own = body(historical, false, base, Value());
-                    own.erase("kind");
-                    own.erase("network_id");
+                    own.erase(sf::kind);
+                    own.erase(sf::network_id);
                     own["vx"] = r.get("bot_vx");
                     own["vy"] = r.get("bot_vy");
                     own["vz"] = r.get("bot_vz");
-                    Value other = body(raw, true, base, raw.get("_kernel").get("collision"));
-                    other.erase("kind");
-                    other.erase("network_id");
+                    Value other = body(raw, true, base, raw.get(sf::_kernel).get("collision"));
+                    other.erase(sf::kind);
+                    other.erase(sf::network_id);
                     other.erase("impulse");
                     for (const char *name :
                          {"x", "y", "z", "yaw", "vx", "vy", "vz", "pitch", "roll"})
@@ -504,8 +510,8 @@ struct TankContacts {
                             alignment > 1e-6 && !flag(r, "contact_screened_player") &&
                             !flag(r, "contact_screened_bot") && a.contains(hit, .75) &&
                             b.contains(hit, .75);
-                    double own_spall = field(own.get("ram_profile"), "spall_coefficient", -1),
-                           own_bonus = field(own.get("ram_profile"), "ramming_bonus", -1);
+                    double own_spall = field(own.get(sf::ram_profile), "spall_coefficient", -1),
+                           own_bonus = field(own.get(sf::ram_profile), "ramming_bonus", -1);
                     valid = valid && own_spall >= 1 && own_spall <= 1.5 && own_bonus >= 0 &&
                             own_bonus <= .15;
                     if (valid) {
@@ -517,12 +523,13 @@ struct TankContacts {
                                                own_spall, spall, own_bonus, bonus,
                                                a.vx || a.vy || a.vz, b.vx || b.vy || b.vz);
                         Response response = resolve(a, std::vector<TankBody>{b}, {}, {}, false);
-                        V before{{field(current.state, "push_x"), field(current.state, "push_z")}};
-                        double previous_speed = field(current.state, "speed");
+                        V before{
+                            {field(current.state, sf::push_x), field(current.state, sf::push_z)}};
+                        double previous_speed = field(current.state, sf::speed);
                         apply(current, response, step, false, false);
-                        if (std::abs(field(current.state, "speed") - previous_speed) > .0001 ||
-                            std::abs(field(current.state, "push_x") - before[0]) > .0001 ||
-                            std::abs(field(current.state, "push_z") - before[1]) > .0001)
+                        if (std::abs(field(current.state, sf::speed) - previous_speed) > .0001 ||
+                            std::abs(field(current.state, sf::push_x) - before[0]) > .0001 ||
+                            std::abs(field(current.state, sf::push_z) - before[1]) > .0001)
                             contacted.insert(id);
                         if (hp.first || hp.second)
                             receipt_reports.append(
@@ -552,10 +559,10 @@ struct TankContacts {
             insertions.push_back(id);
         }
         for (const Value &raw : elements(players)) {
-            if (raw.kind != Value::Object || !raw.has("id"))
+            if (raw.kind != Value::Object || !raw.has(sf::id))
                 continue;
-            Value v = body(raw, true, base, raw.get("_kernel").get("collision"));
-            int id = integer(v, "id");
+            Value v = body(raw, true, base, raw.get(sf::_kernel).get("collision"));
+            int id = integer(v, sf::id);
             bodies.erase(id);
             bodies.emplace(id, TankBody(v));
             insertions.push_back(id);
@@ -579,7 +586,7 @@ struct TankContacts {
         frame_armors.clear();
         for (int id : ordered) {
             Bot &bot = *bots.at(id);
-            if (!flag(bot.state, "alive", true))
+            if (!flag(bot.state, sf::alive, true))
                 continue;
             const TankBody &own = bodies.at(id);
             int x = static_cast<int>(std::floor(own.x / size)),
@@ -602,7 +609,7 @@ struct TankContacts {
                     }
                 }
             if (others.empty()) {
-                if (field(bot.state, "push_x") || field(bot.state, "push_z"))
+                if (field(bot.state, sf::push_x) || field(bot.state, sf::push_z))
                     apply(bot, Response(), elapsed);
                 continue;
             }

--- a/tools/ffi_experiment/kernel_contacts.h
+++ b/tools/ffi_experiment/kernel_contacts.h
@@ -1,0 +1,643 @@
+#ifndef OFFLINE_EXPERIMENT_KERNEL_CONTACTS_H
+#define OFFLINE_EXPERIMENT_KERNEL_CONTACTS_H
+#include "kernel_driver.h"
+
+namespace offline_kernel {
+struct TankBody {
+    Value raw;
+    int id, team;
+    bool alive, impulse, has_y;
+    double x, y, z, yaw, pitch, roll, mass, vx, vy, vz;
+    std::array<double, 4> shape;
+    explicit TankBody(const Value &v)
+        : raw(v), id(integer(v, "id", -1)), team(integer(v, "team")), alive(flag(v, "alive", true)),
+          impulse(flag(v, "impulse", true)), has_y(v.get("y").kind != Value::Null),
+          x(field(v, "x")), y(field(v, "y")), z(field(v, "z")), yaw(field(v, "yaw")),
+          pitch(field(v, "pitch")), roll(field(v, "roll")),
+          mass(std::max(1.0, field(v, "mass", 1))), vx(field(v, "vx")), vy(field(v, "vy")),
+          vz(field(v, "vz")) {
+        const Value &s = v.get("shape");
+        if (s.kind != Value::Array || s.size() != 4)
+            throw std::invalid_argument("kernel tank shape producer");
+        for (size_t i = 0; i < 4; ++i)
+            shape[i] = s[i].number();
+    }
+    using V = std::array<double, 2>;
+    std::array<V, 2> axes() const {
+        double s = std::sin(yaw), c = std::cos(yaw);
+        return {{{{c, -s}}, {{s, c}}}};
+    }
+    double radius(V axis) const {
+        auto a = axes();
+        return shape[0] * std::abs(axis[0] * a[0][0] + axis[1] * a[0][1]) +
+               shape[1] * std::abs(axis[0] * a[1][0] + axis[1] * a[1][1]);
+    }
+    double radius() const { return std::sqrt(shape[0] * shape[0] + shape[1] * shape[1]); }
+    V velocity() const { return {{vx, vz}}; }
+    bool same_team(const TankBody &other) const {
+        return (team == 1 || team == 2) && team == other.team;
+    }
+    bool contains(const Value &point, double slop) const {
+        if (point.kind != Value::Array || point.size() != 3)
+            return false;
+        double sy = std::sin(yaw), cy = std::cos(yaw), sp = std::sin(pitch), cp = std::cos(pitch),
+               sr = std::sin(roll), cr = std::cos(roll);
+        auto rotate = [&](double x, double y, double z) {
+            double after_y = cp * y - sp * z, after_z = sp * y + cp * z;
+            return std::array<double, 3>{{cy * x + sy * after_z, after_y, -sy * x + cy * after_z}};
+        };
+        std::array<std::array<double, 3>, 3> axes = {
+            {rotate(cr, sr, 0), rotate(-sr, cr, 0), rotate(0, 0, 1)}};
+        std::array<double, 3> delta{
+            {point[0].number() - x, point[1].number() - y, point[2].number() - z}},
+            local{};
+        for (size_t i = 0; i < 3; ++i) {
+            double sum = 0;
+            for (size_t j = 0; j < 3; ++j)
+                sum += axes[i][j] * delta[j];
+            local[i] = sum;
+        }
+        return std::isfinite(local[0]) && std::isfinite(local[1]) && std::isfinite(local[2]) &&
+               std::abs(local[0]) <= shape[0] + slop && local[1] >= shape[2] - slop &&
+               local[1] <= shape[3] + slop && std::abs(local[2]) <= shape[1] + slop;
+    }
+};
+struct TankContacts {
+    using V = std::array<double, 2>;
+    using Pair = std::pair<int, int>;
+    using Contact = std::array<double, 3>;
+    using OptionalContact = offline_nav::Optional<Contact>;
+    struct Response {
+        V correction{{0, 0}}, delta{{0, 0}};
+        Value events = Value::array(), diagnostics = Value::array();
+        std::set<Pair> contacts;
+    };
+    std::map<int, std::unique_ptr<Bot>> &bots;
+    Motion &motion;
+    Engine &engine;
+    Value config;
+    std::map<Pair, double> cooldowns;
+    std::set<Pair> active;
+    std::map<int, double> leases;
+    std::map<int, int> human_ack;
+    std::map<Pair, Value> human_reports;
+    std::map<Pair, Value> frame_armors;
+    int sequence = 0;
+    TankContacts(const Value &c, std::map<int, std::unique_ptr<Bot>> &b, Motion &m, Engine &e)
+        : bots(b), motion(m), engine(e), config(c), sequence(integer(c, "sequence")) {}
+    static Value array(V v) { return tuple_value({Value(v[0]), Value(v[1])}); }
+    static Value array(Contact v) { return vector3(v[0], v[1], v[2]); }
+    static Value shape(const TankBody &body) {
+        Value out = Value::array();
+        for (double v : body.shape)
+            out.append(Value(v));
+        return out;
+    }
+    static OptionalContact contact(const TankBody &a, const TankBody &b, bool impact = false) {
+        auto axes_a = a.axes(), axes_b = b.axes();
+        double dx = a.x - b.x, dz = a.z - b.z, rx = a.vx - (b.alive ? b.vx : 0),
+               rz = a.vz - (b.alive ? b.vz : 0);
+        offline_nav::Optional<double> best;
+        Contact result{};
+        for (V axis : {axes_a[0], axes_a[1], axes_b[0], axes_b[1]}) {
+            double extent = a.radius(axis) + b.radius(axis), distance = dx * axis[0] + dz * axis[1],
+                   overlap = extent - std::abs(distance);
+            if (overlap <= 0)
+                return {};
+            if (!impact) {
+                if (!best.has || overlap < best.value) {
+                    best = overlap;
+                    double sign = distance < 0 ? -1 : 1;
+                    result = {{axis[0] * sign, axis[1] * sign, overlap}};
+                }
+            } else {
+                double velocity = rx * axis[0] + rz * axis[1];
+                if (std::abs(velocity) <= 1e-9)
+                    continue;
+                double age =
+                    velocity > 0 ? (extent + distance) / velocity : (extent - distance) / -velocity;
+                if (age < -1e-9)
+                    continue;
+                if (!best.has || age < best.value - 1e-9) {
+                    best = std::max(0.0, age);
+                    double sign = velocity > 0 ? -1 : 1;
+                    result = {{axis[0] * sign, axis[1] * sign, overlap}};
+                }
+            }
+        }
+        if (!best.has || (impact && result[0] * dx + result[1] * dz <= 1e-9))
+            return {};
+        if (!impact && std::abs(dx * result[0] + dz * result[1]) <= 1e-9) {
+            if (result[0] < -1e-9 || (std::abs(result[0]) <= 1e-9 && result[1] < 0)) {
+                result[0] = -result[0];
+                result[1] = -result[1];
+            }
+            if (a.id > b.id) {
+                result[0] = -result[0];
+                result[1] = -result[1];
+            }
+        }
+        return result;
+    }
+    static double closing(V a, V b, Contact normal) {
+        return std::max(0.0, -((a[0] - b[0]) * normal[0] + (a[1] - b[1]) * normal[1]));
+    }
+    static std::pair<int, int> damage(double speed, double self_mass, double other_mass,
+                                      double self_armor, double other_armor, double self_spall,
+                                      double other_spall, double self_bonus, double other_bonus,
+                                      bool self_moves, bool other_moves) {
+        speed = std::abs(speed);
+        double own = std::max(0.0, self_mass) * .001, other = std::max(0.0, other_mass) * .001,
+               combined = own + other;
+        if (combined <= 0 || speed <= 0)
+            return {0, 0};
+        double potential = .5 * combined * speed * speed,
+               alpha_self = potential * (other / combined),
+               alpha_other = potential * (own / combined),
+               raw_self = std::max(0.0, .5 * alpha_self - 1.1 * std::max(0.0, self_armor) *
+                                                              std::max(1.0, self_spall)),
+               raw_other = std::max(0.0, .5 * alpha_other - 1.1 * std::max(0.0, other_armor) *
+                                                                std::max(1.0, other_spall));
+        self_bonus = clamp(self_bonus, 0, .15);
+        other_bonus = clamp(other_bonus, 0, .15);
+        if (self_moves) {
+            raw_self *= 1 - self_bonus;
+            raw_other *= 1 + self_bonus;
+        }
+        if (other_moves) {
+            raw_other *= 1 - other_bonus;
+            raw_self *= 1 + other_bonus;
+        }
+        return {static_cast<int>(raw_other * .25), static_cast<int>(raw_self * .25)};
+    }
+    static offline_nav::Optional<Contact> ram_inputs(const TankBody &body,
+                                                     const Value &provided = Value()) {
+        const Value &armor =
+            provided.kind != Value::Null ? provided : body.raw.get("contact_armor");
+        if (armor.kind == Value::Null)
+            return {};
+        double nominal = armor.number(-1),
+               spall = field(body.raw.get("ram_profile"), "spall_coefficient", 1),
+               bonus = field(body.raw.get("ram_profile"), "ramming_bonus");
+        if (nominal < 0 || !std::isfinite(nominal) || spall < 1 || !std::isfinite(spall) ||
+            bonus < 0 || bonus > .15 || !std::isfinite(bonus))
+            throw std::runtime_error("kernel contact armor producer");
+        return Contact{{nominal, spall, bonus}};
+    }
+    static void encode_body(std::vector<double> &args, const TankBody &b) {
+        args.insert(args.end(), {static_cast<double>(b.id),
+                                 static_cast<double>(b.raw.get("kind").text() == "player"),
+                                 static_cast<double>(b.impulse), b.mass, b.vx, b.vy, b.vz});
+        args.insert(args.end(), b.shape.begin(), b.shape.end());
+        args.push_back(field(b.raw.get("ram_profile"), "spall_coefficient", 1));
+        args.push_back(field(b.raw.get("ram_profile"), "ramming_bonus"));
+    }
+    Value armor_probe(const TankBody &a, const TankBody &b, Contact contact) {
+        Pair pair(std::min(a.id, b.id), std::max(a.id, b.id));
+        auto at = frame_armors.find(pair);
+        if (at == frame_armors.end()) {
+            std::vector<double> args;
+            encode_body(args, a);
+            encode_body(args, b);
+            args.insert(args.end(), contact.begin(), contact.end());
+            auto answer = engine.query(768, a.raw, b.raw, args);
+            Value value;
+            if (answer[0])
+                value = tuple_value({answer[1] ? Value(answer[2]) : Value(),
+                                     answer[3] ? Value(answer[4]) : Value()});
+            if (a.id > b.id && value.kind == Value::Array)
+                std::swap(value[0], value[1]);
+            at = frame_armors.insert({pair, value}).first;
+        }
+        Value result = at->second.copy();
+        if (a.id > b.id && result.kind == Value::Array)
+            std::swap(result[0], result[1]);
+        return result;
+    }
+    Response resolve(const TankBody &own, const std::vector<TankBody> &others,
+                     offline_nav::Optional<double> now, const std::set<Pair> &previous,
+                     bool probe) {
+        Response result;
+        std::set<Pair> overlaps, newly;
+        for (const TankBody &other : others) {
+            if (other.id == own.id)
+                continue;
+            if (own.has_y && other.has_y &&
+                std::min(own.y + own.shape[3], other.y + other.shape[3]) -
+                        std::max(own.y + own.shape[2], other.y + other.shape[2]) <=
+                    .02)
+                continue;
+            double dx = own.x - other.x, dz = own.z - other.z,
+                   reach = own.radius() + other.radius() + .25;
+            if (dx * dx + dz * dz > reach * reach)
+                continue;
+            auto c = contact(own, other);
+            if (!c.has)
+                continue;
+            Pair pair(std::min(own.id, other.id), std::max(own.id, other.id));
+            overlaps.insert(pair);
+            double inverse = 1 / own.mass, other_inverse = other.alive ? 1 / other.mass : 0,
+                   total = inverse + other_inverse,
+                   correction = std::max(c.value[2] - .01, 0.0) * .95 / total;
+            result.correction[0] += c.value[0] * correction * inverse;
+            result.correction[1] += c.value[1] * correction * inverse;
+            V other_velocity = other.alive ? other.velocity() : V{{0, 0}};
+            double normal = (own.vx - other_velocity[0]) * c.value[0] +
+                            (own.vz - other_velocity[1]) * c.value[1];
+            if (normal < 0 && other.impulse) {
+                double impulse = -normal / total;
+                result.delta[0] += c.value[0] * impulse * inverse;
+                result.delta[1] += c.value[1] * impulse * inverse;
+            }
+            if (own.same_team(other))
+                continue;
+            auto impact = contact(own, other, true);
+            if (!impact.has)
+                continue;
+            double speed = closing(own.velocity(), other_velocity, impact.value);
+            if (speed <= 0 || !other.alive || !now.has || previous.count(pair))
+                continue;
+            auto self_inputs = ram_inputs(own), other_inputs = ram_inputs(other);
+            if ((!self_inputs.has || !other_inputs.has) && probe) {
+                Value answer = armor_probe(own, other, impact.value);
+                if (answer.kind != Value::Null) {
+                    if (!self_inputs.has)
+                        self_inputs = ram_inputs(own, answer[0]);
+                    if (!other_inputs.has)
+                        other_inputs = ram_inputs(other, answer[1]);
+                }
+            }
+            if (!self_inputs.has || !other_inputs.has) {
+                Value v = Value::object();
+                v["pair"] = tuple_value({Value(pair.first), Value(pair.second)});
+                v["reason"] = Value("contact_armor_unavailable");
+                v["missing_self"] = Value(!self_inputs.has);
+                v["missing_other"] = Value(!other_inputs.has);
+                result.diagnostics.append(v);
+                continue;
+            }
+            auto self = self_inputs.value, peer = other_inputs.value;
+            auto hp =
+                damage(speed, own.mass, other.mass, self[0], peer[0], self[1], peer[1], self[2],
+                       peer[2], own.vx || own.vy || own.vz, other.vx || other.vy || other.vz);
+            if (!hp.first && !hp.second)
+                continue;
+            newly.insert(pair);
+            cooldowns[pair] = now.value;
+            Value event = Value::object();
+            event["pair"] = tuple_value({Value(pair.first), Value(pair.second)});
+            event["self_id"] = Value(own.id);
+            event["other_id"] = Value(other.id);
+            event["self_vehicle"] = Value(own.raw.get("vehicle").text());
+            event["other_vehicle"] = Value(other.raw.get("vehicle").text());
+            event["mass_self"] = Value(own.mass);
+            event["mass_other"] = Value(other.mass);
+            event["velocity_self"] = array(own.velocity());
+            event["velocity_other"] = array(other.velocity());
+            event["velocity_y_self"] = Value(own.vy);
+            event["velocity_y_other"] = Value(other.vy);
+            event["yaw_self"] = Value(own.yaw);
+            event["yaw_other"] = Value(other.yaw);
+            event["shape_self"] = shape(own);
+            event["shape_other"] = shape(other);
+            event["contact_normal"] = array(V{{impact.value[0], impact.value[1]}});
+            event["contact_penetration"] = Value(impact.value[2]);
+            event["closing_speed"] = Value(speed);
+            double rx = own.vx - other.vx, ry = own.vy - other.vy, rz = own.vz - other.vz;
+            event["relative_speed"] = Value(std::sqrt(rx * rx + ry * ry + rz * rz));
+            event["impact_speed"] = Value(speed);
+            event["armor_self"] = Value(self[0]);
+            event["armor_other"] = Value(peer[0]);
+            event["spall_self"] = Value(self[1]);
+            event["spall_other"] = Value(peer[1]);
+            event["ramming_bonus_self"] = Value(self[2]);
+            event["ramming_bonus_other"] = Value(peer[2]);
+            event["damage_to_other"] = Value(hp.first);
+            event["damage_to_self"] = Value(hp.second);
+            result.events.append(event);
+        }
+        for (Pair pair : previous)
+            if (overlaps.count(pair))
+                result.contacts.insert(pair);
+        result.contacts.insert(newly.begin(), newly.end());
+        return result;
+    }
+    void apply(Bot &bot, const Response &result, double step, bool advance = true,
+               bool correct = true) {
+        Value &s = bot.state;
+        double yaw = field(s, "yaw"), speed = field(s, "speed"),
+               forward = result.delta[0] * std::sin(yaw) + result.delta[1] * std::cos(yaw),
+               applied = 0;
+        if (forward * speed < 0) {
+            applied = std::abs(forward) >= std::abs(speed) ? -speed : forward;
+            s["speed"] = Value(speed + applied);
+        }
+        double px = field(s, "push_x") + result.delta[0] - applied * std::sin(yaw),
+               pz = field(s, "push_z") + result.delta[1] - applied * std::cos(yaw),
+               mx = (correct ? result.correction[0] : 0) + (advance ? px * step : 0),
+               mz = (correct ? result.correction[1] : 0) + (advance ? pz * step : 0),
+               distance = std::sqrt(mx * mx + mz * mz);
+        if (distance > .0001) {
+            double direction = std::atan2(mx, mz), velocity = distance / std::max(step, 1.0 / 120),
+                   relative = direction - yaw, length = std::max(.5, field(s, "half_length", 3.5)),
+                   width = std::max(.3, field(s, "half_width", 1.7)),
+                   support =
+                       length * std::abs(std::cos(relative)) + width * std::abs(std::sin(relative)),
+                   half_width =
+                       length * std::abs(std::sin(relative)) + width * std::abs(std::cos(relative));
+            double packet[128] = {635,           static_cast<double>(integer(s, "id")),
+                                  field(s, "x"), field(s, "y"),
+                                  field(s, "z"), direction,
+                                  velocity,      std::max(1.0, distance + support),
+                                  half_width,    field(s, "speed")};
+            motion.engine_event(packet, 128, s);
+            if (!packet[0]) {
+                mx = mz = px = pz = 0;
+            }
+        }
+        s["x"] = Value(field(s, "x") + mx);
+        s["z"] = Value(field(s, "z") + mz);
+        double decay = advance ? std::pow(.90, std::max(0.0, step) * 60) : 1;
+        s["push_x"] = Value(px * decay);
+        s["push_z"] = Value(pz * decay);
+    }
+    Value report(int id, int other, int self_damage, int other_damage, int player = 0,
+                 int seq = 0) {
+        Value v = Value::object();
+        int base = integer(config, "human_base");
+        v["type"] = Value("bot_ram");
+        v["bot_id"] = Value(id);
+        v["target_kind"] = Value(other >= base ? "human" : "bot");
+        v["target_id"] = Value(other >= base ? other - base : other);
+        v["ram_seq"] = Value(++sequence);
+        v["damage_to_bot"] = Value(self_damage);
+        v["damage_to_target"] = Value(other_damage);
+        if (player) {
+            v["ram_contact_player_id"] = Value(player);
+            v["ram_contact_seq"] = Value(seq);
+        }
+        return v;
+    }
+    bool ack(int player, int seq) {
+        if (player <= 0 || seq <= 0 || seq <= human_ack[player])
+            return false;
+        human_ack[player] = seq;
+        for (auto at = human_reports.begin(); at != human_reports.end();)
+            if (at->first.first == player && at->first.second <= seq)
+                at = human_reports.erase(at);
+            else
+                ++at;
+        return true;
+    }
+    static Value body(const Value &s, bool human, int base, const Value &collision) {
+        int id = integer(s, "id");
+        Value result = Value::object();
+        result["id"] = Value(id + (human ? base : 0));
+        result["network_id"] = Value(id);
+        result["kind"] = Value(human ? "player" : "bot");
+        result["alive"] = Value(flag(s, "alive", true));
+        result["team"] = Value(integer(s, "team"));
+        result["vehicle"] = Value(s.get("vehicle").text());
+        if (human)
+            result["impulse"] = Value(false);
+        for (const char *key : {"x", "y", "z", "yaw"})
+            result[key] = Value(field(s, key));
+        result["mass"] = Value(human ? field(collision, "mass") : field(s, "mass", 25000));
+        result["shape"] = human ? collision.get("shape") : s.get("collision_shape");
+        result["ram_profile"] = human ? collision.get("ram_profile") : s.get("ram_profile");
+        double speed = flag(s, "alive", true) ? field(s, "speed") : 0, yaw = field(s, "yaw");
+        result["vx"] = Value(std::sin(yaw) * speed + (human ? 0 : field(s, "push_x")));
+        result["vz"] = Value(std::cos(yaw) * speed + (human ? 0 : field(s, "push_z")));
+        if (!human) {
+            result["vy"] = Value(field(s, "ram_vy", field(s, "vertical_speed")));
+            result["pitch"] = Value(field(s, "pitch"));
+            result["roll"] = Value(field(s, "roll"));
+        }
+        return result;
+    }
+    Value human_receipts(const Value &players, double step, std::set<Pair> &processed,
+                         std::set<int> &contacted) {
+        std::map<int, std::vector<Value>> entries;
+        int base = integer(config, "human_base");
+        for (const Value &raw : elements(players)) {
+            if (raw.kind != Value::Object || !raw.has("id"))
+                continue;
+            int id = integer(raw, "id"), resolved = integer(raw, "ram_contact_resolved_seq");
+            if (resolved > 0)
+                ack(id, resolved);
+            if (raw.get("ram_contacts").kind == Value::Array) {
+                for (const Value &receipt : elements(raw.get("ram_contacts"))) {
+                    if (receipt.kind != Value::Object)
+                        continue;
+                    Value row = raw.copy();
+                    row["ram_contact"] = receipt;
+                    row["_ram_contact_bot_state"] = receipt.get("_ram_contact_bot_state");
+                    entries[id].push_back(row);
+                }
+            } else
+                entries[id].push_back(raw);
+        }
+        Value reports = Value::array();
+        for (auto &group : entries) {
+            int player = group.first;
+            auto &rows = group.second;
+            std::stable_sort(rows.begin(), rows.end(), [](const Value &a, const Value &b) {
+                return integer(a.get("ram_contact"), "seq", 2147483647) <
+                       integer(b.get("ram_contact"), "seq", 2147483647);
+            });
+            for (const Value &raw : rows) {
+                const Value &r = raw.get("ram_contact"),
+                            &historical = raw.get("_ram_contact_bot_state");
+                if (r.kind != Value::Object || r.get("seq").kind == Value::Null ||
+                    r.get("bot_id").kind == Value::Null)
+                    continue;
+                int seq = integer(r, "seq"), id = integer(r, "bot_id");
+                if (seq <= human_ack[player])
+                    continue;
+                Pair key(player, seq),
+                    pair(std::min(id, base + player), std::max(id, base + player));
+                auto cached = human_reports.find(key);
+                if (cached != human_reports.end()) {
+                    processed.insert(pair);
+                    for (const Value &v : elements(cached->second))
+                        reports.append(v.copy());
+                    break;
+                }
+                if (historical.kind != Value::Object || !bots.count(id))
+                    break;
+                Bot &current = *bots.at(id);
+                Value receipt_reports = Value::array();
+                bool valid =
+                    flag(current.state, "alive", true) && integer(historical, "id", -1) == id;
+                for (const char *name : {"x", "y", "z", "yaw", "vx", "vy", "vz", "bot_vx", "bot_vy",
+                                         "bot_vz", "presentation_time_us", "contact_x", "contact_y",
+                                         "contact_z", "contact_armor_player", "contact_armor_bot",
+                                         "contact_normal_x", "contact_normal_z"})
+                    valid =
+                        valid && r.get(name).kind != Value::Null && std::isfinite(field(r, name));
+                if (valid) {
+                    Value own = body(historical, false, base, Value());
+                    own.erase("kind");
+                    own.erase("network_id");
+                    own["vx"] = r.get("bot_vx");
+                    own["vy"] = r.get("bot_vy");
+                    own["vz"] = r.get("bot_vz");
+                    Value other = body(raw, true, base, raw.get("_kernel").get("collision"));
+                    other.erase("kind");
+                    other.erase("network_id");
+                    other.erase("impulse");
+                    for (const char *name :
+                         {"x", "y", "z", "yaw", "vx", "vy", "vz", "pitch", "roll"})
+                        other[name] = Value(field(r, name));
+                    TankBody a(own), b(other);
+                    double player_armor = field(r, "contact_armor_player"),
+                           bot_armor = field(r, "contact_armor_bot"),
+                           nx = field(r, "contact_normal_x"), nz = field(r, "contact_normal_z"),
+                           normal = std::hypot(nx, nz),
+                           alignment = nx * (b.x - a.x) + nz * (b.z - a.z),
+                           spall = field(r, "contact_spall_player"),
+                           bonus = field(r, "contact_bonus_player", -1);
+                    Value hit = vector3(field(r, "contact_x"), field(r, "contact_y"),
+                                        field(r, "contact_z"));
+                    valid = player_armor > 0 && bot_armor > 0 && spall >= 1 && spall <= 1.5 &&
+                            bonus >= 0 && bonus <= .15 && normal >= .999 && normal <= 1.001 &&
+                            alignment > 1e-6 && !flag(r, "contact_screened_player") &&
+                            !flag(r, "contact_screened_bot") && a.contains(hit, .75) &&
+                            b.contains(hit, .75);
+                    double own_spall = field(own.get("ram_profile"), "spall_coefficient", -1),
+                           own_bonus = field(own.get("ram_profile"), "ramming_bonus", -1);
+                    valid = valid && own_spall >= 1 && own_spall <= 1.5 && own_bonus >= 0 &&
+                            own_bonus <= .15;
+                    if (valid) {
+                        Contact direction{{-nx / normal, -nz / normal, 0}};
+                        double speed = closing(a.velocity(), b.velocity(), direction);
+                        auto hp = a.same_team(b)
+                                      ? std::make_pair(0, 0)
+                                      : damage(speed, a.mass, b.mass, bot_armor, player_armor,
+                                               own_spall, spall, own_bonus, bonus,
+                                               a.vx || a.vy || a.vz, b.vx || b.vy || b.vz);
+                        Response response = resolve(a, std::vector<TankBody>{b}, {}, {}, false);
+                        V before{{field(current.state, "push_x"), field(current.state, "push_z")}};
+                        double previous_speed = field(current.state, "speed");
+                        apply(current, response, step, false, false);
+                        if (std::abs(field(current.state, "speed") - previous_speed) > .0001 ||
+                            std::abs(field(current.state, "push_x") - before[0]) > .0001 ||
+                            std::abs(field(current.state, "push_z") - before[1]) > .0001)
+                            contacted.insert(id);
+                        if (hp.first || hp.second)
+                            receipt_reports.append(
+                                report(id, base + player, hp.second, hp.first, player, seq));
+                    }
+                }
+                if (receipt_reports.size() == 0)
+                    receipt_reports.append(report(id, base + player, 0, 0, player, seq));
+                processed.insert(pair);
+                human_reports[key] = receipt_reports;
+                for (const Value &v : elements(receipt_reports))
+                    reports.append(v.copy());
+                break;
+            }
+        }
+        return reports;
+    }
+    Value step(const Value &players, const std::vector<int> &ordered, double now, double elapsed) {
+        int base = integer(config, "human_base");
+        std::map<int, TankBody> bodies;
+        std::vector<int> insertions;
+        std::map<int, double> radii;
+        double maximum = 4;
+        for (int id : ordered) {
+            Value raw = body(bots.at(id)->state, false, base, Value());
+            bodies.emplace(id, TankBody(raw));
+            insertions.push_back(id);
+        }
+        for (const Value &raw : elements(players)) {
+            if (raw.kind != Value::Object || !raw.has("id"))
+                continue;
+            Value v = body(raw, true, base, raw.get("_kernel").get("collision"));
+            int id = integer(v, "id");
+            bodies.erase(id);
+            bodies.emplace(id, TankBody(v));
+            insertions.push_back(id);
+        }
+        for (const auto &v : bodies) {
+            double radius = v.second.radius();
+            maximum = std::max(maximum, radius);
+            radii[v.first] = radius;
+        }
+        double size = maximum * 2 + 4;
+        std::map<std::pair<int, int>, std::vector<int>> buckets;
+        for (int id : integer_dict_order(insertions, flag(config, "py2", true))) {
+            const TankBody &b = bodies.at(id);
+            buckets[{static_cast<int>(std::floor(b.x / size)),
+                     static_cast<int>(std::floor(b.z / size))}]
+                .push_back(id);
+        }
+        std::set<Pair> processed, current;
+        std::set<int> contacted;
+        Value reports = human_receipts(players, elapsed, processed, contacted);
+        frame_armors.clear();
+        for (int id : ordered) {
+            Bot &bot = *bots.at(id);
+            if (!flag(bot.state, "alive", true))
+                continue;
+            const TankBody &own = bodies.at(id);
+            int x = static_cast<int>(std::floor(own.x / size)),
+                z = static_cast<int>(std::floor(own.z / size));
+            std::vector<TankBody> others;
+            for (int oz = -1; oz <= 1; ++oz)
+                for (int ox = -1; ox <= 1; ++ox) {
+                    auto bucket = buckets.find({x + ox, z + oz});
+                    if (bucket == buckets.end())
+                        continue;
+                    for (int peer : bucket->second) {
+                        if (peer == id || processed.count({std::min(id, peer), std::max(id, peer)}))
+                            continue;
+                        const TankBody &b = bodies.at(peer);
+                        double dx = own.x - b.x, dz = own.z - b.z,
+                               reach = radii[id] + radii[peer] + .25;
+                        if (dx * dx + dz * dz > reach * reach)
+                            continue;
+                        others.push_back(b);
+                    }
+                }
+            if (others.empty()) {
+                if (field(bot.state, "push_x") || field(bot.state, "push_z"))
+                    apply(bot, Response(), elapsed);
+                continue;
+            }
+            std::set<Pair> previous = active;
+            previous.insert(current.begin(), current.end());
+            Response response = resolve(own, others, now, previous, flag(config, "has_armor"));
+            current.insert(response.contacts.begin(), response.contacts.end());
+            if (std::abs(response.delta[0]) > .0001 || std::abs(response.delta[1]) > .0001 ||
+                std::abs(response.correction[0]) > .0001 ||
+                std::abs(response.correction[1]) > .0001)
+                contacted.insert(id);
+            apply(bot, response, elapsed);
+            for (const Value &event : elements(response.events)) {
+                if (motion.diagnostics)
+                    motion.diagnostics->emit("RAM", event);
+                if (integer(event, "other_id") < base)
+                    reports.append(report(id, integer(event, "other_id"),
+                                          integer(event, "damage_to_self"),
+                                          integer(event, "damage_to_other")));
+            }
+        }
+        for (int id : contacted)
+            if (elapsed > 0)
+                leases[id] += elapsed;
+        active = current;
+        return reports;
+    }
+    void finish(int driver) {
+        for (const auto &v : leases) {
+            double packet[] = {204, static_cast<double>(driver), static_cast<double>(v.first), 1,
+                               v.second};
+            offline_driver_dispatch(packet, 5);
+        }
+        leases.clear();
+    }
+};
+} // namespace offline_kernel
+#endif

--- a/tools/ffi_experiment/kernel_core.cpp
+++ b/tools/ffi_experiment/kernel_core.cpp
@@ -1,0 +1,865 @@
+#include "kernel_core.h"
+#include "kernel_bot.h"
+#include "kernel_codec.h"
+#include "kernel_equipment.h"
+#include "kernel_perception.h"
+#include "kernel_launch.h"
+#include "kernel_lanes.h"
+#include "kernel_motion.h"
+#include "kernel_aim.h"
+#include "kernel_driver.h"
+#include "kernel_contacts.h"
+#include "kernel_update.h"
+#include <cstring>
+
+namespace {
+using namespace offline_kernel;
+struct Kernel {
+    std::map<int, std::unique_ptr<Bot>> bots;
+    std::vector<int> order;
+    Codec codec;
+    std::unique_ptr<Perception> perception;
+    std::map<int, Gunnery> gunners;
+    Launches launches;
+    std::unique_ptr<Engine> engine;
+    std::unique_ptr<Lanes> lanes;
+    std::unique_ptr<Motion> motion;
+    std::unique_ptr<Aim> aim;
+    std::map<int, Value> orders;
+    std::unique_ptr<Routes> routes;
+    std::unique_ptr<Driver> driver;
+    Traffic traffic;
+    std::unique_ptr<TankContacts> contacts;
+    std::unique_ptr<Simulation<Kernel>> simulation;
+    int round = 0;
+    std::string output;
+    explicit Kernel(const Value &config) : codec(config.get("codec")) {
+        const Value &states = config.get("bots");
+        if (states.kind != Value::Array || states.size() > 30)
+            throw std::invalid_argument("kernel roster producer");
+        for (const Value &v : states.data->array) {
+            int id = integer(v.get("state"), "id");
+            if (id <= 0 || bots.count(id))
+                throw std::invalid_argument("kernel actor identity");
+            bots[id].reset(new Bot(v));
+            order.push_back(id);
+        }
+        if (config.has("perception"))
+            perception.reset(new Perception(config.get("perception"), bots));
+        round = integer(config, "round_id");
+        for (int id : order)
+            gunners.emplace(id, Gunnery(bots.at(id)->config.get("gunnery")));
+        if (config.has("engine"))
+            engine.reset(new Engine(config.get("engine")));
+        if (config.has("lanes") && perception && engine)
+            lanes.reset(new Lanes(config.get("lanes"), *perception, *engine));
+        if (config.has("motion") && engine)
+            motion.reset(new Motion(config.get("motion"), bots, *engine));
+        if (config.has("aim") && engine)
+            aim.reset(new Aim(config.get("aim"), *engine, gunners, round));
+        if (config.has("orders"))
+            for (const Value &v : elements(config.get("orders")))
+                orders[static_cast<int>(v[0].exact())] = v[1];
+        if (config.has("driver") && motion) {
+            routes.reset(new Routes(config.get("driver"), bots, orders));
+            driver.reset(new Driver(config.get("driver"), *motion, *routes));
+        }
+        if (config.has("contacts") && motion && engine)
+            contacts.reset(new TankContacts(config.get("contacts"), bots, *motion, *engine));
+        if (config.has("simulation"))
+            simulation.reset(new Simulation<Kernel>(*this, config.get("simulation")));
+        if (simulation)
+            perception->engine = engine.get();
+    }
+};
+std::map<int, std::unique_ptr<Kernel>> kernels;
+int next_kernel = 1;
+struct Reader {
+    double *b;
+    int count, index = 1;
+    Reader(double *values, int size) : b(values), count(size) {}
+    int integer(int low = 0, int high = 1000000000) {
+        if (index >= count || !std::isfinite(b[index]) || b[index] != std::floor(b[index]) ||
+            b[index] < low || b[index] > high)
+            throw std::invalid_argument("kernel command integer");
+        return static_cast<int>(b[index++]);
+    }
+    Value value() {
+        int size = integer(0, 12000000);
+        if (size > count - index)
+            throw std::invalid_argument("kernel command JSON width");
+        std::string s;
+        s.reserve(size);
+        for (int i = 0; i < size; ++i)
+            s.push_back(static_cast<char>(integer(0, 255)));
+        return JsonReader(s).read();
+    }
+    void end() {
+        if (index != count)
+            throw std::invalid_argument("kernel command width");
+    }
+};
+Kernel &owner(int id) {
+    auto at = kernels.find(id);
+    if (at == kernels.end())
+        throw std::invalid_argument("kernel owner");
+    return *at->second;
+}
+Value subshots(const std::vector<Subshot> &values) {
+    Value out = Value::array();
+    for (const Subshot &s : values) {
+        Value v = Value::object();
+        v["shot_seq"] = Value(s.seq);
+        v["burst_group_seq"] = Value(s.group);
+        v["burst_index"] = Value(s.index);
+        v["burst_count"] = Value(s.count);
+        v["shell_index"] = Value(s.shell);
+        v["final"] = Value(s.final);
+        v["due_offset"] = Value(s.offset);
+        out.append(v);
+    }
+    return out;
+}
+Value weapon_action(Bot &bot, const Value &action) {
+    const Value &args = action.get("args");
+    std::string name = action.get("method").text();
+    auto n = [&](size_t i, double fallback = 0) {
+        return args.kind == Value::Array && i < args.size() ? args[i].number(fallback) : fallback;
+    };
+    Gun &g = bot.gun;
+    Ammo &a = bot.ammo;
+    Burst &b = bot.burst;
+    Value result;
+    if (name == "gun.tick")
+        g.tick(n(0));
+    else if (name == "gun.tick_dispersion")
+        g.bloom_tick(n(0), n(1), n(2), n(3), n(4, 1), n(5, 1));
+    else if (name == "gun.commit_shot_bloom")
+        g.shot_bloom(n(0, 1), n(1, 1) != 0);
+    else if (name == "gun.rescale_reload")
+        result = Value(g.rescale(n(0)));
+    else if (name == "gun.duration")
+        result = Value(g.duration(n(0, 1)));
+    else if (name == "gun.ready")
+        result = Value(g.ready(n(0, 1)));
+    else if (name == "gun.remaining")
+        result = Value(g.remaining(n(0, 1)));
+    else if (name == "gun.complete_reload") {
+        int value = g.complete(n(0, 1), static_cast<int>(n(1, -1)));
+        if (value >= 0)
+            result = Value(value ? "intra" : "full");
+    } else if (name == "gun.require_full_reload")
+        g.require_full();
+    else if (name == "gun.shell_index")
+        result = Value(g.shell(static_cast<int>(n(0))));
+    else if (name == "gun.begin_burst")
+        result = Value(g.begin_burst(static_cast<int>(n(0)), n(1, 1)));
+    else if (name == "gun.fire_burst_round")
+        result = Value(g.fire_round(n(0) != 0));
+    else if (name == "gun.fire")
+        result = Value(g.begin_burst(1, n(0, 1)) && g.fire_round(true));
+    else if (name == "gun.cancel_burst")
+        result = Value(g.cancel_burst());
+    else if (name == "ammo.stage")
+        result = Value(a.stage(static_cast<int>(n(0)), n(1) != 0, n(2, 1) != 0));
+    else if (name == "ammo.can_fire")
+        result = Value(a.can_fire(n(0) != 0));
+    else if (name == "ammo.consume_loaded")
+        result = Value(a.consume(n(0) != 0));
+    else if (name == "ammo.planned_rounds")
+        result = Value(a.planned());
+    else if (name == "ammo.loaded_shell_requires_full_reload")
+        result = Value(a.requires_full());
+    else if (name == "burst.start")
+        result = Value(
+            b.start(static_cast<int>(n(0)), static_cast<int>(n(1)), n(2), static_cast<int>(n(3))));
+    else if (name == "burst.advance")
+        result = subshots(b.advance(n(0)));
+    else if (name == "burst.cancel")
+        result = Value(b.cancel(static_cast<int>(n(0, -1))));
+    else
+        throw std::invalid_argument("kernel weapon test operation");
+    return result;
+}
+} // namespace
+extern "C" void offline_kernel_reset() { kernels.clear(); }
+extern "C" int offline_kernel_dispatch(double *b, int count) {
+    Reader r(b, count);
+    int op = static_cast<int>(b[0]);
+    if (op == 700) {
+        Value config = r.value();
+        r.end();
+        std::unique_ptr<Kernel> kernel(new Kernel(config));
+        int id = next_kernel++;
+        kernels[id] = std::move(kernel);
+        b[0] = id;
+        return 0;
+    }
+    int id = r.integer(1);
+    Kernel &k = owner(id);
+    if (op == 705) {
+        r.end();
+        kernels.erase(id);
+        return 0;
+    }
+    if (op == 709) {
+        if (k.output.size() + 1 > static_cast<size_t>(count))
+            throw std::invalid_argument("kernel output capacity");
+        b[0] = k.output.size();
+        for (size_t i = 0; i < k.output.size(); ++i)
+            b[i + 1] = static_cast<unsigned char>(k.output[i]);
+        return 0;
+    }
+    if (op == 719) {
+        if (k.output.size() > static_cast<size_t>(count - 1) * sizeof(double))
+            throw std::invalid_argument("kernel packed output capacity");
+        b[0] = k.output.size();
+        std::memcpy(b + 1, k.output.data(), k.output.size());
+        return 0;
+    }
+    if (op == 710) {
+        int bot = r.integer(1);
+        auto at = k.bots.find(bot);
+        if (at == k.bots.end())
+            throw std::invalid_argument("kernel weapon actor");
+        Value actions = r.value();
+        r.end();
+        Value outputs = Value::array();
+        for (const Value &action : elements(actions)) {
+            Value row = Value::object();
+            row["result"] = weapon_action(*at->second, action);
+            row["state"] = at->second->snapshot();
+            outputs.append(row);
+        }
+        k.output = json(outputs);
+        b[0] = k.output.size();
+        return 0;
+    }
+    if (op == 711) {
+        Value values = r.value();
+        r.end();
+        Value rows = Value::array();
+        for (const Value &v : elements(values))
+            rows.append(k.codec.row(v));
+        k.output = json(rows);
+        b[0] = k.output.size();
+        return 0;
+    }
+    if (op == 712) {
+        int bot = r.integer(1);
+        auto at = k.bots.find(bot);
+        if (at == k.bots.end())
+            throw std::invalid_argument("kernel equipment actor");
+        Value actions = r.value();
+        r.end();
+        Value rows = Value::array();
+        for (const Value &action : elements(actions)) {
+            int slot = integer(action, "slot");
+            auto &equipment = at->second->equipment;
+            if (slot < 0 || slot >= static_cast<int>(equipment.size()))
+                throw std::invalid_argument("kernel equipment slot");
+            Equipment &e = equipment[slot];
+            Value result;
+            std::string method = action.get("method").text();
+            double now = field(action, "now");
+            const Value &critical = action.get("critical");
+            bool stunned = flag(action, "stunned");
+            if (method == "ready")
+                result = Value(e.ready(now));
+            else if (method == "poll_bot")
+                result = e.poll_bot(now, critical, stunned);
+            else if (method == "poll_auto")
+                result = e.poll_auto(now, critical);
+            else if (method == "activate")
+                result = e.activate(now, critical, action.get("selected"),
+                                    flag(action, "requested_active"), stunned);
+            else
+                throw std::invalid_argument("kernel equipment operation");
+            Value row = Value::object(), snapshots = Value::array(), wires = Value::array();
+            for (const Equipment &item : equipment) {
+                snapshots.append(item.snapshot());
+                wires.append(item.wire(now));
+            }
+            row["result"] = result;
+            row["states"] = snapshots;
+            row["wires"] = wires;
+            row["passives"] = equipment_passives(equipment);
+            rows.append(row);
+        }
+        k.output = json(rows);
+        b[0] = k.output.size();
+        return 0;
+    }
+    if (op == 713) {
+        Value inputs = r.value();
+        r.end();
+        Value rows = Value::array();
+        for (const Value &v : elements(inputs))
+            rows.append(Value(rounded(v[0].number(), static_cast<int>(v[1].exact()))));
+        k.output = json(rows);
+        b[0] = k.output.size();
+        return 0;
+    }
+    if (op == 714) {
+        int id = r.integer(1);
+        auto at = k.bots.find(id);
+        if (at == k.bots.end())
+            throw std::invalid_argument("kernel critical actor");
+        Bot &bot = *at->second;
+        Value inputs = r.value();
+        r.end();
+        Value rows = Value::array();
+        for (const Value &v : elements(inputs)) {
+            std::string method = v.get("method").text();
+            Value result;
+            double dt = field(v, "dt"), now = field(v, "now"),
+                   equipment_now = field(v, "equipment_now");
+            if (method == "set") {
+                const Value &patch = v.get("state");
+                if (patch.kind != Value::Object)
+                    throw std::invalid_argument("kernel test patch");
+                for (const auto &item : patch.data->object)
+                    bot.state[item.first] = item.second;
+            } else if (method == "critical")
+                result =
+                    Value(bot.advance_critical(dt, now, equipment_now, flag(v, "record", true),
+                                               flag(v, "advance_fire", true), v.get("effects")));
+            else if (method == "drowning")
+                result = Value(bot.advance_drowning(dt, field(v, "depth", -1)));
+            else if (method == "overturn")
+                result = Value(bot.advance_overturn(dt));
+            else if (method == "publish")
+                result = Value(bot.mark_combat());
+            else
+                throw std::invalid_argument("kernel critical operation");
+            Value row = Value::object();
+            row["result"] = result;
+            row["state"] = bot.state.clone();
+            row["sync"] = bot.sync.clone();
+            row["turn_speed"] = Value(bot.turn_speed);
+            row["clear_reposition"] = Value(bot.clear_reposition);
+            rows.append(row);
+        }
+        k.output = json(rows);
+        b[0] = k.output.size();
+        return 0;
+    }
+    if (op == 715) {
+        if (!k.perception)
+            throw std::invalid_argument("kernel perception not configured");
+        Perception &p = *k.perception;
+        Value actions = r.value();
+        r.end();
+        Value rows = Value::array();
+        std::set<int> processed;
+        std::map<int, Contacts> collected;
+        for (const Value &v : elements(actions)) {
+            std::string method = v.get("method").text();
+            double now = field(v, "now");
+            Value result;
+            if (method == "begin")
+                p.begin();
+            else if (method == "finish")
+                p.finish();
+            else if (method == "slice") {
+                p.start_slice(v.get("players"), k.order);
+                processed.clear();
+            } else if (method == "lifecycle")
+                p.lifecycle(now);
+            else if (method == "humans")
+                p.append_humans(now);
+            else if (method == "pack") {
+                if (!k.lanes)
+                    throw std::invalid_argument("kernel lanes absent");
+                result = k.lanes->pack(now);
+            } else if (method == "merge") {
+                if (!k.lanes)
+                    throw std::invalid_argument("kernel lanes absent");
+                k.lanes->merge(now);
+                result = Value(true);
+            } else if (method == "service") {
+                if (!k.lanes)
+                    throw std::invalid_argument("kernel lanes absent");
+                Lanes &lanes = *k.lanes;
+                std::vector<int> order = k.order;
+                std::stable_sort(order.begin(), order.end(), [&](int a, int b) {
+                    return std::make_pair(integer(k.bots.at(a)->state, "slot"),
+                                          integer(k.bots.at(a)->state, "team", 1)) <
+                           std::make_pair(integer(k.bots.at(b)->state, "slot"),
+                                          integer(k.bots.at(b)->state, "team", 1));
+                });
+                std::map<LaneKey, int> selected;
+                for (const Value &row : elements(v.get("selected")))
+                    selected[LaneKey{
+                        {static_cast<int>(row[0].exact()), static_cast<int>(row[1].exact()),
+                         static_cast<int>(row[2].exact())}}] = static_cast<int>(row[3].exact());
+                int budget = integer(v, "budget");
+                lanes.incoming_budget = integer(v, "incoming_budget");
+                int pending =
+                    lanes.service(now, field(v, "cycle"), order, processed, selected, budget);
+                result = Value::array();
+                result.append(Value(pending));
+                result.append(Value(budget));
+                result.append(Value(lanes.incoming_budget));
+            } else if (method == "prepare") {
+                std::vector<int> ordered = k.order;
+                std::stable_sort(ordered.begin(), ordered.end(), [&](int a, int b) {
+                    const Value &x = k.bots.at(a)->state, &y = k.bots.at(b)->state;
+                    return std::make_pair(integer(x, "slot"), integer(x, "team", 1)) <
+                           std::make_pair(integer(y, "slot"), integer(y, "team", 1));
+                });
+                std::set<int> due;
+                for (const Value &id : elements(v.get("due")))
+                    due.insert(static_cast<int>(id.exact()));
+                std::map<int, ActorKey> selected;
+                for (const Value &row : elements(v.get("selected")))
+                    selected[static_cast<int>(row[0].exact())] = ActorKey{
+                        {static_cast<int>(row[1].exact()), static_cast<int>(row[2].exact())}};
+                p.prepare(now, flag(v, "include_humans"), ordered, due, selected);
+            } else {
+                int id = integer(v, "bot");
+                Bot &bot = *k.bots.at(id);
+                if (method == "set")
+                    update(bot.state, v.get("state"));
+                else if (method == "processed")
+                    processed.insert(id);
+                else if (method == "still")
+                    p.note_still(bot.state, now);
+                else if (method == "collect")
+                    p.collect(bot.state, collected.at(id), processed);
+                else if (method == "contacts") {
+                    Contacts contacts = p.contacts(bot.state, now, processed);
+                    collected[id] = contacts;
+                    result = Value::object();
+                    result["contacts"] = contacts.rows;
+                    Value lookup = Value::object();
+                    for (const auto &t : contacts.lookup)
+                        lookup[std::to_string(t.first)] = t.second;
+                    result["targets"] = lookup;
+                } else
+                    throw std::invalid_argument("kernel perception test operation");
+            }
+            Value row = Value::object();
+            row["result"] = result;
+            row["state"] = flag(v, "snapshot") ? p.snapshot() : Value();
+            rows.append(row);
+        }
+        k.output = json(rows);
+        b[0] = k.output.size();
+        return 0;
+    }
+    if (op == 716) {
+        int id = r.integer(1);
+        Bot &bot = *k.bots.at(id);
+        Gunnery &gunner = k.gunners.at(id);
+        Value actions = r.value();
+        r.end();
+        Value rows = Value::array();
+        for (const Value &v : elements(actions)) {
+            std::string method = v.get("method").text();
+            Value result;
+            double now = field(v, "now");
+            const Value &target = v.get("target");
+            if (method == "set")
+                update(bot.state, v.get("state"));
+            else if (method == "hold")
+                result = gunner.hold(bot.state, target, now);
+            else if (method == "error")
+                result = gunner.error(bot.state, target, now, k.round);
+            else if (method == "aimed")
+                result = gunner.aimed(bot.state, target, now, k.round, bot.gun);
+            else if (method == "ready")
+                result = Value(gunner.ready(bot.state, target, now, bot.gun));
+            else if (method == "random") {
+                Random rng(static_cast<uint32_t>(field(v, "seed")));
+                result = Value::array();
+                for (int i = 0; i < integer(v, "count"); ++i)
+                    result.append(Value(flag(v, "gauss") ? rng.gauss(0, field(v, "sigma", 1))
+                                                         : rng.random()));
+            } else if (method == "hash")
+                result = Value(static_cast<int64_t>(seed_hash(v.get("text").text())));
+            else if (method == "dispersed")
+                result = dispersed(id, k.round, integer(v, "seq"), field(v, "yaw"),
+                                   field(v, "pitch"), field(v, "dispersion"), integer(v, "index"),
+                                   integer(v, "group", -1), v.get("base"));
+            else
+                throw std::invalid_argument("kernel gunnery operation");
+            Value row = Value::object();
+            row["result"] = result;
+            row["hold"] = gunner.record.clone();
+            rows.append(row);
+        }
+        k.output = json(rows);
+        b[0] = k.output.size();
+        return 0;
+    }
+    if (op == 717) {
+        int id = r.integer(1);
+        Bot &bot = *k.bots.at(id);
+        Value actions = r.value();
+        r.end();
+        Value rows = Value::array();
+        for (const Value &v : elements(actions)) {
+            std::string method = v.get("method").text();
+            Value result;
+            double factor = field(v, "factor", 1), dispersion = field(v, "dispersion_factor", 1);
+            int64_t time = v.get("time").exact();
+            if (method == "set")
+                update(bot.state, v.get("state"));
+            else if (method == "weapon")
+                result = weapon_action(bot, v.get("action"));
+            else if (method == "fire")
+                result = Value(k.launches.fire(
+                    bot, k.round, factor, dispersion, v.get("receipt"), v.get("preview"), time,
+                    v.has("base") ? v.get("base") : dispersal_base(bot.state)));
+            else if (method == "cancel")
+                result = Value(Launches::cancel(bot, factor));
+            else if (method == "ack")
+                result = Value(k.launches.ack(integer(v, "id", id), integer(v, "seq")));
+            else if (method == "advance") {
+                result = Value::array();
+                for (const Subshot &edge : bot.burst.advance(field(v, "dt"))) {
+                    int64_t at = std::min(
+                        v.get("end").exact(),
+                        time + std::max<int64_t>(
+                                   0, static_cast<int64_t>(rounded(edge.offset * 1000000.0, 0))));
+                    Value preview = v.get("preview");
+                    if (flag(v, "sequence_preview") && preview.kind == Value::Object) {
+                        preview = preview.copy();
+                        preview["fire_seq"] = Value(edge.seq);
+                    }
+                    bool accepted = k.launches.commit(
+                        bot, k.round, factor, dispersion, edge, v.get("receipt"), preview, at,
+                        v.has("base") ? v.get("base") : dispersal_base(bot.state));
+                    result.append(Value(accepted));
+                    if (!accepted) {
+                        Launches::cancel(bot, factor);
+                        break;
+                    }
+                }
+                publish_burst(bot);
+            } else
+                throw std::invalid_argument("kernel launch operation");
+            Value row = Value::object();
+            row["result"] = result;
+            row["state"] = bot.snapshot();
+            row["launches"] = k.launches.pending.clone();
+            rows.append(row);
+        }
+        k.output = json(rows);
+        b[0] = k.output.size();
+        return 0;
+    }
+    if (op == 718) {
+        if (!k.motion)
+            throw std::invalid_argument("kernel motion absent");
+        Motion &m = *k.motion;
+        Value actions = r.value();
+        r.end();
+        Value rows = Value::array();
+        for (const Value &v : elements(actions)) {
+            std::string method = v.get("method").text();
+            Value result, command = v.get("command").copy();
+            if (method == "begin")
+                m.begin();
+            else if (method == "finish")
+                m.finish();
+            else {
+                int id = integer(v, "id");
+                Bot &bot = *k.bots.at(id);
+                if (method == "set") {
+                    update(bot.state, v.get("state"));
+                    if (v.has("turn_speed"))
+                        bot.turn_speed = field(v, "turn_speed");
+                } else if (method == "step")
+                    m.step(bot, command, v.get("target"), field(v, "dt"), field(v, "now"),
+                           flag(v, "decision_due"), flag(v, "refresh"), flag(v, "siege_lock"),
+                           field(v, "siege_yaw", field(bot.state, "yaw")), flag(v, "baked_escape"));
+                else if (method == "vertical")
+                    result = Value(m.vertical(bot, field(v, "dt"), v.get("tick"),
+                                              field(v, "attempted", field(bot.state, "yaw"))));
+                else if (method == "guard")
+                    result =
+                        Value(m.guard(bot, Motion::point(v.get("tick"), Motion::point(bot.state)),
+                                      flag(v, "safe"), field(v, "attempted")));
+                else if (method == "slope")
+                    result = Value(m.slope(bot, integer(v, "tier"), flag(v, "allow_ungrounded")));
+                else if (method == "landing")
+                    result = Value(m.landing(bot, field(v, "speed")));
+                else
+                    throw std::invalid_argument("kernel motion operation");
+            }
+            Value row = Value::object(), states = Value::object(), turns = Value::object(),
+                  waiting = Value::array();
+            for (int id : k.order) {
+                states[std::to_string(id)] = k.bots.at(id)->state.clone();
+                turns[std::to_string(id)] = Value(k.bots.at(id)->turn_speed);
+            }
+            for (const auto &v : m.waiting) {
+                Value pair = Value::array();
+                pair.append(Value(v.first));
+                pair.append(Value(v.second));
+                waiting.append(pair);
+            }
+            row["result"] = result;
+            row["states"] = states;
+            row["turns"] = turns;
+            row["command"] = command;
+            row["waiting"] = waiting;
+            rows.append(row);
+        }
+        k.output = json(rows);
+        b[0] = k.output.size();
+        return 0;
+    }
+    if (op == 720) {
+        if (!k.aim)
+            throw std::invalid_argument("kernel aim absent");
+        Aim &aim = *k.aim;
+        Value actions = r.value();
+        r.end();
+        Value rows = Value::array();
+        for (const Value &v : elements(actions)) {
+            int id = integer(v, "id");
+            Bot &bot = *k.bots.at(id);
+            std::string method = v.get("method").text();
+            Value result;
+            const Value &target = v.get("target");
+            double now = field(v, "now");
+            int shell = integer(v, "shell", integer(bot.state, "shell_index"));
+            if (method == "set")
+                update(bot.state, v.get("state"));
+            else if (method == "cadenced") {
+                auto p =
+                    aim.cadenced(bot, target, shell, now, flag(v, "refresh"), flag(v, "force"));
+                result = Value::array();
+                result.append(p.first);
+                result.append(Value(p.second));
+            } else if (method == "local")
+                result = aim.local(bot, target, shell);
+            else if (method == "artillery")
+                result = aim.artillery(bot, target, shell, now);
+            else if (method == "slew")
+                result = aim.slew(bot, v.get("command"), target, field(v, "dt"));
+            else if (method == "matches")
+                result = Value(aim.direct_matches(bot, target, v.get("solution")));
+            else if (method == "preview")
+                result = aim.preview(bot, shell, v.get("solution"));
+            else if (method == "intent")
+                result = aim.create_intent(bot, target, shell, v.get("solution"), now);
+            else if (method == "active")
+                result = aim.active_intent(bot, target, shell, now);
+            else if (method == "proof")
+                result = aim.active_reproof(bot, target, shell, now);
+            else if (method == "receipt")
+                result = aim.launch_receipt(bot, target, shell, v.get("solution"), now);
+            else if (method == "friendly")
+                result = aim.friendly(bot, target, shell, v.get("launch"), flag(v, "artillery"));
+            else if (method == "cancel")
+                result = Value(aim.cancel(bot, flag(v, "preserve")));
+            else
+                throw std::invalid_argument("kernel aim operation");
+            Value row = Value::object();
+            row["result"] = result.clone();
+            row["state"] = bot.state.clone();
+            row["hold"] = k.gunners.at(id).record.clone();
+            auto intent = aim.intents.find(id), proof = aim.reproofs.find(id);
+            row["intent"] = intent == aim.intents.end() ? Value() : intent->second.clone();
+            row["proof"] = proof == aim.reproofs.end() ? Value() : proof->second.clone();
+            rows.append(row);
+        }
+        k.output = json(rows);
+        b[0] = k.output.size();
+        return 0;
+    }
+    if (op == 721) {
+        if (!k.driver)
+            throw std::invalid_argument("kernel driver absent");
+        Value actions = r.value();
+        r.end();
+        Value rows = Value::array();
+        for (const Value &v : elements(actions)) {
+            int id = integer(v, "id");
+            std::string method = v.get("method").text();
+            Value result, decision = v.get("decision").clone();
+            if (method == "begin") {
+                if (k.routes->nav)
+                    k.routes->nav->begin(field(v, "dt"));
+            } else if (method == "end") {
+                if (k.routes->nav)
+                    k.routes->nav->frame_open = false;
+            } else {
+                Bot &bot = *k.bots.at(id);
+                if (method == "set")
+                    update(bot.state, v.get("state"));
+                else if (method == "orders") {
+                    k.orders.clear();
+                    for (const Value &row : elements(v.get("orders")))
+                        k.orders[static_cast<int>(row[0].exact())] = row[1];
+                } else if (method == "route")
+                    result = Routes::value(k.routes->target(
+                        id, Routes::point(v.get("position")), Routes::point(v.get("goal")),
+                        v.get("order"), decision, flag(v, "pending")));
+                else if (method == "binding") {
+                    const Value &group = v.get("group");
+                    auto p =
+                        k.routes->binding(id, group, Routes::point(v.get("goal")), v.get("order"));
+                    result = tuple_value({Value(p.first), Value(p.second)});
+                } else if (method == "lane_goal") {
+                    auto p = k.routes->lane_goal(id, Routes::point(v.get("position")),
+                                                 Routes::point(v.get("goal")), v.get("order"),
+                                                 field(v, "now"), flag(v, "joining"));
+                    result = tuple_value({Routes::value(p.first),
+                                          tuple_value({Value(static_cast<int>(p.second.first)),
+                                                       Value(static_cast<int>(p.second.second))})});
+                } else if (method == "drive") {
+                    k.driver->probes.clear();
+                    result = k.driver->drive(bot, decision, v.get("order"), flag(v, "pending"));
+                } else if (method == "traffic") {
+                    k.driver->probes.clear();
+                    result = k.traffic.adjust(
+                        id, v.get("body"), v.get("command"), v.get("neighbours"), field(v, "now"),
+                        [&](double yaw) { return k.driver->clear(bot, yaw); });
+                } else
+                    throw std::invalid_argument("kernel driver operation");
+            }
+            Value row = Value::object(), states = Value::object();
+            for (int id : k.order)
+                states[std::to_string(id)] = k.bots.at(id)->state.clone();
+            row["result"] = result.clone();
+            row["states"] = states;
+            row["decision"] = decision;
+            rows.append(row);
+        }
+        k.output = json(rows);
+        b[0] = k.output.size();
+        return 0;
+    }
+    if (op == 722) {
+        if (!k.contacts)
+            throw std::invalid_argument("kernel contacts absent");
+        TankContacts &c = *k.contacts;
+        Value actions = r.value();
+        r.end();
+        Value rows = Value::array();
+        for (const Value &v : elements(actions)) {
+            std::string method = v.get("method").text();
+            Value result;
+            if (method == "set")
+                update(k.bots.at(integer(v, "id"))->state, v.get("state"));
+            else if (method == "ack")
+                result = Value(c.ack(integer(v, "player"), integer(v, "seq")));
+            else if (method == "resolve") {
+                std::vector<TankBody> others;
+                for (const Value &v : elements(v.get("others")))
+                    others.emplace_back(v);
+                std::set<TankContacts::Pair> previous;
+                for (const Value &p : elements(v.get("previous")))
+                    previous.insert(
+                        {static_cast<int>(p[0].exact()), static_cast<int>(p[1].exact())});
+                auto out = c.resolve(TankBody(v.get("body")), others,
+                                     v.get("now").kind == Value::Null
+                                         ? offline_nav::Optional<double>()
+                                         : offline_nav::Optional<double>(field(v, "now")),
+                                     previous, flag(v, "probe"));
+                result = Value::object();
+                result["correction"] = TankContacts::array(out.correction);
+                result["delta_velocity"] = TankContacts::array(out.delta);
+                result["ram_events"] = out.events;
+                result["ram_diagnostics"] = out.diagnostics;
+                Value pairs = Value::array();
+                for (auto p : out.contacts)
+                    pairs.append(tuple_value({Value(p.first), Value(p.second)}));
+                result["contacts"] = pairs;
+            } else if (method == "step") {
+                std::vector<int> ordered = k.order;
+                std::stable_sort(ordered.begin(), ordered.end(), [&](int a, int b) {
+                    return std::make_pair(integer(k.bots.at(a)->state, "slot"),
+                                          integer(k.bots.at(a)->state, "team", 1)) <
+                           std::make_pair(integer(k.bots.at(b)->state, "slot"),
+                                          integer(k.bots.at(b)->state, "team", 1));
+                });
+                result = c.step(v.get("players"), ordered, field(v, "now"), field(v, "dt"));
+            } else if (method == "finish")
+                c.finish(k.driver->handle);
+            else
+                throw std::invalid_argument("kernel contact operation");
+            Value states = Value::object(), cooldowns = Value::array(), pairs = Value::array(),
+                  leases = Value::object();
+            for (int id : k.order)
+                states[std::to_string(id)] = k.bots.at(id)->state.clone();
+            for (const auto &v : c.cooldowns)
+                cooldowns.append(
+                    tuple_value({Value(v.first.first), Value(v.first.second), Value(v.second)}));
+            for (auto p : c.active)
+                pairs.append(tuple_value({Value(p.first), Value(p.second)}));
+            for (const auto &v : c.leases)
+                leases[std::to_string(v.first)] = Value(v.second);
+            Value row = Value::object();
+            row["result"] = result;
+            row["states"] = states;
+            row["cooldowns"] = cooldowns;
+            row["contacts"] = pairs;
+            row["leases"] = leases;
+            rows.append(row);
+        }
+        k.output = json(rows);
+        b[0] = k.output.size();
+        return 0;
+    }
+    if (op == 723) {
+        if (!k.simulation)
+            throw std::invalid_argument("kernel update absent");
+        Value input = r.value();
+        r.end();
+        Value messages = k.simulation->update(input), result = Value::object();
+        result["messages"] = messages;
+        result["logs"] = k.simulation->diagnostic.records;
+        k.simulation->diagnostic.records = Value::array();
+        result["tokens"] = k.simulation->retained_tokens(messages);
+        result["sample"] = Value(k.simulation->sample);
+        result["equipment_now"] = Value(k.simulation->equipment_now);
+        result["steps"] = Value(k.simulation->control_steps);
+        result["maximum_step"] = Value(k.simulation->maximum_step);
+        k.output = json(result);
+        b[0] = k.output.size();
+        return 0;
+    }
+    if (op == 724) {
+        r.end();
+        Value out = Value::object(), states = Value::object();
+        for (int id : k.order)
+            states[std::to_string(id)] = k.bots.at(id)->snapshot();
+        out["bots"] = states;
+        out["pending"] = k.launches.pending;
+        k.output = json(out);
+        b[0] = k.output.size();
+        return 0;
+    }
+    if (op == 726) {
+        r.end();
+        if (!k.simulation)
+            throw std::invalid_argument("kernel diagnostics absent");
+        Value out = Value::object(), counts = Value::object();
+        for (const auto &v : k.simulation->decision_counts)
+            counts[std::to_string(v.first)] = Value(v.second);
+        out["decisions"] = counts;
+        out["diagnostics"] = k.simulation->diagnostics();
+        Value probes = Value::array();
+        for (int v : k.motion->probe_totals)
+            probes.append(Value(v));
+        out["motion_probes"] = probes;
+        out["lane_probes"] = Value(k.lanes->probes);
+        out["cover_probes"] = Value(k.simulation->cover_probes);
+        k.output = json(out);
+        b[0] = k.output.size();
+        return 0;
+    }
+    if (op == 725) {
+        int bot = r.integer(1), seq = r.integer(1);
+        r.end();
+        b[0] = k.launches.ack(bot, seq);
+        return 0;
+    }
+    throw std::invalid_argument("kernel command");
+}

--- a/tools/ffi_experiment/kernel_core.cpp
+++ b/tools/ffi_experiment/kernel_core.cpp
@@ -587,6 +587,19 @@ extern "C" int offline_kernel_dispatch(double *b, int count) {
                     result = Value(m.slope(bot, integer(v, "tier"), flag(v, "allow_ungrounded")));
                 else if (method == "landing")
                     result = Value(m.landing(bot, field(v, sf::speed)));
+                else if (method == "world") {
+                    const Value &values = v.get("query");
+                    if (values.kind != Value::Array || values.size() != 22)
+                        throw std::invalid_argument("kernel world audit request");
+                    std::array<double, 22> query{};
+                    for (size_t i = 0; i < query.size(); ++i)
+                        query[i] = values[i].number();
+                    if (query[0] != 615 || query[1] != id)
+                        throw std::invalid_argument("kernel world audit actor");
+                    WorldResolver resolver(*k.engine, bot.state);
+                    result = Value(resolver.resolve(bot.state, bot.config.get("motion").get("world"),
+                                                    bot.turn_speed, query.data()));
+                }
                 else
                     throw std::invalid_argument("kernel motion operation");
             }

--- a/tools/ffi_experiment/kernel_core.cpp
+++ b/tools/ffi_experiment/kernel_core.cpp
@@ -38,7 +38,7 @@ struct Kernel {
         if (states.kind != Value::Array || states.size() > 30)
             throw std::invalid_argument("kernel roster producer");
         for (const Value &v : states.data->array) {
-            int id = integer(v.get("state"), "id");
+            int id = integer(v.get("state"), sf::id);
             if (id <= 0 || bots.count(id))
                 throw std::invalid_argument("kernel actor identity");
             bots[id].reset(new Bot(v));
@@ -64,8 +64,8 @@ struct Kernel {
             routes.reset(new Routes(config.get("driver"), bots, orders));
             driver.reset(new Driver(config.get("driver"), *motion, *routes));
         }
-        if (config.has("contacts") && motion && engine)
-            contacts.reset(new TankContacts(config.get("contacts"), bots, *motion, *engine));
+        if (config.has(sf::contacts) && motion && engine)
+            contacts.reset(new TankContacts(config.get(sf::contacts), bots, *motion, *engine));
         if (config.has("simulation"))
             simulation.reset(new Simulation<Kernel>(*this, config.get("simulation")));
         if (simulation)
@@ -110,10 +110,10 @@ Value subshots(const std::vector<Subshot> &values) {
     for (const Subshot &s : values) {
         Value v = Value::object();
         v["shot_seq"] = Value(s.seq);
-        v["burst_group_seq"] = Value(s.group);
-        v["burst_index"] = Value(s.index);
-        v["burst_count"] = Value(s.count);
-        v["shell_index"] = Value(s.shell);
+        v[sf::burst_group_seq] = Value(s.group);
+        v[sf::burst_index] = Value(s.index);
+        v[sf::burst_count] = Value(s.count);
+        v[sf::shell_index] = Value(s.shell);
         v["final"] = Value(s.final);
         v["due_offset"] = Value(s.offset);
         out.append(v);
@@ -254,15 +254,15 @@ extern "C" int offline_kernel_dispatch(double *b, int count) {
         r.end();
         Value rows = Value::array();
         for (const Value &action : elements(actions)) {
-            int slot = integer(action, "slot");
+            int slot = integer(action, sf::slot);
             auto &equipment = at->second->equipment;
             if (slot < 0 || slot >= static_cast<int>(equipment.size()))
                 throw std::invalid_argument("kernel equipment slot");
             Equipment &e = equipment[slot];
             Value result;
             std::string method = action.get("method").text();
-            double now = field(action, "now");
-            const Value &critical = action.get("critical");
+            double now = field(action, sf::now);
+            const Value &critical = action.get(sf::critical);
             bool stunned = flag(action, "stunned");
             if (method == "ready")
                 result = Value(e.ready(now));
@@ -312,14 +312,14 @@ extern "C" int offline_kernel_dispatch(double *b, int count) {
         for (const Value &v : elements(inputs)) {
             std::string method = v.get("method").text();
             Value result;
-            double dt = field(v, "dt"), now = field(v, "now"),
+            double dt = field(v, sf::dt), now = field(v, sf::now),
                    equipment_now = field(v, "equipment_now");
             if (method == "set") {
                 const Value &patch = v.get("state");
                 if (patch.kind != Value::Object)
                     throw std::invalid_argument("kernel test patch");
-                for (const auto &item : patch.data->object)
-                    bot.state[item.first] = item.second;
+                patch.visit(
+                    [&](const std::string &name, const Value &value) { bot.state[name] = value; });
             } else if (method == "critical")
                 result =
                     Value(bot.advance_critical(dt, now, equipment_now, flag(v, "record", true),
@@ -355,7 +355,7 @@ extern "C" int offline_kernel_dispatch(double *b, int count) {
         std::map<int, Contacts> collected;
         for (const Value &v : elements(actions)) {
             std::string method = v.get("method").text();
-            double now = field(v, "now");
+            double now = field(v, sf::now);
             Value result;
             if (method == "begin")
                 p.begin();
@@ -383,10 +383,10 @@ extern "C" int offline_kernel_dispatch(double *b, int count) {
                 Lanes &lanes = *k.lanes;
                 std::vector<int> order = k.order;
                 std::stable_sort(order.begin(), order.end(), [&](int a, int b) {
-                    return std::make_pair(integer(k.bots.at(a)->state, "slot"),
-                                          integer(k.bots.at(a)->state, "team", 1)) <
-                           std::make_pair(integer(k.bots.at(b)->state, "slot"),
-                                          integer(k.bots.at(b)->state, "team", 1));
+                    return std::make_pair(integer(k.bots.at(a)->state, sf::slot),
+                                          integer(k.bots.at(a)->state, sf::team, 1)) <
+                           std::make_pair(integer(k.bots.at(b)->state, sf::slot),
+                                          integer(k.bots.at(b)->state, sf::team, 1));
                 });
                 std::map<LaneKey, int> selected;
                 for (const Value &row : elements(v.get("selected")))
@@ -405,8 +405,8 @@ extern "C" int offline_kernel_dispatch(double *b, int count) {
                 std::vector<int> ordered = k.order;
                 std::stable_sort(ordered.begin(), ordered.end(), [&](int a, int b) {
                     const Value &x = k.bots.at(a)->state, &y = k.bots.at(b)->state;
-                    return std::make_pair(integer(x, "slot"), integer(x, "team", 1)) <
-                           std::make_pair(integer(y, "slot"), integer(y, "team", 1));
+                    return std::make_pair(integer(x, sf::slot), integer(x, sf::team, 1)) <
+                           std::make_pair(integer(y, sf::slot), integer(y, sf::team, 1));
                 });
                 std::set<int> due;
                 for (const Value &id : elements(v.get("due")))
@@ -431,7 +431,7 @@ extern "C" int offline_kernel_dispatch(double *b, int count) {
                     Contacts contacts = p.contacts(bot.state, now, processed);
                     collected[id] = contacts;
                     result = Value::object();
-                    result["contacts"] = contacts.rows;
+                    result[sf::contacts] = contacts.rows;
                     Value lookup = Value::object();
                     for (const auto &t : contacts.lookup)
                         lookup[std::to_string(t.first)] = t.second;
@@ -458,7 +458,7 @@ extern "C" int offline_kernel_dispatch(double *b, int count) {
         for (const Value &v : elements(actions)) {
             std::string method = v.get("method").text();
             Value result;
-            double now = field(v, "now");
+            double now = field(v, sf::now);
             const Value &target = v.get("target");
             if (method == "set")
                 update(bot.state, v.get("state"));
@@ -479,8 +479,8 @@ extern "C" int offline_kernel_dispatch(double *b, int count) {
             } else if (method == "hash")
                 result = Value(static_cast<int64_t>(seed_hash(v.get("text").text())));
             else if (method == "dispersed")
-                result = dispersed(id, k.round, integer(v, "seq"), field(v, "yaw"),
-                                   field(v, "pitch"), field(v, "dispersion"), integer(v, "index"),
+                result = dispersed(id, k.round, integer(v, "seq"), field(v, sf::yaw),
+                                   field(v, sf::pitch), field(v, "dispersion"), integer(v, "index"),
                                    integer(v, "group", -1), v.get("base"));
             else
                 throw std::invalid_argument("kernel gunnery operation");
@@ -515,10 +515,10 @@ extern "C" int offline_kernel_dispatch(double *b, int count) {
             else if (method == "cancel")
                 result = Value(Launches::cancel(bot, factor));
             else if (method == "ack")
-                result = Value(k.launches.ack(integer(v, "id", id), integer(v, "seq")));
+                result = Value(k.launches.ack(integer(v, sf::id, id), integer(v, "seq")));
             else if (method == "advance") {
                 result = Value::array();
-                for (const Subshot &edge : bot.burst.advance(field(v, "dt"))) {
+                for (const Subshot &edge : bot.burst.advance(field(v, sf::dt))) {
                     int64_t at = std::min(
                         v.get("end").exact(),
                         time + std::max<int64_t>(
@@ -526,7 +526,7 @@ extern "C" int offline_kernel_dispatch(double *b, int count) {
                     Value preview = v.get("preview");
                     if (flag(v, "sequence_preview") && preview.kind == Value::Object) {
                         preview = preview.copy();
-                        preview["fire_seq"] = Value(edge.seq);
+                        preview[sf::fire_seq] = Value(edge.seq);
                     }
                     bool accepted = k.launches.commit(
                         bot, k.round, factor, dispersion, edge, v.get("receipt"), preview, at,
@@ -565,19 +565,20 @@ extern "C" int offline_kernel_dispatch(double *b, int count) {
             else if (method == "finish")
                 m.finish();
             else {
-                int id = integer(v, "id");
+                int id = integer(v, sf::id);
                 Bot &bot = *k.bots.at(id);
                 if (method == "set") {
                     update(bot.state, v.get("state"));
                     if (v.has("turn_speed"))
                         bot.turn_speed = field(v, "turn_speed");
                 } else if (method == "step")
-                    m.step(bot, command, v.get("target"), field(v, "dt"), field(v, "now"),
+                    m.step(bot, command, v.get("target"), field(v, sf::dt), field(v, sf::now),
                            flag(v, "decision_due"), flag(v, "refresh"), flag(v, "siege_lock"),
-                           field(v, "siege_yaw", field(bot.state, "yaw")), flag(v, "baked_escape"));
+                           field(v, "siege_yaw", field(bot.state, sf::yaw)),
+                           flag(v, "baked_escape"));
                 else if (method == "vertical")
-                    result = Value(m.vertical(bot, field(v, "dt"), v.get("tick"),
-                                              field(v, "attempted", field(bot.state, "yaw"))));
+                    result = Value(m.vertical(bot, field(v, sf::dt), v.get("tick"),
+                                              field(v, "attempted", field(bot.state, sf::yaw))));
                 else if (method == "guard")
                     result =
                         Value(m.guard(bot, Motion::point(v.get("tick"), Motion::point(bot.state)),
@@ -585,7 +586,7 @@ extern "C" int offline_kernel_dispatch(double *b, int count) {
                 else if (method == "slope")
                     result = Value(m.slope(bot, integer(v, "tier"), flag(v, "allow_ungrounded")));
                 else if (method == "landing")
-                    result = Value(m.landing(bot, field(v, "speed")));
+                    result = Value(m.landing(bot, field(v, sf::speed)));
                 else
                     throw std::invalid_argument("kernel motion operation");
             }
@@ -620,13 +621,13 @@ extern "C" int offline_kernel_dispatch(double *b, int count) {
         r.end();
         Value rows = Value::array();
         for (const Value &v : elements(actions)) {
-            int id = integer(v, "id");
+            int id = integer(v, sf::id);
             Bot &bot = *k.bots.at(id);
             std::string method = v.get("method").text();
             Value result;
             const Value &target = v.get("target");
-            double now = field(v, "now");
-            int shell = integer(v, "shell", integer(bot.state, "shell_index"));
+            double now = field(v, sf::now);
+            int shell = integer(v, "shell", integer(bot.state, sf::shell_index));
             if (method == "set")
                 update(bot.state, v.get("state"));
             else if (method == "cadenced") {
@@ -640,7 +641,7 @@ extern "C" int offline_kernel_dispatch(double *b, int count) {
             else if (method == "artillery")
                 result = aim.artillery(bot, target, shell, now);
             else if (method == "slew")
-                result = aim.slew(bot, v.get("command"), target, field(v, "dt"));
+                result = aim.slew(bot, v.get("command"), target, field(v, sf::dt));
             else if (method == "matches")
                 result = Value(aim.direct_matches(bot, target, v.get("solution")));
             else if (method == "preview")
@@ -679,12 +680,12 @@ extern "C" int offline_kernel_dispatch(double *b, int count) {
         r.end();
         Value rows = Value::array();
         for (const Value &v : elements(actions)) {
-            int id = integer(v, "id");
+            int id = integer(v, sf::id);
             std::string method = v.get("method").text();
             Value result, decision = v.get("decision").clone();
             if (method == "begin") {
                 if (k.routes->nav)
-                    k.routes->nav->begin(field(v, "dt"));
+                    k.routes->nav->begin(field(v, sf::dt));
             } else if (method == "end") {
                 if (k.routes->nav)
                     k.routes->nav->frame_open = false;
@@ -698,7 +699,7 @@ extern "C" int offline_kernel_dispatch(double *b, int count) {
                         k.orders[static_cast<int>(row[0].exact())] = row[1];
                 } else if (method == "route")
                     result = Routes::value(k.routes->target(
-                        id, Routes::point(v.get("position")), Routes::point(v.get("goal")),
+                        id, Routes::point(v.get(sf::position)), Routes::point(v.get("goal")),
                         v.get("order"), decision, flag(v, "pending")));
                 else if (method == "binding") {
                     const Value &group = v.get("group");
@@ -706,9 +707,9 @@ extern "C" int offline_kernel_dispatch(double *b, int count) {
                         k.routes->binding(id, group, Routes::point(v.get("goal")), v.get("order"));
                     result = tuple_value({Value(p.first), Value(p.second)});
                 } else if (method == "lane_goal") {
-                    auto p = k.routes->lane_goal(id, Routes::point(v.get("position")),
+                    auto p = k.routes->lane_goal(id, Routes::point(v.get(sf::position)),
                                                  Routes::point(v.get("goal")), v.get("order"),
-                                                 field(v, "now"), flag(v, "joining"));
+                                                 field(v, sf::now), flag(v, "joining"));
                     result = tuple_value({Routes::value(p.first),
                                           tuple_value({Value(static_cast<int>(p.second.first)),
                                                        Value(static_cast<int>(p.second.second))})});
@@ -718,8 +719,8 @@ extern "C" int offline_kernel_dispatch(double *b, int count) {
                 } else if (method == "traffic") {
                     k.driver->probes.clear();
                     result = k.traffic.adjust(
-                        id, v.get("body"), v.get("command"), v.get("neighbours"), field(v, "now"),
-                        [&](double yaw) { return k.driver->clear(bot, yaw); });
+                        id, v.get("body"), v.get("command"), v.get(sf::neighbours),
+                        field(v, sf::now), [&](double yaw) { return k.driver->clear(bot, yaw); });
                 } else
                     throw std::invalid_argument("kernel driver operation");
             }
@@ -746,7 +747,7 @@ extern "C" int offline_kernel_dispatch(double *b, int count) {
             std::string method = v.get("method").text();
             Value result;
             if (method == "set")
-                update(k.bots.at(integer(v, "id"))->state, v.get("state"));
+                update(k.bots.at(integer(v, sf::id))->state, v.get("state"));
             else if (method == "ack")
                 result = Value(c.ack(integer(v, "player"), integer(v, "seq")));
             else if (method == "resolve") {
@@ -758,9 +759,9 @@ extern "C" int offline_kernel_dispatch(double *b, int count) {
                     previous.insert(
                         {static_cast<int>(p[0].exact()), static_cast<int>(p[1].exact())});
                 auto out = c.resolve(TankBody(v.get("body")), others,
-                                     v.get("now").kind == Value::Null
+                                     v.get(sf::now).kind == Value::Null
                                          ? offline_nav::Optional<double>()
-                                         : offline_nav::Optional<double>(field(v, "now")),
+                                         : offline_nav::Optional<double>(field(v, sf::now)),
                                      previous, flag(v, "probe"));
                 result = Value::object();
                 result["correction"] = TankContacts::array(out.correction);
@@ -770,16 +771,16 @@ extern "C" int offline_kernel_dispatch(double *b, int count) {
                 Value pairs = Value::array();
                 for (auto p : out.contacts)
                     pairs.append(tuple_value({Value(p.first), Value(p.second)}));
-                result["contacts"] = pairs;
+                result[sf::contacts] = pairs;
             } else if (method == "step") {
                 std::vector<int> ordered = k.order;
                 std::stable_sort(ordered.begin(), ordered.end(), [&](int a, int b) {
-                    return std::make_pair(integer(k.bots.at(a)->state, "slot"),
-                                          integer(k.bots.at(a)->state, "team", 1)) <
-                           std::make_pair(integer(k.bots.at(b)->state, "slot"),
-                                          integer(k.bots.at(b)->state, "team", 1));
+                    return std::make_pair(integer(k.bots.at(a)->state, sf::slot),
+                                          integer(k.bots.at(a)->state, sf::team, 1)) <
+                           std::make_pair(integer(k.bots.at(b)->state, sf::slot),
+                                          integer(k.bots.at(b)->state, sf::team, 1));
                 });
-                result = c.step(v.get("players"), ordered, field(v, "now"), field(v, "dt"));
+                result = c.step(v.get("players"), ordered, field(v, sf::now), field(v, sf::dt));
             } else if (method == "finish")
                 c.finish(k.driver->handle);
             else
@@ -799,7 +800,7 @@ extern "C" int offline_kernel_dispatch(double *b, int count) {
             row["result"] = result;
             row["states"] = states;
             row["cooldowns"] = cooldowns;
-            row["contacts"] = pairs;
+            row[sf::contacts] = pairs;
             row["leases"] = leases;
             rows.append(row);
         }

--- a/tools/ffi_experiment/kernel_core.h
+++ b/tools/ffi_experiment/kernel_core.h
@@ -1,0 +1,11 @@
+#ifndef OFFLINE_EXPERIMENT_KERNEL_CORE_H
+#define OFFLINE_EXPERIMENT_KERNEL_CORE_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+int offline_kernel_dispatch(double *buffer, int count);
+void offline_kernel_reset(void);
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/tools/ffi_experiment/kernel_critical.h
+++ b/tools/ffi_experiment/kernel_critical.h
@@ -1,0 +1,255 @@
+#ifndef OFFLINE_EXPERIMENT_KERNEL_CRITICAL_H
+#define OFFLINE_EXPERIMENT_KERNEL_CRITICAL_H
+#include "kernel_equipment.h"
+
+namespace offline_kernel {
+struct CriticalConfig {
+    struct Device {
+        double maximum, cap, seconds;
+        bool has_maximum, has_cap, no_fire_repair;
+    };
+    std::map<std::string, Device> devices;
+    Value roster;
+    double fire_duration = 0, fire_fraction = 0, critical_fraction = 0;
+    explicit CriticalConfig(const Value &v) : roster(v.get("roster")) {
+        for (const Value &raw : elements(v.get("devices"))) {
+            Device d;
+            d.maximum = field(raw, "maximum");
+            d.cap = field(raw, "cap");
+            d.seconds = field(raw, "seconds");
+            d.has_maximum = raw.get("maximum").kind != Value::Null;
+            d.has_cap = raw.get("cap").kind != Value::Null;
+            d.no_fire_repair = flag(raw, "no_fire_repair");
+            devices[raw.get("name").text()] = d;
+        }
+        fire_duration = field(v, "fire_duration");
+        fire_fraction = field(v, "fire_fraction");
+        critical_fraction = field(v, "critical_fraction");
+    }
+    const Device *device(const std::string &name) const {
+        auto at = devices.find(name);
+        return at == devices.end() ? nullptr : &at->second;
+    }
+    int condition(double hp, const std::string &name) const {
+        if (hp <= 0)
+            return 2;
+        const Device *d = device(name);
+        return d && d->has_maximum && d->maximum && hp <= d->maximum * critical_fraction ? 1 : 0;
+    }
+};
+struct Critical {
+    const CriticalConfig &config;
+    std::map<std::string, double> hp;
+    std::set<std::string> destroyed, yellow, crew;
+    bool fire = false, rack = false;
+    explicit Critical(const Value &payload, const CriticalConfig &c) : config(c) {
+        const Value &records = payload.get("devices");
+        if (records.kind != Value::Null)
+            for (const Value &v : elements(records)) {
+                std::string name = v.get("name").text();
+                if (name.empty())
+                    throw std::invalid_argument("kernel critical device");
+                hp[name] = std::max(0.0, field(v, "hp"));
+            }
+        destroyed = names(payload.get("destroyed"));
+        crew = names(payload.get("crew_ko"));
+        fire = flag(payload, "fire");
+        rack = flag(payload, "ammo_rack_death");
+        for (const auto &v : hp)
+            if (!destroyed.count(v.first) && config.condition(v.second, v.first) == 1)
+                yellow.insert(v.first);
+    }
+    Value identity() const {
+        Value v = Value::object(), values = Value::object();
+        for (const auto &item : hp)
+            values[item.first] = Value(item.second);
+        v["hp"] = values;
+        v["destroyed"] = name_array(destroyed);
+        v["yellow"] = name_array(yellow);
+        v["crew"] = name_array(crew);
+        v["fire"] = Value(fire);
+        v["rack"] = Value(rack);
+        return v;
+    }
+    Value payload() const {
+        std::set<std::string> all = destroyed;
+        all.insert(yellow.begin(), yellow.end());
+        for (const auto &v : hp)
+            all.insert(v.first);
+        Value result = Value::object(), records = Value::array();
+        for (const std::string &name : all) {
+            auto at = hp.find(name);
+            double health = at == hp.end() ? 0 : at->second;
+            const CriticalConfig::Device *d = config.device(name);
+            double maximum = d && d->has_maximum ? d->maximum : std::max(1.0, rounded(health, 0));
+            maximum = std::max(1.0, rounded(maximum, 3));
+            int condition = destroyed.count(name) ? 2
+                            : yellow.count(name)  ? 1
+                                                  : config.condition(health, name);
+            Value v = Value::object();
+            v["name"] = Value(name);
+            v["hp"] = Value(clamp(rounded(health, 3), 0, maximum));
+            v["max_hp"] = Value(maximum);
+            v["state"] = Value(condition == 2   ? "destroyed"
+                               : condition == 1 ? "critical"
+                                                : "normal");
+            records.append(v);
+        }
+        result["devices"] = records;
+        result["destroyed"] = name_array(destroyed);
+        result["crew_ko"] = name_array(crew);
+        result["fire"] = Value(fire);
+        result["ammo_rack_death"] = Value(rack);
+        result["events"] = Value::array();
+        return result;
+    }
+    bool repair(double dt, int health) {
+        if (dt <= 0 || health <= 0)
+            return false;
+        bool changed = false;
+        for (auto &v : hp) {
+            if (!destroyed.count(v.first))
+                continue;
+            const CriticalConfig::Device *d = config.device(v.first);
+            if (!d || !d->has_cap || v.second >= d->cap || (fire && d->no_fire_repair))
+                continue;
+            double next = std::min(d->cap, v.second + (d->cap / std::max(.1, d->seconds)) * dt);
+            changed = changed || next != v.second;
+            v.second = next;
+            if (v.second >= d->cap) {
+                destroyed.erase(v.first);
+                yellow.insert(v.first);
+            }
+        }
+        return changed;
+    }
+    void extinguish() {
+        fire = false;
+        const std::string name = "fuelTankHealth";
+        const CriticalConfig::Device *d = config.device(name);
+        auto at = hp.find(name);
+        if (d && d->has_cap && at != hp.end() && at->second < d->cap) {
+            at->second = d->cap;
+            destroyed.erase(name);
+            yellow.insert(name);
+        }
+    }
+    int burn(double dt, double now, double started, double &timer, int health, int maximum) {
+        if (dt <= 0 || !fire || health <= 0)
+            return 0;
+        double end = started + config.fire_duration;
+        double active_start = std::max(now - dt, started), active_end = std::min(now, end);
+        timer += std::max(0.0, active_end - active_start);
+        int ticks = static_cast<int>(std::floor(timer + 1e-9)), damage = 0;
+        if (ticks > 0) {
+            timer = std::max(0.0, timer - ticks);
+            damage = std::max(1, static_cast<int>(maximum * config.fire_fraction)) * ticks;
+        }
+        if (now >= end)
+            extinguish();
+        return damage;
+    }
+    Value terminal() {
+        if (fire)
+            extinguish();
+        for (const auto &v : config.devices) {
+            hp[v.first] = 0;
+            destroyed.insert(v.first);
+        }
+        yellow.clear();
+        const auto roster_names = names(config.roster);
+        crew.insert(roster_names.begin(), roster_names.end());
+        Value result = payload();
+        if (config.roster.truth()) {
+            result["crew_roster"] = config.roster;
+            result["crew_ko"] = config.roster;
+        }
+        return result;
+    }
+    bool effect(const Value &effect) {
+        Value before = identity();
+        std::string action = effect.get("action").text();
+        if (action == "extinguish_fire") {
+            if (!fire)
+                return false;
+            extinguish();
+        } else if (action == "repair_devices") {
+            std::set<std::string> all = destroyed;
+            for (const auto &v : hp)
+                all.insert(v.first);
+            if (!flag(effect, "repairAll")) {
+                std::string selected = effect.get("selected").text();
+                if (!selected.empty() &&
+                    (selected.size() < 6 || selected.substr(selected.size() - 6) != "Health"))
+                    selected += "Health";
+                if (!all.count(selected))
+                    return false;
+                all.clear();
+                all.insert(selected);
+            }
+            for (const std::string &name : all) {
+                const CriticalConfig::Device *d = config.device(name);
+                if (!d || !d->has_maximum)
+                    continue;
+                auto at = hp.find(name);
+                double value = at == hp.end() ? d->maximum : at->second;
+                if (destroyed.count(name) || value < d->maximum) {
+                    hp[name] = d->maximum;
+                    destroyed.erase(name);
+                    yellow.erase(name);
+                }
+            }
+        } else if (action == "restore_crew") {
+            if (flag(effect, "repairAll"))
+                crew.clear();
+            else
+                crew.erase(effect.get("selected").text());
+        } else
+            return false;
+        return before != identity();
+    }
+};
+inline Value critical_signature(const Value &p) {
+    Value result = Value::array();
+    if (p.kind != Value::Object || !p.truth())
+        return result;
+    Value records = Value::array();
+    const Value &devices = p.get("devices");
+    if (devices.kind != Value::Null)
+        for (const Value &v : elements(devices)) {
+            Value row = Value::array();
+            row.append(v.get("name"));
+            row.append(Value(rounded(field(v, "hp"), 3)));
+            row.append(Value(rounded(field(v, "max_hp", 1), 3)));
+            row.append(Value(v.get("state").text()));
+            records.append(row);
+        }
+    std::sort(records.data->array.begin(), records.data->array.end(),
+              [](const Value &a, const Value &b) { return a[0].text() < b[0].text(); });
+    Value destroyed = name_array(names(p.get("destroyed"))),
+          crew = name_array(names(p.get("crew_ko"))),
+          roster = name_array(names(p.get("crew_roster")));
+    bool fire = flag(p, "fire"), rack = flag(p, "ammo_rack_death");
+    if (!records.truth() && !destroyed.truth() && !crew.truth() && !roster.truth() && !fire &&
+        !rack)
+        return result;
+    result.append(records);
+    result.append(destroyed);
+    result.append(crew);
+    result.append(roster);
+    result.append(Value(fire));
+    result.append(Value(rack));
+    return result;
+}
+inline Value combat_signature(const Value &state) {
+    Value v = Value::array();
+    v.append(Value(std::max(0, integer(state, "health"))));
+    v.append(Value(flag(state, "alive")));
+    v.append(critical_signature(state.get("critical")));
+    v.append(Value(rounded(field(state, "combat_fire_elapsed"), 6)));
+    v.append(Value(rounded(field(state, "combat_fire_timer"), 6)));
+    v.append(Value(std::max(0, integer(state, "stun_end_server_time_ms"))));
+    return v;
+}
+} // namespace offline_kernel
+#endif

--- a/tools/ffi_experiment/kernel_critical.h
+++ b/tools/ffi_experiment/kernel_critical.h
@@ -14,13 +14,13 @@ struct CriticalConfig {
     explicit CriticalConfig(const Value &v) : roster(v.get("roster")) {
         for (const Value &raw : elements(v.get("devices"))) {
             Device d;
-            d.maximum = field(raw, "maximum");
-            d.cap = field(raw, "cap");
-            d.seconds = field(raw, "seconds");
-            d.has_maximum = raw.get("maximum").kind != Value::Null;
-            d.has_cap = raw.get("cap").kind != Value::Null;
-            d.no_fire_repair = flag(raw, "no_fire_repair");
-            devices[raw.get("name").text()] = d;
+            d.maximum = field(raw, sf::maximum);
+            d.cap = field(raw, sf::cap);
+            d.seconds = field(raw, sf::seconds);
+            d.has_maximum = raw.get(sf::maximum).kind != Value::Null;
+            d.has_cap = raw.get(sf::cap).kind != Value::Null;
+            d.no_fire_repair = flag(raw, sf::no_fire_repair);
+            devices[raw.get(sf::name).text()] = d;
         }
         fire_duration = field(v, "fire_duration");
         fire_fraction = field(v, "fire_fraction");
@@ -46,7 +46,7 @@ struct Critical {
         const Value &records = payload.get("devices");
         if (records.kind != Value::Null)
             for (const Value &v : elements(records)) {
-                std::string name = v.get("name").text();
+                std::string name = v.get(sf::name).text();
                 if (name.empty())
                     throw std::invalid_argument("kernel critical device");
                 hp[name] = std::max(0.0, field(v, "hp"));
@@ -87,7 +87,7 @@ struct Critical {
                             : yellow.count(name)  ? 1
                                                   : config.condition(health, name);
             Value v = Value::object();
-            v["name"] = Value(name);
+            v[sf::name] = Value(name);
             v["hp"] = Value(clamp(rounded(health, 3), 0, maximum));
             v["max_hp"] = Value(maximum);
             v["state"] = Value(condition == 2   ? "destroyed"
@@ -218,7 +218,7 @@ inline Value critical_signature(const Value &p) {
     if (devices.kind != Value::Null)
         for (const Value &v : elements(devices)) {
             Value row = Value::array();
-            row.append(v.get("name"));
+            row.append(v.get(sf::name));
             row.append(Value(rounded(field(v, "hp"), 3)));
             row.append(Value(rounded(field(v, "max_hp", 1), 3)));
             row.append(Value(v.get("state").text()));
@@ -243,12 +243,12 @@ inline Value critical_signature(const Value &p) {
 }
 inline Value combat_signature(const Value &state) {
     Value v = Value::array();
-    v.append(Value(std::max(0, integer(state, "health"))));
-    v.append(Value(flag(state, "alive")));
-    v.append(critical_signature(state.get("critical")));
-    v.append(Value(rounded(field(state, "combat_fire_elapsed"), 6)));
-    v.append(Value(rounded(field(state, "combat_fire_timer"), 6)));
-    v.append(Value(std::max(0, integer(state, "stun_end_server_time_ms"))));
+    v.append(Value(std::max(0, integer(state, sf::health))));
+    v.append(Value(flag(state, sf::alive)));
+    v.append(critical_signature(state.get(sf::critical)));
+    v.append(Value(rounded(field(state, sf::combat_fire_elapsed), 6)));
+    v.append(Value(rounded(field(state, sf::combat_fire_timer), 6)));
+    v.append(Value(std::max(0, integer(state, sf::stun_end_server_time_ms))));
     return v;
 }
 } // namespace offline_kernel

--- a/tools/ffi_experiment/kernel_diagnostics.h
+++ b/tools/ffi_experiment/kernel_diagnostics.h
@@ -1,0 +1,138 @@
+#ifndef OFFLINE_EXPERIMENT_KERNEL_DIAGNOSTICS_H
+#define OFFLINE_EXPERIMENT_KERNEL_DIAGNOSTICS_H
+#include "kernel_factors.h"
+#include <array>
+
+namespace offline_kernel {
+struct Diagnostics {
+    Value config, records = Value::array();
+    std::map<int, std::unique_ptr<Bot>> &bots;
+    std::map<int, std::array<double, 3>> flips;
+    double planner_age = -1;
+    Diagnostics(const Value &c, std::map<int, std::unique_ptr<Bot>> &b) : config(c), bots(b) {}
+    void emit(const std::string &kind, const Value &payload) {
+        Value row = Value::object();
+        row["kind"] = Value(kind);
+        row["payload"] = payload;
+        records.append(row);
+    }
+    void begin(Bot &bot, const Value &command, double throttle, double turn, bool clear,
+               bool frozen, const Value &probe, double now, int grind) {
+        Value &s = bot.state;
+        int id = integer(s, "id");
+        Value p = position(s);
+        if (flag(config, "debug")) {
+            int direction = integer(s, "movement_dir");
+            auto at = flips.find(id);
+            if (at == flips.end())
+                flips[id] = {{static_cast<double>(direction), now, -10}};
+            else if (direction != at->second[0]) {
+                auto prior = at->second;
+                at->second[0] = direction;
+                at->second[1] = now;
+                if (direction && prior[0] && now - prior[1] <= 2 && now - prior[2] >= 1) {
+                    at->second[2] = now;
+                    Value row = Value::object();
+                    row["id"] = Value(id);
+                    row["from"] = Value(static_cast<int>(prior[0]));
+                    row["to"] = Value(direction);
+                    row["elapsed"] = Value(now - prior[1]);
+                    row["position"] = p;
+                    row["path_clear"] = Value(clear);
+                    row["probe"] = probe;
+                    emit("BOT FLIP", row);
+                }
+            }
+        }
+        const Value &prior = s.get("_motion_stall_log");
+        bool moved = false;
+        if (prior.kind == Value::Array) {
+            double dx = p[0].number() - prior[0][0].number(),
+                   dz = p[2].number() - prior[0][2].number();
+            moved = dx * dx + dz * dz >= .25;
+        }
+        if (prior.kind == Value::Null || moved) {
+            Value row = Value::array();
+            row.append(p);
+            row.append(Value(now));
+            s["_motion_stall_log"] = row;
+            return;
+        }
+        if (now - prior[1].number() < 3)
+            return;
+        Value marker = Value::array();
+        marker.append(prior[0]);
+        marker.append(Value(now));
+        s["_motion_stall_log"] = marker;
+        Value trace = Value::object();
+        trace["id"] = Value(id);
+        trace["vehicle"] = s.get("vehicle");
+        trace["native_motion"] = Value(flag(config, "native_motion"));
+        trace["start"] = p;
+        trace["speed_before"] = Value(field(s, "speed"));
+        trace["requested_throttle"] = Value(throttle);
+        trace["turn"] = Value(turn);
+        for (const char *key : {"yaw", "pitch", "roll"})
+            trace[key] = s.get(key);
+        trace["shape"] = s.get("collision_shape");
+        s["_motion_stall_pending"] = trace;
+        Value row = trace.copy();
+        row["command"] = command.copy();
+        row["water_depth"] = Value(field(s, "_water_depth", -1));
+        row["path_clear"] = Value(clear);
+        row["probe"] = probe;
+        row["frozen"] = Value(frozen);
+        row["hull_aiming"] = Value(flag(s, "hull_aiming"));
+        row["grind"] = Value(grind);
+        row["planner_age"] = Value(planner_age);
+        emit("BOT STALL", row);
+    }
+    void finish(Bot &bot, bool support, bool rollback, const Value &settled,
+                const std::set<std::pair<int, int>> &contacts) {
+        Value &s = bot.state;
+        Value trace = s.get("_motion_stall_pending");
+        if (trace.kind == Value::Null)
+            return;
+        s.erase("_motion_stall_pending");
+        Value p = position(s), nearby = Value::array(), pairs = Value::array(),
+              delta = Value::array();
+        int id = integer(s, "id");
+        for (const auto &v : bots) {
+            if (v.first == id)
+                continue;
+            const Value &other = v.second->state;
+            double dx = field(other, "x") - p[0].number(), dz = field(other, "z") - p[2].number();
+            if (dx * dx + dz * dz > 144)
+                continue;
+            Value row = Value::object();
+            row["id"] = Value(v.first);
+            row["position"] = position(other);
+            for (const char *key : {"yaw", "speed"})
+                row[key] = other.get(key);
+            row["alive"] = Value(flag(other, "alive", true));
+            row["shape"] = other.get("collision_shape");
+            nearby.append(row);
+        }
+        for (const auto &pair : contacts) {
+            if (pair.first == id || pair.second == id) {
+                Value row = Value::array();
+                row.append(Value(pair.first));
+                row.append(Value(pair.second));
+                pairs.append(row);
+            }
+        }
+        delta.append(Value(p[0].number() - settled[0].number()));
+        delta.append(Value(p[2].number() - settled[2].number()));
+        trace["nearby"] = nearby;
+        trace["final"] = p;
+        trace["speed_final"] = Value(field(s, "speed"));
+        trace["support_rollback"] = Value(support);
+        trace["pose_rollback"] = Value(rollback);
+        trace["airborne"] = Value(flag(s, "airborne"));
+        trace["post_settle_delta"] = delta;
+        trace["contact_pairs"] = pairs;
+        emit("BOT MOTION", trace);
+    }
+};
+} // namespace offline_kernel
+#endif

--- a/tools/ffi_experiment/kernel_diagnostics.h
+++ b/tools/ffi_experiment/kernel_diagnostics.h
@@ -12,17 +12,17 @@ struct Diagnostics {
     Diagnostics(const Value &c, std::map<int, std::unique_ptr<Bot>> &b) : config(c), bots(b) {}
     void emit(const std::string &kind, const Value &payload) {
         Value row = Value::object();
-        row["kind"] = Value(kind);
+        row[sf::kind] = Value(kind);
         row["payload"] = payload;
         records.append(row);
     }
     void begin(Bot &bot, const Value &command, double throttle, double turn, bool clear,
                bool frozen, const Value &probe, double now, int grind) {
         Value &s = bot.state;
-        int id = integer(s, "id");
+        int id = integer(s, sf::id);
         Value p = position(s);
         if (flag(config, "debug")) {
-            int direction = integer(s, "movement_dir");
+            int direction = integer(s, sf::movement_dir);
             auto at = flips.find(id);
             if (at == flips.end())
                 flips[id] = {{static_cast<double>(direction), now, -10}};
@@ -33,18 +33,18 @@ struct Diagnostics {
                 if (direction && prior[0] && now - prior[1] <= 2 && now - prior[2] >= 1) {
                     at->second[2] = now;
                     Value row = Value::object();
-                    row["id"] = Value(id);
+                    row[sf::id] = Value(id);
                     row["from"] = Value(static_cast<int>(prior[0]));
                     row["to"] = Value(direction);
                     row["elapsed"] = Value(now - prior[1]);
-                    row["position"] = p;
+                    row[sf::position] = p;
                     row["path_clear"] = Value(clear);
                     row["probe"] = probe;
                     emit("BOT FLIP", row);
                 }
             }
         }
-        const Value &prior = s.get("_motion_stall_log");
+        const Value &prior = s.get(sf::_motion_stall_log);
         bool moved = false;
         if (prior.kind == Value::Array) {
             double dx = p[0].number() - prior[0][0].number(),
@@ -55,7 +55,7 @@ struct Diagnostics {
             Value row = Value::array();
             row.append(p);
             row.append(Value(now));
-            s["_motion_stall_log"] = row;
+            s[sf::_motion_stall_log] = row;
             return;
         }
         if (now - prior[1].number() < 3)
@@ -63,26 +63,26 @@ struct Diagnostics {
         Value marker = Value::array();
         marker.append(prior[0]);
         marker.append(Value(now));
-        s["_motion_stall_log"] = marker;
+        s[sf::_motion_stall_log] = marker;
         Value trace = Value::object();
-        trace["id"] = Value(id);
-        trace["vehicle"] = s.get("vehicle");
+        trace[sf::id] = Value(id);
+        trace[sf::vehicle] = s.get(sf::vehicle);
         trace["native_motion"] = Value(flag(config, "native_motion"));
         trace["start"] = p;
-        trace["speed_before"] = Value(field(s, "speed"));
+        trace["speed_before"] = Value(field(s, sf::speed));
         trace["requested_throttle"] = Value(throttle);
         trace["turn"] = Value(turn);
         for (const char *key : {"yaw", "pitch", "roll"})
             trace[key] = s.get(key);
-        trace["shape"] = s.get("collision_shape");
-        s["_motion_stall_pending"] = trace;
+        trace["shape"] = s.get(sf::collision_shape);
+        s[sf::_motion_stall_pending] = trace;
         Value row = trace.copy();
         row["command"] = command.copy();
-        row["water_depth"] = Value(field(s, "_water_depth", -1));
+        row["water_depth"] = Value(field(s, sf::_water_depth, -1));
         row["path_clear"] = Value(clear);
         row["probe"] = probe;
         row["frozen"] = Value(frozen);
-        row["hull_aiming"] = Value(flag(s, "hull_aiming"));
+        row[sf::hull_aiming] = Value(flag(s, sf::hull_aiming));
         row["grind"] = Value(grind);
         row["planner_age"] = Value(planner_age);
         emit("BOT STALL", row);
@@ -90,27 +90,28 @@ struct Diagnostics {
     void finish(Bot &bot, bool support, bool rollback, const Value &settled,
                 const std::set<std::pair<int, int>> &contacts) {
         Value &s = bot.state;
-        Value trace = s.get("_motion_stall_pending");
+        Value trace = s.get(sf::_motion_stall_pending);
         if (trace.kind == Value::Null)
             return;
-        s.erase("_motion_stall_pending");
+        s.erase(sf::_motion_stall_pending);
         Value p = position(s), nearby = Value::array(), pairs = Value::array(),
               delta = Value::array();
-        int id = integer(s, "id");
+        int id = integer(s, sf::id);
         for (const auto &v : bots) {
             if (v.first == id)
                 continue;
             const Value &other = v.second->state;
-            double dx = field(other, "x") - p[0].number(), dz = field(other, "z") - p[2].number();
+            double dx = field(other, sf::x) - p[0].number(),
+                   dz = field(other, sf::z) - p[2].number();
             if (dx * dx + dz * dz > 144)
                 continue;
             Value row = Value::object();
-            row["id"] = Value(v.first);
-            row["position"] = position(other);
+            row[sf::id] = Value(v.first);
+            row[sf::position] = position(other);
             for (const char *key : {"yaw", "speed"})
                 row[key] = other.get(key);
-            row["alive"] = Value(flag(other, "alive", true));
-            row["shape"] = other.get("collision_shape");
+            row[sf::alive] = Value(flag(other, sf::alive, true));
+            row["shape"] = other.get(sf::collision_shape);
             nearby.append(row);
         }
         for (const auto &pair : contacts) {
@@ -125,10 +126,10 @@ struct Diagnostics {
         delta.append(Value(p[2].number() - settled[2].number()));
         trace["nearby"] = nearby;
         trace["final"] = p;
-        trace["speed_final"] = Value(field(s, "speed"));
+        trace["speed_final"] = Value(field(s, sf::speed));
         trace["support_rollback"] = Value(support);
         trace["pose_rollback"] = Value(rollback);
-        trace["airborne"] = Value(flag(s, "airborne"));
+        trace[sf::airborne] = Value(flag(s, sf::airborne));
         trace["post_settle_delta"] = delta;
         trace["contact_pairs"] = pairs;
         emit("BOT MOTION", trace);

--- a/tools/ffi_experiment/kernel_driver.h
+++ b/tools/ffi_experiment/kernel_driver.h
@@ -68,12 +68,12 @@ struct Driver {
     bool clear(Bot &bot, double yaw, offline_nav::Optional<double> distance = {}) {
         Value &s = bot.state;
         auto p = Routes::point(s);
-        int id = integer(s, "id");
+        int id = integer(s, sf::id);
         if (routes.nav) {
             int value = offline_navigation_local_query(
                 integer(config, "navigation"), id, 1, p.x, p.y, p.z, yaw,
-                field(s, "half_length", 3.5), field(s, "half_width", 1.7),
-                field(s, "_water_depth", -1) > .9, flag(config, "bake_admitted"), distance.has,
+                field(s, sf::half_length, 3.5), field(s, sf::half_width, 1.7),
+                field(s, sf::_water_depth, -1) > .9, flag(config, "bake_admitted"), distance.has,
                 distance.value);
             if (value != 2)
                 return value != 0;
@@ -89,7 +89,7 @@ struct Driver {
                               p.y,
                               p.z,
                               yaw,
-                              field(s, "speed"),
+                              field(s, sf::speed),
                               static_cast<double>(distance.has),
                               distance.value,
                               static_cast<double>(distance.has)};
@@ -112,8 +112,8 @@ struct Driver {
         else {
             auto p = Routes::point(active->state);
             packet[0] = !routes.nav || routes.nav->grid->pose(
-                                           p, packet[1], field(active->state, "half_length", 3.5),
-                                           field(active->state, "half_width", 1.7));
+                                           p, packet[1], field(active->state, sf::half_length, 3.5),
+                                           field(active->state, sf::half_width, 1.7));
         }
         return 0;
     }
@@ -121,8 +121,8 @@ struct Driver {
         return static_cast<Driver *>(owner)->event(packet, count);
     }
     Value drive(Bot &bot, Value &state, const Value &order, bool gun_pending) {
-        int id = integer(bot.state, "id");
-        auto current = Routes::point(state.get("position"));
+        int id = integer(bot.state, sf::id);
+        auto current = Routes::point(state.get(sf::position));
         const Value &raw_aim = order.get("aim_position"), &raw_move = order.get("move_position"),
                     &raw_face = order.get("face_position");
         auto aim = raw_aim.kind == Value::Null ? Routes::point(raw_move, current)
@@ -131,42 +131,45 @@ struct Driver {
              face = raw_face.kind == Value::Null ? move : Routes::point(raw_face, current);
         auto target = routes.target(id, current, move, order, state, gun_pending);
         std::string mode = order.get("combat_mode").text("route");
-        bool stop = flag(state, "navigation_stop_at_target", mode != "route" && mode != "advance"),
+        bool stop =
+                 flag(state, sf::navigation_stop_at_target, mode != "route" && mode != "advance"),
              movement = order.get("throttle_override").kind == Value::Null ||
                         field(order, "throttle_override") > 0;
         double requested_x = move.x - current.x, requested_z = move.z - current.z,
                dx = target.x - current.x, dz = target.z - current.z;
         bool wait = movement && requested_x * requested_x + requested_z * requested_z > 225 &&
                     dx * dx + dz * dz <= 1.5 * 1.5;
-        double throttle = 0, turn = 0, yaw = field(state, "yaw");
+        double throttle = 0, turn = 0, yaw = field(state, sf::yaw);
         std::string recovery = "nav_wait";
         if (!wait) {
             std::vector<double> packet = {208, static_cast<double>(handle), static_cast<double>(id),
-                                          static_cast<double>(integer(state, "slot"))};
+                                          static_cast<double>(integer(state, sf::slot))};
             point(packet, current);
             packet.insert(packet.end(),
-                          {field(state, "yaw"), field(state, "speed"), field(state, "dt")});
+                          {field(state, sf::yaw), field(state, sf::speed), field(state, sf::dt)});
             point(packet, target);
-            const Value &neighbours = state.get("neighbours");
-            packet.insert(packet.end(),
-                          {field(state, "half_length", 3.5), field(state, "half_width", 1.7),
-                           static_cast<double>(movement),
-                           static_cast<double>(state.get("stopping_distance").kind != Value::Null),
-                           field(state, "stopping_distance"), static_cast<double>(stop),
-                           field(state, "decision_horizon"), 1, rounded(target.x, 2),
-                           rounded(target.z, 2), static_cast<double>(neighbours.size())});
+            const Value &neighbours = state.get(sf::neighbours);
+            packet.insert(
+                packet.end(),
+                {field(state, sf::half_length, 3.5), field(state, sf::half_width, 1.7),
+                 static_cast<double>(movement),
+                 static_cast<double>(state.get(sf::stopping_distance).kind != Value::Null),
+                 field(state, sf::stopping_distance), static_cast<double>(stop),
+                 field(state, sf::decision_horizon), 1, rounded(target.x, 2), rounded(target.z, 2),
+                 static_cast<double>(neighbours.size())});
             for (const Value &peer : elements(neighbours)) {
-                point(packet, Routes::point(peer.get("position")));
+                point(packet, Routes::point(peer.get(sf::position)));
                 packet.insert(packet.end(),
-                              {field(peer, "yaw"),
-                               field(peer, "half_length", field(state, "half_length", 3.5)),
-                               field(peer, "half_width", field(state, "half_width", 1.7)),
-                               static_cast<double>(peer.get("id").kind != Value::Null),
-                               field(peer, "id"), static_cast<double>(flag(peer, "alive", true))});
+                              {field(peer, sf::yaw),
+                               field(peer, sf::half_length, field(state, sf::half_length, 3.5)),
+                               field(peer, sf::half_width, field(state, sf::half_width, 1.7)),
+                               static_cast<double>(peer.get(sf::id).kind != Value::Null),
+                               field(peer, sf::id),
+                               static_cast<double>(flag(peer, sf::alive, true))});
             }
             packet.insert(packet.end(),
                           {static_cast<double>(integer(config, "navigation")),
-                           static_cast<double>(field(bot.state, "_water_depth", -1) > .9),
+                           static_cast<double>(field(bot.state, sf::_water_depth, -1) > .9),
                            static_cast<double>(flag(config, "bake_admitted"))});
             size_t offset = packet.size();
             packet.resize(offset + 7, 0);
@@ -195,18 +198,18 @@ struct Driver {
         if ((recovery == "arrived" || recovery == "nav_wait") &&
             face_x * face_x + face_z * face_z > .01) {
             yaw = std::atan2(face_x, face_z);
-            turn = clamp(gun_wrap(yaw - field(state, "yaw")) / .58, -1, 1);
+            turn = clamp(gun_wrap(yaw - field(state, sf::yaw)) / .58, -1, 1);
         }
         Value result = Value::object();
         result["bot_id"] = Value(id);
-        result["target_id"] = order.get("target_id");
+        result[sf::target_id] = order.get(sf::target_id);
         result["aim_position"] = Routes::value(aim);
         result["face_position"] = Routes::value(face);
         result["fire_range"] = Value(field(order, "fire_range"));
         result["move_position"] = Routes::value(target);
         result["combat_mode"] = Value(mode);
         result["fire_allowed"] = Value(flag(order, "fire_allowed"));
-        result["shell_index"] = Value(integer(order, "shell_index"));
+        result[sf::shell_index] = Value(integer(order, sf::shell_index));
         result["throttle"] = Value(throttle);
         result["turn"] = Value(turn);
         result["target_yaw"] = Value(yaw);
@@ -216,14 +219,14 @@ struct Driver {
             result["hull_angle_degrees"] = Value(field(order, "hull_angle_degrees"));
         if (order.get("throttle_override").kind != Value::Null &&
             (recovery == "drive" || recovery == "arrived") &&
-            std::abs(gun_wrap(yaw - field(state, "yaw"))) < .65)
+            std::abs(gun_wrap(yaw - field(state, sf::yaw))) < .65)
             result["throttle"] = Value(clamp(field(order, "throttle_override"), -1, 1));
         return result;
     }
     double stopping(Bot &bot, const Value &command) {
-        int id = integer(bot.state, "id");
-        double speed = std::abs(field(bot.state, "speed")),
-               pitch = field(bot.state, "last_drive_pitch");
+        int id = integer(bot.state, sf::id);
+        double speed = std::abs(field(bot.state, sf::speed)),
+               pitch = field(bot.state, sf::last_drive_pitch);
         bool steering = std::abs(field(command, "turn")) > .01;
         auto at = coast.find(id);
         if (at != coast.end() && at->second.speed == speed && at->second.pitch == pitch &&

--- a/tools/ffi_experiment/kernel_driver.h
+++ b/tools/ffi_experiment/kernel_driver.h
@@ -1,0 +1,265 @@
+#ifndef OFFLINE_EXPERIMENT_KERNEL_DRIVER_H
+#define OFFLINE_EXPERIMENT_KERNEL_DRIVER_H
+#include "kernel_traffic.h"
+
+namespace offline_kernel {
+// Body snapshots are built afresh. Integer dictionary iteration affects the
+// first already-overlapping neighbour chosen by #1513's Python 2 driver.
+inline std::vector<int> integer_dict_order(const std::vector<int> &insertions, bool py2) {
+    std::vector<int> insertion;
+    std::set<int> seen;
+    for (int id : insertions)
+        if (seen.insert(id).second)
+            insertion.push_back(id);
+    if (!py2)
+        return insertion;
+    std::vector<int> table(8, -1);
+    size_t used = 0;
+    auto put = [](std::vector<int> &values, int id) {
+        size_t mask = values.size() - 1, hash = static_cast<size_t>(id), slot = hash & mask,
+               perturb = hash;
+        while (values[slot] != -1) {
+            slot = (slot * 5 + perturb + 1) & mask;
+            perturb >>= 5;
+        }
+        values[slot] = id;
+    };
+    for (int id : insertion) {
+        put(table, id);
+        ++used;
+        if (used * 3 >= table.size() * 2) {
+            size_t size = 8;
+            while (size <= used * 4)
+                size *= 2;
+            std::vector<int> grown(size, -1);
+            for (int v : table)
+                if (v != -1)
+                    put(grown, v);
+            table.swap(grown);
+        }
+    }
+    std::vector<int> result;
+    for (int id : table)
+        if (id != -1)
+            result.push_back(id);
+    return result;
+}
+struct Driver {
+    Value config;
+    Motion &motion;
+    Routes &routes;
+    Bot *active = nullptr;
+    const OfflineQueryRoute *route = nullptr;
+    std::map<std::pair<double, double>, bool> probes;
+    struct Coast {
+        double speed, pitch;
+        bool steering;
+        double distance;
+    };
+    std::map<int, Coast> coast;
+    int handle;
+    Driver(const Value &c, Motion &m, Routes &r)
+        : config(c), motion(m), routes(r), handle(integer(c, "driver")) {}
+    static void point(std::vector<double> &out, offline_nav::Point p) {
+        out.push_back(p.x);
+        out.push_back(p.y);
+        out.push_back(p.z);
+    }
+    bool clear(Bot &bot, double yaw, offline_nav::Optional<double> distance = {}) {
+        Value &s = bot.state;
+        auto p = Routes::point(s);
+        int id = integer(s, "id");
+        if (routes.nav) {
+            int value = offline_navigation_local_query(
+                integer(config, "navigation"), id, 1, p.x, p.y, p.z, yaw,
+                field(s, "half_length", 3.5), field(s, "half_width", 1.7),
+                field(s, "_water_depth", -1) > .9, flag(config, "bake_admitted"), distance.has,
+                distance.value);
+            if (value != 2)
+                return value != 0;
+        }
+        auto key =
+            std::make_pair(rounded(angle(yaw), 4), distance.has ? rounded(distance.value, 2) : -1);
+        auto cached = probes.find(key);
+        if (cached != probes.end())
+            return cached->second;
+        double packet[128] = {610,
+                              static_cast<double>(id),
+                              p.x,
+                              p.y,
+                              p.z,
+                              yaw,
+                              field(s, "speed"),
+                              static_cast<double>(distance.has),
+                              distance.value,
+                              static_cast<double>(distance.has)};
+        motion.engine_event(packet, 128, s);
+        bool result = packet[0] == 0 || (packet[0] == 2 && packet[7] != 0) ||
+                      (packet[0] == 2 ? (packet[3] != 0 && packet[4] == 0 && packet[5] == 0 &&
+                                         std::abs(packet[6]) <= .55)
+                                      : packet[2] != 0);
+        probes[key] = result;
+        return result;
+    }
+    int event(double *packet, int count) {
+        int kind = static_cast<int>(packet[0]);
+        if ((kind != 1 && kind != 2) || !active)
+            return route->forward(packet, count);
+        if (kind == 1)
+            packet[0] = clear(*active, packet[1],
+                              packet[2] < 0 ? offline_nav::Optional<double>()
+                                            : offline_nav::Optional<double>(packet[2]));
+        else {
+            auto p = Routes::point(active->state);
+            packet[0] = !routes.nav || routes.nav->grid->pose(
+                                           p, packet[1], field(active->state, "half_length", 3.5),
+                                           field(active->state, "half_width", 1.7));
+        }
+        return 0;
+    }
+    static int callback(void *owner, double *packet, int count) {
+        return static_cast<Driver *>(owner)->event(packet, count);
+    }
+    Value drive(Bot &bot, Value &state, const Value &order, bool gun_pending) {
+        int id = integer(bot.state, "id");
+        auto current = Routes::point(state.get("position"));
+        const Value &raw_aim = order.get("aim_position"), &raw_move = order.get("move_position"),
+                    &raw_face = order.get("face_position");
+        auto aim = raw_aim.kind == Value::Null ? Routes::point(raw_move, current)
+                                               : Routes::point(raw_aim, current),
+             move = raw_move.kind == Value::Null ? aim : Routes::point(raw_move, current),
+             face = raw_face.kind == Value::Null ? move : Routes::point(raw_face, current);
+        auto target = routes.target(id, current, move, order, state, gun_pending);
+        std::string mode = order.get("combat_mode").text("route");
+        bool stop = flag(state, "navigation_stop_at_target", mode != "route" && mode != "advance"),
+             movement = order.get("throttle_override").kind == Value::Null ||
+                        field(order, "throttle_override") > 0;
+        double requested_x = move.x - current.x, requested_z = move.z - current.z,
+               dx = target.x - current.x, dz = target.z - current.z;
+        bool wait = movement && requested_x * requested_x + requested_z * requested_z > 225 &&
+                    dx * dx + dz * dz <= 1.5 * 1.5;
+        double throttle = 0, turn = 0, yaw = field(state, "yaw");
+        std::string recovery = "nav_wait";
+        if (!wait) {
+            std::vector<double> packet = {208, static_cast<double>(handle), static_cast<double>(id),
+                                          static_cast<double>(integer(state, "slot"))};
+            point(packet, current);
+            packet.insert(packet.end(),
+                          {field(state, "yaw"), field(state, "speed"), field(state, "dt")});
+            point(packet, target);
+            const Value &neighbours = state.get("neighbours");
+            packet.insert(packet.end(),
+                          {field(state, "half_length", 3.5), field(state, "half_width", 1.7),
+                           static_cast<double>(movement),
+                           static_cast<double>(state.get("stopping_distance").kind != Value::Null),
+                           field(state, "stopping_distance"), static_cast<double>(stop),
+                           field(state, "decision_horizon"), 1, rounded(target.x, 2),
+                           rounded(target.z, 2), static_cast<double>(neighbours.size())});
+            for (const Value &peer : elements(neighbours)) {
+                point(packet, Routes::point(peer.get("position")));
+                packet.insert(packet.end(),
+                              {field(peer, "yaw"),
+                               field(peer, "half_length", field(state, "half_length", 3.5)),
+                               field(peer, "half_width", field(state, "half_width", 1.7)),
+                               static_cast<double>(peer.get("id").kind != Value::Null),
+                               field(peer, "id"), static_cast<double>(flag(peer, "alive", true))});
+            }
+            packet.insert(packet.end(),
+                          {static_cast<double>(integer(config, "navigation")),
+                           static_cast<double>(field(bot.state, "_water_depth", -1) > .9),
+                           static_cast<double>(flag(config, "bake_admitted"))});
+            size_t offset = packet.size();
+            packet.resize(offset + 7, 0);
+            active = &bot;
+            OfflineQueryRoute scope(callback, this);
+            route = &scope;
+            try {
+                offline_driver_dispatch(packet.data(), packet.size());
+            } catch (...) {
+                route = nullptr;
+                active = nullptr;
+                throw;
+            }
+            route = nullptr;
+            active = nullptr;
+            if (packet[offset] != 0)
+                throw std::runtime_error("native driver did not complete");
+            throttle = packet[offset + 1];
+            turn = packet[offset + 2];
+            yaw = packet[offset + 3];
+            const char *modes[] = {"arrived",      "blocked", "pivot_recovery",
+                                   "reverse_turn", "avoid",   "drive"};
+            recovery = modes[static_cast<int>(packet[offset + 4])];
+        }
+        double face_x = face.x - current.x, face_z = face.z - current.z;
+        if ((recovery == "arrived" || recovery == "nav_wait") &&
+            face_x * face_x + face_z * face_z > .01) {
+            yaw = std::atan2(face_x, face_z);
+            turn = clamp(gun_wrap(yaw - field(state, "yaw")) / .58, -1, 1);
+        }
+        Value result = Value::object();
+        result["bot_id"] = Value(id);
+        result["target_id"] = order.get("target_id");
+        result["aim_position"] = Routes::value(aim);
+        result["face_position"] = Routes::value(face);
+        result["fire_range"] = Value(field(order, "fire_range"));
+        result["move_position"] = Routes::value(target);
+        result["combat_mode"] = Value(mode);
+        result["fire_allowed"] = Value(flag(order, "fire_allowed"));
+        result["shell_index"] = Value(integer(order, "shell_index"));
+        result["throttle"] = Value(throttle);
+        result["turn"] = Value(turn);
+        result["target_yaw"] = Value(yaw);
+        result["recovery_mode"] = Value(recovery);
+        result["movement_intent"] = Value(movement);
+        if (order.get("hull_angle_degrees").kind != Value::Null)
+            result["hull_angle_degrees"] = Value(field(order, "hull_angle_degrees"));
+        if (order.get("throttle_override").kind != Value::Null &&
+            (recovery == "drive" || recovery == "arrived") &&
+            std::abs(gun_wrap(yaw - field(state, "yaw"))) < .65)
+            result["throttle"] = Value(clamp(field(order, "throttle_override"), -1, 1));
+        return result;
+    }
+    double stopping(Bot &bot, const Value &command) {
+        int id = integer(bot.state, "id");
+        double speed = std::abs(field(bot.state, "speed")),
+               pitch = field(bot.state, "last_drive_pitch");
+        bool steering = std::abs(field(command, "turn")) > .01;
+        auto at = coast.find(id);
+        if (at != coast.end() && at->second.speed == speed && at->second.pitch == pitch &&
+            at->second.steering == steering)
+            return at->second.distance;
+        double result = 0, current = speed, dt = field(config, "publication_seconds");
+        if (current > field(config, "speed_epsilon")) {
+            bool settled = false;
+            for (int i = 0; i < 4096; ++i) {
+                double next =
+                    offline_motion::longitudinal(motion.tuning, motion.profiles.at(id), current, 0,
+                                                 steering, pitch, dt, false, 0, false);
+                if (!std::isfinite(next)) {
+                    result = std::numeric_limits<double>::infinity();
+                    settled = true;
+                    break;
+                }
+                if (next <= field(config, "speed_epsilon")) {
+                    result += std::max(0.0, next) * dt;
+                    settled = true;
+                    break;
+                }
+                if (next >= current) {
+                    result = std::numeric_limits<double>::infinity();
+                    settled = true;
+                    break;
+                }
+                result += next * dt;
+                current = next;
+            }
+            if (!settled)
+                result = std::numeric_limits<double>::infinity();
+        }
+        coast[id] = Coast{speed, pitch, steering, result};
+        return result;
+    }
+};
+} // namespace offline_kernel
+#endif

--- a/tools/ffi_experiment/kernel_engine.h
+++ b/tools/ffi_experiment/kernel_engine.h
@@ -1,0 +1,56 @@
+#ifndef OFFLINE_EXPERIMENT_KERNEL_ENGINE_H
+#define OFFLINE_EXPERIMENT_KERNEL_ENGINE_H
+#include "kernel_value.h"
+#include "query_bridge.h"
+#include <array>
+
+namespace offline_kernel {
+struct Engine {
+    const Value config;
+    double sample_time = 0, equipment_time = 0;
+    std::vector<std::string> fields;
+    explicit Engine(const Value &v) : config(v) {
+        for (const Value &name : elements(v.get("fields")))
+            fields.push_back(name.text());
+    }
+    size_t actor(std::array<double, 256> &packet, size_t at, const Value &state) {
+        if (fields.size() > 48)
+            throw std::invalid_argument("kernel engine actor width");
+        packet[at++] = state.get("kind").text() == "human" || state.get("kind").text() == "player";
+        packet[at++] = integer(state, "network_id", integer(state, "id"));
+        size_t mask_at = at++;
+        uint64_t mask = 0;
+        for (size_t i = 0; i < fields.size(); ++i) {
+            const Value &value = state.get(fields[i]);
+            if (value.kind != Value::Null)
+                mask |= uint64_t(1) << i;
+            packet[at++] = value.number();
+        }
+        packet[mask_at] = static_cast<double>(mask);
+        for (const char *name : {"position", "velocity"}) {
+            const Value &v = state.get(name);
+            bool valid = v.kind == Value::Array && v.size() == 3;
+            packet[at++] = valid;
+            for (size_t i = 0; i < 3; ++i)
+                packet[at++] = valid ? v[i].number() : 0;
+        }
+        return at;
+    }
+    std::array<double, 256> query(int kind, const Value &source, const Value &target,
+                                  const std::vector<double> &values = {}) {
+        std::array<double, 256> packet{};
+        packet[0] = kind;
+        size_t at = actor(packet, 1, source);
+        at = actor(packet, at, target);
+        if (at + values.size() > 254)
+            throw std::invalid_argument("kernel engine packet width");
+        std::copy(values.begin(), values.end(), packet.begin() + at);
+        packet[254] = sample_time;
+        packet[255] = equipment_time;
+        if (offline_query(packet.data(), packet.size()))
+            throw std::runtime_error("kernel engine callback");
+        return packet;
+    }
+};
+} // namespace offline_kernel
+#endif

--- a/tools/ffi_experiment/kernel_engine.h
+++ b/tools/ffi_experiment/kernel_engine.h
@@ -8,26 +8,51 @@ namespace offline_kernel {
 struct Engine {
     const Value config;
     double sample_time = 0, equipment_time = 0;
-    std::vector<std::string> fields;
+    std::vector<Field> fields;
+    uint64_t descriptor_fields = 0, position_fields = 0, scan_fields = 0, cancel_fields = 0;
     explicit Engine(const Value &v) : config(v) {
-        for (const Value &name : elements(v.get("fields")))
-            fields.push_back(name.text());
+        for (const Value &name : elements(v.get("fields"))) {
+            if (name.kind != Value::String)
+                throw std::invalid_argument("kernel engine field name");
+            if (fields.size() >= 48)
+                throw std::invalid_argument("kernel engine actor width");
+            uint64_t bit = uint64_t(1) << fields.size();
+            const std::string &key = name.data->string;
+            if (key == "siege_state")
+                descriptor_fields |= bit;
+            if (key == "x" || key == "y" || key == "z")
+                position_fields |= bit;
+            if (key == "id")
+                cancel_fields |= bit;
+            if (key == "id" || key == "yaw" || key == "speed")
+                scan_fields |= bit;
+            fields.push_back(Field{field_slot(key), key.c_str(), key.size()});
+        }
+        scan_fields |= position_fields;
     }
-    size_t actor(std::array<double, 256> &packet, size_t at, const Value &state) {
-        if (fields.size() > 48)
-            throw std::invalid_argument("kernel engine actor width");
-        packet[at++] = state.get("kind").text() == "human" || state.get("kind").text() == "player";
-        packet[at++] = integer(state, "network_id", integer(state, "id"));
+    size_t actor(std::array<double, 256> &packet, size_t at, const Value &state,
+                 uint64_t wanted = ~uint64_t(0)) {
+        if (state.kind != Value::Object || !state.truth())
+            return at + 3 + fields.size() + 8;
+        packet[at++] =
+            state.get(sf::kind).text() == "human" || state.get(sf::kind).text() == "player";
+        packet[at++] = integer(state, sf::network_id, integer(state, sf::id));
         size_t mask_at = at++;
         uint64_t mask = 0;
         for (size_t i = 0; i < fields.size(); ++i) {
+            if (!(wanted & (uint64_t(1) << i))) {
+                ++at;
+                continue;
+            }
             const Value &value = state.get(fields[i]);
             if (value.kind != Value::Null)
                 mask |= uint64_t(1) << i;
             packet[at++] = value.number();
         }
         packet[mask_at] = static_cast<double>(mask);
-        for (const char *name : {"position", "velocity"}) {
+        if (wanted != ~uint64_t(0))
+            return at + 8;
+        for (Field name : {sf::position, sf::velocity}) {
             const Value &v = state.get(name);
             bool valid = v.kind == Value::Array && v.size() == 3;
             packet[at++] = valid;
@@ -40,8 +65,23 @@ struct Engine {
                                   const std::vector<double> &values = {}) {
         std::array<double, 256> packet{};
         packet[0] = kind;
-        size_t at = actor(packet, 1, source);
-        at = actor(packet, at, target);
+        uint64_t wanted = ~uint64_t(0);
+        if (kind == 760 && !values.empty())
+            wanted = values[0] == 615                       ? wanted
+                     : values[0] == 610 || values[0] == 611 ? descriptor_fields
+                                                            : 0;
+        else if (kind == 769)
+            wanted = position_fields;
+        else if (kind == 771)
+            wanted = scan_fields;
+        else if (kind == 766)
+            wanted = cancel_fields;
+        size_t at = actor(packet, 1, source, wanted);
+        // These leaves have no target consumer. Keep the fixed packet offset.
+        if (kind == 760 || kind == 761 || kind == 766 || kind == 769 || kind == 771)
+            at += 3 + fields.size() + 8;
+        else
+            at = actor(packet, at, target);
         if (at + values.size() > 254)
             throw std::invalid_argument("kernel engine packet width");
         std::copy(values.begin(), values.end(), packet.begin() + at);

--- a/tools/ffi_experiment/kernel_engine.py
+++ b/tools/ffi_experiment/kernel_engine.py
@@ -32,6 +32,23 @@ def _make_actor_decoder():
 
 
 _DECODE_ACTOR = _make_actor_decoder()
+_ACTOR_WIDTH = 3 + len(ENGINE_FIELDS) + 8
+_ACTOR_ARGS = 1 + 2 * _ACTOR_WIDTH
+_SOURCE_FIELDS = dict((name, 4 + index) for index, name in enumerate(ENGINE_FIELDS))
+_SOURCE_XYZ = tuple(_SOURCE_FIELDS[name] for name in ('x', 'y', 'z'))
+
+
+def _source_position(query):
+    # BotRuntime._position reads x/y/z, even when a target position is present.
+    return tuple(query[index] for index in _SOURCE_XYZ)
+
+
+def _source_required(query, name):
+    index = _SOURCE_FIELDS[name]
+    if not int(query[3]) & (1 << (index - 4)):
+        raise KeyError(name)
+    return query[index]
+
 
 
 class EngineLeaves(object):
@@ -51,6 +68,8 @@ class EngineLeaves(object):
         self.next_token = 1
         self.owned = False
         self.actor_cache = {}
+        self.actor_calls = 0
+        self.actor_decodes = 0
 
     @classmethod
     def freeze(cls, value):
@@ -102,17 +121,22 @@ class EngineLeaves(object):
                 self.token_keys.pop(self.freeze(value))
 
     def actor(self, query, at):
-        kind, identity, mask = (int(value) for value in query[at:at + 3])
-        end = at + 3 + len(ENGINE_FIELDS) + 8
+        self.actor_calls += 1
+        kind, identity, mask = int(query[at]), int(query[at + 1]), int(query[at + 2])
+        end = at + _ACTOR_WIDTH
         if identity == 0 and mask == 0:
             return dict(kind='human' if kind else 'bot', network_id=0, position=(0.0, 0.0, 0.0)), end
         raw = query[at:end]
         signature = raw.tostring() if hasattr(raw, 'tostring') else raw.tobytes()
-        cache_key = (kind, identity)
+        # Owned updates clear this cache at their frame boundary. Different
+        # projections of one actor can then reuse their exact numeric snapshot
+        # without evicting each other. Standalone leaf audits stay bounded.
+        cache_key = signature if self.owned else (kind, identity)
         cached = self.actor_cache.get(cache_key)
         if cached is not None and cached[0] == signature:
             return dict(cached[1]), end
         value = dict((self.players if kind else self.bots).get(identity, {}))
+        self.actor_decodes += 1
         _DECODE_ACTOR(query, at, mask, value)
         value['kind'] = 'human' if kind else 'bot'
         value['network_id'] = identity
@@ -123,7 +147,8 @@ class EngineLeaves(object):
             else:
                 value.pop(name, None)
             at += 4
-        value.setdefault('position', self.module._position(value))
+        if 'position' not in value:
+            value['position'] = self.module._position(value)
         self.actor_cache[cache_key] = (signature, value)
         return dict(value), at
 
@@ -135,9 +160,35 @@ class EngineLeaves(object):
         if self.owned:
             self.runtime._sample_time_us = int(query[254])
             self.runtime._equipment_now = query[255]
-        source, at = self.actor(query, 1)
-        target, at = self.actor(query, at)
+        at = _ACTOR_ARGS
         self.calls[kind] = self.calls.get(kind, 0) + 1
+        # Primitive leaves do not consume vehicle mappings. Keep fresh copies
+        # for callbacks that do: they may retain or mutate their arguments.
+        if kind == 760:
+            return self.motion(query, at)
+        if kind == 769:
+            try:
+                value = float(self.runtime._water_depth_probe(_source_position(query)))
+                if math.isnan(value) or math.isinf(value):
+                    value = -1
+            except Exception:
+                value = -1
+            query[0], query[1] = value >= 0, value
+            return 0
+        if kind == 771:
+            self.runtime.destructible_body_scan(
+                int(_source_required(query, 'id')), _source_position(query),
+                _source_required(query, 'yaw'), _source_required(query, 'speed'))
+            return 0
+        if kind == 766:
+            try:
+                self.runtime.artillery_launch_cancel(dict(id=int(_source_required(query, 'id'))))
+            except Exception:
+                pass
+            query[0] = 0
+            return 0
+        source, unused = self.actor(query, 1)
+        target = self.actor(query, 1 + _ACTOR_WIDTH)[0] if kind != 761 else None
         if kind in (751, 752):
             callback = (self.runtime.firing_lane_probe if kind == 751
                         else self.runtime.incoming_lane_probe)
@@ -150,8 +201,6 @@ class EngineLeaves(object):
             query[0] = bool(result) if kind == 751 else result is not None
             query[1] = bool(result)
             return 0
-        if kind == 760:
-            return self.motion(query, source, at)
         if 761 <= kind <= 766:
             return self.aim(query, source, target, at)
         if kind == 767:
@@ -165,16 +214,6 @@ class EngineLeaves(object):
             query[0] = bool(value.get('line_of_sight', False)) if isinstance(value, dict) else bool(value)
             query[1] = float(value.get('foliage_bonus', 0)) if isinstance(value, dict) else 0
             return 0
-        if kind == 769:
-            try:
-                value = self.runtime._water_depth_probe(self.module._position(source))
-                value = float(value)
-                if math.isnan(value) or math.isinf(value):
-                    value = -1
-            except Exception:
-                value = -1
-            query[0], query[1] = value >= 0, value
-            return 0
         if kind == 770:
             route = tuple(query[at:at + 3])
             count = int(query[at + 3])
@@ -186,9 +225,6 @@ class EngineLeaves(object):
             except Exception:
                 candidates = []
             query[0], query[1] = bool(candidates), self.token(candidates) if candidates else 0
-            return 0
-        if kind == 771:
-            self.runtime.destructible_body_scan(source['id'], self.module._position(source), source['yaw'], source['speed'])
             return 0
         if kind == 768:
             bodies = []
@@ -218,15 +254,19 @@ class EngineLeaves(object):
 
     def descriptor(self, source):
         identity = source.get('network_id', source.get('id'))
+        return self.descriptor_at(identity, int(source.get('siege_state', 0)))
+
+    def descriptor_at(self, identity, siege_state):
         pair = self.runtime._descriptor_pairs.get(identity) if self.owned else None
-        return (self.module.siege_mechanics.active_descriptor(pair, int(source.get('siege_state', 0)))
+        return (self.module.siege_mechanics.active_descriptor(pair, siege_state)
                 if pair is not None else self.runtime._descriptors.get(identity))
 
-    def motion(self, query, source, at):
+    def motion(self, query, at):
         runtime, module = self.runtime, self.module
         values = query[at:at + 128]
         kind, bot_id = int(values[0]), int(values[1])
-        descriptor = self.descriptor(source)
+        if kind in (610, 611, 615):
+            descriptor = self.descriptor_at(int(query[2]), int(query[_SOURCE_FIELDS['siege_state']]))
         self.calls[kind] = self.calls.get(kind, 0) + 1
         if kind == 610:
             try:
@@ -246,6 +286,7 @@ class EngineLeaves(object):
             result = runtime._physics_ground_probe(values[2], values[3], values[4])
             reply = [result is not None, float(result) if result is not None else 0]
         elif kind == 615:
+            source = self.actor(query, 1)[0]
             # The engine resolver reads these exact callback-visible fields.
             # Its borrowed mirror exists only during this synchronous leaf.
             before = runtime.states.get(bot_id)
@@ -365,11 +406,6 @@ class EngineLeaves(object):
                 reply = [int(clear), 1, int(identity == 'player'),
                          int(verdict['blocker_id']), int(verdict['blocker_team'])] + list(position) + [float(verdict.get('blocker_radius', 0))]
             except (TypeError, KeyError, ValueError, OverflowError):
-                pass
-        else:
-            try:
-                runtime.artillery_launch_cancel(dict(id=source['id']))
-            except Exception:
                 pass
         query[:len(reply)] = array('d', reply)
         return 0

--- a/tools/ffi_experiment/kernel_engine.py
+++ b/tools/ffi_experiment/kernel_engine.py
@@ -345,7 +345,10 @@ class EngineLeaves(object):
 
     def aim(self, query, source, target, at):
         kind, runtime = int(query[0]), self.runtime
-        args = query[at:]
+        # Engine::query lends 256 doubles within a larger reusable buffer.
+        # The widest aim request is the 17-value artillery-friendly receipt;
+        # copying the unused 32K capacity costs gigabytes per workload loop.
+        args = query[at:at + 17]
         descriptor = self.descriptor(source)
         reply = [0]
         if kind == 761:

--- a/tools/ffi_experiment/kernel_engine.py
+++ b/tools/ffi_experiment/kernel_engine.py
@@ -1,0 +1,375 @@
+"""Numeric native-query leaves; mutable simulation state stays in C++."""
+from __future__ import print_function
+
+from array import array
+import math
+
+from kernel_adapter import ENGINE_FIELDS
+from motion_adapter import MotionFlowBackend
+
+
+def _make_actor_decoder():
+    # Compile the fixed numeric ABI once. Field names and conversions are
+    # repository constants, so callbacks do not repeatedly classify fields.
+    boolean = set(('alive', 'airborne', 'grounded_once', 'hull_aiming',
+                   'gun_aligned', '_drowning', '_overturned'))
+    integer = set(('id', 'team', 'fire_seq', 'shell_index', 'health', 'max_health',
+                   'movement_dir', 'rotation_dir', 'siege_state', 'siege_time_left_ms',
+                   'siege_transition_total_ms', 'stun_end_server_time_ms'))
+    lines = ['def decode(query, at, mask, value):']
+    for index, name in enumerate(ENGINE_FIELDS):
+        expression = 'query[at + %d]' % (index + 3)
+        if name in boolean:
+            expression = 'bool(' + expression + ')'
+        elif name in integer:
+            expression = 'int(' + expression + ')'
+        lines.extend(('    if mask & %d:' % (1 << index),
+                      '        value[%r] = %s' % (name, expression),
+                      '    else:', '        value.pop(%r, None)' % name))
+    namespace = {}
+    eval(compile('\n'.join(lines), 'kernel_actor_abi', 'exec'), namespace)
+    return namespace['decode']
+
+
+_DECODE_ACTOR = _make_actor_decoder()
+
+
+class EngineLeaves(object):
+    def __init__(self, module, runtime):
+        self.module, self.runtime = module, runtime
+        self.bots = dict((key, dict(value)) for key, value in runtime.states.items())
+        self.players = {}
+        self.objects = MotionFlowBackend.__new__(MotionFlowBackend)
+        self.objects.module = module
+        self.objects.active = {0: {}}
+        self.objects.next_object = 1
+        # The native motion owner consumes the full reviewed receipt schema.
+        # No opaque Python probe object survives its callback.
+        self.objects._save = lambda unused: 0
+        self.calls = {}
+        self.tokens, self.token_keys = {}, {}
+        self.next_token = 1
+        self.owned = False
+        self.actor_cache = {}
+
+    @classmethod
+    def freeze(cls, value):
+        if isinstance(value, dict):
+            return ('mapping', tuple(sorted((key, cls.freeze(item)) for key, item in value.items())))
+        if isinstance(value, (tuple, list)):
+            return (type(value).__name__, tuple(cls.freeze(item) for item in value))
+        return value
+
+    def token(self, value):
+        if value is None:
+            return 0
+        key = self.freeze(value)
+        token = self.token_keys.get(key)
+        if token is None:
+            token = self.next_token
+            self.next_token += 1
+            self.tokens[token] = value
+            self.token_keys[key] = token
+        return token
+
+    def prepare(self, value, name=None):
+        if name in ('_aim_token', 'aim_token', 'proof_key', 'shot_proof_key'):
+            return None if value is None else dict(_engine_token=self.token(value))
+        if isinstance(value, dict):
+            return dict((key, self.prepare(item, key)) for key, item in value.items())
+        if isinstance(value, (tuple, list)):
+            return [self.prepare(item) for item in value]
+        return value
+
+    def resolve(self, value):
+        if isinstance(value, dict):
+            if set(value) == set(('_engine_token',)):
+                return self.tokens[int(value['_engine_token'])]
+            raw = self.resolve(value.get('_engine_payload'))
+            result = dict(raw) if isinstance(raw, dict) else {}
+            result.update((key, self.resolve(item)) for key, item in value.items()
+                          if key != '_engine_payload')
+            return result
+        if isinstance(value, list):
+            return [self.resolve(item) for item in value]
+        return value
+
+    def retain(self, identities):
+        retained = set(identities)
+        for identity in tuple(self.tokens):
+            if identity not in retained:
+                value = self.tokens.pop(identity)
+                self.token_keys.pop(self.freeze(value))
+
+    def actor(self, query, at):
+        kind, identity, mask = (int(value) for value in query[at:at + 3])
+        end = at + 3 + len(ENGINE_FIELDS) + 8
+        if identity == 0 and mask == 0:
+            return dict(kind='human' if kind else 'bot', network_id=0, position=(0.0, 0.0, 0.0)), end
+        raw = query[at:end]
+        signature = raw.tostring() if hasattr(raw, 'tostring') else raw.tobytes()
+        cache_key = (kind, identity)
+        cached = self.actor_cache.get(cache_key)
+        if cached is not None and cached[0] == signature:
+            return dict(cached[1]), end
+        value = dict((self.players if kind else self.bots).get(identity, {}))
+        _DECODE_ACTOR(query, at, mask, value)
+        value['kind'] = 'human' if kind else 'bot'
+        value['network_id'] = identity
+        at += 3 + len(ENGINE_FIELDS)
+        for name in ('position', 'velocity'):
+            if query[at]:
+                value[name] = tuple(query[at + 1:at + 4])
+            else:
+                value.pop(name, None)
+            at += 4
+        value.setdefault('position', self.module._position(value))
+        self.actor_cache[cache_key] = (signature, value)
+        return dict(value), at
+
+    def __call__(self, query):
+        kind = int(query[0])
+        if 500 <= kind <= 504:
+            self.runtime.navigator._publish_event(query)
+            return 0
+        if self.owned:
+            self.runtime._sample_time_us = int(query[254])
+            self.runtime._equipment_now = query[255]
+        source, at = self.actor(query, 1)
+        target, at = self.actor(query, at)
+        self.calls[kind] = self.calls.get(kind, 0) + 1
+        if kind in (751, 752):
+            callback = (self.runtime.firing_lane_probe if kind == 751
+                        else self.runtime.incoming_lane_probe)
+            try:
+                result = callback(source, target)
+            except Exception:
+                if kind == 751:
+                    raise
+                result = None
+            query[0] = bool(result) if kind == 751 else result is not None
+            query[1] = bool(result)
+            return 0
+        if kind == 760:
+            return self.motion(query, source, at)
+        if 761 <= kind <= 766:
+            return self.aim(query, source, target, at)
+        if kind == 767:
+            try:
+                try:
+                    value = self.runtime.visibility_probe(source, target, bool(query[at]))
+                except TypeError:
+                    value = self.runtime.visibility_probe(source, target)
+            except Exception:
+                value = False
+            query[0] = bool(value.get('line_of_sight', False)) if isinstance(value, dict) else bool(value)
+            query[1] = float(value.get('foliage_bonus', 0)) if isinstance(value, dict) else 0
+            return 0
+        if kind == 769:
+            try:
+                value = self.runtime._water_depth_probe(self.module._position(source))
+                value = float(value)
+                if math.isnan(value) or math.isinf(value):
+                    value = -1
+            except Exception:
+                value = -1
+            query[0], query[1] = value >= 0, value
+            return 0
+        if kind == 770:
+            route = tuple(query[at:at + 3])
+            count = int(query[at + 3])
+            allies = tuple(tuple(query[at + 4 + index * 3:at + 7 + index * 3]) for index in range(count))
+            try:
+                candidates = self.runtime.cover_probe(source, target, route, allies,
+                    self.runtime.navigator.grid.segment_clear if self.runtime.navigator is not None else None)
+                candidates = list(candidates) if candidates else []
+            except Exception:
+                candidates = []
+            query[0], query[1] = bool(candidates), self.token(candidates) if candidates else 0
+            return 0
+        if kind == 771:
+            self.runtime.destructible_body_scan(source['id'], self.module._position(source), source['yaw'], source['speed'])
+            return 0
+        if kind == 768:
+            bodies = []
+            for actor in (source, target):
+                raw = query[at:at + 13]
+                body = dict((key, actor[key]) for key in ('alive', 'team', 'vehicle', 'x', 'y', 'z', 'yaw') if key in actor)
+                body.update(id=int(raw[0]), kind='player' if raw[1] else 'bot',
+                            network_id=actor['network_id'], mass=raw[3],
+                            vx=raw[4], vz=raw[6], shape=tuple(raw[7:11]),
+                            ram_profile=dict(spall_coefficient=raw[11], ramming_bonus=raw[12]))
+                if raw[1]:
+                    body['impulse'] = bool(raw[2])
+                else:
+                    body.update(vy=raw[5], pitch=actor.get('pitch', 0), roll=actor.get('roll', 0))
+                bodies.append(body)
+                at += 13
+            value = self.runtime.ram_contact_probe(bodies[0], bodies[1], tuple(query[at:at + 3]))
+            reply = [0]
+            if value is not None:
+                if not isinstance(value, (list, tuple)) or len(value) != 2:
+                    raise RuntimeError('tank contact armor probe result is invalid')
+                reply = [1, value[0] is not None, float(value[0] or 0),
+                         value[1] is not None, float(value[1] or 0)]
+            query[:len(reply)] = array('d', reply)
+            return 0
+        raise RuntimeError('unknown native kernel engine query %d' % kind)
+
+    def descriptor(self, source):
+        identity = source.get('network_id', source.get('id'))
+        pair = self.runtime._descriptor_pairs.get(identity) if self.owned else None
+        return (self.module.siege_mechanics.active_descriptor(pair, int(source.get('siege_state', 0)))
+                if pair is not None else self.runtime._descriptors.get(identity))
+
+    def motion(self, query, source, at):
+        runtime, module = self.runtime, self.module
+        values = query[at:at + 128]
+        kind, bot_id = int(values[0]), int(values[1])
+        descriptor = self.descriptor(source)
+        self.calls[kind] = self.calls.get(kind, 0) + 1
+        if kind == 610:
+            try:
+                result = runtime.direction_probe(tuple(values[2:5]), values[5], values[6],
+                    descriptor, values[8] if values[7] and values[9] else None, None)
+            except Exception:
+                result = dict(clear=False, collision=True, water=False, slope=0.0)
+            reply = self.objects._probe(result)
+        elif kind == 611:
+            try:
+                result = runtime.world_receipt_probe(tuple(values[2:5]), values[5], values[6],
+                    descriptor, values[9] if values[8] else None)
+            except Exception:
+                result = None
+            reply = self.objects._receipt(result)
+        elif kind == 630:
+            result = runtime._physics_ground_probe(values[2], values[3], values[4])
+            reply = [result is not None, float(result) if result is not None else 0]
+        elif kind == 615:
+            # The engine resolver reads these exact callback-visible fields.
+            # Its borrowed mirror exists only during this synchronous leaf.
+            before = runtime.states.get(bot_id)
+            turn = runtime._turn_speeds.get(bot_id)
+            corridor = runtime.motion_world_corridor_reusable
+            receipt = runtime.motion_world_receipt_reusable
+            runtime.states[bot_id] = source
+            runtime._turn_speeds[bot_id] = source.get('_kernel_turn_speed', 0)
+            runtime.motion_world_corridor_reusable = lambda *unused: bool(values[20])
+            runtime.motion_world_receipt_reusable = lambda *unused: bool(values[21])
+            try:
+                args = (bot_id, tuple(values[2:5]), values[5], values[6],
+                        descriptor, values[7], values[8])
+                if values[9]:
+                    args = (bot_id, tuple(values[2:5]), source.get('yaw', 0), values[6],
+                            descriptor, values[7], values[8], bool(values[10]))
+                    result = runtime.motion_resolver(*args, motion_yaw=(
+                        values[5] if values[6] >= 0 else values[5] + math.pi))
+                else:
+                    result = runtime.motion_resolver(*args)
+            finally:
+                runtime.states[bot_id] = before
+                if turn is None:
+                    runtime._turn_speeds.pop(bot_id, None)
+                else:
+                    runtime._turn_speeds[bot_id] = turn
+                runtime.motion_world_corridor_reusable = corridor
+                runtime.motion_world_receipt_reusable = receipt
+            reply = [('clear', 'crushed', 'soft', 'cap_crushed', 'hard').index(result)]
+        elif kind == 616:
+            runtime.motion_report(bot_id, ('clear', 'crushed', 'soft', 'cap_crushed', 'hard')[int(values[2])], values[3], values[4])
+            reply = [0]
+        elif kind == 635:
+            try:
+                result = runtime.direction_probe(tuple(values[2:5]), values[5], values[6],
+                                                   None, values[7], values[8])
+            except Exception:
+                result = dict(clear=False, collision=True, water=False, slope=0.0)
+            reply = [runtime._probe_is_clear(result)]
+        else:
+            raise RuntimeError('unknown native motion leaf %d' % kind)
+        query[:len(reply)] = array('d', reply)
+        return 0
+
+    @staticmethod
+    def point(value):
+        result = tuple(float(item) for item in value)
+        if len(result) != 3 or any(math.isnan(item) or math.isinf(item) for item in result):
+            raise ValueError('invalid native point')
+        return result
+
+    def aim(self, query, source, target, at):
+        kind, runtime = int(query[0]), self.runtime
+        args = query[at:]
+        descriptor = self.descriptor(source)
+        reply = [0]
+        if kind == 761:
+            try:
+                point = runtime.direct_launch_origin_probe(
+                    source, descriptor, int(args[0]), int(args[1]), args[2], args[3], args[4])
+                reply = [1] + list(self.point(point))
+            except Exception:
+                pass
+        elif kind == 762:
+            value = runtime.direct_aim_point_probe(source, target)
+            try:
+                reply = [1] + list(self.point(value['aim_position'])) + [self.token(value['aim_token'])]
+            except (TypeError, KeyError, ValueError, OverflowError):
+                pass
+        elif kind == 763:
+            value = runtime.ballistic_solution_probe(source, target, descriptor, int(args[0]), args[1])
+            try:
+                position = self.point(value['aim_position'])
+                pitch, flight, yaw = (float(value[name]) for name in ('pitch', 'flight_time', 'yaw'))
+                if any(math.isnan(item) or math.isinf(item) for item in (pitch, flight, yaw)):
+                    raise ValueError('invalid ballistic solution')
+                reply = [1] + list(position) + [pitch, flight, yaw, int(value.get('arc') == 'high'), self.token(value)]
+            except (TypeError, KeyError, ValueError, OverflowError):
+                pass
+        elif kind == 764:
+            value = runtime.artillery_launch_probe(source, target, descriptor,
+                int(args[0]), int(args[1]), args[2], args[3], args[4], args[5])
+            try:
+                point, velocity = self.point(value['origin']), self.point(value['velocity'])
+                numbers = [float(value[name]) for name in (
+                    'shot_yaw', 'shot_pitch', 'gravity', 'max_distance', 'max_time_ms',
+                    'fire_seq', 'shell_index', 'flight_time')]
+                if any(math.isnan(item) or math.isinf(item) for item in numbers):
+                    raise ValueError('invalid artillery receipt')
+                reply = [1] + list(point + velocity) + numbers + [self.token(value['proof_key']), self.token(value)]
+            except (TypeError, KeyError, ValueError, OverflowError):
+                pass
+        elif kind == 765:
+            artillery = bool(args[0])
+            launch = dict(shell_index=int(args[1]), fire_seq=int(args[2]),
+                          shot_yaw=args[3], shot_pitch=args[4], flight_time=args[5],
+                          origin=tuple(args[6:9]))
+            if artillery:
+                raw = self.tokens.get(int(args[16]))
+                if isinstance(raw, dict):
+                    launch = dict(raw)
+                launch.update(velocity=tuple(args[9:12]), gravity=args[12],
+                              max_distance=args[13], max_time_ms=int(args[14]),
+                              proof_key=self.tokens.get(int(args[15])))
+                value = runtime.artillery_friendly_lane_probe(source, target, descriptor,
+                                                               int(args[1]), launch)
+            else:
+                value = runtime.friendly_lane_probe(source, target, descriptor,
+                                                     int(args[1]), launch)
+            clear, verdict = runtime._friendly_lane_verdict(value)
+            reply = [int(clear), 0]
+            try:
+                identity = verdict['blocker_kind']
+                if identity not in ('bot', 'player'):
+                    raise ValueError('invalid blocker kind')
+                position = self.point(verdict['blocker_position'])
+                reply = [int(clear), 1, int(identity == 'player'),
+                         int(verdict['blocker_id']), int(verdict['blocker_team'])] + list(position) + [float(verdict.get('blocker_radius', 0))]
+            except (TypeError, KeyError, ValueError, OverflowError):
+                pass
+        else:
+            try:
+                runtime.artillery_launch_cancel(dict(id=source['id']))
+            except Exception:
+                pass
+        query[:len(reply)] = array('d', reply)
+        return 0

--- a/tools/ffi_experiment/kernel_engine.py
+++ b/tools/ffi_experiment/kernel_engine.py
@@ -70,6 +70,7 @@ class EngineLeaves(object):
         self.actor_cache = {}
         self.actor_calls = 0
         self.actor_decodes = 0
+        self.world = None
 
     @classmethod
     def freeze(cls, value):
@@ -154,6 +155,10 @@ class EngineLeaves(object):
 
     def __call__(self, query):
         kind = int(query[0])
+        if kind == 772:
+            if self.world is None:
+                raise RuntimeError('Native world callback has no battle owner')
+            return self.world(query)
         if 500 <= kind <= 504:
             self.runtime.navigator._publish_event(query)
             return 0

--- a/tools/ffi_experiment/kernel_equipment.h
+++ b/tools/ffi_experiment/kernel_equipment.h
@@ -162,17 +162,6 @@ struct Equipment {
         v["aiPendingElapsed"] = ai_pending ? Value(std::max(0.0, now - ai_since)) : Value();
         return v;
     }
-    Value edge(double now) const {
-        Value v = Value::array();
-        v.append(contract);
-        v.append(Value(uses));
-        v.append(Value(active));
-        v.append(Value(ready_at));
-        v.append(Value(now >= ready_at));
-        v.append(auto_pending ? Value(auto_since) : Value());
-        v.append(ai_pending ? Value(ai_since) : Value());
-        return v;
-    }
 };
 inline Value equipment_passives(const std::vector<Equipment> &equipment) {
     double fire = 1, repair = 0, medkit = 0, crew = 0, power = 1, turret = 1, hp = 0;

--- a/tools/ffi_experiment/kernel_equipment.h
+++ b/tools/ffi_experiment/kernel_equipment.h
@@ -1,0 +1,207 @@
+#ifndef OFFLINE_EXPERIMENT_KERNEL_EQUIPMENT_H
+#define OFFLINE_EXPERIMENT_KERNEL_EQUIPMENT_H
+#include "kernel_value.h"
+#include <set>
+
+namespace offline_kernel {
+inline std::set<std::string> names(const Value &v) {
+    std::set<std::string> result;
+    if (v.kind == Value::Null)
+        return result;
+    for (const Value &item : elements(v))
+        result.insert(item.text());
+    return result;
+}
+inline Value name_array(const std::set<std::string> &v) {
+    Value result = Value::array();
+    for (const std::string &name : v)
+        result.append(Value(name));
+    return result;
+}
+struct Equipment {
+    Value contract;
+    int uses = 0;
+    double ready_at = 0, auto_since = 0, ai_since = 0;
+    bool active = false, auto_pending = false, ai_pending = false;
+    explicit Equipment(const Value &v) : contract(v.get("contract")) {
+        if (contract.kind != Value::Object)
+            throw std::invalid_argument("kernel equipment contract");
+        uses = integer(v, "uses_left");
+        ready_at = field(v, "ready_at");
+        active = flag(v, "active");
+        auto_pending = v.get("_auto_pending_since").kind != Value::Null;
+        ai_pending = v.get("_ai_pending_since").kind != Value::Null;
+        auto_since = field(v, "_auto_pending_since");
+        ai_since = field(v, "_ai_pending_since");
+    }
+    bool ready(double now) const { return uses != 0 && now >= ready_at; }
+    Value effect(const Value &critical, const Value &selected = Value(), bool requested = false,
+                 bool stunned = false) const {
+        std::string kind = contract.get("kind").text(), selection = selected.text("None");
+        Value result = Value::object();
+        if (kind == "extinguisher") {
+            if (!flag(critical, "fire"))
+                return Value();
+            result["action"] = Value("extinguish_fire");
+            return result;
+        }
+        if (kind == "repairkit") {
+            std::set<std::string> damaged = names(critical.get("destroyed"));
+            const Value &devices = critical.get("devices");
+            if (devices.kind != Value::Null)
+                for (const Value &v : elements(devices)) {
+                    std::string name = v.get("name").text(), state = v.get("state").text();
+                    if (!name.empty() && (state == "critical" || state == "destroyed"))
+                        damaged.insert(name);
+                }
+            bool all = flag(contract, "repairAll");
+            if (damaged.empty() || (!all && !damaged.count(selection)))
+                return Value();
+            result["action"] = Value("repair_devices");
+            result["repairAll"] = Value(all);
+            result["selected"] = all ? Value() : Value(selection);
+            result["bonusValue"] = Value(field(contract, "bonusValue"));
+            return result;
+        }
+        if (kind == "medkit") {
+            std::set<std::string> knocked = names(critical.get("crew_ko"));
+            bool all = flag(contract, "repairAll");
+            if ((knocked.empty() && !stunned) || (!all && !knocked.count(selection) && !stunned))
+                return Value();
+            result["action"] = Value("restore_crew");
+            result["repairAll"] = Value(all);
+            result["selected"] = all ? Value() : Value(selection);
+            result["bonusValue"] = Value(field(contract, "bonusValue"));
+            result["clearStun"] = Value(stunned);
+            return result;
+        }
+        if (kind == "rpm_limiter") {
+            if (requested == active)
+                return Value();
+            result["action"] = Value("set_rpm_limiter");
+            result["active"] = Value(requested);
+            result["enginePowerFactor"] = Value(field(contract, "enginePowerFactor", 1));
+            result["engineHpLossPerSecond"] = Value(field(contract, "engineHpLossPerSecond"));
+            return result;
+        }
+        return Value();
+    }
+    Value activate(double now, const Value &critical, const Value &selected = Value(),
+                   bool requested = false, bool stunned = false) {
+        if (!ready(now))
+            return Value();
+        Value result = effect(critical, selected, requested, stunned);
+        if (result.kind == Value::Null)
+            return result;
+        if (result.get("action").text() == "set_rpm_limiter")
+            active = flag(result, "active");
+        else {
+            if (uses > 0)
+                --uses;
+            ready_at = now + std::max(0.0, field(contract, "cooldownSeconds"));
+        }
+        auto_pending = ai_pending = false;
+        return result;
+    }
+    Value poll_auto(double now, const Value &critical) {
+        if (!flag(contract, "autoactivate"))
+            return Value();
+        if (effect(critical).kind == Value::Null || !ready(now)) {
+            auto_pending = false;
+            return Value();
+        }
+        double delay = std::max(0.0, field(contract, "autoReactionSeconds"));
+        if (!auto_pending) {
+            auto_pending = true;
+            auto_since = now;
+            if (delay > 0)
+                return Value();
+        }
+        if (now - auto_since + 1e-9 < delay)
+            return Value();
+        return activate(now, critical);
+    }
+    Value poll_bot(double now, const Value &critical, bool stunned) {
+        std::string kind = contract.get("kind").text();
+        if (kind == "extinguisher")
+            return poll_auto(now, critical);
+        if (kind != "repairkit" && kind != "medkit") {
+            ai_pending = false;
+            return Value();
+        }
+        if (effect(critical, Value(), false, stunned).kind == Value::Null || !ready(now)) {
+            ai_pending = false;
+            return Value();
+        }
+        if (!ai_pending) {
+            ai_pending = true;
+            ai_since = now;
+            return Value();
+        }
+        if (now <= ai_since + 1e-9)
+            return Value();
+        return activate(now, critical, Value(), false, stunned);
+    }
+    Value snapshot() const {
+        Value v = Value::object();
+        v["contract"] = contract;
+        v["uses_left"] = Value(uses);
+        v["ready_at"] = Value(ready_at);
+        v["active"] = Value(active);
+        v["_auto_pending_since"] = auto_pending ? Value(auto_since) : Value();
+        v["_ai_pending_since"] = ai_pending ? Value(ai_since) : Value();
+        return v;
+    }
+    Value wire(double now) const {
+        Value v = Value::object();
+        v["equipment"] = contract;
+        v["usesLeft"] = Value(uses);
+        v["cooldownTimeLeft"] = Value(std::max(0.0, ready_at - now));
+        v["active"] = Value(active);
+        v["autoPendingElapsed"] = auto_pending ? Value(std::max(0.0, now - auto_since)) : Value();
+        v["aiPendingElapsed"] = ai_pending ? Value(std::max(0.0, now - ai_since)) : Value();
+        return v;
+    }
+    Value edge(double now) const {
+        Value v = Value::array();
+        v.append(contract);
+        v.append(Value(uses));
+        v.append(Value(active));
+        v.append(Value(ready_at));
+        v.append(Value(now >= ready_at));
+        v.append(auto_pending ? Value(auto_since) : Value());
+        v.append(ai_pending ? Value(ai_since) : Value());
+        return v;
+    }
+};
+inline Value equipment_passives(const std::vector<Equipment> &equipment) {
+    double fire = 1, repair = 0, medkit = 0, crew = 0, power = 1, turret = 1, hp = 0;
+    for (const Equipment &e : equipment) {
+        const Value &c = e.contract;
+        std::string kind = c.get("kind").text();
+        if (kind == "extinguisher")
+            fire *= std::max(0.0, field(c, "fireStartingChanceFactor", 1));
+        else if (kind == "repairkit")
+            repair += field(c, "bonusValue");
+        else if (kind == "medkit")
+            medkit += field(c, "bonusValue");
+        crew += field(c, "crewLevelIncrease");
+        if (kind == "fuel" || (kind == "rpm_limiter" && e.active))
+            power *= std::max(0.0, field(c, "enginePowerFactor", 1));
+        if (kind == "fuel")
+            turret *= std::max(0.0, field(c, "turretRotationSpeedFactor", 1));
+        if (kind == "rpm_limiter" && e.active)
+            hp += std::max(0.0, field(c, "engineHpLossPerSecond"));
+    }
+    Value v = Value::object();
+    v["fireStartingChanceFactor"] = Value(fire);
+    v["repairkitBonusValue"] = Value(repair);
+    v["medkitBonusValue"] = Value(medkit);
+    v["crewLevelIncrease"] = Value(crew);
+    v["enginePowerFactor"] = Value(power);
+    v["turretRotationSpeedFactor"] = Value(turret);
+    v["engineHpLossPerSecond"] = Value(hp);
+    return v;
+}
+} // namespace offline_kernel
+#endif

--- a/tools/ffi_experiment/kernel_equipment.h
+++ b/tools/ffi_experiment/kernel_equipment.h
@@ -37,7 +37,7 @@ struct Equipment {
     bool ready(double now) const { return uses != 0 && now >= ready_at; }
     Value effect(const Value &critical, const Value &selected = Value(), bool requested = false,
                  bool stunned = false) const {
-        std::string kind = contract.get("kind").text(), selection = selected.text("None");
+        std::string kind = contract.get(sf::kind).text(), selection = selected.text("None");
         Value result = Value::object();
         if (kind == "extinguisher") {
             if (!flag(critical, "fire"))
@@ -50,7 +50,7 @@ struct Equipment {
             const Value &devices = critical.get("devices");
             if (devices.kind != Value::Null)
                 for (const Value &v : elements(devices)) {
-                    std::string name = v.get("name").text(), state = v.get("state").text();
+                    std::string name = v.get(sf::name).text(), state = v.get("state").text();
                     if (!name.empty() && (state == "critical" || state == "destroyed"))
                         damaged.insert(name);
                 }
@@ -122,7 +122,7 @@ struct Equipment {
         return activate(now, critical);
     }
     Value poll_bot(double now, const Value &critical, bool stunned) {
-        std::string kind = contract.get("kind").text();
+        std::string kind = contract.get(sf::kind).text();
         if (kind == "extinguisher")
             return poll_auto(now, critical);
         if (kind != "repairkit" && kind != "medkit") {
@@ -178,7 +178,7 @@ inline Value equipment_passives(const std::vector<Equipment> &equipment) {
     double fire = 1, repair = 0, medkit = 0, crew = 0, power = 1, turret = 1, hp = 0;
     for (const Equipment &e : equipment) {
         const Value &c = e.contract;
-        std::string kind = c.get("kind").text();
+        std::string kind = c.get(sf::kind).text();
         if (kind == "extinguisher")
             fire *= std::max(0.0, field(c, "fireStartingChanceFactor", 1));
         else if (kind == "repairkit")

--- a/tools/ffi_experiment/kernel_factors.h
+++ b/tools/ffi_experiment/kernel_factors.h
@@ -1,0 +1,92 @@
+#ifndef OFFLINE_EXPERIMENT_KERNEL_FACTORS_H
+#define OFFLINE_EXPERIMENT_KERNEL_FACTORS_H
+#include "kernel_critical.h"
+
+namespace offline_kernel {
+struct Factors {
+    Value crew_names, crew_rows, module_specs;
+    double minimum_vision;
+    explicit Factors(const Value &v)
+        : crew_names(v.get("crew_names")), crew_rows(v.get("crew_rows")),
+          module_specs(v.get("module_specs")), minimum_vision(field(v, "minimum_vision")) {
+        if (crew_names.size() != 8)
+            throw std::invalid_argument("kernel factor roster");
+    }
+    double stat(const Value &state, const CriticalConfig &config, const std::string &name,
+                bool include_crew = true) const {
+        const Value &critical = state.get("critical");
+        if (!critical.truth())
+            return 1;
+        std::set<std::string> knocked = names(critical.get("crew_ko")),
+                              destroyed = names(critical.get("destroyed"));
+        unsigned mask = 0;
+        for (size_t i = 0; i < crew_names.size(); ++i)
+            if (knocked.count(crew_names[i].text()))
+                mask |= 1 << i;
+        double crew = 1;
+        if (include_crew && crew_rows.has(name))
+            crew = crew_rows.get(name)[mask].number();
+        const Value &spec = module_specs.get(name);
+        if (spec.kind == Value::Null)
+            return crew;
+        std::map<std::string, const Value *> records;
+        const Value &devices = critical.get("devices");
+        if (devices.kind != Value::Null)
+            for (const Value &v : elements(devices))
+                records[v.get("name").text()] = &v;
+        double factor = 1;
+        for (const Value &v : elements(spec[0])) {
+            std::string device = v.text();
+            if (destroyed.count(device)) {
+                if (spec[2].kind != Value::Null)
+                    factor *= spec[2].number();
+                continue;
+            }
+            auto at = records.find(device);
+            if (at == records.end())
+                continue;
+            const Value &record = *at->second;
+            if (record.get("state").text() == "critical" ||
+                config.condition(field(record, "hp"), device) == 1)
+                factor *= spec[1].number();
+        }
+        return crew * factor;
+    }
+    double vision(double value) const { return clamp(value, minimum_vision, 1); }
+};
+inline Value point(double x, double y, double z) {
+    Value v = Value::array();
+    v.append(Value(x));
+    v.append(Value(y));
+    v.append(Value(z));
+    return v;
+}
+inline Value position(const Value &v) { return point(field(v, "x"), field(v, "y"), field(v, "z")); }
+inline Value target_position(const Value &v) {
+    const Value &p = v.get("position");
+    return p.kind == Value::Array && p.size() == 3 ? p : position(v);
+}
+inline Value select_fields(const Value &source, const Value &keys) {
+    Value v = Value::object();
+    for (const Value &key : elements(keys)) {
+        std::string name = key.text();
+        if (source.has(name))
+            v[name] = source.get(name);
+    }
+    return v;
+}
+inline void update(Value &target, const Value &source) {
+    if (source.kind != Value::Object)
+        throw std::invalid_argument("kernel mapping update");
+    for (const auto &v : source.data->object)
+        target[v.first] = v.second;
+}
+inline double angle(double v) {
+    const double pi = 3.14159265358979323846;
+    v = std::fmod(v + pi, 2 * pi);
+    if (v < 0)
+        v += 2 * pi;
+    return v - pi;
+}
+} // namespace offline_kernel
+#endif

--- a/tools/ffi_experiment/kernel_factors.h
+++ b/tools/ffi_experiment/kernel_factors.h
@@ -14,7 +14,7 @@ struct Factors {
     }
     double stat(const Value &state, const CriticalConfig &config, const std::string &name,
                 bool include_crew = true) const {
-        const Value &critical = state.get("critical");
+        const Value &critical = state.get(sf::critical);
         if (!critical.truth())
             return 1;
         std::set<std::string> knocked = names(critical.get("crew_ko")),
@@ -33,7 +33,7 @@ struct Factors {
         const Value &devices = critical.get("devices");
         if (devices.kind != Value::Null)
             for (const Value &v : elements(devices))
-                records[v.get("name").text()] = &v;
+                records[v.get(sf::name).text()] = &v;
         double factor = 1;
         for (const Value &v : elements(spec[0])) {
             std::string device = v.text();
@@ -55,21 +55,22 @@ struct Factors {
     double vision(double value) const { return clamp(value, minimum_vision, 1); }
 };
 inline Value point(double x, double y, double z) {
-    Value v = Value::array();
+    Value v = Value::array(3);
     v.append(Value(x));
     v.append(Value(y));
     v.append(Value(z));
     return v;
 }
-inline Value position(const Value &v) { return point(field(v, "x"), field(v, "y"), field(v, "z")); }
+inline Value position(const Value &v) {
+    return point(field(v, sf::x), field(v, sf::y), field(v, sf::z));
+}
 inline Value target_position(const Value &v) {
-    const Value &p = v.get("position");
+    const Value &p = v.get(sf::position);
     return p.kind == Value::Array && p.size() == 3 ? p : position(v);
 }
-inline Value select_fields(const Value &source, const Value &keys) {
-    Value v = Value::object();
-    for (const Value &key : elements(keys)) {
-        std::string name = key.text();
+inline Value select_fields(const Value &source, const std::vector<Field> &keys) {
+    Value v = Value::record();
+    for (Field name : keys) {
         if (source.has(name))
             v[name] = source.get(name);
     }
@@ -78,8 +79,7 @@ inline Value select_fields(const Value &source, const Value &keys) {
 inline void update(Value &target, const Value &source) {
     if (source.kind != Value::Object)
         throw std::invalid_argument("kernel mapping update");
-    for (const auto &v : source.data->object)
-        target[v.first] = v.second;
+    target.assign_fields(source);
 }
 inline double angle(double v) {
     const double pi = 3.14159265358979323846;

--- a/tools/ffi_experiment/kernel_fields.h
+++ b/tools/ffi_experiment/kernel_fields.h
@@ -1,0 +1,196 @@
+#ifndef OFFLINE_EXPERIMENT_KERNEL_FIELDS_H
+#define OFFLINE_EXPERIMENT_KERNEL_FIELDS_H
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace offline_kernel {
+// State fields have compile-time slots. Irregular descriptor/ledger mappings
+// retain their string keys; configuration-supplied columns bind once at load.
+struct Field {
+    int slot;
+    const char *name;
+    size_t length;
+    constexpr Field(int slot, const char *name, size_t length = std::string::npos)
+        : slot(slot), name(name), length(length) {}
+    std::string text() const {
+        return length == std::string::npos ? std::string(name) : std::string(name, length);
+    }
+};
+// One list defines slot identities and their serialized names.
+#define OFFLINE_KERNEL_STATE_FIELDS(X)                                                             \
+    X(_drown_check)                                                                                \
+    X(_drown_time)                                                                                 \
+    X(_drowned)                                                                                    \
+    X(_drowning)                                                                                   \
+    X(_kernel)                                                                                     \
+    X(_kernel_turn_speed)                                                                          \
+    X(_motion_stall_log)                                                                           \
+    X(_motion_stall_pending)                                                                       \
+    X(_overturn_check)                                                                             \
+    X(_overturn_level)                                                                             \
+    X(_overturn_time)                                                                              \
+    X(_overturned)                                                                                 \
+    X(_radio_ground_goal)                                                                          \
+    X(_ram_contact_bot_state)                                                                      \
+    X(_route_lane_desired)                                                                         \
+    X(_route_lane_forward)                                                                         \
+    X(_route_lane_gate)                                                                            \
+    X(_route_lane_goal)                                                                            \
+    X(_route_lane_group)                                                                           \
+    X(_route_lane_offset)                                                                          \
+    X(_route_lane_origin)                                                                          \
+    X(_route_lane_row)                                                                             \
+    X(_route_lane_row_desired)                                                                     \
+    X(_route_lane_segment)                                                                         \
+    X(_siege_intent)                                                                               \
+    X(_siege_intent_elapsed)                                                                       \
+    X(_siege_time_left)                                                                            \
+    X(_siege_transition_total)                                                                     \
+    X(_stun_until_equipment_time)                                                                  \
+    X(_water_depth)                                                                                \
+    X(aim_yaw)                                                                                     \
+    X(air_lateral_x)                                                                               \
+    X(air_lateral_z)                                                                               \
+    X(airborne)                                                                                    \
+    X(alive)                                                                                       \
+    X(ammo_reload_pending)                                                                         \
+    X(ammo_remaining)                                                                              \
+    X(burst_active)                                                                                \
+    X(burst_count)                                                                                 \
+    X(burst_group_seq)                                                                             \
+    X(burst_index)                                                                                 \
+    X(burst_interval)                                                                              \
+    X(burst_next_index)                                                                            \
+    X(burst_shell_index)                                                                           \
+    X(burst_time_left)                                                                             \
+    X(cap)                                                                                         \
+    X(class_tag)                                                                                   \
+    X(clip)                                                                                        \
+    X(clip_size)                                                                                   \
+    X(collision_shape)                                                                             \
+    X(combat_ack_seq)                                                                              \
+    X(combat_base_revision)                                                                        \
+    X(combat_fire_elapsed)                                                                         \
+    X(combat_fire_timer)                                                                           \
+    X(combat_revision)                                                                             \
+    X(combat_seq)                                                                                  \
+    X(contact_armor)                                                                               \
+    X(contacts)                                                                                    \
+    X(critical)                                                                                    \
+    X(death_reason)                                                                                \
+    X(decision_horizon)                                                                            \
+    X(destructible_contact_speed)                                                                  \
+    X(display_health)                                                                              \
+    X(dt)                                                                                          \
+    X(effective_params)                                                                            \
+    X(equipment_states)                                                                            \
+    X(fire_seq)                                                                                    \
+    X(grounded_once)                                                                               \
+    X(gun_aligned)                                                                                 \
+    X(gun_pitch)                                                                                   \
+    X(half_length)                                                                                 \
+    X(half_width)                                                                                  \
+    X(health)                                                                                      \
+    X(hull_aiming)                                                                                 \
+    X(id)                                                                                          \
+    X(kind)                                                                                        \
+    X(last_drive_pitch)                                                                            \
+    X(mass)                                                                                        \
+    X(max_health)                                                                                  \
+    X(maximum)                                                                                     \
+    X(movement_dir)                                                                                \
+    X(name)                                                                                        \
+    X(navigation_stop_at_target)                                                                   \
+    X(neighbours)                                                                                  \
+    X(network_id)                                                                                  \
+    X(next_shell_index)                                                                            \
+    X(no_fire_repair)                                                                              \
+    X(now)                                                                                         \
+    X(pitch)                                                                                       \
+    X(pose_sample)                                                                                 \
+    X(position)                                                                                    \
+    X(profile)                                                                                     \
+    X(push_x)                                                                                      \
+    X(push_z)                                                                                      \
+    X(ram_contact)                                                                                 \
+    X(ram_contact_resolved_seq)                                                                    \
+    X(ram_contacts)                                                                                \
+    X(ram_profile)                                                                                 \
+    X(ram_vy)                                                                                      \
+    X(reload_duration)                                                                             \
+    X(reload_time)                                                                                 \
+    X(roll)                                                                                        \
+    X(rotation_dir)                                                                                \
+    X(route)                                                                                       \
+    X(route_anchor)                                                                                \
+    X(route_index)                                                                                 \
+    X(route_join)                                                                                  \
+    X(seconds)                                                                                     \
+    X(shell_index)                                                                                 \
+    X(shells_before_shot)                                                                          \
+    X(shot_origin)                                                                                 \
+    X(shot_pitch)                                                                                  \
+    X(shot_proof_key)                                                                              \
+    X(shot_yaw)                                                                                    \
+    X(siege_state)                                                                                 \
+    X(siege_time_left_ms)                                                                          \
+    X(siege_transition_total_ms)                                                                   \
+    X(skill_rating)                                                                                \
+    X(slide_speed)                                                                                 \
+    X(slot)                                                                                        \
+    X(speed)                                                                                       \
+    X(stopping_distance)                                                                           \
+    X(stun_end_server_time_ms)                                                                     \
+    X(suspension_pitch)                                                                            \
+    X(target_id)                                                                                   \
+    X(target_kind)                                                                                 \
+    X(team)                                                                                        \
+    X(terrain_pitch)                                                                               \
+    X(turret_yaw)                                                                                  \
+    X(vehicle)                                                                                     \
+    X(velocity)                                                                                    \
+    X(vertical_speed)                                                                              \
+    X(view_range)                                                                                  \
+    X(visible)                                                                                     \
+    X(world_pose)                                                                                  \
+    X(x)                                                                                           \
+    X(y)                                                                                           \
+    X(yaw)                                                                                         \
+    X(z)
+namespace sf {
+#define OFFLINE_FIELD_INDEX(name) index_##name,
+enum Index { OFFLINE_KERNEL_STATE_FIELDS(OFFLINE_FIELD_INDEX) count };
+#undef OFFLINE_FIELD_INDEX
+#define OFFLINE_FIELD_VALUE(name) static constexpr Field name = {index_##name, #name};
+OFFLINE_KERNEL_STATE_FIELDS(OFFLINE_FIELD_VALUE)
+#undef OFFLINE_FIELD_VALUE
+} // namespace sf
+inline const char *field_name(int slot) {
+#define OFFLINE_FIELD_NAME(name) #name,
+    static const char *const names[] = {OFFLINE_KERNEL_STATE_FIELDS(OFFLINE_FIELD_NAME)};
+#undef OFFLINE_FIELD_NAME
+    return names[slot];
+}
+#undef OFFLINE_KERNEL_STATE_FIELDS
+inline const std::string &field_string(int slot) {
+    static const std::vector<std::string> names = [] {
+        std::vector<std::string> result;
+        for (int i = 0; i < sf::count; ++i)
+            result.emplace_back(field_name(i));
+        return result;
+    }();
+    return names[slot];
+}
+inline int field_slot(const std::string &name) {
+    static const std::unordered_map<std::string, int> slots = [] {
+        std::unordered_map<std::string, int> result;
+        for (int i = 0; i < sf::count; ++i)
+            result.emplace(field_name(i), i);
+        return result;
+    }();
+    auto at = slots.find(name);
+    return at == slots.end() ? -1 : at->second;
+}
+} // namespace offline_kernel
+#endif

--- a/tools/ffi_experiment/kernel_gunnery.h
+++ b/tools/ffi_experiment/kernel_gunnery.h
@@ -119,7 +119,7 @@ inline uint32_t seed_hash(const std::string &text) {
     return h[0] & 0x7fffffffU;
 }
 inline Value vector3(double a, double b, double c) {
-    Value v = Value::array();
+    Value v = Value::array(3);
     v.append(Value(a));
     v.append(Value(b));
     v.append(Value(c));
@@ -152,26 +152,26 @@ inline Value rotate_z(const Value &v, double angle) {
                    v[2].number());
 }
 inline Value world_barrel(const Value &s) {
-    double yaw = field(s, "yaw"), pitch = field(s, "pitch"), roll = field(s, "roll");
+    double yaw = field(s, sf::yaw), pitch = field(s, sf::pitch), roll = field(s, sf::roll);
     if (std::abs(pitch) <= 1e-12 && std::abs(roll) <= 1e-12)
-        return barrel(s.has("turret_yaw") ? gun_wrap(yaw + field(s, "turret_yaw"))
-                                          : field(s, "aim_yaw", yaw),
-                      field(s, "gun_pitch"));
-    double turret =
-        s.has("turret_yaw") ? field(s, "turret_yaw") : gun_wrap(field(s, "aim_yaw", yaw) - yaw);
-    return rotate_y(rotate_x(rotate_z(barrel(turret, field(s, "gun_pitch")), roll), pitch), yaw);
+        return barrel(s.has(sf::turret_yaw) ? gun_wrap(yaw + field(s, sf::turret_yaw))
+                                            : field(s, sf::aim_yaw, yaw),
+                      field(s, sf::gun_pitch));
+    double turret = s.has(sf::turret_yaw) ? field(s, sf::turret_yaw)
+                                          : gun_wrap(field(s, sf::aim_yaw, yaw) - yaw);
+    return rotate_y(rotate_x(rotate_z(barrel(turret, field(s, sf::gun_pitch)), roll), pitch), yaw);
 }
 inline Value dispersal_base(const Value &s) {
-    return std::abs(field(s, "pitch")) <= 1e-12 && std::abs(field(s, "roll")) <= 1e-12
+    return std::abs(field(s, sf::pitch)) <= 1e-12 && std::abs(field(s, sf::roll)) <= 1e-12
                ? Value()
                : world_barrel(s);
 }
 inline Value velocity(const Value &v) {
-    const Value &raw = v.get("velocity");
+    const Value &raw = v.get(sf::velocity);
     return raw.kind == Value::Array && raw.size() >= 3
                ? vector3(raw[0].number(), raw[1].number(), raw[2].number())
-               : vector3(std::sin(field(v, "yaw")) * field(v, "speed"), 0,
-                         std::cos(field(v, "yaw")) * field(v, "speed"));
+               : vector3(std::sin(field(v, sf::yaw)) * field(v, sf::speed), 0,
+                         std::cos(field(v, sf::yaw)) * field(v, sf::speed));
 }
 inline Value dispersed(int id, int round, int seq, double yaw, double pitch, double dispersion,
                        int burst = 0, int group = -1, const Value &base = Value()) {
@@ -232,27 +232,27 @@ struct Gunnery {
     explicit Gunnery(const Value &v) : config(v) {}
     static Value target_key(const Value &v) {
         Value key = Value::array();
-        key.append(Value(v.get("kind").text("bot")));
-        key.append(Value(integer(v, "network_id", integer(v, "id"))));
+        key.append(Value(v.get(sf::kind).text("bot")));
+        key.append(Value(integer(v, sf::network_id, integer(v, sf::id))));
         return key;
     }
     Value hold(const Value &state, const Value &target, double now) {
         if (target.kind != Value::Object)
             return Value();
         Value key = target_key(target);
-        int seq = integer(state, "fire_seq");
+        int seq = integer(state, sf::fire_seq);
         if (record.kind == Value::Null || record.get("key") != key) {
             record = Value::object();
             record["key"] = key;
             record["since"] = Value(now);
             record["laid_since"] = Value(now);
-            record["fire_seq"] = Value(seq);
+            record[sf::fire_seq] = Value(seq);
             record["fired"] = Value(false);
             record["epoch"] = Value();
             record["error"] = Value();
         }
-        if (integer(record, "fire_seq") != seq) {
-            record["fire_seq"] = Value(seq);
+        if (integer(record, sf::fire_seq) != seq) {
+            record[sf::fire_seq] = Value(seq);
             record["laid_since"] = Value(now);
             record["fired"] = Value(true);
         }
@@ -271,7 +271,7 @@ struct Gunnery {
             record.get("error").kind == Value::Null) {
             const Value &key = record.get("key");
             std::string seed = "bot-gunner-v1|" + std::to_string(round) + "|" +
-                               std::to_string(integer(state, "id")) + "|('" + key[0].text() +
+                               std::to_string(integer(state, sf::id)) + "|('" + key[0].text() +
                                "', " + std::to_string(key[1].exact()) + ")|" +
                                std::to_string(epoch);
             Random rng(seed_hash(seed));
@@ -290,10 +290,10 @@ struct Gunnery {
     Value aimed(const Value &state, const Value &target, double now, int round, const Gun &gun) {
         if (target.kind != Value::Object)
             return target;
-        Value e = error(state, target, now, round), p = target.get("position");
+        Value e = error(state, target, now, round), p = target.get(sf::position);
         if (p.kind != Value::Array || p.size() != 3)
-            p = vector3(field(target, "x"), field(target, "y"), field(target, "z"));
-        double dx = p[0].number() - field(state, "x"), dz = p[2].number() - field(state, "z"),
+            p = vector3(field(target, sf::x), field(target, sf::y), field(target, sf::z));
+        double dx = p[0].number() - field(state, sf::x), dz = p[2].number() - field(state, sf::z),
                horizontal = std::sqrt(dx * dx + dz * dz);
         if (horizontal <= 1)
             return target;
@@ -305,10 +305,10 @@ struct Gunnery {
                    magnitude * std::sin(field(e, "azimuth")) * field(config, "vertical_share", .45),
                scale = field(e, "lead_scale");
         Value result = target.copy(), v = velocity(target);
-        result["position"] =
+        result[sf::position] =
             vector3(p[0].number() + dz / horizontal * lateral, p[1].number() + vertical,
                     p[2].number() - dx / horizontal * lateral);
-        result["velocity"] =
+        result[sf::velocity] =
             vector3(v[0].number() * scale, v[1].number() * scale, v[2].number() * scale);
         return result;
     }

--- a/tools/ffi_experiment/kernel_gunnery.h
+++ b/tools/ffi_experiment/kernel_gunnery.h
@@ -1,0 +1,324 @@
+#ifndef OFFLINE_EXPERIMENT_KERNEL_GUNNERY_H
+#define OFFLINE_EXPERIMENT_KERNEL_GUNNERY_H
+#include "kernel_bot.h"
+#include <array>
+
+namespace offline_kernel {
+// Independent MT19937 implementation with the CPython 2.7 integer-seed and
+// 53-bit output contract. A fresh generator owns each accepted shot/aim epoch.
+struct Random {
+    std::array<uint32_t, 624> words;
+    size_t index = 624;
+    bool spare_ready = false;
+    double spare = 0;
+    explicit Random(uint32_t seed) {
+        words[0] = 19650218U;
+        for (size_t i = 1; i < 624; ++i)
+            words[i] =
+                1812433253U * (words[i - 1] ^ (words[i - 1] >> 30)) + static_cast<uint32_t>(i);
+        size_t i = 1;
+        for (size_t k = 0; k < 624; ++k) {
+            words[i] = (words[i] ^ ((words[i - 1] ^ (words[i - 1] >> 30)) * 1664525U)) + seed;
+            if (++i == 624) {
+                words[0] = words[623];
+                i = 1;
+            }
+        }
+        for (size_t k = 0; k < 623; ++k) {
+            words[i] = (words[i] ^ ((words[i - 1] ^ (words[i - 1] >> 30)) * 1566083941U)) -
+                       static_cast<uint32_t>(i);
+            if (++i == 624) {
+                words[0] = words[623];
+                i = 1;
+            }
+        }
+        words[0] = 0x80000000U;
+    }
+    uint32_t next() {
+        if (index == 624) {
+            for (size_t i = 0; i < 624; ++i) {
+                uint32_t mixed = (words[i] & 0x80000000U) | (words[(i + 1) % 624] & 0x7fffffffU);
+                words[i] = words[(i + 397) % 624] ^ (mixed >> 1) ^ ((mixed & 1) ? 0x9908b0dfU : 0);
+            }
+            index = 0;
+        }
+        uint32_t v = words[index++];
+        v ^= v >> 11;
+        v ^= (v << 7) & 0x9d2c5680U;
+        v ^= (v << 15) & 0xefc60000U;
+        return v ^ (v >> 18);
+    }
+    double random() {
+        uint32_t a = next() >> 5, b = next() >> 6;
+        return (a * 67108864.0 + b) * (1.0 / 9007199254740992.0);
+    }
+    double uniform(double a, double b) { return a + (b - a) * random(); }
+    double gauss(double mean, double sigma) {
+        double z = spare;
+        if (spare_ready)
+            spare_ready = false;
+        else {
+            double theta = random() * 6.283185307179586,
+                   radial = std::sqrt(-2.0 * std::log(1.0 - random()));
+            z = std::cos(theta) * radial;
+            spare = std::sin(theta) * radial;
+            spare_ready = true;
+        }
+        return mean + z * sigma;
+    }
+};
+inline uint32_t rotate_left(uint32_t v, unsigned n) { return (v << n) | (v >> (32 - n)); }
+// Only the first SHA-1 word is used by the source seed contract.
+inline uint32_t seed_hash(const std::string &text) {
+    std::vector<unsigned char> bytes(text.begin(), text.end());
+    uint64_t bits = static_cast<uint64_t>(bytes.size()) * 8;
+    bytes.push_back(128);
+    while (bytes.size() % 64 != 56)
+        bytes.push_back(0);
+    for (int i = 7; i >= 0; --i)
+        bytes.push_back(static_cast<unsigned char>(bits >> (i * 8)));
+    std::array<uint32_t, 5> h = {{0x67452301U, 0xefcdab89U, 0x98badcfeU, 0x10325476U, 0xc3d2e1f0U}};
+    for (size_t offset = 0; offset < bytes.size(); offset += 64) {
+        std::array<uint32_t, 80> w;
+        for (size_t i = 0; i < 16; ++i) {
+            w[i] = 0;
+            for (size_t j = 0; j < 4; ++j)
+                w[i] = (w[i] << 8) | bytes[offset + 4 * i + j];
+        }
+        for (size_t i = 16; i < 80; ++i)
+            w[i] = rotate_left(w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16], 1);
+        uint32_t a = h[0], b = h[1], c = h[2], d = h[3], e = h[4];
+        for (size_t i = 0; i < 80; ++i) {
+            uint32_t f, k;
+            if (i < 20) {
+                f = (b & c) | ((~b) & d);
+                k = 0x5a827999U;
+            } else if (i < 40) {
+                f = b ^ c ^ d;
+                k = 0x6ed9eba1U;
+            } else if (i < 60) {
+                f = (b & c) | (b & d) | (c & d);
+                k = 0x8f1bbcdcU;
+            } else {
+                f = b ^ c ^ d;
+                k = 0xca62c1d6U;
+            }
+            uint32_t t = rotate_left(a, 5) + f + e + k + w[i];
+            e = d;
+            d = c;
+            c = rotate_left(b, 30);
+            b = a;
+            a = t;
+        }
+        h[0] += a;
+        h[1] += b;
+        h[2] += c;
+        h[3] += d;
+        h[4] += e;
+    }
+    return h[0] & 0x7fffffffU;
+}
+inline Value vector3(double a, double b, double c) {
+    Value v = Value::array();
+    v.append(Value(a));
+    v.append(Value(b));
+    v.append(Value(c));
+    return v;
+}
+inline double gun_wrap(double v) {
+    while (v > 3.141592653589793)
+        v -= 6.283185307179586;
+    while (v < -3.141592653589793)
+        v += 6.283185307179586;
+    return v;
+}
+inline Value barrel(double yaw, double pitch) {
+    return vector3(std::sin(yaw) * std::cos(pitch), -std::sin(pitch),
+                   std::cos(yaw) * std::cos(pitch));
+}
+inline Value rotate_x(const Value &v, double angle) {
+    double s = std::sin(angle), c = std::cos(angle);
+    return vector3(v[0].number(), c * v[1].number() - s * v[2].number(),
+                   s * v[1].number() + c * v[2].number());
+}
+inline Value rotate_y(const Value &v, double angle) {
+    double s = std::sin(angle), c = std::cos(angle);
+    return vector3(c * v[0].number() + s * v[2].number(), v[1].number(),
+                   -s * v[0].number() + c * v[2].number());
+}
+inline Value rotate_z(const Value &v, double angle) {
+    double s = std::sin(angle), c = std::cos(angle);
+    return vector3(c * v[0].number() - s * v[1].number(), s * v[0].number() + c * v[1].number(),
+                   v[2].number());
+}
+inline Value world_barrel(const Value &s) {
+    double yaw = field(s, "yaw"), pitch = field(s, "pitch"), roll = field(s, "roll");
+    if (std::abs(pitch) <= 1e-12 && std::abs(roll) <= 1e-12)
+        return barrel(s.has("turret_yaw") ? gun_wrap(yaw + field(s, "turret_yaw"))
+                                          : field(s, "aim_yaw", yaw),
+                      field(s, "gun_pitch"));
+    double turret =
+        s.has("turret_yaw") ? field(s, "turret_yaw") : gun_wrap(field(s, "aim_yaw", yaw) - yaw);
+    return rotate_y(rotate_x(rotate_z(barrel(turret, field(s, "gun_pitch")), roll), pitch), yaw);
+}
+inline Value dispersal_base(const Value &s) {
+    return std::abs(field(s, "pitch")) <= 1e-12 && std::abs(field(s, "roll")) <= 1e-12
+               ? Value()
+               : world_barrel(s);
+}
+inline Value velocity(const Value &v) {
+    const Value &raw = v.get("velocity");
+    return raw.kind == Value::Array && raw.size() >= 3
+               ? vector3(raw[0].number(), raw[1].number(), raw[2].number())
+               : vector3(std::sin(field(v, "yaw")) * field(v, "speed"), 0,
+                         std::cos(field(v, "yaw")) * field(v, "speed"));
+}
+inline Value dispersed(int id, int round, int seq, double yaw, double pitch, double dispersion,
+                       int burst = 0, int group = -1, const Value &base = Value()) {
+    if (!std::isfinite(dispersion) || dispersion <= 0)
+        throw std::invalid_argument("kernel shot dispersion");
+    std::array<double, 3> d = {
+        {std::sin(yaw) * std::cos(pitch), -std::sin(pitch), std::cos(yaw) * std::cos(pitch)}};
+    if (base.kind != Value::Null) {
+        if (base.kind != Value::Array || base.size() != 3)
+            throw std::invalid_argument("kernel barrel direction");
+        double length = 0;
+        for (size_t i = 0; i < 3; ++i) {
+            d[i] = base[i].number();
+            if (!std::isfinite(d[i]))
+                throw std::invalid_argument("kernel barrel direction");
+            length += d[i] * d[i];
+        }
+        length = std::sqrt(length);
+        if (length <= 1e-12)
+            throw std::invalid_argument("kernel barrel direction");
+        for (double &v : d)
+            v /= length;
+    }
+    uint64_t seed = (static_cast<uint64_t>(round & 0xffff) * 1000003 +
+                     static_cast<uint64_t>(id & 0xffff) * 9176 +
+                     static_cast<uint64_t>((group < 0 ? seq : group) & 0x7fffffff) * 6113 +
+                     static_cast<uint64_t>(burst & 0xffff) * 3571) &
+                    0x7fffffff;
+    Random rng(static_cast<uint32_t>(seed));
+    double radius = std::abs(rng.gauss(0, dispersion / 2));
+    if (radius > dispersion)
+        radius = dispersion * rng.uniform(0, 1);
+    double azimuth = rng.uniform(0, 6.283185307179586);
+    std::array<double, 3> reference = {{0, 0, 0}};
+    reference[std::abs(d[0]) <= std::abs(d[1]) && std::abs(d[0]) <= std::abs(d[2]) ? 0
+              : std::abs(d[1]) <= std::abs(d[2])                                   ? 1
+                                                                                   : 2] = 1;
+    auto cross = [](const std::array<double, 3> &a, const std::array<double, 3> &b) {
+        return std::array<double, 3>{
+            {a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0]}};
+    };
+    auto tangent = cross(d, reference);
+    double norm =
+        std::sqrt(tangent[0] * tangent[0] + tangent[1] * tangent[1] + tangent[2] * tangent[2]);
+    for (double &v : tangent)
+        v /= norm;
+    auto up = cross(d, tangent);
+    for (size_t i = 0; i < 3; ++i)
+        d[i] = d[i] * std::cos(radius) +
+               (tangent[i] * std::cos(azimuth) + up[i] * std::sin(azimuth)) * std::sin(radius);
+    Value result = Value::array();
+    result.append(Value(std::atan2(d[0], d[2])));
+    result.append(Value(std::atan2(d[1], std::max(1e-9, std::sqrt(d[0] * d[0] + d[2] * d[2])))));
+    return result;
+}
+struct Gunnery {
+    Value config, record;
+    explicit Gunnery(const Value &v) : config(v) {}
+    static Value target_key(const Value &v) {
+        Value key = Value::array();
+        key.append(Value(v.get("kind").text("bot")));
+        key.append(Value(integer(v, "network_id", integer(v, "id"))));
+        return key;
+    }
+    Value hold(const Value &state, const Value &target, double now) {
+        if (target.kind != Value::Object)
+            return Value();
+        Value key = target_key(target);
+        int seq = integer(state, "fire_seq");
+        if (record.kind == Value::Null || record.get("key") != key) {
+            record = Value::object();
+            record["key"] = key;
+            record["since"] = Value(now);
+            record["laid_since"] = Value(now);
+            record["fire_seq"] = Value(seq);
+            record["fired"] = Value(false);
+            record["epoch"] = Value();
+            record["error"] = Value();
+        }
+        if (integer(record, "fire_seq") != seq) {
+            record["fire_seq"] = Value(seq);
+            record["laid_since"] = Value(now);
+            record["fired"] = Value(true);
+        }
+        Value result = Value::array();
+        result.append(Value(std::max(0.0, now - field(record, "since"))));
+        result.append(Value(std::max(0.0, now - field(record, "laid_since"))));
+        result.append(Value(!flag(record, "fired")));
+        return result;
+    }
+    Value error(const Value &state, const Value &target, double now, int round) {
+        Value held = hold(state, target, now);
+        if (held.kind == Value::Null)
+            return Value();
+        int epoch = static_cast<int>(held[0].number() / field(config, "epoch_seconds", 1.5));
+        if (record.get("epoch").kind == Value::Null || integer(record, "epoch") != epoch ||
+            record.get("error").kind == Value::Null) {
+            const Value &key = record.get("key");
+            std::string seed = "bot-gunner-v1|" + std::to_string(round) + "|" +
+                               std::to_string(integer(state, "id")) + "|('" + key[0].text() +
+                               "', " + std::to_string(key[1].exact()) + ")|" +
+                               std::to_string(epoch);
+            Random rng(seed_hash(seed));
+            double radius = std::abs(rng.gauss(0, .5));
+            if (radius > 1)
+                radius = rng.random();
+            Value result = Value::object();
+            result["radius"] = Value(radius);
+            result["azimuth"] = Value(rng.uniform(0, 6.283185307179586));
+            result["lead_scale"] = Value(1 + rng.uniform(-1, 1) * field(config, "lead_error"));
+            record["epoch"] = Value(epoch);
+            record["error"] = result;
+        }
+        return record.get("error");
+    }
+    Value aimed(const Value &state, const Value &target, double now, int round, const Gun &gun) {
+        if (target.kind != Value::Object)
+            return target;
+        Value e = error(state, target, now, round), p = target.get("position");
+        if (p.kind != Value::Array || p.size() != 3)
+            p = vector3(field(target, "x"), field(target, "y"), field(target, "z"));
+        double dx = p[0].number() - field(state, "x"), dz = p[2].number() - field(state, "z"),
+               horizontal = std::sqrt(dx * dx + dz * dz);
+        if (horizontal <= 1)
+            return target;
+        double magnitude = std::min(field(config, "maximum_offset", 8),
+                                    field(config, "aim_bias_factor") * gun.fully_aimed *
+                                        horizontal * field(e, "radius"));
+        double lateral = magnitude * std::cos(field(e, "azimuth")),
+               vertical =
+                   magnitude * std::sin(field(e, "azimuth")) * field(config, "vertical_share", .45),
+               scale = field(e, "lead_scale");
+        Value result = target.copy(), v = velocity(target);
+        result["position"] =
+            vector3(p[0].number() + dz / horizontal * lateral, p[1].number() + vertical,
+                    p[2].number() - dx / horizontal * lateral);
+        result["velocity"] =
+            vector3(v[0].number() * scale, v[1].number() * scale, v[2].number() * scale);
+        return result;
+    }
+    bool ready(const Value &state, const Value &target, double now, const Gun &gun) {
+        Value held = hold(state, target, now);
+        if (held.kind == Value::Null || held[0].number() < field(config, "reaction_seconds"))
+            return false;
+        return !held[2].truth() || gun.current_factor <= field(config, "converged_factor") ||
+               held[1].number() >= field(config, "patience_seconds");
+    }
+};
+} // namespace offline_kernel
+#endif

--- a/tools/ffi_experiment/kernel_lanes.h
+++ b/tools/ffi_experiment/kernel_lanes.h
@@ -1,0 +1,359 @@
+#ifndef OFFLINE_EXPERIMENT_KERNEL_LANES_H
+#define OFFLINE_EXPERIMENT_KERNEL_LANES_H
+#include "kernel_perception.h"
+#include "kernel_engine.h"
+
+namespace offline_kernel {
+typedef std::array<int, 3> LaneKey;
+struct LaneReceipt {
+    double time;
+    bool clear;
+};
+struct Lanes {
+    Value config;
+    Perception &perception;
+    Engine &engine;
+    std::map<LaneKey, LaneReceipt> samples, incoming;
+    std::map<LaneKey, double> deadlines;
+    std::vector<LaneKey> work;
+    std::set<LaneKey> work_set;
+    std::set<TeamKey> enqueued;
+    std::array<std::vector<int>, 2> sources;
+    double cycle = 0;
+    bool has_cycle = false, has_sources = false;
+    size_t cursor = 0;
+    int incoming_budget = 0, completed = 0, deferred = 0, probes = 0;
+    Lanes(const Value &v, Perception &p, Engine &e) : config(v), perception(p), engine(e) {}
+    static LaneKey key(const Value &source, const Value &target) {
+        return LaneKey{{integer(source, "id"), Perception::kind(target), Perception::id(target)}};
+    }
+    double phase(LaneKey key) const {
+        int bucket = (std::abs(key[0]) * 31 + std::abs(key[2]) * 17 + (key[1] == 1 ? 11 : 0)) %
+                     integer(config, "phases");
+        return static_cast<double>(bucket) / field(config, "phases") * field(config, "refresh");
+    }
+    double distance_limit(const Value &source) const {
+        return field(config, source.get("profile").get("class_tag").text() == "SPG" ? "spg_distance"
+                                                                                    : "distance");
+    }
+    static double distance(const Value &source, const Value &target) {
+        Value a = position(source), b = target_position(target);
+        double dx = a[0].number() - b[0].number(), dz = a[2].number() - b[2].number();
+        return std::sqrt(dx * dx + dz * dz);
+    }
+    bool enqueue(LaneKey key, double now) {
+        auto at = deadlines.find(key);
+        if ((at != deadlines.end() && at->second == now) || work_set.count(key))
+            return false;
+        work.push_back(key);
+        work_set.insert(key);
+        return true;
+    }
+    void prepare(double now, const std::vector<int> &ordered) {
+        if (!has_cycle || cycle != now) {
+            cycle = now;
+            has_cycle = true;
+            work.clear();
+            work_set.clear();
+            enqueued.clear();
+            has_sources = false;
+            cursor = 0;
+        }
+        std::array<std::vector<int>, 2> live;
+        for (int id : ordered) {
+            const Value &s = perception.bots.at(id)->state;
+            int team = integer(s, "team");
+            if ((team == 1 || team == 2) && flag(s, "alive", true))
+                live[team - 1].push_back(id);
+        }
+        if (!has_sources || sources != live) {
+            sources = live;
+            has_sources = true;
+            for (TeamKey target : enqueued)
+                if (target[0] == 1 || target[0] == 2)
+                    for (int id : live[target[0] - 1])
+                        enqueue(LaneKey{{id, target[1], target[2]}}, now);
+        }
+        for (const auto &v : perception.team_visible)
+            if (v.second && !enqueued.count(v.first)) {
+                TeamKey target = v.first;
+                if (target[0] != 1 && target[0] != 2)
+                    continue;
+                enqueued.insert(target);
+                for (int id : live[target[0] - 1])
+                    enqueue(LaneKey{{id, target[1], target[2]}}, now);
+            }
+    }
+    Value clear(const Value &source, const Value &target, double now, bool force,
+                int *budget = nullptr, const LaneKey *provided = nullptr,
+                double cached_distance = -1) {
+        LaneKey k = provided ? *provided : key(source, target);
+        double reach = cached_distance < 0 ? distance(source, target) : cached_distance;
+        if (reach > distance_limit(source)) {
+            samples[k] = LaneReceipt{now, false};
+            return Value(false);
+        }
+        auto cached = samples.find(k);
+        if (!force && cached != samples.end() &&
+            now - cached->second.time <= field(config, "seconds") + 1e-9)
+            return Value(cached->second.clear);
+        if (budget) {
+            if (*budget <= 0)
+                return Value();
+            --*budget;
+        }
+        ++probes;
+        auto answer = engine.query(751, source, target);
+        bool clear = answer[0] != 0;
+        samples[k] = LaneReceipt{now, clear};
+        if (samples.size() > 1024) {
+            std::vector<std::pair<double, LaneKey>> oldest;
+            for (const auto &v : samples)
+                oldest.push_back({v.second.time, v.first});
+            std::stable_sort(oldest.begin(), oldest.end());
+            for (size_t i = 0; i < 256; ++i) {
+                samples.erase(oldest[i].second);
+                deadlines.erase(oldest[i].second);
+            }
+        }
+        return Value(clear);
+    }
+    bool refresh(const Value &source, const Value &target, double now, double cycle, int &budget,
+                 LaneKey key, double reach) {
+        auto deadline = deadlines.find(key);
+        if (deadline != deadlines.end() && deadline->second == cycle)
+            return false;
+        double start = cycle - field(config, "refresh");
+        auto cached = samples.find(key);
+        if (cached != samples.end() && cached->second.time > start + 1e-9) {
+            deadlines[key] = cycle;
+            ++completed;
+            return false;
+        }
+        if (now + 1e-9 < start + phase(key))
+            return false;
+        Value value = clear(source, target, now, true, &budget, &key, reach);
+        if (value.kind == Value::Null) {
+            ++deferred;
+            return false;
+        }
+        deadlines[key] = cycle;
+        ++completed;
+        return true;
+    }
+    bool live(LaneKey key, Value &source, size_t &target_index, TeamKey &tk) {
+        auto s = perception.bots.find(key[0]);
+        if (s == perception.bots.end() || !flag(s->second->state, "alive", true))
+            return false;
+        source = s->second->state;
+        int team = integer(source, "team");
+        auto at = perception.indices.find(ActorKey{{key[1], key[2]}});
+        if (at == perception.indices.end())
+            return false;
+        target_index = at->second;
+        const Value &t = perception.roster[target_index].raw;
+        if (!flag(t, "alive", true) || integer(t, "team") == team)
+            return false;
+        tk = TeamKey{{team, key[1], key[2]}};
+        return true;
+    }
+    int service(double now, double cycle, const std::vector<int> &ordered,
+                const std::set<int> &processed, const std::map<LaneKey, int> &priorities,
+                int &budget) {
+        prepare(cycle, ordered);
+        if (work_set.empty())
+            return 0;
+        int maximum = std::max(0, budget), materialized = 0;
+        double start = cycle - field(config, "refresh");
+        std::set<LaneKey> attempted;
+        auto attempt = [&](LaneKey key) {
+            if (attempted.count(key) || !work_set.count(key))
+                return;
+            attempted.insert(key);
+            auto completed_at = deadlines.find(key);
+            if (completed_at != deadlines.end() && completed_at->second == cycle) {
+                work_set.erase(key);
+                return;
+            }
+            Value source;
+            size_t index = 0;
+            TeamKey tk;
+            if (!live(key, source, index, tk)) {
+                work_set.erase(key);
+                return;
+            }
+            if (!perception.team_visible[tk])
+                return;
+            auto cached = samples.find(key);
+            if (cached != samples.end() && cached->second.time > start + 1e-9) {
+                deadlines[key] = cycle;
+                ++completed;
+                work_set.erase(key);
+                return;
+            }
+            if (now + 1e-9 < start + phase(key))
+                return;
+            double reach = distance(source, perception.roster[index].raw);
+            bool incoming_due = incoming_budget && flag(config, "has_incoming");
+            if (reach > distance_limit(source) && !incoming_due) {
+                samples[key] = LaneReceipt{now, false};
+                deadlines[key] = cycle;
+                ++completed;
+                work_set.erase(key);
+                return;
+            }
+            if (materialized >= maximum)
+                return;
+            Value target = perception.target(index, key[1] == 0 && processed.count(key[2]));
+            if (key != Lanes::key(source, target)) {
+                work_set.erase(key);
+                return;
+            }
+            if (incoming_due) {
+                --incoming_budget;
+                ++probes;
+                auto result = engine.query(752, source, target);
+                if (result[0] != 0)
+                    incoming[key] = LaneReceipt{now, result[1] != 0};
+            }
+            ++materialized;
+            refresh(source, target, now, cycle, budget, key, reach);
+            if (deadlines.count(key) && deadlines.at(key) == cycle)
+                work_set.erase(key);
+        };
+        std::vector<std::pair<int, LaneKey>> selected;
+        for (const auto &v : priorities)
+            if (work_set.count(v.first))
+                selected.push_back({v.second, v.first});
+        std::sort(selected.begin(), selected.end());
+        for (const auto &v : selected) {
+            if (materialized >= maximum)
+                break;
+            attempt(v.second);
+        }
+        if (!work.empty()) {
+            size_t start_at = cursor % work.size(), checked = 0;
+            while (checked < work.size() && materialized < maximum) {
+                attempt(work[(start_at + checked) % work.size()]);
+                ++checked;
+            }
+            cursor = (start_at + checked) % work.size();
+        }
+        if (work.size() > std::max<size_t>(64, work_set.size() * 2)) {
+            work.erase(std::remove_if(work.begin(), work.end(),
+                                      [&](LaneKey k) { return !work_set.count(k); }),
+                       work.end());
+            cursor = work.empty() ? 0 : cursor % work.size();
+        }
+        int pending = 0;
+        for (LaneKey key : work_set) {
+            Value source;
+            size_t index = 0;
+            TeamKey tk;
+            if (!live(key, source, index, tk) || !perception.team_visible[tk])
+                continue;
+            ++pending;
+            if (materialized < maximum || attempted.count(key) || now + 1e-9 < start + phase(key))
+                continue;
+            auto cached = samples.find(key);
+            if (cached != samples.end() && cached->second.time > start + 1e-9)
+                continue;
+            if (distance(source, perception.roster[index].raw) <= distance_limit(source))
+                ++deferred;
+        }
+        return pending;
+    }
+    void merge(double now) {
+        double age = field(config, "refresh") + field(config, "control") + 1e-9;
+        for (const auto &v : samples) {
+            auto source = perception.bots.find(v.first[0]);
+            if (source == perception.bots.end() || !flag(source->second->state, "alive", true) ||
+                !v.second.clear || now - v.second.time > age)
+                continue;
+            TeamKey key = {{integer(source->second->state, "team"), v.first[1], v.first[2]}};
+            auto at = perception.observations.find(key);
+            if (perception.team_visible[key] && at != perception.observations.end())
+                at->second.shootable.insert(v.first[0]);
+        }
+    }
+    Value pack(double now) {
+        std::map<TeamKey, std::set<int>> threats;
+        double age = field(config, "refresh") + field(config, "control");
+        for (auto at = incoming.begin(); at != incoming.end();) {
+            auto source = perception.bots.find(at->first[0]);
+            if (source == perception.bots.end() || !flag(source->second->state, "alive", true) ||
+                now - at->second.time > age) {
+                at = incoming.erase(at);
+                continue;
+            }
+            if (at->second.clear)
+                threats[TeamKey{
+                            {integer(source->second->state, "team"), at->first[1], at->first[2]}}]
+                    .insert(at->first[0]);
+            ++at;
+        }
+        for (const auto &v : samples) {
+            LaneKey key = v.first;
+            if (key[1] != 0 || !v.second.clear || now - v.second.time > age)
+                continue;
+            auto e = perception.bots.find(key[0]), o = perception.bots.find(key[2]);
+            if (e == perception.bots.end() || o == perception.bots.end())
+                continue;
+            const Value &enemy = e->second->state, &own = o->second->state;
+            if (!flag(enemy, "alive", true) || !flag(own, "alive", true) ||
+                integer(enemy, "team") == integer(own, "team") ||
+                enemy.get("profile").get("class_tag").text() == "SPG")
+                continue;
+            TeamKey tk = {{integer(own, "team"), 0, key[0]}};
+            if (perception.observations.count(tk))
+                threats[tk].insert(key[2]);
+        }
+        Value out = Value::array();
+        for (auto &v : perception.observations) {
+            TeamKey key = v.first;
+            Observation &o = v.second;
+            double left = perception.remaining(key, now);
+            bool visible = left > 0;
+            auto pose = perception.remembered.find(key);
+            if (visible && pose == perception.remembered.end()) {
+                visible = false;
+                left = 0;
+            } else if (visible)
+                update(o.target, pose->second);
+            bool fresh = visible && (!o.humans.empty() || !o.bots.empty());
+            Value row = Value::object();
+            row["observing_team"] = Value(key[0]);
+            row["target_kind"] = Value(key[1] == 1 ? "human" : "bot");
+            row["target_id"] = Value(key[2]);
+            row["target_team"] = Value(integer(o.target, "team"));
+            row["visible"] = Value(visible);
+            row["fresh"] = Value(fresh);
+            row["time_left"] = Value(rounded(visible ? left : 0, 6));
+            auto ids = [](const std::set<int> &ids, bool allowed) {
+                Value out = Value::array();
+                if (allowed)
+                    for (int id : ids)
+                        out.append(Value(id));
+                return out;
+            };
+            row["visible_by_player_ids"] = ids(o.humans, visible);
+            row["visible_by_bot_ids"] = ids(o.bots, visible);
+            row["shootable_by_bot_ids"] = ids(o.shootable, fresh);
+            row["threatened_bot_ids"] = ids(threats[key], fresh);
+            for (const char *name : {"x", "y", "z"})
+                row[name] = Value(field(o.target, name));
+            row["health"] = Value(std::max(0, integer(o.target, "health", 1)));
+            row["max_health"] = Value(std::max(1, integer(o.target, "max_health", 1)));
+            row["class_tag"] =
+                o.target.has("class_tag")
+                    ? o.target.get("class_tag")
+                    : Value(o.target.get("profile").get("class_tag").text("unknown"));
+            row["armor"] = Value(
+                std::max(0.0, field(o.target, "armor", field(o.target.get("profile"), "armor"))));
+            out.append(row);
+        }
+        return out;
+    }
+};
+} // namespace offline_kernel
+#endif

--- a/tools/ffi_experiment/kernel_lanes.h
+++ b/tools/ffi_experiment/kernel_lanes.h
@@ -25,7 +25,7 @@ struct Lanes {
     int incoming_budget = 0, completed = 0, deferred = 0, probes = 0;
     Lanes(const Value &v, Perception &p, Engine &e) : config(v), perception(p), engine(e) {}
     static LaneKey key(const Value &source, const Value &target) {
-        return LaneKey{{integer(source, "id"), Perception::kind(target), Perception::id(target)}};
+        return LaneKey{{integer(source, sf::id), Perception::kind(target), Perception::id(target)}};
     }
     double phase(LaneKey key) const {
         int bucket = (std::abs(key[0]) * 31 + std::abs(key[2]) * 17 + (key[1] == 1 ? 11 : 0)) %
@@ -33,8 +33,9 @@ struct Lanes {
         return static_cast<double>(bucket) / field(config, "phases") * field(config, "refresh");
     }
     double distance_limit(const Value &source) const {
-        return field(config, source.get("profile").get("class_tag").text() == "SPG" ? "spg_distance"
-                                                                                    : "distance");
+        return field(config, source.get(sf::profile).get(sf::class_tag).text() == "SPG"
+                                 ? "spg_distance"
+                                 : "distance");
     }
     static double distance(const Value &source, const Value &target) {
         Value a = position(source), b = target_position(target);
@@ -62,8 +63,8 @@ struct Lanes {
         std::array<std::vector<int>, 2> live;
         for (int id : ordered) {
             const Value &s = perception.bots.at(id)->state;
-            int team = integer(s, "team");
-            if ((team == 1 || team == 2) && flag(s, "alive", true))
+            int team = integer(s, sf::team);
+            if ((team == 1 || team == 2) && flag(s, sf::alive, true))
                 live[team - 1].push_back(id);
         }
         if (!has_sources || sources != live) {
@@ -95,7 +96,7 @@ struct Lanes {
         }
         auto cached = samples.find(k);
         if (!force && cached != samples.end() &&
-            now - cached->second.time <= field(config, "seconds") + 1e-9)
+            now - cached->second.time <= field(config, sf::seconds) + 1e-9)
             return Value(cached->second.clear);
         if (budget) {
             if (*budget <= 0)
@@ -143,16 +144,16 @@ struct Lanes {
     }
     bool live(LaneKey key, Value &source, size_t &target_index, TeamKey &tk) {
         auto s = perception.bots.find(key[0]);
-        if (s == perception.bots.end() || !flag(s->second->state, "alive", true))
+        if (s == perception.bots.end() || !flag(s->second->state, sf::alive, true))
             return false;
         source = s->second->state;
-        int team = integer(source, "team");
+        int team = integer(source, sf::team);
         auto at = perception.indices.find(ActorKey{{key[1], key[2]}});
         if (at == perception.indices.end())
             return false;
         target_index = at->second;
         const Value &t = perception.roster[target_index].raw;
-        if (!flag(t, "alive", true) || integer(t, "team") == team)
+        if (!flag(t, sf::alive, true) || integer(t, sf::team) == team)
             return false;
         tk = TeamKey{{team, key[1], key[2]}};
         return true;
@@ -267,10 +268,10 @@ struct Lanes {
         double age = field(config, "refresh") + field(config, "control") + 1e-9;
         for (const auto &v : samples) {
             auto source = perception.bots.find(v.first[0]);
-            if (source == perception.bots.end() || !flag(source->second->state, "alive", true) ||
+            if (source == perception.bots.end() || !flag(source->second->state, sf::alive, true) ||
                 !v.second.clear || now - v.second.time > age)
                 continue;
-            TeamKey key = {{integer(source->second->state, "team"), v.first[1], v.first[2]}};
+            TeamKey key = {{integer(source->second->state, sf::team), v.first[1], v.first[2]}};
             auto at = perception.observations.find(key);
             if (perception.team_visible[key] && at != perception.observations.end())
                 at->second.shootable.insert(v.first[0]);
@@ -281,14 +282,14 @@ struct Lanes {
         double age = field(config, "refresh") + field(config, "control");
         for (auto at = incoming.begin(); at != incoming.end();) {
             auto source = perception.bots.find(at->first[0]);
-            if (source == perception.bots.end() || !flag(source->second->state, "alive", true) ||
+            if (source == perception.bots.end() || !flag(source->second->state, sf::alive, true) ||
                 now - at->second.time > age) {
                 at = incoming.erase(at);
                 continue;
             }
             if (at->second.clear)
                 threats[TeamKey{
-                            {integer(source->second->state, "team"), at->first[1], at->first[2]}}]
+                            {integer(source->second->state, sf::team), at->first[1], at->first[2]}}]
                     .insert(at->first[0]);
             ++at;
         }
@@ -300,11 +301,11 @@ struct Lanes {
             if (e == perception.bots.end() || o == perception.bots.end())
                 continue;
             const Value &enemy = e->second->state, &own = o->second->state;
-            if (!flag(enemy, "alive", true) || !flag(own, "alive", true) ||
-                integer(enemy, "team") == integer(own, "team") ||
-                enemy.get("profile").get("class_tag").text() == "SPG")
+            if (!flag(enemy, sf::alive, true) || !flag(own, sf::alive, true) ||
+                integer(enemy, sf::team) == integer(own, sf::team) ||
+                enemy.get(sf::profile).get(sf::class_tag).text() == "SPG")
                 continue;
-            TeamKey tk = {{integer(own, "team"), 0, key[0]}};
+            TeamKey tk = {{integer(own, sf::team), 0, key[0]}};
             if (perception.observations.count(tk))
                 threats[tk].insert(key[2]);
         }
@@ -323,10 +324,10 @@ struct Lanes {
             bool fresh = visible && (!o.humans.empty() || !o.bots.empty());
             Value row = Value::object();
             row["observing_team"] = Value(key[0]);
-            row["target_kind"] = Value(key[1] == 1 ? "human" : "bot");
-            row["target_id"] = Value(key[2]);
-            row["target_team"] = Value(integer(o.target, "team"));
-            row["visible"] = Value(visible);
+            row[sf::target_kind] = Value(key[1] == 1 ? "human" : "bot");
+            row[sf::target_id] = Value(key[2]);
+            row["target_team"] = Value(integer(o.target, sf::team));
+            row[sf::visible] = Value(visible);
             row["fresh"] = Value(fresh);
             row["time_left"] = Value(rounded(visible ? left : 0, 6));
             auto ids = [](const std::set<int> &ids, bool allowed) {
@@ -342,14 +343,14 @@ struct Lanes {
             row["threatened_bot_ids"] = ids(threats[key], fresh);
             for (const char *name : {"x", "y", "z"})
                 row[name] = Value(field(o.target, name));
-            row["health"] = Value(std::max(0, integer(o.target, "health", 1)));
-            row["max_health"] = Value(std::max(1, integer(o.target, "max_health", 1)));
-            row["class_tag"] =
-                o.target.has("class_tag")
-                    ? o.target.get("class_tag")
-                    : Value(o.target.get("profile").get("class_tag").text("unknown"));
+            row[sf::health] = Value(std::max(0, integer(o.target, sf::health, 1)));
+            row[sf::max_health] = Value(std::max(1, integer(o.target, sf::max_health, 1)));
+            row[sf::class_tag] =
+                o.target.has(sf::class_tag)
+                    ? o.target.get(sf::class_tag)
+                    : Value(o.target.get(sf::profile).get(sf::class_tag).text("unknown"));
             row["armor"] = Value(
-                std::max(0.0, field(o.target, "armor", field(o.target.get("profile"), "armor"))));
+                std::max(0.0, field(o.target, "armor", field(o.target.get(sf::profile), "armor"))));
             out.append(row);
         }
         return out;

--- a/tools/ffi_experiment/kernel_launch.h
+++ b/tools/ffi_experiment/kernel_launch.h
@@ -6,32 +6,32 @@
 namespace offline_kernel {
 inline void publish_ammo(Bot &bot) {
     Value &s = bot.state;
-    s["shell_index"] = Value(bot.ammo.loaded);
-    s["next_shell_index"] = Value(bot.ammo.next);
-    s["ammo_reload_pending"] = Value(bot.ammo.reload_pending);
+    s[sf::shell_index] = Value(bot.ammo.loaded);
+    s[sf::next_shell_index] = Value(bot.ammo.next);
+    s[sf::ammo_reload_pending] = Value(bot.ammo.reload_pending);
     Value q = Value::array();
     for (int n : bot.ammo.quantities)
         q.append(Value(n));
-    s["ammo_remaining"] = q;
+    s[sf::ammo_remaining] = q;
 }
 inline void publish_burst(Bot &bot) {
     Value &s = bot.state;
     const Burst &b = bot.burst;
-    s["burst_active"] = Value(b.active);
-    s["burst_group_seq"] = Value(b.group);
-    s["burst_count"] = Value(b.count);
-    s["burst_next_index"] = Value(b.next);
-    s["burst_interval"] = Value(rounded(b.interval, 6));
-    s["burst_time_left"] = Value(rounded(std::max(0.0, b.left), 6));
-    s["burst_shell_index"] = Value(b.shell);
+    s[sf::burst_active] = Value(b.active);
+    s[sf::burst_group_seq] = Value(b.group);
+    s[sf::burst_count] = Value(b.count);
+    s[sf::burst_next_index] = Value(b.next);
+    s[sf::burst_interval] = Value(rounded(b.interval, 6));
+    s[sf::burst_time_left] = Value(rounded(std::max(0.0, b.left), 6));
+    s[sf::burst_shell_index] = Value(b.shell);
 }
 inline void publish_reload(Bot &bot, double factor) {
-    bot.state["clip"] = Value(bot.gun.clip);
-    bot.state["reload_time"] = Value(bot.gun.remaining(factor));
-    bot.state["reload_duration"] = Value(bot.gun.duration(factor));
+    bot.state[sf::clip] = Value(bot.gun.clip);
+    bot.state[sf::reload_time] = Value(bot.gun.remaining(factor));
+    bot.state[sf::reload_duration] = Value(bot.gun.duration(factor));
 }
 inline Value launch_record(const Value &s, int64_t time) {
-    if (!s.has("shot_yaw") || !s.has("shot_pitch") || time < 0)
+    if (!s.has(sf::shot_yaw) || !s.has(sf::shot_pitch) || time < 0)
         return Value();
     Value row = Value::object(), pose = Value::array();
     for (const char *name : {"x", "y", "z", "yaw", "pitch", "roll"}) {
@@ -44,11 +44,11 @@ inline Value launch_record(const Value &s, int64_t time) {
         row[name] = Value(integer(s, name));
     for (const char *name : {"shot_yaw", "shot_pitch"})
         row[name] = s.get(name);
-    std::string type = s.get("profile").get("class_tag").text();
-    row["class_tag"] = Value(type);
-    row["burst_group_seq"] = Value(integer(s, "burst_group_seq", integer(s, "fire_seq")));
-    row["burst_index"] = Value(integer(s, "burst_index"));
-    row["burst_count"] = Value(integer(s, "burst_count", 1));
+    std::string type = s.get(sf::profile).get(sf::class_tag).text();
+    row[sf::class_tag] = Value(type);
+    row[sf::burst_group_seq] = Value(integer(s, sf::burst_group_seq, integer(s, sf::fire_seq)));
+    row[sf::burst_index] = Value(integer(s, sf::burst_index));
+    row[sf::burst_count] = Value(integer(s, sf::burst_count, 1));
     row["launch_time_us"] = Value(time);
     row["launch_pose"] = pose;
     for (const char *name : {"shot_origin", "shells_before_shot"})
@@ -66,7 +66,7 @@ struct Launches {
     std::map<std::pair<int, int>, Value> keys;
     std::map<int, std::vector<std::pair<int, int>>> by_bot;
     bool queue(const Value &launch) {
-        std::pair<int, int> key(integer(launch, "id"), integer(launch, "fire_seq"));
+        std::pair<int, int> key(integer(launch, sf::id), integer(launch, sf::fire_seq));
         if (key.first <= 0 || key.second <= 0)
             throw std::invalid_argument("kernel launch identity");
         auto before = keys.find(key);
@@ -88,7 +88,7 @@ struct Launches {
             return false;
         auto &rows = pending.data->array;
         auto row = std::find_if(rows.begin(), rows.end(), [&](const Value &v) {
-            return integer(v, "id") == id && integer(v, "fire_seq") == seq;
+            return integer(v, sf::id) == id && integer(v, sf::fire_seq) == seq;
         });
         if (row == rows.end())
             return false;
@@ -104,7 +104,8 @@ struct Launches {
         Gun &g = bot.gun;
         if (!b.active && g.burst_remaining <= 0)
             return false;
-        int launched = b.group > 0 ? std::max(0, integer(bot.state, "fire_seq") - b.group + 1) : 0;
+        int launched =
+            b.group > 0 ? std::max(0, integer(bot.state, sf::fire_seq) - b.group + 1) : 0;
         launched = std::min(launched, b.next);
         b.cancel(launched);
         g.cancel_burst();
@@ -114,16 +115,16 @@ struct Launches {
         return true;
     }
     static Value preview_angles(const Value &preview, int seq) {
-        if (integer(preview, "fire_seq", -1) != seq)
+        if (integer(preview, sf::fire_seq, -1) != seq)
             return Value();
         const Value &origin = preview.get("origin");
-        if (origin.kind != Value::Array || origin.size() != 3 || !preview.has("shot_yaw") ||
-            !preview.has("shot_pitch"))
+        if (origin.kind != Value::Array || origin.size() != 3 || !preview.has(sf::shot_yaw) ||
+            !preview.has(sf::shot_pitch))
             return Value();
         for (const Value &n : elements(origin))
             if (n.kind == Value::Null || !std::isfinite(n.number()))
                 return Value();
-        double yaw = field(preview, "shot_yaw"), pitch = field(preview, "shot_pitch");
+        double yaw = field(preview, sf::shot_yaw), pitch = field(preview, sf::shot_pitch);
         if (!std::isfinite(yaw) || !std::isfinite(pitch))
             return Value();
         Value result = Value::array();
@@ -137,36 +138,36 @@ struct Launches {
         Value &s = bot.state;
         Gun &g = bot.gun;
         Ammo &a = bot.ammo;
-        if (flag(s, "_drowning") || flag(s, "_overturned"))
+        if (flag(s, sf::_drowning) || flag(s, sf::_overturned))
             return false;
-        if (edge.seq != integer(s, "fire_seq") + 1 || edge.seq != edge.group + edge.index ||
+        if (edge.seq != integer(s, sf::fire_seq) + 1 || edge.seq != edge.group + edge.index ||
             edge.index < 0 || edge.index >= edge.count || edge.shell != a.loaded)
             return false;
         Value angles;
         if (receipt.kind != Value::Null) {
             if (preview.kind != Value::Null || edge.count != 1 ||
-                integer(receipt, "fire_seq", -1) != edge.seq)
+                integer(receipt, sf::fire_seq, -1) != edge.seq)
                 return false;
         } else if (preview.kind != Value::Null) {
             angles = preview_angles(preview, edge.seq);
             if (angles.kind == Value::Null)
                 return false;
         } else if (base.kind == Value::Null &&
-                   (std::abs(field(s, "pitch")) > 1e-12 || std::abs(field(s, "roll")) > 1e-12))
+                   (std::abs(field(s, sf::pitch)) > 1e-12 || std::abs(field(s, sf::roll)) > 1e-12))
             return false;
         bool continuing = edge.index > 0;
         if (!a.can_fire(continuing) || !g.fire_round(edge.final))
             return false;
         if (!a.consume(continuing))
             throw std::runtime_error("kernel atomic ammunition changed");
-        s["shells_before_shot"] =
+        s[sf::shells_before_shot] =
             Value(std::accumulate(a.quantities.begin(), a.quantities.end(), 1));
         if (edge.final && a.requires_full())
             g.require_full();
-        s["fire_seq"] = Value(edge.seq);
-        s["burst_group_seq"] = Value(edge.group);
-        s["burst_index"] = Value(edge.index);
-        s["burst_count"] = Value(edge.count);
+        s[sf::fire_seq] = Value(edge.seq);
+        s[sf::burst_group_seq] = Value(edge.group);
+        s[sf::burst_index] = Value(edge.index);
+        s[sf::burst_count] = Value(edge.count);
         for (const char *name : {"shot_origin", "shot_velocity", "shot_gravity",
                                  "shot_max_distance", "shot_max_time_ms", "shot_proof_key"})
             s.erase(name);
@@ -177,16 +178,16 @@ struct Launches {
                  {"origin", "velocity", "gravity", "max_distance", "max_time_ms", "proof_key"})
                 s[std::string("shot_") + name] = receipt.get(name);
         } else if (angles.kind != Value::Null) {
-            s["shot_yaw"] = angles[0];
-            s["shot_pitch"] = angles[1];
-            s["shot_origin"] = angles[2];
+            s[sf::shot_yaw] = angles[0];
+            s[sf::shot_pitch] = angles[1];
+            s[sf::shot_origin] = angles[2];
         } else {
-            Value ray = dispersed(integer(s, "id"), round, edge.seq, field(s, "aim_yaw"),
-                                  field(s, "gun_pitch"),
+            Value ray = dispersed(integer(s, sf::id), round, edge.seq, field(s, sf::aim_yaw),
+                                  field(s, sf::gun_pitch),
                                   std::max(g.dispersion, g.fully_aimed * dispersion_factor),
                                   edge.index, edge.group, base);
-            s["shot_yaw"] = ray[0];
-            s["shot_pitch"] = ray[1];
+            s[sf::shot_yaw] = ray[0];
+            s[sf::shot_pitch] = ray[1];
         }
         g.shot_bloom(dispersion_factor, edge.final);
         publish_reload(bot, factor);
@@ -199,7 +200,8 @@ struct Launches {
     }
     bool fire(Bot &bot, int round, double factor, double dispersion_factor, const Value &receipt,
               const Value &preview, int64_t time, const Value &base) {
-        if (flag(bot.state, "_drowning") || flag(bot.state, "_overturned") || !bot.ammo.can_fire())
+        if (flag(bot.state, sf::_drowning) || flag(bot.state, sf::_overturned) ||
+            !bot.ammo.can_fire())
             return false;
         Gun &g = bot.gun;
         Ammo &a = bot.ammo;
@@ -212,7 +214,7 @@ struct Launches {
             count = 1;
             interval = 0;
         }
-        if (!b.start(integer(bot.state, "fire_seq") + 1, count, interval, a.loaded) ||
+        if (!b.start(integer(bot.state, sf::fire_seq) + 1, count, interval, a.loaded) ||
             !g.begin_burst(count, factor)) {
             b.cancel(0);
             return false;

--- a/tools/ffi_experiment/kernel_launch.h
+++ b/tools/ffi_experiment/kernel_launch.h
@@ -1,0 +1,231 @@
+#ifndef OFFLINE_EXPERIMENT_KERNEL_LAUNCH_H
+#define OFFLINE_EXPERIMENT_KERNEL_LAUNCH_H
+#include "kernel_gunnery.h"
+#include <numeric>
+
+namespace offline_kernel {
+inline void publish_ammo(Bot &bot) {
+    Value &s = bot.state;
+    s["shell_index"] = Value(bot.ammo.loaded);
+    s["next_shell_index"] = Value(bot.ammo.next);
+    s["ammo_reload_pending"] = Value(bot.ammo.reload_pending);
+    Value q = Value::array();
+    for (int n : bot.ammo.quantities)
+        q.append(Value(n));
+    s["ammo_remaining"] = q;
+}
+inline void publish_burst(Bot &bot) {
+    Value &s = bot.state;
+    const Burst &b = bot.burst;
+    s["burst_active"] = Value(b.active);
+    s["burst_group_seq"] = Value(b.group);
+    s["burst_count"] = Value(b.count);
+    s["burst_next_index"] = Value(b.next);
+    s["burst_interval"] = Value(rounded(b.interval, 6));
+    s["burst_time_left"] = Value(rounded(std::max(0.0, b.left), 6));
+    s["burst_shell_index"] = Value(b.shell);
+}
+inline void publish_reload(Bot &bot, double factor) {
+    bot.state["clip"] = Value(bot.gun.clip);
+    bot.state["reload_time"] = Value(bot.gun.remaining(factor));
+    bot.state["reload_duration"] = Value(bot.gun.duration(factor));
+}
+inline Value launch_record(const Value &s, int64_t time) {
+    if (!s.has("shot_yaw") || !s.has("shot_pitch") || time < 0)
+        return Value();
+    Value row = Value::object(), pose = Value::array();
+    for (const char *name : {"x", "y", "z", "yaw", "pitch", "roll"}) {
+        double n = field(s, name);
+        if (!std::isfinite(n))
+            return Value();
+        pose.append(Value(n));
+    }
+    for (const char *name : {"id", "fire_seq", "shell_index"})
+        row[name] = Value(integer(s, name));
+    for (const char *name : {"shot_yaw", "shot_pitch"})
+        row[name] = s.get(name);
+    std::string type = s.get("profile").get("class_tag").text();
+    row["class_tag"] = Value(type);
+    row["burst_group_seq"] = Value(integer(s, "burst_group_seq", integer(s, "fire_seq")));
+    row["burst_index"] = Value(integer(s, "burst_index"));
+    row["burst_count"] = Value(integer(s, "burst_count", 1));
+    row["launch_time_us"] = Value(time);
+    row["launch_pose"] = pose;
+    for (const char *name : {"shot_origin", "shells_before_shot"})
+        if (s.has(name))
+            row[name] = s.get(name);
+    if (type == "SPG")
+        for (const char *name : {"shot_velocity", "shot_gravity", "shot_max_distance",
+                                 "shot_max_time_ms", "shot_proof_key"})
+            if (s.has(name))
+                row[name] = s.get(name);
+    return row;
+}
+struct Launches {
+    Value pending = Value::array();
+    std::map<std::pair<int, int>, Value> keys;
+    std::map<int, std::vector<std::pair<int, int>>> by_bot;
+    bool queue(const Value &launch) {
+        std::pair<int, int> key(integer(launch, "id"), integer(launch, "fire_seq"));
+        if (key.first <= 0 || key.second <= 0)
+            throw std::invalid_argument("kernel launch identity");
+        auto before = keys.find(key);
+        if (before != keys.end()) {
+            if (before->second != launch)
+                throw std::runtime_error("kernel launch identity changed");
+            return false;
+        }
+        Value frozen = launch.copy();
+        pending.append(frozen);
+        keys[key] = frozen;
+        by_bot[key.first].push_back(key);
+        return true;
+    }
+    bool ack(int id, int seq) {
+        std::pair<int, int> key(id, seq);
+        auto at = by_bot.find(id);
+        if (at == by_bot.end() || at->second.empty() || at->second[0] != key || !keys.count(key))
+            return false;
+        auto &rows = pending.data->array;
+        auto row = std::find_if(rows.begin(), rows.end(), [&](const Value &v) {
+            return integer(v, "id") == id && integer(v, "fire_seq") == seq;
+        });
+        if (row == rows.end())
+            return false;
+        rows.erase(row);
+        keys.erase(key);
+        at->second.erase(at->second.begin());
+        if (at->second.empty())
+            by_bot.erase(at);
+        return true;
+    }
+    static bool cancel(Bot &bot, double factor) {
+        Burst &b = bot.burst;
+        Gun &g = bot.gun;
+        if (!b.active && g.burst_remaining <= 0)
+            return false;
+        int launched = b.group > 0 ? std::max(0, integer(bot.state, "fire_seq") - b.group + 1) : 0;
+        launched = std::min(launched, b.next);
+        b.cancel(launched);
+        g.cancel_burst();
+        publish_ammo(bot);
+        publish_reload(bot, factor);
+        publish_burst(bot);
+        return true;
+    }
+    static Value preview_angles(const Value &preview, int seq) {
+        if (integer(preview, "fire_seq", -1) != seq)
+            return Value();
+        const Value &origin = preview.get("origin");
+        if (origin.kind != Value::Array || origin.size() != 3 || !preview.has("shot_yaw") ||
+            !preview.has("shot_pitch"))
+            return Value();
+        for (const Value &n : elements(origin))
+            if (n.kind == Value::Null || !std::isfinite(n.number()))
+                return Value();
+        double yaw = field(preview, "shot_yaw"), pitch = field(preview, "shot_pitch");
+        if (!std::isfinite(yaw) || !std::isfinite(pitch))
+            return Value();
+        Value result = Value::array();
+        result.append(Value(yaw));
+        result.append(Value(pitch));
+        result.append(origin);
+        return result;
+    }
+    bool commit(Bot &bot, int round, double factor, double dispersion_factor, const Subshot &edge,
+                const Value &receipt, const Value &preview, int64_t time, const Value &base) {
+        Value &s = bot.state;
+        Gun &g = bot.gun;
+        Ammo &a = bot.ammo;
+        if (flag(s, "_drowning") || flag(s, "_overturned"))
+            return false;
+        if (edge.seq != integer(s, "fire_seq") + 1 || edge.seq != edge.group + edge.index ||
+            edge.index < 0 || edge.index >= edge.count || edge.shell != a.loaded)
+            return false;
+        Value angles;
+        if (receipt.kind != Value::Null) {
+            if (preview.kind != Value::Null || edge.count != 1 ||
+                integer(receipt, "fire_seq", -1) != edge.seq)
+                return false;
+        } else if (preview.kind != Value::Null) {
+            angles = preview_angles(preview, edge.seq);
+            if (angles.kind == Value::Null)
+                return false;
+        } else if (base.kind == Value::Null &&
+                   (std::abs(field(s, "pitch")) > 1e-12 || std::abs(field(s, "roll")) > 1e-12))
+            return false;
+        bool continuing = edge.index > 0;
+        if (!a.can_fire(continuing) || !g.fire_round(edge.final))
+            return false;
+        if (!a.consume(continuing))
+            throw std::runtime_error("kernel atomic ammunition changed");
+        s["shells_before_shot"] =
+            Value(std::accumulate(a.quantities.begin(), a.quantities.end(), 1));
+        if (edge.final && a.requires_full())
+            g.require_full();
+        s["fire_seq"] = Value(edge.seq);
+        s["burst_group_seq"] = Value(edge.group);
+        s["burst_index"] = Value(edge.index);
+        s["burst_count"] = Value(edge.count);
+        for (const char *name : {"shot_origin", "shot_velocity", "shot_gravity",
+                                 "shot_max_distance", "shot_max_time_ms", "shot_proof_key"})
+            s.erase(name);
+        if (receipt.kind != Value::Null) {
+            for (const char *name : {"shot_yaw", "shot_pitch"})
+                s[name] = receipt.get(name);
+            for (const char *name :
+                 {"origin", "velocity", "gravity", "max_distance", "max_time_ms", "proof_key"})
+                s[std::string("shot_") + name] = receipt.get(name);
+        } else if (angles.kind != Value::Null) {
+            s["shot_yaw"] = angles[0];
+            s["shot_pitch"] = angles[1];
+            s["shot_origin"] = angles[2];
+        } else {
+            Value ray = dispersed(integer(s, "id"), round, edge.seq, field(s, "aim_yaw"),
+                                  field(s, "gun_pitch"),
+                                  std::max(g.dispersion, g.fully_aimed * dispersion_factor),
+                                  edge.index, edge.group, base);
+            s["shot_yaw"] = ray[0];
+            s["shot_pitch"] = ray[1];
+        }
+        g.shot_bloom(dispersion_factor, edge.final);
+        publish_reload(bot, factor);
+        publish_ammo(bot);
+        Value launch = launch_record(s, time);
+        if (launch.kind == Value::Null)
+            throw std::runtime_error("kernel launch incomplete");
+        queue(launch);
+        return true;
+    }
+    bool fire(Bot &bot, int round, double factor, double dispersion_factor, const Value &receipt,
+              const Value &preview, int64_t time, const Value &base) {
+        if (flag(bot.state, "_drowning") || flag(bot.state, "_overturned") || !bot.ammo.can_fire())
+            return false;
+        Gun &g = bot.gun;
+        Ammo &a = bot.ammo;
+        Burst &b = bot.burst;
+        int count = std::max(0, std::min(g.burst_count, std::min(a.quantities[a.loaded], g.clip)));
+        double interval = g.burst_interval;
+        if (count <= 0)
+            return false;
+        if (receipt.kind != Value::Null) {
+            count = 1;
+            interval = 0;
+        }
+        if (!b.start(integer(bot.state, "fire_seq") + 1, count, interval, a.loaded) ||
+            !g.begin_burst(count, factor)) {
+            b.cancel(0);
+            return false;
+        }
+        Subshot edge = b.advance(0).at(0);
+        if (!commit(bot, round, factor, dispersion_factor, edge, receipt, preview, time, base)) {
+            g.cancel_burst();
+            b.cancel(0);
+            return false;
+        }
+        publish_burst(bot);
+        return true;
+    }
+};
+} // namespace offline_kernel
+#endif

--- a/tools/ffi_experiment/kernel_motion.h
+++ b/tools/ffi_experiment/kernel_motion.h
@@ -3,6 +3,7 @@
 #include "kernel_engine.h"
 #include "kernel_diagnostics.h"
 #include "kernel_factors.h"
+#include "kernel_world.h"
 #include "motion_vertical.h"
 #include "navigation_flow.h"
 
@@ -157,8 +158,6 @@ struct Motion {
             ++probe_totals[3];
         if (kind == 615) {
             int id = static_cast<int>(packet[1]);
-            source = source.copy();
-            source[sf::_kernel_turn_speed] = Value(bots.at(id)->turn_speed);
             auto cache = flow.caches.find(id);
             bool corridor = false, receipt = false;
             double yaw = packet[5], speed = packet[6], dt = packet[7], now = packet[8];
@@ -180,6 +179,15 @@ struct Motion {
             }
             packet[20] = corridor;
             packet[21] = receipt;
+            const Bot &bot = *bots.at(id);
+            const Value &world = bot.config.get("motion").get("world");
+            if (world.truth()) {
+                WorldResolver resolver(engine, source);
+                packet[0] = resolver.resolve(source, world, bot.turn_speed, packet);
+                return 0;
+            }
+            source = source.copy();
+            source[sf::_kernel_turn_speed] = Value(bot.turn_speed);
         }
         std::vector<double> args(packet, packet + count);
         auto answer = engine.query(760, source, Value::object(), args);

--- a/tools/ffi_experiment/kernel_motion.h
+++ b/tools/ffi_experiment/kernel_motion.h
@@ -1,0 +1,589 @@
+#ifndef OFFLINE_EXPERIMENT_KERNEL_MOTION_H
+#define OFFLINE_EXPERIMENT_KERNEL_MOTION_H
+#include "kernel_engine.h"
+#include "kernel_diagnostics.h"
+#include "kernel_factors.h"
+#include "motion_vertical.h"
+#include "navigation_flow.h"
+
+namespace offline_kernel {
+struct Motion {
+    Value config;
+    std::map<int, std::unique_ptr<Bot>> &bots;
+    Engine &engine;
+    Factors factors;
+    offline_motion::Flow flow;
+    offline_motion::Tuning tuning;
+    std::map<int, offline_motion::Params> profiles;
+    std::map<int, int> grinds;
+    std::map<int, double> attempted;
+    std::map<int, Value> locked;
+    std::set<int> invalidated;
+    Value *command = nullptr;
+    const OfflineQueryRoute *route = nullptr;
+    int navigation = 0, driver = 0;
+    std::vector<std::pair<int, bool>> waiting, frame_waiting;
+    std::vector<int> requested;
+    std::set<int> requested_set, priority, attempted_receipts, deferred_receipts;
+    std::map<int, bool> waiting_initial, request_uncached;
+    std::map<int, int> results;
+    bool receipt_frame = false, initial_first = false;
+    int receipt_budget = 0;
+    Diagnostics *diagnostics = nullptr;
+    double current_now = 0;
+    std::array<int, 5> probe_totals{{0, 0, 0, 0, 0}};
+    Motion(const Value &v, std::map<int, std::unique_ptr<Bot>> &states, Engine &e)
+        : config(v), bots(states), engine(e), factors(v.get("factors")) {
+        const Value &t = v.get("tuning");
+#define LOAD_TUNING(name) tuning.name = field(t, #name);
+        OFFLINE_MOTION_CONSTANTS(LOAD_TUNING)
+#undef LOAD_TUNING
+        flow.probe_seconds = field(v, "probe_seconds");
+        navigation = integer(v, "navigation");
+        driver = integer(v, "driver");
+        for (const auto &item : bots) {
+            const Value &p = item.second->config.get("motion").get("physics");
+            if (p.kind != Value::Object)
+                continue;
+            profiles[item.first] = params(p);
+        }
+    }
+    static offline_motion::Params params(const Value &v) {
+        offline_motion::Params p;
+        double *values[] = {&p.mass,       &p.powerW,   &p.nativePowerRatio, &p.specificFriction,
+                            &p.brakeDecel, &p.speedFwd, &p.speedBwd,         &p.rotSpd};
+        const char *names[] = {"mass",       "powerW",   "nativePowerRatio", "specificFriction",
+                               "brakeDecel", "speedFwd", "speedBwd",         "rotSpd"};
+        for (size_t i = 0; i < 8; ++i)
+            *values[i] = field(v, names[i], i == 2 ? 1 : 0);
+        const Value &terrain = v.get("terrainResist");
+        if (terrain.kind != Value::Array || terrain.size() != 3)
+            throw std::invalid_argument("kernel motion terrain producer");
+        for (size_t i = 0; i < 3; ++i)
+            p.terrainResist[i] = terrain[i].number();
+        if (p.mass <= 0 || p.terrainResist[0] <= 0 || p.terrainResist[1] <= 0 ||
+            p.terrainResist[2] <= 0)
+            throw std::invalid_argument("kernel motion producer");
+        return p;
+    }
+    static offline_nav::Point point(const Value &v) {
+        return offline_nav::Point(field(v, "x"), field(v, "y"), field(v, "z"));
+    }
+    static offline_nav::Point point(const Value &v, offline_nav::Point fallback) {
+        return v.kind == Value::Array && v.size() == 3
+                   ? offline_nav::Point(v[0].number(), v[1].number(), v[2].number())
+                   : fallback;
+    }
+    static Value value(offline_nav::Point p) {
+        Value v = Value::array();
+        v.append(Value(p.x));
+        v.append(Value(p.y));
+        v.append(Value(p.z));
+        return v;
+    }
+    static void assign(Value &s, offline_nav::Point p) {
+        s["x"] = Value(p.x);
+        s["y"] = Value(p.y);
+        s["z"] = Value(p.z);
+    }
+    static void destructible(Value &s, bool has, double speed) {
+        if (has)
+            s["destructible_contact_speed"] = Value(speed);
+        else
+            s.erase("destructible_contact_speed");
+    }
+    void begin() {
+        frame_waiting.clear();
+        std::set<int> seen;
+        for (const auto &v : waiting) {
+            auto at = bots.find(v.first);
+            if (!seen.count(v.first) && at != bots.end() &&
+                flag(at->second->state, "alive", true)) {
+                frame_waiting.push_back(v);
+                seen.insert(v.first);
+            }
+        }
+        receipt_budget = integer(config, "receipt_budget");
+        priority.clear();
+        waiting_initial.clear();
+        initial_first = false;
+        for (const auto &v : frame_waiting) {
+            waiting_initial[v.first] = v.second;
+            if (v.second)
+                initial_first = true;
+        }
+        for (const auto &v : frame_waiting)
+            if ((!initial_first || v.second) &&
+                priority.size() < static_cast<size_t>(receipt_budget))
+                priority.insert(v.first);
+        requested.clear();
+        requested_set.clear();
+        request_uncached.clear();
+        attempted_receipts.clear();
+        results.clear();
+        deferred_receipts.clear();
+        receipt_frame = true;
+    }
+    void finish() {
+        if (!receipt_frame)
+            return;
+        waiting.clear();
+        std::set<int> seen;
+        auto append = [&](int id, bool initial) {
+            if (!seen.count(id)) {
+                waiting.push_back({id, initial});
+                seen.insert(id);
+            }
+        };
+        for (const auto &v : frame_waiting)
+            if (requested_set.count(v.first) && !attempted_receipts.count(v.first))
+                append(v.first, request_uncached[v.first]);
+        for (int id : requested)
+            if (!attempted_receipts.count(id))
+                append(id, request_uncached[id]);
+        for (const auto &v : frame_waiting)
+            if (deferred_receipts.count(v.first))
+                append(v.first, false);
+        for (int id : requested)
+            if (deferred_receipts.count(id))
+                append(id, false);
+        receipt_frame = false;
+    }
+    int engine_event(double *packet, int count, Value source) {
+        int kind = static_cast<int>(packet[0]);
+        if (kind == 610 || kind == 611 || kind == 635)
+            ++probe_totals[4];
+        else if (kind == 630)
+            ++probe_totals[3];
+        if (kind == 615) {
+            int id = static_cast<int>(packet[1]);
+            source = source.copy();
+            source["_kernel_turn_speed"] = Value(bots.at(id)->turn_speed);
+            auto cache = flow.caches.find(id);
+            bool corridor = false, receipt = false;
+            double yaw = packet[5], speed = packet[6], dt = packet[7], now = packet[8];
+            offline_nav::Point p(packet[2], packet[3], packet[4]);
+            if (packet[9] == 0 && speed < 0)
+                yaw += 3.141592653589793;
+            if (packet[9] != 0 && speed < 0)
+                yaw += 3.141592653589793;
+            if (cache != flow.caches.end() && cache->second.has && cache->second.result.kind == 2) {
+                const auto &c = cache->second;
+                const auto &probe = c.result;
+                receipt = probe.receipt.kind == 2 &&
+                          offline_motion::reusable(c, p, yaw, speed, now, false, dt);
+                corridor = probe.receipt.kind == 2
+                               ? (!probe.deferred && probe.is_clear() &&
+                                  offline_motion::contains(probe.receipt, p, yaw, speed, dt))
+                               : probe.pending && offline_motion::reusable(c, p, yaw, speed, now,
+                                                                           false, dt, true);
+            }
+            packet[20] = corridor;
+            packet[21] = receipt;
+        }
+        std::vector<double> args(packet, packet + count);
+        auto answer = engine.query(760, source, Value::object(), args);
+        std::copy(answer.begin(), answer.begin() + count, packet);
+        return 0;
+    }
+    int receipt(double *packet, int count, Value source) {
+        if (!flag(config, "has_receipt")) {
+            std::fill(packet, packet + 10, 0);
+            return 0;
+        }
+        auto defer = [&]() {
+            std::fill(packet, packet + 10, 0);
+            packet[0] = 3;
+            return 0;
+        };
+        if (!receipt_frame)
+            return defer();
+        int id = static_cast<int>(packet[1]);
+        if (!requested_set.count(id)) {
+            requested.push_back(id);
+            requested_set.insert(id);
+            auto at = waiting_initial.find(id);
+            request_uncached[id] = at == waiting_initial.end() ? packet[7] != 0 : at->second;
+        }
+        if (attempted_receipts.count(id)) {
+            if (results[id] == 1) {
+                std::fill(packet, packet + 10, 0);
+                packet[0] = 1;
+                return 0;
+            }
+            return defer();
+        }
+        if ((initial_first && !request_uncached[id]) || (!priority.empty() && !priority.count(id)))
+            return defer();
+        priority.erase(id);
+        if (receipt_budget <= 0)
+            return defer();
+        --receipt_budget;
+        attempted_receipts.insert(id);
+        engine_event(packet, count, source);
+        results[id] = static_cast<int>(packet[0]);
+        if (packet[0] == 3)
+            deferred_receipts.insert(id);
+        return 0;
+    }
+    int event(double *packet, int count) {
+        int kind = static_cast<int>(packet[0]);
+        if (kind < 610 || kind > 635)
+            return route ? route->forward(packet, count) : 18;
+        int id = static_cast<int>(packet[1]);
+        auto at = bots.find(id);
+        if (at == bots.end())
+            throw std::invalid_argument("kernel motion callback actor");
+        Bot &bot = *at->second;
+        Value &s = bot.state;
+        if (kind == 610 || kind == 630)
+            return engine_event(packet, count, s);
+        if (kind == 611)
+            return receipt(packet, count, s);
+        if (kind == 612) {
+            offline_motion::Values values{packet, 2};
+            auto cache = values.cache();
+            const auto &p = cache.result;
+            packet[0] =
+                cache.has &&
+                (p.truth || (p.kind == 2 && p.copied &&
+                             (!p.clear || p.collision || p.pending || p.receipt.kind != 0)));
+            return 0;
+        }
+        if (kind == 613) {
+            int phase = static_cast<int>(packet[2]);
+            if (phase == 0) {
+                s["hull_aiming"] = Value(packet[3] != 0);
+                attempted[id] = packet[5];
+                if (packet[4] != 0) {
+                    if (command) {
+                        (*command)["fire_allowed"] = Value(false);
+                        (*command)["throttle"] = Value(0.0);
+                        (*command)["turn"] = Value(0.0);
+                        (*command)["movement_intent"] = Value(false);
+                    }
+                    for (const char *name : {"speed", "push_x", "push_z"})
+                        s[name] = Value(0.0);
+                    s["movement_dir"] = Value(0);
+                    s["rotation_dir"] = Value(0);
+                    bot.turn_speed = 0;
+                    locked[id] =
+                        value(offline_nav::Point(field(s, "x"), field(s, "z"), field(s, "yaw")));
+                }
+            } else if (phase == 1) {
+                s["movement_dir"] = Value(static_cast<int>(packet[3]));
+                s["rotation_dir"] = Value(static_cast<int>(packet[4]));
+                attempted[id] = packet[9];
+                if (diagnostics && command) {
+                    offline_motion::Values values{packet, 10};
+                    auto probe = values.probe();
+                    Value v = Value::object();
+                    if (probe.kind == 2) {
+                        v["clear"] = Value(probe.clear);
+                        v["collision"] = Value(probe.collision);
+                        v["water"] = Value(probe.water);
+                        v["deferred"] = Value(probe.deferred);
+                        v["slope"] = Value(probe.slope);
+                    }
+                    diagnostics->begin(bot, *command, packet[5], packet[6], packet[7] != 0,
+                                       packet[8] != 0, v, current_now,
+                                       grinds.count(id) ? grinds.at(id) : 0);
+                }
+            } else if (phase == 2) {
+                s["yaw"] = Value(packet[3]);
+                bot.turn_speed = packet[4];
+                s["rotation_dir"] = Value(static_cast<int>(packet[5]));
+                s["movement_dir"] = Value(static_cast<int>(packet[6]));
+                s["last_drive_pitch"] = Value(packet[7]);
+                attempted[id] = packet[13];
+                destructible(s, packet[14] != 0, packet[15]);
+            } else
+                throw std::invalid_argument("kernel motion phase");
+            return 0;
+        }
+        if (kind == 614) {
+            invalidated.insert(id);
+            s.erase("destructible_contact_speed");
+            return 0;
+        }
+        if (kind == 615) {
+            Value source = s;
+            if (packet[9] != 0) {
+                source = s.copy();
+                source["movement_dir"] = Value(0);
+            }
+            return engine_event(packet, count, source);
+        }
+        if (kind == 616) {
+            destructible(s, packet[5] != 0, packet[6]);
+            if (packet[7] != 0)
+                grinds[id] = static_cast<int>(packet[8]);
+            return engine_event(packet, count, s);
+        }
+        if (kind == 617) {
+            Value trace = s.get("_motion_stall_pending");
+            if (trace.kind == Value::Object) {
+                const char *status[] = {"clear", "crushed", "soft", "cap_crushed", "hard"};
+                trace["world_status"] = Value(status[static_cast<int>(packet[2])]);
+                trace["hard_contact"] = Value(packet[3] != 0);
+                trace["integrated"] = offline_kernel::point(packet[4], packet[5], packet[6]);
+                trace["world_speed"] = Value(packet[7]);
+            }
+            return 0;
+        }
+        if (kind == 631) {
+            Value trace = s.get("_motion_stall_pending");
+            if (trace.kind == Value::Object) {
+                if (packet[2] == 0) {
+                    trace["support_highest"] = packet[3] ? Value(packet[4]) : Value();
+                    trace["support_centre"] = packet[5] ? Value(packet[6]) : Value();
+                    trace["grounded_before"] = Value(packet[7] != 0);
+                } else {
+                    trace["support_limit"] = Value(packet[3]);
+                    trace["support_rise_obstacle"] = Value(packet[4] != 0);
+                    trace["support_rise_continuous"] = Value(packet[5] != 0);
+                }
+            }
+            return 0;
+        }
+        if (kind == 635) {
+            s["speed"] = Value(packet[9]);
+            return engine_event(packet, count, s);
+        }
+        return route ? route->forward(packet, count) : 18;
+    }
+    static int callback(void *owner, double *packet, int count) {
+        return static_cast<Motion *>(owner)->event(packet, count);
+    }
+    struct Scope {
+        Motion &motion;
+        const OfflineQueryRoute *previous;
+        OfflineQueryRoute current;
+        explicit Scope(Motion &m) : motion(m), previous(m.route), current(Motion::callback, &m) {
+            m.route = &current;
+        }
+        ~Scope() { motion.route = previous; }
+    };
+    void invalidate(int id, double yaw) {
+        invalidated.insert(id);
+        flow.caches.erase(id);
+        if (driver)
+            offline_driver_remember(driver, id, yaw, true, 5.0);
+    }
+    void step(Bot &bot, Value &order, const Value &target, double dt, double now, bool decision_due,
+              bool refresh, bool siege_lock, double siege_yaw, bool baked_escape) {
+        current_now = now;
+        Value &s = bot.state;
+        const Value &c = bot.config.get("motion");
+        int id = integer(s, "id");
+        offline_motion::Input in;
+        in.bot = id;
+        in.navigation = navigation;
+        in.driver = driver;
+        in.position = point(s);
+        in.aim = point(order.get("aim_position"), point(target.get("position"), in.position));
+        if (order.get("move_position").kind != Value::Null)
+            in.move = point(order.get("move_position"), in.position);
+        in.yaw = field(s, "yaw");
+        in.speed = field(s, "speed");
+        in.turn_speed = bot.turn_speed;
+        in.half_length = field(s, "half_length", 3.5);
+        in.half_width = field(s, "half_width", 1.7);
+        in.throttle = field(order, "throttle");
+        in.turn = field(order, "turn");
+        const Value &limits = c.get("yaw_limits");
+        in.minimum_yaw = limits[0].number();
+        in.maximum_yaw = limits[1].number();
+        std::set<std::string> destroyed = names(s.get("critical").get("destroyed"));
+        in.mobility_blocked = flag(s, "_overturned") || destroyed.count("engineHealth") ||
+                              destroyed.count("leftTrackHealth") ||
+                              destroyed.count("rightTrackHealth");
+        in.mobility = !in.mobility_blocked && std::abs(in.throttle) > .01
+                          ? factors.stat(s, *bot.critical, "mobility")
+                          : 1;
+        in.step = dt;
+        in.now = now;
+        in.water = field(s, "_water_depth", -1);
+        in.tick_siege_yaw = siege_yaw;
+        const std::string recovery = order.get("recovery_mode").text("drive");
+        in.recovery = recovery == "drive"            ? 0
+                      : recovery == "avoid"          ? 1
+                      : recovery == "blocked"        ? 2
+                      : recovery == "reverse_turn"   ? 3
+                      : recovery == "pivot_recovery" ? 4
+                                                     : 5;
+        auto grind = grinds.find(id);
+        in.grind_present = grind != grinds.end();
+        in.grind = in.grind_present ? grind->second : 0;
+        in.has_target =
+            target.kind != Value::Null && order.get("combat_mode").text() != "base_defense";
+        in.movement = flag(order, "movement_intent", true);
+        in.airborne = flag(s, "airborne");
+        in.grounded = flag(s, "grounded_once");
+        in.siege_locked = siege_lock;
+        in.bake_admitted = flag(config, "bake_admitted");
+        in.baked_escape = baked_escape;
+        in.decision_due = decision_due;
+        in.refresh = refresh;
+        in.has_resolver = flag(config, "has_resolver");
+        in.has_report = flag(config, "has_report");
+        if (integer(s, "siege_state") == integer(config, "siege_enabled") &&
+            c.get("siege_limit").kind != Value::Null)
+            in.siege_limit = c.get("siege_limit").number();
+        if (s.has("destructible_contact_speed"))
+            in.destructible_speed = field(s, "destructible_contact_speed");
+        Scope scope(*this);
+        Value *previous = command;
+        command = &order;
+        offline_motion::Output out(in);
+        try {
+            out = flow.step(in, profiles.at(id), tuning,
+                            navigation ? &offline_runtime_navigation(navigation) : nullptr);
+        } catch (...) {
+            command = previous;
+            throw;
+        }
+        command = previous;
+        assign(s, out.position);
+        s["yaw"] = Value(out.yaw);
+        s["speed"] = Value(out.speed);
+        bot.turn_speed = out.turn_speed;
+        s["last_drive_pitch"] = Value(out.drive_pitch);
+        attempted[id] = out.attempted_yaw;
+        s["movement_dir"] = Value(out.movement);
+        s["rotation_dir"] = Value(out.rotation);
+        if (out.grind_present)
+            grinds[id] = out.grind;
+        destructible(s, out.destructible_speed.has, out.destructible_speed.value);
+    }
+    int landing(Bot &bot, double speed) {
+        Value &s = bot.state;
+        double lx = field(s, "air_lateral_x"), lz = field(s, "air_lateral_z"),
+               lateral = std::sqrt(lx * lx + lz * lz);
+        if (lateral > .01)
+            s["slide_speed"] = Value(std::max(field(s, "slide_speed"), lateral));
+        s["air_lateral_x"] = Value(0.0);
+        s["air_lateral_z"] = Value(0.0);
+        speed = std::sqrt(speed * speed + lateral * lateral);
+        int maximum = std::max(1, integer(s, "max_health", integer(s, "health", 1)));
+        int damage = speed <= tuning.FALL_SAFE_SPEED
+                         ? 0
+                         : static_cast<int>(maximum * (speed - tuning.FALL_SAFE_SPEED) *
+                                            tuning.FALL_DMG_PER_MS);
+        if (damage <= 0)
+            return 0;
+        int health = std::max(0, integer(s, "health", maximum) - damage);
+        s["health"] = Value(health);
+        s["display_health"] = Value(health);
+        s["alive"] = Value(health > 0);
+        if (health > 0)
+            return damage;
+        Critical terminal(s.get("critical"), *bot.critical);
+        s["critical"] = terminal.terminal();
+        s["combat_fire_elapsed"] = Value(0.0);
+        s["combat_fire_timer"] = Value(0.0);
+        bot.death(3, 0);
+        s["push_x"] = Value(0.0);
+        s["push_z"] = Value(0.0);
+        bot.turn_speed = 0;
+        return damage;
+    }
+    bool vertical(Bot &bot, double dt, const Value &tick = Value(), double yaw = 0) {
+        Value &s = bot.state;
+        offline_motion::Vertical v;
+        v.bot = integer(s, "id");
+        v.position = point(s);
+        v.yaw = field(s, "yaw");
+        v.speed = field(s, "speed");
+        v.half_length = std::max(1.5, field(s, "half_length", 3.5));
+        v.step = dt;
+        v.vertical = field(s, "vertical_speed");
+        v.pitch = field(s, "last_drive_pitch");
+        v.airborne = flag(s, "airborne");
+        v.grounded = flag(s, "grounded_once");
+        v.trace = s.get("_motion_stall_pending").kind == Value::Object;
+        if (v.trace)
+            s["_motion_stall_pending"]["suspension"] = Value(false);
+        if (tick.kind != Value::Null)
+            v.tick = point(tick, v.position);
+        Scope scope(*this);
+        auto result = offline_motion::vertical_step(flow, tuning, v);
+        assign(s, result.position);
+        s["speed"] = Value(result.speed);
+        s["vertical_speed"] = Value(result.vertical);
+        s["airborne"] = Value(result.airborne);
+        s["grounded_once"] = Value(result.grounded);
+        if (result.blocked) {
+            s["movement_dir"] = Value(0);
+            s["rotation_dir"] = Value(0);
+            s["push_x"] = Value(0.0);
+            s["push_z"] = Value(0.0);
+            s.erase("destructible_contact_speed");
+            bot.turn_speed = 0;
+            invalidate(v.bot, yaw);
+            return true;
+        }
+        if (result.landed)
+            landing(bot, result.impact);
+        return false;
+    }
+    bool safe(offline_nav::Point p) const {
+        if (!navigation)
+            return true;
+        const auto &grid = *offline_runtime_navigation(navigation).grid;
+        double x = std::round((p.x - grid.data->ox) / grid.data->cell),
+               z = std::round((p.z - grid.data->oz) / grid.data->cell);
+        return x >= 0 && z >= 0 && x < grid.data->width && z < grid.data->height &&
+               !(grid.data->hazards[static_cast<int>(z) * grid.data->width + static_cast<int>(x)] &
+                 9);
+    }
+    bool guard(Bot &bot, offline_nav::Point tick, bool was_safe, double attempted_yaw) {
+        if (!navigation)
+            return false;
+        Value &s = bot.state;
+        double yaw = field(s, "yaw");
+        auto &grid = *offline_runtime_navigation(navigation).grid;
+        offline_nav::Point current = point(s);
+        if (offline_motion::boundary(grid, tick, yaw, current, yaw, field(s, "half_length", 3.5),
+                                     field(s, "half_width", 1.7)) &&
+            (!was_safe || safe(current)))
+            return false;
+        assign(s, tick);
+        for (const char *name : {"speed", "push_x", "push_z", "vertical_speed"})
+            s[name] = Value(0.0);
+        s["movement_dir"] = Value(0);
+        s["rotation_dir"] = Value(0);
+        s["airborne"] = Value(false);
+        invalidate(integer(s, "id"), attempted_yaw);
+        return true;
+    }
+    bool slope(Bot &bot, int tier, bool allow_ungrounded = false) {
+        Value &s = bot.state;
+        if (flag(s, "airborne") || (!allow_ungrounded && !flag(s, "grounded_once")))
+            return false;
+        const Value &prior = s.get("pose_sample");
+        double yaw = field(s, "yaw"), x = field(s, "x"), z = field(s, "z");
+        if (prior.kind == Value::Array && prior.size() == 3 &&
+            std::abs(x - prior[0].number()) < config.get("slope_metres")[tier].number() &&
+            std::abs(z - prior[1].number()) < config.get("slope_metres")[tier].number() &&
+            std::abs(yaw - prior[2].number()) < config.get("slope_radians")[tier].number())
+            return false;
+        double suspension = field(s, "suspension_pitch"),
+               pitch = field(s, "terrain_pitch", field(s, "pitch") - suspension);
+        Scope scope(*this);
+        auto result = offline_motion::slope(flow, integer(s, "id"), point(s), yaw,
+                                            field(s, "half_length", 3.5),
+                                            field(s, "half_width", 1.7), pitch, field(s, "roll"));
+        s["terrain_pitch"] = Value(result.first);
+        s["pitch"] = Value(result.first + suspension);
+        s["roll"] = Value(result.second);
+        Value marker = Value::array();
+        marker.append(Value(x));
+        marker.append(Value(z));
+        marker.append(Value(yaw));
+        s["pose_sample"] = marker;
+        return true;
+    }
+};
+} // namespace offline_kernel
+#endif

--- a/tools/ffi_experiment/kernel_motion.h
+++ b/tools/ffi_experiment/kernel_motion.h
@@ -67,7 +67,7 @@ struct Motion {
         return p;
     }
     static offline_nav::Point point(const Value &v) {
-        return offline_nav::Point(field(v, "x"), field(v, "y"), field(v, "z"));
+        return offline_nav::Point(field(v, sf::x), field(v, sf::y), field(v, sf::z));
     }
     static offline_nav::Point point(const Value &v, offline_nav::Point fallback) {
         return v.kind == Value::Array && v.size() == 3
@@ -82,15 +82,15 @@ struct Motion {
         return v;
     }
     static void assign(Value &s, offline_nav::Point p) {
-        s["x"] = Value(p.x);
-        s["y"] = Value(p.y);
-        s["z"] = Value(p.z);
+        s[sf::x] = Value(p.x);
+        s[sf::y] = Value(p.y);
+        s[sf::z] = Value(p.z);
     }
     static void destructible(Value &s, bool has, double speed) {
         if (has)
-            s["destructible_contact_speed"] = Value(speed);
+            s[sf::destructible_contact_speed] = Value(speed);
         else
-            s.erase("destructible_contact_speed");
+            s.erase(sf::destructible_contact_speed);
     }
     void begin() {
         frame_waiting.clear();
@@ -98,7 +98,7 @@ struct Motion {
         for (const auto &v : waiting) {
             auto at = bots.find(v.first);
             if (!seen.count(v.first) && at != bots.end() &&
-                flag(at->second->state, "alive", true)) {
+                flag(at->second->state, sf::alive, true)) {
                 frame_waiting.push_back(v);
                 seen.insert(v.first);
             }
@@ -158,7 +158,7 @@ struct Motion {
         if (kind == 615) {
             int id = static_cast<int>(packet[1]);
             source = source.copy();
-            source["_kernel_turn_speed"] = Value(bots.at(id)->turn_speed);
+            source[sf::_kernel_turn_speed] = Value(bots.at(id)->turn_speed);
             auto cache = flow.caches.find(id);
             bool corridor = false, receipt = false;
             double yaw = packet[5], speed = packet[6], dt = packet[7], now = packet[8];
@@ -253,7 +253,7 @@ struct Motion {
         if (kind == 613) {
             int phase = static_cast<int>(packet[2]);
             if (phase == 0) {
-                s["hull_aiming"] = Value(packet[3] != 0);
+                s[sf::hull_aiming] = Value(packet[3] != 0);
                 attempted[id] = packet[5];
                 if (packet[4] != 0) {
                     if (command) {
@@ -264,15 +264,15 @@ struct Motion {
                     }
                     for (const char *name : {"speed", "push_x", "push_z"})
                         s[name] = Value(0.0);
-                    s["movement_dir"] = Value(0);
-                    s["rotation_dir"] = Value(0);
+                    s[sf::movement_dir] = Value(0);
+                    s[sf::rotation_dir] = Value(0);
                     bot.turn_speed = 0;
-                    locked[id] =
-                        value(offline_nav::Point(field(s, "x"), field(s, "z"), field(s, "yaw")));
+                    locked[id] = value(
+                        offline_nav::Point(field(s, sf::x), field(s, sf::z), field(s, sf::yaw)));
                 }
             } else if (phase == 1) {
-                s["movement_dir"] = Value(static_cast<int>(packet[3]));
-                s["rotation_dir"] = Value(static_cast<int>(packet[4]));
+                s[sf::movement_dir] = Value(static_cast<int>(packet[3]));
+                s[sf::rotation_dir] = Value(static_cast<int>(packet[4]));
                 attempted[id] = packet[9];
                 if (diagnostics && command) {
                     offline_motion::Values values{packet, 10};
@@ -290,11 +290,11 @@ struct Motion {
                                        grinds.count(id) ? grinds.at(id) : 0);
                 }
             } else if (phase == 2) {
-                s["yaw"] = Value(packet[3]);
+                s[sf::yaw] = Value(packet[3]);
                 bot.turn_speed = packet[4];
-                s["rotation_dir"] = Value(static_cast<int>(packet[5]));
-                s["movement_dir"] = Value(static_cast<int>(packet[6]));
-                s["last_drive_pitch"] = Value(packet[7]);
+                s[sf::rotation_dir] = Value(static_cast<int>(packet[5]));
+                s[sf::movement_dir] = Value(static_cast<int>(packet[6]));
+                s[sf::last_drive_pitch] = Value(packet[7]);
                 attempted[id] = packet[13];
                 destructible(s, packet[14] != 0, packet[15]);
             } else
@@ -303,14 +303,14 @@ struct Motion {
         }
         if (kind == 614) {
             invalidated.insert(id);
-            s.erase("destructible_contact_speed");
+            s.erase(sf::destructible_contact_speed);
             return 0;
         }
         if (kind == 615) {
             Value source = s;
             if (packet[9] != 0) {
                 source = s.copy();
-                source["movement_dir"] = Value(0);
+                source[sf::movement_dir] = Value(0);
             }
             return engine_event(packet, count, source);
         }
@@ -321,7 +321,7 @@ struct Motion {
             return engine_event(packet, count, s);
         }
         if (kind == 617) {
-            Value trace = s.get("_motion_stall_pending");
+            Value trace = s.get(sf::_motion_stall_pending);
             if (trace.kind == Value::Object) {
                 const char *status[] = {"clear", "crushed", "soft", "cap_crushed", "hard"};
                 trace["world_status"] = Value(status[static_cast<int>(packet[2])]);
@@ -332,7 +332,7 @@ struct Motion {
             return 0;
         }
         if (kind == 631) {
-            Value trace = s.get("_motion_stall_pending");
+            Value trace = s.get(sf::_motion_stall_pending);
             if (trace.kind == Value::Object) {
                 if (packet[2] == 0) {
                     trace["support_highest"] = packet[3] ? Value(packet[4]) : Value();
@@ -347,7 +347,7 @@ struct Motion {
             return 0;
         }
         if (kind == 635) {
-            s["speed"] = Value(packet[9]);
+            s[sf::speed] = Value(packet[9]);
             return engine_event(packet, count, s);
         }
         return route ? route->forward(packet, count) : 18;
@@ -375,27 +375,27 @@ struct Motion {
         current_now = now;
         Value &s = bot.state;
         const Value &c = bot.config.get("motion");
-        int id = integer(s, "id");
+        int id = integer(s, sf::id);
         offline_motion::Input in;
         in.bot = id;
         in.navigation = navigation;
         in.driver = driver;
         in.position = point(s);
-        in.aim = point(order.get("aim_position"), point(target.get("position"), in.position));
+        in.aim = point(order.get("aim_position"), point(target.get(sf::position), in.position));
         if (order.get("move_position").kind != Value::Null)
             in.move = point(order.get("move_position"), in.position);
-        in.yaw = field(s, "yaw");
-        in.speed = field(s, "speed");
+        in.yaw = field(s, sf::yaw);
+        in.speed = field(s, sf::speed);
         in.turn_speed = bot.turn_speed;
-        in.half_length = field(s, "half_length", 3.5);
-        in.half_width = field(s, "half_width", 1.7);
+        in.half_length = field(s, sf::half_length, 3.5);
+        in.half_width = field(s, sf::half_width, 1.7);
         in.throttle = field(order, "throttle");
         in.turn = field(order, "turn");
         const Value &limits = c.get("yaw_limits");
         in.minimum_yaw = limits[0].number();
         in.maximum_yaw = limits[1].number();
-        std::set<std::string> destroyed = names(s.get("critical").get("destroyed"));
-        in.mobility_blocked = flag(s, "_overturned") || destroyed.count("engineHealth") ||
+        std::set<std::string> destroyed = names(s.get(sf::critical).get("destroyed"));
+        in.mobility_blocked = flag(s, sf::_overturned) || destroyed.count("engineHealth") ||
                               destroyed.count("leftTrackHealth") ||
                               destroyed.count("rightTrackHealth");
         in.mobility = !in.mobility_blocked && std::abs(in.throttle) > .01
@@ -403,7 +403,7 @@ struct Motion {
                           : 1;
         in.step = dt;
         in.now = now;
-        in.water = field(s, "_water_depth", -1);
+        in.water = field(s, sf::_water_depth, -1);
         in.tick_siege_yaw = siege_yaw;
         const std::string recovery = order.get("recovery_mode").text("drive");
         in.recovery = recovery == "drive"            ? 0
@@ -418,8 +418,8 @@ struct Motion {
         in.has_target =
             target.kind != Value::Null && order.get("combat_mode").text() != "base_defense";
         in.movement = flag(order, "movement_intent", true);
-        in.airborne = flag(s, "airborne");
-        in.grounded = flag(s, "grounded_once");
+        in.airborne = flag(s, sf::airborne);
+        in.grounded = flag(s, sf::grounded_once);
         in.siege_locked = siege_lock;
         in.bake_admitted = flag(config, "bake_admitted");
         in.baked_escape = baked_escape;
@@ -427,11 +427,11 @@ struct Motion {
         in.refresh = refresh;
         in.has_resolver = flag(config, "has_resolver");
         in.has_report = flag(config, "has_report");
-        if (integer(s, "siege_state") == integer(config, "siege_enabled") &&
+        if (integer(s, sf::siege_state) == integer(config, "siege_enabled") &&
             c.get("siege_limit").kind != Value::Null)
             in.siege_limit = c.get("siege_limit").number();
-        if (s.has("destructible_contact_speed"))
-            in.destructible_speed = field(s, "destructible_contact_speed");
+        if (s.has(sf::destructible_contact_speed))
+            in.destructible_speed = field(s, sf::destructible_contact_speed);
         Scope scope(*this);
         Value *previous = command;
         command = &order;
@@ -445,80 +445,80 @@ struct Motion {
         }
         command = previous;
         assign(s, out.position);
-        s["yaw"] = Value(out.yaw);
-        s["speed"] = Value(out.speed);
+        s[sf::yaw] = Value(out.yaw);
+        s[sf::speed] = Value(out.speed);
         bot.turn_speed = out.turn_speed;
-        s["last_drive_pitch"] = Value(out.drive_pitch);
+        s[sf::last_drive_pitch] = Value(out.drive_pitch);
         attempted[id] = out.attempted_yaw;
-        s["movement_dir"] = Value(out.movement);
-        s["rotation_dir"] = Value(out.rotation);
+        s[sf::movement_dir] = Value(out.movement);
+        s[sf::rotation_dir] = Value(out.rotation);
         if (out.grind_present)
             grinds[id] = out.grind;
         destructible(s, out.destructible_speed.has, out.destructible_speed.value);
     }
     int landing(Bot &bot, double speed) {
         Value &s = bot.state;
-        double lx = field(s, "air_lateral_x"), lz = field(s, "air_lateral_z"),
+        double lx = field(s, sf::air_lateral_x), lz = field(s, sf::air_lateral_z),
                lateral = std::sqrt(lx * lx + lz * lz);
         if (lateral > .01)
-            s["slide_speed"] = Value(std::max(field(s, "slide_speed"), lateral));
-        s["air_lateral_x"] = Value(0.0);
-        s["air_lateral_z"] = Value(0.0);
+            s[sf::slide_speed] = Value(std::max(field(s, sf::slide_speed), lateral));
+        s[sf::air_lateral_x] = Value(0.0);
+        s[sf::air_lateral_z] = Value(0.0);
         speed = std::sqrt(speed * speed + lateral * lateral);
-        int maximum = std::max(1, integer(s, "max_health", integer(s, "health", 1)));
+        int maximum = std::max(1, integer(s, sf::max_health, integer(s, sf::health, 1)));
         int damage = speed <= tuning.FALL_SAFE_SPEED
                          ? 0
                          : static_cast<int>(maximum * (speed - tuning.FALL_SAFE_SPEED) *
                                             tuning.FALL_DMG_PER_MS);
         if (damage <= 0)
             return 0;
-        int health = std::max(0, integer(s, "health", maximum) - damage);
-        s["health"] = Value(health);
-        s["display_health"] = Value(health);
-        s["alive"] = Value(health > 0);
+        int health = std::max(0, integer(s, sf::health, maximum) - damage);
+        s[sf::health] = Value(health);
+        s[sf::display_health] = Value(health);
+        s[sf::alive] = Value(health > 0);
         if (health > 0)
             return damage;
-        Critical terminal(s.get("critical"), *bot.critical);
-        s["critical"] = terminal.terminal();
-        s["combat_fire_elapsed"] = Value(0.0);
-        s["combat_fire_timer"] = Value(0.0);
+        Critical terminal(s.get(sf::critical), *bot.critical);
+        s[sf::critical] = terminal.terminal();
+        s[sf::combat_fire_elapsed] = Value(0.0);
+        s[sf::combat_fire_timer] = Value(0.0);
         bot.death(3, 0);
-        s["push_x"] = Value(0.0);
-        s["push_z"] = Value(0.0);
+        s[sf::push_x] = Value(0.0);
+        s[sf::push_z] = Value(0.0);
         bot.turn_speed = 0;
         return damage;
     }
     bool vertical(Bot &bot, double dt, const Value &tick = Value(), double yaw = 0) {
         Value &s = bot.state;
         offline_motion::Vertical v;
-        v.bot = integer(s, "id");
+        v.bot = integer(s, sf::id);
         v.position = point(s);
-        v.yaw = field(s, "yaw");
-        v.speed = field(s, "speed");
-        v.half_length = std::max(1.5, field(s, "half_length", 3.5));
+        v.yaw = field(s, sf::yaw);
+        v.speed = field(s, sf::speed);
+        v.half_length = std::max(1.5, field(s, sf::half_length, 3.5));
         v.step = dt;
-        v.vertical = field(s, "vertical_speed");
-        v.pitch = field(s, "last_drive_pitch");
-        v.airborne = flag(s, "airborne");
-        v.grounded = flag(s, "grounded_once");
-        v.trace = s.get("_motion_stall_pending").kind == Value::Object;
+        v.vertical = field(s, sf::vertical_speed);
+        v.pitch = field(s, sf::last_drive_pitch);
+        v.airborne = flag(s, sf::airborne);
+        v.grounded = flag(s, sf::grounded_once);
+        v.trace = s.get(sf::_motion_stall_pending).kind == Value::Object;
         if (v.trace)
-            s["_motion_stall_pending"]["suspension"] = Value(false);
+            s[sf::_motion_stall_pending]["suspension"] = Value(false);
         if (tick.kind != Value::Null)
             v.tick = point(tick, v.position);
         Scope scope(*this);
         auto result = offline_motion::vertical_step(flow, tuning, v);
         assign(s, result.position);
-        s["speed"] = Value(result.speed);
-        s["vertical_speed"] = Value(result.vertical);
-        s["airborne"] = Value(result.airborne);
-        s["grounded_once"] = Value(result.grounded);
+        s[sf::speed] = Value(result.speed);
+        s[sf::vertical_speed] = Value(result.vertical);
+        s[sf::airborne] = Value(result.airborne);
+        s[sf::grounded_once] = Value(result.grounded);
         if (result.blocked) {
-            s["movement_dir"] = Value(0);
-            s["rotation_dir"] = Value(0);
-            s["push_x"] = Value(0.0);
-            s["push_z"] = Value(0.0);
-            s.erase("destructible_contact_speed");
+            s[sf::movement_dir] = Value(0);
+            s[sf::rotation_dir] = Value(0);
+            s[sf::push_x] = Value(0.0);
+            s[sf::push_z] = Value(0.0);
+            s.erase(sf::destructible_contact_speed);
             bot.turn_speed = 0;
             invalidate(v.bot, yaw);
             return true;
@@ -541,47 +541,47 @@ struct Motion {
         if (!navigation)
             return false;
         Value &s = bot.state;
-        double yaw = field(s, "yaw");
+        double yaw = field(s, sf::yaw);
         auto &grid = *offline_runtime_navigation(navigation).grid;
         offline_nav::Point current = point(s);
-        if (offline_motion::boundary(grid, tick, yaw, current, yaw, field(s, "half_length", 3.5),
-                                     field(s, "half_width", 1.7)) &&
+        if (offline_motion::boundary(grid, tick, yaw, current, yaw, field(s, sf::half_length, 3.5),
+                                     field(s, sf::half_width, 1.7)) &&
             (!was_safe || safe(current)))
             return false;
         assign(s, tick);
         for (const char *name : {"speed", "push_x", "push_z", "vertical_speed"})
             s[name] = Value(0.0);
-        s["movement_dir"] = Value(0);
-        s["rotation_dir"] = Value(0);
-        s["airborne"] = Value(false);
-        invalidate(integer(s, "id"), attempted_yaw);
+        s[sf::movement_dir] = Value(0);
+        s[sf::rotation_dir] = Value(0);
+        s[sf::airborne] = Value(false);
+        invalidate(integer(s, sf::id), attempted_yaw);
         return true;
     }
     bool slope(Bot &bot, int tier, bool allow_ungrounded = false) {
         Value &s = bot.state;
-        if (flag(s, "airborne") || (!allow_ungrounded && !flag(s, "grounded_once")))
+        if (flag(s, sf::airborne) || (!allow_ungrounded && !flag(s, sf::grounded_once)))
             return false;
-        const Value &prior = s.get("pose_sample");
-        double yaw = field(s, "yaw"), x = field(s, "x"), z = field(s, "z");
+        const Value &prior = s.get(sf::pose_sample);
+        double yaw = field(s, sf::yaw), x = field(s, sf::x), z = field(s, sf::z);
         if (prior.kind == Value::Array && prior.size() == 3 &&
             std::abs(x - prior[0].number()) < config.get("slope_metres")[tier].number() &&
             std::abs(z - prior[1].number()) < config.get("slope_metres")[tier].number() &&
             std::abs(yaw - prior[2].number()) < config.get("slope_radians")[tier].number())
             return false;
-        double suspension = field(s, "suspension_pitch"),
-               pitch = field(s, "terrain_pitch", field(s, "pitch") - suspension);
+        double suspension = field(s, sf::suspension_pitch),
+               pitch = field(s, sf::terrain_pitch, field(s, sf::pitch) - suspension);
         Scope scope(*this);
-        auto result = offline_motion::slope(flow, integer(s, "id"), point(s), yaw,
-                                            field(s, "half_length", 3.5),
-                                            field(s, "half_width", 1.7), pitch, field(s, "roll"));
-        s["terrain_pitch"] = Value(result.first);
-        s["pitch"] = Value(result.first + suspension);
-        s["roll"] = Value(result.second);
+        auto result = offline_motion::slope(
+            flow, integer(s, sf::id), point(s), yaw, field(s, sf::half_length, 3.5),
+            field(s, sf::half_width, 1.7), pitch, field(s, sf::roll));
+        s[sf::terrain_pitch] = Value(result.first);
+        s[sf::pitch] = Value(result.first + suspension);
+        s[sf::roll] = Value(result.second);
         Value marker = Value::array();
         marker.append(Value(x));
         marker.append(Value(z));
         marker.append(Value(yaw));
-        s["pose_sample"] = marker;
+        s[sf::pose_sample] = marker;
         return true;
     }
 };

--- a/tools/ffi_experiment/kernel_perception.h
+++ b/tools/ffi_experiment/kernel_perception.h
@@ -1,0 +1,637 @@
+#ifndef OFFLINE_EXPERIMENT_KERNEL_PERCEPTION_H
+#define OFFLINE_EXPERIMENT_KERNEL_PERCEPTION_H
+#include "kernel_bot.h"
+#include "kernel_engine.h"
+#include "kernel_factors.h"
+#include "perception_core.h"
+#include "query_bridge.h"
+#include <array>
+
+namespace offline_kernel {
+typedef std::array<int, 2> ActorKey;
+typedef std::array<int, 3> TeamKey;
+struct Contacts {
+    Value rows = Value::array();
+    std::map<int, Value> lookup;
+};
+struct Observation {
+    bool visible = false;
+    std::set<int> shootable, humans, bots;
+    Value target;
+};
+struct Perception {
+    struct Actor {
+        int kind, id;
+        Value raw, config;
+    };
+    const Value config;
+    Factors factors;
+    int handle = 0;
+    Engine *engine = nullptr;
+    std::map<int, std::unique_ptr<Bot>> &bots;
+    std::vector<Actor> roster;
+    std::map<ActorKey, size_t> indices;
+    std::map<std::pair<size_t, bool>, Value> templates;
+    std::map<TeamKey, Value> remembered;
+    std::map<TeamKey, bool> team_visible;
+    std::map<ActorKey, double> source_still, target_still;
+    std::map<ActorKey, std::pair<bool, Value>> projection_cache;
+    std::map<ActorKey, Value> profile_cache;
+    std::map<int, CriticalConfig> human_critical;
+    std::map<int, bool> human_alive;
+    std::map<int, Value> human_last_critical;
+    std::map<int, double> human_vengeance;
+    std::map<int, std::set<ActorKey>> human_direct;
+    std::map<TeamKey, Observation> observations;
+    std::map<std::array<int, 3>, Value> probe_targets;
+    explicit Perception(const Value &v, std::map<int, std::unique_ptr<Bot>> &states)
+        : config(v), factors(v.get("factors")), bots(states) {
+        std::vector<double> packet = {300};
+        for (const char *name :
+             {"ttl", "shot_seconds", "proximity", "maximum", "memory", "designated", "budget"})
+            packet.push_back(field(v, name));
+        call(packet);
+        handle = static_cast<int>(packet[0]);
+    }
+    ~Perception() {
+        if (handle) {
+            std::vector<double> packet = {312, static_cast<double>(handle)};
+            try {
+                call(packet);
+            } catch (...) {
+            }
+        }
+    }
+    static void call(std::vector<double> &packet) {
+        offline_perception_dispatch(packet.data(), static_cast<int>(packet.size()));
+    }
+    void simple(int op) {
+        std::vector<double> packet = {static_cast<double>(op), static_cast<double>(handle)};
+        call(packet);
+    }
+    static int kind(const Value &v) { return v.get("kind").text() == "human" ? 1 : 0; }
+    static int id(const Value &v) { return integer(v, "network_id", integer(v, "id")); }
+    static ActorKey key(const Value &v) { return ActorKey{{kind(v), id(v)}}; }
+    static TeamKey team_key(int team, const Value &target) {
+        return TeamKey{{team, kind(target), id(target)}};
+    }
+    static int fire(const Value &v) {
+        return v.get("fire_seq").kind == Value::Null ? -1 : std::max(0, integer(v, "fire_seq"));
+    }
+    void record(std::vector<double> &packet, const Value &state, int identity = -1) {
+        Value p = target_position(state);
+        packet.push_back(kind(state));
+        packet.push_back(identity < 0 ? id(state) : identity);
+        packet.push_back(integer(state, "team"));
+        for (const Value &v : elements(p))
+            packet.push_back(v.number());
+        packet.push_back(fire(state));
+    }
+    void begin() { simple(301); }
+    void finish() { simple(303); }
+    void start_slice(const Value &players, const std::vector<int> &order) {
+        roster.clear();
+        indices.clear();
+        templates.clear();
+        team_visible.clear();
+        projection_cache.clear();
+        profile_cache.clear();
+        human_critical.clear();
+        observations.clear();
+        probe_targets.clear();
+        for (const Value &raw : elements(players)) {
+            if (raw.kind != Value::Object || !raw.has("id"))
+                continue;
+            int identity = integer(raw, "id");
+            Actor actor{1, identity, raw, raw.get("_kernel")};
+            indices[ActorKey{{1, identity}}] = roster.size();
+            roster.push_back(actor);
+            human_critical.emplace(identity, CriticalConfig(actor.config.get("critical_config")));
+        }
+        for (int identity : order) {
+            Bot &bot = *bots.at(identity);
+            indices[ActorKey{{0, identity}}] = roster.size();
+            roster.push_back(Actor{0, identity, bot.state, bot.config.get("perception")});
+        }
+        std::vector<double> packet = {305, static_cast<double>(handle),
+                                      static_cast<double>(roster.size())};
+        for (const Actor &actor : roster) {
+            packet.push_back(actor.kind);
+            packet.push_back(actor.id);
+            packet.push_back(integer(actor.raw, "team"));
+            packet.push_back(flag(actor.raw, "alive", true));
+        }
+        call(packet);
+    }
+    void prepare(double now, bool include_humans, const std::vector<int> &ordered,
+                 const std::set<int> &due, const std::map<int, ActorKey> &selected_targets) {
+        std::vector<double> packet = {302, static_cast<double>(handle), now, 0};
+        int count = 0;
+        for (int id : ordered) {
+            const Value &state = bots.at(id)->state;
+            if (!flag(state, "alive", true))
+                continue;
+            auto selected = selected_targets.find(id);
+            packet.push_back(0);
+            packet.push_back(id);
+            packet.push_back(integer(state, "team"));
+            packet.push_back(fire(state));
+            packet.push_back(selected != selected_targets.end() ? selected->second[0] : -1);
+            packet.push_back(selected != selected_targets.end() ? selected->second[1] : 0);
+            packet.push_back(due.count(id) != 0);
+            ++count;
+        }
+        for (const Actor &actor : roster)
+            if (actor.kind == 1 && flag(actor.raw, "alive", true)) {
+                packet.push_back(1);
+                packet.push_back(actor.id);
+                packet.push_back(integer(actor.raw, "team"));
+                packet.push_back(fire(actor.raw));
+                packet.push_back(-1);
+                packet.push_back(0);
+                packet.push_back(include_humans);
+                ++count;
+            }
+        packet[3] = count;
+        call(packet);
+    }
+    void note_still(const Value &source, double now) {
+        ActorKey identity = key(source);
+        if (std::abs(field(source, "speed")) > field(config, "moving_epsilon"))
+            source_still.erase(identity);
+        else
+            source_still.emplace(identity, now);
+    }
+    Value target(size_t index, bool processed) {
+        const Actor &actor = roster.at(index);
+        auto cache_key = std::make_pair(index, actor.kind == 0 && processed);
+        auto at = templates.find(cache_key);
+        if (at != templates.end())
+            return at->second;
+        Value result =
+            select_fields(actor.raw, config.get(actor.kind == 1 ? "human_fields" : "bot_fields"));
+        result["kind"] = Value(actor.kind == 1 ? "human" : "bot");
+        result["network_id"] = Value(actor.id);
+        result["id"] = Value(actor.kind == 1 ? integer(config, "human_base") + actor.id : actor.id);
+        result["position"] = position(actor.raw);
+        if (actor.kind == 1) {
+            result["class_tag"] = actor.config.get("class_tag");
+            result["armor"] = actor.config.get("armor");
+        }
+        templates[cache_key] = result;
+        return result;
+    }
+    Value pose(const Value &target) const {
+        Value p = select_fields(target, config.get("pose_fields"));
+        p["position"] = position(target);
+        for (const char *name : {"x", "y", "z", "yaw", "speed"})
+            if (!p.has(name))
+                p[name] = Value(0.0);
+        return p;
+    }
+    Value dynamic(const Value &target) const {
+        const Value &snapshot = target.get("effective_params"),
+                    &projection = snapshot.get("crew").get("dynamic_spotting");
+        std::set<std::string> knocked = names(target.get("critical").get("crew_ko"));
+        const Value &roster = projection.get("crew");
+        unsigned mask = 0;
+        for (size_t i = 0; i < roster.size(); ++i)
+            if (knocked.erase(roster[i].text()))
+                mask |= 1 << i;
+        if (!knocked.empty())
+            throw std::invalid_argument("kernel human critical roster");
+        std::string name =
+            std::to_string(mask) + ":" + (flag(target.get("critical"), "fire") ? "1" : "0");
+        const Value &row = projection.get("states").get(name);
+        if (row.kind != Value::Object)
+            throw std::invalid_argument("kernel human dynamic spotting");
+        return row;
+    }
+    Value profile(const Value &target) {
+        ActorKey identity = key(target);
+        auto at = profile_cache.find(identity);
+        if (at != profile_cache.end())
+            return at->second;
+        Value result;
+        if (identity[0] == 0)
+            result = bots.at(identity[1])->config.get("perception").get("profile");
+        else {
+            Value row = dynamic(target), p = target.get("effective_params").get("spotting").copy();
+            p["vision_factor"] = Value(field(p, "vision_factor") * field(row, "vision", 1));
+            p["camouflage_factor"] =
+                Value(field(p, "camouflage_factor") * field(row, "camouflage", 1));
+            p["invisibility_moving"] = row.get("invisibility_moving");
+            p["invisibility_still"] = row.get("invisibility_still");
+            result = Value::array();
+            Value base = Value::array();
+            base.append(row.get("base_moving"));
+            base.append(row.get("base_still"));
+            result.append(base);
+            result.append(target.get("effective_params").get("camouflage").get("shot_factor"));
+            result.append(p);
+        }
+        profile_cache[identity] = result;
+        return result;
+    }
+    double view(const Value &source, double now) {
+        ActorKey identity = key(source);
+        auto since = source_still.find(identity);
+        if (identity[0] == 0) {
+            Bot &bot = *bots.at(identity[1]);
+            const Value &v = bot.config.get("perception").get("vision");
+            double value = field(source, "view_range", 330);
+            if (v.kind == Value::Array)
+                value = v[2].kind != Value::Null && since != source_still.end() &&
+                                now - since->second >= std::max(0.0, v[2].number())
+                            ? v[1].number()
+                            : v[0].number();
+            return value * factors.vision(factors.stat(source, *bot.critical, "vision"));
+        }
+        const Actor &actor = roster[indices.at(identity)];
+        const Value &snapshot = source.get("effective_params"), &p = snapshot.get("spotting");
+        Value row = dynamic(source);
+        double damage =
+            factors.vision(field(row, "vision", 1) *
+                           factors.stat(source, human_critical.at(identity[1]), "vision", false));
+        bool binocular = flag(p, "has_binoculars") && since != source_still.end() &&
+                         now - since->second >= std::max(0.0, field(p, "binocular_delay", 3));
+        double value = std::max(field(config, "proximity"), field(actor.config, "base_view", 330));
+        value *= std::max(0.0, field(actor.config, "view_misc", 1) * damage);
+        value *= std::max(0.0, field(p, "vision_factor"));
+        if (binocular)
+            value *= std::max(1.0, field(p, "binocular_factor", 1));
+        return std::max(field(config, "proximity"), value);
+    }
+    Value projection(const Value &target, double now) {
+        ActorKey identity = key(target);
+        bool moving = std::abs(field(target, "speed")) > field(config, "moving_epsilon");
+        auto cached = projection_cache.find(identity);
+        if (cached != projection_cache.end() && cached->second.first == moving)
+            return cached->second.second;
+        Value bundle = profile(target);
+        const Value &p = bundle[2];
+        double still = 0;
+        if (moving)
+            target_still.erase(identity);
+        else {
+            auto at = target_still.emplace(identity, now).first;
+            still = std::max(0.0, now - at->second);
+        }
+        bool ready = still >= std::max(0.0, field(p, "camouflage_net_delay", 3));
+        const Value &aspect =
+            p.get(moving || (flag(p, "has_camouflage_net") && !ready) ? "invisibility_moving"
+                                                                      : "invisibility_still");
+        Value result = Value::array();
+        result.append(bundle[0][0]);
+        result.append(bundle[0][1]);
+        result.append(bundle[1]);
+        result.append(Value(moving));
+        result.append(aspect[0]);
+        result.append(aspect[1]);
+        projection_cache[identity] = std::make_pair(moving, result);
+        return result;
+    }
+    Value engine_visibility(const Value &source, const Value &target, bool fired) {
+        if (engine) {
+            auto reply = engine->query(767, source, target, {static_cast<double>(fired)});
+            Value out = Value::array();
+            out.append(Value(reply[0] != 0));
+            out.append(Value(reply[1]));
+            return out;
+        }
+        std::array<double, 32> packet{};
+        packet[0] = 750;
+        packet[1] = kind(source);
+        packet[2] = id(source);
+        packet[3] = kind(target);
+        packet[4] = id(target);
+        packet[5] = fired;
+        Value first = position(source), second = target_position(target);
+        for (int i = 0; i < 3; ++i) {
+            packet[6 + i] = first[i].number();
+            packet[9 + i] = second[i].number();
+        }
+        if (offline_query(packet.data(), packet.size()))
+            throw std::runtime_error("kernel visibility engine callback");
+        Value result = Value::array();
+        result.append(Value(packet[0] != 0));
+        result.append(Value(packet[1]));
+        return result;
+    }
+    std::vector<std::array<int, 4>> run(std::vector<double> packet, const Value &source, double now,
+                                        const std::set<int> &processed,
+                                        const Value &single = Value()) {
+        packet.resize(576, 0);
+        call(packet);
+        bool has_view = false;
+        double source_view = 0;
+        while (packet[64] != 0) {
+            int stage = static_cast<int>(packet[64]), index = static_cast<int>(packet[65]);
+            bool phase = packet[66] != 0, fired = packet[67] != 0;
+            Value active = single.kind != Value::Null ? single : target(index, phase);
+            std::vector<double> reply = {306, static_cast<double>(handle),
+                                         static_cast<double>(stage)};
+            if (stage == 1)
+                record(reply, active);
+            else if (stage == 2) {
+                if (!has_view) {
+                    source_view = view(source, now);
+                    has_view = true;
+                }
+                reply.push_back(source_view);
+                Value p = projection(active, now);
+                for (const Value &v : elements(p))
+                    reply.push_back(v.number());
+            } else if (stage == 3) {
+                Value result = engine_visibility(source, active, fired);
+                reply.push_back(result[0].number());
+                reply.push_back(result[1].number());
+            } else
+                throw std::invalid_argument("kernel perception stage");
+            std::copy(reply.begin(), reply.end(), packet.begin());
+            call(packet);
+        }
+        (void)processed;
+        std::vector<std::array<int, 4>> rows;
+        int count = static_cast<int>(packet[65]);
+        for (int i = 0; i < count; ++i) {
+            std::array<int, 4> row;
+            for (int j = 0; j < 4; ++j)
+                row[j] = static_cast<int>(packet[66 + i * 4 + j]);
+            rows.push_back(row);
+        }
+        return rows;
+    }
+    bool visible(const Value &source, const Value &target, double now) {
+        std::vector<double> packet = {307, static_cast<double>(handle)};
+        record(packet, source);
+        packet.push_back(now);
+        record(packet, target);
+        auto rows = run(packet, source, now, {}, target);
+        return rows.at(0)[1] != 0;
+    }
+    void renew(TeamKey key, double now, double duration) {
+        std::vector<double> packet = {308,
+                                      static_cast<double>(handle),
+                                      static_cast<double>(key[0]),
+                                      static_cast<double>(key[1]),
+                                      static_cast<double>(key[2]),
+                                      now,
+                                      duration};
+        call(packet);
+    }
+    double remaining(TeamKey key, double now) {
+        std::vector<double> packet = {309,
+                                      static_cast<double>(handle),
+                                      static_cast<double>(key[0]),
+                                      static_cast<double>(key[1]),
+                                      static_cast<double>(key[2]),
+                                      now};
+        call(packet);
+        return packet[0];
+    }
+    static bool perk(const Value &snapshot, const Value &state, const std::string &wanted) {
+        std::set<std::string> knocked = names(state.get("critical").get("crew_ko"));
+        for (const Value &member : elements(snapshot.get("crew").get("members"))) {
+            if (knocked.count(member.get("instance").text()))
+                continue;
+            for (const Value &skill : elements(member.get("skills")))
+                if (skill.get("name").text() == wanted && flag(skill, "active") &&
+                    flag(skill, "enabled") && field(skill, "level") >= 100)
+                    return true;
+        }
+        return false;
+    }
+    void lifecycle(double now) {
+        std::set<int> present;
+        for (const Actor &a : roster)
+            if (a.kind == 1) {
+                present.insert(a.id);
+                bool alive = flag(a.raw, "alive", true);
+                auto before = human_alive.find(a.id);
+                if (before != human_alive.end() && before->second && !alive) {
+                    Value prior = Value::object();
+                    auto at = human_last_critical.find(a.id);
+                    prior["critical"] =
+                        at == human_last_critical.end() ? Value::object() : at->second;
+                    if (perk(a.raw.get("effective_params"), prior, "radioman_lasteffort"))
+                        human_vengeance[a.id] = now + field(config, "last_effort");
+                } else if (alive) {
+                    const Value &p = a.raw.get("critical");
+                    human_last_critical[a.id] =
+                        p.kind == Value::Object ? p.copy() : Value::object();
+                    human_vengeance.erase(a.id);
+                }
+                human_alive[a.id] = alive;
+            }
+        for (auto at = human_alive.begin(); at != human_alive.end();)
+            if (!present.count(at->first)) {
+                int id = at->first;
+                at = human_alive.erase(at);
+                human_last_critical.erase(id);
+                human_direct.erase(id);
+                human_vengeance.erase(id);
+                source_still.erase(ActorKey{{1, id}});
+            } else
+                ++at;
+        for (auto at = human_vengeance.begin(); at != human_vengeance.end();)
+            if (now >= at->second) {
+                human_direct.erase(at->first);
+                at = human_vengeance.erase(at);
+            } else
+                ++at;
+    }
+    double designated(const Value &source, const Value &target) {
+        if (!perk(source.get("effective_params"), source, "gunner_rancorous"))
+            return field(config, "memory");
+        Value start = position(source), end = target_position(target);
+        double dx = end[0].number() - start[0].number(), dz = end[2].number() - start[2].number();
+        if (dx * dx + dz * dz <= .000001)
+            return field(config, "designated");
+        double bearing = std::atan2(dx, dz), yaw = field(source, "aim_yaw", field(source, "yaw"));
+        return std::abs(angle(bearing - yaw)) <= .08726646259971647 + 1e-9
+                   ? field(config, "designated")
+                   : field(config, "memory");
+    }
+    void append_humans(double now) {
+        std::vector<Value> targets;
+        for (size_t i = 0; i < roster.size(); ++i)
+            if (flag(roster[i].raw, "alive", true))
+                targets.push_back(target(i, false));
+        for (const Actor &a : roster)
+            if (a.kind == 1) {
+                Value source = a.raw.copy();
+                source["kind"] = Value("human");
+                source["network_id"] = Value(a.id);
+                source["id"] = Value(a.id);
+                int team = integer(source, "team");
+                if ((team != 1 && team != 2) || a.id <= 0)
+                    throw std::invalid_argument("kernel human observer identity");
+                bool alive = flag(source, "alive", true);
+                std::set<ActorKey> direct;
+                if (alive)
+                    note_still(source, now);
+                else {
+                    auto until = human_vengeance.find(a.id);
+                    if (until != human_vengeance.end() && now < until->second)
+                        direct = human_direct[a.id];
+                }
+                for (Value &t : targets) {
+                    if (integer(t, "team") == team)
+                        continue;
+                    ActorKey identity = key(t);
+                    TeamKey tk = team_key(team, t);
+                    bool seen = alive ? visible(source, t, now) : direct.count(identity) != 0;
+                    if (seen && alive)
+                        direct.insert(identity);
+                    Observation &entry = observations[tk];
+                    entry.visible = entry.visible || seen;
+                    entry.target = t;
+                    if (!seen)
+                        continue;
+                    entry.humans.insert(a.id);
+                    team_visible[tk] = true;
+                    Value p = pose(t);
+                    remembered[tk] = p;
+                    update(entry.target, p);
+                    renew(tk, now, alive ? designated(source, t) : field(config, "memory"));
+                }
+                if (alive)
+                    human_direct[a.id] = direct;
+            }
+    }
+    Value refresh(const Value &cached) {
+        Value result = cached.copy();
+        ActorKey identity = key(cached);
+        auto at = indices.find(identity);
+        if (at == indices.end())
+            return result;
+        const Value &live = roster[at->second].raw;
+        if (flag(cached, "fresh_visible")) {
+            result["position"] = position(live);
+            for (const Value &v : elements(config.get("pose_fields"))) {
+                std::string name = v.text();
+                if (live.has(name))
+                    result[name] = live.get(name);
+            }
+        }
+        for (const char *name : {"alive", "health", "max_health", "team"})
+            if (live.has(name))
+                result[name] = live.get(name);
+        return result;
+    }
+    void collect(const Value &source, const Contacts &contacts, const std::set<int> &processed) {
+        std::map<int, Value> live;
+        for (const auto &v : contacts.lookup) {
+            ActorKey identity = key(v.second);
+            std::array<int, 3> pk = {{identity[0], identity[1],
+                                      identity[0] == 0 && processed.count(identity[1]) ? 1 : 0}};
+            auto at = probe_targets.find(pk);
+            if (at == probe_targets.end())
+                at = probe_targets.emplace(pk, refresh(v.second)).first;
+            live[v.first] = at->second;
+        }
+        int team = integer(source, "team");
+        for (const Value &cached : elements(contacts.rows)) {
+            auto at = live.find(integer(cached, "id"));
+            Value observed = at == live.end() ? cached : at->second;
+            TeamKey tk = team_key(team, observed);
+            bool fresh = flag(cached, "fresh_visible");
+            team_visible[tk] = fresh || team_visible[tk];
+            if (fresh) {
+                Value p = pose(observed);
+                remembered[tk] = p;
+                update(observed, p);
+            }
+            Observation &entry = observations[tk];
+            entry.visible = entry.visible || flag(cached, "visible");
+            entry.target = observed;
+            if (flag(cached, "direct_visible"))
+                entry.bots.insert(integer(source, "id"));
+        }
+    }
+    Contacts contacts(const Value &source, double now, const std::set<int> &processed) {
+        std::vector<double> packet = {304, static_cast<double>(handle)};
+        record(packet, source, integer(source, "id"));
+        packet.push_back(now);
+        int team = integer(source, "team");
+        for (const Actor &a : roster) {
+            packet.push_back(a.kind == 0 && processed.count(a.id));
+            packet.push_back(team_visible[TeamKey{{team, a.kind, a.id}}]);
+            packet.push_back(flag(a.raw, "alive", true));
+            packet.push_back(integer(a.raw, "team"));
+        }
+        auto results = run(packet, source, now, processed);
+        Contacts out;
+        for (const auto &row : results) {
+            const Actor &a = roster.at(row[0]);
+            Value base = target(row[0], a.kind == 0 && processed.count(a.id)), t = base.copy();
+            bool visible = row[1] != 0, direct = row[2] != 0, fresh = row[3] != 0;
+            TeamKey key = {{team, a.kind, a.id}};
+            if (direct)
+                team_visible[key] = true;
+            if (fresh) {
+                Value p = pose(base);
+                remembered[key] = p;
+                update(t, p);
+            } else {
+                for (const Value &name : elements(config.get("pose_fields")))
+                    t.erase(name.text());
+                auto prior = remembered.find(key);
+                if (prior == remembered.end()) {
+                    t["position"] = point(0, 0, 0);
+                    for (const char *name : {"x", "y", "z", "yaw", "speed"})
+                        t[name] = Value(0.0);
+                    visible = false;
+                } else
+                    update(t, prior->second);
+            }
+            t["visible"] = Value(visible);
+            t["direct_visible"] = Value(direct);
+            t["fresh_visible"] = Value(fresh);
+            if (visible)
+                out.lookup[integer(t, "id")] = t;
+            out.rows.append(t);
+        }
+        return out;
+    }
+    Value snapshot() const {
+        Value result = Value::object(), poses = Value::array(), source = Value::array(),
+              target = Value::array(), visible = Value::array();
+        for (const auto &v : remembered) {
+            Value row = Value::array();
+            for (int n : v.first)
+                row.append(Value(n));
+            row.append(v.second);
+            poses.append(row);
+        }
+        for (const auto &v : source_still) {
+            Value row = Value::array();
+            for (int n : v.first)
+                row.append(Value(n));
+            row.append(Value(v.second));
+            source.append(row);
+        }
+        for (const auto &v : target_still) {
+            Value row = Value::array();
+            for (int n : v.first)
+                row.append(Value(n));
+            row.append(Value(v.second));
+            target.append(row);
+        }
+        for (const auto &v : team_visible)
+            if (v.second) {
+                Value row = Value::array();
+                for (int n : v.first)
+                    row.append(Value(n));
+                visible.append(row);
+            }
+        result["remembered"] = poses;
+        result["source_still"] = source;
+        result["target_still"] = target;
+        result["team_visible"] = visible;
+        return result;
+    }
+};
+} // namespace offline_kernel
+#endif

--- a/tools/ffi_experiment/kernel_perception.h
+++ b/tools/ffi_experiment/kernel_perception.h
@@ -25,6 +25,7 @@ struct Perception {
         Value raw, config;
     };
     const Value config;
+    const std::vector<Field> human_fields, bot_fields, pose_fields;
     Factors factors;
     int handle = 0;
     Engine *engine = nullptr;
@@ -45,7 +46,9 @@ struct Perception {
     std::map<TeamKey, Observation> observations;
     std::map<std::array<int, 3>, Value> probe_targets;
     explicit Perception(const Value &v, std::map<int, std::unique_ptr<Bot>> &states)
-        : config(v), factors(v.get("factors")), bots(states) {
+        : config(v), human_fields(bind_fields(v.get("human_fields"))),
+          bot_fields(bind_fields(v.get("bot_fields"))),
+          pose_fields(bind_fields(v.get("pose_fields"))), factors(v.get("factors")), bots(states) {
         std::vector<double> packet = {300};
         for (const char *name :
              {"ttl", "shot_seconds", "proximity", "maximum", "memory", "designated", "budget"})
@@ -69,20 +72,20 @@ struct Perception {
         std::vector<double> packet = {static_cast<double>(op), static_cast<double>(handle)};
         call(packet);
     }
-    static int kind(const Value &v) { return v.get("kind").text() == "human" ? 1 : 0; }
-    static int id(const Value &v) { return integer(v, "network_id", integer(v, "id")); }
+    static int kind(const Value &v) { return v.get(sf::kind).text() == "human" ? 1 : 0; }
+    static int id(const Value &v) { return integer(v, sf::network_id, integer(v, sf::id)); }
     static ActorKey key(const Value &v) { return ActorKey{{kind(v), id(v)}}; }
     static TeamKey team_key(int team, const Value &target) {
         return TeamKey{{team, kind(target), id(target)}};
     }
     static int fire(const Value &v) {
-        return v.get("fire_seq").kind == Value::Null ? -1 : std::max(0, integer(v, "fire_seq"));
+        return v.get(sf::fire_seq).kind == Value::Null ? -1 : std::max(0, integer(v, sf::fire_seq));
     }
     void record(std::vector<double> &packet, const Value &state, int identity = -1) {
         Value p = target_position(state);
         packet.push_back(kind(state));
         packet.push_back(identity < 0 ? id(state) : identity);
-        packet.push_back(integer(state, "team"));
+        packet.push_back(integer(state, sf::team));
         for (const Value &v : elements(p))
             packet.push_back(v.number());
         packet.push_back(fire(state));
@@ -100,10 +103,10 @@ struct Perception {
         observations.clear();
         probe_targets.clear();
         for (const Value &raw : elements(players)) {
-            if (raw.kind != Value::Object || !raw.has("id"))
+            if (raw.kind != Value::Object || !raw.has(sf::id))
                 continue;
-            int identity = integer(raw, "id");
-            Actor actor{1, identity, raw, raw.get("_kernel")};
+            int identity = integer(raw, sf::id);
+            Actor actor{1, identity, raw, raw.get(sf::_kernel)};
             indices[ActorKey{{1, identity}}] = roster.size();
             roster.push_back(actor);
             human_critical.emplace(identity, CriticalConfig(actor.config.get("critical_config")));
@@ -118,8 +121,8 @@ struct Perception {
         for (const Actor &actor : roster) {
             packet.push_back(actor.kind);
             packet.push_back(actor.id);
-            packet.push_back(integer(actor.raw, "team"));
-            packet.push_back(flag(actor.raw, "alive", true));
+            packet.push_back(integer(actor.raw, sf::team));
+            packet.push_back(flag(actor.raw, sf::alive, true));
         }
         call(packet);
     }
@@ -129,12 +132,12 @@ struct Perception {
         int count = 0;
         for (int id : ordered) {
             const Value &state = bots.at(id)->state;
-            if (!flag(state, "alive", true))
+            if (!flag(state, sf::alive, true))
                 continue;
             auto selected = selected_targets.find(id);
             packet.push_back(0);
             packet.push_back(id);
-            packet.push_back(integer(state, "team"));
+            packet.push_back(integer(state, sf::team));
             packet.push_back(fire(state));
             packet.push_back(selected != selected_targets.end() ? selected->second[0] : -1);
             packet.push_back(selected != selected_targets.end() ? selected->second[1] : 0);
@@ -142,10 +145,10 @@ struct Perception {
             ++count;
         }
         for (const Actor &actor : roster)
-            if (actor.kind == 1 && flag(actor.raw, "alive", true)) {
+            if (actor.kind == 1 && flag(actor.raw, sf::alive, true)) {
                 packet.push_back(1);
                 packet.push_back(actor.id);
-                packet.push_back(integer(actor.raw, "team"));
+                packet.push_back(integer(actor.raw, sf::team));
                 packet.push_back(fire(actor.raw));
                 packet.push_back(-1);
                 packet.push_back(0);
@@ -157,7 +160,7 @@ struct Perception {
     }
     void note_still(const Value &source, double now) {
         ActorKey identity = key(source);
-        if (std::abs(field(source, "speed")) > field(config, "moving_epsilon"))
+        if (std::abs(field(source, sf::speed)) > field(config, "moving_epsilon"))
             source_still.erase(identity);
         else
             source_still.emplace(identity, now);
@@ -168,31 +171,31 @@ struct Perception {
         auto at = templates.find(cache_key);
         if (at != templates.end())
             return at->second;
-        Value result =
-            select_fields(actor.raw, config.get(actor.kind == 1 ? "human_fields" : "bot_fields"));
-        result["kind"] = Value(actor.kind == 1 ? "human" : "bot");
-        result["network_id"] = Value(actor.id);
-        result["id"] = Value(actor.kind == 1 ? integer(config, "human_base") + actor.id : actor.id);
-        result["position"] = position(actor.raw);
+        Value result = select_fields(actor.raw, actor.kind == 1 ? human_fields : bot_fields);
+        result[sf::kind] = Value(actor.kind == 1 ? "human" : "bot");
+        result[sf::network_id] = Value(actor.id);
+        result[sf::id] =
+            Value(actor.kind == 1 ? integer(config, "human_base") + actor.id : actor.id);
+        result[sf::position] = position(actor.raw);
         if (actor.kind == 1) {
-            result["class_tag"] = actor.config.get("class_tag");
+            result[sf::class_tag] = actor.config.get(sf::class_tag);
             result["armor"] = actor.config.get("armor");
         }
         templates[cache_key] = result;
         return result;
     }
     Value pose(const Value &target) const {
-        Value p = select_fields(target, config.get("pose_fields"));
-        p["position"] = position(target);
+        Value p = select_fields(target, pose_fields);
+        p[sf::position] = position(target);
         for (const char *name : {"x", "y", "z", "yaw", "speed"})
             if (!p.has(name))
                 p[name] = Value(0.0);
         return p;
     }
     Value dynamic(const Value &target) const {
-        const Value &snapshot = target.get("effective_params"),
+        const Value &snapshot = target.get(sf::effective_params),
                     &projection = snapshot.get("crew").get("dynamic_spotting");
-        std::set<std::string> knocked = names(target.get("critical").get("crew_ko"));
+        std::set<std::string> knocked = names(target.get(sf::critical).get("crew_ko"));
         const Value &roster = projection.get("crew");
         unsigned mask = 0;
         for (size_t i = 0; i < roster.size(); ++i)
@@ -201,7 +204,7 @@ struct Perception {
         if (!knocked.empty())
             throw std::invalid_argument("kernel human critical roster");
         std::string name =
-            std::to_string(mask) + ":" + (flag(target.get("critical"), "fire") ? "1" : "0");
+            std::to_string(mask) + ":" + (flag(target.get(sf::critical), "fire") ? "1" : "0");
         const Value &row = projection.get("states").get(name);
         if (row.kind != Value::Object)
             throw std::invalid_argument("kernel human dynamic spotting");
@@ -214,9 +217,10 @@ struct Perception {
             return at->second;
         Value result;
         if (identity[0] == 0)
-            result = bots.at(identity[1])->config.get("perception").get("profile");
+            result = bots.at(identity[1])->config.get("perception").get(sf::profile);
         else {
-            Value row = dynamic(target), p = target.get("effective_params").get("spotting").copy();
+            Value row = dynamic(target),
+                  p = target.get(sf::effective_params).get("spotting").copy();
             p["vision_factor"] = Value(field(p, "vision_factor") * field(row, "vision", 1));
             p["camouflage_factor"] =
                 Value(field(p, "camouflage_factor") * field(row, "camouflage", 1));
@@ -227,7 +231,7 @@ struct Perception {
             base.append(row.get("base_moving"));
             base.append(row.get("base_still"));
             result.append(base);
-            result.append(target.get("effective_params").get("camouflage").get("shot_factor"));
+            result.append(target.get(sf::effective_params).get("camouflage").get("shot_factor"));
             result.append(p);
         }
         profile_cache[identity] = result;
@@ -239,7 +243,7 @@ struct Perception {
         if (identity[0] == 0) {
             Bot &bot = *bots.at(identity[1]);
             const Value &v = bot.config.get("perception").get("vision");
-            double value = field(source, "view_range", 330);
+            double value = field(source, sf::view_range, 330);
             if (v.kind == Value::Array)
                 value = v[2].kind != Value::Null && since != source_still.end() &&
                                 now - since->second >= std::max(0.0, v[2].number())
@@ -248,7 +252,7 @@ struct Perception {
             return value * factors.vision(factors.stat(source, *bot.critical, "vision"));
         }
         const Actor &actor = roster[indices.at(identity)];
-        const Value &snapshot = source.get("effective_params"), &p = snapshot.get("spotting");
+        const Value &snapshot = source.get(sf::effective_params), &p = snapshot.get("spotting");
         Value row = dynamic(source);
         double damage =
             factors.vision(field(row, "vision", 1) *
@@ -264,7 +268,7 @@ struct Perception {
     }
     Value projection(const Value &target, double now) {
         ActorKey identity = key(target);
-        bool moving = std::abs(field(target, "speed")) > field(config, "moving_epsilon");
+        bool moving = std::abs(field(target, sf::speed)) > field(config, "moving_epsilon");
         auto cached = projection_cache.find(identity);
         if (cached != projection_cache.end() && cached->second.first == moving)
             return cached->second.second;
@@ -391,12 +395,12 @@ struct Perception {
         return packet[0];
     }
     static bool perk(const Value &snapshot, const Value &state, const std::string &wanted) {
-        std::set<std::string> knocked = names(state.get("critical").get("crew_ko"));
+        std::set<std::string> knocked = names(state.get(sf::critical).get("crew_ko"));
         for (const Value &member : elements(snapshot.get("crew").get("members"))) {
             if (knocked.count(member.get("instance").text()))
                 continue;
             for (const Value &skill : elements(member.get("skills")))
-                if (skill.get("name").text() == wanted && flag(skill, "active") &&
+                if (skill.get(sf::name).text() == wanted && flag(skill, "active") &&
                     flag(skill, "enabled") && field(skill, "level") >= 100)
                     return true;
         }
@@ -407,17 +411,17 @@ struct Perception {
         for (const Actor &a : roster)
             if (a.kind == 1) {
                 present.insert(a.id);
-                bool alive = flag(a.raw, "alive", true);
+                bool alive = flag(a.raw, sf::alive, true);
                 auto before = human_alive.find(a.id);
                 if (before != human_alive.end() && before->second && !alive) {
                     Value prior = Value::object();
                     auto at = human_last_critical.find(a.id);
-                    prior["critical"] =
+                    prior[sf::critical] =
                         at == human_last_critical.end() ? Value::object() : at->second;
-                    if (perk(a.raw.get("effective_params"), prior, "radioman_lasteffort"))
+                    if (perk(a.raw.get(sf::effective_params), prior, "radioman_lasteffort"))
                         human_vengeance[a.id] = now + field(config, "last_effort");
                 } else if (alive) {
-                    const Value &p = a.raw.get("critical");
+                    const Value &p = a.raw.get(sf::critical);
                     human_last_critical[a.id] =
                         p.kind == Value::Object ? p.copy() : Value::object();
                     human_vengeance.erase(a.id);
@@ -442,13 +446,14 @@ struct Perception {
                 ++at;
     }
     double designated(const Value &source, const Value &target) {
-        if (!perk(source.get("effective_params"), source, "gunner_rancorous"))
+        if (!perk(source.get(sf::effective_params), source, "gunner_rancorous"))
             return field(config, "memory");
         Value start = position(source), end = target_position(target);
         double dx = end[0].number() - start[0].number(), dz = end[2].number() - start[2].number();
         if (dx * dx + dz * dz <= .000001)
             return field(config, "designated");
-        double bearing = std::atan2(dx, dz), yaw = field(source, "aim_yaw", field(source, "yaw"));
+        double bearing = std::atan2(dx, dz),
+               yaw = field(source, sf::aim_yaw, field(source, sf::yaw));
         return std::abs(angle(bearing - yaw)) <= .08726646259971647 + 1e-9
                    ? field(config, "designated")
                    : field(config, "memory");
@@ -456,18 +461,18 @@ struct Perception {
     void append_humans(double now) {
         std::vector<Value> targets;
         for (size_t i = 0; i < roster.size(); ++i)
-            if (flag(roster[i].raw, "alive", true))
+            if (flag(roster[i].raw, sf::alive, true))
                 targets.push_back(target(i, false));
         for (const Actor &a : roster)
             if (a.kind == 1) {
                 Value source = a.raw.copy();
-                source["kind"] = Value("human");
-                source["network_id"] = Value(a.id);
-                source["id"] = Value(a.id);
-                int team = integer(source, "team");
+                source[sf::kind] = Value("human");
+                source[sf::network_id] = Value(a.id);
+                source[sf::id] = Value(a.id);
+                int team = integer(source, sf::team);
                 if ((team != 1 && team != 2) || a.id <= 0)
                     throw std::invalid_argument("kernel human observer identity");
-                bool alive = flag(source, "alive", true);
+                bool alive = flag(source, sf::alive, true);
                 std::set<ActorKey> direct;
                 if (alive)
                     note_still(source, now);
@@ -477,7 +482,7 @@ struct Perception {
                         direct = human_direct[a.id];
                 }
                 for (Value &t : targets) {
-                    if (integer(t, "team") == team)
+                    if (integer(t, sf::team) == team)
                         continue;
                     ActorKey identity = key(t);
                     TeamKey tk = team_key(team, t);
@@ -508,9 +513,8 @@ struct Perception {
             return result;
         const Value &live = roster[at->second].raw;
         if (flag(cached, "fresh_visible")) {
-            result["position"] = position(live);
-            for (const Value &v : elements(config.get("pose_fields"))) {
-                std::string name = v.text();
+            result[sf::position] = position(live);
+            for (Field name : pose_fields) {
                 if (live.has(name))
                     result[name] = live.get(name);
             }
@@ -531,9 +535,9 @@ struct Perception {
                 at = probe_targets.emplace(pk, refresh(v.second)).first;
             live[v.first] = at->second;
         }
-        int team = integer(source, "team");
+        int team = integer(source, sf::team);
         for (const Value &cached : elements(contacts.rows)) {
-            auto at = live.find(integer(cached, "id"));
+            auto at = live.find(integer(cached, sf::id));
             Value observed = at == live.end() ? cached : at->second;
             TeamKey tk = team_key(team, observed);
             bool fresh = flag(cached, "fresh_visible");
@@ -544,22 +548,22 @@ struct Perception {
                 update(observed, p);
             }
             Observation &entry = observations[tk];
-            entry.visible = entry.visible || flag(cached, "visible");
+            entry.visible = entry.visible || flag(cached, sf::visible);
             entry.target = observed;
             if (flag(cached, "direct_visible"))
-                entry.bots.insert(integer(source, "id"));
+                entry.bots.insert(integer(source, sf::id));
         }
     }
     Contacts contacts(const Value &source, double now, const std::set<int> &processed) {
         std::vector<double> packet = {304, static_cast<double>(handle)};
-        record(packet, source, integer(source, "id"));
+        record(packet, source, integer(source, sf::id));
         packet.push_back(now);
-        int team = integer(source, "team");
+        int team = integer(source, sf::team);
         for (const Actor &a : roster) {
             packet.push_back(a.kind == 0 && processed.count(a.id));
             packet.push_back(team_visible[TeamKey{{team, a.kind, a.id}}]);
-            packet.push_back(flag(a.raw, "alive", true));
-            packet.push_back(integer(a.raw, "team"));
+            packet.push_back(flag(a.raw, sf::alive, true));
+            packet.push_back(integer(a.raw, sf::team));
         }
         auto results = run(packet, source, now, processed);
         Contacts out;
@@ -579,18 +583,18 @@ struct Perception {
                     t.erase(name.text());
                 auto prior = remembered.find(key);
                 if (prior == remembered.end()) {
-                    t["position"] = point(0, 0, 0);
+                    t[sf::position] = point(0, 0, 0);
                     for (const char *name : {"x", "y", "z", "yaw", "speed"})
                         t[name] = Value(0.0);
                     visible = false;
                 } else
                     update(t, prior->second);
             }
-            t["visible"] = Value(visible);
+            t[sf::visible] = Value(visible);
             t["direct_visible"] = Value(direct);
             t["fresh_visible"] = Value(fresh);
             if (visible)
-                out.lookup[integer(t, "id")] = t;
+                out.lookup[integer(t, sf::id)] = t;
             out.rows.append(t);
         }
         return out;

--- a/tools/ffi_experiment/kernel_publication.h
+++ b/tools/ffi_experiment/kernel_publication.h
@@ -1,0 +1,90 @@
+#ifndef OFFLINE_EXPERIMENT_KERNEL_PUBLICATION_H
+#define OFFLINE_EXPERIMENT_KERNEL_PUBLICATION_H
+#include "kernel_equipment.h"
+#include <array>
+
+namespace offline_kernel {
+// Retain the signature's ordered structure and missing/null distinction without
+// allocating a Value container for every tuple and every (presence, value) pair.
+// Two buffers keep allocations stable after warmup. Values retain the same
+// shallow ownership as the old signature; this does not mutate Bot state.
+struct PublicationEdges {
+    struct Key {
+        std::string name;
+        int slot;
+        Field field() const { return Field{slot, name.c_str(), name.size()}; }
+    };
+    struct Scalar {
+        bool present = false;
+        Value value;
+        bool operator==(const Scalar &other) const {
+            return present == other.present && value == other.value;
+        }
+    };
+    struct BotEdge {
+        std::vector<Scalar> scalars;
+        Value ammo;
+        std::vector<std::array<Value, 7>> equipment;
+        std::array<Scalar, 2> shot;
+        bool operator==(const BotEdge &other) const {
+            return scalars == other.scalars && ammo == other.ammo &&
+                   equipment == other.equipment && shot == other.shot;
+        }
+    };
+    struct Signature {
+        std::vector<BotEdge> bots;
+        std::vector<std::array<Value, 2>> launches;
+        std::vector<std::array<Value, 4>> rams;
+        bool operator==(const Signature &other) const {
+            return bots == other.bots && launches == other.launches && rams == other.rams;
+        }
+    };
+    std::vector<Key> fields;
+    Signature current, previous;
+    bool valid = false;
+    explicit PublicationEdges(const Value &names) {
+        for (const Value &name : elements(names)) {
+            std::string key = name.text();
+            fields.push_back(Key{key, field_slot(key)});
+        }
+    }
+    void begin(size_t count) { current.bots.resize(count); }
+    static void scalar(Scalar &out, const Value &state, Field key) {
+        out.present = state.has(key);
+        out.value = state.get(key);
+    }
+    void capture(size_t index, const Value &state, const std::vector<Equipment> &equipment,
+                 double now) {
+        BotEdge &out = current.bots.at(index);
+        out.scalars.resize(fields.size());
+        for (size_t i = 0; i < fields.size(); ++i)
+            scalar(out.scalars[i], state, fields[i].field());
+        out.ammo = state.get(sf::ammo_remaining);
+        out.equipment.resize(equipment.size());
+        for (size_t i = 0; i < equipment.size(); ++i) {
+            const Equipment &e = equipment[i];
+            out.equipment[i] = {{e.contract, Value(e.uses), Value(e.active), Value(e.ready_at),
+                                 Value(now >= e.ready_at),
+                                 e.auto_pending ? Value(e.auto_since) : Value(),
+                                 e.ai_pending ? Value(e.ai_since) : Value()}};
+        }
+        scalar(out.shot[0], state, sf::shot_yaw);
+        scalar(out.shot[1], state, sf::shot_pitch);
+    }
+    bool finish(const Value &launches, const Value &rams) {
+        current.launches.resize(launches.size());
+        for (size_t i = 0; i < launches.size(); ++i)
+            current.launches[i] = {{launches[i].get(sf::id), launches[i].get(sf::fire_seq)}};
+        current.rams.resize(rams.size());
+        for (size_t i = 0; i < rams.size(); ++i)
+            current.rams[i] = {{rams[i].get("bot_id"), rams[i].get(sf::target_kind),
+                                rams[i].get(sf::target_id), rams[i].get("ram_seq")}};
+        if (valid && current == previous)
+            return false;
+        std::swap(current, previous);
+        valid = true;
+        return true;
+    }
+};
+} // namespace offline_kernel
+#endif

--- a/tools/ffi_experiment/kernel_routes.h
+++ b/tools/ffi_experiment/kernel_routes.h
@@ -1,0 +1,540 @@
+#ifndef OFFLINE_EXPERIMENT_KERNEL_ROUTES_H
+#define OFFLINE_EXPERIMENT_KERNEL_ROUTES_H
+#include "kernel_motion.h"
+#include "navigation_state.h"
+#include <tuple>
+
+namespace offline_kernel {
+inline Value tuple_value(std::initializer_list<Value> values) {
+    Value v = Value::array();
+    for (const Value &item : values)
+        v.append(item);
+    return v;
+}
+inline std::string python_key(const Value &v) {
+    if (v.kind == Value::Null)
+        return "None";
+    if (v.kind == Value::Boolean)
+        return v.truth() ? "True" : "False";
+    if (v.kind == Value::String) {
+        std::string out = "'";
+        for (unsigned char c : v.text()) {
+            if (c == '\\' || c == '\'')
+                out += '\\';
+            out += c;
+        }
+        return out + "'";
+    }
+    if (v.kind == Value::Array) {
+        std::string out = "(";
+        for (size_t i = 0; i < v.size(); ++i) {
+            if (i)
+                out += ", ";
+            out += python_key(v[i]);
+        }
+        if (v.size() == 1)
+            out += ",";
+        return out + ")";
+    }
+    return json(v);
+}
+struct Routes {
+    using Point = offline_nav::Point;
+    using Pair = std::pair<double, double>;
+    std::map<int, std::unique_ptr<Bot>> &bots;
+    std::map<int, Value> &orders;
+    offline_nav::Navigator *nav;
+    Value config;
+    explicit Routes(const Value &c, std::map<int, std::unique_ptr<Bot>> &b, std::map<int, Value> &o)
+        : bots(b), orders(o),
+          nav(integer(c, "navigation") ? &offline_runtime_navigation(integer(c, "navigation"))
+                                       : nullptr),
+          config(c) {}
+    static Value value(Point p) { return vector3(p.x, p.y, p.z); }
+    static Point point(const Value &v, Point fallback = Point()) {
+        if (v.kind == Value::Object)
+            return Point(field(v, "x", fallback.x), field(v, "y", fallback.y),
+                         field(v, "z", fallback.z));
+        return v.kind == Value::Array && v.size() == 3
+                   ? Point(v[0].number(), v[1].number(), v[2].number())
+                   : fallback;
+    }
+    static std::vector<double> lanes(double offset) {
+        if (offset >= 7.5)
+            return {10, 5, 0};
+        if (offset <= -7.5)
+            return {-10, -5, 0};
+        if (offset > 0)
+            return {5, 0};
+        if (offset < 0)
+            return {-5, 0};
+        return {0};
+    }
+    static std::vector<double> rows(double offset) {
+        return std::abs(offset) < 1e-9 ? std::vector<double>{0}
+                                       : std::vector<double>{offset, offset * .5, 0};
+    }
+    static std::vector<double> layout(int n) {
+        if (n <= 1)
+            return {0};
+        if (n == 2)
+            return {-5, 5};
+        if (n == 3)
+            return {-5, 0, 5};
+        if (n == 4)
+            return {-10, -5, 5, 10};
+        std::vector<double> out;
+        for (int i = 0; i < n; ++i)
+            out.push_back(-10 + 5 * ((2 * i + 1) * 5 / (2 * n)));
+        return out;
+    }
+    static std::vector<double> row_layout(int n) {
+        std::vector<double> out;
+        if (n <= 1)
+            return {0};
+        int count = std::min(5, n);
+        for (int i = 0; i < n; ++i) {
+            int row =
+                n == count
+                    ? i
+                    : static_cast<int>(rounded(i * static_cast<double>(count - 1) / (n - 1), 0));
+            out.push_back(-4 + 8.0 * row / (count - 1));
+        }
+        return out;
+    }
+    static bool group_matches(const Value &s, const Value &group) {
+        return s.get("_route_lane_group") == group;
+    }
+    std::vector<Value *> cohort(int id, const Value &group, const Value &gate) {
+        std::vector<Value *> out;
+        for (const auto &v : bots) {
+            Value &s = v.second->state;
+            if (!flag(s, "alive", true) || integer(s, "team") != group[0].exact())
+                continue;
+            Value route_id, peer_gate;
+            const Value &prior = s.get("_route_lane_gate");
+            if (group_matches(s, group) && prior.kind == Value::Array && prior.size() == 2) {
+                route_id = group[1];
+                peer_gate = prior;
+            } else {
+                auto order = orders.find(v.first);
+                if (order != orders.end()) {
+                    route_id = order->second.get("route_id");
+                    if (order->second.get("route_index").kind != Value::Null &&
+                        order->second.has("route_join"))
+                        peer_gate = tuple_value({Value(integer(order->second, "route_index")),
+                                                 Value(flag(order->second, "route_join"))});
+                } else if (!orders.empty())
+                    continue;
+            }
+            if (route_id.kind == Value::Null && orders.empty()) {
+                route_id = s.get("route").get("id");
+                if (s.get("route_index").kind != Value::Null &&
+                    s.get("route_join").kind != Value::Null)
+                    peer_gate = tuple_value({s.get("route_index"), Value(flag(s, "route_join"))});
+                else if (v.first == id)
+                    peer_gate = gate;
+            }
+            if (route_id.text() != group[1].text() || peer_gate != gate)
+                continue;
+            out.push_back(&s);
+        }
+        Value *own = &bots.at(id)->state;
+        if (std::find(out.begin(), out.end(), own) == out.end())
+            out.push_back(own);
+        std::sort(out.begin(), out.end(), [](const Value *a, const Value *b) {
+            return std::make_pair(integer(*a, "slot"), integer(*a, "id")) <
+                   std::make_pair(integer(*b, "slot"), integer(*b, "id"));
+        });
+        return out;
+    }
+    static Pair waypoint(const Value &v) {
+        return v.kind == Value::Object ? Pair(field(v, "x"), field(v, "z"))
+                                       : Pair(v[0].number(), v[1].number());
+    }
+    static Pair forward(const Value &s, Point goal, const Value &order) {
+        const Value &route = s.get("route"), &points = route.get("waypoints");
+        int index = integer(order, "route_index");
+        if (route.get("id").kind != Value::Null &&
+            route.get("id").text() == order.get("route_id").text("direct") && points.size() > 1) {
+            int a = index > 0 && index < static_cast<int>(points.size()) ? index - 1 : 0, b = a + 1;
+            Pair first = waypoint(points[a]), second = waypoint(points[b]);
+            double dx = second.first - first.first, dz = second.second - first.second,
+                   length = std::hypot(dx, dz);
+            if (length >= .25)
+                return {dx / length, dz / length};
+        }
+        Point anchor = point(order.get("route_anchor"), point(s));
+        double dx = goal.x - anchor.x, dz = goal.z - anchor.z, length = std::hypot(dx, dz);
+        return length < .25 ? Pair(std::sin(field(s, "yaw")), std::cos(field(s, "yaw")))
+                            : Pair(dx / length, dz / length);
+    }
+    static void clear_lane(Value &s) {
+        for (const char *name :
+             {"_route_lane_segment", "_route_lane_offset", "_route_lane_row", "_route_lane_goal"})
+            s.erase(name);
+    }
+    Pair binding(int id, const Value &group, Point goal, const Value &order) {
+        Value &s = bots.at(id)->state;
+        Value gate;
+        auto at = orders.find(id);
+        if (at != orders.end() && at->second.get("route_id").text() == group[1].text() &&
+            at->second.get("route_index").kind != Value::Null && at->second.has("route_join"))
+            gate = tuple_value(
+                {Value(integer(at->second, "route_index")), Value(flag(at->second, "route_join"))});
+        else
+            gate = tuple_value(
+                {Value(integer(order, "route_index")), Value(flag(order, "route_join"))});
+        if (group_matches(s, group)) {
+            if (gate[1].truth() && s.get("_route_lane_gate") != gate) {
+                s["_route_lane_gate"] = gate;
+                Pair f = forward(s, goal, order);
+                s["_route_lane_forward"] = tuple_value({Value(f.first), Value(f.second)});
+                clear_lane(s);
+            }
+            return {field(s, "_route_lane_desired"), field(s, "_route_lane_row_desired")};
+        }
+        std::vector<Value *> peers = cohort(id, group, gate);
+        for (Value *peer : peers)
+            if (!group_matches(*peer, group) || peer->get("_route_lane_gate") != gate ||
+                peer->get("_route_lane_origin").kind == Value::Null)
+                (*peer)["_route_lane_origin"] = position(*peer);
+        Pair f = forward(s, goal, order);
+        auto rank = [&](Value *peer, bool lateral) {
+            const Value &p = peer->get("_route_lane_origin");
+            return std::make_tuple(p[0].number() * (lateral ? -f.second : f.first) +
+                                       p[2].number() * (lateral ? f.first : f.second),
+                                   integer(*peer, "slot"), integer(*peer, "id"));
+        };
+        std::vector<Value *> ordered = peers;
+        std::sort(ordered.begin(), ordered.end(),
+                  [&](Value *a, Value *b) { return rank(a, true) < rank(b, true); });
+        std::vector<double> pattern = layout(ordered.size());
+        std::map<double, std::vector<Value *>> members;
+        for (size_t i = 0; i < ordered.size(); ++i)
+            members[pattern[i]].push_back(ordered[i]);
+        std::map<int, Pair> assigned;
+        for (auto &lane : members) {
+            auto &values = lane.second;
+            std::sort(values.begin(), values.end(),
+                      [&](Value *a, Value *b) { return rank(a, false) < rank(b, false); });
+            auto pattern = row_layout(values.size());
+            for (size_t i = 0; i < values.size(); ++i)
+                assigned[integer(*values[i], "id")] = Pair(lane.first, pattern[i]);
+        }
+        std::set<Pair> occupied;
+        for (Value *peer : peers)
+            if (group_matches(*peer, group) && peer->get("_route_lane_gate") == gate)
+                occupied.insert(
+                    {field(*peer, "_route_lane_desired"), field(*peer, "_route_lane_row_desired")});
+        if (!occupied.empty())
+            for (Value *peer : ordered) {
+                if (group_matches(*peer, group))
+                    continue;
+                int peer_id = integer(*peer, "id");
+                Pair expected = assigned[peer_id];
+                std::vector<Pair> available;
+                for (double lane : {-10, -5, 0, 5, 10}) {
+                    bool used = false;
+                    for (Pair p : occupied)
+                        used = used || p.first == lane;
+                    if (!used)
+                        available.push_back({lane, 0});
+                }
+                bool reuse = available.empty();
+                if (reuse)
+                    for (double lane : {-10, -5, 0, 5, 10})
+                        for (double row : {-4, -2, 0, 2, 4})
+                            if (!occupied.count({lane, row}))
+                                available.push_back({lane, row});
+                auto score = [&](Pair p) {
+                    double nearest = 1e100;
+                    for (Pair used : occupied)
+                        nearest = std::min(nearest,
+                                           (p.first - used.first) * (p.first - used.first) +
+                                               (p.second - used.second) * (p.second - used.second));
+                    double dx = p.first - expected.first, dz = p.second - expected.second;
+                    return std::make_tuple(reuse ? -nearest : 0, dx * dx + dz * dz, std::abs(dx),
+                                           std::abs(dz), p.first, p.second);
+                };
+                Pair selected =
+                    available.empty()
+                        ? Pair(0, 0)
+                        : *std::min_element(available.begin(), available.end(),
+                                            [&](Pair a, Pair b) { return score(a) < score(b); });
+                assigned[peer_id] = selected;
+                occupied.insert(selected);
+            }
+        for (Value *peer : peers) {
+            if (group_matches(*peer, group))
+                continue;
+            Pair choice = assigned[integer(*peer, "id")];
+            (*peer)["_route_lane_group"] = group;
+            (*peer)["_route_lane_gate"] = gate;
+            (*peer)["_route_lane_desired"] = Value(choice.first);
+            (*peer)["_route_lane_row_desired"] = Value(choice.second);
+            (*peer)["_route_lane_forward"] = tuple_value({Value(f.first), Value(f.second)});
+            clear_lane(*peer);
+        }
+        return {field(s, "_route_lane_desired"), field(s, "_route_lane_row_desired")};
+    }
+    static offline_nav::Optional<Pair> leg(const Value &s, Point current, Point goal,
+                                           const Value &order, bool joining) {
+        if (joining) {
+            const Value &v = s.get("_route_lane_forward");
+            if (v.size() == 2) {
+                double length = std::hypot(v[0].number(), v[1].number());
+                if (length >= .25)
+                    return Pair(v[0].number() / length, v[1].number() / length);
+            }
+        }
+        Point anchor = point(order.get("route_anchor"), current);
+        double dx = goal.x - anchor.x, dz = goal.z - anchor.z, length = std::hypot(dx, dz);
+        if (length < .25) {
+            dx = goal.x - current.x;
+            dz = goal.z - current.z;
+            length = std::hypot(dx, dz);
+        }
+        return length < .25 ? offline_nav::Optional<Pair>()
+                            : offline_nav::Optional<Pair>(Pair(dx / length, dz / length));
+    }
+    bool within(const Value &s, Point p, double yaw) const {
+        if (!nav || !nav->grid->bounded)
+            return false;
+        auto &b = nav->grid->bounds;
+        double sine = std::abs(std::sin(yaw)), cosine = std::abs(std::cos(yaw)),
+               length = std::max(.5, field(s, "half_length", 3.5)),
+               width = std::max(.3, field(s, "half_width", 1.7)),
+               x = cosine * width + sine * length, z = sine * width + cosine * length;
+        return b[0] + x - p.x <= 1e-6 && p.x + x - b[2] <= 1e-6 && b[1] + z - p.z <= 1e-6 &&
+               p.z + z - b[3] <= 1e-6;
+    }
+    offline_nav::Optional<Point> safe_goal(const Value &s, Point goal, Pair forward, double lateral,
+                                           double row, double now) {
+        if (std::abs(lateral) < 1e-9 && std::abs(row) < 1e-9)
+            return goal;
+        if (!nav)
+            return {};
+        Point candidate(goal.x - forward.second * lateral + forward.first * row, goal.y,
+                        goal.z + forward.first * lateral + forward.second * row);
+        if (std::hypot(candidate.x - goal.x, candidate.z - goal.z) + 1.5 > 13 + 1e-9)
+            return {};
+        auto &g = *nav->grid;
+        if (!g.ground(candidate, candidate.y) || g.point_hazard(goal, 7) ||
+            g.point_hazard(candidate, 7) || g.hazard(goal, candidate, 7) ||
+            !g.dry(goal, candidate, now) ||
+            !within(s, candidate, std::atan2(forward.first, forward.second)))
+            return {};
+        return candidate;
+    }
+    std::pair<Point, Pair> lane_goal(int id, Point current, Point goal, const Value &order,
+                                     double now, bool joining) {
+        Value &s = bots.at(id)->state;
+        Value group =
+            tuple_value({Value(integer(s, "team")), Value(order.get("route_id").text("direct"))});
+        Pair desired = binding(id, group, goal, order);
+        Value segment =
+            tuple_value({group[0], group[1], Value(integer(order, "route_index")), Value(joining)});
+        if (s.get("_route_lane_segment") != segment) {
+            s["_route_lane_segment"] = segment;
+            s["_route_lane_offset"] = Value(desired.first);
+            s["_route_lane_row"] = Value(joining ? desired.second : 0);
+            s.erase("_route_lane_goal");
+        }
+        auto f = leg(s, current, goal, order, joining);
+        auto fallback = [&]() {
+            s["_route_lane_offset"] = Value(0.0);
+            s["_route_lane_row"] = Value(0.0);
+            s["_route_lane_goal"] = value(goal);
+            return std::make_pair(goal, Pair(0, 0));
+        };
+        if (!f.has)
+            return fallback();
+        bool reject = false;
+        if (nav) {
+            auto at = nav->states.find(id);
+            if (at != nav->states.end() && at->second.status == 2 &&
+                s.get("_route_lane_goal").kind != Value::Null && at->second.planned_goal.has)
+                reject = offline_nav::distance(point(s.get("_route_lane_goal")),
+                                               at->second.planned_goal.value) < .25;
+        }
+        bool first = true;
+        std::set<Pair> seen;
+        for (double row : rows(field(s, "_route_lane_row")))
+            for (double lane : lanes(field(s, "_route_lane_offset"))) {
+                Pair identity(rounded(lane, 6), rounded(row, 6));
+                if (!seen.insert(identity).second)
+                    continue;
+                if (reject && first) {
+                    first = false;
+                    continue;
+                }
+                first = false;
+                auto candidate = safe_goal(s, goal, f.value, lane, row, now);
+                if (!candidate.has)
+                    continue;
+                s["_route_lane_offset"] = Value(lane);
+                s["_route_lane_row"] = Value(row);
+                s["_route_lane_goal"] = value(candidate.value);
+                return {candidate.value, Pair(rounded(lane * 1000, 0), rounded(row * 1000, 0))};
+            }
+        return fallback();
+    }
+    Point lane_target(int id, Point current, Point goal, Point selected, const Value &order,
+                      double now) {
+        Value &s = bots.at(id)->state;
+        double dx = selected.x - current.x, dz = selected.z - current.z;
+        if (!nav || std::hypot(dx, dz) < .25)
+            return selected;
+        Value group =
+            tuple_value({Value(integer(s, "team")), Value(order.get("route_id").text("direct"))});
+        Pair desired = binding(id, group, goal, order);
+        Value segment = tuple_value({group[0], group[1], Value(integer(order, "route_index"))});
+        if (s.get("_route_lane_segment") != segment) {
+            s["_route_lane_segment"] = segment;
+            s["_route_lane_offset"] = Value(desired.first);
+        }
+        auto at = nav->states.find(id);
+        if (at != nav->states.end() && at->second.shallow.has) {
+            s["_route_lane_offset"] = Value(0.0);
+            return selected;
+        }
+        Point anchor = point(order.get("route_anchor"), current);
+        double route_dx = goal.x - anchor.x, route_dz = goal.z - anchor.z,
+               length = std::hypot(route_dx, route_dz);
+        if (length < .25) {
+            route_dx = dx;
+            route_dz = dz;
+            length = std::hypot(dx, dz);
+        }
+        if (length < .25)
+            return selected;
+        for (double offset : lanes(field(s, "_route_lane_offset"))) {
+            if (std::abs(offset) < 1e-9)
+                break;
+            Point candidate(selected.x - route_dz / length * offset, selected.y,
+                            selected.z + route_dx / length * offset);
+            double cx = candidate.x - current.x, cz = candidate.z - current.z;
+            if (std::hypot(cx, cz) <= 1.5 + 1e-9 || dx * cx + dz * cz <= 1e-9)
+                continue;
+            auto &g = *nav->grid;
+            if (!g.ground(candidate, candidate.y) || nav->penalized(id, current, candidate, now) ||
+                g.point_hazard(candidate, 7) || g.hazard(current, candidate, 7) ||
+                !g.dry(current, candidate, now) || !within(s, candidate, std::atan2(cx, cz)))
+                continue;
+            s["_route_lane_offset"] = Value(offset);
+            return candidate;
+        }
+        s["_route_lane_offset"] = Value(0.0);
+        return selected;
+    }
+    offline_nav::Optional<Point> radio_goal(int id, Point current, Point goal, const Value &order) {
+        const Value &area = order.get("move_area_bounds");
+        if (!nav || area.size() != 4)
+            return {};
+        Value key = tuple_value({order.get("team_command_id"), area});
+        Value &s = bots.at(id)->state;
+        const Value &cached = s.get("_radio_ground_goal");
+        if (cached.kind == Value::Array && cached.size() == 2 && cached[0] == key)
+            return cached[1].kind == Value::Null ? offline_nav::Optional<Point>()
+                                                 : offline_nav::Optional<Point>(point(cached[1]));
+        auto &g = *nav->grid;
+        auto low = g.cell(Point(area[0].number(), current.y, area[1].number())),
+             high = g.cell(Point(area[2].number(), current.y, area[3].number()));
+        offline_nav::Optional<Point> best;
+        std::tuple<bool, double, offline_nav::Cell> score;
+        for (int z = low.second; z <= high.second; ++z)
+            for (int x = low.first; x <= high.first; ++x) {
+                offline_nav::Cell cell(x, z);
+                int index = g.index(cell);
+                if (index < 0)
+                    continue;
+                Point p = g.point(cell, g.data->heights[index] / 1000.0);
+                if (p.x < area[0].number() || p.x > area[2].number() || p.z < area[1].number() ||
+                    p.z > area[3].number() || g.point_hazard(p, 3))
+                    continue;
+                auto next =
+                    std::make_tuple(g.point_hazard(p, 4), offline_nav::distance(p, goal), cell);
+                if (!best.has || next < score) {
+                    best = p;
+                    score = next;
+                }
+            }
+        s["_radio_ground_goal"] = tuple_value({key, best.has ? value(best.value) : Value()});
+        return best;
+    }
+    Point target(int id, Point current, Point goal, const Value &order, Value &decision,
+                 bool gun_pending) {
+        std::string mode = order.get("combat_mode").text("route");
+        bool stop = mode != "route" && mode != "advance";
+        if (!nav) {
+            decision["navigation_stop_at_target"] = Value(stop);
+            return goal;
+        }
+        if (order.get("move_area_bounds").kind != Value::Null) {
+            auto grounded = radio_goal(id, current, goal, order);
+            if (!grounded.has) {
+                decision["navigation_stop_at_target"] = Value(true);
+                return current;
+            }
+            goal = grounded.value;
+        }
+        double now = field(decision, "now");
+        int route = integer(order, "route_index");
+        Value path;
+        offline_nav::Optional<Point> anchor;
+        if (mode == "base_defense")
+            path = tuple_value(
+                {Value("local"), Value(id), Value("base_defense"),
+                 Value(order.get("defense_base_id").truth() ? order.get("defense_base_id").text()
+                                                            : "own_base")});
+        else if (mode == "route" || mode == "advance" || mode == "hold") {
+            if (flag(order, "route_join") && order.get("route_anchor").kind != Value::Null)
+                anchor = point(order.get("route_anchor"));
+            Pair lane(0, 0);
+            if ((mode == "route" || mode == "advance") && anchor.has) {
+                auto selected = lane_goal(id, current, goal, order, now, true);
+                goal = selected.first;
+                lane = selected.second;
+            }
+            if (anchor.has)
+                path = tuple_value(
+                    {Value("route_join"), Value(id), Value(integer(bots.at(id)->state, "team")),
+                     Value(order.get("route_id").text("direct")), Value(route),
+                     Value(static_cast<int>(lane.first)), Value(static_cast<int>(lane.second))});
+            else
+                path = tuple_value({Value("route"), Value(integer(bots.at(id)->state, "team")),
+                                    Value(order.get("route_id").text("direct")), Value(route)});
+        } else
+            path = tuple_value({Value("local"), Value(id), Value(mode), order.get("target_id")});
+        offline_nav::Identity key;
+        key.repr = python_key(path);
+        key.kind = path[0].text();
+        key.owner = key.kind == "route" ? -1 : id;
+        key.prefer = key.kind == "route";
+        bool direct = offline_nav::distance(current, goal) <= 15 &&
+                      !nav->penalized(id, current, goal, now) && nav->grid->dry(current, goal, now);
+        bool movement = (order.get("throttle_override").kind == Value::Null ||
+                         field(order, "throttle_override") > 0) &&
+                        !offline_driver_waiting(integer(config, "driver"), id) && !gun_pending;
+        Point selected;
+        if (direct) {
+            auto escape = nav->observe_direct(id, current, goal, key, now, movement);
+            selected = escape.has ? escape.value : goal;
+        } else
+            selected = nav->next_target(
+                id, current, goal, key, now, anchor, offline_nav::Path(),
+                std::max(std::max(1.0, nav->grid->data->cell) * 2,
+                         std::abs(field(decision, "speed")) * field(config, "lookahead", 1.5)),
+                movement);
+        auto at = nav->states.find(id);
+        decision["navigation_stop_at_target"] =
+            Value(stop && ((direct && selected == goal) ||
+                           (!direct && at != nav->states.end() && at->second.terminal)));
+        return (mode == "route" || mode == "advance") && !anchor.has
+                   ? lane_target(id, current, goal, selected, order, now)
+                   : selected;
+    }
+};
+} // namespace offline_kernel
+#endif

--- a/tools/ffi_experiment/kernel_routes.h
+++ b/tools/ffi_experiment/kernel_routes.h
@@ -53,8 +53,8 @@ struct Routes {
     static Value value(Point p) { return vector3(p.x, p.y, p.z); }
     static Point point(const Value &v, Point fallback = Point()) {
         if (v.kind == Value::Object)
-            return Point(field(v, "x", fallback.x), field(v, "y", fallback.y),
-                         field(v, "z", fallback.z));
+            return Point(field(v, sf::x, fallback.x), field(v, sf::y, fallback.y),
+                         field(v, sf::z, fallback.z));
         return v.kind == Value::Array && v.size() == 3
                    ? Point(v[0].number(), v[1].number(), v[2].number())
                    : fallback;
@@ -103,16 +103,16 @@ struct Routes {
         return out;
     }
     static bool group_matches(const Value &s, const Value &group) {
-        return s.get("_route_lane_group") == group;
+        return s.get(sf::_route_lane_group) == group;
     }
     std::vector<Value *> cohort(int id, const Value &group, const Value &gate) {
         std::vector<Value *> out;
         for (const auto &v : bots) {
             Value &s = v.second->state;
-            if (!flag(s, "alive", true) || integer(s, "team") != group[0].exact())
+            if (!flag(s, sf::alive, true) || integer(s, sf::team) != group[0].exact())
                 continue;
             Value route_id, peer_gate;
-            const Value &prior = s.get("_route_lane_gate");
+            const Value &prior = s.get(sf::_route_lane_gate);
             if (group_matches(s, group) && prior.kind == Value::Array && prior.size() == 2) {
                 route_id = group[1];
                 peer_gate = prior;
@@ -120,18 +120,19 @@ struct Routes {
                 auto order = orders.find(v.first);
                 if (order != orders.end()) {
                     route_id = order->second.get("route_id");
-                    if (order->second.get("route_index").kind != Value::Null &&
-                        order->second.has("route_join"))
-                        peer_gate = tuple_value({Value(integer(order->second, "route_index")),
-                                                 Value(flag(order->second, "route_join"))});
+                    if (order->second.get(sf::route_index).kind != Value::Null &&
+                        order->second.has(sf::route_join))
+                        peer_gate = tuple_value({Value(integer(order->second, sf::route_index)),
+                                                 Value(flag(order->second, sf::route_join))});
                 } else if (!orders.empty())
                     continue;
             }
             if (route_id.kind == Value::Null && orders.empty()) {
-                route_id = s.get("route").get("id");
-                if (s.get("route_index").kind != Value::Null &&
-                    s.get("route_join").kind != Value::Null)
-                    peer_gate = tuple_value({s.get("route_index"), Value(flag(s, "route_join"))});
+                route_id = s.get(sf::route).get(sf::id);
+                if (s.get(sf::route_index).kind != Value::Null &&
+                    s.get(sf::route_join).kind != Value::Null)
+                    peer_gate =
+                        tuple_value({s.get(sf::route_index), Value(flag(s, sf::route_join))});
                 else if (v.first == id)
                     peer_gate = gate;
             }
@@ -143,20 +144,20 @@ struct Routes {
         if (std::find(out.begin(), out.end(), own) == out.end())
             out.push_back(own);
         std::sort(out.begin(), out.end(), [](const Value *a, const Value *b) {
-            return std::make_pair(integer(*a, "slot"), integer(*a, "id")) <
-                   std::make_pair(integer(*b, "slot"), integer(*b, "id"));
+            return std::make_pair(integer(*a, sf::slot), integer(*a, sf::id)) <
+                   std::make_pair(integer(*b, sf::slot), integer(*b, sf::id));
         });
         return out;
     }
     static Pair waypoint(const Value &v) {
-        return v.kind == Value::Object ? Pair(field(v, "x"), field(v, "z"))
+        return v.kind == Value::Object ? Pair(field(v, sf::x), field(v, sf::z))
                                        : Pair(v[0].number(), v[1].number());
     }
     static Pair forward(const Value &s, Point goal, const Value &order) {
-        const Value &route = s.get("route"), &points = route.get("waypoints");
-        int index = integer(order, "route_index");
-        if (route.get("id").kind != Value::Null &&
-            route.get("id").text() == order.get("route_id").text("direct") && points.size() > 1) {
+        const Value &route = s.get(sf::route), &points = route.get("waypoints");
+        int index = integer(order, sf::route_index);
+        if (route.get(sf::id).kind != Value::Null &&
+            route.get(sf::id).text() == order.get("route_id").text("direct") && points.size() > 1) {
             int a = index > 0 && index < static_cast<int>(points.size()) ? index - 1 : 0, b = a + 1;
             Pair first = waypoint(points[a]), second = waypoint(points[b]);
             double dx = second.first - first.first, dz = second.second - first.second,
@@ -164,9 +165,9 @@ struct Routes {
             if (length >= .25)
                 return {dx / length, dz / length};
         }
-        Point anchor = point(order.get("route_anchor"), point(s));
+        Point anchor = point(order.get(sf::route_anchor), point(s));
         double dx = goal.x - anchor.x, dz = goal.z - anchor.z, length = std::hypot(dx, dz);
-        return length < .25 ? Pair(std::sin(field(s, "yaw")), std::cos(field(s, "yaw")))
+        return length < .25 ? Pair(std::sin(field(s, sf::yaw)), std::cos(field(s, sf::yaw)))
                             : Pair(dx / length, dz / length);
     }
     static void clear_lane(Value &s) {
@@ -179,32 +180,32 @@ struct Routes {
         Value gate;
         auto at = orders.find(id);
         if (at != orders.end() && at->second.get("route_id").text() == group[1].text() &&
-            at->second.get("route_index").kind != Value::Null && at->second.has("route_join"))
-            gate = tuple_value(
-                {Value(integer(at->second, "route_index")), Value(flag(at->second, "route_join"))});
+            at->second.get(sf::route_index).kind != Value::Null && at->second.has(sf::route_join))
+            gate = tuple_value({Value(integer(at->second, sf::route_index)),
+                                Value(flag(at->second, sf::route_join))});
         else
             gate = tuple_value(
-                {Value(integer(order, "route_index")), Value(flag(order, "route_join"))});
+                {Value(integer(order, sf::route_index)), Value(flag(order, sf::route_join))});
         if (group_matches(s, group)) {
-            if (gate[1].truth() && s.get("_route_lane_gate") != gate) {
-                s["_route_lane_gate"] = gate;
+            if (gate[1].truth() && s.get(sf::_route_lane_gate) != gate) {
+                s[sf::_route_lane_gate] = gate;
                 Pair f = forward(s, goal, order);
-                s["_route_lane_forward"] = tuple_value({Value(f.first), Value(f.second)});
+                s[sf::_route_lane_forward] = tuple_value({Value(f.first), Value(f.second)});
                 clear_lane(s);
             }
-            return {field(s, "_route_lane_desired"), field(s, "_route_lane_row_desired")};
+            return {field(s, sf::_route_lane_desired), field(s, sf::_route_lane_row_desired)};
         }
         std::vector<Value *> peers = cohort(id, group, gate);
         for (Value *peer : peers)
             if (!group_matches(*peer, group) || peer->get("_route_lane_gate") != gate ||
                 peer->get("_route_lane_origin").kind == Value::Null)
-                (*peer)["_route_lane_origin"] = position(*peer);
+                (*peer)[sf::_route_lane_origin] = position(*peer);
         Pair f = forward(s, goal, order);
         auto rank = [&](Value *peer, bool lateral) {
             const Value &p = peer->get("_route_lane_origin");
             return std::make_tuple(p[0].number() * (lateral ? -f.second : f.first) +
                                        p[2].number() * (lateral ? f.first : f.second),
-                                   integer(*peer, "slot"), integer(*peer, "id"));
+                                   integer(*peer, sf::slot), integer(*peer, sf::id));
         };
         std::vector<Value *> ordered = peers;
         std::sort(ordered.begin(), ordered.end(),
@@ -220,18 +221,18 @@ struct Routes {
                       [&](Value *a, Value *b) { return rank(a, false) < rank(b, false); });
             auto pattern = row_layout(values.size());
             for (size_t i = 0; i < values.size(); ++i)
-                assigned[integer(*values[i], "id")] = Pair(lane.first, pattern[i]);
+                assigned[integer(*values[i], sf::id)] = Pair(lane.first, pattern[i]);
         }
         std::set<Pair> occupied;
         for (Value *peer : peers)
             if (group_matches(*peer, group) && peer->get("_route_lane_gate") == gate)
-                occupied.insert(
-                    {field(*peer, "_route_lane_desired"), field(*peer, "_route_lane_row_desired")});
+                occupied.insert({field(*peer, sf::_route_lane_desired),
+                                 field(*peer, sf::_route_lane_row_desired)});
         if (!occupied.empty())
             for (Value *peer : ordered) {
                 if (group_matches(*peer, group))
                     continue;
-                int peer_id = integer(*peer, "id");
+                int peer_id = integer(*peer, sf::id);
                 Pair expected = assigned[peer_id];
                 std::vector<Pair> available;
                 for (double lane : {-10, -5, 0, 5, 10}) {
@@ -268,27 +269,27 @@ struct Routes {
         for (Value *peer : peers) {
             if (group_matches(*peer, group))
                 continue;
-            Pair choice = assigned[integer(*peer, "id")];
-            (*peer)["_route_lane_group"] = group;
-            (*peer)["_route_lane_gate"] = gate;
-            (*peer)["_route_lane_desired"] = Value(choice.first);
-            (*peer)["_route_lane_row_desired"] = Value(choice.second);
-            (*peer)["_route_lane_forward"] = tuple_value({Value(f.first), Value(f.second)});
+            Pair choice = assigned[integer(*peer, sf::id)];
+            (*peer)[sf::_route_lane_group] = group;
+            (*peer)[sf::_route_lane_gate] = gate;
+            (*peer)[sf::_route_lane_desired] = Value(choice.first);
+            (*peer)[sf::_route_lane_row_desired] = Value(choice.second);
+            (*peer)[sf::_route_lane_forward] = tuple_value({Value(f.first), Value(f.second)});
             clear_lane(*peer);
         }
-        return {field(s, "_route_lane_desired"), field(s, "_route_lane_row_desired")};
+        return {field(s, sf::_route_lane_desired), field(s, sf::_route_lane_row_desired)};
     }
     static offline_nav::Optional<Pair> leg(const Value &s, Point current, Point goal,
                                            const Value &order, bool joining) {
         if (joining) {
-            const Value &v = s.get("_route_lane_forward");
+            const Value &v = s.get(sf::_route_lane_forward);
             if (v.size() == 2) {
                 double length = std::hypot(v[0].number(), v[1].number());
                 if (length >= .25)
                     return Pair(v[0].number() / length, v[1].number() / length);
             }
         }
-        Point anchor = point(order.get("route_anchor"), current);
+        Point anchor = point(order.get(sf::route_anchor), current);
         double dx = goal.x - anchor.x, dz = goal.z - anchor.z, length = std::hypot(dx, dz);
         if (length < .25) {
             dx = goal.x - current.x;
@@ -303,8 +304,8 @@ struct Routes {
             return false;
         auto &b = nav->grid->bounds;
         double sine = std::abs(std::sin(yaw)), cosine = std::abs(std::cos(yaw)),
-               length = std::max(.5, field(s, "half_length", 3.5)),
-               width = std::max(.3, field(s, "half_width", 1.7)),
+               length = std::max(.5, field(s, sf::half_length, 3.5)),
+               width = std::max(.3, field(s, sf::half_width, 1.7)),
                x = cosine * width + sine * length, z = sine * width + cosine * length;
         return b[0] + x - p.x <= 1e-6 && p.x + x - b[2] <= 1e-6 && b[1] + z - p.z <= 1e-6 &&
                p.z + z - b[3] <= 1e-6;
@@ -331,21 +332,21 @@ struct Routes {
                                      double now, bool joining) {
         Value &s = bots.at(id)->state;
         Value group =
-            tuple_value({Value(integer(s, "team")), Value(order.get("route_id").text("direct"))});
+            tuple_value({Value(integer(s, sf::team)), Value(order.get("route_id").text("direct"))});
         Pair desired = binding(id, group, goal, order);
-        Value segment =
-            tuple_value({group[0], group[1], Value(integer(order, "route_index")), Value(joining)});
-        if (s.get("_route_lane_segment") != segment) {
-            s["_route_lane_segment"] = segment;
-            s["_route_lane_offset"] = Value(desired.first);
-            s["_route_lane_row"] = Value(joining ? desired.second : 0);
-            s.erase("_route_lane_goal");
+        Value segment = tuple_value(
+            {group[0], group[1], Value(integer(order, sf::route_index)), Value(joining)});
+        if (s.get(sf::_route_lane_segment) != segment) {
+            s[sf::_route_lane_segment] = segment;
+            s[sf::_route_lane_offset] = Value(desired.first);
+            s[sf::_route_lane_row] = Value(joining ? desired.second : 0);
+            s.erase(sf::_route_lane_goal);
         }
         auto f = leg(s, current, goal, order, joining);
         auto fallback = [&]() {
-            s["_route_lane_offset"] = Value(0.0);
-            s["_route_lane_row"] = Value(0.0);
-            s["_route_lane_goal"] = value(goal);
+            s[sf::_route_lane_offset] = Value(0.0);
+            s[sf::_route_lane_row] = Value(0.0);
+            s[sf::_route_lane_goal] = value(goal);
             return std::make_pair(goal, Pair(0, 0));
         };
         if (!f.has)
@@ -354,14 +355,14 @@ struct Routes {
         if (nav) {
             auto at = nav->states.find(id);
             if (at != nav->states.end() && at->second.status == 2 &&
-                s.get("_route_lane_goal").kind != Value::Null && at->second.planned_goal.has)
-                reject = offline_nav::distance(point(s.get("_route_lane_goal")),
+                s.get(sf::_route_lane_goal).kind != Value::Null && at->second.planned_goal.has)
+                reject = offline_nav::distance(point(s.get(sf::_route_lane_goal)),
                                                at->second.planned_goal.value) < .25;
         }
         bool first = true;
         std::set<Pair> seen;
-        for (double row : rows(field(s, "_route_lane_row")))
-            for (double lane : lanes(field(s, "_route_lane_offset"))) {
+        for (double row : rows(field(s, sf::_route_lane_row)))
+            for (double lane : lanes(field(s, sf::_route_lane_offset))) {
                 Pair identity(rounded(lane, 6), rounded(row, 6));
                 if (!seen.insert(identity).second)
                     continue;
@@ -373,9 +374,9 @@ struct Routes {
                 auto candidate = safe_goal(s, goal, f.value, lane, row, now);
                 if (!candidate.has)
                     continue;
-                s["_route_lane_offset"] = Value(lane);
-                s["_route_lane_row"] = Value(row);
-                s["_route_lane_goal"] = value(candidate.value);
+                s[sf::_route_lane_offset] = Value(lane);
+                s[sf::_route_lane_row] = Value(row);
+                s[sf::_route_lane_goal] = value(candidate.value);
                 return {candidate.value, Pair(rounded(lane * 1000, 0), rounded(row * 1000, 0))};
             }
         return fallback();
@@ -387,19 +388,19 @@ struct Routes {
         if (!nav || std::hypot(dx, dz) < .25)
             return selected;
         Value group =
-            tuple_value({Value(integer(s, "team")), Value(order.get("route_id").text("direct"))});
+            tuple_value({Value(integer(s, sf::team)), Value(order.get("route_id").text("direct"))});
         Pair desired = binding(id, group, goal, order);
-        Value segment = tuple_value({group[0], group[1], Value(integer(order, "route_index"))});
-        if (s.get("_route_lane_segment") != segment) {
-            s["_route_lane_segment"] = segment;
-            s["_route_lane_offset"] = Value(desired.first);
+        Value segment = tuple_value({group[0], group[1], Value(integer(order, sf::route_index))});
+        if (s.get(sf::_route_lane_segment) != segment) {
+            s[sf::_route_lane_segment] = segment;
+            s[sf::_route_lane_offset] = Value(desired.first);
         }
         auto at = nav->states.find(id);
         if (at != nav->states.end() && at->second.shallow.has) {
-            s["_route_lane_offset"] = Value(0.0);
+            s[sf::_route_lane_offset] = Value(0.0);
             return selected;
         }
-        Point anchor = point(order.get("route_anchor"), current);
+        Point anchor = point(order.get(sf::route_anchor), current);
         double route_dx = goal.x - anchor.x, route_dz = goal.z - anchor.z,
                length = std::hypot(route_dx, route_dz);
         if (length < .25) {
@@ -409,7 +410,7 @@ struct Routes {
         }
         if (length < .25)
             return selected;
-        for (double offset : lanes(field(s, "_route_lane_offset"))) {
+        for (double offset : lanes(field(s, sf::_route_lane_offset))) {
             if (std::abs(offset) < 1e-9)
                 break;
             Point candidate(selected.x - route_dz / length * offset, selected.y,
@@ -422,10 +423,10 @@ struct Routes {
                 g.point_hazard(candidate, 7) || g.hazard(current, candidate, 7) ||
                 !g.dry(current, candidate, now) || !within(s, candidate, std::atan2(cx, cz)))
                 continue;
-            s["_route_lane_offset"] = Value(offset);
+            s[sf::_route_lane_offset] = Value(offset);
             return candidate;
         }
-        s["_route_lane_offset"] = Value(0.0);
+        s[sf::_route_lane_offset] = Value(0.0);
         return selected;
     }
     offline_nav::Optional<Point> radio_goal(int id, Point current, Point goal, const Value &order) {
@@ -434,7 +435,7 @@ struct Routes {
             return {};
         Value key = tuple_value({order.get("team_command_id"), area});
         Value &s = bots.at(id)->state;
-        const Value &cached = s.get("_radio_ground_goal");
+        const Value &cached = s.get(sf::_radio_ground_goal);
         if (cached.kind == Value::Array && cached.size() == 2 && cached[0] == key)
             return cached[1].kind == Value::Null ? offline_nav::Optional<Point>()
                                                  : offline_nav::Optional<Point>(point(cached[1]));
@@ -460,7 +461,7 @@ struct Routes {
                     score = next;
                 }
             }
-        s["_radio_ground_goal"] = tuple_value({key, best.has ? value(best.value) : Value()});
+        s[sf::_radio_ground_goal] = tuple_value({key, best.has ? value(best.value) : Value()});
         return best;
     }
     Point target(int id, Point current, Point goal, const Value &order, Value &decision,
@@ -468,19 +469,19 @@ struct Routes {
         std::string mode = order.get("combat_mode").text("route");
         bool stop = mode != "route" && mode != "advance";
         if (!nav) {
-            decision["navigation_stop_at_target"] = Value(stop);
+            decision[sf::navigation_stop_at_target] = Value(stop);
             return goal;
         }
         if (order.get("move_area_bounds").kind != Value::Null) {
             auto grounded = radio_goal(id, current, goal, order);
             if (!grounded.has) {
-                decision["navigation_stop_at_target"] = Value(true);
+                decision[sf::navigation_stop_at_target] = Value(true);
                 return current;
             }
             goal = grounded.value;
         }
-        double now = field(decision, "now");
-        int route = integer(order, "route_index");
+        double now = field(decision, sf::now);
+        int route = integer(order, sf::route_index);
         Value path;
         offline_nav::Optional<Point> anchor;
         if (mode == "base_defense")
@@ -489,8 +490,8 @@ struct Routes {
                  Value(order.get("defense_base_id").truth() ? order.get("defense_base_id").text()
                                                             : "own_base")});
         else if (mode == "route" || mode == "advance" || mode == "hold") {
-            if (flag(order, "route_join") && order.get("route_anchor").kind != Value::Null)
-                anchor = point(order.get("route_anchor"));
+            if (flag(order, sf::route_join) && order.get(sf::route_anchor).kind != Value::Null)
+                anchor = point(order.get(sf::route_anchor));
             Pair lane(0, 0);
             if ((mode == "route" || mode == "advance") && anchor.has) {
                 auto selected = lane_goal(id, current, goal, order, now, true);
@@ -499,14 +500,14 @@ struct Routes {
             }
             if (anchor.has)
                 path = tuple_value(
-                    {Value("route_join"), Value(id), Value(integer(bots.at(id)->state, "team")),
+                    {Value("route_join"), Value(id), Value(integer(bots.at(id)->state, sf::team)),
                      Value(order.get("route_id").text("direct")), Value(route),
                      Value(static_cast<int>(lane.first)), Value(static_cast<int>(lane.second))});
             else
-                path = tuple_value({Value("route"), Value(integer(bots.at(id)->state, "team")),
+                path = tuple_value({Value("route"), Value(integer(bots.at(id)->state, sf::team)),
                                     Value(order.get("route_id").text("direct")), Value(route)});
         } else
-            path = tuple_value({Value("local"), Value(id), Value(mode), order.get("target_id")});
+            path = tuple_value({Value("local"), Value(id), Value(mode), order.get(sf::target_id)});
         offline_nav::Identity key;
         key.repr = python_key(path);
         key.kind = path[0].text();
@@ -525,10 +526,10 @@ struct Routes {
             selected = nav->next_target(
                 id, current, goal, key, now, anchor, offline_nav::Path(),
                 std::max(std::max(1.0, nav->grid->data->cell) * 2,
-                         std::abs(field(decision, "speed")) * field(config, "lookahead", 1.5)),
+                         std::abs(field(decision, sf::speed)) * field(config, "lookahead", 1.5)),
                 movement);
         auto at = nav->states.find(id);
-        decision["navigation_stop_at_target"] =
+        decision[sf::navigation_stop_at_target] =
             Value(stop && ((direct && selected == goal) ||
                            (!direct && at != nav->states.end() && at->second.terminal)));
         return (mode == "route" || mode == "advance") && !anchor.has

--- a/tools/ffi_experiment/kernel_traffic.h
+++ b/tools/ffi_experiment/kernel_traffic.h
@@ -21,22 +21,22 @@ struct Traffic {
     static double cross(V a, V b) { return a[0] * b[1] - a[1] * b[0]; }
     static V sub(V a, V b) { return {{a[0] - b[0], a[1] - b[1]}}; }
     static V pos(const Value &v) {
-        auto p = Routes::point(v.get("position"));
+        auto p = Routes::point(v.get(sf::position));
         return {{p.x, p.z}};
     }
     static V vel(const Value &v) {
-        const Value &p = v.get("velocity");
+        const Value &p = v.get(sf::velocity);
         return {{p[0].number(), p[2].number()}};
     }
     static std::array<V, 2> axes(const Value &v) {
-        double s = std::sin(field(v, "yaw")), c = std::cos(field(v, "yaw"));
+        double s = std::sin(field(v, sf::yaw)), c = std::cos(field(v, sf::yaw));
         return {{{{c, -s}}, {{s, c}}}};
     }
     static double radius(const Value &v, V axis) {
         const Value &shape = v.get("shape");
         auto a = axes(v);
-        double width = shape.kind == Value::Null ? field(v, "half_width") : shape[0].number(),
-               length = shape.kind == Value::Null ? field(v, "half_length") : shape[1].number();
+        double width = shape.kind == Value::Null ? field(v, sf::half_width) : shape[0].number(),
+               length = shape.kind == Value::Null ? field(v, sf::half_length) : shape[1].number();
         return std::abs(dot(a[0], axis)) * width + std::abs(dot(a[1], axis)) * length;
     }
     static std::pair<V, double> travel(const Value &v) {
@@ -49,7 +49,7 @@ struct Traffic {
         const Value &x = a.get("shape"), &y = b.get("shape");
         if (x.kind == Value::Null || y.kind == Value::Null)
             return true;
-        double ay = a.get("position")[1].number(), by = b.get("position")[1].number();
+        double ay = a.get(sf::position)[1].number(), by = b.get(sf::position)[1].number();
         return std::min(ay + x[3].number(), by + y[3].number()) >
                std::max(ay + x[2].number(), by + y[2].number());
     }
@@ -83,18 +83,18 @@ struct Traffic {
         return V{{p[0] + axis_a[0] * distance, p[1] + axis_a[1] * distance}};
     }
     bool holding(const Value &v, double now) const {
-        auto at = held.find(integer(v, "id"));
+        auto at = held.find(integer(v, sf::id));
         return at != held.end() && now - at->second <= 1.5;
     }
     static std::tuple<int, double, int> arrival(const Value &v, V axis, double speed, V gate,
                                                 double reference) {
         double front = dot(sub(gate, pos(v)), axis) - radius(v, axis);
         if (front <= 0)
-            return std::make_tuple(0, front, integer(v, "id"));
+            return std::make_tuple(0, front, integer(v, sf::id));
         double pace = speed > 1e-9 ? speed : reference;
         return std::make_tuple(1,
                                pace > 1e-9 ? front / pace : std::numeric_limits<double>::infinity(),
-                               integer(v, "id"));
+                               integer(v, sf::id));
     }
     offline_nav::Optional<Lease> begin(const Value &a, const Value &b, double now) {
         if (dot(vel(a), axes(a)[1]) < -1e-9 || dot(vel(b), axes(b)[1]) < -1e-9)
@@ -115,8 +115,8 @@ struct Traffic {
                 return {};
             lease.head = true;
             lease.axis = first.first;
-            lease.targets[integer(a, "id")] = field(a, "yaw") + .42;
-            lease.targets[integer(b, "id")] = field(b, "yaw") + .42;
+            lease.targets[integer(a, sf::id)] = field(a, sf::yaw) + .42;
+            lease.targets[integer(b, sf::id)] = field(b, sf::yaw) + .42;
             return lease;
         }
         if (!contact.has)
@@ -131,7 +131,7 @@ struct Traffic {
         bool won = rank_a <= rank_b;
         const Value &winner = won ? a : b, &loser = won ? b : a;
         V axis = won ? first.first : second.first;
-        lease.winner = integer(winner, "id");
+        lease.winner = integer(winner, sf::id);
         lease.axis = axis;
         lease.clear_after = dot(gate.value, axis) + radius(winner, axis) + radius(loser, axis);
         lease.until = now + 1.5;
@@ -139,7 +139,7 @@ struct Traffic {
     }
     static bool cleared(const Lease &lease, const Value &a, const Value &b) {
         if (!lease.head)
-            return dot(pos(integer(a, "id") == lease.winner ? a : b), lease.axis) >
+            return dot(pos(integer(a, sf::id) == lease.winner ? a : b), lease.axis) >
                    lease.clear_after;
         V delta = sub(pos(b), pos(a)), side{{lease.axis[1], -lease.axis[0]}};
         return dot(delta, lease.axis) <= 0 ||
@@ -149,15 +149,15 @@ struct Traffic {
                  double now, const std::function<bool(double)> &clear) {
         Value result = command.copy();
         std::string mode = command.get("combat_mode").text("route");
-        if (!flag(body, "alive", true) || command.get("recovery_mode").text("drive") != "drive" ||
+        if (!flag(body, sf::alive, true) || command.get("recovery_mode").text("drive") != "drive" ||
             (mode != "route" && mode != "advance") || field(command, "throttle") <= 0 ||
             dot(vel(body), axes(body)[1]) < -1e-9)
             return result;
         std::map<int, Value> peers;
         for (const Value &peer : elements(neighbours)) {
-            int other = integer(peer, "id");
-            if (other != id && flag(peer, "alive", true) &&
-                integer(peer, "team") == integer(body, "team") && level(body, peer))
+            int other = integer(peer, sf::id);
+            if (other != id && flag(peer, sf::alive, true) &&
+                integer(peer, sf::team) == integer(body, sf::team) && level(body, peer))
                 peers[other] = peer;
         }
         for (auto at = pairs.begin(); at != pairs.end();) {
@@ -170,7 +170,7 @@ struct Traffic {
         for (const auto &peer : peers) {
             const Value &first = id < peer.first ? body : peer.second,
                         &second = id < peer.first ? peer.second : body;
-            Pair pair(integer(first, "id"), integer(second, "id"));
+            Pair pair(integer(first, sf::id), integer(second, sf::id));
             auto at = pairs.find(pair);
             if (at != pairs.end() && cleared(at->second, first, second)) {
                 pairs.erase(at);
@@ -208,13 +208,13 @@ struct Traffic {
                     continue;
                 result["throttle"] = Value(0.0);
                 result["turn"] = Value(0.0);
-                result["target_yaw"] = body.get("yaw");
+                result["target_yaw"] = body.get(sf::yaw);
                 result["traffic_mode"] = Value("head_on_blocked");
                 held[id] = now;
                 continue;
             }
             lease.blocked.reset();
-            result["turn"] = Value(clamp(angle(target - field(body, "yaw")) / .58, -1, 1));
+            result["turn"] = Value(clamp(angle(target - field(body, sf::yaw)) / .58, -1, 1));
             result["target_yaw"] = Value(target);
             result["traffic_mode"] = Value("head_on");
         }

--- a/tools/ffi_experiment/kernel_traffic.h
+++ b/tools/ffi_experiment/kernel_traffic.h
@@ -1,0 +1,225 @@
+#ifndef OFFLINE_EXPERIMENT_KERNEL_TRAFFIC_H
+#define OFFLINE_EXPERIMENT_KERNEL_TRAFFIC_H
+#include "kernel_routes.h"
+#include <functional>
+
+namespace offline_kernel {
+struct Traffic {
+    using V = std::array<double, 2>;
+    using Pair = std::pair<int, int>;
+    struct Lease {
+        bool head = false;
+        int winner = 0;
+        V axis{{0, 0}};
+        double clear_after = 0, until = 0;
+        std::map<int, double> targets;
+        offline_nav::Optional<double> blocked;
+    };
+    std::map<Pair, Lease> pairs;
+    std::map<int, double> held;
+    static double dot(V a, V b) { return a[0] * b[0] + a[1] * b[1]; }
+    static double cross(V a, V b) { return a[0] * b[1] - a[1] * b[0]; }
+    static V sub(V a, V b) { return {{a[0] - b[0], a[1] - b[1]}}; }
+    static V pos(const Value &v) {
+        auto p = Routes::point(v.get("position"));
+        return {{p.x, p.z}};
+    }
+    static V vel(const Value &v) {
+        const Value &p = v.get("velocity");
+        return {{p[0].number(), p[2].number()}};
+    }
+    static std::array<V, 2> axes(const Value &v) {
+        double s = std::sin(field(v, "yaw")), c = std::cos(field(v, "yaw"));
+        return {{{{c, -s}}, {{s, c}}}};
+    }
+    static double radius(const Value &v, V axis) {
+        const Value &shape = v.get("shape");
+        auto a = axes(v);
+        double width = shape.kind == Value::Null ? field(v, "half_width") : shape[0].number(),
+               length = shape.kind == Value::Null ? field(v, "half_length") : shape[1].number();
+        return std::abs(dot(a[0], axis)) * width + std::abs(dot(a[1], axis)) * length;
+    }
+    static std::pair<V, double> travel(const Value &v) {
+        V velocity = vel(v);
+        double speed = std::hypot(velocity[0], velocity[1]);
+        return speed > 1e-9 ? std::make_pair(V{{velocity[0] / speed, velocity[1] / speed}}, speed)
+                            : std::make_pair(axes(v)[1], 0.0);
+    }
+    static bool level(const Value &a, const Value &b) {
+        const Value &x = a.get("shape"), &y = b.get("shape");
+        if (x.kind == Value::Null || y.kind == Value::Null)
+            return true;
+        double ay = a.get("position")[1].number(), by = b.get("position")[1].number();
+        return std::min(ay + x[3].number(), by + y[3].number()) >
+               std::max(ay + x[2].number(), by + y[2].number());
+    }
+    static offline_nav::Optional<double> contact_time(const Value &a, const Value &b) {
+        V delta = sub(pos(b), pos(a)), relative = sub(vel(b), vel(a));
+        double enter = 0, leave = 1;
+        auto first = axes(a), second = axes(b);
+        for (V axis : {first[0], first[1], second[0], second[1]}) {
+            double distance = dot(delta, axis), rate = dot(relative, axis),
+                   extent = radius(a, axis) + radius(b, axis);
+            if (std::abs(rate) <= 1e-9) {
+                if (std::abs(distance) >= extent)
+                    return {};
+                continue;
+            }
+            double start = (-extent - distance) / rate, end = (extent - distance) / rate;
+            enter = std::max(enter, std::min(start, end));
+            leave = std::min(leave, std::max(start, end));
+            if (enter >= leave)
+                return {};
+        }
+        return enter;
+    }
+    static offline_nav::Optional<V> intersection(const Value &a, const Value &b, V axis_a,
+                                                 V axis_b) {
+        double denominator = cross(axis_a, axis_b);
+        if (std::abs(denominator) <= 1e-9)
+            return {};
+        V p = pos(a), delta = sub(pos(b), p);
+        double distance = cross(delta, axis_b) / denominator;
+        return V{{p[0] + axis_a[0] * distance, p[1] + axis_a[1] * distance}};
+    }
+    bool holding(const Value &v, double now) const {
+        auto at = held.find(integer(v, "id"));
+        return at != held.end() && now - at->second <= 1.5;
+    }
+    static std::tuple<int, double, int> arrival(const Value &v, V axis, double speed, V gate,
+                                                double reference) {
+        double front = dot(sub(gate, pos(v)), axis) - radius(v, axis);
+        if (front <= 0)
+            return std::make_tuple(0, front, integer(v, "id"));
+        double pace = speed > 1e-9 ? speed : reference;
+        return std::make_tuple(1,
+                               pace > 1e-9 ? front / pace : std::numeric_limits<double>::infinity(),
+                               integer(v, "id"));
+    }
+    offline_nav::Optional<Lease> begin(const Value &a, const Value &b, double now) {
+        if (dot(vel(a), axes(a)[1]) < -1e-9 || dot(vel(b), axes(b)[1]) < -1e-9)
+            return {};
+        auto first = travel(a), second = travel(b);
+        double alignment = dot(first.first, second.first);
+        if (alignment >= std::cos(.35))
+            return {};
+        auto contact = contact_time(a, b);
+        Lease lease;
+        if (alignment <= -std::cos(.60)) {
+            V delta = sub(pos(b), pos(a)), side{{first.first[1], -first.first[0]}};
+            double ahead = dot(delta, first.first), second_ahead = -dot(delta, second.first),
+                   lateral = std::abs(dot(delta, side)), width = radius(a, side) + radius(b, side),
+                   gap = ahead - radius(a, first.first) - radius(b, first.first);
+            if (ahead <= 0 || second_ahead <= 0 || lateral >= width ||
+                (!contact.has && gap > width * .5))
+                return {};
+            lease.head = true;
+            lease.axis = first.first;
+            lease.targets[integer(a, "id")] = field(a, "yaw") + .42;
+            lease.targets[integer(b, "id")] = field(b, "yaw") + .42;
+            return lease;
+        }
+        if (!contact.has)
+            return {};
+        auto gate = intersection(a, b, first.first, second.first);
+        if (!gate.has)
+            return {};
+        double pace = std::max(first.second, second.second);
+        auto rank_a = arrival(a, first.first, first.second, gate.value, holding(a, now) ? pace : 0),
+             rank_b =
+                 arrival(b, second.first, second.second, gate.value, holding(b, now) ? pace : 0);
+        bool won = rank_a <= rank_b;
+        const Value &winner = won ? a : b, &loser = won ? b : a;
+        V axis = won ? first.first : second.first;
+        lease.winner = integer(winner, "id");
+        lease.axis = axis;
+        lease.clear_after = dot(gate.value, axis) + radius(winner, axis) + radius(loser, axis);
+        lease.until = now + 1.5;
+        return lease;
+    }
+    static bool cleared(const Lease &lease, const Value &a, const Value &b) {
+        if (!lease.head)
+            return dot(pos(integer(a, "id") == lease.winner ? a : b), lease.axis) >
+                   lease.clear_after;
+        V delta = sub(pos(b), pos(a)), side{{lease.axis[1], -lease.axis[0]}};
+        return dot(delta, lease.axis) <= 0 ||
+               std::abs(dot(delta, side)) >= radius(a, side) + radius(b, side);
+    }
+    Value adjust(int id, const Value &body, const Value &command, const Value &neighbours,
+                 double now, const std::function<bool(double)> &clear) {
+        Value result = command.copy();
+        std::string mode = command.get("combat_mode").text("route");
+        if (!flag(body, "alive", true) || command.get("recovery_mode").text("drive") != "drive" ||
+            (mode != "route" && mode != "advance") || field(command, "throttle") <= 0 ||
+            dot(vel(body), axes(body)[1]) < -1e-9)
+            return result;
+        std::map<int, Value> peers;
+        for (const Value &peer : elements(neighbours)) {
+            int other = integer(peer, "id");
+            if (other != id && flag(peer, "alive", true) &&
+                integer(peer, "team") == integer(body, "team") && level(body, peer))
+                peers[other] = peer;
+        }
+        for (auto at = pairs.begin(); at != pairs.end();) {
+            int a = at->first.first, b = at->first.second;
+            if ((a == id && !peers.count(b)) || (b == id && !peers.count(a)))
+                at = pairs.erase(at);
+            else
+                ++at;
+        }
+        for (const auto &peer : peers) {
+            const Value &first = id < peer.first ? body : peer.second,
+                        &second = id < peer.first ? peer.second : body;
+            Pair pair(integer(first, "id"), integer(second, "id"));
+            auto at = pairs.find(pair);
+            if (at != pairs.end() && cleared(at->second, first, second)) {
+                pairs.erase(at);
+                at = pairs.end();
+            }
+            if (at == pairs.end()) {
+                auto next = begin(first, second, now);
+                if (!next.has)
+                    continue;
+                at = pairs.insert({pair, next.value}).first;
+            }
+            Lease &lease = at->second;
+            if (!lease.head) {
+                if (id != lease.winner && now < lease.until) {
+                    result["throttle"] = Value(0.0);
+                    result["turn"] = Value(0.0);
+                    result["traffic_mode"] = Value("yield");
+                    held[id] = now;
+                }
+                continue;
+            }
+            if (result.get("traffic_mode").text() == "yield")
+                continue;
+            double target = lease.targets.at(id);
+            bool okay = false;
+            try {
+                okay = clear(target);
+            } catch (...) {
+                okay = false;
+            }
+            if (!okay) {
+                if (!lease.blocked.has)
+                    lease.blocked = now + 1.5;
+                if (now >= lease.blocked.value && id != lease.targets.rbegin()->first)
+                    continue;
+                result["throttle"] = Value(0.0);
+                result["turn"] = Value(0.0);
+                result["target_yaw"] = body.get("yaw");
+                result["traffic_mode"] = Value("head_on_blocked");
+                held[id] = now;
+                continue;
+            }
+            lease.blocked.reset();
+            result["turn"] = Value(clamp(angle(target - field(body, "yaw")) / .58, -1, 1));
+            result["target_yaw"] = Value(target);
+            result["traffic_mode"] = Value("head_on");
+        }
+        return result;
+    }
+};
+} // namespace offline_kernel
+#endif

--- a/tools/ffi_experiment/kernel_update.h
+++ b/tools/ffi_experiment/kernel_update.h
@@ -1,0 +1,1157 @@
+#ifndef OFFLINE_EXPERIMENT_KERNEL_UPDATE_H
+#define OFFLINE_EXPERIMENT_KERNEL_UPDATE_H
+#include "kernel_contacts.h"
+#include "kernel_aim.h"
+#include "kernel_lanes.h"
+#include "kernel_codec.h"
+
+namespace offline_kernel {
+template <class Owner> struct Simulation {
+    Owner &k;
+    Diagnostics diagnostic;
+    Value config, camera, edge_signature, pending_ram = Value::array();
+    double accumulator = 0, next_publication = 0, next_observation = 0, next_lane = 0,
+           next_cover = 0, equipment_now = 0;
+    int64_t sample = 0, edge_sample = 0, edge_revision = 0;
+    int max_lane_pending = 0, max_lane_age = 0;
+    double lane_cycle = 0, lane_now = 0;
+    offline_nav::Optional<double> lane_due;
+    int control_steps = 0, alive_ticks = 0, slope_cursor = 0, cover_cursor = 0, cover_probes = 0,
+        lane_pending = 0;
+    double maximum_step = 0;
+    struct Decision {
+        Value token, command;
+        double deadline, now;
+        Contacts contacts;
+    };
+    std::map<int, Decision> decisions;
+    std::map<int, int> decision_counts;
+    std::map<int, Value> repositions;
+    struct CoverJob {
+        double ready;
+        int id;
+        Value source, target, route, allies;
+    };
+    std::deque<CoverJob> cover_queue;
+    Value cover_results = Value::array(), hull_key;
+    std::map<int, Value> traffic_bodies;
+    std::map<std::pair<int, int>, std::vector<int>> traffic_buckets;
+    bool traffic_ready = false;
+    explicit Simulation(Owner &owner, const Value &v)
+        : k(owner), diagnostic(v, owner.bots), config(v), camera(v.get("camera")),
+          accumulator(field(v, "accumulator")), next_publication(field(v, "next_publication")),
+          next_observation(field(v, "next_observation")), next_lane(field(v, "next_lane")),
+          next_cover(field(v, "next_cover")), equipment_now(field(v, "equipment_now")),
+          sample(v.get("sample").exact()), edge_sample(v.get("edge_sample").exact()),
+          edge_revision(v.get("edge_revision").exact()) {
+        if (!k.driver || !k.perception || !k.aim || !k.contacts || !k.lanes)
+            throw std::invalid_argument("kernel update configuration incomplete");
+        k.motion->diagnostics = &diagnostic;
+        for (int id : k.order)
+            if (!k.orders.count(id))
+                throw std::invalid_argument("kernel requires mandatory server Bot orders");
+    }
+    std::vector<int> ordered() const {
+        std::vector<int> ids = k.order;
+        std::stable_sort(ids.begin(), ids.end(), [&](int a, int b) {
+            return std::make_pair(integer(k.bots.at(a)->state, "slot"),
+                                  integer(k.bots.at(a)->state, "team", 1)) <
+                   std::make_pair(integer(k.bots.at(b)->state, "slot"),
+                                  integer(k.bots.at(b)->state, "team", 1));
+        });
+        return ids;
+    }
+    int tier(const Value &s) const {
+        if (camera.kind == Value::Null)
+            return 0;
+        double dx = field(s, "x") - camera[0].number(), dz = field(s, "z") - camera[2].number(),
+               d = dx * dx + dz * dz, near = field(config, "near"), far = field(config, "far");
+        return d <= near * near ? 0 : d <= far * far ? 1 : 2;
+    }
+    static Value overlay(const Value &command, const Value &target, const Value &source) {
+        Value result = command.copy();
+        if (result.get("target_id").kind == Value::Null)
+            return result;
+        if (target.kind == Value::Null || !flag(target, "alive", true)) {
+            result["fire_allowed"] = Value(false);
+            return result;
+        }
+        Value p = target.get("position");
+        result["aim_position"] = p;
+        if (!flag(result, "stable_hull_face")) {
+            if (result.get("hull_angle_degrees").kind == Value::Null)
+                result["face_position"] = p;
+            else {
+                double angle = field(result, "hull_angle_degrees") * 0.017453292519943295,
+                       dx = p[0].number() - source[0].number(),
+                       dz = p[2].number() - source[2].number(), c = std::cos(angle),
+                       s = std::sin(angle);
+                result["face_position"] =
+                    vector3(source[0].number() + dx * c - dz * s, source[1].number(),
+                            source[2].number() + dx * s + dz * c);
+            }
+        }
+        if (result.get("combat_mode").text() == "advance_contact")
+            result["move_position"] = p;
+        return result;
+    }
+    void clear_reposition(int id) {
+        if (repositions.erase(id))
+            decisions.erase(id);
+    }
+    std::pair<Value, bool> reposition(Bot &bot, const Contacts &contacts, double now) {
+        int id = integer(bot.state, "id");
+        auto at = repositions.find(id);
+        if (at == repositions.end())
+            return {Value(), false};
+        Value m = at->second;
+        if (now >= field(m, "deadline")) {
+            clear_reposition(id);
+            return {Value(), true};
+        }
+        auto target = contacts.lookup.find(integer(m, "target_id"));
+        if (target == contacts.lookup.end() || !flag(target->second, "alive", true) ||
+            (target->second.has("health") && field(target->second, "health") <= 0) ||
+            Lanes::distance(bot.state, tuple_target(m.get("destination"))) <=
+                field(config, "arrival")) {
+            clear_reposition(id);
+            return {Value(), false};
+        }
+        Value order = Value::object();
+        for (const char *name : {"target_id", "fire_range", "shell_index"})
+            order[name] = m.get(name);
+        order["aim_position"] = target_position(target->second);
+        order["face_position"] = order.get("aim_position");
+        order["move_position"] = m.get("destination");
+        order["fire_allowed"] = Value(false);
+        order["combat_mode"] = Value("friendly_lane_reposition");
+        order["throttle_override"] = Value(.72);
+        return {order, false};
+    }
+    static Value tuple_target(const Value &p) {
+        Value t = Value::object();
+        t["position"] = p;
+        return t;
+    }
+    void mark_reposition(Bot &bot, const Value &command, const Value &target, const Value &launch,
+                         const Value &verdict, double now) {
+        Value &s = bot.state;
+        int id = integer(s, "id"), blocker = integer(verdict, "blocker_id");
+        std::string kind = verdict.get("blocker_kind").text();
+        if ((kind != "bot" && kind != "player") || blocker <= 0 ||
+            integer(verdict, "blocker_team") != integer(s, "team") ||
+            (kind == "bot" && blocker == id) || command.get("target_id").kind == Value::Null ||
+            verdict.get("blocker_position").kind != Value::Array)
+            return;
+        const Value &shape = s.get("collision_shape");
+        double radius = shape.kind == Value::Array
+                            ? std::hypot(shape[0].number(), shape[1].number())
+                            : std::hypot(std::max(.3, field(s, "half_width", 1.7)),
+                                         std::max(.5, field(s, "half_length", 3.5))),
+               other = field(verdict, "blocker_radius", radius);
+        if (!std::isfinite(other) || other <= 0)
+            other = radius;
+        double clearance = radius + other + field(config, "contact_slop"),
+               side = (id + integer(launch, "fire_seq")) & 1 ? 1 : -1,
+               yaw = field(launch, "shot_yaw");
+        Value m = Value::object();
+        m["target_id"] = command.get("target_id");
+        m["target_kind"] = target.get("kind");
+        m["destination"] = vector3(field(s, "x") + std::cos(yaw) * clearance * side, field(s, "y"),
+                                   field(s, "z") - std::sin(yaw) * clearance * side);
+        m["shell_index"] = s.get("shell_index");
+        m["fire_range"] = Value(std::max(0.0, field(command, "fire_range")));
+        m["deadline"] = Value(now + field(config, "reposition_seconds"));
+        repositions[id] = m;
+        decisions.erase(id);
+    }
+    void traffic_snapshot(const Value &supplied, const Value &players) {
+        traffic_ready = true;
+        traffic_bodies.clear();
+        traffic_buckets.clear();
+        std::vector<int> insertions;
+        for (const Value &raw : elements(supplied))
+            if (raw.has("id")) {
+                int id = integer(raw, "id");
+                Value b = raw.copy();
+                b["position"] = position(raw);
+                traffic_bodies[id] = b;
+                insertions.push_back(id);
+            }
+        for (const Value &raw : elements(players)) {
+            int id = integer(config, "human_base") + integer(raw, "id");
+            Value b = Value::object();
+            double yaw = field(raw, "yaw"),
+                   speed = flag(raw, "alive", true) ? field(raw, "speed") : 0;
+            const Value &shape = raw.get("_kernel").get("collision").get("shape");
+            // The reference traffic snapshot reprojects the supplied human row
+            // from x/y/z after its neighbour producer emitted position only.
+            b["id"] = Value(id);
+            b["position"] = vector3(0, 0, 0);
+            b["team"] = Value(integer(raw, "team"));
+            b["yaw"] = Value(yaw);
+            b["alive"] = Value(flag(raw, "alive", true));
+            b["shape"] = shape;
+            b["half_width"] = shape[0];
+            b["half_length"] = shape[1];
+            b["velocity"] = vector3(std::sin(yaw) * speed, 0, std::cos(yaw) * speed);
+            traffic_bodies[id] = b;
+            insertions.push_back(id);
+        }
+        for (int id : k.order) {
+            const Value &s = k.bots.at(id)->state;
+            Value b = Value::object();
+            double yaw = field(s, "yaw"), speed = flag(s, "alive", true) ? field(s, "speed") : 0;
+            b["id"] = Value(id);
+            b["position"] = position(s);
+            b["yaw"] = Value(yaw);
+            b["team"] = Value(integer(s, "team"));
+            b["alive"] = Value(flag(s, "alive", true));
+            b["shape"] = s.get("collision_shape");
+            b["half_length"] = Value(field(s, "half_length", 3.5));
+            b["half_width"] = Value(field(s, "half_width", 1.7));
+            b["velocity"] = vector3(std::sin(yaw) * speed + field(s, "push_x"), 0,
+                                    std::cos(yaw) * speed + field(s, "push_z"));
+            traffic_bodies[id] = b;
+            insertions.push_back(id);
+        }
+        for (int id : integer_dict_order(insertions, flag(config, "py2"))) {
+            Value p = traffic_bodies.at(id).get("position");
+            traffic_buckets[{static_cast<int>(std::floor(p[0].number() / 24)),
+                             static_cast<int>(std::floor(p[2].number() / 24))}]
+                .push_back(id);
+        }
+    }
+    Value neighbours(const Value &state) {
+        Value rows = Value::array();
+        int id = integer(state, "id"), x = static_cast<int>(std::floor(field(state, "x") / 24)),
+            z = static_cast<int>(std::floor(field(state, "z") / 24));
+        for (int dz = -1; dz <= 1; ++dz)
+            for (int dx = -1; dx <= 1; ++dx) {
+                auto at = traffic_buckets.find({x + dx, z + dz});
+                if (at != traffic_buckets.end())
+                    for (int peer : at->second)
+                        if (peer != id)
+                            rows.append(traffic_bodies.at(peer));
+            }
+        return rows;
+    }
+    void static_hulls(const Value &players) {
+        if (!k.routes->nav)
+            return;
+        Value key = Value::array();
+        auto add = [&](int id, const Value &s, double length, double width) {
+            key.append(
+                tuple_value({Value(id), Value(rounded(field(s, "x"), 2)),
+                             Value(rounded(field(s, "z"), 2)), Value(rounded(field(s, "yaw"), 3)),
+                             Value(rounded(length, 2)), Value(rounded(width, 2))}));
+        };
+        for (int id : k.order) {
+            const Value &s = k.bots.at(id)->state;
+            if (!flag(s, "alive", true))
+                add(id, s, field(s, "half_length", 3.5), field(s, "half_width", 1.7));
+        }
+        for (const Value &s : elements(players))
+            if (!flag(s, "alive", true)) {
+                const Value &shape = s.get("_kernel").get("collision").get("shape");
+                if (shape.kind == Value::Array)
+                    add(integer(config, "human_base") + integer(s, "id"), s, shape[1].number(),
+                        shape[0].number());
+            }
+        std::sort(key.data->array.begin(), key.data->array.end(),
+                  [](const Value &a, const Value &b) { return a[0].exact() < b[0].exact(); });
+        if (key == hull_key)
+            return;
+        hull_key = key;
+        auto &grid = *k.routes->nav->grid;
+        ++grid.hull_revision;
+        grid.hulls.clear();
+        double half = grid.data->cell * .5;
+        for (const Value &v : elements(key)) {
+            double x = v[1].number(), z = v[2].number(), s = std::sin(v[3].number()),
+                   c = std::cos(v[3].number()), length = std::max(.5, v[4].number()),
+                   width = std::max(.3, v[5].number()),
+                   radius = std::sqrt(length * length + width * width);
+            auto first = grid.cell({x - radius, 0, z - radius}),
+                 last = grid.cell({x + radius, 0, z + radius});
+            for (int cz = first.second; cz <= last.second; ++cz)
+                for (int cx = first.first; cx <= last.first; ++cx) {
+                    auto p = grid.point({cx, cz}, 0);
+                    double dx = x - p.x, dz = z - p.z, extent = half * (std::abs(s) + std::abs(c));
+                    if (std::abs(dx) > half + std::abs(s) * length + std::abs(c) * width ||
+                        std::abs(dz) > half + std::abs(c) * length + std::abs(s) * width ||
+                        std::abs(dx * s + dz * c) > length + extent ||
+                        std::abs(dx * c - dz * s) > width + extent)
+                        continue;
+                    for (int ez = -1; ez <= 1; ++ez)
+                        for (int ex = -1; ex <= 1; ++ex)
+                            if (ex || ez) {
+                                offline_nav::Cell a(cx, cz), b(cx + ex, cz + ez);
+                                grid.hulls[a < b ? offline_nav::Edge(a, b)
+                                                 : offline_nav::Edge(b, a)] =
+                                    field(config, "hull_penalty");
+                            }
+                }
+        }
+    }
+    bool cover_current(const CoverJob &job, double now) {
+        auto bot = k.bots.find(job.id);
+        if (bot == k.bots.end())
+            return false;
+        const Value &s = bot->second->state;
+        TeamKey key = Perception::team_key(integer(job.source, "team"), job.target);
+        return flag(s, "alive", true) && integer(s, "team") == integer(job.source, "team") &&
+               k.perception->remembered.count(key) && k.perception->remaining(key, now) > 0;
+    }
+    Value cover(double now, bool refresh, bool collect, bool observation,
+                std::vector<CoverJob> jobs) {
+        Value completed = observation ? cover_results : Value::array();
+        if (observation)
+            cover_results = Value::array();
+        std::sort(jobs.begin(), jobs.end(),
+                  [](const CoverJob &a, const CoverJob &b) { return a.id < b.id; });
+        if (collect)
+            next_cover = now + field(config, "cover_seconds");
+        if (collect && !jobs.empty()) {
+            size_t cursor = cover_cursor % jobs.size(),
+                   count = std::min<size_t>(integer(config, "cover_jobs"), jobs.size());
+            cover_cursor = (cursor + count) % jobs.size();
+            for (size_t i = 0; i < count; ++i) {
+                CoverJob job = jobs[(cursor + i) % jobs.size()];
+                job.ready = now + field(config, "cover_window") * i / count;
+                job.allies = Value::array();
+                for (int id : k.order) {
+                    const Value &s = k.bots.at(id)->state;
+                    if (flag(s, "alive") && integer(s, "team") == integer(job.source, "team"))
+                        job.allies.append(position(s));
+                }
+                cover_queue.push_back(job);
+            }
+        }
+        if (refresh && !cover_queue.empty() && now + 1e-9 >= cover_queue.front().ready) {
+            CoverJob job = cover_queue.front();
+            cover_queue.pop_front();
+            ++cover_probes;
+            if (cover_current(job, now)) {
+                job.source = k.bots.at(job.id)->state;
+                job.target = job.target.copy();
+                offline_kernel::update(job.target, k.perception->remembered.at(Perception::team_key(
+                                                       integer(job.source, "team"), job.target)));
+                std::vector<double> args;
+                Aim::point(args, job.route);
+                args.push_back(job.allies.size());
+                for (const Value &p : elements(job.allies))
+                    Aim::point(args, p);
+                auto reply = k.engine->query(770, job.source, job.target, args);
+                if (reply[0]) {
+                    Value row = Value::object();
+                    row["bot_id"] = Value(job.id);
+                    row["target_id"] = Value(Perception::id(job.target));
+                    row["target_kind"] = Value(job.target.get("kind").text("human"));
+                    row["candidates"] = engine_token(static_cast<int>(reply[1]));
+                    cover_results.append(row);
+                }
+            }
+        }
+        return completed;
+    }
+    void siege_set(Bot &bot, int next, double duration = 0, double total = 0) {
+        Value &s = bot.state;
+        int id = integer(s, "id"), before = integer(s, "siege_state");
+        if (next != 1 && next != 3)
+            duration = total = 0;
+        s["siege_state"] = Value(next);
+        s["_siege_time_left"] = Value(std::max(0.0, duration));
+        s["_siege_transition_total"] = Value(std::max(0.0, total));
+        s["siege_time_left_ms"] =
+            Value(duration > 0 ? static_cast<int>(std::ceil(duration * 1000 - 1e-9)) : 0);
+        s["siege_transition_total_ms"] =
+            Value(total > 0 ? static_cast<int>(std::ceil(total * 1000 - 1e-9)) : 0);
+        const Value &modes = bot.config.get("siege_modes");
+        if (!modes.truth() || (before == 2) == (next == 2))
+            return;
+        const Value &mode = modes[next == 2 ? 1 : 0];
+        Gun candidate;
+        candidate.load(mode.get("gun"));
+        Gun &g = bot.gun;
+        if (candidate.shell_count != g.shell_count || candidate.clip_size != g.clip_size)
+            throw std::runtime_error("Siege descriptor changed ammunition contract");
+        double dispersion = g.dispersion;
+        g.fully_aimed = candidate.fully_aimed;
+        g.after_shot = candidate.after_shot;
+        g.after_in_burst = candidate.after_in_burst;
+        g.burst_count = candidate.burst_count;
+        g.burst_interval = candidate.burst_interval;
+        g.turret_factor = candidate.turret_factor;
+        g.aiming_time = candidate.aiming_time;
+        g.movement_factor = candidate.movement_factor;
+        g.rotation_factor = candidate.rotation_factor;
+        g.reload_full = candidate.reload_full;
+        g.reload_intra = candidate.reload_intra;
+        g.current_factor = std::max(1.0, dispersion / g.fully_aimed);
+        double aiming_time = std::max(g.aiming_time, .1),
+               maximum = g.current_factor > 0 && g.current_factor <= 1000
+                             ? aiming_time * std::log(1000 / g.current_factor)
+                             : 0;
+        if (g.aiming_elapsed > maximum) {
+            g.aiming_start = std::max(g.current_factor, 1000.0);
+            g.aiming_elapsed = maximum;
+        } else
+            g.aiming_start = g.current_factor * std::exp(g.aiming_elapsed / aiming_time);
+        g.dispersion = g.fully_aimed * g.current_factor;
+        for (const char *key : {"aim", "motion", "perception"}) {
+            bot.config[key] = mode.get(key);
+        }
+        offline_kernel::update(bot.config, mode.get("health"));
+        bot.critical.reset(new CriticalConfig(mode.get("critical")));
+        offline_kernel::update(s, mode.get("state"));
+        k.motion->profiles[id] = Motion::params(mode.get("motion").get("physics"));
+        k.motion->flow.caches.erase(id);
+        k.driver->coast.erase(id);
+        k.traffic.held.erase(id);
+        for (auto at = k.traffic.pairs.begin(); at != k.traffic.pairs.end();)
+            if (at->first.first == id || at->first.second == id)
+                at = k.traffic.pairs.erase(at);
+            else
+                ++at;
+        k.aim->cancel(bot);
+        for (const char *key : {"suspension_pitch_velocity", "suspension_roll_velocity",
+                                "_suspension_support_vertical_speed"}) {
+            s[key] = Value(0.0);
+        }
+        for (const char *key : {"_suspension_support_gradient", "_spring_ground_memory",
+                                "_pseudo_ground_memory", "_suspension_ground_plane"})
+            s.erase(key);
+    }
+    void siege_advance(Bot &bot, double dt) {
+        Value &s = bot.state;
+        if (!bot.config.get("siege_modes").truth()) {
+            siege_set(bot, 0);
+            return;
+        }
+        int current = integer(s, "siege_state");
+        if (current != 1 && current != 3) {
+            s["_siege_time_left"] = Value(0.0);
+            s["siege_time_left_ms"] = Value(0);
+            s["_siege_transition_total"] = Value(0.0);
+            s["siege_transition_total_ms"] = Value(0);
+            return;
+        }
+        double left = std::max(0.0, field(s, "_siege_time_left") - dt);
+        if (left > 1e-9) {
+            s["_siege_time_left"] = Value(left);
+            s["siege_time_left_ms"] = Value(static_cast<int>(std::ceil(left * 1000 - 1e-9)));
+            return;
+        }
+        int final = current == 1 ? 2 : 0;
+        siege_set(bot, final);
+        s["_siege_intent"] = Value(final == 2);
+        s["_siege_intent_elapsed"] = Value(0.0);
+    }
+    bool siege_intent(Bot &bot, Value &command, const Value &target, double dt) {
+        Value &s = bot.state;
+        if (!bot.config.get("siege_modes").truth())
+            return false;
+        if (bot.burst.active) {
+            s["_siege_intent_elapsed"] = Value(0.0);
+            return false;
+        }
+        int current = integer(s, "siege_state");
+        bool switching = current == 1 || current == 3;
+        if (switching)
+            command["fire_allowed"] = Value(false);
+        Value goal = command.get("move_position");
+        if (goal.kind == Value::Null)
+            goal = position(s);
+        bool desired =
+            target.kind == Value::Object && flag(target, "alive", true) &&
+            !(flag(command, "movement_intent", std::abs(field(command, "throttle")) > .05) &&
+              Lanes::distance(s, tuple_target(goal)) > field(config, "siege_long"));
+        if (s.get("_siege_intent").kind == Value::Null || flag(s, "_siege_intent") != desired) {
+            s["_siege_intent"] = Value(desired);
+            s["_siege_intent_elapsed"] = Value(0.0);
+            return switching;
+        }
+        if ((current == 1 && desired) || (current == 3 && !desired)) {
+            s["_siege_intent_elapsed"] = Value(0.0);
+            return true;
+        }
+        double elapsed = field(s, "_siege_intent_elapsed") + dt;
+        s["_siege_intent_elapsed"] = Value(elapsed);
+        if ((desired && current == 2) || (!desired && current == 0) ||
+            elapsed + 1e-9 <
+                field(config, desired ? "siege_enable_debounce" : "siege_disable_debounce"))
+            return false;
+        std::set<std::string> destroyed = names(s.get("critical").get("destroyed"));
+        if (destroyed.count("engineHealth")) {
+            s["_siege_intent_elapsed"] = Value(0.0);
+            return false;
+        }
+        bool yellow = false;
+        const Value &devices = s.get("critical").get("devices");
+        if (devices.kind == Value::Array)
+            for (const Value &v : elements(devices))
+                if (v.get("name").text() == "engineHealth")
+                    yellow = v.get("state").text() == "critical" ||
+                             bot.critical->condition(field(v, "hp"), "engineHealth") == 1;
+        const Value &params = bot.config.get("siege_params");
+        double total = params[desired ? 0 : 1].number() * (yellow ? params[3].number() : 1),
+               left = total;
+        int next = desired ? 1 : 3;
+        if (switching) {
+            double previous_total = field(s, "_siege_transition_total");
+            if (previous_total <= 0)
+                throw std::invalid_argument("Siege transition total missing");
+            double remaining =
+                std::min(std::max(0.0, field(s, "_siege_time_left")), previous_total);
+            left = clamp((previous_total - remaining) / previous_total, 0, 1) * total;
+            if (left <= 1e-9) {
+                next = desired ? 2 : 0;
+                left = total = 0;
+            }
+        }
+        siege_set(bot, next, left, total);
+        command["fire_allowed"] = Value(false);
+        s["_siege_intent_elapsed"] = Value(0.0);
+        return true;
+    }
+    void siege_lock() {
+        for (const auto &v : k.motion->locked) {
+            Bot &bot = *k.bots.at(v.first);
+            Value &s = bot.state;
+            s["x"] = v.second[0];
+            s["z"] = v.second[1];
+            s["yaw"] = v.second[2];
+            for (const char *key : {"speed", "push_x", "push_z"})
+                s[key] = Value(0.0);
+            s["movement_dir"] = Value(0);
+            s["rotation_dir"] = Value(0);
+            bot.turn_speed = 0;
+        }
+    }
+    void burst(Bot &bot, const Value &target, const Value &solution, double dt, int64_t start,
+               int64_t end, double reload, double dispersion,
+               const std::set<std::string> &destroyed) {
+        if (!bot.burst.active)
+            return;
+        for (const Subshot &edge : bot.burst.advance(dt)) {
+            int64_t time = std::min(end, start + static_cast<int64_t>(std::max(
+                                                     0.0, rounded(edge.offset * 1000000, 0))));
+            Value &s = bot.state;
+            int siege = integer(s, "siege_state");
+            if (!flag(s, "alive") || flag(s, "_drowning") || flag(s, "_overturned") ||
+                destroyed.count("gunHealth") || siege == 1 || siege == 3 ||
+                !bot.ammo.can_fire(true)) {
+                Launches::cancel(bot, reload);
+                break;
+            }
+            Value preview = k.aim->preview(bot, bot.burst.shell, solution, &edge);
+            if (preview.kind == Value::Null ||
+                !flag(k.aim->friendly(bot, target, bot.burst.shell, preview, false), "clear") ||
+                !k.launches.commit(bot, k.round, reload, dispersion, edge, Value(), preview, time,
+                                   Value())) {
+                Launches::cancel(bot, reload);
+                break;
+            }
+        }
+        publish_burst(bot);
+    }
+    Value publication(const std::vector<int> &ids, int64_t end) {
+        Value rows = Value::array(), signature = Value::array(), bot_edges = Value::array();
+        for (int id : ids) {
+            Bot &bot = *k.bots.at(id);
+            publish_burst(bot);
+            bot.state["equipment_states"] = bot.equipment_wire(equipment_now);
+            rows.append(k.codec.row(bot.state));
+            Value scalar = Value::array();
+            for (const Value &name : elements(config.get("edge_fields"))) {
+                std::string key = name.text();
+                scalar.append(tuple_value({Value(bot.state.has(key)), bot.state.get(key)}));
+            }
+            Value equipment = Value::array();
+            for (const Equipment &e : bot.equipment)
+                equipment.append(e.edge(equipment_now));
+            Value shot = Value::array();
+            for (const char *key : {"shot_yaw", "shot_pitch"})
+                shot.append(tuple_value({Value(bot.state.has(key)), bot.state.get(key)}));
+            bot_edges.append(
+                tuple_value({scalar, bot.state.get("ammo_remaining"), equipment, shot}));
+        }
+        Value launches = Value::array(), rams = Value::array();
+        for (const Value &v : elements(k.launches.pending))
+            launches.append(tuple_value({v.get("id"), v.get("fire_seq")}));
+        for (const Value &v : elements(pending_ram))
+            rams.append(tuple_value(
+                {v.get("bot_id"), v.get("target_kind"), v.get("target_id"), v.get("ram_seq")}));
+        signature = tuple_value({bot_edges, launches, rams});
+        if (signature != edge_signature) {
+            edge_signature = signature;
+            edge_sample = end;
+            ++edge_revision;
+        }
+        Value out = Value::object();
+        out["type"] = Value("bot_state");
+        out["rows"] = rows;
+        out["sample_time_us"] = Value(end);
+        out["edge_sample_time_us"] = Value(edge_sample);
+        out["edge_revision"] = Value(edge_revision);
+        if (k.launches.pending.truth())
+            out["launches"] = k.launches.pending.copy();
+        return out;
+    }
+    Value slice(double dt, double now, const Value &players, const Value &supplied, bool refresh,
+                bool publish) {
+        auto &p = *k.perception;
+        auto &motion = *k.motion;
+        auto &aim = *k.aim;
+        auto &lanes = *k.lanes;
+        std::vector<int> ids = ordered();
+        std::set<int> processed, integrated;
+        std::map<int, Value> ticks, settled;
+        std::map<int, bool> safe, blocked, ballistic;
+        int64_t end = sample + std::max<int64_t>(1, static_cast<int64_t>(rounded(dt * 1000000, 0)));
+        if (next_publication <= 0) {
+            next_publication = now;
+        }
+        while (next_publication <= now + 1e-9)
+            next_publication += field(config, "control");
+        equipment_now += dt;
+        k.engine->sample_time = sample;
+        k.engine->equipment_time = equipment_now;
+        lanes.incoming_budget = refresh ? 1 : 0;
+        motion.locked.clear();
+        p.start_slice(players, k.order);
+        p.lifecycle(now);
+        bool observation = publish && refresh && now >= next_observation,
+             due_lane = now >= next_lane,
+             reserved = refresh && !cover_queue.empty() &&
+                        now + 1e-9 >= cover_queue.front().ready &&
+                        cover_current(cover_queue.front(), now),
+             refresh_lane = refresh && !reserved &&
+                            (due_lane || (next_lane > 0 &&
+                                          now + field(config, "lane_seconds") + 1e-9 >= next_lane)),
+             collect_cover = refresh && publish && cover_queue.empty() && now >= next_cover;
+        int final_budget = integer(config, "final_lane_budget"),
+            supplemental = integer(config, "lane_budget");
+        if (refresh)
+            static_hulls(players);
+        traffic_ready = false;
+        std::set<int> due;
+        std::map<int, ActorKey> selected;
+        for (int id : ids) {
+            auto at = decisions.find(id);
+            bool valid =
+                at != decisions.end() && at->second.token == k.orders.at(id).get("_kernel_token");
+            if (refresh && (!valid || now >= at->second.deadline))
+                due.insert(id);
+            const Value &order = k.orders.at(id);
+            std::string kind = order.get("target_kind").text();
+            if ((kind == "bot" || kind == "human") && order.get("target_id").kind != Value::Null)
+                selected[id] = ActorKey{{kind == "human" ? 1 : 0, integer(order, "target_id")}};
+            else if (at != decisions.end()) {
+                auto t =
+                    at->second.contacts.lookup.find(integer(at->second.command, "target_id", -1));
+                if (t != at->second.contacts.lookup.end())
+                    selected[id] = Perception::key(t->second);
+            }
+        }
+        p.prepare(now, observation || refresh_lane, ids, due, selected);
+        if (observation || refresh_lane)
+            p.append_humans(now);
+        std::map<LaneKey, int> priorities;
+        std::vector<CoverJob> jobs;
+        for (int id : k.order) {
+            Bot &bot = *k.bots.at(id);
+            Value &s = bot.state;
+            auto cancel = [&]() {
+                Launches::cancel(bot, aim.factors.stat(s, *bot.critical, "reload"));
+                if (bot.clear_reposition) {
+                    clear_reposition(id);
+                    bot.clear_reposition = false;
+                }
+            };
+            if (!flag(s, "alive")) {
+                cancel();
+                continue;
+            }
+            p.note_still(s, now);
+            integrated.insert(id);
+            bot.advance_critical(dt, now, equipment_now);
+            if (!flag(s, "alive")) {
+                cancel();
+                continue;
+            }
+            double depth = -1;
+            if (bot.drowning_due(dt) && flag(config, "has_water")) {
+                auto result = k.engine->query(769, s, Value::object());
+                depth = result[0] ? result[1] : -1;
+            }
+            bot.advance_drowning(dt, depth);
+            if (!flag(s, "alive")) {
+                cancel();
+                continue;
+            }
+            bot.advance_overturn(dt);
+            if (!flag(s, "alive")) {
+                cancel();
+                continue;
+            }
+            double siege_yaw = field(s, "yaw");
+            bool siege_locked = integer(s, "siege_state") == 1 || integer(s, "siege_state") == 3;
+            siege_advance(bot, dt);
+            Value position_now = position(s);
+            ticks[id] = position_now;
+            safe[id] = motion.safe(Motion::point(s));
+            Contacts contacts;
+            Value command;
+            bool decision_due = due.count(id) > 0;
+            auto cached = decisions.find(id);
+            bool valid = cached != decisions.end() &&
+                         cached->second.token == k.orders.at(id).get("_kernel_token");
+            bool initial_decision = cached == decisions.end();
+            double decision_time = initial_decision ? dt : std::max(dt, now - cached->second.now);
+            if (valid && !decision_due) {
+                command = cached->second.command.copy();
+                contacts = cached->second.contacts;
+            } else if (!refresh) {
+                command = Value::object();
+                command["bot_id"] = Value(id);
+                command["target_id"] = Value();
+                for (const char *key : {"aim_position", "face_position", "move_position"})
+                    command[key] = position_now;
+                command["fire_range"] = Value(0.0);
+                command["combat_mode"] = Value("physical_hold");
+                command["fire_allowed"] = Value(false);
+                command["shell_index"] = Value(integer(s, "shell_index"));
+                command["throttle"] = Value(0.0);
+                command["turn"] = Value(0.0);
+                command["target_yaw"] = s.get("yaw");
+                command["recovery_mode"] = Value("physical_hold");
+                command["movement_intent"] = Value(false);
+            } else {
+                contacts = p.contacts(s, now, processed);
+                if (!traffic_ready)
+                    traffic_snapshot(supplied, players);
+                Value state = Value::object();
+                for (const char *key : {"id", "slot", "yaw", "speed", "health", "max_health",
+                                        "half_length", "half_width"})
+                    state[key] = s.get(key);
+                state["position"] = position_now;
+                state["dt"] = Value(decision_time);
+                state["now"] = Value(now);
+                state["neighbours"] = neighbours(s);
+                state["contacts"] = contacts.rows;
+                state["velocity"] = vector3(std::sin(field(s, "yaw")) * field(s, "speed"), 0,
+                                            std::cos(field(s, "yaw")) * field(s, "speed"));
+                double horizon = field(config, "decision_seconds") *
+                                 config.get("decision_tiers")[tier(s)].number();
+                state["decision_horizon"] = Value(horizon);
+                std::string expected = k.orders.at(id).get("combat_mode").text("route");
+                state["stopping_distance"] =
+                    std::abs(field(s, "speed")) > .35 && expected != "route" &&
+                            expected != "advance"
+                        ? Value(k.driver->stopping(
+                              bot, cached == decisions.end() ? Value() : cached->second.command))
+                        : Value();
+                auto override_order = reposition(bot, contacts, now);
+                Value order = override_order.first;
+                if (order.kind == Value::Null) {
+                    order = k.orders.at(id).copy();
+                    if (order.get("target_kind").text() == "human" &&
+                        order.get("target_id").kind != Value::Null)
+                        order["target_id"] =
+                            Value(integer(config, "human_base") + integer(order, "target_id"));
+                    auto target = contacts.lookup.find(integer(order, "target_id", -1));
+                    order =
+                        overlay(order, target == contacts.lookup.end() ? Value() : target->second,
+                                position_now);
+                }
+                k.driver->probes.clear();
+                command = k.driver->drive(bot, state, order,
+                                          aim.intents.count(id) || aim.reproofs.count(id));
+                command =
+                    k.traffic.adjust(id, traffic_bodies.at(id), command, state.get("neighbours"),
+                                     now, [&](double yaw) { return k.driver->clear(bot, yaw); });
+                if (override_order.second)
+                    command["fire_allowed"] = Value(false);
+                ++decision_counts[id];
+                decisions[id] =
+                    Decision{k.orders.at(id).get("_kernel_token"), command.copy(),
+                             cache_deadline(now, id, horizon, 3, initial_decision), now, contacts};
+            }
+            command["throttle"] = Value(clamp(field(command, "throttle"), -1, 1));
+            if (refresh_lane && !observation)
+                for (const Value &t : elements(contacts.rows))
+                    if (flag(t, "fresh_visible"))
+                        p.team_visible[Perception::team_key(integer(s, "team"), t)] = true;
+            if (observation)
+                p.collect(s, contacts, processed);
+            Value target;
+            auto chosen = contacts.lookup.find(integer(command, "target_id", -1));
+            if (chosen != contacts.lookup.end())
+                target = p.refresh(chosen->second);
+            if (target.kind != Value::Null)
+                priorities[Lanes::key(s, target)] = flag(command, "fire_allowed") ? 0 : 1;
+            command = overlay(command, target, position_now);
+            s["target_kind"] = target.get("kind");
+            s["target_id"] = target.get("network_id");
+            siege_locked = siege_intent(bot, command, target, dt) || siege_locked;
+            double reload = aim.factors.stat(s, *bot.critical, "reload");
+            if (!bot.burst.active) {
+                bot.gun.rescale(reload);
+                bot.gun.tick(dt);
+                int completed = bot.gun.complete(reload, bot.ammo.planned());
+                bot.ammo.stage(bot.gun.shell(integer(command, "shell_index")), completed >= 0,
+                               completed == 0);
+            }
+            publish_ammo(bot);
+            bool spg = s.get("profile").get("class_tag").text() == "SPG";
+            Value intent, reproof;
+            if (spg) {
+                if (!flag(command, "fire_allowed"))
+                    aim.cancel(bot);
+                else {
+                    intent = aim.active_intent(bot, target, bot.ammo.loaded, now);
+                    reproof = aim.active_reproof(bot, target, bot.ammo.loaded, now);
+                }
+                Value frozen = intent.kind != Value::Null ? intent.get("solution")
+                                                          : reproof.get("hold_solution");
+                if (frozen.kind == Value::Object) {
+                    command["aim_position"] = frozen.get("aim_position");
+                    command["face_position"] = frozen.get("aim_position");
+                }
+                if (reproof.kind != Value::Null) {
+                    command["throttle"] = Value(0.0);
+                    command["turn"] = Value(0.0);
+                    command["movement_intent"] = Value(false);
+                }
+            }
+            bool escape = k.routes->nav && k.routes->nav->grid->point_hazard(Motion::point(s), 4);
+            diagnostic.planner_age = decisions.count(id) ? now - decisions.at(id).now : -1;
+            motion.step(bot, command, target, dt, now, decision_due, refresh, siege_locked,
+                        siege_yaw, escape);
+            publish_ammo(bot);
+            auto local = aim.cadenced(bot, target, bot.ammo.loaded, now, refresh,
+                                      bot.burst.active || intent.kind != Value::Null ||
+                                          reproof.kind != Value::Null);
+            command["_ballistic_solution"] = local.first;
+            double old_turret = field(s, "turret_yaw");
+            aim.slew(bot, command, target, dt);
+            double turret = std::abs(angle_delta(field(s, "turret_yaw") - old_turret)) /
+                            std::max(dt, 1e-9),
+                   dispersion = aim.factors.stat(s, *bot.critical, "dispersion");
+            bot.gun.bloom_tick(dt, std::abs(field(s, "speed")), std::abs(bot.turn_speed), turret,
+                               dispersion, aim.factors.stat(s, *bot.critical, "aim_time"));
+            s["clip_size"] = Value(bot.gun.clip_size);
+            publish_reload(bot, reload);
+            std::set<std::string> destroyed = names(s.get("critical").get("destroyed"));
+            burst(bot, target, local.first, dt, sample, end, reload, dispersion, destroyed);
+            double distance = target.kind == Value::Null ? 0 : Lanes::distance(s, target),
+                   range = std::max(0.0, field(command, "fire_range"));
+            bool in_range = target.kind != Value::Null && distance > 1 &&
+                            local.first.kind != Value::Null && (range <= 0 || distance < range);
+            if (publish && local.second && flag(command, "fire_allowed") && in_range &&
+                !flag(s, "_drowning") && !flag(s, "_overturned") && !destroyed.count("gunHealth") &&
+                flag(s, "gun_aligned") && !bot.burst.active && bot.gun.ready(reload) &&
+                bot.ammo.can_fire() &&
+                (intent.kind != Value::Null || reproof.kind != Value::Null ||
+                 lanes.clear(s, target, now, false, &final_budget).truth()) &&
+                k.gunners.at(id).ready(s, target, now, bot.gun)) {
+                Value receipt, preview;
+                if (spg)
+                    receipt = aim.launch_receipt(bot, target, bot.ammo.loaded, local.first, now);
+                else if (aim.direct_matches(bot, target, local.first))
+                    preview = aim.preview(bot, bot.ammo.loaded, local.first);
+                Value launch = spg ? receipt : preview;
+                if (launch.kind != Value::Null) {
+                    Value verdict = aim.friendly(bot, target, bot.ammo.loaded, launch, spg);
+                    if (flag(verdict, "clear")) {
+                        clear_reposition(id);
+                        bool fired = k.launches.fire(bot, k.round, reload, dispersion, receipt,
+                                                     preview, end, Value());
+                        if (fired && spg)
+                            aim.cancel(bot);
+                    } else {
+                        mark_reposition(bot, command, target, launch, verdict, now);
+                        if (spg)
+                            aim.cancel(bot);
+                    }
+                }
+            }
+            std::string mode = command.get("combat_mode").text();
+            static const std::set<std::string> cover_modes = {"take_cover",
+                                                              "cover_hold",
+                                                              "cover_peek",
+                                                              "cover_return",
+                                                              "under_fire_withdraw",
+                                                              "low_health_retreat",
+                                                              "crossfire_withdraw"},
+                                               fire_modes = {"engage", "advance_contact",
+                                                             "jiggle_forward", "jiggle_back"};
+            if (collect_cover && target.kind != Value::Null && flag(target, "visible") &&
+                flag(config, "has_cover") &&
+                (cover_modes.count(mode) ||
+                 (flag(command, "fire_allowed") && fire_modes.count(mode))))
+                jobs.push_back(CoverJob{now, id, s.clone(), target.copy(),
+                                        command.get("move_position").kind == Value::Null
+                                            ? position_now
+                                            : command.get("move_position"),
+                                        Value()});
+            processed.insert(id);
+        }
+        if (refresh_lane) {
+            lane_pending = lanes.service(now, next_lane, ids, processed, priorities, supplemental);
+        }
+        if (observation)
+            lanes.merge(now);
+        lane_diagnostics(now, next_lane, due_lane);
+        if (due_lane && refresh_lane && lane_pending <= 0)
+            next_lane = now + field(config, "lane_seconds");
+        Value affordances = cover(now, refresh, collect_cover, observation, jobs);
+        siege_lock();
+        std::vector<int> slope;
+        for (int id : ids) {
+            Bot &bot = *k.bots.at(id);
+            if (flag(bot.state, "alive", true) && integrated.count(id)) {
+                bool was = flag(bot.state, "airborne");
+                blocked[id] = motion.vertical(bot, dt, ticks.at(id), motion.attempted[id]);
+                ballistic[id] = was || flag(bot.state, "airborne");
+                settled[id] = position(bot.state);
+                slope.push_back(id);
+            }
+        }
+        size_t prior = pending_ram.size();
+        Value reports = k.contacts->step(players, ids, now, dt);
+        for (const Value &v : elements(reports))
+            pending_ram.append(v);
+        siege_lock();
+        if (!publish && pending_ram.size() > prior)
+            publish = true;
+        for (int id : slope) {
+            Bot &bot = *k.bots.at(id);
+            Value trace = bot.state.get("_motion_stall_pending");
+            if (trace.kind == Value::Object)
+                trace["after_contacts"] = position(bot.state);
+            bool rollback = false;
+            if (!blocked[id] && !ballistic[id] && !flag(bot.state, "airborne"))
+                rollback =
+                    motion.guard(bot, Routes::point(ticks.at(id)), safe[id], motion.attempted[id]);
+            diagnostic.finish(bot, blocked[id], rollback, settled.at(id), k.contacts->active);
+        }
+        for (int id : motion.invalidated)
+            decisions.erase(id);
+        motion.invalidated.clear();
+        alive_ticks += slope.size();
+        if (refresh && !slope.empty()) {
+            size_t start = slope_cursor % slope.size(), visited = 0, sampled = 0;
+            while (visited < slope.size() &&
+                   sampled < static_cast<size_t>(integer(config, "slope_budget"))) {
+                Bot &bot = *k.bots.at(slope[(start + visited) % slope.size()]);
+                if (motion.slope(bot, tier(bot.state)))
+                    ++sampled;
+                ++visited;
+            }
+            slope_cursor = (start + std::max<size_t>(1, visited)) % slope.size();
+        }
+        Value outgoing = Value::array();
+        if (publish) {
+            for (int id : ids)
+                k.bots.at(id)->mark_combat();
+            outgoing.append(publication(ids, end));
+            for (const Value &v : elements(pending_ram))
+                outgoing.append(v);
+            pending_ram = Value::array();
+            if (observation) {
+                next_observation = now + field(config, "observation_seconds");
+                Value row = Value::object();
+                row["type"] = Value("bot_observation");
+                row["contacts"] = lanes.pack(now);
+                row["affordances"] = affordances;
+                outgoing.append(row);
+            }
+        }
+        sample = end;
+        k.engine->sample_time = sample;
+        return outgoing;
+    }
+    void lane_diagnostics(double now, double cycle, bool due) {
+        if (lane_cycle != cycle) {
+            lane_cycle = cycle;
+            lane_due.reset();
+        }
+        lane_now = now;
+        max_lane_pending = std::max(max_lane_pending, lane_pending);
+        if (lane_pending <= 0) {
+            lane_due.reset();
+            return;
+        }
+        if (due && !lane_due.has)
+            lane_due = cycle > 0 ? cycle : now;
+        if (lane_due.has)
+            max_lane_age = std::max(
+                max_lane_age,
+                static_cast<int>(std::max(0.0, rounded((now - lane_due.value) * 1000, 0))));
+    }
+    Value diagnostics() {
+        Value result = Value::object();
+        double values[20] = {310, static_cast<double>(k.perception->handle)};
+        offline_perception_dispatch(values, 20);
+        const char *names[] = {"visibility_queue_depth",
+                               "visibility_queue_max_depth",
+                               "visibility_oldest_stale_age_ms",
+                               "visibility_oldest_stale_max_age_ms",
+                               "visibility_admitted",
+                               "visibility_completed",
+                               "visibility_deferred",
+                               "visibility_selected_services",
+                               "visibility_fire_services",
+                               "visibility_new_services",
+                               "visibility_ordinary_services"};
+        for (int i = 0; i < 11; ++i)
+            result[names[i]] = Value(
+                static_cast<int>(i == 2 || i == 3 ? rounded(values[i] * 1000, 0) : values[i]));
+        result["alive_bot_ticks"] = Value(alive_ticks);
+        result["suspension_param_failures"] = Value(integer(config, "suspension_failures"));
+        result["shot_lane_pending_pairs"] = Value(lane_pending);
+        result["shot_lane_pending_max_pairs"] = Value(max_lane_pending);
+        result["shot_lane_oldest_due_age_ms"] = Value(
+            lane_pending > 0 && lane_due.has
+                ? static_cast<int>(std::max(0.0, rounded((lane_now - lane_due.value) * 1000, 0)))
+                : 0);
+        result["shot_lane_oldest_due_max_age_ms"] = Value(max_lane_age);
+        result["shot_lane_completed_pairs"] = Value(k.lanes->completed);
+        result["shot_lane_budget_deferred_attempts"] = Value(k.lanes->deferred);
+        return result;
+    }
+    static void references(const Value &value, std::set<int> &out) {
+        if (value.kind == Value::Object) {
+            if (value.has("_engine_token")) {
+                out.insert(integer(value, "_engine_token"));
+                return;
+            }
+            for (const auto &v : value.data->object)
+                references(v.second, out);
+        } else if (value.kind == Value::Array)
+            for (const Value &v : elements(value))
+                references(v, out);
+    }
+    Value retained_tokens(const Value &outgoing) {
+        std::set<int> refs;
+        references(outgoing, refs);
+        for (int id : k.order)
+            references(k.bots.at(id)->state.get("shot_proof_key"), refs);
+        for (const auto &v : k.aim->cache)
+            references(v.second.solution, refs);
+        for (const auto &v : k.aim->intents)
+            references(v.second, refs);
+        for (const auto &v : k.aim->reproofs)
+            references(v.second, refs);
+        references(k.launches.pending, refs);
+        references(cover_results, refs);
+        for (const CoverJob &job : cover_queue) {
+            references(job.target, refs);
+            references(job.source.get("shot_proof_key"), refs);
+        }
+        Value result = Value::array();
+        for (int id : refs)
+            result.append(Value(id));
+        return result;
+    }
+    Value update(const Value &input) {
+        if (input.has("orders")) {
+            std::map<int, Value> accepted;
+            for (const Value &row : elements(input.get("orders"))) {
+                int id = static_cast<int>(row[0].exact());
+                if (!k.bots.count(id) || accepted.count(id))
+                    throw std::invalid_argument("kernel order actor");
+                accepted[id] = row[1];
+            }
+            if (accepted.size() != k.bots.size())
+                throw std::invalid_argument("kernel requires complete server Bot orders");
+            for (const auto &entry : accepted) {
+                int id = entry.first;
+                const Value &previous = k.orders.at(id), &next = entry.second;
+                if (previous.get("_kernel_token") == next.get("_kernel_token"))
+                    continue;
+                if (!(previous.get("route_id") == next.get("route_id"))) {
+                    for (const char *key :
+                         {"_route_lane_group", "_route_lane_gate", "_route_lane_origin",
+                          "_route_lane_desired", "_route_lane_row_desired", "_route_lane_forward",
+                          "_route_lane_segment", "_route_lane_offset", "_route_lane_row",
+                          "_route_lane_goal"})
+                        k.bots.at(id)->state.erase(key);
+                }
+                decisions.erase(id);
+                k.motion->flow.caches.erase(id);
+            }
+            k.orders.swap(accepted);
+        }
+        double dt = std::max(0.0, field(input, "dt")), now = field(input, "now");
+        if (input.has("camera"))
+            camera = input.get("camera");
+        control_steps = 0;
+        maximum_step = 0;
+        k.contacts->leases.clear();
+        accumulator += dt;
+        auto nav = k.routes->nav;
+        if (nav)
+            nav->begin(dt);
+        Value outgoing = Value::array();
+        bool begun = false;
+        try {
+            if (accumulator + 1e-9 >= field(config, "control")) {
+                k.motion->begin();
+                k.perception->begin();
+                begun = true;
+                double elapsed = accumulator;
+                accumulator = 0;
+                bool refresh = true;
+                while (elapsed > 1e-12) {
+                    double step = std::min(elapsed, field(config, "maximum_step"));
+                    for (int id : k.order) {
+                        const Burst &b = k.bots.at(id)->burst;
+                        if (b.active)
+                            step = std::min(step, b.left <= 1e-9 ? 1e-9 : b.left);
+                    }
+                    elapsed = std::max(0.0, elapsed - step);
+                    ++control_steps;
+                    maximum_step = std::max(maximum_step, step);
+                    Value rows =
+                        slice(step, now - elapsed, input.get("players"), input.get("neighbours"),
+                              refresh, refresh || elapsed <= 1e-12);
+                    for (const Value &row : elements(rows))
+                        outgoing.append(row);
+                    refresh = false;
+                }
+                k.contacts->finish(k.driver->handle);
+                if (flag(config, "has_destructible"))
+                    for (int id : ordered()) {
+                        const Value &s = k.bots.at(id)->state;
+                        if (flag(s, "alive") && field(s, "health") > 0 &&
+                            std::abs(field(s, "speed")) >= field(config, "destructible_speed"))
+                            k.engine->query(771, s, Value::object());
+                    }
+            }
+        } catch (...) {
+            if (begun) {
+                k.perception->finish();
+                k.motion->finish();
+            }
+            if (nav)
+                nav->frame_open = false;
+            throw;
+        }
+        if (begun) {
+            k.perception->finish();
+            k.motion->finish();
+        }
+        if (nav)
+            nav->frame_open = false;
+        for (Value &row : outgoing.data->array)
+            if (row.get("type").text() == "bot_state")
+                row["source_batch_horizon_us"] = Value(sample);
+        return outgoing;
+    }
+};
+} // namespace offline_kernel
+#endif

--- a/tools/ffi_experiment/kernel_update.h
+++ b/tools/ffi_experiment/kernel_update.h
@@ -4,12 +4,14 @@
 #include "kernel_aim.h"
 #include "kernel_lanes.h"
 #include "kernel_codec.h"
+#include "kernel_publication.h"
 
 namespace offline_kernel {
 template <class Owner> struct Simulation {
     Owner &k;
     Diagnostics diagnostic;
-    Value config, camera, edge_signature, pending_ram = Value::array();
+    Value config, camera, pending_ram = Value::array();
+    PublicationEdges edges;
     double accumulator = 0, next_publication = 0, next_observation = 0, next_lane = 0,
            next_cover = 0, equipment_now = 0;
     int64_t sample = 0, edge_sample = 0, edge_revision = 0;
@@ -39,6 +41,7 @@ template <class Owner> struct Simulation {
     bool traffic_ready = false;
     explicit Simulation(Owner &owner, const Value &v)
         : k(owner), diagnostic(v, owner.bots), config(v), camera(v.get("camera")),
+          edges(v.get("edge_fields")),
           accumulator(field(v, "accumulator")), next_publication(field(v, "next_publication")),
           next_observation(field(v, "next_observation")), next_lane(field(v, "next_lane")),
           next_cover(field(v, "next_cover")), equipment_now(field(v, "equipment_now")),
@@ -559,35 +562,16 @@ template <class Owner> struct Simulation {
         publish_burst(bot);
     }
     Value publication(const std::vector<int> &ids, int64_t end) {
-        Value rows = Value::array(), signature = Value::array(), bot_edges = Value::array();
-        for (int id : ids) {
-            Bot &bot = *k.bots.at(id);
+        Value rows = Value::array(ids.size());
+        edges.begin(ids.size());
+        for (size_t i = 0; i < ids.size(); ++i) {
+            Bot &bot = *k.bots.at(ids[i]);
             publish_burst(bot);
             bot.state[sf::equipment_states] = bot.equipment_wire(equipment_now);
             rows.append(k.codec.row(bot.state));
-            Value scalar = Value::array();
-            for (const Value &name : elements(config.get("edge_fields"))) {
-                std::string key = name.text();
-                scalar.append(tuple_value({Value(bot.state.has(key)), bot.state.get(key)}));
-            }
-            Value equipment = Value::array();
-            for (const Equipment &e : bot.equipment)
-                equipment.append(e.edge(equipment_now));
-            Value shot = Value::array();
-            for (const char *key : {"shot_yaw", "shot_pitch"})
-                shot.append(tuple_value({Value(bot.state.has(key)), bot.state.get(key)}));
-            bot_edges.append(
-                tuple_value({scalar, bot.state.get(sf::ammo_remaining), equipment, shot}));
+            edges.capture(i, bot.state, bot.equipment, equipment_now);
         }
-        Value launches = Value::array(), rams = Value::array();
-        for (const Value &v : elements(k.launches.pending))
-            launches.append(tuple_value({v.get(sf::id), v.get(sf::fire_seq)}));
-        for (const Value &v : elements(pending_ram))
-            rams.append(tuple_value(
-                {v.get("bot_id"), v.get(sf::target_kind), v.get(sf::target_id), v.get("ram_seq")}));
-        signature = tuple_value({bot_edges, launches, rams});
-        if (signature != edge_signature) {
-            edge_signature = signature;
+        if (edges.finish(k.launches.pending, pending_ram)) {
             edge_sample = end;
             ++edge_revision;
         }

--- a/tools/ffi_experiment/kernel_update.h
+++ b/tools/ffi_experiment/kernel_update.h
@@ -54,29 +54,29 @@ template <class Owner> struct Simulation {
     std::vector<int> ordered() const {
         std::vector<int> ids = k.order;
         std::stable_sort(ids.begin(), ids.end(), [&](int a, int b) {
-            return std::make_pair(integer(k.bots.at(a)->state, "slot"),
-                                  integer(k.bots.at(a)->state, "team", 1)) <
-                   std::make_pair(integer(k.bots.at(b)->state, "slot"),
-                                  integer(k.bots.at(b)->state, "team", 1));
+            return std::make_pair(integer(k.bots.at(a)->state, sf::slot),
+                                  integer(k.bots.at(a)->state, sf::team, 1)) <
+                   std::make_pair(integer(k.bots.at(b)->state, sf::slot),
+                                  integer(k.bots.at(b)->state, sf::team, 1));
         });
         return ids;
     }
     int tier(const Value &s) const {
         if (camera.kind == Value::Null)
             return 0;
-        double dx = field(s, "x") - camera[0].number(), dz = field(s, "z") - camera[2].number(),
+        double dx = field(s, sf::x) - camera[0].number(), dz = field(s, sf::z) - camera[2].number(),
                d = dx * dx + dz * dz, near = field(config, "near"), far = field(config, "far");
         return d <= near * near ? 0 : d <= far * far ? 1 : 2;
     }
     static Value overlay(const Value &command, const Value &target, const Value &source) {
         Value result = command.copy();
-        if (result.get("target_id").kind == Value::Null)
+        if (result.get(sf::target_id).kind == Value::Null)
             return result;
-        if (target.kind == Value::Null || !flag(target, "alive", true)) {
+        if (target.kind == Value::Null || !flag(target, sf::alive, true)) {
             result["fire_allowed"] = Value(false);
             return result;
         }
-        Value p = target.get("position");
+        Value p = target.get(sf::position);
         result["aim_position"] = p;
         if (!flag(result, "stable_hull_face")) {
             if (result.get("hull_angle_degrees").kind == Value::Null)
@@ -100,7 +100,7 @@ template <class Owner> struct Simulation {
             decisions.erase(id);
     }
     std::pair<Value, bool> reposition(Bot &bot, const Contacts &contacts, double now) {
-        int id = integer(bot.state, "id");
+        int id = integer(bot.state, sf::id);
         auto at = repositions.find(id);
         if (at == repositions.end())
             return {Value(), false};
@@ -109,9 +109,9 @@ template <class Owner> struct Simulation {
             clear_reposition(id);
             return {Value(), true};
         }
-        auto target = contacts.lookup.find(integer(m, "target_id"));
-        if (target == contacts.lookup.end() || !flag(target->second, "alive", true) ||
-            (target->second.has("health") && field(target->second, "health") <= 0) ||
+        auto target = contacts.lookup.find(integer(m, sf::target_id));
+        if (target == contacts.lookup.end() || !flag(target->second, sf::alive, true) ||
+            (target->second.has(sf::health) && field(target->second, sf::health) <= 0) ||
             Lanes::distance(bot.state, tuple_target(m.get("destination"))) <=
                 field(config, "arrival")) {
             clear_reposition(id);
@@ -130,36 +130,37 @@ template <class Owner> struct Simulation {
     }
     static Value tuple_target(const Value &p) {
         Value t = Value::object();
-        t["position"] = p;
+        t[sf::position] = p;
         return t;
     }
     void mark_reposition(Bot &bot, const Value &command, const Value &target, const Value &launch,
                          const Value &verdict, double now) {
         Value &s = bot.state;
-        int id = integer(s, "id"), blocker = integer(verdict, "blocker_id");
+        int id = integer(s, sf::id), blocker = integer(verdict, "blocker_id");
         std::string kind = verdict.get("blocker_kind").text();
         if ((kind != "bot" && kind != "player") || blocker <= 0 ||
-            integer(verdict, "blocker_team") != integer(s, "team") ||
-            (kind == "bot" && blocker == id) || command.get("target_id").kind == Value::Null ||
+            integer(verdict, "blocker_team") != integer(s, sf::team) ||
+            (kind == "bot" && blocker == id) || command.get(sf::target_id).kind == Value::Null ||
             verdict.get("blocker_position").kind != Value::Array)
             return;
-        const Value &shape = s.get("collision_shape");
+        const Value &shape = s.get(sf::collision_shape);
         double radius = shape.kind == Value::Array
                             ? std::hypot(shape[0].number(), shape[1].number())
-                            : std::hypot(std::max(.3, field(s, "half_width", 1.7)),
-                                         std::max(.5, field(s, "half_length", 3.5))),
+                            : std::hypot(std::max(.3, field(s, sf::half_width, 1.7)),
+                                         std::max(.5, field(s, sf::half_length, 3.5))),
                other = field(verdict, "blocker_radius", radius);
         if (!std::isfinite(other) || other <= 0)
             other = radius;
         double clearance = radius + other + field(config, "contact_slop"),
-               side = (id + integer(launch, "fire_seq")) & 1 ? 1 : -1,
-               yaw = field(launch, "shot_yaw");
+               side = (id + integer(launch, sf::fire_seq)) & 1 ? 1 : -1,
+               yaw = field(launch, sf::shot_yaw);
         Value m = Value::object();
-        m["target_id"] = command.get("target_id");
-        m["target_kind"] = target.get("kind");
-        m["destination"] = vector3(field(s, "x") + std::cos(yaw) * clearance * side, field(s, "y"),
-                                   field(s, "z") - std::sin(yaw) * clearance * side);
-        m["shell_index"] = s.get("shell_index");
+        m[sf::target_id] = command.get(sf::target_id);
+        m[sf::target_kind] = target.get(sf::kind);
+        m["destination"] =
+            vector3(field(s, sf::x) + std::cos(yaw) * clearance * side, field(s, sf::y),
+                    field(s, sf::z) - std::sin(yaw) * clearance * side);
+        m[sf::shell_index] = s.get(sf::shell_index);
         m["fire_range"] = Value(std::max(0.0, field(command, "fire_range")));
         m["deadline"] = Value(now + field(config, "reposition_seconds"));
         repositions[id] = m;
@@ -171,52 +172,53 @@ template <class Owner> struct Simulation {
         traffic_buckets.clear();
         std::vector<int> insertions;
         for (const Value &raw : elements(supplied))
-            if (raw.has("id")) {
-                int id = integer(raw, "id");
+            if (raw.has(sf::id)) {
+                int id = integer(raw, sf::id);
                 Value b = raw.copy();
-                b["position"] = position(raw);
+                b[sf::position] = position(raw);
                 traffic_bodies[id] = b;
                 insertions.push_back(id);
             }
         for (const Value &raw : elements(players)) {
-            int id = integer(config, "human_base") + integer(raw, "id");
+            int id = integer(config, "human_base") + integer(raw, sf::id);
             Value b = Value::object();
-            double yaw = field(raw, "yaw"),
-                   speed = flag(raw, "alive", true) ? field(raw, "speed") : 0;
-            const Value &shape = raw.get("_kernel").get("collision").get("shape");
+            double yaw = field(raw, sf::yaw),
+                   speed = flag(raw, sf::alive, true) ? field(raw, sf::speed) : 0;
+            const Value &shape = raw.get(sf::_kernel).get("collision").get("shape");
             // The reference traffic snapshot reprojects the supplied human row
             // from x/y/z after its neighbour producer emitted position only.
-            b["id"] = Value(id);
-            b["position"] = vector3(0, 0, 0);
-            b["team"] = Value(integer(raw, "team"));
-            b["yaw"] = Value(yaw);
-            b["alive"] = Value(flag(raw, "alive", true));
+            b[sf::id] = Value(id);
+            b[sf::position] = vector3(0, 0, 0);
+            b[sf::team] = Value(integer(raw, sf::team));
+            b[sf::yaw] = Value(yaw);
+            b[sf::alive] = Value(flag(raw, sf::alive, true));
             b["shape"] = shape;
-            b["half_width"] = shape[0];
-            b["half_length"] = shape[1];
-            b["velocity"] = vector3(std::sin(yaw) * speed, 0, std::cos(yaw) * speed);
+            b[sf::half_width] = shape[0];
+            b[sf::half_length] = shape[1];
+            b[sf::velocity] = vector3(std::sin(yaw) * speed, 0, std::cos(yaw) * speed);
             traffic_bodies[id] = b;
             insertions.push_back(id);
         }
         for (int id : k.order) {
             const Value &s = k.bots.at(id)->state;
             Value b = Value::object();
-            double yaw = field(s, "yaw"), speed = flag(s, "alive", true) ? field(s, "speed") : 0;
-            b["id"] = Value(id);
-            b["position"] = position(s);
-            b["yaw"] = Value(yaw);
-            b["team"] = Value(integer(s, "team"));
-            b["alive"] = Value(flag(s, "alive", true));
-            b["shape"] = s.get("collision_shape");
-            b["half_length"] = Value(field(s, "half_length", 3.5));
-            b["half_width"] = Value(field(s, "half_width", 1.7));
-            b["velocity"] = vector3(std::sin(yaw) * speed + field(s, "push_x"), 0,
-                                    std::cos(yaw) * speed + field(s, "push_z"));
+            double yaw = field(s, sf::yaw),
+                   speed = flag(s, sf::alive, true) ? field(s, sf::speed) : 0;
+            b[sf::id] = Value(id);
+            b[sf::position] = position(s);
+            b[sf::yaw] = Value(yaw);
+            b[sf::team] = Value(integer(s, sf::team));
+            b[sf::alive] = Value(flag(s, sf::alive, true));
+            b["shape"] = s.get(sf::collision_shape);
+            b[sf::half_length] = Value(field(s, sf::half_length, 3.5));
+            b[sf::half_width] = Value(field(s, sf::half_width, 1.7));
+            b[sf::velocity] = vector3(std::sin(yaw) * speed + field(s, sf::push_x), 0,
+                                      std::cos(yaw) * speed + field(s, sf::push_z));
             traffic_bodies[id] = b;
             insertions.push_back(id);
         }
         for (int id : integer_dict_order(insertions, flag(config, "py2"))) {
-            Value p = traffic_bodies.at(id).get("position");
+            Value p = traffic_bodies.at(id).get(sf::position);
             traffic_buckets[{static_cast<int>(std::floor(p[0].number() / 24)),
                              static_cast<int>(std::floor(p[2].number() / 24))}]
                 .push_back(id);
@@ -224,8 +226,8 @@ template <class Owner> struct Simulation {
     }
     Value neighbours(const Value &state) {
         Value rows = Value::array();
-        int id = integer(state, "id"), x = static_cast<int>(std::floor(field(state, "x") / 24)),
-            z = static_cast<int>(std::floor(field(state, "z") / 24));
+        int id = integer(state, sf::id), x = static_cast<int>(std::floor(field(state, sf::x) / 24)),
+            z = static_cast<int>(std::floor(field(state, sf::z) / 24));
         for (int dz = -1; dz <= 1; ++dz)
             for (int dx = -1; dx <= 1; ++dx) {
                 auto at = traffic_buckets.find({x + dx, z + dz});
@@ -241,21 +243,21 @@ template <class Owner> struct Simulation {
             return;
         Value key = Value::array();
         auto add = [&](int id, const Value &s, double length, double width) {
-            key.append(
-                tuple_value({Value(id), Value(rounded(field(s, "x"), 2)),
-                             Value(rounded(field(s, "z"), 2)), Value(rounded(field(s, "yaw"), 3)),
-                             Value(rounded(length, 2)), Value(rounded(width, 2))}));
+            key.append(tuple_value({Value(id), Value(rounded(field(s, sf::x), 2)),
+                                    Value(rounded(field(s, sf::z), 2)),
+                                    Value(rounded(field(s, sf::yaw), 3)), Value(rounded(length, 2)),
+                                    Value(rounded(width, 2))}));
         };
         for (int id : k.order) {
             const Value &s = k.bots.at(id)->state;
-            if (!flag(s, "alive", true))
-                add(id, s, field(s, "half_length", 3.5), field(s, "half_width", 1.7));
+            if (!flag(s, sf::alive, true))
+                add(id, s, field(s, sf::half_length, 3.5), field(s, sf::half_width, 1.7));
         }
         for (const Value &s : elements(players))
-            if (!flag(s, "alive", true)) {
-                const Value &shape = s.get("_kernel").get("collision").get("shape");
+            if (!flag(s, sf::alive, true)) {
+                const Value &shape = s.get(sf::_kernel).get("collision").get("shape");
                 if (shape.kind == Value::Array)
-                    add(integer(config, "human_base") + integer(s, "id"), s, shape[1].number(),
+                    add(integer(config, "human_base") + integer(s, sf::id), s, shape[1].number(),
                         shape[0].number());
             }
         std::sort(key.data->array.begin(), key.data->array.end(),
@@ -299,8 +301,8 @@ template <class Owner> struct Simulation {
         if (bot == k.bots.end())
             return false;
         const Value &s = bot->second->state;
-        TeamKey key = Perception::team_key(integer(job.source, "team"), job.target);
-        return flag(s, "alive", true) && integer(s, "team") == integer(job.source, "team") &&
+        TeamKey key = Perception::team_key(integer(job.source, sf::team), job.target);
+        return flag(s, sf::alive, true) && integer(s, sf::team) == integer(job.source, sf::team) &&
                k.perception->remembered.count(key) && k.perception->remaining(key, now) > 0;
     }
     Value cover(double now, bool refresh, bool collect, bool observation,
@@ -322,7 +324,7 @@ template <class Owner> struct Simulation {
                 job.allies = Value::array();
                 for (int id : k.order) {
                     const Value &s = k.bots.at(id)->state;
-                    if (flag(s, "alive") && integer(s, "team") == integer(job.source, "team"))
+                    if (flag(s, sf::alive) && integer(s, sf::team) == integer(job.source, sf::team))
                         job.allies.append(position(s));
                 }
                 cover_queue.push_back(job);
@@ -336,7 +338,7 @@ template <class Owner> struct Simulation {
                 job.source = k.bots.at(job.id)->state;
                 job.target = job.target.copy();
                 offline_kernel::update(job.target, k.perception->remembered.at(Perception::team_key(
-                                                       integer(job.source, "team"), job.target)));
+                                                       integer(job.source, sf::team), job.target)));
                 std::vector<double> args;
                 Aim::point(args, job.route);
                 args.push_back(job.allies.size());
@@ -346,8 +348,8 @@ template <class Owner> struct Simulation {
                 if (reply[0]) {
                     Value row = Value::object();
                     row["bot_id"] = Value(job.id);
-                    row["target_id"] = Value(Perception::id(job.target));
-                    row["target_kind"] = Value(job.target.get("kind").text("human"));
+                    row[sf::target_id] = Value(Perception::id(job.target));
+                    row[sf::target_kind] = Value(job.target.get(sf::kind).text("human"));
                     row["candidates"] = engine_token(static_cast<int>(reply[1]));
                     cover_results.append(row);
                 }
@@ -357,15 +359,15 @@ template <class Owner> struct Simulation {
     }
     void siege_set(Bot &bot, int next, double duration = 0, double total = 0) {
         Value &s = bot.state;
-        int id = integer(s, "id"), before = integer(s, "siege_state");
+        int id = integer(s, sf::id), before = integer(s, sf::siege_state);
         if (next != 1 && next != 3)
             duration = total = 0;
-        s["siege_state"] = Value(next);
-        s["_siege_time_left"] = Value(std::max(0.0, duration));
-        s["_siege_transition_total"] = Value(std::max(0.0, total));
-        s["siege_time_left_ms"] =
+        s[sf::siege_state] = Value(next);
+        s[sf::_siege_time_left] = Value(std::max(0.0, duration));
+        s[sf::_siege_transition_total] = Value(std::max(0.0, total));
+        s[sf::siege_time_left_ms] =
             Value(duration > 0 ? static_cast<int>(std::ceil(duration * 1000 - 1e-9)) : 0);
-        s["siege_transition_total_ms"] =
+        s[sf::siege_transition_total_ms] =
             Value(total > 0 ? static_cast<int>(std::ceil(total * 1000 - 1e-9)) : 0);
         const Value &modes = bot.config.get("siege_modes");
         if (!modes.truth() || (before == 2) == (next == 2))
@@ -402,8 +404,8 @@ template <class Owner> struct Simulation {
         for (const char *key : {"aim", "motion", "perception"}) {
             bot.config[key] = mode.get(key);
         }
-        offline_kernel::update(bot.config, mode.get("health"));
-        bot.critical.reset(new CriticalConfig(mode.get("critical")));
+        offline_kernel::update(bot.config, mode.get(sf::health));
+        bot.critical.reset(new CriticalConfig(mode.get(sf::critical)));
         offline_kernel::update(s, mode.get("state"));
         k.motion->profiles[id] = Motion::params(mode.get("motion").get("physics"));
         k.motion->flow.caches.erase(id);
@@ -429,34 +431,34 @@ template <class Owner> struct Simulation {
             siege_set(bot, 0);
             return;
         }
-        int current = integer(s, "siege_state");
+        int current = integer(s, sf::siege_state);
         if (current != 1 && current != 3) {
-            s["_siege_time_left"] = Value(0.0);
-            s["siege_time_left_ms"] = Value(0);
-            s["_siege_transition_total"] = Value(0.0);
-            s["siege_transition_total_ms"] = Value(0);
+            s[sf::_siege_time_left] = Value(0.0);
+            s[sf::siege_time_left_ms] = Value(0);
+            s[sf::_siege_transition_total] = Value(0.0);
+            s[sf::siege_transition_total_ms] = Value(0);
             return;
         }
-        double left = std::max(0.0, field(s, "_siege_time_left") - dt);
+        double left = std::max(0.0, field(s, sf::_siege_time_left) - dt);
         if (left > 1e-9) {
-            s["_siege_time_left"] = Value(left);
-            s["siege_time_left_ms"] = Value(static_cast<int>(std::ceil(left * 1000 - 1e-9)));
+            s[sf::_siege_time_left] = Value(left);
+            s[sf::siege_time_left_ms] = Value(static_cast<int>(std::ceil(left * 1000 - 1e-9)));
             return;
         }
         int final = current == 1 ? 2 : 0;
         siege_set(bot, final);
-        s["_siege_intent"] = Value(final == 2);
-        s["_siege_intent_elapsed"] = Value(0.0);
+        s[sf::_siege_intent] = Value(final == 2);
+        s[sf::_siege_intent_elapsed] = Value(0.0);
     }
     bool siege_intent(Bot &bot, Value &command, const Value &target, double dt) {
         Value &s = bot.state;
         if (!bot.config.get("siege_modes").truth())
             return false;
         if (bot.burst.active) {
-            s["_siege_intent_elapsed"] = Value(0.0);
+            s[sf::_siege_intent_elapsed] = Value(0.0);
             return false;
         }
-        int current = integer(s, "siege_state");
+        int current = integer(s, sf::siege_state);
         bool switching = current == 1 || current == 3;
         if (switching)
             command["fire_allowed"] = Value(false);
@@ -464,34 +466,34 @@ template <class Owner> struct Simulation {
         if (goal.kind == Value::Null)
             goal = position(s);
         bool desired =
-            target.kind == Value::Object && flag(target, "alive", true) &&
+            target.kind == Value::Object && flag(target, sf::alive, true) &&
             !(flag(command, "movement_intent", std::abs(field(command, "throttle")) > .05) &&
               Lanes::distance(s, tuple_target(goal)) > field(config, "siege_long"));
-        if (s.get("_siege_intent").kind == Value::Null || flag(s, "_siege_intent") != desired) {
-            s["_siege_intent"] = Value(desired);
-            s["_siege_intent_elapsed"] = Value(0.0);
+        if (s.get(sf::_siege_intent).kind == Value::Null || flag(s, sf::_siege_intent) != desired) {
+            s[sf::_siege_intent] = Value(desired);
+            s[sf::_siege_intent_elapsed] = Value(0.0);
             return switching;
         }
         if ((current == 1 && desired) || (current == 3 && !desired)) {
-            s["_siege_intent_elapsed"] = Value(0.0);
+            s[sf::_siege_intent_elapsed] = Value(0.0);
             return true;
         }
-        double elapsed = field(s, "_siege_intent_elapsed") + dt;
-        s["_siege_intent_elapsed"] = Value(elapsed);
+        double elapsed = field(s, sf::_siege_intent_elapsed) + dt;
+        s[sf::_siege_intent_elapsed] = Value(elapsed);
         if ((desired && current == 2) || (!desired && current == 0) ||
             elapsed + 1e-9 <
                 field(config, desired ? "siege_enable_debounce" : "siege_disable_debounce"))
             return false;
-        std::set<std::string> destroyed = names(s.get("critical").get("destroyed"));
+        std::set<std::string> destroyed = names(s.get(sf::critical).get("destroyed"));
         if (destroyed.count("engineHealth")) {
-            s["_siege_intent_elapsed"] = Value(0.0);
+            s[sf::_siege_intent_elapsed] = Value(0.0);
             return false;
         }
         bool yellow = false;
-        const Value &devices = s.get("critical").get("devices");
+        const Value &devices = s.get(sf::critical).get("devices");
         if (devices.kind == Value::Array)
             for (const Value &v : elements(devices))
-                if (v.get("name").text() == "engineHealth")
+                if (v.get(sf::name).text() == "engineHealth")
                     yellow = v.get("state").text() == "critical" ||
                              bot.critical->condition(field(v, "hp"), "engineHealth") == 1;
         const Value &params = bot.config.get("siege_params");
@@ -499,11 +501,11 @@ template <class Owner> struct Simulation {
                left = total;
         int next = desired ? 1 : 3;
         if (switching) {
-            double previous_total = field(s, "_siege_transition_total");
+            double previous_total = field(s, sf::_siege_transition_total);
             if (previous_total <= 0)
                 throw std::invalid_argument("Siege transition total missing");
             double remaining =
-                std::min(std::max(0.0, field(s, "_siege_time_left")), previous_total);
+                std::min(std::max(0.0, field(s, sf::_siege_time_left)), previous_total);
             left = clamp((previous_total - remaining) / previous_total, 0, 1) * total;
             if (left <= 1e-9) {
                 next = desired ? 2 : 0;
@@ -512,20 +514,20 @@ template <class Owner> struct Simulation {
         }
         siege_set(bot, next, left, total);
         command["fire_allowed"] = Value(false);
-        s["_siege_intent_elapsed"] = Value(0.0);
+        s[sf::_siege_intent_elapsed] = Value(0.0);
         return true;
     }
     void siege_lock() {
         for (const auto &v : k.motion->locked) {
             Bot &bot = *k.bots.at(v.first);
             Value &s = bot.state;
-            s["x"] = v.second[0];
-            s["z"] = v.second[1];
-            s["yaw"] = v.second[2];
+            s[sf::x] = v.second[0];
+            s[sf::z] = v.second[1];
+            s[sf::yaw] = v.second[2];
             for (const char *key : {"speed", "push_x", "push_z"})
                 s[key] = Value(0.0);
-            s["movement_dir"] = Value(0);
-            s["rotation_dir"] = Value(0);
+            s[sf::movement_dir] = Value(0);
+            s[sf::rotation_dir] = Value(0);
             bot.turn_speed = 0;
         }
     }
@@ -538,8 +540,8 @@ template <class Owner> struct Simulation {
             int64_t time = std::min(end, start + static_cast<int64_t>(std::max(
                                                      0.0, rounded(edge.offset * 1000000, 0))));
             Value &s = bot.state;
-            int siege = integer(s, "siege_state");
-            if (!flag(s, "alive") || flag(s, "_drowning") || flag(s, "_overturned") ||
+            int siege = integer(s, sf::siege_state);
+            if (!flag(s, sf::alive) || flag(s, sf::_drowning) || flag(s, sf::_overturned) ||
                 destroyed.count("gunHealth") || siege == 1 || siege == 3 ||
                 !bot.ammo.can_fire(true)) {
                 Launches::cancel(bot, reload);
@@ -561,7 +563,7 @@ template <class Owner> struct Simulation {
         for (int id : ids) {
             Bot &bot = *k.bots.at(id);
             publish_burst(bot);
-            bot.state["equipment_states"] = bot.equipment_wire(equipment_now);
+            bot.state[sf::equipment_states] = bot.equipment_wire(equipment_now);
             rows.append(k.codec.row(bot.state));
             Value scalar = Value::array();
             for (const Value &name : elements(config.get("edge_fields"))) {
@@ -575,14 +577,14 @@ template <class Owner> struct Simulation {
             for (const char *key : {"shot_yaw", "shot_pitch"})
                 shot.append(tuple_value({Value(bot.state.has(key)), bot.state.get(key)}));
             bot_edges.append(
-                tuple_value({scalar, bot.state.get("ammo_remaining"), equipment, shot}));
+                tuple_value({scalar, bot.state.get(sf::ammo_remaining), equipment, shot}));
         }
         Value launches = Value::array(), rams = Value::array();
         for (const Value &v : elements(k.launches.pending))
-            launches.append(tuple_value({v.get("id"), v.get("fire_seq")}));
+            launches.append(tuple_value({v.get(sf::id), v.get(sf::fire_seq)}));
         for (const Value &v : elements(pending_ram))
             rams.append(tuple_value(
-                {v.get("bot_id"), v.get("target_kind"), v.get("target_id"), v.get("ram_seq")}));
+                {v.get("bot_id"), v.get(sf::target_kind), v.get(sf::target_id), v.get("ram_seq")}));
         signature = tuple_value({bot_edges, launches, rams});
         if (signature != edge_signature) {
             edge_signature = signature;
@@ -645,12 +647,12 @@ template <class Owner> struct Simulation {
             if (refresh && (!valid || now >= at->second.deadline))
                 due.insert(id);
             const Value &order = k.orders.at(id);
-            std::string kind = order.get("target_kind").text();
-            if ((kind == "bot" || kind == "human") && order.get("target_id").kind != Value::Null)
-                selected[id] = ActorKey{{kind == "human" ? 1 : 0, integer(order, "target_id")}};
+            std::string kind = order.get(sf::target_kind).text();
+            if ((kind == "bot" || kind == "human") && order.get(sf::target_id).kind != Value::Null)
+                selected[id] = ActorKey{{kind == "human" ? 1 : 0, integer(order, sf::target_id)}};
             else if (at != decisions.end()) {
                 auto t =
-                    at->second.contacts.lookup.find(integer(at->second.command, "target_id", -1));
+                    at->second.contacts.lookup.find(integer(at->second.command, sf::target_id, -1));
                 if (t != at->second.contacts.lookup.end())
                     selected[id] = Perception::key(t->second);
             }
@@ -670,14 +672,14 @@ template <class Owner> struct Simulation {
                     bot.clear_reposition = false;
                 }
             };
-            if (!flag(s, "alive")) {
+            if (!flag(s, sf::alive)) {
                 cancel();
                 continue;
             }
             p.note_still(s, now);
             integrated.insert(id);
             bot.advance_critical(dt, now, equipment_now);
-            if (!flag(s, "alive")) {
+            if (!flag(s, sf::alive)) {
                 cancel();
                 continue;
             }
@@ -687,17 +689,18 @@ template <class Owner> struct Simulation {
                 depth = result[0] ? result[1] : -1;
             }
             bot.advance_drowning(dt, depth);
-            if (!flag(s, "alive")) {
+            if (!flag(s, sf::alive)) {
                 cancel();
                 continue;
             }
             bot.advance_overturn(dt);
-            if (!flag(s, "alive")) {
+            if (!flag(s, sf::alive)) {
                 cancel();
                 continue;
             }
-            double siege_yaw = field(s, "yaw");
-            bool siege_locked = integer(s, "siege_state") == 1 || integer(s, "siege_state") == 3;
+            double siege_yaw = field(s, sf::yaw);
+            bool siege_locked =
+                integer(s, sf::siege_state) == 1 || integer(s, sf::siege_state) == 3;
             siege_advance(bot, dt);
             Value position_now = position(s);
             ticks[id] = position_now;
@@ -716,16 +719,16 @@ template <class Owner> struct Simulation {
             } else if (!refresh) {
                 command = Value::object();
                 command["bot_id"] = Value(id);
-                command["target_id"] = Value();
+                command[sf::target_id] = Value();
                 for (const char *key : {"aim_position", "face_position", "move_position"})
                     command[key] = position_now;
                 command["fire_range"] = Value(0.0);
                 command["combat_mode"] = Value("physical_hold");
                 command["fire_allowed"] = Value(false);
-                command["shell_index"] = Value(integer(s, "shell_index"));
+                command[sf::shell_index] = Value(integer(s, sf::shell_index));
                 command["throttle"] = Value(0.0);
                 command["turn"] = Value(0.0);
-                command["target_yaw"] = s.get("yaw");
+                command["target_yaw"] = s.get(sf::yaw);
                 command["recovery_mode"] = Value("physical_hold");
                 command["movement_intent"] = Value(false);
             } else {
@@ -736,19 +739,19 @@ template <class Owner> struct Simulation {
                 for (const char *key : {"id", "slot", "yaw", "speed", "health", "max_health",
                                         "half_length", "half_width"})
                     state[key] = s.get(key);
-                state["position"] = position_now;
-                state["dt"] = Value(decision_time);
-                state["now"] = Value(now);
-                state["neighbours"] = neighbours(s);
-                state["contacts"] = contacts.rows;
-                state["velocity"] = vector3(std::sin(field(s, "yaw")) * field(s, "speed"), 0,
-                                            std::cos(field(s, "yaw")) * field(s, "speed"));
+                state[sf::position] = position_now;
+                state[sf::dt] = Value(decision_time);
+                state[sf::now] = Value(now);
+                state[sf::neighbours] = neighbours(s);
+                state[sf::contacts] = contacts.rows;
+                state[sf::velocity] = vector3(std::sin(field(s, sf::yaw)) * field(s, sf::speed), 0,
+                                              std::cos(field(s, sf::yaw)) * field(s, sf::speed));
                 double horizon = field(config, "decision_seconds") *
                                  config.get("decision_tiers")[tier(s)].number();
-                state["decision_horizon"] = Value(horizon);
+                state[sf::decision_horizon] = Value(horizon);
                 std::string expected = k.orders.at(id).get("combat_mode").text("route");
-                state["stopping_distance"] =
-                    std::abs(field(s, "speed")) > .35 && expected != "route" &&
+                state[sf::stopping_distance] =
+                    std::abs(field(s, sf::speed)) > .35 && expected != "route" &&
                             expected != "advance"
                         ? Value(k.driver->stopping(
                               bot, cached == decisions.end() ? Value() : cached->second.command))
@@ -757,11 +760,11 @@ template <class Owner> struct Simulation {
                 Value order = override_order.first;
                 if (order.kind == Value::Null) {
                     order = k.orders.at(id).copy();
-                    if (order.get("target_kind").text() == "human" &&
-                        order.get("target_id").kind != Value::Null)
-                        order["target_id"] =
-                            Value(integer(config, "human_base") + integer(order, "target_id"));
-                    auto target = contacts.lookup.find(integer(order, "target_id", -1));
+                    if (order.get(sf::target_kind).text() == "human" &&
+                        order.get(sf::target_id).kind != Value::Null)
+                        order[sf::target_id] =
+                            Value(integer(config, "human_base") + integer(order, sf::target_id));
+                    auto target = contacts.lookup.find(integer(order, sf::target_id, -1));
                     order =
                         overlay(order, target == contacts.lookup.end() ? Value() : target->second,
                                 position_now);
@@ -770,7 +773,7 @@ template <class Owner> struct Simulation {
                 command = k.driver->drive(bot, state, order,
                                           aim.intents.count(id) || aim.reproofs.count(id));
                 command =
-                    k.traffic.adjust(id, traffic_bodies.at(id), command, state.get("neighbours"),
+                    k.traffic.adjust(id, traffic_bodies.at(id), command, state.get(sf::neighbours),
                                      now, [&](double yaw) { return k.driver->clear(bot, yaw); });
                 if (override_order.second)
                     command["fire_allowed"] = Value(false);
@@ -783,29 +786,29 @@ template <class Owner> struct Simulation {
             if (refresh_lane && !observation)
                 for (const Value &t : elements(contacts.rows))
                     if (flag(t, "fresh_visible"))
-                        p.team_visible[Perception::team_key(integer(s, "team"), t)] = true;
+                        p.team_visible[Perception::team_key(integer(s, sf::team), t)] = true;
             if (observation)
                 p.collect(s, contacts, processed);
             Value target;
-            auto chosen = contacts.lookup.find(integer(command, "target_id", -1));
+            auto chosen = contacts.lookup.find(integer(command, sf::target_id, -1));
             if (chosen != contacts.lookup.end())
                 target = p.refresh(chosen->second);
             if (target.kind != Value::Null)
                 priorities[Lanes::key(s, target)] = flag(command, "fire_allowed") ? 0 : 1;
             command = overlay(command, target, position_now);
-            s["target_kind"] = target.get("kind");
-            s["target_id"] = target.get("network_id");
+            s[sf::target_kind] = target.get(sf::kind);
+            s[sf::target_id] = target.get(sf::network_id);
             siege_locked = siege_intent(bot, command, target, dt) || siege_locked;
             double reload = aim.factors.stat(s, *bot.critical, "reload");
             if (!bot.burst.active) {
                 bot.gun.rescale(reload);
                 bot.gun.tick(dt);
                 int completed = bot.gun.complete(reload, bot.ammo.planned());
-                bot.ammo.stage(bot.gun.shell(integer(command, "shell_index")), completed >= 0,
+                bot.ammo.stage(bot.gun.shell(integer(command, sf::shell_index)), completed >= 0,
                                completed == 0);
             }
             publish_ammo(bot);
-            bool spg = s.get("profile").get("class_tag").text() == "SPG";
+            bool spg = s.get(sf::profile).get(sf::class_tag).text() == "SPG";
             Value intent, reproof;
             if (spg) {
                 if (!flag(command, "fire_allowed"))
@@ -835,25 +838,25 @@ template <class Owner> struct Simulation {
                                       bot.burst.active || intent.kind != Value::Null ||
                                           reproof.kind != Value::Null);
             command["_ballistic_solution"] = local.first;
-            double old_turret = field(s, "turret_yaw");
+            double old_turret = field(s, sf::turret_yaw);
             aim.slew(bot, command, target, dt);
-            double turret = std::abs(angle_delta(field(s, "turret_yaw") - old_turret)) /
+            double turret = std::abs(angle_delta(field(s, sf::turret_yaw) - old_turret)) /
                             std::max(dt, 1e-9),
                    dispersion = aim.factors.stat(s, *bot.critical, "dispersion");
-            bot.gun.bloom_tick(dt, std::abs(field(s, "speed")), std::abs(bot.turn_speed), turret,
+            bot.gun.bloom_tick(dt, std::abs(field(s, sf::speed)), std::abs(bot.turn_speed), turret,
                                dispersion, aim.factors.stat(s, *bot.critical, "aim_time"));
-            s["clip_size"] = Value(bot.gun.clip_size);
+            s[sf::clip_size] = Value(bot.gun.clip_size);
             publish_reload(bot, reload);
-            std::set<std::string> destroyed = names(s.get("critical").get("destroyed"));
+            std::set<std::string> destroyed = names(s.get(sf::critical).get("destroyed"));
             burst(bot, target, local.first, dt, sample, end, reload, dispersion, destroyed);
             double distance = target.kind == Value::Null ? 0 : Lanes::distance(s, target),
                    range = std::max(0.0, field(command, "fire_range"));
             bool in_range = target.kind != Value::Null && distance > 1 &&
                             local.first.kind != Value::Null && (range <= 0 || distance < range);
             if (publish && local.second && flag(command, "fire_allowed") && in_range &&
-                !flag(s, "_drowning") && !flag(s, "_overturned") && !destroyed.count("gunHealth") &&
-                flag(s, "gun_aligned") && !bot.burst.active && bot.gun.ready(reload) &&
-                bot.ammo.can_fire() &&
+                !flag(s, sf::_drowning) && !flag(s, sf::_overturned) &&
+                !destroyed.count("gunHealth") && flag(s, sf::gun_aligned) && !bot.burst.active &&
+                bot.gun.ready(reload) && bot.ammo.can_fire() &&
                 (intent.kind != Value::Null || reproof.kind != Value::Null ||
                  lanes.clear(s, target, now, false, &final_budget).truth()) &&
                 k.gunners.at(id).ready(s, target, now, bot.gun)) {
@@ -888,7 +891,7 @@ template <class Owner> struct Simulation {
                                                               "crossfire_withdraw"},
                                                fire_modes = {"engage", "advance_contact",
                                                              "jiggle_forward", "jiggle_back"};
-            if (collect_cover && target.kind != Value::Null && flag(target, "visible") &&
+            if (collect_cover && target.kind != Value::Null && flag(target, sf::visible) &&
                 flag(config, "has_cover") &&
                 (cover_modes.count(mode) ||
                  (flag(command, "fire_allowed") && fire_modes.count(mode))))
@@ -912,10 +915,10 @@ template <class Owner> struct Simulation {
         std::vector<int> slope;
         for (int id : ids) {
             Bot &bot = *k.bots.at(id);
-            if (flag(bot.state, "alive", true) && integrated.count(id)) {
-                bool was = flag(bot.state, "airborne");
+            if (flag(bot.state, sf::alive, true) && integrated.count(id)) {
+                bool was = flag(bot.state, sf::airborne);
                 blocked[id] = motion.vertical(bot, dt, ticks.at(id), motion.attempted[id]);
-                ballistic[id] = was || flag(bot.state, "airborne");
+                ballistic[id] = was || flag(bot.state, sf::airborne);
                 settled[id] = position(bot.state);
                 slope.push_back(id);
             }
@@ -929,11 +932,11 @@ template <class Owner> struct Simulation {
             publish = true;
         for (int id : slope) {
             Bot &bot = *k.bots.at(id);
-            Value trace = bot.state.get("_motion_stall_pending");
+            Value trace = bot.state.get(sf::_motion_stall_pending);
             if (trace.kind == Value::Object)
                 trace["after_contacts"] = position(bot.state);
             bool rollback = false;
-            if (!blocked[id] && !ballistic[id] && !flag(bot.state, "airborne"))
+            if (!blocked[id] && !ballistic[id] && !flag(bot.state, sf::airborne))
                 rollback =
                     motion.guard(bot, Routes::point(ticks.at(id)), safe[id], motion.attempted[id]);
             diagnostic.finish(bot, blocked[id], rollback, settled.at(id), k.contacts->active);
@@ -965,7 +968,7 @@ template <class Owner> struct Simulation {
                 next_observation = now + field(config, "observation_seconds");
                 Value row = Value::object();
                 row["type"] = Value("bot_observation");
-                row["contacts"] = lanes.pack(now);
+                row[sf::contacts] = lanes.pack(now);
                 row["affordances"] = affordances;
                 outgoing.append(row);
             }
@@ -1029,8 +1032,7 @@ template <class Owner> struct Simulation {
                 out.insert(integer(value, "_engine_token"));
                 return;
             }
-            for (const auto &v : value.data->object)
-                references(v.second, out);
+            value.visit([&](const std::string &, const Value &item) { references(item, out); });
         } else if (value.kind == Value::Array)
             for (const Value &v : elements(value))
                 references(v, out);
@@ -1039,7 +1041,7 @@ template <class Owner> struct Simulation {
         std::set<int> refs;
         references(outgoing, refs);
         for (int id : k.order)
-            references(k.bots.at(id)->state.get("shot_proof_key"), refs);
+            references(k.bots.at(id)->state.get(sf::shot_proof_key), refs);
         for (const auto &v : k.aim->cache)
             references(v.second.solution, refs);
         for (const auto &v : k.aim->intents)
@@ -1050,7 +1052,7 @@ template <class Owner> struct Simulation {
         references(cover_results, refs);
         for (const CoverJob &job : cover_queue) {
             references(job.target, refs);
-            references(job.source.get("shot_proof_key"), refs);
+            references(job.source.get(sf::shot_proof_key), refs);
         }
         Value result = Value::array();
         for (int id : refs)
@@ -1086,7 +1088,7 @@ template <class Owner> struct Simulation {
             }
             k.orders.swap(accepted);
         }
-        double dt = std::max(0.0, field(input, "dt")), now = field(input, "now");
+        double dt = std::max(0.0, field(input, sf::dt)), now = field(input, sf::now);
         if (input.has("camera"))
             camera = input.get("camera");
         control_steps = 0;
@@ -1117,7 +1119,7 @@ template <class Owner> struct Simulation {
                     ++control_steps;
                     maximum_step = std::max(maximum_step, step);
                     Value rows =
-                        slice(step, now - elapsed, input.get("players"), input.get("neighbours"),
+                        slice(step, now - elapsed, input.get("players"), input.get(sf::neighbours),
                               refresh, refresh || elapsed <= 1e-12);
                     for (const Value &row : elements(rows))
                         outgoing.append(row);
@@ -1127,8 +1129,8 @@ template <class Owner> struct Simulation {
                 if (flag(config, "has_destructible"))
                     for (int id : ordered()) {
                         const Value &s = k.bots.at(id)->state;
-                        if (flag(s, "alive") && field(s, "health") > 0 &&
-                            std::abs(field(s, "speed")) >= field(config, "destructible_speed"))
+                        if (flag(s, sf::alive) && field(s, sf::health) > 0 &&
+                            std::abs(field(s, sf::speed)) >= field(config, "destructible_speed"))
                             k.engine->query(771, s, Value::object());
                     }
             }

--- a/tools/ffi_experiment/kernel_value.h
+++ b/tools/ffi_experiment/kernel_value.h
@@ -1,8 +1,9 @@
 #ifndef OFFLINE_EXPERIMENT_KERNEL_VALUE_H
 #define OFFLINE_EXPERIMENT_KERNEL_VALUE_H
 
-// Round/configuration and publication values. Hot pose and gun fields have
-// typed owners; this tree carries the irregular pinned descriptor/ledger data.
+// State records use fixed slots; configuration and irregular ledger data keep
+// mapping semantics. A present null is distinct from an absent state field.
+#include "kernel_fields.h"
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
@@ -33,8 +34,16 @@ struct Value {
     explicit Value(double v) : kind(Real), integer(0), real(v) {}
     explicit Value(const std::string &v);
     explicit Value(const char *v) : Value(std::string(v)) {}
-    static Value array();
+    static Value array(size_t capacity = 0);
     static Value object();
+    static Value record();
+    Value as_record() const;
+    void assign_fields(const Value &source);
+    bool has(Field key) const;
+    const Value &get(Field key) const;
+    Value &operator[](Field key);
+    void erase(Field key);
+    template <typename Visitor> void visit(Visitor visitor) const;
     bool has(const std::string &key) const;
     const Value &get(const std::string &key) const;
     Value &operator[](const std::string &key);
@@ -56,37 +65,116 @@ struct Container {
     std::string string;
     std::vector<Value> array;
     std::unordered_map<std::string, Value> object;
+    std::vector<Value> slots;
+    std::vector<unsigned char> present;
+    size_t populated = 0;
 };
 inline Value::Value(const std::string &v)
-    : kind(String), integer(0), real(0), data(new Container()) {
+    : kind(String), integer(0), real(0), data(std::make_shared<Container>()) {
     data->string = v;
 }
-inline Value Value::array() {
+inline Value Value::array(size_t capacity) {
     Value v;
     v.kind = Array;
-    v.data.reset(new Container());
+    v.data = std::make_shared<Container>();
+    v.data->array.reserve(capacity);
     return v;
 }
 inline Value Value::object() {
     Value v;
     v.kind = Object;
-    v.data.reset(new Container());
+    v.data = std::make_shared<Container>();
     return v;
 }
+inline Value Value::record() {
+    Value v = object();
+    v.data->slots.resize(sf::count);
+    v.data->present.resize(sf::count, 0);
+    return v;
+}
+inline Value Value::as_record() const {
+    if (kind != Object)
+        throw std::invalid_argument("kernel state must be a mapping");
+    if (!data->slots.empty())
+        return *this;
+    Value v = record();
+    for (const auto &item : data->object)
+        v[item.first] = item.second;
+    return v;
+}
+inline void Value::assign_fields(const Value &source) {
+    if (kind != Object || source.kind != Object)
+        throw std::invalid_argument("kernel mapping update");
+    for (size_t i = 0; i < source.data->slots.size(); ++i)
+        if (source.data->present[i])
+            (*this)[Field{static_cast<int>(i), field_name(static_cast<int>(i))}] =
+                source.data->slots[i];
+    for (const auto &item : source.data->object)
+        (*this)[item.first] = item.second;
+}
+inline bool Value::has(Field key) const {
+    if (kind != Object)
+        return false;
+    if (key.slot >= 0 && !data->slots.empty())
+        return data->present[key.slot] != 0;
+    return key.slot >= 0 ? data->object.count(field_string(key.slot)) != 0
+                         : data->object.count(key.text()) != 0;
+}
+inline const Value &Value::get(Field key) const {
+    static const Value missing;
+    if (kind != Object)
+        return missing;
+    if (key.slot >= 0 && !data->slots.empty())
+        return data->present[key.slot] ? data->slots[key.slot] : missing;
+    auto i =
+        key.slot >= 0 ? data->object.find(field_string(key.slot)) : data->object.find(key.text());
+    return i == data->object.end() ? missing : i->second;
+}
+inline Value &Value::operator[](Field key) {
+    if (kind != Object)
+        throw std::invalid_argument("kernel value is not a mapping");
+    if (key.slot >= 0 && !data->slots.empty()) {
+        if (!data->present[key.slot]) {
+            data->present[key.slot] = 1;
+            ++data->populated;
+        }
+        return data->slots[key.slot];
+    }
+    return key.slot >= 0 ? data->object[field_string(key.slot)] : data->object[key.text()];
+}
+inline void Value::erase(Field key) {
+    if (kind != Object)
+        return;
+    if (key.slot >= 0 && !data->slots.empty()) {
+        if (data->present[key.slot]) {
+            data->present[key.slot] = 0;
+            --data->populated;
+            data->slots[key.slot] = Value();
+        }
+    } else
+        key.slot >= 0 ? data->object.erase(field_string(key.slot)) : data->object.erase(key.text());
+}
 inline bool Value::has(const std::string &key) const {
-    return kind == Object && data->object.count(key);
+    if (kind != Object)
+        return false;
+    int slot = data->slots.empty() ? -1 : field_slot(key);
+    return slot >= 0 ? data->present[slot] != 0 : data->object.count(key) != 0;
 }
 inline const Value &Value::get(const std::string &key) const {
     static const Value missing;
     if (kind != Object)
         return missing;
-    auto i = data->object.find(key);
-    return i == data->object.end() ? missing : i->second;
+    int slot = data->slots.empty() ? -1 : field_slot(key);
+    if (slot >= 0)
+        return data->present[slot] ? data->slots[slot] : missing;
+    auto at = data->object.find(key);
+    return at == data->object.end() ? missing : at->second;
 }
 inline Value &Value::operator[](const std::string &key) {
     if (kind != Object)
         throw std::invalid_argument("kernel value is not a mapping");
-    return data->object[key];
+    int slot = data->slots.empty() ? -1 : field_slot(key);
+    return slot >= 0 ? (*this)[Field{slot, key.c_str()}] : data->object[key];
 }
 inline const Value &Value::operator[](size_t i) const {
     if (kind != Array || i >= data->array.size())
@@ -99,12 +187,26 @@ inline Value &Value::operator[](size_t i) {
     return data->array[i];
 }
 inline void Value::erase(const std::string &key) {
-    if (kind == Object)
+    if (kind != Object)
+        return;
+    int slot = data->slots.empty() ? -1 : field_slot(key);
+    if (slot >= 0)
+        erase(Field{slot, key.c_str()});
+    else
         data->object.erase(key);
+}
+template <typename Visitor> inline void Value::visit(Visitor visitor) const {
+    if (kind != Object)
+        throw std::invalid_argument("kernel mapping visit");
+    for (size_t i = 0; i < data->slots.size(); ++i)
+        if (data->present[i])
+            visitor(field_name(static_cast<int>(i)), data->slots[i]);
+    for (const auto &item : data->object)
+        visitor(item.first, item.second);
 }
 inline size_t Value::size() const {
     return kind == Array    ? data->array.size()
-           : kind == Object ? data->object.size()
+           : kind == Object ? data->object.size() + data->populated
            : kind == String ? data->string.size()
                             : 0;
 }
@@ -149,7 +251,7 @@ inline std::string Value::text(const std::string &fallback) const {
 inline Value Value::copy() const {
     Value v = *this;
     if (data)
-        v.data.reset(new Container(*data));
+        v.data = std::make_shared<Container>(*data);
     return v;
 }
 inline Value Value::clone() const {
@@ -157,9 +259,13 @@ inline Value Value::clone() const {
     if (kind == Array)
         for (Value &item : v.data->array)
             item = item.clone();
-    else if (kind == Object)
+    else if (kind == Object) {
         for (auto &item : v.data->object)
             item.second = item.second.clone();
+        for (size_t i = 0; i < v.data->slots.size(); ++i)
+            if (v.data->present[i])
+                v.data->slots[i] = v.data->slots[i].clone();
+    }
     return v;
 }
 inline bool Value::operator==(const Value &o) const {
@@ -174,8 +280,15 @@ inline bool Value::operator==(const Value &o) const {
         return data->string == o.data->string;
     if (kind == Array)
         return data->array == o.data->array;
-    if (kind == Object)
-        return data->object == o.data->object;
+    if (kind == Object) {
+        if (size() != o.size())
+            return false;
+        bool same = true;
+        visit([&](const std::string &name, const Value &value) {
+            same = same && o.has(name) && value == o.get(name);
+        });
+        return same;
+    }
     return false;
 }
 inline void utf8(std::string &s, unsigned c) {
@@ -405,14 +518,14 @@ inline void write_json(std::ostream &out, const Value &v) {
     } else {
         out << '{';
         bool comma = false;
-        for (const auto &item : v.data->object) {
+        v.visit([&](const std::string &name, const Value &value) {
             if (comma)
                 out << ',';
-            write_string(out, item.first);
+            write_string(out, name);
             out << ':';
-            write_json(out, item.second);
+            write_json(out, value);
             comma = true;
-        }
+        });
         out << '}';
     }
 }
@@ -426,13 +539,25 @@ inline const std::vector<Value> &elements(const Value &v) {
         throw std::invalid_argument("kernel array required");
     return v.data->array;
 }
-inline double field(const Value &v, const char *name, double fallback = 0) {
+// Returned names borrow the immutable configuration tree, which their owner
+// retains for the lifetime of these bindings.
+inline std::vector<Field> bind_fields(const Value &names) {
+    std::vector<Field> result;
+    for (const Value &v : elements(names)) {
+        if (v.kind != Value::String)
+            throw std::invalid_argument("kernel field name required");
+        const std::string &name = v.data->string;
+        result.push_back(Field{field_slot(name), name.c_str(), name.size()});
+    }
+    return result;
+}
+template <typename Key> inline double field(const Value &v, Key name, double fallback = 0) {
     return v.get(name).number(fallback);
 }
-inline int integer(const Value &v, const char *name, int fallback = 0) {
+template <typename Key> inline int integer(const Value &v, Key name, int fallback = 0) {
     return static_cast<int>(v.get(name).exact(fallback));
 }
-inline bool flag(const Value &v, const char *name, bool fallback = false) {
+template <typename Key> inline bool flag(const Value &v, Key name, bool fallback = false) {
     return v.has(name) ? v.get(name).truth() : fallback;
 }
 inline double clamp(double x, double a, double b) { return std::max(a, std::min(b, x)); }

--- a/tools/ffi_experiment/kernel_value.h
+++ b/tools/ffi_experiment/kernel_value.h
@@ -1,0 +1,463 @@
+#ifndef OFFLINE_EXPERIMENT_KERNEL_VALUE_H
+#define OFFLINE_EXPERIMENT_KERNEL_VALUE_H
+
+// Round/configuration and publication values. Hot pose and gun fields have
+// typed owners; this tree carries the irregular pinned descriptor/ledger data.
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <cstdio>
+#include <iomanip>
+#include <map>
+#include <limits>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+#include <unordered_map>
+
+namespace offline_kernel {
+struct Value;
+struct Container;
+struct Value {
+    enum Kind { Null, Boolean, Integer, Real, String, Array, Object } kind;
+    int64_t integer;
+    double real;
+    std::shared_ptr<Container> data;
+    Value() : kind(Null), integer(0), real(0) {}
+    explicit Value(bool v) : kind(Boolean), integer(v), real(0) {}
+    explicit Value(int v) : kind(Integer), integer(v), real(0) {}
+    explicit Value(int64_t v) : kind(Integer), integer(v), real(0) {}
+    explicit Value(double v) : kind(Real), integer(0), real(v) {}
+    explicit Value(const std::string &v);
+    explicit Value(const char *v) : Value(std::string(v)) {}
+    static Value array();
+    static Value object();
+    bool has(const std::string &key) const;
+    const Value &get(const std::string &key) const;
+    Value &operator[](const std::string &key);
+    const Value &operator[](size_t i) const;
+    Value &operator[](size_t i);
+    void erase(const std::string &key);
+    size_t size() const;
+    void append(const Value &v);
+    bool truth() const;
+    double number(double fallback = 0) const;
+    int64_t exact(int64_t fallback = 0) const;
+    std::string text(const std::string &fallback = "") const;
+    Value copy() const;
+    Value clone() const;
+    bool operator==(const Value &other) const;
+    bool operator!=(const Value &other) const { return !(*this == other); }
+};
+struct Container {
+    std::string string;
+    std::vector<Value> array;
+    std::unordered_map<std::string, Value> object;
+};
+inline Value::Value(const std::string &v)
+    : kind(String), integer(0), real(0), data(new Container()) {
+    data->string = v;
+}
+inline Value Value::array() {
+    Value v;
+    v.kind = Array;
+    v.data.reset(new Container());
+    return v;
+}
+inline Value Value::object() {
+    Value v;
+    v.kind = Object;
+    v.data.reset(new Container());
+    return v;
+}
+inline bool Value::has(const std::string &key) const {
+    return kind == Object && data->object.count(key);
+}
+inline const Value &Value::get(const std::string &key) const {
+    static const Value missing;
+    if (kind != Object)
+        return missing;
+    auto i = data->object.find(key);
+    return i == data->object.end() ? missing : i->second;
+}
+inline Value &Value::operator[](const std::string &key) {
+    if (kind != Object)
+        throw std::invalid_argument("kernel value is not a mapping");
+    return data->object[key];
+}
+inline const Value &Value::operator[](size_t i) const {
+    if (kind != Array || i >= data->array.size())
+        throw std::out_of_range("kernel array index");
+    return data->array[i];
+}
+inline Value &Value::operator[](size_t i) {
+    if (kind != Array || i >= data->array.size())
+        throw std::out_of_range("kernel array index");
+    return data->array[i];
+}
+inline void Value::erase(const std::string &key) {
+    if (kind == Object)
+        data->object.erase(key);
+}
+inline size_t Value::size() const {
+    return kind == Array    ? data->array.size()
+           : kind == Object ? data->object.size()
+           : kind == String ? data->string.size()
+                            : 0;
+}
+inline void Value::append(const Value &v) {
+    if (kind != Array)
+        throw std::invalid_argument("kernel array append");
+    data->array.push_back(v);
+}
+inline bool Value::truth() const {
+    if (kind == Null)
+        return false;
+    if (kind == Boolean || kind == Integer)
+        return integer != 0;
+    if (kind == Real)
+        return real != 0;
+    return size() != 0;
+}
+inline double Value::number(double fallback) const {
+    if (kind == Real)
+        return real;
+    if (kind == Integer || kind == Boolean)
+        return static_cast<double>(integer);
+    if (kind == String) {
+        char *end = nullptr;
+        double v = std::strtod(data->string.c_str(), &end);
+        if (end != data->string.c_str() && !*end)
+            return v;
+    }
+    return fallback;
+}
+inline int64_t Value::exact(int64_t fallback) const {
+    if (kind == Integer || kind == Boolean)
+        return integer;
+    if (kind == Real && std::isfinite(real) && real >= -9007199254740991.0 &&
+        real <= 9007199254740991.0)
+        return static_cast<int64_t>(real);
+    return fallback;
+}
+inline std::string Value::text(const std::string &fallback) const {
+    return kind == String ? data->string : fallback;
+}
+inline Value Value::copy() const {
+    Value v = *this;
+    if (data)
+        v.data.reset(new Container(*data));
+    return v;
+}
+inline Value Value::clone() const {
+    Value v = copy();
+    if (kind == Array)
+        for (Value &item : v.data->array)
+            item = item.clone();
+    else if (kind == Object)
+        for (auto &item : v.data->object)
+            item.second = item.second.clone();
+    return v;
+}
+inline bool Value::operator==(const Value &o) const {
+    if (kind <= Real && o.kind <= Real) {
+        if (kind == Null || o.kind == Null)
+            return kind == o.kind;
+        return number() == o.number();
+    }
+    if (kind != o.kind)
+        return false;
+    if (kind == String)
+        return data->string == o.data->string;
+    if (kind == Array)
+        return data->array == o.data->array;
+    if (kind == Object)
+        return data->object == o.data->object;
+    return false;
+}
+inline void utf8(std::string &s, unsigned c) {
+    if (c <= 0x7f)
+        s.push_back(static_cast<char>(c));
+    else if (c <= 0x7ff) {
+        s.push_back(static_cast<char>(0xc0 | (c >> 6)));
+        s.push_back(static_cast<char>(0x80 | (c & 63)));
+    } else if (c <= 0xffff) {
+        s.push_back(static_cast<char>(0xe0 | (c >> 12)));
+        s.push_back(static_cast<char>(0x80 | ((c >> 6) & 63)));
+        s.push_back(static_cast<char>(0x80 | (c & 63)));
+    } else {
+        s.push_back(static_cast<char>(0xf0 | (c >> 18)));
+        s.push_back(static_cast<char>(0x80 | ((c >> 12) & 63)));
+        s.push_back(static_cast<char>(0x80 | ((c >> 6) & 63)));
+        s.push_back(static_cast<char>(0x80 | (c & 63)));
+    }
+}
+struct JsonReader {
+    const std::string &source;
+    size_t at = 0;
+    unsigned depth = 0;
+    explicit JsonReader(const std::string &s) : source(s) {}
+    void space() {
+        while (at < source.size() && (source[at] == ' ' || source[at] == '\r' ||
+                                      source[at] == '\n' || source[at] == '\t'))
+            ++at;
+    }
+    char take() {
+        if (at >= source.size())
+            throw std::invalid_argument("truncated kernel JSON");
+        return source[at++];
+    }
+    unsigned hex() {
+        unsigned n = 0;
+        for (int i = 0; i < 4; ++i) {
+            char c = take();
+            unsigned v = c >= '0' && c <= '9'   ? c - '0'
+                         : c >= 'a' && c <= 'f' ? c - 'a' + 10
+                         : c >= 'A' && c <= 'F' ? c - 'A' + 10
+                                                : 16;
+            if (v == 16)
+                throw std::invalid_argument("kernel JSON unicode");
+            n = (n << 4) | v;
+        }
+        return n;
+    }
+    std::string string() {
+        if (take() != '"')
+            throw std::invalid_argument("kernel JSON string");
+        std::string s;
+        for (;;) {
+            unsigned char c = static_cast<unsigned char>(take());
+            if (c == '"')
+                return s;
+            if (c < 32)
+                throw std::invalid_argument("kernel JSON control");
+            if (c != '\\') {
+                s.push_back(static_cast<char>(c));
+                continue;
+            }
+            c = static_cast<unsigned char>(take());
+            if (c == '"' || c == '\\' || c == '/')
+                s.push_back(static_cast<char>(c));
+            else if (c == 'b')
+                s.push_back('\b');
+            else if (c == 'f')
+                s.push_back('\f');
+            else if (c == 'n')
+                s.push_back('\n');
+            else if (c == 'r')
+                s.push_back('\r');
+            else if (c == 't')
+                s.push_back('\t');
+            else if (c == 'u') {
+                unsigned cp = hex();
+                if (cp >= 0xd800 && cp <= 0xdbff) {
+                    if (take() != '\\' || take() != 'u')
+                        throw std::invalid_argument("kernel JSON surrogate");
+                    unsigned low = hex();
+                    if (low < 0xdc00 || low > 0xdfff)
+                        throw std::invalid_argument("kernel JSON surrogate");
+                    cp = 0x10000 + ((cp - 0xd800) << 10) + (low - 0xdc00);
+                } else if (cp >= 0xdc00 && cp <= 0xdfff)
+                    throw std::invalid_argument("kernel JSON surrogate");
+                utf8(s, cp);
+            } else
+                throw std::invalid_argument("kernel JSON escape");
+        }
+    }
+    Value value() {
+        space();
+        if (++depth > 128)
+            throw std::invalid_argument("kernel JSON nesting");
+        if (at >= source.size())
+            throw std::invalid_argument("kernel JSON value");
+        char c = source[at];
+        Value v;
+        if (c == '"')
+            v = Value(string());
+        else if (c == '[' || c == '{') {
+            ++at;
+            v = c == '[' ? Value::array() : Value::object();
+            space();
+            char close = c == '[' ? ']' : '}';
+            if (at < source.size() && source[at] == close)
+                ++at;
+            else
+                for (;;) {
+                    space();
+                    if (c == '[')
+                        v.append(value());
+                    else {
+                        std::string key = string();
+                        space();
+                        if (take() != ':')
+                            throw std::invalid_argument("kernel JSON colon");
+                        if (v.has(key))
+                            throw std::invalid_argument("duplicate kernel JSON key");
+                        v[key] = value();
+                    }
+                    space();
+                    char sep = take();
+                    if (sep == close)
+                        break;
+                    if (sep != ',')
+                        throw std::invalid_argument("kernel JSON separator");
+                }
+        } else if (source.compare(at, 4, "null") == 0)
+            at += 4;
+        else if (source.compare(at, 4, "true") == 0) {
+            v = Value(true);
+            at += 4;
+        } else if (source.compare(at, 5, "false") == 0) {
+            v = Value(false);
+            at += 5;
+        } else {
+            size_t start = at;
+            if (source[at] == '-')
+                ++at;
+            if (at >= source.size() || source[at] < '0' || source[at] > '9')
+                throw std::invalid_argument("kernel JSON number");
+            if (source[at] == '0')
+                ++at;
+            else
+                while (at < source.size() && source[at] >= '0' && source[at] <= '9')
+                    ++at;
+            bool floating = false;
+            if (at < source.size() && source[at] == '.') {
+                floating = true;
+                ++at;
+                size_t digits = at;
+                while (at < source.size() && source[at] >= '0' && source[at] <= '9')
+                    ++at;
+                if (at == digits)
+                    throw std::invalid_argument("kernel JSON fraction");
+            }
+            if (at < source.size() && (source[at] == 'e' || source[at] == 'E')) {
+                floating = true;
+                ++at;
+                if (at < source.size() && (source[at] == '+' || source[at] == '-'))
+                    ++at;
+                size_t digits = at;
+                while (at < source.size() && source[at] >= '0' && source[at] <= '9')
+                    ++at;
+                if (at == digits)
+                    throw std::invalid_argument("kernel JSON exponent");
+            }
+            std::string raw = source.substr(start, at - start);
+            char *end = nullptr;
+            double n = std::strtod(raw.c_str(), &end);
+            if (!std::isfinite(n) || !end || *end)
+                throw std::invalid_argument("kernel JSON numeric range");
+            if (!floating && n >= -9007199254740991.0 && n <= 9007199254740991.0)
+                v = Value(static_cast<int64_t>(n));
+            else
+                v = Value(n);
+        }
+        --depth;
+        return v;
+    }
+    Value read() {
+        Value v = value();
+        space();
+        if (at != source.size())
+            throw std::invalid_argument("kernel JSON suffix");
+        return v;
+    }
+};
+inline void write_string(std::ostream &out, const std::string &s) {
+    static const char hex[] = "0123456789abcdef";
+    out << '"';
+    for (unsigned char c : s) {
+        if (c == '"' || c == '\\')
+            out << '\\' << static_cast<char>(c);
+        else if (c < 32)
+            out << "\\u00" << hex[c >> 4] << hex[c & 15];
+        else
+            out << static_cast<char>(c);
+    }
+    out << '"';
+}
+inline void write_json(std::ostream &out, const Value &v) {
+    if (v.kind == Value::Null)
+        out << "null";
+    else if (v.kind == Value::Boolean)
+        out << (v.integer ? "true" : "false");
+    else if (v.kind == Value::Integer)
+        out << v.integer;
+    else if (v.kind == Value::Real) {
+        if (!std::isfinite(v.real))
+            throw std::domain_error("nonfinite kernel output");
+        out << std::setprecision(17) << v.real;
+    } else if (v.kind == Value::String)
+        write_string(out, v.data->string);
+    else if (v.kind == Value::Array) {
+        out << '[';
+        bool comma = false;
+        for (const Value &item : v.data->array) {
+            if (comma)
+                out << ',';
+            write_json(out, item);
+            comma = true;
+        }
+        out << ']';
+    } else {
+        out << '{';
+        bool comma = false;
+        for (const auto &item : v.data->object) {
+            if (comma)
+                out << ',';
+            write_string(out, item.first);
+            out << ':';
+            write_json(out, item.second);
+            comma = true;
+        }
+        out << '}';
+    }
+}
+inline std::string json(const Value &v) {
+    std::ostringstream out;
+    write_json(out, v);
+    return out.str();
+}
+inline const std::vector<Value> &elements(const Value &v) {
+    if (v.kind != Value::Array)
+        throw std::invalid_argument("kernel array required");
+    return v.data->array;
+}
+inline double field(const Value &v, const char *name, double fallback = 0) {
+    return v.get(name).number(fallback);
+}
+inline int integer(const Value &v, const char *name, int fallback = 0) {
+    return static_cast<int>(v.get(name).exact(fallback));
+}
+inline bool flag(const Value &v, const char *name, bool fallback = false) {
+    return v.has(name) ? v.get(name).truth() : fallback;
+}
+inline double clamp(double x, double a, double b) { return std::max(a, std::min(b, x)); }
+inline double rounded(double v, int digits) {
+    // CPython 2.7 rounds the binary value to decimal, correcting true ties
+    // away from zero. Multiplying first can create a false halfway value.
+    if (!std::isfinite(v) || digits < 0 || digits > 6)
+        throw std::invalid_argument("kernel decimal rounding");
+    int exponent = 0;
+    double fraction = std::frexp(std::abs(v), &exponent);
+    uint64_t mantissa = static_cast<uint64_t>(std::ldexp(fraction, 53));
+    exponent -= 53;
+    while (mantissa && !(mantissa & 1)) {
+        mantissa >>= 1;
+        ++exponent;
+    }
+    if (mantissa && exponent + digits == -1) {
+        double scale = std::pow(10.0, digits);
+        return std::round(v * scale) / scale;
+    }
+    char output[384];
+    int n = std::snprintf(output, sizeof(output), "%.*f", digits, v);
+    if (n < 0 || static_cast<size_t>(n) >= sizeof(output))
+        throw std::invalid_argument("kernel decimal width");
+    return std::strtod(output, nullptr);
+}
+} // namespace offline_kernel
+#endif

--- a/tools/ffi_experiment/kernel_weapon.h
+++ b/tools/ffi_experiment/kernel_weapon.h
@@ -1,0 +1,357 @@
+#ifndef OFFLINE_EXPERIMENT_KERNEL_WEAPON_H
+#define OFFLINE_EXPERIMENT_KERNEL_WEAPON_H
+#include "kernel_value.h"
+
+namespace offline_kernel {
+// The descriptor producer initializes these once. Every reload, selection,
+// burst and bloom transition thereafter belongs to the native Bot owner.
+struct Gun {
+    int clip = 0, clip_size = 1, shell_count = 1, burst_count = 1, burst_remaining = 0;
+    double elapsed = 0, reload_factor = 1, reload_duration = 0, reload_full = 0, reload_intra = 0;
+    bool intra = false;
+    double movement_factor = 0, rotation_factor = 0, turret_factor = 0;
+    double dispersion = 0, fully_aimed = 0, aiming_time = 0, current_factor = 1;
+    double aiming_start = 1, aiming_elapsed = 0, motion_squared = 0, after_shot = 0,
+           after_in_burst = 0, burst_interval = 0;
+    void load(const Value &v) {
+        clip = integer(v, "clip");
+        clip_size = integer(v, "clip_size", 1);
+        shell_count = integer(v, "shell_count", 1);
+        burst_count = integer(v, "burst_count", 1);
+        burst_remaining = integer(v, "_burst_remaining");
+        elapsed = field(v, "elapsed");
+        reload_factor = field(v, "reload_factor", 1);
+        reload_duration = field(v, "reload_duration");
+        reload_full = field(v, "reload_full");
+        reload_intra = field(v, "reload_intra");
+        intra = v.get("reload_kind").text() == "intra";
+        movement_factor = field(v, "movement_dispersion_factor");
+        rotation_factor = field(v, "rotation_dispersion_factor");
+        turret_factor = field(v, "turret_dispersion_factor");
+        dispersion = field(v, "dispersion");
+        fully_aimed = field(v, "fully_aimed_dispersion");
+        aiming_time = field(v, "aiming_time");
+        current_factor = field(v, "current_dispersion_factor", 1);
+        aiming_start = field(v, "aiming_start_factor", 1);
+        aiming_elapsed = field(v, "aiming_elapsed");
+        motion_squared = field(v, "motion_dispersion_squared");
+        after_shot = field(v, "after_shot");
+        after_in_burst = field(v, "after_shot_in_burst");
+        burst_interval = field(v, "burst_interval");
+        if (clip_size < 1 || shell_count < 1 || shell_count > 5 || clip < 0 || clip > clip_size ||
+            reload_full <= 0 || reload_intra < 0 || fully_aimed <= 0)
+            throw std::invalid_argument("kernel gun producer");
+    }
+    double duration(double factor = 1) const {
+        return reload_duration * (intra ? 1 : std::max(0.0, factor));
+    }
+    bool ready(double factor = 1) const { return elapsed > duration(factor); }
+    double remaining(double factor = 1) const { return std::max(0.0, duration(factor) - elapsed); }
+    void tick(double dt) { elapsed += std::max(0.0, dt); }
+    void bloom_tick(double dt, double move, double rotation, double turret, double factor = 1,
+                    double aim_factor = 1) {
+        dt = std::max(0.0, dt);
+        double a = std::abs(move) * movement_factor, b = std::abs(rotation) * rotation_factor,
+               c = std::abs(turret) * turret_factor;
+        motion_squared = a * a + b * b + c * c;
+        double ideal = std::max(0.0, factor) * std::sqrt(1.0 + motion_squared);
+        if (!std::isfinite(ideal) || ideal <= 0)
+            throw std::domain_error("dynamic bot shot dispersion must be positive");
+        double time = aiming_time * std::max(0.0, aim_factor), passed = aiming_elapsed + dt;
+        double candidate = aiming_start * std::exp(-passed / std::max(time, 0.1));
+        if (candidate < ideal) {
+            current_factor = aiming_start = ideal;
+            aiming_elapsed = 0;
+        } else {
+            current_factor = candidate;
+            aiming_elapsed = passed;
+        }
+        dispersion = fully_aimed * current_factor;
+    }
+    void shot_bloom(double factor, bool final_round) {
+        double bloom = final_round ? after_shot : after_in_burst;
+        double ideal = std::max(0.0, factor) * std::sqrt(1.0 + motion_squared + bloom * bloom);
+        if (current_factor < ideal) {
+            current_factor = aiming_start = ideal;
+            aiming_elapsed = 0;
+            dispersion = fully_aimed * ideal;
+        }
+    }
+    bool rescale(double factor) {
+        factor = std::max(0.0, factor);
+        if (std::abs(factor - reload_factor) <= 1e-9)
+            return false;
+        double old = duration(reload_factor), next = duration(factor);
+        if (old > 0) {
+            if (elapsed < old)
+                elapsed = next * clamp(elapsed / old, 0, 1);
+            else
+                elapsed = next + (elapsed - old);
+        }
+        reload_factor = factor;
+        return true;
+    }
+    // -1: pending, 0: full, 1: intra-clip. Readiness is deliberately strict.
+    int complete(double factor, int available = -1) {
+        if (!ready(factor))
+            return -1;
+        if (!intra && clip == 0)
+            clip = available < 0 ? clip_size : std::min(clip_size, std::max(0, available));
+        return intra ? 1 : 0;
+    }
+    void require_full() {
+        clip = 0;
+        intra = false;
+        reload_duration = reload_full;
+    }
+    int shell(int requested) const { return std::max(0, std::min(requested, shell_count - 1)); }
+    bool begin_burst(int count, double factor) {
+        if (burst_remaining > 0 || !ready(factor))
+            return false;
+        if (clip <= 0)
+            complete(factor);
+        count = std::min(count, clip);
+        if (count <= 0)
+            return false;
+        burst_remaining = count;
+        return true;
+    }
+    bool fire_round(bool final_round) {
+        if (burst_remaining <= 0 || clip <= 0 || final_round != (burst_remaining == 1))
+            return false;
+        --clip;
+        --burst_remaining;
+        if (!final_round)
+            return true;
+        elapsed = 0;
+        intra = clip > 0;
+        if (!intra)
+            clip = 0;
+        reload_duration = intra ? reload_intra : reload_full;
+        return true;
+    }
+    bool cancel_burst() {
+        if (burst_remaining <= 0)
+            return false;
+        burst_remaining = 0;
+        elapsed = 0;
+        intra = clip > 0;
+        reload_duration = intra ? reload_intra : reload_full;
+        return true;
+    }
+    Value snapshot() const {
+        Value v = Value::object();
+        v["clip"] = Value(clip);
+        v["clip_size"] = Value(clip_size);
+        v["shell_count"] = Value(shell_count);
+        v["burst_count"] = Value(burst_count);
+        v["_burst_remaining"] = Value(burst_remaining);
+        v["elapsed"] = Value(elapsed);
+        v["reload_factor"] = Value(reload_factor);
+        v["reload_duration"] = Value(reload_duration);
+        v["reload_full"] = Value(reload_full);
+        v["reload_intra"] = Value(reload_intra);
+        v["reload_kind"] = Value(intra ? "intra" : "full");
+        v["movement_dispersion_factor"] = Value(movement_factor);
+        v["rotation_dispersion_factor"] = Value(rotation_factor);
+        v["turret_dispersion_factor"] = Value(turret_factor);
+        v["dispersion"] = Value(dispersion);
+        v["fully_aimed_dispersion"] = Value(fully_aimed);
+        v["aiming_time"] = Value(aiming_time);
+        v["current_dispersion_factor"] = Value(current_factor);
+        v["aiming_start_factor"] = Value(aiming_start);
+        v["aiming_elapsed"] = Value(aiming_elapsed);
+        v["motion_dispersion_squared"] = Value(motion_squared);
+        v["after_shot"] = Value(after_shot);
+        v["after_shot_in_burst"] = Value(after_in_burst);
+        v["burst_interval"] = Value(burst_interval);
+        return v;
+    }
+};
+struct Ammo {
+    std::vector<int> quantities;
+    Value categories;
+    int loaded = 0, next = 0;
+    bool reload_pending = false, plan_pending = true;
+    void load(const Value &v) {
+        const Value &values = v.get("remaining");
+        if (values.kind != Value::Array || values.size() < 1 || values.size() > 5)
+            throw std::invalid_argument("kernel ammunition producer");
+        quantities.clear();
+        categories = v.get("categories");
+        for (size_t i = 0; i < values.size(); ++i) {
+            int n = static_cast<int>(values[i].exact(-1));
+            if (n < 0 || n > 1000)
+                throw std::invalid_argument("kernel ammunition quantity");
+            quantities.push_back(n);
+        }
+        loaded = integer(v, "loaded");
+        next = integer(v, "next");
+        reload_pending = flag(v, "reload_pending");
+        plan_pending = flag(v, "plan_pending", true);
+        if (loaded < 0 || next < 0 || loaded >= static_cast<int>(quantities.size()) ||
+            next >= static_cast<int>(quantities.size()))
+            throw std::invalid_argument("kernel ammunition selection");
+    }
+    int fallback() const {
+        int first = -1;
+        for (size_t i = 0; i < quantities.size(); ++i)
+            if (quantities[i] > 0) {
+                if (first < 0)
+                    first = static_cast<int>(i);
+                if (categories.get(std::to_string(i)).text() == "standard")
+                    return static_cast<int>(i);
+            }
+        return first < 0 ? 0 : first;
+    }
+    int available(int requested) const {
+        return requested >= 0 && requested < static_cast<int>(quantities.size()) &&
+                       quantities[requested] > 0
+                   ? requested
+                   : fallback();
+    }
+    bool stage(int requested, bool ready, bool full) {
+        if (!ready)
+            return false;
+        bool changed = false;
+        if (reload_pending) {
+            if (full) {
+                int selected = available(next);
+                if (selected != loaded) {
+                    loaded = selected;
+                    changed = true;
+                }
+            }
+            reload_pending = false;
+            plan_pending = true;
+        }
+        if (plan_pending) {
+            int selected = available(requested);
+            if (selected != next) {
+                next = selected;
+                changed = true;
+            }
+            plan_pending = false;
+        }
+        return changed;
+    }
+    bool can_fire(bool continuing = false) const {
+        return loaded >= 0 && loaded < static_cast<int>(quantities.size()) &&
+               quantities[loaded] > 0 && (continuing || !reload_pending);
+    }
+    bool consume(bool continuing = false) {
+        if (!can_fire(continuing))
+            return false;
+        --quantities[loaded];
+        next = available(next);
+        reload_pending = true;
+        plan_pending = false;
+        return true;
+    }
+    int planned() const {
+        return next >= 0 && next < static_cast<int>(quantities.size()) ? quantities[next] : 0;
+    }
+    bool requires_full() const {
+        if (loaded < 0 || loaded >= static_cast<int>(quantities.size()) || quantities[loaded] > 0)
+            return false;
+        for (int n : quantities)
+            if (n > 0)
+                return true;
+        return false;
+    }
+    Value snapshot() const {
+        Value v = Value::object(), q = Value::array();
+        for (int n : quantities)
+            q.append(Value(n));
+        v["remaining"] = q;
+        v["categories"] = categories;
+        v["shell_count"] = Value(static_cast<int>(quantities.size()));
+        v["loaded"] = Value(loaded);
+        v["next"] = Value(next);
+        v["reload_pending"] = Value(reload_pending);
+        v["plan_pending"] = Value(plan_pending);
+        return v;
+    }
+};
+struct Subshot {
+    int seq, group, index, count, shell;
+    bool final;
+    double offset;
+};
+struct Burst {
+    bool active = false;
+    int group = 0, count = 0, next = 0, shell = 0;
+    double interval = 0, left = 0;
+    void load(const Value &v) {
+        active = flag(v, "active");
+        group = integer(v, "group_seq");
+        count = integer(v, "count");
+        next = integer(v, "next_index");
+        shell = integer(v, "shell_index");
+        interval = field(v, "interval");
+        left = field(v, "time_left");
+    }
+    bool start(int sequence, int wanted, double spacing, int selected) {
+        if (active || sequence <= 0 || wanted < 1 || wanted > 64 || selected < 0 ||
+            !std::isfinite(spacing) || spacing < 0 || spacing > 10 || (wanted > 1 && spacing <= 0))
+            return false;
+        active = true;
+        group = sequence;
+        count = wanted;
+        next = 0;
+        interval = wanted > 1 ? spacing : 0;
+        left = 0;
+        shell = selected;
+        return true;
+    }
+    std::vector<Subshot> advance(double dt) {
+        std::vector<Subshot> due;
+        if (!active || !std::isfinite(dt))
+            return due;
+        dt = std::max(0.0, dt);
+        double offset = std::max(0.0, left);
+        left -= dt;
+        while (active && left <= 1e-9) {
+            int index = next;
+            due.push_back(Subshot{group + index, group, index, count, shell, index + 1 >= count,
+                                  std::min(dt, offset)});
+            ++next;
+            if (next >= count) {
+                active = false;
+                left = 0;
+            } else {
+                left += interval;
+                offset += interval;
+            }
+        }
+        return due;
+    }
+    bool cancel(int launched = -1) {
+        bool changed = active || count > 0;
+        if (launched < 0)
+            launched = next;
+        if (launched < 0 || launched > next)
+            return false;
+        active = false;
+        next = launched;
+        if (launched == 0) {
+            group = count = shell = 0;
+            interval = 0;
+        }
+        left = 0;
+        return changed;
+    }
+    Value snapshot() const {
+        Value v = Value::object();
+        v["active"] = Value(active);
+        v["group_seq"] = Value(group);
+        v["count"] = Value(count);
+        v["next_index"] = Value(next);
+        v["shell_index"] = Value(shell);
+        v["interval"] = Value(interval);
+        v["time_left"] = Value(left);
+        return v;
+    }
+};
+} // namespace offline_kernel
+#endif

--- a/tools/ffi_experiment/kernel_weapon.h
+++ b/tools/ffi_experiment/kernel_weapon.h
@@ -14,14 +14,14 @@ struct Gun {
     double aiming_start = 1, aiming_elapsed = 0, motion_squared = 0, after_shot = 0,
            after_in_burst = 0, burst_interval = 0;
     void load(const Value &v) {
-        clip = integer(v, "clip");
-        clip_size = integer(v, "clip_size", 1);
+        clip = integer(v, sf::clip);
+        clip_size = integer(v, sf::clip_size, 1);
         shell_count = integer(v, "shell_count", 1);
-        burst_count = integer(v, "burst_count", 1);
+        burst_count = integer(v, sf::burst_count, 1);
         burst_remaining = integer(v, "_burst_remaining");
         elapsed = field(v, "elapsed");
         reload_factor = field(v, "reload_factor", 1);
-        reload_duration = field(v, "reload_duration");
+        reload_duration = field(v, sf::reload_duration);
         reload_full = field(v, "reload_full");
         reload_intra = field(v, "reload_intra");
         intra = v.get("reload_kind").text() == "intra";
@@ -37,7 +37,7 @@ struct Gun {
         motion_squared = field(v, "motion_dispersion_squared");
         after_shot = field(v, "after_shot");
         after_in_burst = field(v, "after_shot_in_burst");
-        burst_interval = field(v, "burst_interval");
+        burst_interval = field(v, sf::burst_interval);
         if (clip_size < 1 || shell_count < 1 || shell_count > 5 || clip < 0 || clip > clip_size ||
             reload_full <= 0 || reload_intra < 0 || fully_aimed <= 0)
             throw std::invalid_argument("kernel gun producer");
@@ -141,14 +141,14 @@ struct Gun {
     }
     Value snapshot() const {
         Value v = Value::object();
-        v["clip"] = Value(clip);
-        v["clip_size"] = Value(clip_size);
+        v[sf::clip] = Value(clip);
+        v[sf::clip_size] = Value(clip_size);
         v["shell_count"] = Value(shell_count);
-        v["burst_count"] = Value(burst_count);
+        v[sf::burst_count] = Value(burst_count);
         v["_burst_remaining"] = Value(burst_remaining);
         v["elapsed"] = Value(elapsed);
         v["reload_factor"] = Value(reload_factor);
-        v["reload_duration"] = Value(reload_duration);
+        v[sf::reload_duration] = Value(reload_duration);
         v["reload_full"] = Value(reload_full);
         v["reload_intra"] = Value(reload_intra);
         v["reload_kind"] = Value(intra ? "intra" : "full");
@@ -164,7 +164,7 @@ struct Gun {
         v["motion_dispersion_squared"] = Value(motion_squared);
         v["after_shot"] = Value(after_shot);
         v["after_shot_in_burst"] = Value(after_in_burst);
-        v["burst_interval"] = Value(burst_interval);
+        v[sf::burst_interval] = Value(burst_interval);
         return v;
     }
 };
@@ -287,7 +287,7 @@ struct Burst {
         group = integer(v, "group_seq");
         count = integer(v, "count");
         next = integer(v, "next_index");
-        shell = integer(v, "shell_index");
+        shell = integer(v, sf::shell_index);
         interval = field(v, "interval");
         left = field(v, "time_left");
     }
@@ -347,7 +347,7 @@ struct Burst {
         v["group_seq"] = Value(group);
         v["count"] = Value(count);
         v["next_index"] = Value(next);
-        v["shell_index"] = Value(shell);
+        v[sf::shell_index] = Value(shell);
         v["interval"] = Value(interval);
         v["time_left"] = Value(left);
         return v;

--- a/tools/ffi_experiment/kernel_world.h
+++ b/tools/ffi_experiment/kernel_world.h
@@ -1,0 +1,127 @@
+#ifndef OFFLINE_EXPERIMENT_KERNEL_WORLD_H
+#define OFFLINE_EXPERIMENT_KERNEL_WORLD_H
+#include "kernel_engine.h"
+#include "world_core.h"
+
+namespace offline_kernel {
+// One stack-owned resolver composes the world sweep directly. Python retains
+// descriptors, native hit/filter objects and canonical destructible operations.
+struct WorldResolver {
+    Engine &engine;
+    int identity, mode;
+    const OfflineQueryRoute *route = nullptr;
+    WorldResolver(Engine &e, const Value &state)
+        : engine(e), identity(integer(state, sf::id)), mode(integer(state, sf::siege_state)) {}
+
+    std::array<double, 64> call(int operation, const double *values, size_t count) {
+        if (count > 58)
+            throw std::invalid_argument("kernel world request width");
+        std::array<double, 64> packet{};
+        packet[0] = 772;
+        packet[1] = operation;
+        packet[2] = identity;
+        packet[3] = mode;
+        std::copy(values, values + count, packet.begin() + 4);
+        packet[62] = engine.sample_time;
+        packet[63] = engine.equipment_time;
+        int status = route ? route->forward(packet.data(), packet.size())
+                           : offline_query(packet.data(), packet.size());
+        if (status)
+            throw std::runtime_error("kernel world callback");
+        return packet;
+    }
+    static int callback(void *owner, double *packet, int count) {
+        WorldResolver &self = *static_cast<WorldResolver *>(owner);
+        if (count == 33 && packet[0] == 5) {
+            auto answer = self.call(3, packet + 1, 32);
+            std::copy(answer.begin(), answer.begin() + 16, packet);
+            return 0;
+        }
+        if (count != 16 || packet[0] < 1 || packet[0] > 4)
+            return self.route ? self.route->forward(packet, count) : 18;
+        auto answer = self.call(1, packet, count);
+        std::copy(answer.begin(), answer.begin() + 8, packet);
+        return 0;
+    }
+    int resolve(const Value &state, const Value &profile, double turn_speed, const double *motion) {
+        const Value &extents = profile.get("extents");
+        if (extents.kind != Value::Array || extents.size() != 3 || !profile.has("forward") ||
+            !profile.has("backward"))
+            throw std::invalid_argument("kernel world descriptor profile");
+        offline_world::Input input;
+        input.pos = offline_world::Point(motion[2], motion[3], motion[4]);
+        input.yaw = motion[9] ? field(state, sf::yaw) : motion[5];
+        input.speed = motion[6];
+        input.dt = motion[7];
+        input.has_motion = motion[9] != 0;
+        input.motion = motion[5] + (input.speed < 0 ? 3.141592653589793 : 0);
+        input.airborne = flag(state, sf::airborne);
+        input.pitch = state.has(sf::terrain_pitch) ? state.get(sf::terrain_pitch).number()
+                                                   : field(state, sf::pitch);
+        input.roll = field(state, sf::roll);
+        input.hw = extents[0].number();
+        input.back = extents[1].number();
+        input.front = extents[2].number();
+        bool driving = integer(state, sf::movement_dir) * input.speed > 0;
+        bool turning = integer(state, sf::rotation_dir) != 0 || std::abs(turn_speed) > .01;
+        bool reuse = !input.airborne && driving && !turning && motion[20] != 0;
+        bool crush = !input.airborne && driving;
+        bool commit = !input.has_motion || motion[10] != 0;
+        double kinetic =
+            crush ? (input.speed < 0 ? -field(profile, "backward") : field(profile, "forward")) : 0;
+        // The reason is only a diagnostic classification, never a stop command.
+        double reason = input.airborne ? 1 : !driving ? 2 : turning ? 3 : 0;
+        double begin[] = {input.pos.x,   input.pos.y,   input.pos.z, input.yaw,
+                          input.speed,   input.dt,      motion[8],   double(input.has_motion),
+                          input.motion,  double(crush), kinetic,     double(commit),
+                          double(reuse), reason};
+        auto initial = call(0, begin, 14);
+        if ((initial[0] != 0 && initial[0] != 1) || (initial[1] != 0 && initial[1] != 1))
+            throw std::invalid_argument("kernel world begin answer");
+        if (initial[0] != 0)
+            return 0; // The exact corridor and current catalog both allow reuse.
+        bool has_catalog = initial[1] != 0;
+        int world_status;
+        {
+            OfflineQueryRoute current(callback, this);
+            route = &current;
+            world_status = offline_world::sweep(input, true);
+            route = nullptr;
+        }
+        // Catalog calls and their native side effects keep source order. A
+        // later Bot cannot observe this pose before the resolver completes.
+        int operation = world_status == 0 && has_catalog                      ? 1
+                        : world_status != 0 && has_catalog && !input.airborne ? 2
+                                                                              : 0;
+        double finish[] = {double(operation)};
+        auto detail = call(2, finish, 1);
+        if (operation < 2) {
+            if (detail[0] != 0 && detail[0] != 1)
+                throw std::invalid_argument("kernel world contact answer");
+        } else {
+            if (!std::isfinite(detail[0]) || detail[0] != std::floor(detail[0]) || detail[0] < 0 ||
+                detail[0] > 5 || detail[0] == 3)
+                throw std::invalid_argument("kernel world catalog answer");
+            for (size_t i = 1; i < 4; ++i)
+                if (detail[i] != 0 && detail[i] != 1)
+                    throw std::invalid_argument("kernel world catalog flags");
+        }
+        if (world_status == 0)
+            return detail[0] != 0 ? 2 : 4;
+        if (!has_catalog || input.airborne)
+            return world_status == 1 ? 0 : 4;
+        int status = static_cast<int>(detail[0]);
+        if (status == 4)
+            return 4;
+        bool accepted = detail[1] != 0, kinetic_used = detail[2] != 0;
+        if (kinetic_used && !(accepted && status == 1 && detail[3] != 0))
+            throw std::runtime_error("bot cap-crush receipt is inconsistent");
+        if (accepted && (status == 0 || status == 5 || status == 2))
+            throw std::runtime_error("bot contact receipt is inconsistent");
+        if (status == 5)
+            return 0; // A lookahead approach is not physical contact.
+        return accepted && kinetic_used ? 3 : status;
+    }
+};
+} // namespace offline_kernel
+#endif

--- a/tools/ffi_experiment/kernel_world.py
+++ b/tools/ffi_experiment/kernel_world.py
@@ -1,0 +1,193 @@
+"""Borrow native/catalog leaves for the stack-owned collision resolver.
+
+Only the explicit experiment runner supplies a battle owner. Each operation
+owns fresh hit/filter references; no native pointer or result survives update
+failure or teardown. The source catalog retains mutation and event ownership.
+"""
+from __future__ import print_function
+from array import array
+import math
+
+_ZERO = array('d', [0]) * 8
+_STATUSES = ('clear', 'crushed', 'soft', 'cap_crushed', 'hard', 'approach')
+
+
+def descriptor_profile(descriptor):
+    from gui.mods.offline_lan_0922 import vehicle_physics, world_collision
+    extents = world_collision._vehicle_motion_extents(descriptor)
+    if extents is None:
+        raise ValueError('Native world experiment requires exact collision extents')
+    # The resolver derives unmodified descriptor limits, not crew/equipment
+    # adjusted Bot driving parameters. Compile the same producer per mode.
+    params = vehicle_physics.derive_params(descriptor)
+    return dict(extents=extents, forward=params['speedFwd'], backward=params['speedBwd'])
+
+
+class Context(object):
+    def __init__(self, owner, descriptor, identity, values):
+        self.identity, self.descriptor = identity, descriptor
+        self.position = owner._vector(tuple(values[:3]))
+        self.yaw, self.speed, self.dt, self.now = values[3:7]
+        self.motion = {'motion_yaw': values[8]} if values[7] else {}
+        self.crush, self.commit = bool(values[9]), bool(values[11])
+        self.kinetic = values[10] if self.crush else None
+        self.filter, self.crush_state, self.hits, self.sequence = None, [False], {}, 0
+
+
+class WorldLeaves(object):
+    def __init__(self, owner, engine):
+        from gui.mods.offline_lan_0922 import world_collision
+        if owner._bots is not engine.runtime:
+            raise ValueError('Native world owner does not own this Bot runtime')
+        self.owner, self.engine, self.world = owner, engine, world_collision
+        self.space, self.round = owner._avatar.spaceID, engine.runtime.round_id
+        self.catalog = owner._destructibles
+        self.context = None
+        self.calls = [0, 0, 0, 0]
+
+    def clear(self):
+        self.context = None
+
+    def check_owner(self):
+        if (self.owner._bots is not self.engine.runtime or
+                self.owner._avatar.spaceID != self.space or
+                self.engine.runtime.round_id != self.round or
+                self.owner._destructibles is not self.catalog):
+            raise RuntimeError('Native world operation lifetime changed')
+
+    def __call__(self, packet):
+        operation = int(packet[1])
+        if operation not in (0, 1, 2, 3):
+            raise RuntimeError('Unknown native world operation')
+        self.check_owner()
+        self.calls[operation] += 1
+        if operation == 0:
+            self.engine.runtime._sample_time_us = int(packet[62])
+            self.engine.runtime._equipment_now = packet[63]
+            self.begin(packet, int(packet[2]), int(packet[3]))
+            self.check_owner()
+            return
+        if self.context is None or self.context.identity != packet[2]:
+            raise RuntimeError('Native world operation has no matching owner')
+        if operation == 1:
+            return self.query(packet)
+        if operation == 3:
+            self.query(packet)
+            # The scalar C++ reader rejects non-finite answers before issuing
+            # another ray. Preserve that barrier inside the paired callback.
+            if packet[0] and any(math.isnan(v) or math.isinf(v) for v in packet[1:7]):
+                raise RuntimeError('world engine answer')
+            self.check_owner()
+            return self.query(packet, 20, 8)
+        if operation == 2:
+            try:
+                self.finish(packet)
+                self.check_owner()
+                return
+            finally:
+                self.clear()
+        raise RuntimeError('Unknown native world operation')
+
+    def begin(self, packet, identity, mode):
+        owner = self.owner
+        if self.context is not None:
+            raise RuntimeError('Native world operation is already active')
+        values = packet[4:18]
+        descriptor = self.engine.descriptor_at(identity, mode)
+        context = Context(owner, descriptor, identity, values)
+        self.context = context
+        reusable = bool(values[12]) and self.catalog is not None
+        if reusable:
+            reusable = not self.catalog._catalog_hull_contact(
+                context.position, context.yaw, context.speed, descriptor,
+                context.dt, **context.motion)
+        diagnostic = getattr(owner, '_combat_diagnostics', None)
+        if diagnostic is not None:
+            diagnostic.count('motion_world_reused' if reusable else 'motion_world_fallback')
+            reason = int(values[13])
+            if not reusable and reason:
+                diagnostic.count(('unused', 'motion_world_airborne',
+                                  'motion_world_coast_or_reverse', 'motion_world_turning')[reason])
+        packet[0], packet[1] = reusable, self.catalog is not None
+        if reusable:
+            self.clear()
+
+    def query(self, packet, at=4, out=0):
+        import BigWorld
+        import Math
+        context, world = self.context, self.world
+        kind, hit_identity = int(packet[at]), int(packet[at + 7])
+        start = Math.Vector3(packet[at + 1], packet[at + 2], packet[at + 3])
+        end = Math.Vector3(packet[at + 4], packet[at + 5], packet[at + 6])
+        context.sequence += 1
+        packet[out:out + 8] = _ZERO
+        if kind == 1:
+            context.filter = world.prepare_horizontal_collision_filter(start, end)
+        elif kind == 2:
+            try:
+                args = (self.space, start, end, 128)
+                if context.filter is not None:
+                    args += (context.filter,)
+                hit = world.observed_ray('native.motion.ground', BigWorld.wg_collideSegment, *args)
+                if hit is not None:
+                    packet[out], packet[out + 2] = 1, float(hit[0].y)
+            except (AttributeError, IndexError, TypeError, ValueError):
+                packet[out:out + 8] = _ZERO
+        elif kind == 3:
+            hit = world._collide_horizontal(self.space, start, end, context.filter)
+            if hit is not None:
+                packet[out] = 1
+                packet[out + 1], packet[out + 2], packet[out + 3] = hit[0].x, hit[0].y, hit[0].z
+                try:
+                    normal = hit[1]
+                    nx, ny, nz = normal.x, normal.y, normal.z
+                except (AttributeError, IndexError, TypeError):
+                    nx, ny, nz = 0, 0, 0
+                packet[out + 4], packet[out + 5], packet[out + 6] = nx, ny, nz
+                packet[out + 7] = context.sequence
+                context.hits[context.sequence] = hit
+        elif kind == 4:
+            result = world._destroy_and_recast(
+                self.space, start, end, context.hits[hit_identity],
+                context.yaw, context.speed, context.descriptor,
+                context.crush_state, context.crush, context.kinetic,
+                context.commit, context.filter)
+            packet[out] = 2 if result == 'kinetic' else 1 if result is True else 0
+        else:
+            raise RuntimeError('Unknown native world query')
+
+    def finish(self, packet):
+        context, owner = self.context, self.owner
+        action = int(packet[4])
+        owner._bot_motion_kinds[context.identity] = '-'
+        packet[:8] = _ZERO
+        if action == 1:
+            pending = self.catalog._catalog_pending_at_hull(
+                context.position, context.yaw, context.speed, context.descriptor,
+                context.now, context.dt, **context.motion)
+            if pending:
+                owner._bot_motion_kinds[context.identity] = 'broken'
+            packet[0] = bool(pending)
+        elif action == 2:
+            detail = self.catalog._catalog_motion_blocked(
+                self.space, context.position, context.yaw, context.speed,
+                context.descriptor, context.now, dt=context.dt,
+                kinetic_speed=context.kinetic, return_detail=True,
+                kinetic_commit=context.crush and context.commit,
+                commit_enabled=context.commit, **context.motion)
+            if isinstance(detail, bool):
+                detail = {'status': 'hard' if detail else 'clear'}
+            elif isinstance(detail, str):
+                detail = {'status': detail}
+            if not isinstance(detail, dict):
+                raise RuntimeError('bot motion resolver detail is unavailable')
+            status = detail.get('status')
+            if status not in ('clear', 'crushed', 'soft', 'hard', 'approach'):
+                raise RuntimeError('bot motion resolver returned an invalid status')
+            owner._bot_motion_kinds[context.identity] = str(detail.get('kinds', '-'))
+            packet[0] = _STATUSES.index(status)
+            packet[1] = bool(detail.get('accepted_now', False))
+            packet[2] = bool(detail.get('used_kinetic_speed', False))
+            packet[3] = bool(detail.get('token'))
+        elif action != 0:
+            raise RuntimeError('Unknown native world completion')

--- a/tools/ffi_experiment/motion_adapter.py
+++ b/tools/ffi_experiment/motion_adapter.py
@@ -1,0 +1,520 @@
+"""One copied-motion owner with descriptor and tuning inputs frozen at install."""
+from __future__ import print_function
+
+CONSTANTS = (
+    'GRAVITY GRAVITY_FACTOR COHESION DRIVE_TRACTION '
+    'SLOPE_GRIP_LNG_FULL_Y SLOPE_GRIP_LNG_FULL SLOPE_GRIP_LNG_MIN_Y SLOPE_GRIP_LNG_MIN '
+    'POWER_FACTOR BKWD_POWER_FRACTION ENGINE_MIN_V STEER_RESIST_MULT '
+    'COH_DECAY_Y COH_DECAY_FACTOR COH_DECAY_POW SLOPE_COH_DECAY_Y SLOPE_COH_DECAY COH_DECAY_BOUND '
+    'COAST_BRAKE_SHARE SLIDE_KINETIC SLIDE_HOLD_TAN SLIP_THRESHOLD_TAN SLIP_DRAG '
+    'OVERSPEED_MAX_FACTOR OVERSPEED_BUILD OVERSPEED_DAMP '
+    'SPEED_AFFECT_ROT_DECREASE ANG_ACCELERATION_TIME '
+    'HARD_CONTACT_ENTRY_FACTOR HARD_CONTACT_SLIDE_DECAY HARD_CONTACT_BRAKE_DECAY HARD_CONTACT_STOP_SPEED '
+    'GROUND_PITCH_LIMIT GROUND_FOLLOW_BASE GROUND_FOLLOW_MIN GROUND_FOLLOW_MAX '
+    'SLIDE_DRAG SLIDE_MAX FALL_SAFE_SPEED FALL_DMG_PER_MS'
+).split()
+
+
+class Physics(object):
+    def __init__(self, backend, module):
+        self.backend = backend
+        self.handle = int(backend.call([600] + [getattr(module, name) for name in CONSTANTS])[0])
+        self.profiles = {}
+
+    def profile(self, params):
+        key = (params['mass'], params['powerW'], params.get('nativePowerRatio', 1.0),
+               params['specificFriction'], params['brakeDecel'], params['speedFwd'],
+               params['speedBwd'], params['rotSpd']) + tuple(params['terrainResist'])
+        handle = self.profiles.get(key)
+        if handle is None:
+            handle = int(self.backend.call([601, self.handle] + list(key))[0])
+            self.profiles[key] = handle
+        return handle
+
+    def batch(self, params, kind, rows):
+        result = self.backend.call([602, self.profile(params), kind, len(rows)] +
+                                   [value for row in rows for value in row])
+        width = 3 if kind == 2 else 1
+        return [tuple(result[1 + i * width:1 + (i + 1) * width]) if width > 1 else result[1 + i]
+                for i in range(int(result[0]))]
+
+
+def _optional(value):
+    return [int(value is not None), value if value is not None else 0.0]
+
+
+class MotionFlowBackend(object):
+    """Replace the complete horizontal preparation/integration source block.
+
+    Only engine queries, opaque receipts, diagnostics and publication cross the
+    callback boundary. The copied motion, cache decisions and navigation guards
+    execute on one C++ stack, with per-Bot ordering identical to the source.
+    """
+    def __init__(self, backend, runtime, module):
+        import inspect
+        import textwrap
+        import types
+        from array import array
+        self.backend, self.runtime, self.module = backend, runtime, module
+        if runtime.native_motion:
+            raise ValueError('motion-flow is the copied-physics experiment')
+        if not hasattr(runtime.navigator, 'handle') or not hasattr(runtime.adapter.driver, 'handle'):
+            raise ValueError('motion-flow requires navigation-flow and driver-flow')
+        self.physics = Physics(backend, module.vehicle_physics)
+        self.handle = int(backend.call([610, module.MOTION_PROBE_SECONDS])[0])
+        self.packet = array('d', [0.0] * 128)
+        self.tokens, self.objects, self.cache_ids = {}, {}, {}
+        self.next_object = 1
+        self.patches = []
+        self.vertical_counts = {'native': 0, 'suspension_source': 0}
+        self.bake_admitted = runtime.adapter.driver.bake_admitted
+        self.original_present = '_update_once' in runtime.__dict__
+        self.original_update = runtime._update_once
+        source = open(inspect.getsourcefile(module.BotRuntime), 'rb').read().decode('utf-8')
+        start_method = source.index("    @timed('bot.slice')\n    def _update_once(")
+        end_method = source.find('\n    def ', start_method + 30)
+        source = textwrap.dedent(source[start_method:end_method if end_method != -1 else len(source)])
+        start = source.index("        throttle = max(-1.0, min(1.0, command['throttle']))")
+        end = source.index("        if diagnostic is not None:\n            diagnostic.phase('bot.aim_fire')", start)
+        replacement = (
+            '        destroyed_devices = self._experimental_motion_step(\n'
+            '            state, command, target, descriptor, position, step, now,\n'
+            '            decision_due, refresh_control, siege_motion_locked,\n'
+            '            tick_siege_yaw, siege_locked_poses, attempted_yaws,\n'
+            '            baked_shallow_escape, diagnostic)\n')
+        scope = dict(module.__dict__)
+        eval(compile(source[:start] + replacement + source[end:],
+                     '<experimental-motion-flow>', 'exec'), scope)
+        runtime._experimental_motion_step = self.step
+        for name, replacement in (('_update_vertical_motion', self.vertical),
+                                  ('_update_slope_pose', self.slope),
+                                  ('_cached_traffic_stopping_distance', self.stopping),
+                                  ('_guard_realised_pose', self.guard),
+                                  ('_apply_tank_contact_response', self.contact_response)):
+            self.patches.append((name, name in runtime.__dict__, getattr(runtime, name)))
+            setattr(runtime, name, replacement)
+        self.source_vertical = self.patches[0][2]
+        self.source_guard = self.patches[3][2]
+        navigation_source = open(inspect.getsourcefile(module.BotRuntime), 'rb').read().decode('utf-8')
+        nav_start = navigation_source.index('    def _navigation_target(')
+        nav_end = navigation_source.index('\n    def ', nav_start + 10)
+        navigation_source = textwrap.dedent(navigation_source[nav_start:nav_end])
+        begin = navigation_source.index('    direct = getattr(grid,')
+        finish = navigation_source.index("    if mode in ('route', 'advance') and anchor is None:", begin)
+        selection = '''    throttle_override = strategic.get('throttle_override')
+    driver_state = getattr(self.adapter.driver, 'states', {}).get(int(bot_id), {})
+    movement_intent = bool(
+        (throttle_override is None or float(throttle_override) > 0.0)
+        and not driver_state.get('traffic_waiting', False)
+        and int(bot_id) not in self._artillery_intents
+        and int(bot_id) not in self._artillery_reproofs)
+    target, state['navigation_stop_at_target'] = self.navigator.motion_target(
+        bot_id, position, goal, path_key, now, anchor, lookahead_distance,
+        movement_intent, stop_at_goal)
+'''
+        navigation_scope = dict(module.__dict__)
+        eval(compile(navigation_source[:begin] + selection + navigation_source[finish:],
+                     '<experimental-motion-target>', 'exec'), navigation_scope)
+        navigation_function = navigation_scope['_navigation_target']
+        try:
+            navigation_function = types.MethodType(navigation_function, runtime)
+        except TypeError:
+            navigation_function = types.MethodType(navigation_function, runtime, type(runtime))
+        self.original_navigation_target = runtime.adapter.navigation_target
+        runtime.adapter.navigation_target = navigation_function
+        function = scope['_update_once']
+        try:
+            runtime._update_once = types.MethodType(function, runtime)
+        except TypeError:
+            runtime._update_once = types.MethodType(function, runtime, type(runtime))
+
+    def _save(self, value):
+        if value is None:
+            return 0
+        key = self.next_object
+        self.next_object += 1
+        self.active[key] = value
+        return key
+
+    def _receipt(self, value):
+        rt = self.module
+        kind = (0 if value is None else 1 if value is False else
+                2 if isinstance(value, dict) else 3 if value == 'deferred' else 4)
+        row = value if kind == 2 else {}
+        origin = row.get('origin')
+        valid = isinstance(origin, (tuple, list)) and len(origin) == 3
+        values = [kind, self._save(value), int(valid)]
+        values.extend(rt._number(item) for item in (origin if valid else (0.0, 0.0, 0.0)))
+        return values + [
+                    rt._number(row.get('yaw')), int(rt._number(row.get('direction'))),
+                    rt._number(row.get('leading')), rt._number(row.get('distance'))]
+
+    def _probe(self, value):
+        rt = self.module
+        row = value if isinstance(value, dict) else {}
+        return [0 if value is None else 2 if isinstance(value, dict) else 1,
+                self._save(value), int(bool(value)), int(bool(row.get('clear', True))),
+                int(bool(row.get('collision', False))), int(bool(row.get('water', False))),
+                rt._number(row.get('slope')), int(bool(row.get('deferred', False))),
+                int(bool(row.get('_world_receipt_pending', False)))] + self._receipt(row.get('world_receipt')) + [0]
+
+    def _cache(self, value):
+        rt = self.module
+        if value is None:
+            return [0.0] * 33
+        position = value.get('position')
+        valid = isinstance(position, (tuple, list)) and len(position) == 3
+        return ([1, int(valid)] + [rt._number(item) for item in (position if valid else (0, 0, 0))] +
+                [rt._number(value.get('yaw'))] + _optional(value.get('maximum_distance')) +
+                _optional(value.get('probe_distance')) + _optional(value.get('probe_leading')) +
+                [rt._number(value.get('deadline'))] + self._probe(value.get('result')))
+
+    def _read_probe(self, values, offset=0):
+        key = int(values[offset + 1])
+        probe = self.active.get(key) if key else ({} if values[offset] == 2 else None)
+        if values[offset + 19]:
+            probe = dict(probe)
+            for index, name, default in ((3, 'clear', True), (4, 'collision', False),
+                                          (8, '_world_receipt_pending', False)):
+                changed = bool(values[offset + index])
+                if changed != bool(probe.get(name, default)):
+                    probe[name] = changed
+            receipt_key = int(values[offset + 10])
+            receipt = self.active.get(receipt_key) if receipt_key else None
+            if receipt is not probe.get('world_receipt'):
+                probe['world_receipt'] = receipt
+            self.active[key] = probe
+        return probe
+
+    def _read_cache(self, values, offset=0):
+        if not values[offset]:
+            return None
+        return dict(position=tuple(values[offset + 2:offset + 5]), yaw=values[offset + 5],
+                    maximum_distance=values[offset + 7] if values[offset + 6] else None,
+                    probe_distance=values[offset + 9] if values[offset + 8] else None,
+                    probe_leading=values[offset + 11] if values[offset + 10] else None,
+                    deadline=values[offset + 12], result=self._read_probe(values, offset + 13))
+
+    def step(self, state, command, target, descriptor, position, step, now,
+             decision_due, refresh_control, siege_motion_locked, tick_siege_yaw,
+             siege_locked_poses, attempted_yaws, baked_shallow_escape, diagnostic):
+        from array import array
+        rt, runtime, bot_id = self.module, self.runtime, state['id']
+        self.active = self.objects.setdefault(bot_id, {0: {}})
+        raw_cache = runtime._motion_probe_cache.get(bot_id)
+        seed = bot_id not in self.tokens or raw_cache is not self.tokens[bot_id]
+        cache_packet = self._cache(raw_cache) if seed else []
+        active_ids = ([int(cache_packet[14]), int(cache_packet[23])]
+                      if seed else list(self.cache_ids.get(bot_id, ())))
+        aim = rt._point(command.get('aim_position'),
+                        target.get('position') if target is not None else rt._position(state))
+        limits = runtime._gun_yaw_limits.get(bot_id)
+        if limits is None:
+            limits = rt.ai_driver.gun_yaw_limits(descriptor)
+            runtime._gun_yaw_limits[bot_id] = limits
+        unused, destroyed, unused_crew, unused_yellow = rt._critical_parts(state)
+        blocked = state.get('_overturned', False) or bool(destroyed.intersection(
+            ('engineHealth', 'leftTrackHealth', 'rightTrackHealth')))
+        mobility = rt._critical_factor(state, descriptor, 'mobility') if not blocked and abs(command['throttle']) > 0.01 else 1.0
+        params = runtime._physics_params_for(bot_id)
+        profile = self.physics.profile(params)
+        siege_limit = (rt.siege_mechanics.enabled_speed_limit(state.get('vehicle', ''))
+                       if state.get('siege_state') == rt.siege_mechanics.ENABLED else None)
+        move = command.get('move_position')
+        recovery = {'drive': 0, 'avoid': 1, 'blocked': 2, 'reverse_turn': 3, 'pivot_recovery': 4}.get(command.get('recovery_mode', 'drive'), 5)
+        values = ([611, self.handle, profile, bot_id, runtime.navigator.handle,
+                   runtime.adapter.driver.handle] + list(position) + list(aim) +
+                  [int(move is not None)] + list(rt._point(move, position)) +
+                  [state['yaw'], state['speed'], runtime._turn_speeds.get(bot_id, 0.0),
+                   state.get('half_length', 3.5), state.get('half_width', 1.7),
+                   command['throttle'], command.get('turn', 0.0), limits[0], limits[1],
+                   mobility, step, now, state.get('_water_depth', -1.0), tick_siege_yaw,
+                   recovery, runtime._hard_contact_grinds.get(bot_id, 0)] +
+                  [int(bool(value)) for value in (
+                      target is not None and command.get('combat_mode') != 'base_defense',
+                      command.get('movement_intent', True), blocked, state.get('airborne', False),
+                      state.get('grounded_once', False), siege_motion_locked, self.bake_admitted,
+                      baked_shallow_escape, decision_due, refresh_control,
+                      callable(runtime.motion_resolver), callable(runtime.motion_report),
+                      bot_id in runtime._hard_contact_grinds)] +
+                  _optional(siege_limit) + _optional(state.get('destructible_contact_speed')) +
+                  [int(seed)] + cache_packet)
+        statuses = ('clear', 'crushed', 'soft', 'cap_crushed', 'hard')
+        packet = self.packet
+
+        def destructible(present, speed):
+            if present:
+                state['destructible_contact_speed'] = speed
+            else:
+                state.pop('destructible_contact_speed', None)
+
+        def query():
+            kind = int(packet[0])
+            if kind == 504:
+                # A blocked motion step can cancel a pending route search on
+                # this same native stack. Its retired key belongs to navigation.
+                runtime.navigator._publish_event(packet)
+                return
+            if int(packet[1]) != bot_id:
+                raise RuntimeError('motion callback owner changed')
+            if kind == 610:
+                arguments = (tuple(packet[2:5]), packet[5], packet[6], descriptor)
+                if packet[9]:
+                    arguments += (packet[8] if packet[7] else None,)
+                answer = runtime._probe_direction(*arguments)
+                packet[:20] = array('d', self._probe(answer))
+            elif kind == 611:
+                answer = runtime._probe_world_receipt(bot_id, tuple(packet[2:5]), packet[5],
+                    packet[6], descriptor, bool(packet[7]), packet[9] if packet[8] else None)
+                packet[:10] = array('d', self._receipt(answer))
+            elif kind == 612:
+                cache = self._read_cache(packet, 2)
+                active_ids[:] = [int(packet[16]), int(packet[25])] if cache is not None else []
+                if cache is None:
+                    runtime._motion_probe_cache.pop(bot_id, None)
+                else:
+                    runtime._motion_probe_cache[bot_id] = cache
+                packet[0] = int(bool(cache and cache['result']))
+            elif kind == 613:
+                phase = int(packet[2])
+                if phase == 0:
+                    state['hull_aiming'] = bool(packet[3])
+                    attempted_yaws[bot_id] = packet[5]
+                    if packet[4]:
+                        command.update(fire_allowed=False, throttle=0.0, turn=0.0, movement_intent=False)
+                        state.update(speed=0.0, movement_dir=0, rotation_dir=0, push_x=0.0, push_z=0.0)
+                        runtime._turn_speeds[bot_id] = 0.0
+                        siege_locked_poses[bot_id] = (position[0], position[2], tick_siege_yaw)
+                elif phase == 1:
+                    state['movement_dir'], state['rotation_dir'] = int(packet[3]), int(packet[4])
+                    probe = self._read_probe(packet, 10)
+                    attempted_yaws[bot_id] = packet[9]
+                    runtime._log_direction_flip(state, bool(packet[7]), probe, now)
+                    runtime._log_motion_stall(state, command, packet[5], packet[6], bool(packet[7]), probe, now, bool(packet[8]))
+                    if diagnostic is not None:
+                        diagnostic.phase('bot.integrate')
+                elif phase == 2:
+                    state['yaw'], runtime._turn_speeds[bot_id] = packet[3], packet[4]
+                    state['rotation_dir'], state['movement_dir'] = int(packet[5]), int(packet[6])
+                    state['last_drive_pitch'] = packet[7]
+                    attempted_yaws[bot_id] = packet[13]
+                    trace = state.get('_motion_stall_pending')
+                    if trace is not None:
+                        trace.update(dt=step, drive_speed=packet[8], drive_pitch=packet[7], throttle=packet[9],
+                            baked_veto=bool(packet[10]), path_clear=bool(packet[11]), frozen=bool(packet[12]),
+                            mass=params['mass'], powerW=params['powerW'], nativePowerRatio=params.get('nativePowerRatio', 1.0),
+                            terrainResist=params['terrainResist'], specificFriction=params['specificFriction'])
+                    destructible(packet[14], packet[15])
+                else:
+                    raise RuntimeError('motion publication phase')
+            elif kind == 614:
+                runtime._decision_cache.pop(bot_id, None)
+                runtime._motion_probe_cache.pop(bot_id, None)
+                state.pop('destructible_contact_speed', None)
+                active_ids[:] = []
+            elif kind == 615:
+                if packet[9]:
+                    answer = runtime._passive_motion_status(state, tuple(packet[2:5]), packet[5], packet[6],
+                        descriptor, packet[7], packet[8], commit_enabled=bool(packet[10]))
+                else:
+                    started = runtime._probe_started() if runtime._probe_timing_enabled() else None
+                    try:
+                        answer = rt.timed_call(runtime._combat_diagnostics, 'bot.physics', runtime.motion_resolver,
+                            bot_id, tuple(packet[2:5]), packet[5], packet[6], descriptor, packet[7], packet[8])
+                    finally:
+                        if started is not None:
+                            runtime._probe_finished(4, started)
+                if answer not in statuses:
+                    raise RuntimeError('bot motion resolver returned an invalid status')
+                packet[0] = statuses.index(answer)
+            elif kind == 616:
+                destructible(packet[5], packet[6])
+                if packet[7]:
+                    runtime._hard_contact_grinds[bot_id] = int(packet[8])
+                runtime.motion_report(bot_id, statuses[int(packet[2])], packet[3], packet[4])
+            elif kind == 617:
+                trace = state.get('_motion_stall_pending')
+                if trace is not None:
+                    trace.update(world_status=statuses[int(packet[2])], hard_contact=bool(packet[3]),
+                                 integrated=tuple(packet[4:7]), world_speed=packet[7])
+            else:
+                raise RuntimeError('unknown motion event: %d' % kind)
+
+        complete = False
+        try:
+            output = self.backend.call_sync(values, packet, query)
+            state['x'], state['y'], state['z'] = output[:3]
+            state['yaw'], state['speed'] = output[3:5]
+            runtime._turn_speeds[bot_id] = output[5]
+            state['last_drive_pitch'], attempted_yaws[bot_id] = output[6:8]
+            state['movement_dir'], state['rotation_dir'] = int(output[8]), int(output[9])
+            if output[11]:
+                runtime._hard_contact_grinds[bot_id] = int(output[10])
+            destructible(output[13], output[14])
+            runtime.navigator._publish(bot_id, output, 15)
+            runtime.navigator._progress = None
+            complete = True
+        finally:
+            cache = runtime._motion_probe_cache.get(bot_id)
+            if complete:
+                self.tokens[bot_id] = cache
+            else:
+                # Re-import the actual Python cache after an interrupted
+                # callback, regardless of how far native admission progressed.
+                self.tokens.pop(bot_id, None)
+            # Retain numeric identities, not all objects equal/identical to a
+            # singleton False/None. Repeated failed probes stay bounded too.
+            self.cache_ids[bot_id] = active_ids if cache is not None else []
+            keep = set(self.cache_ids[bot_id])
+            keep.add(0)
+            self.objects[bot_id] = dict((key, value) for key, value in self.active.items() if key in keep)
+        return destroyed
+
+    def close(self):
+        runtime = self.runtime
+        for name, present, original in reversed(self.patches):
+            if present:
+                setattr(runtime, name, original)
+            else:
+                runtime.__dict__.pop(name, None)
+        self.patches = []
+        runtime.adapter.navigation_target = self.original_navigation_target
+        if self.original_present:
+            runtime._update_once = self.original_update
+        else:
+            runtime.__dict__.pop('_update_once', None)
+        runtime.__dict__.pop('_experimental_motion_step', None)
+        if self.handle is not None and not self.backend.closed:
+            self.backend.call([612, self.handle])
+        self.handle = None
+        self.objects.clear()
+        self.tokens.clear()
+        self.cache_ids.clear()
+
+    def stopping(self, source, command, params):
+        rt, runtime = self.module, self.runtime
+        bot_id = int(rt._number(source.get('id')))
+        speed = abs(rt._number(source.get('speed')))
+        pitch = rt._number(source.get('last_drive_pitch'))
+        steer = abs(rt._number(command.get('turn'))) > 0.01
+        key = (id(params), speed, pitch, steer)
+        cached = runtime._traffic_stopping_cache.get(bot_id)
+        if cached is not None and cached[0] == key:
+            return cached[1]
+        distance = self.backend.call([623, self.physics.profile(params), speed, pitch, int(steer),
+                                      rt.PUBLICATION_SECONDS, rt.TRAFFIC_DIRECTION_SPEED_EPSILON])[0]
+        runtime._traffic_stopping_cache[bot_id] = (key, distance)
+        return distance
+
+    def _ground_query(self, bot_id, trace):
+        rt, packet = self.runtime, self.packet
+        if int(packet[1]) != bot_id:
+            raise RuntimeError('vertical callback owner changed')
+        if packet[0] == 630:
+            rt._probe_totals[3] += 1
+            started = rt._probe_started()
+            try:
+                value = rt._physics_ground_probe(packet[2], packet[3], packet[4])
+            finally:
+                rt._probe_finished(3, started)
+            packet[0] = int(value is not None)
+            packet[1] = float(value) if value is not None else 0.0
+        elif packet[0] == 631 and trace is not None:
+            if packet[2] == 0:
+                trace.update(support_highest=packet[4] if packet[3] else None,
+                             support_centre=packet[6] if packet[5] else None,
+                             grounded_before=bool(packet[7]))
+            else:
+                trace.update(support_limit=packet[3], support_rise_obstacle=bool(packet[4]),
+                             support_rise_continuous=bool(packet[5]))
+        else:
+            raise RuntimeError('unknown vertical query')
+
+    def vertical(self, state, step, tick_pose=None, attempted_yaw=None,
+                 suspension_motion_pose=None):
+        rt, module, bot_id = self.runtime, self.module, state['id']
+        # The optional ten-spring trial has its own solver and admission rules.
+        # Keep that explicitly counted source path; it is outside the captured
+        # legacy-motion workload and is never included in native coverage.
+        if rt._suspension_params_for(bot_id) is not None:
+            self.vertical_counts['suspension_source'] += 1
+            return self.source_vertical(state, step, tick_pose, attempted_yaw, suspension_motion_pose)
+        self.vertical_counts['native'] += 1
+        trace = state.get('_motion_stall_pending')
+        if trace is not None:
+            trace['suspension'] = False
+        values = ([620, self.handle, self.physics.handle, bot_id] + list(module._position(state)) +
+                  [module._number(state.get('yaw')), max(1.5, module._number(state.get('half_length'), 3.5)),
+                   state['speed'], step, state.get('vertical_speed', 0.0), state.get('last_drive_pitch', 0.0),
+                   int(bool(state.get('airborne', False))), int(bool(state.get('grounded_once', False))),
+                   int(tick_pose is not None)] + list(tick_pose or (0.0, 0.0, 0.0)) + [int(trace is not None)])
+        def query():
+            self._ground_query(bot_id, trace)
+        output = self.backend.call_sync(values, self.packet, query)
+        state['x'], state['y'], state['z'] = output[:3]
+        state['speed'], state['vertical_speed'] = output[3:5]
+        state['airborne'], state['grounded_once'] = bool(output[5]), bool(output[6])
+        if output[7]:
+            state.update(movement_dir=0, rotation_dir=0, push_x=0.0, push_z=0.0)
+            state.pop('destructible_contact_speed', None)
+            rt._turn_speeds[bot_id] = 0.0
+            rt._invalidate_realised_motion(bot_id, state['yaw'] if attempted_yaw is None else attempted_yaw)
+            return True
+        if output[8]:
+            rt._apply_bot_landing_impact(state, output[9])
+        return False
+
+    def slope(self, state, allow_ungrounded=False):
+        rt, module, bot_id = self.runtime, self.module, int(state.get('id', -1))
+        if (getattr(rt, '_suspension_params', {}).get(bot_id) is not None or state.get('airborne', False) or
+                (not allow_ungrounded and not state.get('grounded_once', False))):
+            return False
+        yaw, x, z = state['yaw'], state['x'], state['z']
+        tier = rt._detail_tier(state)
+        marker = state.get('pose_sample')
+        if (isinstance(marker, (list, tuple)) and len(marker) == 3 and
+                abs(x - marker[0]) < module.SLOPE_SAMPLE_METRES[tier] and
+                abs(z - marker[1]) < module.SLOPE_SAMPLE_METRES[tier] and
+                abs(yaw - marker[2]) < module.SLOPE_SAMPLE_RADIANS[tier]):
+            return False
+        suspension = state.get('suspension_pitch', 0.0)
+        pitch = state.get('terrain_pitch', state.get('pitch', 0.0) - suspension)
+        values = [622, self.handle, self.physics.handle, bot_id, x, state['y'], z, yaw,
+                  state.get('half_length', 3.5), state.get('half_width', 1.7), pitch, state.get('roll', 0.0)]
+        def query():
+            self._ground_query(bot_id, None)
+        output = self.backend.call_sync(values, self.packet, query)
+        state['terrain_pitch'], state['pitch'] = output[0], output[0] + suspension
+        state['roll'], state['pose_sample'] = output[1], (x, z, yaw)
+        return True
+
+    def guard(self, state, tick_pose, tick_was_safe, attempted_yaw, suspension_snapshot=None):
+        rt, module, bot_id = self.runtime, self.module, state['id']
+        if suspension_snapshot is not None or rt._suspension_params.get(int(bot_id)) is not None:
+            return self.source_guard(state, tick_pose, tick_was_safe, attempted_yaw, suspension_snapshot)
+        blocked = self.backend.call([624, rt.navigator.handle] + list(module._position(state)) +
+            list(tick_pose) + [state.get('yaw', 0.0), state.get('half_length', 3.5),
+                              state.get('half_width', 1.7), int(bool(tick_was_safe))])[0]
+        if not blocked:
+            return False
+        state['x'], state['y'], state['z'] = tick_pose
+        state.update(speed=0.0, movement_dir=0, rotation_dir=0, push_x=0.0, push_z=0.0,
+                     vertical_speed=0.0, airborne=False)
+        rt._invalidate_realised_motion(bot_id, attempted_yaw)
+        return True
+
+    def contact_response(self, state, result, step, advance_push=True, apply_correction=True):
+        rt, module, packet = self.runtime, self.module, self.packet
+        values = ([625, self.handle, state['id']] + list(module._position(state)) +
+                  [state['yaw'], state['speed'], state.get('push_x', 0.0), state.get('push_z', 0.0),
+                   state.get('half_length', 3.5), state.get('half_width', 1.7)] +
+                  list(result['delta_velocity']) + list(result['correction']) +
+                  [step, int(bool(advance_push)), int(bool(apply_correction))])
+        def query():
+            if packet[0] != 635 or int(packet[1]) != state['id']:
+                raise RuntimeError('unknown contact-motion event')
+            state['speed'] = packet[9]
+            answer = rt._clear(tuple(packet[2:5]), packet[5], packet[6], None, packet[7], packet[8])
+            packet[0] = int(bool(answer))
+        output = self.backend.call_sync(values, packet, query)
+        state['x'], state['z'], state['speed'], state['push_x'], state['push_z'] = output[:5]

--- a/tools/ffi_experiment/motion_core.cpp
+++ b/tools/ffi_experiment/motion_core.cpp
@@ -1,0 +1,166 @@
+// The copied-motion owner. Physics inputs are pinned to the descriptor/tuning
+// producer, and the full update uses these laws directly within C++.
+#include "motion_core.h"
+#include "vehicle_motion.h"
+#include "motion_flow.h"
+#include "motion_vertical.h"
+#include "navigation_flow.h"
+#include <map>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+using namespace offline_motion;
+struct Reader {
+    double *b;int n,i;
+    double number(){if(i>=n||!std::isfinite(b[i]))throw std::invalid_argument("motion packet");return b[i++];}
+    int integer(int low=-1000000000,int high=1000000000){double v=number();if(v<low||v>high||v!=std::floor(v))throw std::invalid_argument("motion integer");return static_cast<int>(v);}
+    void end(){if(i!=n)throw std::invalid_argument("motion packet width");}
+};
+struct Profile {int owner;Params params;};
+std::map<int,Tuning> tuning;
+std::map<int,Profile> profiles;
+std::map<int,Flow> flows;
+int next_flow=1;
+int next_tuning=1,next_profile=1;
+const Tuning &get_tuning(int id){auto found=tuning.find(id);if(found==tuning.end())throw std::invalid_argument("motion tuning owner");return found->second;}
+const Profile &get_profile(int id){auto found=profiles.find(id);if(found==profiles.end())throw std::invalid_argument("motion profile owner");return found->second;}
+}
+extern "C" void offline_motion_reset(void){flows.clear();profiles.clear();tuning.clear();}
+extern "C" int offline_motion_dispatch(double *b,int n){
+    Reader r{b,n,1};int op=static_cast<int>(b[0]);
+    if(op==600){
+        Tuning value;
+#define READ(name) value.name=r.number();
+        OFFLINE_MOTION_CONSTANTS(READ)
+#undef READ
+        r.end();int id=next_tuning++;tuning[id]=value;b[0]=id;return 0;
+    }
+    if(op==601){
+        Profile value;value.owner=r.integer(1);get_tuning(value.owner);Params &p=value.params;
+        p.mass=r.number();p.powerW=r.number();p.nativePowerRatio=r.number();p.specificFriction=r.number();p.brakeDecel=r.number();
+        p.speedFwd=r.number();p.speedBwd=r.number();p.rotSpd=r.number();for(double &v:p.terrainResist)v=r.number();r.end();
+        if(p.mass<=0||p.terrainResist[0]<=0||p.terrainResist[1]<=0||p.terrainResist[2]<=0)throw std::invalid_argument("motion descriptor");
+        int id=next_profile++;profiles[id]=value;b[0]=id;return 0;
+    }
+    if(op==602){
+        const Profile &profile=get_profile(r.integer(1));const Params &p=profile.params;const Tuning &c=get_tuning(profile.owner);
+        int kind=r.integer(0,4),count=r.integer(0,1000000);std::vector<double> output;
+        for(int i=0;i<count;++i){
+            if(kind==0){
+                double v=r.number(),throttle=r.number();bool steering=r.integer(0,1)!=0;double pitch=r.number(),dt=r.number();
+                bool airborne=r.integer(0,1)!=0;int terrain=r.integer(0,2);bool handbrake=r.integer(0,1)!=0;
+                if(dt==0&&!airborne&&!handbrake&&((throttle>0&&v<-0.1)||(throttle<0&&v>0.1)))throw std::domain_error("zero motion step");
+                output.push_back(longitudinal(c,p,v,throttle,steering,pitch,dt,airborne,terrain,handbrake));
+            }else if(kind==1){
+                double omega=r.number(),steer=r.number(),v=r.number(),dt=r.number();int terrain=r.integer(0,2);double intent=r.number();
+                output.push_back(traverse(c,p,omega,steer,v,dt,terrain,intent));
+            }else if(kind==2){
+                double speed=r.number(),dt=r.number();bool grinding=r.integer(0,1)!=0,slide=r.integer(0,1)!=0;double yaw=r.number();
+                auto result=hard_contact(c,speed,dt,grinding,slide,yaw);output.insert(output.end(),result.begin(),result.end());
+            }else if(kind==3){double speed=r.number(),pitch=r.number(),dt=r.number();output.push_back(ground_gap(c,speed,pitch,dt));}
+            else{double current=r.number(),tangent=r.number(),dt=r.number();output.push_back(slope_slide(c,current,tangent,dt));}
+        }
+        r.end();if(output.size()+1>static_cast<size_t>(n))throw std::invalid_argument("motion result capacity");
+        for(double value:output)if(!std::isfinite(value))throw std::domain_error("nonfinite physical result");
+        b[0]=count;for(size_t i=0;i<output.size();++i)b[i+1]=output[i];return 0;
+    }
+    if(op==624){
+        auto &nav=offline_runtime_navigation(r.integer(1));
+        double x=r.number(),y=r.number(),z=r.number();Point position(x,y,z);
+        double tx=r.number(),ty=r.number(),tz=r.number();Point tick(tx,ty,tz);
+        double yaw=r.number(),length=r.number(),width=r.number();bool safe=r.integer(0,1)!=0;r.end();
+        double column=std::round((position.x-nav.grid->data->ox)/nav.grid->data->cell);
+        double row=std::round((position.z-nav.grid->data->oz)/nav.grid->data->cell);
+        int cell=-1;
+        if(column>=0&&column<nav.grid->data->width&&row>=0&&row<nav.grid->data->height)
+            cell=static_cast<int>(row)*nav.grid->data->width+static_cast<int>(column);
+        b[0]=!boundary(*nav.grid,tick,yaw,position,yaw,length,width)||
+            (safe&&(cell<0||(nav.grid->data->hazards[cell]&9)));return 0;
+    }
+    if(op==625){
+        auto owner=flows.find(r.integer(1));if(owner==flows.end())throw std::invalid_argument("contact flow owner");
+        Flow &flow=owner->second;int bot=r.integer(0);
+        double x=r.number(),y=r.number(),z=r.number(),yaw=r.number(),speed=r.number(),push_x=r.number(),push_z=r.number();
+        double length=r.number(),width=r.number(),dx=r.number(),dz=r.number(),cx=r.number(),cz=r.number(),dt=r.number();
+        bool advance=r.integer(0,1)!=0,correct=r.integer(0,1)!=0;r.end();
+        double s=std::sin(yaw),c=std::cos(yaw),forward=dx*s+dz*c,applied=0;
+        if(forward*speed<0){applied=std::abs(forward)>=std::abs(speed)?-speed:forward;speed+=applied;}
+        push_x=push_x+dx-applied*s;push_z=push_z+dz-applied*c;
+        double mx=(correct?cx:0)+(advance?push_x*dt:0),mz=(correct?cz:0)+(advance?push_z*dt:0);
+        double distance=std::sqrt(mx*mx+mz*mz);
+        if(distance>0.0001){
+            double contact_yaw=std::atan2(mx,mz),contact_speed=distance/std::max(dt,1.0/120.0),relative=contact_yaw-yaw;
+            double cs=std::abs(std::cos(relative)),ss=std::abs(std::sin(relative));
+            double support=std::max(0.5,length)*cs+std::max(0.3,width)*ss;
+            double corridor=std::max(0.5,length)*ss+std::max(0.3,width)*cs;
+            auto answer=flow.event(635,bot,{x,y,z,contact_yaw,contact_speed,std::max(1.0,distance+support),corridor,speed});
+            if(answer[0]==0)mx=mz=push_x=push_z=0;
+        }
+        double decay=advance?std::pow(0.90,std::max(0.0,dt)*60.0):1;
+        b[0]=x+mx;b[1]=z+mz;b[2]=speed;b[3]=push_x*decay;b[4]=push_z*decay;return 0;
+    }
+    if(op==623){
+        const Profile &profile=get_profile(r.integer(1));double speed=r.number(),pitch=r.number();
+        bool steer=r.integer(0,1)!=0;double dt=r.number(),epsilon=r.number();r.end();
+        b[0]=stopping_distance(get_tuning(profile.owner),profile.params,speed,pitch,steer,dt,epsilon);return 0;
+    }
+    if(op==620||op==622){
+        auto owner=flows.find(r.integer(1));if(owner==flows.end())throw std::invalid_argument("vertical owner");
+        const Tuning &t=get_tuning(r.integer(1));Flow &flow=owner->second;
+        int bot=r.integer(0);double x=r.number(),y=r.number(),z=r.number();Point position(x,y,z);
+        double yaw=r.number(),length=r.number();
+        if(op==622){
+            double width=r.number(),pitch=r.number(),roll=r.number();r.end();
+            auto result=slope(flow,bot,position,yaw,length,width,pitch,roll);b[0]=result.first;b[1]=result.second;return 0;
+        }
+        Vertical v;v.bot=bot;v.position=position;v.yaw=yaw;v.half_length=length;
+        v.speed=r.number();v.step=r.number();v.vertical=r.number();v.pitch=r.number();v.airborne=r.integer(0,1)!=0;v.grounded=r.integer(0,1)!=0;
+        bool tick=r.integer(0,1)!=0;double tx=r.number(),ty=r.number(),tz=r.number();if(tick)v.tick=Point(tx,ty,tz);v.trace=r.integer(0,1)!=0;r.end();
+        if(v.step<0||v.step>0.2)throw std::invalid_argument("vertical interval");
+        auto result=vertical_step(flow,t,v);std::vector<double> out;put(out,result.position);
+        out.insert(out.end(),{result.speed,result.vertical,static_cast<double>(result.airborne),static_cast<double>(result.grounded),
+            static_cast<double>(result.blocked),static_cast<double>(result.landed),result.impact});
+        put(out,result.highest);put(out,result.centre);out.push_back(result.maximum_climb);out.push_back(result.rise_obstacle);out.push_back(result.rise_continuous);
+        if(out.size()>static_cast<size_t>(n))throw std::invalid_argument("vertical output width");
+        std::copy(out.begin(),out.end(),b);return 0;
+    }
+    if(op==610){
+        Flow flow;flow.probe_seconds=r.number();r.end();if(flow.probe_seconds<=0)throw std::invalid_argument("motion cadence");
+        int id=next_flow++;flows[id]=flow;b[0]=id;return 0;
+    }
+    if(op==612){int id=r.integer(1);r.end();flows.erase(id);return 0;}
+    if(op==611){
+        auto owner=flows.find(r.integer(1));if(owner==flows.end())throw std::invalid_argument("motion flow owner");
+        const Profile &profile=get_profile(r.integer(1));Flow &flow=owner->second;
+        Input in;in.bot=r.integer(0);in.navigation=r.integer(0);in.driver=r.integer(0);
+        auto point=[&](){double x=r.number(),y=r.number(),z=r.number();return Point(x,y,z);};
+        auto optional=[&](){bool has=r.integer(0,1)!=0;double v=r.number();return has?Optional<double>(v):Optional<double>();};
+        in.position=point();in.aim=point();bool move=r.integer(0,1)!=0;Point target=point();if(move)in.move=target;
+        in.yaw=r.number();in.speed=r.number();in.turn_speed=r.number();in.half_length=r.number();in.half_width=r.number();
+        in.throttle=r.number();in.turn=r.number();in.minimum_yaw=r.number();in.maximum_yaw=r.number();in.mobility=r.number();
+        in.step=r.number();in.now=r.number();in.water=r.number();in.tick_siege_yaw=r.number();
+        in.recovery=r.integer(0,5);in.grind=r.integer(0);
+        in.has_target=r.integer(0,1)!=0;in.movement=r.integer(0,1)!=0;in.mobility_blocked=r.integer(0,1)!=0;
+        in.airborne=r.integer(0,1)!=0;in.grounded=r.integer(0,1)!=0;in.siege_locked=r.integer(0,1)!=0;
+        in.bake_admitted=r.integer(0,1)!=0;in.baked_escape=r.integer(0,1)!=0;in.decision_due=r.integer(0,1)!=0;
+        in.refresh=r.integer(0,1)!=0;in.has_resolver=r.integer(0,1)!=0;in.has_report=r.integer(0,1)!=0;in.grind_present=r.integer(0,1)!=0;
+        in.siege_limit=optional();in.destructible_speed=optional();bool seed=r.integer(0,1)!=0;
+        Cache seeded;
+        if(seed){if(n-r.i!=33)throw std::invalid_argument("motion cache width");Values values{b,r.i};seeded=values.cache();r.i=values.i;}
+        r.end();if(in.step<=0||in.step>0.2)throw std::invalid_argument("motion elapsed interval");
+        offline_nav::Navigator *nav=in.navigation?&offline_runtime_navigation(in.navigation):nullptr;
+        if(seed)flow.caches[in.bot]=seeded;
+        Output out=flow.step(in,profile.params,get_tuning(profile.owner),nav);
+        std::vector<double> result;put(result,out.position);
+        for(double value:{out.yaw,out.speed,out.turn_speed,out.drive_pitch,out.attempted_yaw,
+                static_cast<double>(out.movement),static_cast<double>(out.rotation),static_cast<double>(out.grind),
+                static_cast<double>(out.grind_present),static_cast<double>(out.hull_aiming)})result.push_back(value);
+        put(result,out.destructible_speed);
+        bool found=nav&&nav->states.count(in.bot);result.push_back(found);
+        if(found){const auto &s=nav->states.at(in.bot);result.push_back(s.status);result.push_back(s.planned_goal.has);put(result,s.planned_goal.value);result.push_back(s.shallow.has);put(result,s.shallow.value);result.push_back(s.terminal);}
+        if(result.size()>static_cast<size_t>(n))throw std::invalid_argument("motion output width");
+        std::copy(result.begin(),result.end(),b);return 0;
+    }
+    throw std::invalid_argument("motion operation");
+}

--- a/tools/ffi_experiment/motion_core.h
+++ b/tools/ffi_experiment/motion_core.h
@@ -1,0 +1,11 @@
+#ifndef OFFLINE_EXPERIMENT_MOTION_CORE_H
+#define OFFLINE_EXPERIMENT_MOTION_CORE_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+int offline_motion_dispatch(double *buffer,int count);
+void offline_motion_reset(void);
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/tools/ffi_experiment/motion_flow.h
+++ b/tools/ffi_experiment/motion_flow.h
@@ -1,0 +1,263 @@
+#ifndef OFFLINE_EXPERIMENT_MOTION_FLOW_H
+#define OFFLINE_EXPERIMENT_MOTION_FLOW_H
+#include "vehicle_motion.h"
+#include "navigation_state.h"
+#include "driver_core.h"
+#include "query_bridge.h"
+#include <array>
+#include <map>
+#include <limits>
+#include <cstdint>
+
+namespace offline_motion {
+using offline_nav::Point;
+using offline_nav::Optional;
+struct Receipt {
+    int kind=0,id=0,direction=0;bool origin_valid=false;
+    Point origin;double yaw=0,leading=0,distance=0;
+};
+struct Probe {
+    int kind=0,id=0;bool truth=false,clear=true,collision=false,water=false,deferred=false,pending=false,copied=false;
+    double slope=0;Receipt receipt;
+    bool is_clear()const{return kind==2?clear&&!collision&&!water&&std::abs(slope)<=0.55:truth;}
+};
+struct Cache {
+    bool has=false,position_valid=false;Point position;double yaw=0,deadline=0;
+    Optional<double> maximum,distance,leading;Probe result;
+};
+struct Input {
+    int bot,navigation,driver;
+    Point position,aim;Optional<Point> move;
+    double yaw,speed,turn_speed,half_length,half_width,throttle,turn,minimum_yaw,maximum_yaw,mobility,step,now,water;
+    double tick_siege_yaw;
+    int recovery,grind;
+    bool has_target,movement,mobility_blocked,airborne,grounded,siege_locked,bake_admitted,baked_escape;
+    bool decision_due,refresh,has_resolver,has_report,grind_present;
+    Optional<double> siege_limit,destructible_speed;
+};
+struct Output {
+    Point position;double yaw,speed,turn_speed,drive_pitch=0,attempted_yaw;
+    int movement=0,rotation=0,grind;bool hull_aiming=false,grind_present;
+    Optional<double> destructible_speed;
+    explicit Output(const Input &in):position(in.position),yaw(in.yaw),speed(in.speed),turn_speed(in.turn_speed),attempted_yaw(in.yaw),grind(in.grind),grind_present(in.grind_present),destructible_speed(in.destructible_speed){}
+};
+inline void put(std::vector<double> &b,Point p){b.push_back(p.x);b.push_back(p.y);b.push_back(p.z);}
+inline void put(std::vector<double> &b,Optional<double> v){b.push_back(v.has);b.push_back(v.value);}
+inline void put(std::vector<double> &b,const Receipt &r){
+    b.push_back(r.kind);b.push_back(r.id);b.push_back(r.origin_valid);put(b,r.origin);
+    b.push_back(r.yaw);b.push_back(r.direction);b.push_back(r.leading);b.push_back(r.distance);
+}
+inline void put(std::vector<double> &b,const Probe &p){
+    b.push_back(p.kind);b.push_back(p.id);b.push_back(p.truth);b.push_back(p.clear);b.push_back(p.collision);
+    b.push_back(p.water);b.push_back(p.slope);b.push_back(p.deferred);b.push_back(p.pending);put(b,p.receipt);b.push_back(p.copied);
+}
+inline void put(std::vector<double> &b,const Cache &c){
+    b.push_back(c.has);b.push_back(c.position_valid);put(b,c.position);b.push_back(c.yaw);
+    put(b,c.maximum);put(b,c.distance);put(b,c.leading);b.push_back(c.deadline);put(b,c.result);
+}
+struct Values {
+    const double *b;int i;
+    double next(){double v=b[i++];if(!std::isfinite(v))throw std::invalid_argument("motion query result");return v;}
+    int integer(){double v=next();if(std::abs(v)>1000000000||v!=std::floor(v))throw std::invalid_argument("motion query integer");return static_cast<int>(v);}
+    Point point(){double x=next(),y=next(),z=next();return Point(x,y,z);}
+    Optional<double> optional(){bool has=integer()!=0;double v=next();return has?Optional<double>(v):Optional<double>();}
+    Receipt receipt(){Receipt r;r.kind=integer();r.id=integer();r.origin_valid=integer()!=0;r.origin=point();r.yaw=next();r.direction=integer();r.leading=next();r.distance=next();return r;}
+    Probe probe(){Probe p;p.kind=integer();p.id=integer();p.truth=integer()!=0;p.clear=integer()!=0;p.collision=integer()!=0;p.water=integer()!=0;p.slope=next();p.deferred=integer()!=0;p.pending=integer()!=0;p.receipt=receipt();p.copied=integer()!=0;return p;}
+    Cache cache(){Cache c;c.has=integer()!=0;c.position_valid=integer()!=0;c.position=point();c.yaw=next();c.maximum=optional();c.distance=optional();c.leading=optional();c.deadline=next();c.result=probe();return c;}
+};
+inline bool contains(const Receipt &r,Point position,double yaw,double speed,double dt){
+    if(r.kind!=2||!r.origin_valid||(r.direction!=-1&&r.direction!=1)||r.direction!=(speed<0?-1:1))return false;
+    double dx=position.x-r.origin.x,dy=std::abs(position.y-r.origin.y),dz=position.z-r.origin.z;
+    double s=std::sin(r.yaw),c=std::cos(r.yaw),forward=dx*s+dz*c,lateral=std::abs(dx*c-dz*s);
+    double angle=std::abs(offline_nav::wrap(yaw-r.yaw)),leading=std::max(0.0,r.leading),distance=std::max(0.0,r.distance);
+    double reach=std::max(0.4,std::abs(speed)*clamp(dt,0,0.2)+0.2);
+    return forward>=-0.0001&&forward+leading+reach<=distance&&dy<=0.0001&&lateral<=0.0001&&angle<=0.00001;
+}
+inline bool refresh_due(const Receipt &r,Point position,double yaw,double speed,double dt){
+    if(!contains(r,position,yaw,speed,dt))return false;
+    double dx=position.x-r.origin.x,dz=position.z-r.origin.z;
+    double forward=dx*std::sin(r.yaw)+dz*std::cos(r.yaw),reach=std::max(0.4,std::abs(speed)*clamp(dt,0,0.2)+0.2);
+    return std::max(0.0,r.distance)-forward-std::max(0.0,r.leading)-reach<=6.0;
+}
+inline bool covers(const Cache &c,Optional<double> maximum){
+    if(!c.has)return false;
+    if(!maximum.has)return !c.maximum.has;
+    return !c.maximum.has||c.maximum.value+1e-6>=maximum.value;
+}
+inline bool reusable(const Cache &c,Point position,double yaw,double speed,double now,bool settled,double dt,bool ignore=false){
+    if(!c.has||(c.result.kind==2&&c.result.deferred)||!c.position_valid)return false;
+    double dx=position.x-c.position.x,dy=std::abs(position.y-c.position.y),dz=position.z-c.position.z;
+    double s=std::sin(c.yaw),co=std::cos(c.yaw),forward=dx*s+dz*co,lateral=std::abs(dx*co-dz*s),angle=std::abs(offline_nav::wrap(yaw-c.yaw));
+    if(settled)return std::abs(forward)<=0.05&&lateral<=0.05&&dy<=0.05&&angle<=0.005;
+    if(!ignore&&now>=c.deadline)return false;
+    double lookahead=std::abs(speed)>5?20:15,budget=3.5;
+    if(ignore&&c.distance.has&&c.leading.has){double reach=std::max(0.4,std::abs(speed)*clamp(dt,0,0.2)+0.2);budget=std::max(0.0,c.distance.value-std::max(0.5,c.leading.value)-reach);}
+    if(forward<-0.1||forward>budget||lateral+lookahead*std::abs(std::sin(angle))>1.0)return false;
+    return c.result.receipt.kind==0||contains(c.result.receipt,position,yaw,speed,dt);
+}
+inline bool boundary(offline_nav::Grid &g,Point before,double before_yaw,Point after,double after_yaw,double length,double width){
+    if(!g.bounded||g.bounds[0]>=g.bounds[2]||g.bounds[1]>=g.bounds[3])return true;
+    length=std::max(0.5,length);width=std::max(0.3,width);double overflow[2][4];Point positions[]={before,after};double yaws[]={before_yaw,after_yaw};
+    for(int i=0;i<2;++i){
+        double s=std::abs(std::sin(yaws[i])),c=std::abs(std::cos(yaws[i])),ex=c*width+s*length,ez=s*width+c*length;
+        overflow[i][0]=std::max(0.0,g.bounds[0]+ex-positions[i].x);overflow[i][1]=std::max(0.0,positions[i].x+ex-g.bounds[2]);
+        overflow[i][2]=std::max(0.0,g.bounds[1]+ez-positions[i].z);overflow[i][3]=std::max(0.0,positions[i].z+ez-g.bounds[3]);
+    }
+    for(int i=0;i<4;++i)if(overflow[1][i]>overflow[0][i]+1e-6)return false;
+    return true;
+}
+struct Flow {
+    std::map<int,Cache> caches;
+    double probe_seconds=0.15;
+    std::array<double,128> event(int kind,int bot,const std::vector<double> &args={}){
+        std::array<double,128> packet{};if(args.size()+2>packet.size())throw std::invalid_argument("motion event width");
+        packet[0]=kind;packet[1]=bot;std::copy(args.begin(),args.end(),packet.begin()+2);
+        if(offline_query(packet.data(),packet.size()))throw std::runtime_error("motion engine event");
+        return packet;
+    }
+    Probe direction(const Input &in,double yaw,Optional<double> maximum,Optional<double> query_speed={}){
+        std::vector<double> args;put(args,in.position);args.push_back(yaw);args.push_back(query_speed.has?query_speed.value:in.speed);put(args,maximum);args.push_back(!query_speed.has);
+        auto packet=event(610,in.bot,args);Values values{packet.data(),0};return values.probe();
+    }
+    Receipt receipt(const Input &in,double yaw,double speed,bool uncached,Optional<double> maximum){
+        std::vector<double> args;put(args,in.position);args.push_back(yaw);args.push_back(speed);args.push_back(uncached);put(args,maximum);
+        auto packet=event(611,in.bot,args);Values values{packet.data(),0};return values.receipt();
+    }
+    void cache(int bot,Cache value){std::vector<double> args;put(args,value);auto answer=event(612,bot,args);value.result.truth=answer[0]!=0;value.result.copied=false;caches[bot]=value;}
+    void remember(const Input &in,double yaw,bool hard=false){if(in.driver)offline_driver_remember(in.driver,in.bot,yaw,hard,5.0);}
+    void invalidate(const Input &in,double yaw){caches[in.bot]=Cache();event(614,in.bot);remember(in,yaw,true);}
+    int resolve(const Input &in,double yaw,double speed,bool passive=false,bool commit=true){
+        std::vector<double> args;put(args,in.position);args.push_back(yaw);args.push_back(speed);args.push_back(in.step);args.push_back(in.now);args.push_back(passive);args.push_back(commit);
+        auto result=event(615,in.bot,args);double value=result[0];
+        if(value!=std::floor(value)||value<0||value>4||(passive&&value==3))throw std::invalid_argument("motion resolver status");
+        return static_cast<int>(value);
+    }
+    Output step(Input in,const Params &p,const Tuning &t,offline_nav::Navigator *nav){
+        Output out(in);double throttle=clamp(in.throttle,-1,1),turn=clamp(in.turn,-1,1);
+        double ax=in.aim.x-in.position.x,az=in.aim.z-in.position.z,aim_distance=std::sqrt(ax*ax+az*az);
+        double desired=aim_distance>0.1?std::atan2(ax,az):in.yaw;
+        bool limited=!(in.minimum_yaw<=-offline_nav::pi+0.1&&in.maximum_yaw>=offline_nav::pi-0.1);
+        if(in.has_target&&(in.recovery==0||in.recovery==5)&&limited){
+            double relative=offline_nav::wrap(desired-in.yaw);
+            if(!(in.minimum_yaw+0.04<=relative&&relative<=in.maximum_yaw-0.04)){turn=clamp(relative/0.58,-1,1);throttle=0;out.hull_aiming=true;}
+        }
+        if(in.siege_locked){throttle=0;turn=0;in.movement=false;in.speed=out.speed=0;in.turn_speed=out.turn_speed=0;}
+        if(in.mobility_blocked){throttle=0;turn=0;}else if(std::abs(throttle)>0.01)throttle*=in.mobility;
+        double sign=(throttle<0||(std::abs(throttle)<=0.01&&in.speed<0))?-1.0:1.0;
+        double travel=in.yaw+(sign<0?offline_nav::pi:0);out.attempted_yaw=travel;
+        event(613,in.bot,{0.0,static_cast<double>(out.hull_aiming),static_cast<double>(in.siege_locked),travel});
+        Optional<double> maximum;
+        if(nav){
+            double horizon=std::max(nav->grid->data->cell,std::abs(in.speed)*1.5);
+            if(sign>0&&in.move.has&&in.movement&&(in.recovery==0||in.recovery==1)){
+                double remaining=std::max(0.5,offline_nav::distance(in.position,in.move.value)-1.5);maximum=std::min(remaining,horizon);
+            }else if(sign<0&&in.recovery==3)maximum=horizon;
+        }
+        Cache previous=caches[in.bot];bool frozen=false;
+        bool settled=std::abs(throttle)<=0.01&&std::abs(turn)<=0.01&&std::abs(in.speed)<=0.02&&in.grounded&&!in.airborne;
+        bool reuse=(!in.decision_due||covers(previous,maximum))&&reusable(previous,in.position,travel,in.speed,in.now,settled,in.step,!in.refresh);
+        Probe previous_result=previous.result;
+        if(!previous.has||!previous_result.truth){previous_result=Probe();previous_result.kind=2;previous_result.clear=true;}
+        bool geometry=previous_result.kind==2&&previous_result.is_clear()&&covers(previous,maximum)&&reusable(previous,in.position,travel,in.speed,in.now,settled,in.step,true);
+        bool catchup_reprobe=!in.refresh&&!reuse&&previous.has&&previous_result.kind==2&&previous_result.is_clear()&&
+            (std::abs(throttle)>0.01||std::abs(in.speed)>0.0001||std::abs(turn)>0.01||std::abs(in.turn_speed)>0.01);
+        bool hold=!in.refresh&&!reuse&&!catchup_reprobe;Probe probe;
+        if(hold){throttle=0;turn=0;frozen=true;}
+        else if(!reuse){
+            probe=direction(in,travel,maximum);
+            if(probe.kind==2&&probe.is_clear()&&!probe.deferred&&std::abs(probe.slope)<=0.01&&
+                    (std::abs(throttle)>0.01||std::abs(in.speed)>0.0001)&&std::abs(turn)<=0.01&&std::abs(in.turn_speed)<=0.01&&!in.airborne){
+                probe.copied=true;double receipt_speed=std::abs(in.speed);
+                if(throttle<0||(std::abs(throttle)<=0.01&&in.speed<0))receipt_speed=-std::max(receipt_speed,0.000001);
+                bool contained=previous.has&&previous.result.kind==2&&!previous.result.deferred&&previous.result.is_clear()&&contains(previous.result.receipt,in.position,travel,receipt_speed,in.step);
+                if(contained){
+                    Receipt proof=previous.result.receipt;
+                    if(refresh_due(proof,in.position,travel,receipt_speed,in.step)){
+                        Receipt refreshed=receipt(in,travel,receipt_speed,false,maximum);
+                        if(refreshed.kind==1){probe.clear=false;probe.collision=true;}
+                        else if(refreshed.kind==3)probe.pending=true;
+                        else if(contains(refreshed,in.position,travel,receipt_speed,in.step))proof=refreshed;
+                    }
+                    probe.receipt=proof;
+                }else{
+                    Receipt proof=receipt(in,travel,receipt_speed,previous_result.receipt.kind!=2,maximum);
+                    if(proof.kind==3)probe.pending=true;
+                    else if(proof.kind==1){probe.clear=false;probe.collision=true;}
+                    else if(proof.kind==2)probe.receipt=proof;
+                }
+            }
+            bool deferred=probe.kind==2&&probe.deferred;
+            if(probe.kind!=0&&!deferred){
+                Cache next;next.has=next.position_valid=true;next.position=in.position;next.yaw=travel;next.maximum=maximum;
+                next.distance=std::min(std::abs(in.speed)>5.0?20.0:15.0,maximum.has?maximum.value:std::numeric_limits<double>::infinity());
+                next.leading=std::max(0.5,in.half_length);next.result=probe;
+                double phase=(((std::abs(static_cast<int64_t>(in.bot))*17+7*11)%29)+1)/29.0;
+                next.deadline=probe.pending?in.now:in.now+probe_seconds*(previous.has?1.0:phase);
+                cache(in.bot,next);probe.copied=false;
+            }else if(deferred){
+                if(geometry)probe=previous_result;
+                else{cache(in.bot,Cache());if(previous.has){throttle=0;turn=0;frozen=true;}}
+            }else if(previous_result.receipt.kind!=2)cache(in.bot,Cache());
+        }else probe=previous.result;
+        bool deferred=probe.kind==2&&probe.deferred;
+        bool exact=in.has_resolver&&probe.kind==2&&!deferred&&probe.collision&&!probe.water&&std::abs(probe.slope)<=0.55;
+        bool clear=(hold||deferred||probe.kind==0||exact||(std::abs(throttle)<=0.01&&std::abs(in.speed)<=0.0001)||in.airborne)?true:probe.is_clear();
+        if(!clear){throttle=0;if(!deferred)remember(in,travel);
+            if(nav&&!deferred&&!(probe.kind==2&&probe.collision)&&in.move.has)nav->report_blocked(in.bot,in.position,in.move,in.now);
+        }
+        int steering=std::abs(turn)>0.01?(turn>0?1:-1):0;
+        out.movement=throttle>0.01?1:throttle<-0.01?-1:0;out.rotation=steering;
+        std::vector<double> logs{1.0,static_cast<double>(out.movement),static_cast<double>(out.rotation),throttle,turn,static_cast<double>(clear),static_cast<double>(frozen),travel};put(logs,probe);event(613,in.bot,logs);
+        double pitch=sign*-std::atan(probe.kind==2?probe.slope:0.0);
+        out.turn_speed=in.siege_locked?0.0:traverse(t,p,in.turn_speed,turn,in.speed,in.step,0,throttle);
+        out.yaw=offline_nav::wrap(in.yaw+out.turn_speed*in.step);
+        if(nav&&!boundary(*nav->grid,in.position,in.yaw,in.position,out.yaw,in.half_length,in.half_width)){out.turn_speed=0;out.yaw=in.yaw;out.rotation=0;}
+        out.attempted_yaw=out.yaw+(sign<0?offline_nav::pi:0);
+        bool wet=in.baked_escape||in.water>0.90;
+        bool shallow=nav&&(nav->shallow_step(in.bot,in.position,out.attempted_yaw)||nav->shallow_step(in.bot,in.position,out.attempted_yaw,0.45,true));
+        bool veto=false;
+        if(nav&&!wet&&in.bake_admitted&&nav->grid->index(nav->grid->cell(in.position))>=0){
+            double distance=std::max(1.0,nav->grid->data->cell);
+            Point end(in.position.x+std::sin(out.attempted_yaw)*distance,in.position.y,in.position.z+std::cos(out.attempted_yaw)*distance);
+            veto=nav->grid->motion_hazard(in.position,end,shallow?9:13);
+        }
+        if(veto){clear=false;throttle=0;out.movement=0;}
+        double speed=in.siege_locked?0.0:longitudinal(t,p,in.speed,throttle,steering!=0,pitch,in.step,in.airborne,0,false);
+        out.drive_pitch=pitch;double drive_speed=speed;bool hard=false,deflected=false;
+        if(!clear){if(probe.kind==2&&probe.collision&&!exact)hard=true;else speed*=0.2;out.destructible_speed.reset();}
+        std::vector<double> integrated{2.0,out.yaw,out.turn_speed,static_cast<double>(out.rotation),static_cast<double>(out.movement),pitch,drive_speed,throttle,static_cast<double>(veto),static_cast<double>(clear),static_cast<double>(frozen),out.attempted_yaw};
+        put(integrated,out.destructible_speed);event(613,in.bot,integrated);
+        int status=0;bool resolved=false;double contact=out.destructible_speed.has?out.destructible_speed.value:speed,v0=speed;
+        if(clear&&!frozen&&std::abs(speed)>0.0001&&in.has_resolver){
+            resolved=true;status=resolve(in,out.yaw,speed);
+            if(status!=0&&status!=1){clear=false;
+                if(status==2){contact=std::min(std::abs(contact),std::abs(speed));speed=speed<0?-contact:contact;out.destructible_speed=speed;}
+                else if(status==3){speed=in.speed;out.destructible_speed.reset();}
+                else if(status==4){invalidate(in,travel);hard=true;out.destructible_speed.reset();}
+            }else out.destructible_speed.reset();
+        }
+        if(hard&&!in.airborne){
+            Optional<double> slide;const double offsets[]={0.55,-0.55,1.0,-1.0};
+            for(double offset:offsets){
+                double yaw=out.yaw+offset;bool fits;
+                if(in.has_resolver){int value=resolve(in,yaw,speed,true,false);fits=value==0||value==1;}
+                else fits=direction(in,yaw,{},speed).is_clear();
+                if(fits){if(in.has_resolver){int value=resolve(in,yaw,speed,true,true);if(value==0||value==1)slide=yaw;}else slide=yaw;break;}
+            }
+            auto response=hard_contact(t,speed,in.step,out.grind>0,slide.has,slide.value);
+            speed=response[0];out.position=Point(in.position.x+response[1],in.position.y,in.position.z+response[2]);
+            deflected=slide.has;out.grind=4;out.grind_present=true;
+            if(nav&&in.move.has)nav->report_blocked(in.bot,in.position,in.move,in.now);
+        }else if(status==2||status==3){out.grind=1;out.grind_present=true;}
+        if(resolved&&in.has_report){std::vector<double> args{static_cast<double>(status),v0,speed};put(args,out.destructible_speed);args.push_back(out.grind_present);args.push_back(out.grind);event(616,in.bot,args);}
+        if(in.siege_limit.has)speed=clamp(speed,-in.siege_limit.value,in.siege_limit.value);
+        out.speed=speed;
+        if(!deflected&&clear&&!frozen){out.position.x+=std::sin(out.yaw)*speed*in.step;out.position.z+=std::cos(out.yaw)*speed*in.step;
+            if(std::abs(speed)>0.0001){out.grind=std::max(0,out.grind-1);out.grind_present=true;}
+        }
+        event(617,in.bot,{static_cast<double>(status),static_cast<double>(hard),out.position.x,out.position.y,out.position.z,out.speed});
+        return out;
+    }
+};
+}
+#endif

--- a/tools/ffi_experiment/motion_vertical.h
+++ b/tools/ffi_experiment/motion_vertical.h
@@ -1,0 +1,103 @@
+#ifndef OFFLINE_EXPERIMENT_MOTION_VERTICAL_H
+#define OFFLINE_EXPERIMENT_MOTION_VERTICAL_H
+#include "motion_flow.h"
+
+namespace offline_motion {
+struct Vertical {
+    int bot=0,driver=0;
+    Point position;Optional<Point> tick;
+    double yaw=0,speed=0,half_length=3.5,step=0,vertical=0,pitch=0,attempted=0;
+    bool airborne=false,grounded=false,blocked=false,landed=false,trace=false;
+    double impact=0;
+    Optional<double> highest,centre;
+    double maximum_climb=0;
+    bool rise_obstacle=false,rise_continuous=false;
+};
+inline Optional<double> ground(Flow &flow,int bot,double x,double z,double hint){
+    auto packet=flow.event(630,bot,{x,z,hint});Values result{packet.data(),0};return result.optional();
+}
+inline bool continuous_rise(Flow &flow,const Vertical &v){
+    if(!v.centre.has||!v.tick.has)return false;
+    double dx=v.position.x-v.tick.value.x,dz=v.position.z-v.tick.value.z;
+    double distance=std::sqrt(dx*dx+dz*dz),rise=v.centre.value-v.tick.value.y;
+    if(distance<=0.0001||rise<=0||rise>distance*0.55+0.02)return false;
+    int segments=std::max(2,static_cast<int>(std::ceil(distance/1.5)));if(segments>5)return false;
+    double limit=distance/static_cast<double>(segments)*0.55+0.02,previous=v.tick.value.y;
+    for(int i=1;i<segments;++i){
+        double fraction=static_cast<double>(i)/segments;
+        auto support=ground(flow,v.bot,v.tick.value.x+dx*fraction,v.tick.value.z+dz*fraction,v.tick.value.y+rise*fraction);
+        if(!support.has||std::abs(support.value-previous)>limit)return false;
+        previous=support.value;
+    }
+    return std::abs(v.centre.value-previous)<=limit;
+}
+inline Vertical vertical_step(Flow &flow,const Tuning &t,Vertical v){
+    v.centre=ground(flow,v.bot,v.position.x,v.position.z,v.position.y);v.highest=v.centre;
+    if(!v.centre.has){
+        double s=std::sin(v.yaw),c=std::cos(v.yaw),length=std::max(1.5,v.half_length);
+        for(double offset:{length,-length}){
+            auto support=ground(flow,v.bot,v.position.x+s*offset,v.position.z+c*offset,v.position.y);
+            if(support.has&&(!v.highest.has||support.value>v.highest.value))v.highest=support;
+        }
+    }
+    if(v.trace){std::vector<double> args{0.0};put(args,v.highest);put(args,v.centre);args.push_back(v.grounded);flow.event(631,v.bot,args);}
+    Optional<double> support=v.centre.has?v.centre:v.highest;
+    if(support.has){
+        double gap=ground_gap(t,v.speed,v.pitch,v.step);
+        v.maximum_climb=std::max(0.6,std::abs(v.speed)*v.step*2.5);
+        v.rise_obstacle=v.grounded&&v.centre.has&&v.centre.value-v.position.y>std::min(std::max(0.0,v.maximum_climb),0.85)+0.02;
+        if(v.rise_obstacle){
+            v.rise_continuous=continuous_rise(flow,v);
+            if(v.rise_continuous)v.maximum_climb=std::max(v.maximum_climb,std::max(0.0,v.centre.value-v.tick.value.y));
+        }
+        if(v.trace)flow.event(631,v.bot,{1.0,v.maximum_climb,static_cast<double>(v.rise_obstacle),static_cast<double>(v.rise_continuous)});
+        double com_gap=v.position.y-support.value,landing=v.centre.has?v.centre.value:support.value;
+        if(!v.grounded){v.position.y=landing;v.vertical=0;v.airborne=false;v.grounded=true;}
+        else if(v.rise_obstacle&&!v.rise_continuous){
+            if(v.tick.has)v.position=v.tick.value;
+            v.speed=0;v.vertical=0;v.airborne=false;v.blocked=true;
+        }else if(v.position.y<=support.value||(com_gap<=gap&&!v.airborne)){
+            v.impact=v.airborne?v.vertical:0;
+            if(v.position.y<support.value)v.position.y+=std::min(support.value-v.position.y,v.maximum_climb);
+            else{v.position.y+=(support.value-v.position.y)*std::min(1.0,v.step*15.0);v.position.y=std::min(v.position.y,support.value+0.12);}
+            v.vertical=0;v.airborne=false;v.landed=v.impact<0;
+        }else{
+            if(!v.airborne)v.vertical=launch_speed(v.speed,v.pitch);
+            v.airborne=true;
+            int substeps=std::min(8,std::max(1,static_cast<int>(std::abs(v.vertical*v.step)/0.5)+1));
+            double dt=v.step/static_cast<double>(substeps);
+            for(int i=0;i<substeps;++i){
+                v.vertical-=t.GRAVITY*dt;v.position.y+=v.vertical*dt;
+                if(v.position.y<=landing){v.impact=v.vertical;v.position.y=landing;v.vertical=0;v.airborne=false;v.landed=true;break;}
+            }
+        }
+    }else if(v.grounded){
+        if(!v.airborne)v.vertical=launch_speed(v.speed,v.pitch);
+        v.airborne=true;v.vertical-=t.GRAVITY*v.step;v.position.y+=v.vertical*v.step;
+    }else{v.vertical=0;v.airborne=false;}
+    return v;
+}
+inline std::pair<double,double> slope(Flow &flow,int bot,Point position,double yaw,double half_length,double half_width,double pitch,double roll){
+    double length=std::max(3.0,2*half_length),width=std::max(2.0,2*half_width),s=std::sin(yaw),c=std::cos(yaw);
+    auto front=ground(flow,bot,position.x+s*length*0.5,position.z+c*length*0.5,position.y);
+    auto rear=ground(flow,bot,position.x-s*length*0.5,position.z-c*length*0.5,position.y);
+    auto right=ground(flow,bot,position.x+c*width*0.5,position.z-s*width*0.5,position.y);
+    auto left=ground(flow,bot,position.x-c*width*0.5,position.z+s*width*0.5,position.y);
+    if(!front.has||!rear.has||!right.has||!left.has)return {pitch,roll};
+    double p=-std::atan2(front.value-rear.value,length)*0.9,r=std::atan2(right.value-left.value,width)*0.9;
+    double tilt=std::sqrt(p*p+r*r);if(tilt>0.61){double scale=0.61/tilt;p*=scale;r*=scale;}
+    return {pitch+(p-pitch)*0.5,roll+(r-roll)*0.5};
+}
+inline double stopping_distance(const Tuning &t,const Params &p,double speed,double pitch,bool steer,double dt,double epsilon){
+    double current=std::abs(speed);if(current<=epsilon)return 0;double distance=0;
+    for(int i=0;i<4096;++i){
+        double following=longitudinal(t,p,current,0,steer,pitch,dt,false,0,false);
+        if(!std::isfinite(following))return std::numeric_limits<double>::infinity();
+        if(following<=epsilon)return distance+std::max(0.0,following)*dt;
+        if(following>=current)return std::numeric_limits<double>::infinity();
+        distance+=following*dt;current=following;
+    }
+    return std::numeric_limits<double>::infinity();
+}
+}
+#endif

--- a/tools/ffi_experiment/navigation_adapter.py
+++ b/tools/ffi_experiment/navigation_adapter.py
@@ -24,6 +24,11 @@ class Backend(object):
             spec.loader.exec_module(self.module)
         if self.module.layout_self_test(11, 22, 33) != 112233:
             raise RuntimeError('native A* bridge layout self-test failed')
+        if hasattr(self.module, 'callback_self_test'):
+            def callback_probe(a, b, c):
+                return a * 10000 + b * 100 + c
+            if self.module.callback_self_test(callback_probe, (11, 22, 33)) != 112233:
+                raise RuntimeError('native callback bridge self-test failed')
         self.closed = False
         self.graphs = {}
         self.searches = weakref.WeakValueDictionary()
@@ -40,6 +45,19 @@ class Backend(object):
         self.calls += 1
         if status:
             raise RuntimeError('native A* command %s failed: status=%s' % (buffer[0], status))
+        return buffer
+
+    def call_sync(self, values, query_packet, callback):
+        buffer = values if isinstance(values, array) else array('d', values)
+        address, count = buffer.buffer_info()
+        query_address, query_count = query_packet.buffer_info()
+        status = self.module.dispatch_sync(
+            int(address & 0xffff), int(address >> 16), int(count),
+            int(query_address & 0xffff), int(query_address >> 16), int(query_count),
+            callback, ())
+        self.calls += 1
+        if status:
+            raise RuntimeError('native synchronous command %s failed: status=%s' % (buffer[0], status))
         return buffer
 
     def graph(self, grid, navigation):

--- a/tools/ffi_experiment/navigation_adapter.py
+++ b/tools/ffi_experiment/navigation_adapter.py
@@ -1,0 +1,289 @@
+"""Opt-in experiment: persistent native A* with the unchanged Python finish.
+
+Only experiment runners install these patches; production imports no module
+from this directory. Every native command uses one caller-owned double array.
+The native module keeps graph/search data, never the array or Python objects.
+Both CPython 2.7 and 3 can exercise this exact adapter.
+"""
+from __future__ import print_function
+
+from array import array
+import sys
+import weakref
+
+
+class Backend(object):
+    def __init__(self, module_path):
+        if sys.version_info[0] == 2:
+            import imp
+            self.module = imp.load_dynamic('offline_astar_native', module_path)
+        else:
+            import importlib.util
+            spec = importlib.util.spec_from_file_location('offline_astar_native', module_path)
+            self.module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(self.module)
+        if self.module.layout_self_test(11, 22, 33) != 112233:
+            raise RuntimeError('native A* bridge layout self-test failed')
+        self.closed = False
+        self.graphs = {}
+        self.searches = weakref.WeakValueDictionary()
+        self.calls = 0
+        self.expansions = 0
+        self.completed = 0
+        self.original_begin = None
+        self.original_advance = None
+
+    def call(self, values):
+        buffer = values if isinstance(values, array) else array('d', values)
+        address, count = buffer.buffer_info()
+        status = self.module.dispatch(int(address & 0xffff), int(address >> 16), int(count))
+        self.calls += 1
+        if status:
+            raise RuntimeError('native A* command %s failed: status=%s' % (buffer[0], status))
+        return buffer
+
+    def graph(self, grid, navigation):
+        owner = self.graphs.get(grid)
+        if owner is None:
+            owner = Graph(self, grid, navigation)
+            self.graphs[grid] = owner
+        return owner
+
+    def install(self, navigation, batch=True):
+        if self.original_begin is not None:
+            raise RuntimeError('native A* experiment is already installed')
+        self.navigation = navigation
+        self.original_begin = navigation.TerrainGrid.__dict__['begin_plan']
+        self.original_advance = navigation.TerrainNavigator.__dict__['_advance_searches']
+        backend = self
+
+        def begin(grid, start, goal, avoid_points=None, max_expansions=1600,
+                  now=0.0, prefer_clearance=False, edge_penalties=None,
+                  hard_edge_penalties=None):
+            if not grid.prebaked:
+                raise RuntimeError('native A* experiment requires a baked graph')
+            return Search(backend.graph(grid, navigation), start, goal,
+                          avoid_points, max_expansions, now, prefer_clearance,
+                          edge_penalties, hard_edge_penalties)
+
+        def advance(navigator, now):
+            return backend.advance(navigator, now)
+
+        self.patched_begin = begin
+        self.patched_advance = advance
+        navigation.TerrainGrid.begin_plan = begin
+        if batch:
+            navigation.TerrainNavigator._advance_searches = advance
+        return self
+
+    def batch(self, queue, budget, now=None):
+        if not queue or budget <= 0:
+            return 0, queue, None
+        graph = queue[0].graph
+        graph.sync_globals()
+        for search in queue:
+            if search.graph is not graph:
+                raise RuntimeError('one fair queue must belong to one graph')
+            search.ensure_started()
+            search.sync_inputs()
+        packet = self.call([5, int(budget), len(queue), 0, 0, 0, 0, 0] +
+                           [search.handle for search in queue])
+        consumed, completed = int(packet[3]), int(packet[4])
+        self.expansions += int(packet[6])
+        if now is not None:
+            for search in queue[:min(consumed, len(queue))]:
+                search.last_frame = float(now)
+        remaining = [self.searches[int(handle)] for handle in packet[8:8 + int(packet[5])]]
+        graph.drain_expired()
+        finished = self.searches[completed] if completed else None
+        if finished is not None:
+            finished.finish()
+            self.completed += 1
+        return consumed, remaining, finished
+
+    def advance(self, navigator, now):
+        """Copy the existing credit/rotation law, batch only the paid steps."""
+        nav = self.navigation
+        navigator.search_now = float(now)
+        if not navigator.search_frame_open:
+            navigator._begin_automatic_frame(now)
+        if navigator.search_processed_frame == navigator.search_frame_serial:
+            nav.combat_count('nav_batch_already_processed')
+            return
+        navigator.search_processed_frame = navigator.search_frame_serial
+        navigator.search_frame_time = float(now)
+        keys = sorted(navigator.searches, key=lambda value: repr(value))
+        if not keys:
+            navigator.search_next_key = None
+            return
+        if navigator.search_next_key in keys:
+            start = keys.index(navigator.search_next_key)
+            keys = keys[start:] + keys[:start]
+        queue = [navigator.searches[key] for key in keys]
+        owners = dict((id(navigator.searches[key]), key) for key in keys)
+        budget = min(max(0, int(navigator.search_credit)),
+                     max(0, int(navigator.search_frame_budget)))
+        processed = 0
+        nav.combat_count('nav_batch_pending_jobs', len(queue))
+        expansions_before = self.expansions
+        while budget > 0 and queue:
+            consumed, queue, finished = self.batch(queue, budget, now)
+            if consumed <= 0:
+                raise RuntimeError('native A* made no paid progress')
+            budget -= consumed
+            processed += consumed
+            if finished is not None:
+                navigator._finish_search(owners[id(finished)], finished, now)
+        navigator.search_credit = max(0.0, navigator.search_credit - processed)
+        navigator.search_frame_budget = max(0, int(navigator.search_frame_budget) - processed)
+        navigator.search_next_key = owners[id(queue[0])] if queue else None
+        nav.combat_count('nav_astar_expansions', self.expansions - expansions_before)
+        nav.combat_count('nav_search_steps', processed)
+        if queue and budget <= 0:
+            nav.combat_count('nav_batch_budget_exhausted')
+        navigator._trim_cache(now)
+
+    def close(self):
+        if self.closed:
+            return
+        if self.original_begin is not None:
+            if self.navigation.TerrainGrid.__dict__['begin_plan'] is self.patched_begin:
+                self.navigation.TerrainGrid.begin_plan = self.original_begin
+            if self.navigation.TerrainNavigator.__dict__['_advance_searches'] is self.patched_advance:
+                self.navigation.TerrainNavigator._advance_searches = self.original_advance
+        self.call([0])
+        self.closed = True
+        self.graphs.clear()
+
+
+class Graph(object):
+    def __init__(self, backend, grid, nav):
+        self.backend, self.grid = backend, grid
+        self.failed = None
+        self.hulls = None
+        packet = array('d', [1, grid._baked_width, grid._baked_height,
+                            grid.cell_size, grid._baked_origin[0], grid._baked_origin[1],
+                            grid._baked_max_grade, grid.heuristic_weight,
+                            nav.BAKED_EDGE_CLEARANCE_WEIGHT,
+                            nav.BAKED_SHALLOW_WATER_PENALTY, nav.SQRT_TWO])
+        for height, links, hazards in zip(grid._baked_heights, grid._baked_links,
+                                         grid._baked_hazards):
+            packet.extend((float('nan') if height is None else height, links, hazards))
+        self.handle = int(backend.call(packet)[0])
+
+    def index(self, cell):
+        if cell is None:
+            return -1
+        x, z = cell
+        if not (0 <= x < self.grid._baked_width and 0 <= z < self.grid._baked_height):
+            return -1
+        return z * self.grid._baked_width + x
+
+    def cell(self, index):
+        return index % self.grid._baked_width, index // self.grid._baked_width
+
+    def edges(self, items, timed=False, hard=False):
+        result = []
+        for key, value in items:
+            first, second = self.index(key[0]), self.index(key[1])
+            if first < 0 or second < 0:
+                continue
+            result.extend((first, second))
+            if timed:
+                result.extend((float(value[0]), float(value[1])))
+            elif not hard:
+                result.append(float(value))
+        return result
+
+    def sync_globals(self):
+        grid = self.grid
+        if self.failed == grid._failed_edges and self.hulls == grid._static_hull_edges:
+            return
+        failed = self.edges(grid._failed_edges.items(), timed=True)
+        hulls = self.edges(grid._static_hull_edges.items())
+        self.backend.call([2, self.handle, len(failed) // 4] + failed +
+                          [len(hulls) // 3] + hulls)
+        self.failed = dict(grid._failed_edges)
+        self.hulls = dict(grid._static_hull_edges)
+
+    def drain_expired(self):
+        if not self.failed:
+            return
+        packet = self.backend.call([7, self.handle] + [0] * (2 * len(self.failed)))
+        for index in range(int(packet[0])):
+            edge = tuple(sorted((self.cell(int(packet[1 + index * 2])),
+                                 self.cell(int(packet[2 + index * 2])))))
+            self.grid._failed_edges.pop(edge, None)
+            self.failed.pop(edge, None)
+
+
+class Search(object):
+    def __init__(self, graph, start, goal, avoid, maximum, now, prefer, local, hard):
+        self.graph, self.start, self.goal = graph, start, goal
+        self.avoid, self.local, self.hard = avoid, local, hard
+        self.maximum, self.now, self.prefer = int(maximum), float(now), bool(prefer)
+        self.hull_revision = graph.grid.static_hull_revision
+        self.done = False
+        self.result = None
+        self.last_frame = None
+        self.handle = None
+        self.inputs = None
+        self.closed = False
+
+    def ensure_started(self):
+        if self.handle is not None:
+            return
+        grid = self.graph.grid
+        self.start_cell = grid._nearest_baked_cell(grid.cell_for(self.start), 3)
+        self.goal_cell = grid._nearest_baked_cell(grid.cell_for(self.goal), 3)
+        packet = self.graph.backend.call([
+            3, self.graph.handle, self.graph.index(self.start_cell),
+            self.graph.index(self.goal_cell), self.maximum, self.now, int(self.prefer)])
+        self.handle = int(packet[0])
+        self.graph.backend.searches[self.handle] = self
+
+    def sync_inputs(self):
+        avoid = tuple((float(point[0]), float(point[2])) for point in self.avoid or ())
+        if (self.inputs is not None and self.inputs[0] == avoid and
+                self.inputs[1] == (self.local or {}) and
+                self.inputs[2] == set(self.hard or ())):
+            return
+        local = self.graph.edges((self.local or {}).items())
+        hard = self.graph.edges(((edge, 0) for edge in self.hard or ()), hard=True)
+        self.graph.backend.call(
+            [4, self.handle, len(avoid)] + [v for point in avoid for v in point] +
+            [len(local) // 3] + local + [int(bool(self.hard)), len(hard) // 2] + hard)
+        self.inputs = (avoid, dict(self.local or {}), set(self.hard or ()))
+
+    def finish(self):
+        grid = self.graph.grid
+        packet = self.graph.backend.call([6, self.handle] + [0] * max(1, self.maximum + 1))
+        count = int(packet[0])
+        if count:
+            cells = [self.graph.cell(int(index)) for index in packet[2:2 + count]]
+            path = [grid.point_for(cell, grid._baked_cell_height(cell)) for cell in cells]
+            goal_y = grid._ground(float(self.goal[0]), float(self.goal[2]), path[-1][1])
+            goal_point = (float(self.goal[0]), goal_y if goal_y is not None else path[-1][1],
+                          float(self.goal[2]))
+            if (grid.segment_clear(path[-1], goal_point) and
+                    not grid.path_has_edge_penalty((path[-1], goal_point), self.hard)):
+                path.append(goal_point)
+            self.result = grid._smooth(tuple(path), self.now, self.prefer, self.hard)
+        else:
+            self.result = ()
+        self.done = True
+        self.close()
+
+    def step(self, budget):
+        if self.done:
+            return True
+        self.graph.backend.batch([self], max(1, int(budget)))
+        return self.done
+
+    def close(self):
+        if not self.closed and self.handle is not None and not self.graph.backend.closed:
+            self.graph.backend.call([8, self.handle])
+        self.closed = True
+
+    def __del__(self):
+        self.close()

--- a/tools/ffi_experiment/navigation_flow.cpp
+++ b/tools/ffi_experiment/navigation_flow.cpp
@@ -1,0 +1,198 @@
+// Persistent navigation and its complete baked geometry. The numeric bridge
+// also exposes geometry entry points for existing runtime safety consumers.
+#include "navigation_flow.h"
+#include "navigation_grid.h"
+#include "navigation_snapshot.h"
+
+namespace {
+using namespace offline_nav;
+struct Reader {
+    double *b;int n,i;
+    double number(){if(i>=n||!std::isfinite(b[i]))throw std::invalid_argument("navigation packet");return b[i++];}
+    int integer(int low=-1000000000,int high=1000000000){
+        double v=number();if(v<low||v>high||v!=std::floor(v))throw std::invalid_argument("navigation integer");return static_cast<int>(v);
+    }
+    Point point(){double x=number(),y=number(),z=number();return Point(x,y,z);}
+    Cell cell(){int x=integer(),z=integer();return Cell(x,z);}
+    Edge edge(){Cell a=cell(),b=cell();return offline_nav::edge(a,b);}
+    Path path(){Path out;int size=integer(0,1000000);for(int j=0;j<size;++j)out.push_back(point());return out;}
+    Penalties penalties(){Penalties out;int size=integer(0,1000000);for(int j=0;j<size;++j){Edge e=edge();out[e]=number();}return out;}
+    std::string string(){std::string out;int size=integer(0,65536);for(int j=0;j<size;++j)out+=static_cast<char>(integer(0,255));return out;}
+    void end(){if(i!=n)throw std::invalid_argument("navigation packet width");}
+};
+struct Writer {
+    double *b;int n,i;
+    void number(double v){if(i>=n)throw std::invalid_argument("navigation result capacity");b[i++]=v;}
+    void point(Point p){number(p.x);number(p.y);number(p.z);}
+    void cell(Cell c){number(c.first);number(c.second);}
+    void path(const Path &path){number(path.size());for(Point p:path)point(p);}
+};
+std::map<int,std::shared_ptr<Grid> > grids;
+int next_grid=1;
+Grid &grid(int id){auto it=grids.find(id);if(it==grids.end())throw std::invalid_argument("navigation owner");return *it->second;}
+struct NavigationOwner {
+    Navigator nav;
+    std::map<int,Identity> identities;
+    int next_identity=1;
+    std::string snapshot;
+    explicit NavigationOwner(std::shared_ptr<Grid> value):nav(value){}
+};
+std::map<int,std::unique_ptr<NavigationOwner> > navigators;
+int next_navigator=1;
+NavigationOwner &navigator(int id){auto it=navigators.find(id);if(it==navigators.end())throw std::invalid_argument("navigator owner");return *it->second;}
+void projection(const Navigator &nav,int id,Writer &w){
+    auto found=nav.states.find(id);w.number(found!=nav.states.end());if(found==nav.states.end())return;
+    const State &s=found->second;w.number(s.status);w.number(s.planned_goal.has);w.point(s.planned_goal.value);
+    w.number(s.shallow.has);w.point(s.shallow.value);w.number(s.terminal);
+}
+void navigate(NavigationOwner &owner,int kind,Reader &r,Writer &w){
+    Navigator &nav=owner.nav;
+    if(kind==0){double elapsed=r.number();r.end();nav.begin(elapsed);}
+    else if(kind==1){r.end();nav.frame_open=false;}
+    else if(kind==2||kind==11){double now=r.number();r.end();if(kind==2)nav.tick(now);else nav.advance(now);}
+    else if(kind==3||kind==4||kind==13){
+        int id=r.integer(0),identity=r.integer(1);Point current=r.point(),goal=r.point();double now=r.number();bool movement=r.integer(0,1)!=0;
+        auto found=owner.identities.find(identity);if(found==owner.identities.end())throw std::invalid_argument("navigation identity");
+        if(kind==13){
+            Optional<Point> anchor;if(r.integer(0,1))anchor=r.point();
+            double horizon=r.number();bool stop=r.integer(0,1)!=0;r.end();
+            bool direct=distance(current,goal)<=15.0&&!nav.penalized(id,current,goal,now)&&nav.grid->dry(current,goal,now);
+            Point target;
+            if(direct){auto escape=nav.observe_direct(id,current,goal,found->second,now,movement);target=escape.has?escape.value:goal;}
+            else target=nav.next_target(id,current,goal,found->second,now,anchor,Path(),horizon,movement);
+            auto state=nav.states.find(id);
+            bool terminal=state!=nav.states.end()&&state->second.terminal;
+            w.number(stop&&((direct&&target==goal)||(!direct&&terminal)));w.point(target);projection(nav,id,w);
+        }else if(kind==3){
+            Optional<Point> anchor;if(r.integer(0,1))anchor=r.point();
+            Optional<double> horizon;if(r.integer(0,1))horizon=r.number();
+            Path avoid=r.path();r.end();Point target=nav.next_target(id,current,goal,found->second,now,anchor,avoid,horizon,movement);
+            w.number(1);w.point(target);projection(nav,id,w);
+        }else{r.end();auto target=nav.observe_direct(id,current,goal,found->second,now,movement);w.number(target.has);w.point(target.value);projection(nav,id,w);}
+    }
+    else if(kind==5){int id=r.integer(0);Point current=r.point();Optional<Point> target;if(r.integer(0,1))target=r.point();double now=r.number();r.end();w.number(nav.report_blocked(id,current,target,now));projection(nav,id,w);}
+    else if(kind==6){int id=r.integer(0);Point a=r.point(),b=r.point();double now=r.number();r.end();w.number(nav.penalized(id,a,b,now));}
+    else if(kind==7||kind==8){int id=r.integer(0);Point p=r.point();double yaw=r.number(),maximum=r.number();r.end();w.number(nav.shallow_step(id,p,yaw,maximum,kind==8));}
+    else if(kind==9){int id=r.integer(0);r.end();auto found=nav.states.find(id);w.number(found!=nav.states.end()&&found->second.terminal);}
+    else if(kind==10){int maximum=r.integer(0,1000000);r.end();nav.maximum=maximum;}
+    else if(kind==12){
+        std::set<int> active;int count=r.integer(0,10000);for(int i=0;i<count;++i)active.insert(r.integer(0));r.end();
+        for(auto it=nav.modes.begin();it!=nav.modes.end();)if(!active.count(it->first))it=nav.modes.erase(it);else ++it;
+    }
+    else throw std::invalid_argument("navigator operation");
+}
+
+void geometry(Grid &g,int kind,Reader &r,Writer &w){
+    if(kind==0){Point p=r.point();r.end();double y=0;bool has=g.ground(p,y);w.number(has);w.number(y);}
+    else if(kind==1||kind==2||kind==3||kind==4||kind==10){
+        Point a=r.point(),b=r.point();double extra=kind==1?0:(kind==3||kind==4?r.integer(0,255):r.number());r.end();
+        if(kind==1)w.number(g.segment_clear(a,b));
+        if(kind==2)w.number(g.dry(a,b,extra));
+        if(kind==3)w.number(g.hazard(a,b,static_cast<int>(extra)));
+        if(kind==4)w.number(g.motion_hazard(a,b,static_cast<int>(extra)));
+        if(kind==10)w.number(g.segment_penalty(a,b,extra));
+    }
+    else if(kind==5||kind==6||kind==7){Point p=r.point();int value=r.integer(0,10000);r.end();
+        if(kind==5)w.number(g.point_hazard(p,value));
+        if(kind==6)w.number(g.hazard_near(p,value));
+        if(kind==7){Cell c;w.number(g.nearest(g.cell(p),value,c));}
+    }
+    else if(kind==8){Point p=r.point();double yaw=r.number(),length=r.number(),width=r.number();r.end();w.number(g.pose(p,yaw,length,width));}
+    else if(kind==9){Point p=r.point();r.end();std::pair<double,double> result;w.number(g.local_corridor(p,result));w.number(result.first);w.number(result.second);}
+    else if(kind==11||kind==12){
+        Point a=r.point(),b=r.point();int value=r.integer(0,255);r.end();std::vector<Cell> cells;
+        if(kind==11){cells=g.segment_cells(a,b,value!=0);w.number(cells.size());}
+        else {bool valid=g.hazard_cells(a,b,value,cells);w.number(valid?static_cast<int>(cells.size()):-1);}
+        for(Cell c:cells)w.cell(c);
+    }
+    else if(kind==13){
+        Path path=r.path();double now=r.number();bool prefer=r.integer(0,1)!=0;Penalties hard=r.penalties();r.end();w.path(g.smooth(path,now,prefer,hard));
+    }
+    else if(kind==14){
+        Point a=r.point(),b=r.point();double now=r.number(),side=r.number(),minimum=r.number();Path avoid=r.path();Penalties hard=r.penalties();r.end();
+        Point result;w.number(g.safe_local(a,b,now,avoid,side,hard,minimum,result));w.point(result);
+    }
+    else if(kind==15){Path p=r.path();Penalties hard=r.penalties();r.end();w.number(g.path_penalty(p,hard));}
+    else if(kind==16){Path p=r.path();r.end();double value=0;w.number(g.exposure(p,value));w.number(value);}
+    else if(kind==17||kind==18||kind==19){
+        Point current;if(kind==18)current=r.point();Path p=r.path();int a=r.integer(0,static_cast<int>(p.size())),b=r.integer(-1,static_cast<int>(p.size())-1);
+        double grade=0,turn=0,exposure=0;
+        if(kind==17){grade=r.number();turn=r.number();}
+        if(kind==19)exposure=r.number();
+        r.end();
+        if(kind==17)w.number(climb(p,a,b,grade,turn));
+        if(kind==18)w.number(live_climb(current,p,a,b));
+        if(kind==19)w.number(g.clearance(p,a,b,exposure));
+    }
+    else if(kind==20){Path p=r.path();double now=r.number();r.end();w.number(g.path_timed(p,now));}
+    else if(kind==21){Path p=r.path();r.end();w.number(g.path_penalty(p,g.hulls));}
+    else if(kind==22){Point a=r.point(),b=r.point();r.end();auto edges=g.edges(a,b);w.number(edges.size());for(Edge e:edges){w.cell(e.first);w.cell(e.second);}}
+    else if(kind==23){Point a=r.point(),b=r.point();r.end();auto result=g.corridor(a,b);w.number(result.first);w.number(result.second);}
+    else throw std::invalid_argument("navigation geometry operation");
+}
+}
+offline_nav::Navigator &offline_runtime_navigation(int owner){return navigator(owner).nav;}
+extern "C" void offline_navigation_reset(void){navigators.clear();grids.clear();}
+extern "C" int offline_navigation_local_query(int owner,int bot,int kind,
+        double x,double y,double z,double yaw,double length,double width,
+        int wet_escape,int bake_admitted,int has_distance,double maximum_distance){
+    Navigator &nav=navigator(owner).nav;Grid &g=*nav.grid;Point start(x,y,z);
+    if(kind==2)return g.pose(start,yaw,length,width)?1:0;
+    if(wet_escape||g.point_hazard(start,4)||!bake_admitted||g.index(g.cell(start))<0)return 2;
+    bool shallow=nav.shallow_step(bot,start,yaw);
+    double distance=std::max(1.0,g.data->cell);
+    if(has_distance)distance=std::min(distance,std::max(0.0,maximum_distance));
+    Point end(x+std::sin(yaw)*distance,y,z+std::cos(yaw)*distance);
+    if(g.motion_hazard(start,end,shallow?9:13))return 0;
+    return g.segment_clear(start,end)?1:2;
+}
+extern "C" int offline_navigation_dispatch(double *b,int n){
+    Reader r{b,n,1};int op=static_cast<int>(b[0]);
+    if(op==500){
+        auto owner=std::make_shared<Grid>(offline_navigation_graph(r.integer(1)));
+        owner->bounded=r.integer(0,1)!=0;
+        for(int j=0;j<4;++j)owner->bounds[j]=r.number();
+        r.end();int id=next_grid++;grids[id]=owner;b[0]=id;return 0;
+    }
+    if(op==510){int handle=r.integer(1);r.end();grid(handle);int id=next_navigator++;navigators[id].reset(new NavigationOwner(grids.at(handle)));b[0]=id;return 0;}
+    if(op>=511){
+        int handle=r.integer(1);NavigationOwner &owner=navigator(handle);
+        if(op==511){
+            Identity key;key.repr=r.string();key.kind=r.string();key.owner=r.integer(-1);key.prefer=r.integer(0,1)!=0;r.end();
+            int id=owner.next_identity++;owner.identities[id]=key;b[0]=id;return 0;
+        }
+        if(op==512){int kind=r.integer(0,13),size=r.integer(0,n-4);r.n=4+size;Writer w{b,n,0};navigate(owner,kind,r,w);return 0;}
+        if(op==513){bool full=r.integer(0,1)!=0;r.end();owner.snapshot=offline_nav::snapshot(owner.nav,full);b[0]=owner.snapshot.size();return 0;}
+        if(op==514){
+            if(n<static_cast<int>(owner.snapshot.size()+1))throw std::invalid_argument("navigation snapshot capacity");
+            b[0]=owner.snapshot.size();for(size_t i=0;i<owner.snapshot.size();++i)b[i+1]=static_cast<unsigned char>(owner.snapshot[i]);owner.snapshot.clear();return 0;
+        }
+        if(op==515){r.end();navigators.erase(handle);return 0;}
+        if(op==516){
+            Navigator &nav=owner.nav;int needed=6+6*static_cast<int>(nav.searches.size());
+            if(n<needed){b[0]=needed;b[1]=-1;return 0;}
+            Writer w{b,n,0};w.number(nav.searches.size());w.number(nav.credit);w.number(nav.budget);w.number(nav.completed);w.number(nav.failed_count);
+            w.number(nav.next_key.empty()?0:nav.key_ids.at(nav.next_key));
+            for(const auto &item:nav.searches){
+                w.number(nav.key_ids.at(item.first));w.number(item.second.last_frame.has);w.number(item.second.last_frame.value);
+                w.number(item.second.revision);w.number(item.second.search->done());w.number(item.second.search->expansions());
+            }
+            return 0;
+        }
+        throw std::invalid_argument("navigator bridge operation");
+    }
+    int handle=r.integer(1);Grid &g=grid(handle);
+    if(op==501){
+        int kind=r.integer(0,23),size=r.integer(0,n-4);r.n=4+size;
+        Writer w{b,n,0};geometry(g,kind,r,w);return 0;
+    }
+    if(op==502){
+        int revision=r.integer(0);TimedPenalties failed;int size=r.integer(0,1000000);
+        for(int j=0;j<size;++j){Edge e=r.edge();double expiry=r.number(),cost=r.number();failed[e]=std::make_pair(expiry,cost);}
+        Penalties hulls=r.penalties();r.end();
+        g.failed.swap(failed);g.hulls.swap(hulls);g.hull_revision=revision;
+        return 0;
+    }
+    if(op==503){r.end();grids.erase(handle);return 0;}
+    throw std::invalid_argument("navigation operation");
+}

--- a/tools/ffi_experiment/navigation_flow.h
+++ b/tools/ffi_experiment/navigation_flow.h
@@ -1,0 +1,17 @@
+#ifndef OFFLINE_EXPERIMENT_NAVIGATION_FLOW_H
+#define OFFLINE_EXPERIMENT_NAVIGATION_FLOW_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+int offline_navigation_dispatch(double *buffer,int count);
+void offline_navigation_reset(void);
+/* 0 blocked, 1 clear, 2 requires the real native direction probe. */
+int offline_navigation_local_query(int owner,int bot,int kind,
+    double x,double y,double z,double yaw,double length,double width,
+    int wet_escape,int bake_admitted,int has_distance,double maximum_distance);
+#ifdef __cplusplus
+}
+namespace offline_nav {struct Navigator;}
+offline_nav::Navigator &offline_runtime_navigation(int owner);
+#endif
+#endif

--- a/tools/ffi_experiment/navigation_flow_adapter.py
+++ b/tools/ffi_experiment/navigation_flow_adapter.py
@@ -1,0 +1,442 @@
+"""Opt-in persistent route/motion navigation; Python owns external identities."""
+from __future__ import print_function
+
+import ast
+import json
+import sys
+from array import array
+
+
+def _path(path):
+    return [len(path)] + [float(value) for point in path for value in point]
+
+
+def _penalties(values):
+    values = values or {}
+    rows = []
+    for edge in values:
+        rows.extend(edge[0] + edge[1])
+        rows.append(float(values[edge]) if isinstance(values, dict) else 1.0)
+    return [len(values)] + rows
+
+
+class NativeGrid(object):
+    def __init__(self, backend, original, navigation):
+        if not original.prebaked:
+            raise ValueError('native navigation requires a reviewed baked graph')
+        self.backend, self.original = backend, original
+        self.graph = backend.graph(original, navigation)
+        bounds = original.bounds
+        if bounds is not None and len(bounds) != 4:
+            raise ValueError('native navigation requires normalized bounds')
+        self.handle = int(backend.call([500, self.graph.handle, int(bounds is not None)] +
+                                       list(bounds or (0, 0, 0, 0)))[0])
+        self.failed = self.hulls = self.revision = None
+        self.sync_globals()
+
+    def __getattr__(self, name):
+        return getattr(self.original, name)
+
+    def sync_globals(self):
+        original = self.original
+        if (self.failed == original._failed_edges and self.hulls == original._static_hull_edges and
+                self.revision == original.static_hull_revision):
+            return
+        failed = []
+        for edge, value in original._failed_edges.items():
+            failed.extend(edge[0] + edge[1] + value)
+        self.backend.call([502, self.handle, original.static_hull_revision,
+                           len(original._failed_edges)] + failed +
+                          _penalties(original._static_hull_edges))
+        self.failed = dict(original._failed_edges)
+        self.hulls = dict(original._static_hull_edges)
+        self.revision = original.static_hull_revision
+
+    def geometry(self, kind, values, capacity=0):
+        packet = [501, self.handle, kind, len(values)] + list(values)
+        packet.extend([0.0] * max(0, capacity - len(packet)))
+        return self.backend.call(packet)
+
+    def _ground(self, x, z, hint_y):
+        packet = self.geometry(0, (x, hint_y, z))
+        return packet[1] if packet[0] else None
+
+    def segment_clear(self, start, end):
+        return bool(self.geometry(1, tuple(start) + tuple(end))[0])
+
+    def dry_segment_clear(self, start, end, now):
+        return bool(self.geometry(2, tuple(start) + tuple(end) + (now,))[0])
+
+    def segment_has_baked_hazard(self, start, end, mask):
+        return bool(self.geometry(3, tuple(start) + tuple(end) + (mask,))[0])
+
+    def segment_has_motion_hazard(self, start, end, mask):
+        return bool(self.geometry(4, tuple(start) + tuple(end) + (mask,))[0])
+
+    def point_has_baked_hazard(self, point, mask):
+        return bool(self.geometry(5, tuple(point) + (mask,))[0])
+
+    def baked_hazard_near(self, point, max_radius=0):
+        return bool(self.geometry(6, tuple(point) + (max(0, int(max_radius)),))[0])
+
+    def near_baked_navigation(self, point, max_radius=1):
+        return bool(self.geometry(7, tuple(point) + (max(0, int(max_radius)),))[0])
+
+    def hull_pose_clear(self, point, yaw, half_length, half_width):
+        return bool(self.geometry(8, tuple(point) + (yaw, half_length, half_width))[0])
+
+    def local_corridor(self, point):
+        packet = self.geometry(9, point)
+        return tuple(packet[1:3]) if packet[0] else None
+
+    def segment_penalty(self, start, end, now):
+        return self.geometry(10, tuple(start) + tuple(end) + (now,))[0]
+
+    def _cell_capacity(self, start, end):
+        a, b = self.cell_for(start), self.cell_for(end)
+        return max(abs(a[0] - b[0]), abs(a[1] - b[1])) + 5
+
+    def _baked_segment_cells(self, start, end, require_height=True):
+        packet = self.geometry(11, tuple(start) + tuple(end) + (int(require_height),),
+                               1 + self._cell_capacity(start, end) * 2)
+        return tuple((int(packet[1 + i * 2]), int(packet[2 + i * 2]))
+                     for i in range(int(packet[0])))
+
+    def baked_hazard_cells(self, start, end, mask):
+        packet = self.geometry(12, tuple(start) + tuple(end) + (mask,),
+                               1 + self._cell_capacity(start, end) * 2)
+        if packet[0] < 0:
+            return None
+        return tuple((int(packet[1 + i * 2]), int(packet[2 + i * 2]))
+                     for i in range(int(packet[0])))
+
+    def _smooth(self, path, now=0.0, prefer_clearance=False, edge_penalties=None):
+        packet = self.geometry(13, _path(path) + [now, int(prefer_clearance)] +
+                               _penalties(edge_penalties), 1 + len(path) * 3)
+        return tuple(tuple(packet[1 + i * 3:4 + i * 3]) for i in range(int(packet[0])))
+
+    def safe_local_target(self, current, goal, now, avoid_points=None,
+                          side_preference=1.0, edge_penalties=None, minimum_offset=0.0):
+        packet = self.geometry(14, list(current) + list(goal) + [now, side_preference, minimum_offset] +
+                               _path(avoid_points or ()) + _penalties(edge_penalties))
+        return tuple(packet[1:4]) if packet[0] else None
+
+    def path_has_edge_penalty(self, path, edge_penalties):
+        return bool(self.geometry(15, _path(path) + _penalties(edge_penalties))[0])
+
+    def _baked_clearance_exposure(self, path):
+        packet = self.geometry(16, _path(path))
+        return packet[1] if packet[0] else None
+
+    def shortcut_preserves_climb_approach(self, path, start_index, end_index,
+                                         minimum_grade=0.10, minimum_turn=0.30):
+        return bool(self.geometry(17, _path(path) +
+                                 [start_index, end_index, minimum_grade, minimum_turn])[0])
+
+    def live_shortcut_preserves_climb_approach(self, current, path, start_index, end_index):
+        return bool(self.geometry(18, list(current) + _path(path) + [start_index, end_index])[0])
+
+    def shortcut_preserves_baked_clearance(self, path, start_index, end_index,
+                                         maximum_exposure_increase=0.25):
+        return bool(self.geometry(19, _path(path) +
+                                 [start_index, end_index, maximum_exposure_increase])[0])
+
+    def path_has_penalty(self, path, now):
+        return bool(self.geometry(20, _path(path) + [now])[0])
+
+    def path_crosses_static_hull(self, path):
+        return bool(self.geometry(21, _path(path))[0])
+
+    def _edge_keys_for_segment(self, start, end):
+        packet = self.geometry(22, list(start) + list(end),
+                               1 + self._cell_capacity(start, end) * 4)
+        return tuple(((int(packet[1 + i * 4]), int(packet[2 + i * 4])),
+                      (int(packet[3 + i * 4]), int(packet[4 + i * 4])))
+                     for i in range(int(packet[0])))
+
+    def _baked_corridor(self, start, end):
+        packet = self.geometry(23, list(start) + list(end))
+        return bool(packet[0]), None if packet[1] < 0 else int(packet[1])
+
+    def set_static_hulls(self, hulls):
+        changed = self.original.set_static_hulls(hulls)
+        self.sync_globals()
+        return changed
+
+    def close(self):
+        if self.handle is not None and not self.backend.closed:
+            self.backend.call([503, self.handle])
+        self.handle = None
+
+
+def _text(value):
+    encoded = value.encode('utf-8')
+    return [len(encoded)] + list(bytearray(encoded))
+
+
+def _tuples(value):
+    if isinstance(value, list):
+        return tuple(_tuples(item) for item in value)
+    if isinstance(value, dict):
+        result = dict((key, _tuples(item)) for key, item in value.items())
+        for key in ('path_key', 'request_key', 'request_path_key', 'macro_progress_path_key'):
+            if result.get(key) is not None:
+                result[key] = ast.literal_eval(result[key])
+        return result
+    return value
+
+
+class SearchProjection(object):
+    def __init__(self, values):
+        self.__dict__.update(values)
+
+
+class NativeNavigator(object):
+    def __init__(self, backend, original, navigation):
+        self.backend, self.original, self.navigation = backend, original, navigation
+        self.grid = NativeGrid(backend, original.grid, navigation)
+        self.handle = int(backend.call([510, self.grid.handle])[0])
+        self.identities = {}
+        self._native_keys = {}
+        self._cache_order = {}
+        self.paths = {}
+        self.bot_states = {}
+        self._snapshot = None
+        self._snapshot_full = False
+        self._progress = None
+        self._query_packet = array('d', [0.0] * 16384)
+        self._progress_packet = array('d', [0.0] * 1024)
+        navigator = self
+
+        def publish(packet=None):
+            if packet is None:
+                packet = navigator._query_packet
+            kind, identity = int(packet[0]), int(packet[1])
+            if kind == 503:
+                key = bytearray(int(value) for value in packet[3:3 + int(packet[2])]).decode('utf-8')
+                navigator._native_keys[identity] = ast.literal_eval(key)
+            elif kind == 500:
+                key = navigator._native_keys[identity]
+                navigator.paths[key] = tuple(tuple(packet[3 + i * 3:6 + i * 3]) for i in range(int(packet[2])))
+                navigator._cache_order[key] = identity
+            elif kind == 501:
+                key = navigator._native_keys[identity]
+                navigator.paths.pop(key, None)
+                navigator._cache_order.pop(key, None)
+            elif kind == 504:
+                navigator._native_keys.pop(identity)
+            elif kind == 502:
+                order = list(navigator._cache_order.values())
+                if len(order) != identity:
+                    raise AssertionError('native cache keys differ from their projection')
+                packet[2:2 + len(order)] = array('d', order)
+            else:
+                raise RuntimeError('unknown navigation identity event: %s' % kind)
+
+        self._publish_event = publish
+        self.search_max_expansions = original.search_max_expansions
+
+    def __getattr__(self, name):
+        if name in ('searches', 'search_next_key', 'search_credit',
+                    'search_frame_budget', 'search_completed', 'search_failed'):
+            return self.progress_state()[name]
+        if name.startswith(('search_', 'path_', 'fallback_', 'bot_')) or name in ('paths', 'searches', 'housekeeping_time'):
+            full = name not in ('paths', 'searches', 'search_next_key', 'search_credit',
+                                'search_frame_budget', 'search_completed', 'search_failed')
+            snapshot = self.dump_state(full)
+            if name in snapshot:
+                return snapshot[name]
+        return getattr(self.original, name)
+
+    def call(self, kind, values=()):
+        self._snapshot = None
+        self._progress = None
+        packet = [512, self.handle, kind, len(values)] + list(values)
+        packet.extend([0.0] * max(0, 16 - len(packet)))
+        return self.backend.call_sync(packet, self._query_packet, self._publish_event)
+
+    def identity(self, key):
+        key = tuple(key)
+        handle = self.identities.get(key)
+        if handle is None:
+            required = len(repr(key)) + 1024 + self._search_max_expansions * 3
+            if required > len(self._query_packet):
+                self._query_packet = array('d', [0.0] * required)
+            owner = self.original._path_owner(key)
+            handle = int(self.backend.call(
+                [511, self.handle] + _text(repr(key)) + _text(str(key[0]) if key else '') +
+                [-1 if owner is None else owner, int(self.original._prefers_baked_clearance(key))])[0])
+            self.identities[key] = handle
+        return handle
+
+    def _publish(self, bot_id, packet, offset):
+        if not packet[offset]:
+            return
+        row = {'navigation_status': ('pending', 'safe', 'blocked')[int(packet[offset + 1])],
+               'target_is_terminal': bool(packet[offset + 10])}
+        if packet[offset + 2]:
+            row['planned_goal'] = tuple(packet[offset + 3:offset + 6])
+        if packet[offset + 6]:
+            row['controlled_shallow_target'] = tuple(packet[offset + 7:offset + 10])
+        self.bot_states[int(bot_id)] = row
+
+    def begin_frame(self, elapsed):
+        self.call(0, [elapsed])
+
+    def end_frame(self):
+        self.call(1)
+
+    def tick(self, now):
+        self.call(2, [now])
+
+    def _advance_searches(self, now):
+        self.call(11, [now])
+
+    def next_target(self, bot_id, current, goal, path_key, now, anchor=None,
+                    avoid_points=None, lookahead_distance=None, movement_intent=True):
+        values = ([bot_id, self.identity(path_key)] + list(current) + list(goal) +
+                  [now, int(movement_intent), int(anchor is not None)])
+        if anchor is not None:
+            values.extend(anchor)
+        values.append(int(lookahead_distance is not None))
+        if lookahead_distance is not None:
+            values.append(lookahead_distance)
+        packet = self.call(3, values + _path(avoid_points or ()))
+        self._publish(bot_id, packet, 4)
+        return tuple(packet[1:4])
+
+    def observe_direct_target(self, bot_id, current, goal, path_key, now, movement_intent=True):
+        packet = self.call(4, [bot_id, self.identity(path_key)] + list(current) + list(goal) +
+                           [now, int(movement_intent)])
+        self._publish(bot_id, packet, 4)
+        return tuple(packet[1:4]) if packet[0] else None
+
+    def motion_target(self, bot_id, current, goal, path_key, now, anchor,
+                      lookahead_distance, movement_intent, stop_at_goal):
+        values = ([bot_id, self.identity(path_key)] + list(current) + list(goal) +
+                  [now, int(movement_intent), int(anchor is not None)])
+        if anchor is not None:
+            values.extend(anchor)
+        packet = self.call(13, values + [lookahead_distance, int(stop_at_goal)])
+        self._publish(bot_id, packet, 4)
+        return tuple(packet[1:4]), bool(packet[0])
+
+    def report_blocked_step(self, bot_id, current, target, now):
+        values = [bot_id] + list(current) + [int(target is not None)]
+        if target is not None:
+            values.extend(target)
+        packet = self.call(5, values + [now])
+        self._publish(bot_id, packet, 1)
+        return bool(packet[0])
+
+    def bot_segment_penalized(self, bot_id, start, end, now):
+        return bool(self.call(6, [bot_id] + list(start) + list(end) + [now])[0])
+
+    def controlled_shallow_step(self, bot_id, current, sample_yaw, maximum_yaw_error=0.45):
+        return bool(self.call(7, [bot_id] + list(current) + [sample_yaw, maximum_yaw_error])[0])
+
+    def controlled_shallow_committed(self, bot_id, current, travel_yaw):
+        return bool(self.call(8, [bot_id] + list(current) + [travel_yaw, 0.45])[0])
+
+    def target_is_terminal(self, bot_id):
+        return self.bot_states.get(int(bot_id), {}).get('target_is_terminal', False)
+
+    @property
+    def search_max_expansions(self):
+        return self._search_max_expansions
+
+    @search_max_expansions.setter
+    def search_max_expansions(self, value):
+        required = max(16384, int(value) * 3 + 1024)
+        if required > len(self._query_packet):
+            self._query_packet = array('d', [0.0] * required)
+        self.call(10, [int(value)])
+        self._search_max_expansions = int(value)
+
+    def progress_state(self):
+        if self._progress is not None:
+            return self._progress
+        while True:
+            self._progress_packet[0:2] = array('d', [516, self.handle])
+            packet = self.backend.call(self._progress_packet)
+            if packet[1] >= 0:
+                break
+            self._progress_packet = array('d', [0.0] * int(packet[0]))
+        searches = {}
+        for index in range(int(packet[0])):
+            offset = 6 + index * 6
+            key = self._native_keys[int(packet[offset])]
+            searches[key] = SearchProjection(dict(
+                last_frame=packet[offset + 2] if packet[offset + 1] else None,
+                hull_revision=int(packet[offset + 3]), done=bool(packet[offset + 4]),
+                expansions=int(packet[offset + 5])))
+        self._progress = dict(searches=searches, search_credit=packet[1], search_frame_budget=int(packet[2]),
+                              search_completed=int(packet[3]), search_failed=int(packet[4]),
+                              search_next_key=self._native_keys[int(packet[5])] if packet[5] else None)
+        return self._progress
+
+    def dump_state(self, full=True):
+        if self._snapshot is not None and (self._snapshot_full or not full):
+            return self._snapshot
+        size = int(self.backend.call([513, self.handle, int(full)])[0])
+        packet = self.backend.call(array('d', [514, self.handle] + [0.0] * max(0, size - 1)))
+        encoded = bytearray(int(value) for value in packet[1:size + 1])
+        result = json.loads(encoded.decode('utf-8'))
+        for name in ('paths', 'searches', 'path_times', 'path_hull_revisions', 'search_times'):
+            if name in result:
+                result[name] = dict((ast.literal_eval(key), _tuples(value))
+                                    for key, value in result[name].items())
+        result['searches'] = dict((key, SearchProjection(value)) for key, value in result['searches'].items())
+        if result['search_next_key'] is not None:
+            result['search_next_key'] = ast.literal_eval(result['search_next_key'])
+        for name in ('bot_states', 'bot_direct_progress', 'fallback_modes'):
+            if name in result:
+                result[name] = dict((int(key), _tuples(value)) for key, value in result[name].items())
+        for name in ('bot_failed_edges', 'bot_macro_edges'):
+            if name in result:
+                result[name] = dict((int(bot_id), dict((_tuples(row[0]), tuple(row[1:])) for row in rows))
+                                    for bot_id, rows in result[name].items())
+        if 'grid_failed_edges' in result:
+            result['grid_failed_edges'] = dict((_tuples(row[0]), tuple(row[1:])) for row in result['grid_failed_edges'])
+        self._snapshot, self._snapshot_full = result, full
+        return result
+
+    def fallback_diagnostics(self, active_bot_ids=None, now=None):
+        if active_bot_ids is not None:
+            self.call(12, [len(active_bot_ids)] + list(active_bot_ids))
+        snapshot = self.dump_state()
+        active = dict((key, 0) for key in ('pending', 'safe_direct', 'safe_local', 'reactive'))
+        for mode in snapshot['fallback_modes'].values():
+            active[mode] += 1
+        times = snapshot['search_times']
+        search_now = snapshot['search_now']
+        return dict(
+            graph=dict(source='baked', cell_mm=int(round(self.grid.cell_size * 1000.0)),
+                       nodes=sum(1 for value in self.grid._baked_heights if value is not None)),
+            total=dict(snapshot['fallback_totals']), active=active, recovered=snapshot['fallback_recovered'],
+            search=dict(pending=len(snapshot['searches']), completed=snapshot['search_completed'],
+                        failed=snapshot['search_failed'],
+                        oldest_ms=int(max(0.0, search_now - min(times.values())) * 1000.0) if times else 0,
+                        tick_age_ms=int(max(0.0, now - search_now) * 1000.0) if now is not None else 0),
+            blocked_step_replans=sum(state['blocked_step_replans'] for state in snapshot['bot_states'].values()),
+            macro_progress_replans=(sum(state['macro_progress_replans'] for state in snapshot['bot_states'].values()) +
+                                    sum(state['replans'] for state in snapshot['bot_direct_progress'].values())))
+
+    def close(self):
+        if self.handle is not None and not self.backend.closed:
+            self.backend.call([515, self.handle])
+        self.handle = None
+        self.grid.close()
+
+
+class NavigationFlowBackend(object):
+    def __init__(self, backend, runtime, navigation):
+        self.runtime = runtime
+        self.original = runtime.navigator
+        self.navigator = NativeNavigator(backend, self.original, navigation)
+        runtime.navigator = self.navigator
+
+    def close(self):
+        if self.runtime.navigator is self.navigator:
+            self.runtime.navigator = self.original
+        self.navigator.close()

--- a/tools/ffi_experiment/navigation_graph.h
+++ b/tools/ffi_experiment/navigation_graph.h
@@ -1,0 +1,31 @@
+#ifndef OFFLINE_EXPERIMENT_NAVIGATION_GRAPH_H
+#define OFFLINE_EXPERIMENT_NAVIGATION_GRAPH_H
+
+#include <cmath>
+#include <cstdint>
+#include <memory>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+// Shared immutable map storage for A*, corridor tests, route state and motion.
+// Handles own C++ data only; neither a Python object nor a caller buffer lives
+// here. Index edges are used only by the search, whose endpoints are in bounds.
+struct OfflineNavGraph {
+    int width, height;
+    double cell, ox, oz, grade, heuristic, clearance, shallow, diagonal;
+    std::vector<double> heights;
+    std::vector<unsigned char> links, hazards;
+    std::unordered_map<uint64_t, std::pair<double, double> > failed;
+    std::unordered_map<uint64_t, double> hulls;
+    std::vector<uint64_t> expired;
+    bool valid(int i) const {
+        return i >= 0 && i < width * height && std::isfinite(heights[i]);
+    }
+    double distance(int a, int b) const {
+        double dx = a % width - b % width, dz = a / width - b / width;
+        return std::sqrt(dx * dx + dz * dz);
+    }
+};
+std::shared_ptr<OfflineNavGraph> offline_navigation_graph(int handle);
+#endif

--- a/tools/ffi_experiment/navigation_grid.h
+++ b/tools/ffi_experiment/navigation_grid.h
@@ -1,0 +1,301 @@
+#ifndef OFFLINE_EXPERIMENT_NAVIGATION_GRID_H
+#define OFFLINE_EXPERIMENT_NAVIGATION_GRID_H
+
+#include "navigation_graph.h"
+#include <algorithm>
+#include <array>
+#include <deque>
+#include <map>
+#include <set>
+#include <stdexcept>
+#include <tuple>
+
+namespace offline_nav {
+const double pi = 3.14159265358979323846;
+struct Point {
+    double x, y, z;
+    Point(double a=0, double b=0, double c=0):x(a),y(b),z(c){}
+    bool operator==(const Point &v) const { return x==v.x && y==v.y && z==v.z; }
+    bool operator!=(const Point &v) const { return !(*this==v); }
+};
+using Cell = std::pair<int,int>;
+using Edge = std::pair<Cell,Cell>;
+using Path = std::vector<Point>;
+using Penalties = std::map<Edge,double>;
+using TimedPenalties = std::map<Edge,std::pair<double,double> >;
+inline double distance(Point a,Point b) {
+    double x=a.x-b.x,z=a.z-b.z;return std::sqrt(x*x+z*z);
+}
+inline double wrap(double v) {
+    while(v>pi)v-=2*pi;
+    while(v<-pi)v+=2*pi;
+    return v;
+}
+inline Edge edge(Cell a,Cell b) {return a<b?Edge(a,b):Edge(b,a);}
+inline std::vector<Cell> line(Cell start,Cell end) {
+    std::vector<Cell> cells(1,start);
+    int x=start.first,z=start.second,dx=std::abs(end.first-x),dz=std::abs(end.second-z);
+    int sx=x<end.first?1:-1,sz=z<end.second?1:-1,error=dx-dz;
+    while(x!=end.first||z!=end.second){
+        int twice=error*2;
+        if(twice>-dz){error-=dz;x+=sx;}
+        if(twice<dx){error+=dx;z+=sz;}
+        cells.push_back(Cell(x,z));
+    }
+    return cells;
+}
+inline bool climb(const Path &path,int first,int last,double grade=0.10,double turn_limit=0.30) {
+    if(last-first<2)return true;
+    for(int i=first+1;i<last;++i){
+        Point before=path[i-1],pivot=path[i],after=path[i+1];
+        double ox=after.x-pivot.x,oz=after.z-pivot.z,run=std::sqrt(ox*ox+oz*oz);
+        if(run<=0.1||(after.y-pivot.y)/run<=grade)continue;
+        double ix=pivot.x-before.x,iz=pivot.z-before.z;
+        if(std::abs(ix)+std::abs(iz)<=0.1)continue;
+        if(std::abs(wrap(std::atan2(ox,oz)-std::atan2(ix,iz)))>turn_limit)return false;
+    }
+    return true;
+}
+inline bool live_climb(Point current,const Path &path,int first,int last) {
+    if(last<first)return true;
+    Path live(1,current);live.insert(live.end(),path.begin()+first,path.begin()+last+1);
+    return climb(live,0,static_cast<int>(live.size())-1);
+}
+
+struct Grid {
+    std::shared_ptr<OfflineNavGraph> data;
+    bool bounded=false;
+    std::array<double,4> bounds;
+    TimedPenalties failed;
+    Penalties hulls;
+    int hull_revision=0;
+    // A corridor's hazard value -1 is the source's None sentinel. The start
+    // cell is excluded from hazard accumulation so a vehicle can leave water.
+    std::map<std::pair<Cell,Cell>,std::pair<bool,int> > corridors;
+    std::deque<std::pair<Cell,Cell> > corridor_order;
+    std::map<Cell,std::pair<double,double> > local_corridors;
+    explicit Grid(std::shared_ptr<OfflineNavGraph> graph):data(graph){}
+    Cell cell(Point p) const {
+        double x=std::floor((p.x-data->ox)/data->cell+0.5);
+        double z=std::floor((p.z-data->oz)/data->cell+0.5);
+        if(!std::isfinite(x)||!std::isfinite(z)||std::abs(x)>1000000||std::abs(z)>1000000)
+            throw std::invalid_argument("navigation coordinate");
+        return Cell(static_cast<int>(x),static_cast<int>(z));
+    }
+    int index(Cell c,bool height=true) const {
+        if(c.first<0||c.second<0||c.first>=data->width||c.second>=data->height)return -1;
+        int i=c.second*data->width+c.first;
+        return height&&!data->valid(i)?-1:i;
+    }
+    bool inside(Point p) const {
+        return !bounded||(bounds[0]<=p.x&&p.x<=bounds[2]&&bounds[1]<=p.z&&p.z<=bounds[3]);
+    }
+    Point point(Cell c,double y) const {return Point(data->ox+c.first*data->cell,y,data->oz+c.second*data->cell);}
+    bool nearest(Cell c,int radius,Cell &result) const {
+        if(index(c)>=0){result=c;return true;}
+        for(int r=1;r<=radius;++r){
+            bool found=false;double best=0;
+            for(int z=c.second-r;z<=c.second+r;++z)for(int x=c.first-r;x<=c.first+r;++x){
+                if(std::max(std::abs(x-c.first),std::abs(z-c.second))!=r||index(Cell(x,z))<0)continue;
+                double dx=x-c.first,dz=z-c.second,d=dx*dx+dz*dz;
+                if(!found||d<best){result=Cell(x,z);found=true;best=d;}
+            }
+            if(found)return true;
+        }
+        return false;
+    }
+    bool ground(Point p,double &height) const {
+        int i=index(cell(p));if(!inside(p)||i<0)return false;
+        height=data->heights[i]/1000.0;return true;
+    }
+    std::vector<Cell> segment_cells(Point start,Point end,bool height=true) const {
+        Cell a=cell(start),b=cell(end);
+        if(height&&!nearest(a,2,a))return {};
+        if(index(a,height)<0||index(b,height)<0)return {};
+        return line(a,b);
+    }
+    std::vector<Edge> edges(Point a,Point b) const {
+        auto cells=line(cell(a),cell(b));std::vector<Edge> out;
+        for(size_t i=1;i<cells.size();++i)out.push_back(edge(cells[i-1],cells[i]));
+        return out;
+    }
+    bool linked(Cell a,Cell b) const {
+        int ia=index(a),ib=index(b);if(ia<0||ib<0)return false;
+        static const int xs[]={-1,0,1,-1,1,-1,0,1},zs[]={-1,-1,-1,0,0,1,1,1};
+        for(int i=0;i<8;++i)if(b.first-a.first==xs[i]&&b.second-a.second==zs[i])
+            return (data->links[ia]&(1<<i))!=0;
+        return false;
+    }
+    int link_count(Cell c) const {
+        int i=index(c),count=0;if(i<0)return 0;
+        for(int bit=0;bit<8;++bit)count+=!!(data->links[i]&(1<<bit));
+        return count;
+    }
+    std::pair<bool,int> corridor(Point start,Point end) {
+        auto key=std::make_pair(cell(start),cell(end));auto cached=corridors.find(key);
+        if(cached!=corridors.end())return cached->second;
+        auto cells=segment_cells(start,end);bool clear=!cells.empty();int hazards=clear?0:-1;
+        for(size_t i=1;i<cells.size();++i){
+            int idx=index(cells[i]);if(idx<0){clear=false;hazards=-1;break;}
+            hazards|=data->hazards[idx];
+            if(clear&&!linked(cells[i-1],cells[i]))clear=false;
+        }
+        if(corridors.size()>=2048){corridors.erase(corridor_order.front());corridor_order.pop_front();}
+        auto answer=std::make_pair(clear,hazards);corridors[key]=answer;corridor_order.push_back(key);return answer;
+    }
+    bool hazard(Point a,Point b,int mask) {
+        int bits=corridor(a,b).second;return bits<0||(bits&mask)!=0;
+    }
+    bool motion_hazard(Point a,Point b,int mask) const {
+        auto cells=segment_cells(a,b,false);if(cells.empty())return true;
+        for(size_t j=1;j<cells.size();++j){int i=index(cells[j],false);if(i<0||(data->hazards[i]&mask))return true;}
+        return false;
+    }
+    bool hazard_cells(Point a,Point b,int mask,std::vector<Cell> &result) const {
+        if(index(cell(a))<0)return false;
+        auto cells=segment_cells(a,b);if(cells.empty())return false;
+        for(size_t j=1;j<cells.size();++j){
+            int i=index(cells[j]);if(i<0)return false;
+            if(data->hazards[i]&mask)result.push_back(cells[j]);
+        }
+        return true;
+    }
+    bool point_hazard(Point p,int mask) const {
+        int i=index(cell(p),false);return i>=0&&(data->hazards[i]&mask);
+    }
+    bool hazard_near(Point p,int radius) const {
+        Cell c=cell(p);
+        for(int z=c.second-radius;z<=c.second+radius;++z)for(int x=c.first-radius;x<=c.first+radius;++x){
+            int i=index(Cell(x,z),false);if(i>=0&&(data->hazards[i]&3))return true;
+        }
+        return false;
+    }
+    bool segment_clear(Point a,Point b) {
+        if(!inside(b))return false;
+        return distance(a,b)<0.25||corridor(a,b).first;
+    }
+    double timed(Edge e,double now) {
+        auto it=failed.find(e);if(it==failed.end())return 0;
+        if(now>=it->second.first){failed.erase(it);return 0;}
+        return it->second.second;
+    }
+    double segment_penalty(Point a,Point b,double now) {
+        if(failed.empty()&&hulls.empty())return 0;
+        double value=0;
+        for(Edge e:edges(a,b)){auto h=hulls.find(e);value=std::max(value,std::max(h==hulls.end()?0.0:h->second,timed(e,now)));}
+        return value;
+    }
+    bool dry(Point a,Point b,double now) {
+        return segment_penalty(a,b,now)<=0&&!hazard(a,b,4)&&segment_clear(a,b);
+    }
+    bool path_timed(const Path &path,double now) {
+        if(failed.empty())return false;
+        for(size_t i=1;i<path.size();++i)for(Edge e:edges(path[i-1],path[i]))if(timed(e,now)>0)return true;
+        return false;
+    }
+    bool path_penalty(const Path &path,const Penalties &penalties) const {
+        if(penalties.empty())return false;
+        for(size_t i=1;i<path.size();++i)for(Edge e:edges(path[i-1],path[i]))if(penalties.count(e))return true;
+        return false;
+    }
+    bool exposure(const Path &path,double &value) const {
+        if(path.empty()){value=0;return true;}
+        std::vector<Cell> cells;
+        if(path.size()==1){Cell c;if(!nearest(cell(path[0]),2,c))return false;cells.push_back(c);}
+        else for(size_t i=1;i<path.size();++i){
+            auto segment=segment_cells(path[i-1],path[i]);if(segment.empty())return false;
+            size_t begin=!cells.empty()&&cells.back()==segment.front()?1:0;
+            cells.insert(cells.end(),segment.begin()+begin,segment.end());
+        }
+        if(cells.empty())return false;
+        int missing=0;for(Cell c:cells)missing+=8-link_count(c);
+        value=static_cast<double>(missing)/cells.size();return true;
+    }
+    bool clearance(const Path &path,int first,int last,double maximum=0.25) const {
+        if(last-first<2)return true;
+        double original,shortcut;
+        return exposure(Path(path.begin()+first,path.begin()+last+1),original)&&
+            exposure(Path{path[first],path[last]},shortcut)&&shortcut<=original+maximum;
+    }
+    double penalty(Cell c,const Path &avoid,bool prefer=false) const {
+        double value=prefer?static_cast<double>(8-link_count(c))*data->cell*data->clearance:0;
+        int i=index(c);if(i>=0&&(data->hazards[i]&4))value+=data->cell*data->shallow;
+        Point p=point(c,0);
+        for(Point other:avoid){double d=distance(p,other);if(d<data->cell*1.5)value+=(data->cell*1.5-d)*3.0;}
+        return value;
+    }
+    bool safe_local(Point current,Point goal,double now,const Path &avoid,double side,
+                    const Penalties &hard,double minimum,Point &result) {
+        double dx=goal.x-current.x,dz=goal.z-current.z;
+        if(std::abs(dx)+std::abs(dz)<0.1)return false;
+        double desired=std::atan2(dx,dz);side=side>=0?1:-1;
+        double offsets[]={0,side*0.45,-side*0.45,side*0.85,-side*0.85,side*1.30,-side*1.30,side*1.75,-side*1.75};
+        double distances[]={data->cell*0.78,data->cell*0.52};
+        bool found=false;std::pair<double,double> best;
+        for(double d:distances)for(double offset:offsets){
+            if(std::abs(offset)<std::max(0.0,minimum))continue;
+            Point p(current.x+std::sin(desired+offset)*d,current.y,current.z+std::cos(desired+offset)*d);
+            if(!ground(p,p.y)||!dry(current,p,now)||path_penalty(Path{current,p},hard))continue;
+            double score=distance(p,goal)+std::abs(offset)*3.5+penalty(cell(p),avoid)*2.0;
+            auto rank=std::make_pair(score,std::abs(offset));
+            if(!found||rank<best){found=true;best=rank;result=p;}
+        }
+        return found;
+    }
+    Path smooth(const Path &path,double now,bool prefer,const Penalties &hard) {
+        if(path.size()<3)return path;
+        Path out(1,path[0]);int i=0,last=static_cast<int>(path.size())-1;
+        while(i<last){
+            int furthest=std::min(last,i+6);
+            while(furthest>i+1){
+                if((!prefer||clearance(path,i,furthest))&&climb(path,i,furthest)&&
+                        !path_penalty(Path{path[i],path[furthest]},hard)&&dry(path[i],path[furthest],now))break;
+                --furthest;
+            }
+            out.push_back(path[furthest]);i=furthest;
+        }
+        return out;
+    }
+    bool pose(Point p,double yaw,double length,double width) const {
+        length=std::max(0.5,length);width=std::max(0.3,width);
+        double s=std::sin(yaw),c=std::cos(yaw),along[]={-length,0,length},across[]={-width,0,width};
+        for(double a:along)for(double b:across)if(index(cell(Point(p.x+s*a+c*b,0,p.z+c*a-s*b)))<0)return false;
+        return true;
+    }
+    bool local_corridor(Point p,std::pair<double,double> &result) {
+        Cell base=cell(p);if(index(base)<0)return false;
+        auto cached=local_corridors.find(base);if(cached!=local_corridors.end()){result=cached->second;return true;}
+        const int xs[]={1,1,0,-1},zs[]={0,1,1,1};double spans[4];int longest=0;
+        for(int axis=0;axis<4;++axis){
+            int cells=1;
+            for(int sign:{1,-1})for(int reach=1;reach<=5;++reach){
+                if(index(Cell(base.first+xs[axis]*reach*sign,base.second+zs[axis]*reach*sign))<0)break;
+                ++cells;
+            }
+            spans[axis]=cells*(std::hypot(xs[axis],zs[axis])*data->cell);
+            if(spans[axis]>spans[longest])longest=axis;
+        }
+        result=std::make_pair(std::atan2(static_cast<double>(xs[longest]),static_cast<double>(zs[longest])),spans[(longest+2)%4]);
+        local_corridors[base]=result;return true;
+    }
+    bool search_edge(Edge e,uint64_t &key) const {
+        int a=index(e.first,false),b=index(e.second,false);
+        if(a<0||b<0)return false;
+        if(a>b)std::swap(a,b);
+        key=(static_cast<uint64_t>(a)<<32)|static_cast<uint32_t>(b);return true;
+    }
+    void search_globals(){
+        data->failed.clear();data->hulls.clear();data->expired.clear();uint64_t key;
+        for(auto item:failed)if(search_edge(item.first,key))data->failed[key]=item.second;
+        for(auto item:hulls)if(search_edge(item.first,key))data->hulls[key]=item.second;
+    }
+    void drain_search_expiry(){
+        for(uint64_t key:data->expired){
+            int a=static_cast<int>(key>>32),b=static_cast<uint32_t>(key);
+            failed.erase(edge(Cell(a%data->width,a/data->width),Cell(b%data->width,b/data->width)));
+        }
+        data->expired.clear();
+    }
+};
+}
+#endif

--- a/tools/ffi_experiment/navigation_search.h
+++ b/tools/ffi_experiment/navigation_search.h
@@ -1,0 +1,23 @@
+#ifndef OFFLINE_EXPERIMENT_NAVIGATION_SEARCH_H
+#define OFFLINE_EXPERIMENT_NAVIGATION_SEARCH_H
+#include "navigation_graph.h"
+#include <unordered_set>
+
+// The complete navigator calls this directly; there is no Python conversion or
+// FFI dispatch between a paid search step and native route finalization.
+class OfflineNavigationSearch {
+    struct Impl;
+    std::unique_ptr<Impl> impl;
+public:
+    OfflineNavigationSearch(std::shared_ptr<OfflineNavGraph> graph,int start,int goal,
+                            int maximum,double now,bool prefer);
+    ~OfflineNavigationSearch();
+    void inputs(const std::vector<std::pair<double,double> > &avoid,
+                const std::unordered_map<uint64_t,double> &local,
+                const std::unordered_set<uint64_t> &hard,bool hard_present);
+    void step();
+    bool done() const;
+    int expansions() const;
+    const std::vector<int> &path() const;
+};
+#endif

--- a/tools/ffi_experiment/navigation_snapshot.h
+++ b/tools/ffi_experiment/navigation_snapshot.h
@@ -1,0 +1,102 @@
+#ifndef OFFLINE_EXPERIMENT_NAVIGATION_SNAPSHOT_H
+#define OFFLINE_EXPERIMENT_NAVIGATION_SNAPSHOT_H
+#include "navigation_state.h"
+#include <iomanip>
+#include <sstream>
+
+// Diagnostic projection is explicit and outside the native navigation flow.
+// It exists to compare every persistent field with the Python reference.
+namespace offline_nav {
+inline std::string quoted(const std::string &value){
+    std::string out="\"";
+    const char *digits="0123456789abcdef";
+    for(unsigned char c:value){
+        if(c=='"'||c=='\\'){out+='\\';out+=c;}
+        else if(c<32){out+="\\u00";out+=digits[c>>4];out+=digits[c&15];}
+        else out+=c;
+    }
+    return out+'"';
+}
+inline std::string number(double v){std::ostringstream out;out<<std::setprecision(17)<<v;return out.str();}
+inline std::string boolean(bool v){return v?"true":"false";}
+inline std::string key_value(const std::string &v){return v.empty()?"null":quoted(v);}
+inline std::string point_value(Point p){return "["+number(p.x)+","+number(p.y)+","+number(p.z)+"]";}
+inline std::string cell_value(Cell c){return "["+std::to_string(c.first)+","+std::to_string(c.second)+"]";}
+inline std::string edge_value(Edge e){return "["+cell_value(e.first)+","+cell_value(e.second)+"]";}
+inline std::string point_value(Optional<Point> p){return p.has?point_value(p.value):"null";}
+inline std::string number(Optional<double> v){return v.has?number(v.value):"null";}
+inline std::string path_value(const Path &path){std::string out="[";for(Point p:path){if(out.size()>1)out+=',';out+=point_value(p);}return out+"]";}
+struct Object {
+    std::string text="{";
+    void field(const std::string &key,const std::string &value){if(text.size()>1)text+=',';text+=quoted(key)+":"+value;}
+    std::string done()const{return text+"}";}
+};
+inline std::string state_value(const State &s){
+    Object out;
+    out.field("last_position",point_value(s.last_position));out.field("progress_time",number(s.progress_time));
+    out.field("path_key",key_value(s.path_key));out.field("index",number(s.index));out.field("recovery",number(s.recovery));
+    out.field("recovery_until",number(s.recovery_until));out.field("recovery_key","null");out.field("recovery_start",point_value(s.recovery_start));
+    out.field("request_key",key_value(s.request_key));out.field("request_path_key",key_value(s.request_path_key));out.field("planned_goal",point_value(s.planned_goal));
+    out.field("planned_at",number(s.planned_at));out.field("navigation_status",quoted(s.status==0?"pending":s.status==1?"safe":"blocked"));
+    out.field("target_is_terminal",boolean(s.terminal));out.field("replan_generation",number(s.generation));out.field("replan_active",boolean(s.replan_active));
+    out.field("macro_replan_active",boolean(s.macro_active));out.field("macro_progress_replans",number(s.macro_replans));out.field("macro_progress_at",number(s.macro_at));
+    out.field("macro_progress_position",point_value(s.macro_position));out.field("macro_progress_target",point_value(s.macro_target));
+    out.field("macro_progress_path_key",key_value(s.macro_path_key));out.field("macro_progress_index",number(s.macro_index));
+    out.field("blocked_step_replans",number(s.blocked_replans));out.field("blocked_step_escalated_until",number(s.blocked_until));
+    if(s.tracker.has){
+        const BlockedTracker &t=s.tracker.value;Object tracker;
+        tracker.field("key",edge_value(t.key));tracker.field("count",number(t.count));tracker.field("first_at",number(t.first));
+        tracker.field("last_at",number(t.last));tracker.field("origin",point_value(t.origin));out.field("blocked_step_tracker",tracker.done());
+    }else out.field("blocked_step_tracker","null");
+    if(s.last_target.has)out.field("last_target",point_value(s.last_target));
+    if(s.shallow.has)out.field("controlled_shallow_target",point_value(s.shallow));
+    if(s.pending_since.has)out.field("pending_since",number(s.pending_since));
+    if(s.escape.has)out.field("macro_escape_target",point_value(s.escape));
+    if(s.escape_until.has)out.field("macro_escape_until",number(s.escape_until));
+    return out.done();
+}
+inline std::string timed_value(const TimedPenalties &values){
+    std::string out="[";for(auto item:values){if(out.size()>1)out+=',';out+="["+edge_value(item.first)+","+number(item.second.first)+","+number(item.second.second)+"]";}return out+"]";
+}
+inline std::string penalties_value(const std::map<int,TimedPenalties> &values){
+    Object out;for(const auto &item:values)out.field(std::to_string(item.first),timed_value(item.second));return out.done();
+}
+inline std::string snapshot(const Navigator &nav,bool full){
+    Object out,paths,searches,times,revisions,search_times;
+    for(const auto &item:nav.paths)paths.field(item.first,path_value(*item.second));
+    for(const auto &item:nav.searches){
+        Object job;job.field("last_frame",number(item.second.last_frame));job.field("hull_revision",number(item.second.revision));
+        job.field("done",boolean(item.second.search->done()));job.field("expansions",number(item.second.search->expansions()));
+        searches.field(item.first,job.done());
+    }
+    out.field("paths",paths.done());out.field("searches",searches.done());
+    out.field("search_next_key",key_value(nav.next_key));out.field("search_credit",number(nav.credit));out.field("search_frame_budget",number(nav.budget));
+    out.field("search_completed",number(nav.completed));out.field("search_failed",number(nav.failed_count));
+    if(!full)return out.done();
+    for(const auto &item:nav.path_times)times.field(item.first,number(item.second));
+    for(const auto &item:nav.revisions)revisions.field(item.first,number(item.second));
+    for(const auto &item:nav.search_times)search_times.field(item.first,number(item.second));
+    out.field("path_times",times.done());out.field("path_hull_revisions",revisions.done());out.field("search_times",search_times.done());
+    out.field("search_frame_time",number(nav.frame_time));out.field("housekeeping_time",number(nav.housekeeping));
+    out.field("search_frame_serial",number(nav.serial));out.field("search_processed_frame",number(nav.processed));out.field("search_frame_open",boolean(nav.frame_open));
+    out.field("search_auto_time",number(nav.auto_time));out.field("search_now",number(nav.now));out.field("search_max_expansions",number(nav.maximum));
+    Object states,direct,modes,totals;
+    for(const auto &item:nav.states)states.field(std::to_string(item.first),state_value(item.second));
+    for(const auto &item:nav.direct){
+        const DirectState &s=item.second;Object value;
+        value.field("path_key",key_value(s.path_key));value.field("target",point_value(s.target));value.field("position",point_value(s.position));
+        value.field("progress_at",number(s.progress_at));value.field("replans",number(s.replans));
+        if(s.escape.has)value.field("escape_target",point_value(s.escape));
+        if(s.until.has)value.field("escape_until",number(s.until));
+        direct.field(std::to_string(item.first),value.done());
+    }
+    const char *names[]={"pending","safe_direct","safe_local","reactive"};
+    for(const auto &item:nav.modes)modes.field(std::to_string(item.first),quoted(names[item.second]));
+    for(int i=0;i<4;++i)totals.field(names[i],number(nav.totals[i]));
+    out.field("bot_states",states.done());out.field("bot_direct_progress",direct.done());out.field("fallback_modes",modes.done());out.field("fallback_totals",totals.done());
+    out.field("fallback_recovered",number(nav.recovered));out.field("bot_failed_edges",penalties_value(nav.failed));out.field("bot_macro_edges",penalties_value(nav.macro));
+    out.field("grid_failed_edges",timed_value(nav.grid->failed));
+    return out.done();
+}
+}
+#endif

--- a/tools/ffi_experiment/navigation_state.h
+++ b/tools/ffi_experiment/navigation_state.h
@@ -1,0 +1,452 @@
+#ifndef OFFLINE_EXPERIMENT_NAVIGATION_STATE_H
+#define OFFLINE_EXPERIMENT_NAVIGATION_STATE_H
+
+#include "navigation_grid.h"
+#include "navigation_search.h"
+#include "query_bridge.h"
+#include <string>
+
+namespace offline_nav {
+template<class T> struct Optional {
+    bool has=false;T value{};
+    Optional(){}
+    Optional(T v):has(true),value(v){}
+    Optional &operator=(T v){has=true;value=v;return *this;}
+    void reset(){has=false;}
+};
+struct Identity {
+    std::string repr,kind;
+    int owner=-1;
+    bool prefer=false;
+};
+inline std::string cell_repr(Cell c){return "("+std::to_string(c.first)+", "+std::to_string(c.second)+")";}
+inline Identity prefixed(const Identity &base,const std::string &kind,int owner,const std::string &third){
+    Identity result;
+    result.repr="('"+kind+"', "+std::to_string(owner)+", "+third;
+    result.repr+=(base.repr=="()"?")":", "+base.repr.substr(1));
+    result.kind=kind;result.owner=owner;result.prefer=kind=="continue"&&base.kind=="route";
+    return result;
+}
+struct BlockedTracker {Edge key;int count;double first,last;Point origin;};
+struct State {
+    Point last_position,macro_position;
+    double progress_time,planned_at=0,macro_at;
+    std::string path_key,request_key,request_path_key,macro_path_key;
+    Optional<Point> last_target,planned_goal,recovery_start,macro_target,shallow,escape;
+    Optional<double> pending_since,escape_until;
+    int index=0,recovery=0,generation=0,macro_replans=0,macro_index=0,blocked_replans=0;
+    double recovery_until=0,blocked_until=0;
+    bool terminal=false,replan_active=false,macro_active=false;
+    int status=0; // pending, safe, blocked
+    Optional<BlockedTracker> tracker;
+    State(Point current,double now):last_position(current),macro_position(current),progress_time(now),macro_at(now){}
+};
+struct DirectState {
+    std::string path_key;Point target,position;double progress_at;
+    int replans=0;Optional<Point> escape;Optional<double> until;
+    DirectState(const std::string &key,Point goal,Point current,double now):path_key(key),target(goal),position(current),progress_at(now){}
+};
+struct SearchJob {
+    Identity identity;Point goal;Penalties hard;
+    int revision;Optional<double> last_frame;
+    std::unique_ptr<OfflineNavigationSearch> search;
+};
+struct Navigator {
+    std::shared_ptr<Grid> grid;
+    std::map<std::string,std::shared_ptr<Path> > paths;
+    std::map<std::string,double> path_times,search_times;
+    std::map<std::string,int> revisions;
+    std::map<std::string,int> key_ids;
+    int next_key_id=1;
+    std::map<std::string,SearchJob> searches;
+    std::map<int,State> states;
+    std::map<int,DirectState> direct;
+    std::map<int,TimedPenalties> failed,macro;
+    std::map<int,int> modes;
+    std::array<int,4> totals{{0,0,0,0}}; // pending, safe_direct, safe_local, reactive
+    int recovered=0,completed=0,failed_count=0,maximum=4096;
+    Optional<double> frame_time,housekeeping,auto_time;
+    std::string next_key;
+    double credit=0,now=0;
+    int serial=0,processed=-1,budget=96;
+    bool frame_open=false;
+    explicit Navigator(std::shared_ptr<Grid> value):grid(value){}
+    std::string cache_key(const Identity &identity,Point goal) const {
+        return "("+identity.repr+", "+cell_repr(grid->cell(goal))+")";
+    }
+    void set_mode(int id,int mode){
+        if(mode<0||mode==1){auto state=states.find(id);if(state!=states.end())state->second.pending_since.reset();}
+        auto old=modes.find(id);
+        if(old!=modes.end()&&old->second==mode)return;
+        if(old==modes.end()&&mode<0)return;
+        if(old!=modes.end()&&mode<0)++recovered;
+        if(mode<0)modes.erase(id);else{modes[id]=mode;++totals[mode];}
+    }
+    Penalties active(std::map<int,TimedPenalties> &collection,int owner,double at){
+        Penalties result;if(owner<0)return result;
+        auto found=collection.find(owner);if(found==collection.end())return result;
+        for(auto it=found->second.begin();it!=found->second.end();){
+            if(at>=it->second.first)it=found->second.erase(it);
+            else{result[it->first]=it->second.second;++it;}
+        }
+        if(found->second.empty())collection.erase(found);
+        return result;
+    }
+    Penalties planning(int owner,double at){
+        Penalties result=active(failed,owner,at);
+        for(auto item:active(macro,owner,at))result[item.first]=item.second;
+        return result;
+    }
+    bool penalized(int owner,Point a,Point b,double at,bool only_macro=false){
+        return grid->path_penalty(Path{a,b},only_macro?active(macro,owner,at):planning(owner,at));
+    }
+    void cancel(int owner,const std::string &keep="",const std::string &kind=""){
+        for(auto it=searches.begin();it!=searches.end();){
+            if(it->second.identity.owner==owner&&it->first!=keep&&(kind.empty()||it->second.identity.kind==kind)){
+                std::string retired=it->first;
+                search_times.erase(retired);it=searches.erase(it);retire_key(retired);
+            }else ++it;
+        }
+    }
+    void reset_macro(State &s,Point current,Optional<Point> target,double at){
+        s.macro_at=at;s.macro_position=current;s.macro_target=target;s.macro_path_key=s.path_key;s.macro_index=s.index;
+    }
+    void finish_macro(int id,State &s){
+        macro.erase(id);s.escape.reset();s.escape_until.reset();s.macro_active=false;s.replan_active=false;
+        s.recovery_start.reset();s.path_key.clear();s.index=0;cancel(id);
+    }
+    bool start_macro(int id,State &s,Point current,Point target,double at){
+        Point escape;bool has=grid->safe_local(current,target,at,{},id%2?1:-1,{},0.42,escape);
+        auto edges=grid->edges(current,target);
+        if(edges.empty()&&!has)return false;
+        if(has){s.escape=escape;s.escape_until=at+4.0;}
+        else macro[id][edges[0]]=std::make_pair(at+4.0,240.0);
+        ++s.generation;++s.macro_replans;s.path_key.clear();s.index=0;s.recovery_start=current;
+        s.replan_active=!has;s.macro_active=true;s.pending_since=at-0.6;s.shallow.reset();cancel(id);
+        reset_macro(s,current,target,at);return true;
+    }
+    bool observe_macro(int id,State &s,Point current,Point goal,double at){
+        Optional<Point> target=s.last_target;
+        if(s.macro_active&&!s.escape.has&&active(macro,id,at).empty()){
+            finish_macro(id,s);reset_macro(s,current,target,at);return false;
+        }
+        if(!target.has||distance(current,target.value)<=1.5||distance(current,goal)<=1.5){reset_macro(s,current,target,at);return false;}
+        bool changed=s.macro_path_key!=s.path_key||s.macro_index!=s.index;
+        if(!s.macro_target.has||changed||distance(s.macro_target.value,target.value)>2.0){reset_macro(s,current,target,at);return false;}
+        double progress=distance(s.macro_position,target.value)-distance(current,target.value);
+        s.macro_target=target;
+        if(progress>=0.20){if(s.macro_active)finish_macro(id,s);reset_macro(s,current,target,at);return false;}
+        return at-s.macro_at>=12.0?start_macro(id,s,current,target.value,at):false;
+    }
+    Optional<Point> observe_direct(int id,Point current,Point goal,const Identity &identity,double at,bool movement){
+        auto it=direct.find(id);
+        if(it==direct.end())it=direct.emplace(id,DirectState(identity.repr,goal,current,at)).first;
+        DirectState &s=it->second;
+        if(s.path_key!=identity.repr||distance(s.target,goal)>2.0||!movement||distance(current,goal)<=1.5){
+            s.path_key=identity.repr;s.target=goal;s.position=current;s.progress_at=at;s.escape.reset();s.until.reset();return {};
+        }
+        if(s.escape.has){
+            if(at<(s.until.has?s.until.value:at)&&distance(current,s.escape.value)>1.5&&grid->dry(current,s.escape.value,at))return s.escape;
+            s.target=goal;s.position=current;s.progress_at=at;s.escape.reset();s.until.reset();return {};
+        }
+        double progress=distance(s.position,s.target)-distance(current,s.target);
+        if(progress>=0.20){s.target=goal;s.position=current;s.progress_at=at;return {};}
+        if(at-s.progress_at<12.0)return {};
+        Point escape;bool has=grid->safe_local(current,goal,at,{},id%2?1:-1,{},0.42,escape);
+        s.target=goal;s.position=current;s.progress_at=at;
+        if(!has)return {};
+        s.escape=escape;s.until=at+4.0;++s.replans;return escape;
+    }
+    bool report_blocked(int id,Point current,Optional<Point> target,double at){
+        auto found=states.find(id);if(found==states.end()||!target.has||distance(current,target.value)<=1.5)return false;
+        auto edges=grid->edges(current,target.value);if(edges.empty())return false;
+        State &s=found->second;if(at<s.blocked_until)return false;
+        bool same=s.tracker.has&&s.tracker.value.key==edges[0]&&at-s.tracker.value.last<=0.5&&
+            distance(current,s.tracker.value.origin)<=std::max(1.5,grid->data->cell*0.5);
+        if(same){++s.tracker.value.count;s.tracker.value.last=at;}
+        else s.tracker=BlockedTracker{edges[0],1,at,at,current};
+        if(s.tracker.value.count<4||at-s.tracker.value.first<1.0)return false;
+        failed[id][edges[0]]=std::make_pair(at+12.0,240.0);
+        ++s.generation;++s.blocked_replans;s.blocked_until=at+2.0;s.tracker.reset();s.path_key.clear();s.index=0;
+        s.recovery_start=current;s.replan_active=true;s.macro_active=false;macro.erase(id);
+        s.escape.reset();s.escape_until.reset();s.shallow.reset();cancel(id);return true;
+    }
+    void accrue(double elapsed){credit=std::min(384.0,credit+std::max(0.0,elapsed)*960.0);budget=std::min(384,std::max(96,static_cast<int>(credit)));}
+    void begin(double elapsed){++serial;frame_open=true;accrue(elapsed);}
+    void automatic(double at){
+        if(auto_time.has&&std::abs(at-auto_time.value)<0.000001)return;
+        double elapsed=auto_time.has?std::max(0.0,at-auto_time.value):0.10;
+        auto_time=at;++serial;accrue(elapsed);
+    }
+    void callback(std::vector<double> &packet){
+        if(offline_query(packet.data(),static_cast<int>(packet.size())))throw std::runtime_error("navigation identity callback");
+    }
+    int key_id(const std::string &key){
+        auto found=key_ids.find(key);if(found!=key_ids.end())return found->second;
+        int id=next_key_id++;
+        std::vector<double> packet{503.0,static_cast<double>(id),static_cast<double>(key.size())};
+        for(unsigned char c:key)packet.push_back(c);
+        callback(packet);key_ids[key]=id;return id;
+    }
+    void save_path(const std::string &key,std::shared_ptr<Path> path,double at,int revision){
+        int id=key_id(key);std::vector<double> packet{500.0,static_cast<double>(id),static_cast<double>(path->size())};
+        for(Point p:*path){packet.push_back(p.x);packet.push_back(p.y);packet.push_back(p.z);}
+        callback(packet);
+        paths[key]=path;path_times[key]=at;revisions[key]=revision;
+    }
+    void retire_key(const std::string &key){
+        auto found=key_ids.find(key);
+        if(found==key_ids.end()||paths.count(key)||searches.count(key)||next_key==key)return;
+        std::vector<double> packet{504.0,static_cast<double>(found->second)};callback(packet);key_ids.erase(found);
+    }
+    void erase_path(const std::string &key){
+        std::vector<double> packet{501.0,static_cast<double>(key_id(key))};callback(packet);
+        paths.erase(key);path_times.erase(key);revisions.erase(key);retire_key(key);
+    }
+    void trim(){
+        if(paths.size()<=96)return;
+        std::vector<std::string> keys;for(auto item:path_times)keys.push_back(item.first);
+        // Python's stable timestamp sort inherits the exact interpreter's
+        // dictionary order on ties. Ask its tiny key-only mirror for that
+        // order; no geometry, search, route or Bot state crosses this boundary.
+        std::vector<double> packet(2+keys.size(),0.0);packet[0]=502;packet[1]=keys.size();callback(packet);
+        std::map<int,int> rank;
+        for(size_t i=0;i<keys.size();++i){
+            double raw=packet[i+2];if(!std::isfinite(raw)||raw<1||raw>=next_key_id||raw!=std::floor(raw))throw std::invalid_argument("navigation cache order");
+            int id=static_cast<int>(raw);if(rank.count(id))throw std::invalid_argument("duplicate cache key");rank[id]=static_cast<int>(i);
+        }
+        for(const std::string &key:keys)if(!rank.count(key_ids.at(key)))throw std::invalid_argument("missing cache key");
+        std::sort(keys.begin(),keys.end(),[this,&rank](const std::string &a,const std::string &b){
+            if(path_times.at(a)!=path_times.at(b))return path_times.at(a)<path_times.at(b);
+            return rank.at(key_ids.at(a))<rank.at(key_ids.at(b));
+        });
+        for(size_t i=0;i<keys.size()-80;++i)erase_path(keys[i]);
+    }
+    void finish_search(const std::string &key,double at){
+        SearchJob &job=searches.at(key);Path path;
+        for(int i:job.search->path())path.push_back(grid->point(Cell(i%grid->data->width,i/grid->data->width),grid->data->heights[i]/1000.0));
+        if(!path.empty()){
+            Point goal=job.goal;goal.y=path.back().y;grid->ground(job.goal,goal.y);
+            if(grid->segment_clear(path.back(),goal)&&!grid->path_penalty(Path{path.back(),goal},job.hard))path.push_back(goal);
+            path=grid->smooth(path,job.search?search_times.at(key):at,job.identity.prefer,job.hard);
+        }
+        save_path(key,std::make_shared<Path>(path),at,job.revision);
+        if(path.empty())++failed_count;else ++completed;
+        searches.erase(key);search_times.erase(key);
+    }
+    void advance(double at){
+        now=at;if(!frame_open)automatic(at);if(processed==serial)return;
+        processed=serial;frame_time=at;
+        if(searches.empty()){std::string retired=next_key;next_key.clear();retire_key(retired);return;}
+        std::vector<std::string> keys;for(const auto &item:searches)keys.push_back(item.first);
+        auto next=std::find(keys.begin(),keys.end(),next_key);if(next!=keys.end())std::rotate(keys.begin(),next,keys.end());
+        std::deque<std::string> queue(keys.begin(),keys.end());
+        int remaining=std::min(std::max(0,static_cast<int>(credit)),std::max(0,budget)),spent=0;
+        grid->search_globals();
+        while(remaining>0&&!queue.empty()){
+            std::string key=queue.front();queue.pop_front();auto found=searches.find(key);if(found==searches.end())continue;
+            found->second.search->step();found->second.last_frame=at;--remaining;++spent;
+            grid->drain_search_expiry();
+            if(found->second.search->done())finish_search(key,at);else queue.push_back(key);
+        }
+        credit=std::max(0.0,credit-spent);budget=std::max(0,budget-spent);
+        std::string retired=next_key;next_key=queue.empty()?"":queue.front();retire_key(retired);trim();
+    }
+    void tick(double at){
+        advance(at);
+        if(!housekeeping.has||at-housekeeping.value>=1.0){
+            housekeeping=at;
+            for(auto it=grid->failed.begin();it!=grid->failed.end();)if(at>=it->second.first)it=grid->failed.erase(it);else ++it;
+            if(grid->failed.size()>128){
+                std::vector<Edge> edges;for(auto item:grid->failed)edges.push_back(item.first);
+                std::stable_sort(edges.begin(),edges.end(),[this](Edge a,Edge b){return grid->failed.at(a).first<grid->failed.at(b).first;});
+                for(size_t i=0;i<edges.size()-128;++i)grid->failed.erase(edges[i]);
+            }
+            std::vector<int> ids;for(auto item:failed)ids.push_back(item.first);for(int id:ids)active(failed,id,at);
+            ids.clear();for(auto item:macro)ids.push_back(item.first);for(int id:ids)active(macro,id,at);
+        }
+    }
+    std::pair<std::string,std::shared_ptr<Path> > path(const Identity &identity,Point start,Point goal,double at){
+        std::string key=cache_key(identity,goal);int owner=identity.owner;
+        if(owner>=0)cancel(owner,key,identity.kind);
+        auto cached=paths.find(key);
+        if(cached!=paths.end()){
+            auto value=cached->second;Penalties hard=active(macro,owner,at);
+            bool hull=revisions.at(key)!=grid->hull_revision&&grid->path_penalty(*value,grid->hulls);
+            if(!value->empty()&&!hull&&!grid->path_timed(*value,at)&&!grid->path_penalty(*value,hard)){
+                path_times[key]=at;revisions[key]=grid->hull_revision;return {key,value};
+            }
+            if(value->empty()&&at-path_times.at(key)<8.0)return {key,value};
+            erase_path(key);
+        }
+        if(!searches.count(key)){
+            Penalties local=planning(owner,at),hard=active(macro,owner,at);
+            if(!grid->path_penalty(Path{start,goal},local)&&grid->dry(start,goal,at)){
+                auto value=std::make_shared<Path>(Path{start,goal});save_path(key,value,at,grid->hull_revision);return {key,value};
+            }
+            Cell first,last;int a=grid->nearest(grid->cell(start),3,first)?grid->index(first):-1;
+            int b=grid->nearest(grid->cell(goal),3,last)?grid->index(last):-1;
+            SearchJob job;job.identity=identity;job.goal=goal;job.hard=hard;job.revision=grid->hull_revision;
+            job.search.reset(new OfflineNavigationSearch(grid->data,a,b,maximum,at,identity.prefer));
+            std::unordered_map<uint64_t,double> native_local;std::unordered_set<uint64_t> native_hard;uint64_t edge;
+            for(auto item:local)if(grid->search_edge(item.first,edge))native_local[edge]=item.second;
+            for(auto item:hard)if(grid->search_edge(item.first,edge))native_hard.insert(edge);
+            job.search->inputs({},native_local,native_hard,!hard.empty());
+            searches.emplace(key,std::move(job));search_times[key]=at;
+            key_id(key);
+        }
+        advance(at);cached=paths.find(key);return {key,cached==paths.end()?std::shared_ptr<Path>():cached->second};
+    }
+    Point fallback(int id,Point current,Point goal,double at,const Path &avoid,State &s,bool safe=true){
+        if(s.shallow.has&&(distance(current,s.shallow.value)<=1.5||penalized(id,current,s.shallow.value,at)||
+                grid->hazard(current,s.shallow.value,3)||!grid->segment_clear(current,s.shallow.value)))s.shallow.reset();
+        Point target;
+        if(safe&&grid->safe_local(current,goal,at,avoid,id%2?1:-1,active(macro,id,at),0,target)){
+            s.last_target=target;s.status=1;s.terminal=distance(target,goal)<=1.5;set_mode(id,2);return target;
+        }
+        s.last_target=goal;s.status=2;s.terminal=false;set_mode(id,3);return goal;
+    }
+    Point pending(int id,Point current,Point goal,double at,State &s,const Path &avoid,bool allow=true,bool immediate=false){
+        if(allow&&s.last_target.has){
+            Point target=s.last_target.value;bool shallow=grid->hazard(current,target,4);
+            if(grid->segment_penalty(current,target,at)<=0&&!penalized(id,current,target,at,true)&&grid->segment_clear(current,target)&&
+                    (!shallow||(s.shallow.has&&s.shallow.value==target))&&distance(current,target)>1.5){
+                s.status=0;s.terminal=false;set_mode(id,0);return target;
+            }
+        }
+        if(!s.pending_since.has)s.pending_since=at;
+        Point target;
+        if((immediate||at-s.pending_since.value>=0.6)&&
+                grid->safe_local(current,goal,at,avoid,id%2?1:-1,active(macro,id,at),0,target)){
+            s.last_target=target;s.status=0;s.terminal=false;set_mode(id,2);return target;
+        }
+        s.last_target=current;s.status=0;s.terminal=false;set_mode(id,0);return current;
+    }
+    bool planned_next(Point current,const Path &path,int index,double at){
+        if(index+1>=static_cast<int>(path.size()))return false;
+        Point target=path[index+1];bool reached=distance(current,path[index])<=1.5;
+        if((!reached&&!live_climb(current,path,index,index+1))||grid->segment_penalty(current,target,at)>0||!grid->segment_clear(current,target))return false;
+        return !grid->hazard(current,target,4)||grid->hazard(path[index],target,4);
+    }
+    bool planned_current(Point current,const Path &path,int index,double at,Optional<Point> selected){
+        if(index<=0||index>=static_cast<int>(path.size()))return false;
+        Point target=path[index];
+        if(((!selected.has||selected.value!=target)&&!live_climb(current,path,index-1,index))||grid->segment_penalty(current,target,at)>0||!grid->segment_clear(current,target))return false;
+        return !grid->hazard(current,target,4)||grid->hazard(path[index-1],target,4);
+    }
+    int lookahead(Point current,const Path &path,int index,const Identity &identity,double at,Optional<double> distance_limit){
+        int result=index,limit=std::min(static_cast<int>(path.size()),index+(distance_limit.has?7:3));
+        double horizon=distance_limit.has?std::max(grid->data->cell*2.0,distance_limit.value):0;
+        Penalties hard=active(macro,identity.owner,at);
+        for(int candidate=index+1;candidate<limit;++candidate){
+            if(distance_limit.has&&candidate>index+1&&distance(current,path[candidate])>horizon)break;
+            if((!identity.prefer||grid->clearance(path,index,candidate))&&live_climb(current,path,index,candidate)&&
+                    !grid->path_penalty(Path{current,path[candidate]},hard)&&grid->dry(current,path[candidate],at))result=candidate;
+            else break;
+        }
+        return result;
+    }
+    Point selected(int id,State &s,Point current,Point target,Point goal){
+        s.last_target=target;if(grid->hazard(current,target,4))s.shallow=target;else s.shallow.reset();
+        s.status=1;s.terminal=distance(target,goal)<=1.5;set_mode(id,-1);return target;
+    }
+    Point next_target(int id,Point current,Point goal,const Identity &identity,double at,
+                      Optional<Point> anchor,const Path &avoid,Optional<double> horizon,bool movement){
+        direct.erase(id);tick(at);
+        auto found=states.find(id);if(found==states.end())found=states.emplace(id,State(current,at)).first;
+        State &s=found->second;
+        if(s.request_path_key==identity.repr&&s.planned_goal.has&&distance(s.planned_goal.value,goal)<grid->data->cell*2.0&&at-s.planned_at<2.0)goal=s.planned_goal.value;
+        else{s.request_path_key=identity.repr;s.planned_goal=goal;s.planned_at=at;}
+        std::string request=cache_key(identity,goal);bool changed=s.request_key!=request;
+        bool transition=!s.request_key.empty()&&changed,allow=true;
+        if(changed){
+            allow=s.last_target.has&&(s.last_target.value.x-current.x)*(goal.x-current.x)+(s.last_target.value.z-current.z)*(goal.z-current.z)>0&&
+                distance(s.last_target.value,goal)+0.20<distance(current,goal);
+            if(!allow)s.last_target.reset();
+            cancel(id);s.request_key=request;s.path_key.clear();s.index=0;
+            s.last_position=current;s.progress_time=at;s.recovery=0;s.recovery_until=0;s.recovery_start.reset();
+            s.replan_active=false;s.macro_active=false;macro.erase(id);s.escape.reset();s.escape_until.reset();s.pending_since.reset();s.shallow.reset();
+            reset_macro(s,current,s.last_target,at);
+        }else if(movement)observe_macro(id,s,current,goal,at);
+        else{if(s.macro_active)finish_macro(id,s);reset_macro(s,current,s.last_target,at);}
+        if(s.escape.has){
+            Point escape=s.escape.value;
+            if(at<(s.escape_until.has?s.escape_until.value:at)&&distance(current,escape)>1.5&&grid->dry(current,escape,at)){
+                s.shallow.reset();s.last_target=escape;s.status=1;s.terminal=false;set_mode(id,-1);return escape;
+            }
+            finish_macro(id,s);reset_macro(s,current,s.last_target,at);
+        }
+        if(!s.macro_active&&distance(current,s.last_position)>=2.0){
+            s.last_position=current;s.progress_time=at;s.recovery=0;s.recovery_until=0;s.replan_active=false;s.recovery_start.reset();
+        }
+        Point start=anchor.has?anchor.value:current;if(anchor.has)start.y=current.y;
+        Identity effective=identity;
+        if(s.replan_active){effective=prefixed(identity,"recovery",id,std::to_string(s.generation));start=s.recovery_start.has?s.recovery_start.value:current;}
+        auto previous=paths.find(s.path_key);std::shared_ptr<Path> previous_path=previous==paths.end()?std::shared_ptr<Path>():previous->second;
+        auto planned=path(effective,start,goal,at);std::string key=planned.first;auto route=planned.second;
+        if(!route||route->empty()){
+            if(grid->dry(current,goal,at)&&!penalized(id,current,goal,at,true)){
+                s.shallow.reset();s.last_target=goal;s.status=1;s.terminal=true;set_mode(id,1);return goal;
+            }
+            if(!route)return pending(id,current,goal,at,s,avoid,allow,transition);
+            s.path_key=key;return fallback(id,current,goal,at,avoid,s);
+        }
+        std::string active_key=s.path_key;
+        if(!active_key.empty()&&active_key!=key){
+            auto active_path=paths.find(active_key);
+            if(active_path!=paths.end()&&!active_path->second->empty()&&!grid->path_timed(*active_path->second,at)){
+                key=active_key;route=active_path->second;path_times[key]=at;
+            }
+        }
+        if(s.path_key!=key){
+            s.path_key=key;s.index=0;double best=1e18;
+            for(size_t i=0;i<route->size();++i){double d=distance(current,(*route)[i]);if(d<best){best=d;s.index=static_cast<int>(i);}}
+        }
+        int index=std::min(s.index,static_cast<int>(route->size())-1);Optional<Point> selected_target;
+        if(active_key==key&&previous_path==route&&s.last_target.has&&s.last_target.value==(*route)[index])selected_target=s.shallow;
+        bool shallow=grid->hazard(current,(*route)[index],4);
+        if(grid->segment_penalty(current,(*route)[index],at)>0||penalized(id,current,(*route)[index],at,true)||
+                (shallow&&!planned_current(current,*route,index,at,selected_target))||!grid->segment_clear(current,(*route)[index])){
+            Identity join=prefixed(identity,"join",id,cell_repr(grid->cell(current)));
+            planned=path(join,current,goal,at);key=planned.first;
+            if(!planned.second)return pending(id,current,goal,at,s,avoid,allow,transition);
+            if(planned.second->empty()){s.path_key=key;return fallback(id,current,goal,at,avoid,s);}
+            route=planned.second;s.path_key=key;s.index=0;index=0;
+        }
+        double radius=std::min(10.0,std::max(1.5,grid->data->cell*0.55));
+        while(index+1<static_cast<int>(route->size())&&distance(current,(*route)[index])<radius&&planned_next(current,*route,index,at))++index;
+        int look=lookahead(current,*route,index,effective,at,horizon);
+        if(look==static_cast<int>(route->size())-1&&distance(current,(*route)[look])<radius&&distance((*route)[look],goal)>radius){
+            Identity continuation=prefixed(identity,"continue",id,cell_repr(grid->cell(current)));
+            planned=path(continuation,current,goal,at);
+            if(planned.second&&!planned.second->empty()){
+                route=planned.second;s.path_key=planned.first;int next=route->size()>1&&planned_next(current,*route,0,at)?1:0;
+                next=lookahead(current,*route,next,continuation,at,horizon);s.index=next;
+                return selected(id,s,current,(*route)[next],goal);
+            }
+            if(!planned.second)return pending(id,current,goal,at,s,avoid,allow,transition);
+            return fallback(id,current,goal,at,avoid,s);
+        }
+        Point target=(*route)[look];
+        if(distance(current,target)<=1.5&&distance(current,goal)>15.0)return fallback(id,current,goal,at,avoid,s);
+        s.index=look;return selected(id,s,current,target,goal);
+    }
+    bool shallow_corridor(Point current,Point target,double yaw){
+        double distance=std::max(1.0,grid->data->cell);Point end(current.x+std::sin(yaw)*distance,current.y,current.z+std::cos(yaw)*distance);
+        std::vector<Cell> planned,committed;
+        if(!grid->hazard_cells(current,target,4,planned)||planned.empty()||!grid->hazard_cells(current,end,4,committed)||
+                grid->hazard(current,target,3)||grid->hazard(current,end,3))return false;
+        std::set<Cell> allowed(planned.begin(),planned.end());for(Cell c:committed)if(!allowed.count(c))return false;return true;
+    }
+    bool shallow_step(int id,Point current,double yaw,double maximum_yaw=0.45,bool committed=false){
+        auto found=states.find(id);if(found==states.end()||!found->second.shallow.has)return false;
+        Point target=found->second.shallow.value;double dx=target.x-current.x,dz=target.z-current.z;
+        if(committed){double length=std::sqrt(dx*dx+dz*dz);if(length<0.1)return false;
+            return (std::sin(yaw)*dx+std::cos(yaw)*dz)/length>0.5&&shallow_corridor(current,target,yaw);
+        }
+        if(std::abs(dx)+std::abs(dz)<0.1)return false;
+        return std::abs(wrap(yaw-std::atan2(dx,dz)))<=std::max(0.0,maximum_yaw)&&shallow_corridor(current,target,yaw);
+    }
+};
+}
+#endif

--- a/tools/ffi_experiment/perception_adapter.py
+++ b/tools/ffi_experiment/perception_adapter.py
@@ -1,0 +1,250 @@
+"""Native perception state; Python descriptor, engine, and message adapters.
+
+Numeric roster templates are transferred at most once per actor motion phase
+in a slice. The runtime's original pose dictionaries stay at its publication
+boundary, including hidden-pose removal and per-team remembered articulation.
+"""
+from __future__ import print_function
+from array import array
+
+KINDS = {'bot': 0, 'human': 1}
+OUTPUT, PACKET = 64, 576
+
+
+class PerceptionBackend(object):
+    def __init__(self, backend, runtime, runtime_module):
+        self.backend, self.runtime, self.rt = backend, runtime, runtime_module
+        self.originals = {}
+        self.handle = None
+        self.tick = None
+        self.templates = {}
+        self.roster = []
+        self.cache_identity = None
+        self.reset()
+        for name, replacement in (
+                ('_contacts_for', self.contacts), ('_visible', self.visible),
+                ('_begin_visibility_frame', self.begin),
+                ('_prepare_visibility_frame', self.prepare),
+                ('_finish_visibility_frame', self.finish),
+                ('_renew_team_spot', self.renew),
+                ('_team_spot_time_left', self.remaining),
+                ('diagnostic_totals', self.diagnostics)):
+            self.originals[name] = (name in runtime.__dict__, getattr(runtime, name))
+            setattr(runtime, name, replacement)
+
+    def reset(self):
+        if self.handle is not None:
+            self.backend.call([312, self.handle])
+        s = self.rt.spotting
+        self.handle = int(self.backend.call(
+            [300, self.rt.VISIBILITY_SAMPLE_SECONDS, s.SHOT_CAMOUFLAGE_SECONDS,
+             s.PROXIMITY_SPOT_DISTANCE, s.MAX_SPOT_DISTANCE, s.SPOT_MEMORY_SECONDS,
+             s.DESIGNATED_SPOT_MEMORY_SECONDS, self.rt.MAX_VISIBILITY_PROBES_PER_FRAME])[0])
+        self.tick, self.templates, self.roster = None, {}, []
+        self.cache_identity = self.runtime._visibility_cache
+
+    def close(self):
+        for name, (had_local, original) in self.originals.items():
+            if had_local:
+                setattr(self.runtime, name, original)
+            else:
+                delattr(self.runtime, name)
+        self.originals.clear()
+
+    def begin(self):
+        if self.cache_identity is not self.runtime._visibility_cache:
+            self.reset()
+        self.backend.call([301, self.handle])
+
+    def prepare(self, players, now, include_humans):
+        rt = self.runtime
+        rows = []
+        for state in rt._ordered_states():
+            if not state.get('alive', True):
+                continue
+            selected = rt._selected_visibility_target(state)
+            rows.extend((0, int(state['id']), int(state.get('team', 0)),
+                         self.fire(state), KINDS[selected[0]] if selected else -1,
+                         selected[1] if selected else 0,
+                         int(rt._visibility_decision_due(state, now))))
+        for raw in players or ():
+            if not isinstance(raw, dict) or raw.get('id') is None or not raw.get('alive', True):
+                continue
+            rows.extend((1, int(raw['id']), int(raw.get('team', 0)),
+                         self.fire(raw), -1, 0, int(bool(include_humans))))
+        return bool(self.backend.call([302, self.handle, now, len(rows) // 7] + rows)[0])
+
+    def finish(self):
+        return bool(self.backend.call([303, self.handle])[0])
+
+    def diagnostics(self):
+        report = self.originals['diagnostic_totals'][1]()
+        values = self.backend.call([310, self.handle] + [0] * 18)
+        for index, key in enumerate(('visibility_queue_depth', 'visibility_queue_max_depth',
+                                      'visibility_oldest_stale_age_ms', 'visibility_oldest_stale_max_age_ms',
+                                      'visibility_admitted', 'visibility_completed', 'visibility_deferred',
+                                      'visibility_selected_services', 'visibility_fire_services',
+                                      'visibility_new_services', 'visibility_ordinary_services')):
+            report[key] = int(round(values[index] * 1000)) if index in (2, 3) else int(values[index])
+        return report
+
+    def renew(self, key, now, duration=None):
+        duration = self.rt.spotting.SPOT_MEMORY_SECONDS if duration is None else duration
+        self.backend.call([308, self.handle, key[0], KINDS[key[1]], key[2], now, duration])
+        return True
+
+    def remaining(self, key, now):
+        return self.backend.call([309, self.handle, key[0], KINDS[key[1]], key[2], now])[0]
+
+    def fire(self, raw):
+        value = self.runtime._visibility_fire_sequence(raw)
+        return -1 if value is None else value
+
+    def record(self, raw, kind=None, identity=None, position=None):
+        kind = raw.get('kind', 'bot') if kind is None else kind
+        identity = raw.get('network_id', raw.get('id', 0)) if identity is None else identity
+        position = position if position is not None else raw.get('position') or self.rt._position(raw)
+        return [KINDS[kind], int(identity), int(raw.get('team', 0)),
+                position[0], position[1], position[2], self.fire(raw)]
+
+    def roster_for(self, players, tick):
+        if tick is not None and self.tick is tick:
+            return
+        rows, roster = [], []
+        for raw in players or ():
+            if isinstance(raw, dict) and raw.get('id') is not None:
+                roster.append(('human', int(raw['id']), raw))
+        for bot_id, raw in self.runtime.states.items():
+            roster.append(('bot', int(bot_id), raw))
+        for kind, identity, raw in roster:
+            rows.extend((KINDS[kind], identity, int(raw.get('team', 0)), int(bool(raw.get('alive', True)))))
+        self.backend.call([305, self.handle, len(roster)] + rows)
+        self.tick, self.roster, self.templates = tick, roster, {}
+
+    def template(self, index, phase, tick, processed):
+        key = (index, phase)
+        target = self.templates.get(key)
+        if target is None:
+            kind, identity, raw = self.roster[index]
+            if kind == 'human':
+                target = self.runtime._human_observation_target(raw, tick, identity)
+            else:
+                target = self.runtime._bot_observation_target(identity, raw, tick, processed)
+            self.templates[key] = target
+        return target
+
+    def run(self, values, source, now, tick, processed=None, target=None,
+            view_resolver=None):
+        packet = array('d', values)
+        packet.extend([0] * (PACKET - len(packet)))
+        view = [None]
+        try:
+            while True:
+                self.backend.call(packet)
+                stage = int(packet[OUTPUT])
+                if not stage:
+                    count = int(packet[OUTPUT + 1])
+                    return [tuple(int(v) for v in packet[OUTPUT+2+i*4:OUTPUT+6+i*4])
+                            for i in range(count)]
+                index, phase, fired = int(packet[OUTPUT+1]), int(packet[OUTPUT+2]), bool(packet[OUTPUT+3])
+                active = target if target is not None else self.template(index, phase, tick, processed)
+                if stage == 1:
+                    reply = self.record(active)
+                elif stage == 2:
+                    if view[0] is None:
+                        view[0] = (view_resolver() if callable(view_resolver) else
+                                   self.runtime._source_view_range(source, now, tick))
+                    base, shot, unused_profile, moving, additive, multiplier = \
+                        self.runtime._target_detection_projection(
+                            active, active.get('network_id', active.get('id', 0)), now, tick)
+                    reply = [view[0], base[0], base[1], shot, int(moving), additive, multiplier]
+                elif stage == 3:
+                    runtime = self.runtime
+                    try:
+                        runtime._probe_totals[0] += 1
+                        started = runtime._probe_started()
+                        try:
+                            try:
+                                visibility = runtime.visibility_probe(source, active, fired)
+                            except TypeError:
+                                visibility = runtime.visibility_probe(source, active)
+                        finally:
+                            runtime._probe_finished(0, started)
+                    except Exception:
+                        visibility = False
+                    if isinstance(visibility, dict):
+                        reply = [int(bool(visibility.get('line_of_sight', False))),
+                                 self.rt._number(visibility.get('foliage_bonus'), 0.0)]
+                    else:
+                        reply = [int(bool(visibility)), 0.0]
+                else:
+                    raise RuntimeError('unknown native perception query')
+                packet[:3+len(reply)] = array('d', [306, self.handle, stage] + reply)
+        except Exception:
+            self.backend.call([311, self.handle])
+            raise
+
+    def visible(self, source, target, now, tick_cache=None,
+                source_position=None, view_range_resolver=None):
+        rows = self.run([307, self.handle] + self.record(source, identity=source.get('id', 0),
+                                                        position=source_position) +
+                        [now] + self.record(target), source, now, tick_cache,
+                        target=target, view_resolver=view_range_resolver)
+        return bool(rows[0][1])
+
+    def contacts(self, source, players, now, team_spotted=None,
+                 visibility_tick=None, processed_bot_ids=None):
+        self.roster_for(players, visibility_tick)
+        source_team = int(source.get('team', 0))
+        flags = []
+        for kind, identity, raw in self.roster:
+            key = (source_team, kind, identity)
+            flags.extend((int(kind == 'bot' and processed_bot_ids is not None and identity in processed_bot_ids),
+                          int(bool(team_spotted is not None and team_spotted.get(key, False))),
+                          int(bool(raw.get('alive', True))), int(raw.get('team', 0))))
+        rows = self.run([304, self.handle] + self.record(source, identity=source.get('id', 0),
+                                                        position=self.rt._position(source)) +
+                        [now] + flags, source, now, visibility_tick, processed_bot_ids)
+        contacts, lookup = [], {}
+        pose_cache = (visibility_tick.setdefault('target_pose_snapshots', {})
+                      if isinstance(visibility_tick, dict) else None)
+        hidden = (visibility_tick.setdefault('hidden_target_templates', {})
+                  if isinstance(visibility_tick, dict) else {})
+        for index, visible, direct, fresh in rows:
+            kind, identity, unused_raw = self.roster[index]
+            phase = int(kind == 'bot' and processed_bot_ids is not None and identity in processed_bot_ids)
+            template = self.templates[(index, phase)]
+            target = dict(template)
+            target.update(visible=bool(visible), direct_visible=bool(direct), fresh_visible=bool(fresh))
+            key = (source_team, kind, identity)
+            if direct and team_spotted is not None:
+                team_spotted[key] = True
+            if fresh:
+                remembered = self.runtime._target_pose_snapshot(template, pose_cache)
+                self.runtime._visible_target_poses[key] = remembered
+                target.update(remembered)
+                keep = True
+            else:
+                remembered = self.runtime._visible_target_poses.get(key)
+                cache_key = (source_team, id(template), id(remembered))
+                cached = hidden.get(cache_key)
+                if cached is not None:
+                    keep = bool(visible and remembered is not None)
+                    target = dict(cached[2])
+                    target.update(visible=keep, direct_visible=bool(direct), fresh_visible=bool(fresh))
+                else:
+                    for name in self.rt._TARGET_POSE_FIELDS:
+                        target.pop(name, None)
+                    if remembered is None:
+                        target.update(position=(0.0, 0.0, 0.0), x=0.0, y=0.0, z=0.0, yaw=0.0, speed=0.0, visible=False)
+                    else:
+                        target.update(remembered)
+                    projection = dict(target)
+                    for name in ('visible', 'direct_visible', 'fresh_visible'):
+                        projection.pop(name, None)
+                    hidden[cache_key] = (template, remembered, projection)
+                    keep = bool(target.get('visible'))
+            if keep:
+                lookup[target['id']] = target
+            contacts.append(target)
+        return contacts, lookup

--- a/tools/ffi_experiment/perception_core.cpp
+++ b/tools/ffi_experiment/perception_core.cpp
@@ -1,0 +1,292 @@
+// Persistent visibility/cache/scheduler/lease state with ordered query yields.
+#include "perception_core.h"
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <map>
+#include <set>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+const int OUTPUT=64,PACKET=576;
+typedef std::array<int,2> Identity;
+typedef std::array<int,3> TeamKey;
+typedef std::array<int,4> Key;
+struct Reader {
+    double *b;int n,i;
+    Reader(double *v,int size):b(v),n(size),i(1){}
+    double next(){if(i>=n||!std::isfinite(b[i]))throw std::invalid_argument("perception buffer");return b[i++];}
+    int integer(){double v=next();if(v!=std::floor(v)||std::abs(v)>1000000000)throw std::invalid_argument("perception int");return static_cast<int>(v);}
+    void end(){if(i!=n)throw std::invalid_argument("perception width");}
+};
+struct Record {int kind,id,team,fire;bool alive;double x,y,z;};
+struct Cached {double now;bool value;int fire;};
+struct Projection {double view,base0,base1,shot,add,multiply;bool moving;};
+struct Frame {
+    bool active,prepared;double now;int budget;size_t next;
+    std::vector<Key> order,prior,parked;
+    std::set<Key> allowed,completed,requested,admitted,deferred;
+    std::map<Key,int> classification;
+    Frame():active(false),prepared(false),now(0),budget(0),next(0){}
+};
+struct Job {
+    bool active,single,fired;int cursor,phase,stage;
+    Record source,target;double now,distance;Key key;
+    std::vector<bool> processed,shared;
+    std::vector<std::array<int,4> > results;
+    Projection projection;
+    Job():active(false),single(false),fired(false),cursor(0),phase(0),stage(0),source(),target(),now(0),distance(0),key(),projection(){}
+};
+struct Owner {
+    double ttl,shot_seconds,proximity,maximum,memory,designated;
+    int budget;Frame frame;Job job;
+    std::map<Key,Cached> cache;
+    std::map<Identity,std::pair<int,double> > fire;
+    std::map<TeamKey,double> spot;
+    std::map<TeamKey,bool> remembered;
+    std::map<Key,double> deferred;
+    std::vector<Key> waiting;
+    std::vector<Record> roster;
+    std::map<std::pair<int,int>,Record> templates;
+    double diagnostic_now;long admitted,completed,deferred_count,services[4];
+    size_t max_depth;double max_age;
+    Owner():diagnostic_now(0),admitted(0),completed(0),deferred_count(0),max_depth(0),max_age(0){for(int i=0;i<4;++i)services[i]=0;}
+};
+std::map<int,Owner> owners;int next_owner=1;
+double clamp(double v,double low,double high){return std::max(low,std::min(high,v));}
+Owner &owner(Reader &r){auto it=owners.find(r.integer());if(it==owners.end())throw std::invalid_argument("unknown perception owner");return it->second;}
+Key pair_key(Record s,Record t){return Key{{s.kind,s.id,t.kind,t.id}};}
+TeamKey team_key(int team,Record t){return TeamKey{{team,t.kind,t.id}};}
+void renew(Owner &o,TeamKey key,double now,double duration){
+    double deadline=now+clamp(duration,0,o.designated);
+    auto it=o.spot.find(key);double prior=it==o.spot.end()?0:it->second;
+    o.spot[key]=std::max(prior,deadline);
+}
+double remaining(Owner &o,TeamKey key,double now){
+    auto it=o.spot.find(key);double value=(it==o.spot.end()?0:it->second)-now;
+    if(value<=0){if(it!=o.spot.end())o.spot.erase(it);return 0;}
+    return std::min(o.designated,value);
+}
+void complete(Owner &o,Key key){
+    Frame &f=o.frame;if(!f.active)return;
+    if(f.completed.insert(key).second)++o.completed;
+    o.deferred.erase(key);f.allowed.erase(key);
+    while(static_cast<int>(f.allowed.size())<f.budget && f.next<f.order.size()){
+        Key candidate=f.order[f.next++];if(!f.completed.count(candidate))f.allowed.insert(candidate);
+    }
+}
+bool allowed(const Owner &o,Key key){return !o.frame.active||(o.frame.allowed.count(key)&&o.frame.budget>0);}
+void defer(Owner &o,Key key){
+    Frame &f=o.frame;if(!f.active)return;
+    f.requested.insert(key);if(f.deferred.insert(key).second)++o.deferred_count;
+    o.deferred.insert(std::make_pair(key,f.now));
+}
+bool admit(Owner &o,Key key){
+    Frame &f=o.frame;if(!f.active)return true;
+    f.requested.insert(key);if(!allowed(o,key)){defer(o,key);return false;}
+    --f.budget;
+    if(f.admitted.insert(key).second){++o.admitted;auto it=f.classification.find(key);++o.services[it==f.classification.end()?3:it->second];}
+    return true;
+}
+void store(Owner &o,bool value){
+    Job &j=o.job;o.cache[j.key]=Cached{j.now,value,j.target.fire};complete(o,j.key);
+    if(o.cache.size()>1024){
+        // Supported rooms have at most thirty actors, hence at most 450
+        // opposing live pairs. Reject an unbounded synthetic identity stream
+        // instead of inventing Python-dict tie ordering for its prune branch.
+        throw std::invalid_argument("perception room identity capacity");
+    }
+}
+void result(Owner &o,bool value){
+    Job &j=o.job;
+    if(j.single){j.results.push_back(std::array<int,4>{{0,value,0,0}});j.active=false;return;}
+    TeamKey key=team_key(j.source.team,j.target);
+    if(value){renew(o,key,j.now,o.memory);o.remembered[key]=true;j.shared[j.cursor]=true;}
+    if(!o.remembered.count(key))o.remembered[key]=remaining(o,key,j.now)>0;
+    bool fresh=value||j.shared[j.cursor],visible=value||o.remembered[key]||j.shared[j.cursor];
+    j.results.push_back(std::array<int,4>{{j.cursor,visible,value,fresh}});
+    ++j.cursor;j.stage=0;
+}
+double camouflage(Projection p,bool fired,double foliage,bool upper){
+    double value=p.moving?p.base0:p.base1;
+    value=(value+(upper?0:p.add))*std::max(0.0,upper?1:p.multiply);
+    if(fired)value*=clamp(p.shot,0,1);
+    value+=clamp(foliage,0,0.60);return clamp(value,0,0.95);
+}
+bool detected(const Owner &o,double distance,double view,double camouflage,bool los){
+    distance=std::max(0.0,distance);if(distance<=o.proximity)return true;
+    view=std::max(o.proximity,view);camouflage=clamp(camouflage,0,0.95);
+    return los&&distance<=clamp(view-(view-o.proximity)*camouflage,o.proximity,o.maximum);
+}
+// Continue all cache hits and pure rejections together; stop at each Python
+// descriptor or engine leaf, preserving cache/fire/lease mutation order.
+void advance(Owner &o,double *b){
+    Job &j=o.job;
+    while(j.active){
+        if(j.stage!=0)break;
+        if(!j.single){
+            while(j.cursor<static_cast<int>(o.roster.size())){
+                Record r=o.roster[j.cursor];
+                if(r.alive&&r.team!=j.source.team&&!(r.kind==0&&r.id==j.source.id))break;
+                ++j.cursor;
+            }
+            if(j.cursor==static_cast<int>(o.roster.size())){j.active=false;break;}
+            j.phase=j.processed[j.cursor]?1:0;
+            auto it=o.templates.find(std::make_pair(j.cursor,j.phase));
+            if(it==o.templates.end()){j.stage=1;break;}
+            j.target=it->second;
+        }
+        j.key=pair_key(j.source,j.target);j.fired=false;bool changed=false;
+        if(j.target.fire>=0){
+            Identity id={{j.target.kind,j.target.id}};auto it=o.fire.find(id);
+            if(it==o.fire.end()||j.target.fire<it->second.first)o.fire[id]=std::make_pair(j.target.fire,0.0);
+            else if(j.target.fire>it->second.first){o.fire[id]=std::make_pair(j.target.fire,j.now+o.shot_seconds);j.fired=true;changed=true;}
+            else j.fired=j.now<it->second.second;
+        }
+        auto cached=o.cache.find(j.key);
+        if(!changed&&cached!=o.cache.end()&&cached->second.fire==j.target.fire&&j.now-cached->second.now<o.ttl){result(o,cached->second.value);continue;}
+        double dx=j.source.x-j.target.x,dz=j.source.z-j.target.z;
+        j.distance=std::sqrt(dx*dx+dz*dz);
+        if(j.distance<=o.proximity){store(o,true);result(o,true);continue;}
+        if(j.distance>o.maximum){store(o,false);result(o,false);continue;}
+        if(!allowed(o,j.key)){defer(o,j.key);result(o,false);continue;}
+        j.stage=2;
+    }
+    b[OUTPUT]=j.active?j.stage:0;b[OUTPUT+1]=j.cursor;b[OUTPUT+2]=j.phase;b[OUTPUT+3]=j.fired;
+    if(!j.active){
+        b[OUTPUT+1]=j.results.size();int k=OUTPUT+2;
+        for(auto r:j.results)for(int v:r)b[k++]=v;
+    }
+}
+struct Source {Record record;Identity selected;bool eligible;};
+void prepare(Owner &o,const std::vector<Source> &sources,double now){
+    Frame &f=o.frame;f.prepared=true;f.now=now;
+    std::map<Key,bool> valid;std::map<Key,std::array<bool,4> > candidates;
+    for(const Source &s:sources){
+        if(s.record.team!=1&&s.record.team!=2)continue;
+        for(const Source &t:sources){
+            if(t.record.team==s.record.team||(t.record.team!=1&&t.record.team!=2))continue;
+            Key key=pair_key(s.record,t.record);auto it=o.cache.find(key);
+            bool fresh=it==o.cache.end(),fire=!fresh&&it->second.fire!=t.record.fire;
+            bool stale=fresh||fire||now-it->second.now>=o.ttl;valid[key]=stale;
+            if(stale&&s.eligible)candidates[key]=std::array<bool,4>{{s.record.kind==1,s.selected==Identity{{t.record.kind,t.record.id}},fire,fresh}};
+        }
+    }
+    for(auto it=o.deferred.begin();it!=o.deferred.end();){if(!valid[it->first])it=o.deferred.erase(it);else ++it;}
+    std::vector<Key> waiting;std::set<Key> waiting_set;
+    for(Key key:o.waiting)if(valid[key]){
+        f.prior.push_back(key);
+        if(candidates.count(key)){waiting.push_back(key);waiting_set.insert(key);}else f.parked.push_back(key);
+    }
+    std::vector<Key> cohorts[7];
+    for(Key key:waiting){
+        auto flags=candidates[key];
+        if(flags[0])cohorts[0].push_back(key);
+        if(!flags[0]&&!flags[1]&&!flags[2]&&!flags[3])cohorts[5].push_back(key);
+    }
+    for(auto entry:candidates){
+        Key key=entry.first;auto flags=entry.second;
+        if(flags[0]&&!waiting_set.count(key))cohorts[1].push_back(key);
+        if(flags[1]&&!flags[0])cohorts[2].push_back(key);
+        if(flags[2]&&!flags[0]&&!flags[1])cohorts[3].push_back(key);
+        if(flags[3]&&!flags[0]&&!flags[1]&&!flags[2])cohorts[4].push_back(key);
+        if(!waiting_set.count(key)&&!flags[0]&&!flags[1]&&!flags[2]&&!flags[3])cohorts[6].push_back(key);
+    }
+    std::set<Key> seen;
+    for(const auto &cohort:cohorts)for(Key key:cohort)if(seen.insert(key).second)f.order.push_back(key);
+    for(Key key:waiting)if(seen.insert(key).second)f.order.push_back(key);
+    for(Key key:f.order){auto flags=candidates[key];f.classification[key]=flags[1]?0:(flags[2]?1:(flags[3]?2:3));}
+    f.next=std::min(f.order.size(),static_cast<size_t>(f.budget));
+    f.allowed.insert(f.order.begin(),f.order.begin()+f.next);
+}
+void finish(Owner &o){
+    Frame &f=o.frame;
+    std::set<Key> unfinished(f.parked.begin(),f.parked.end()),seen;
+    for(Key key:f.order)if(!f.completed.count(key))unfinished.insert(key);
+    o.waiting.clear();
+    for(Key key:f.prior)if(unfinished.count(key)&&seen.insert(key).second)o.waiting.push_back(key);
+    for(Key key:f.order)if(unfinished.count(key)&&seen.insert(key).second)o.waiting.push_back(key);
+    for(Key key:o.waiting)o.deferred.insert(std::make_pair(key,f.now));
+    o.diagnostic_now=f.now;o.max_depth=std::max(o.max_depth,o.waiting.size());
+    for(auto item:o.deferred)o.max_age=std::max(o.max_age,std::max(0.0,f.now-item.second));
+    f.active=false;
+}
+Record record(Reader &r,bool position){
+    Record t={};t.kind=r.integer();t.id=r.integer();t.team=r.integer();t.alive=true;
+    if(t.kind<0||t.kind>1)throw std::invalid_argument("actor kind");
+    if(position){t.x=r.next();t.y=r.next();t.z=r.next();t.fire=r.integer();}
+    return t;
+}
+}
+void offline_perception_reset(){owners.clear();}
+int offline_perception_dispatch(double *b,int n){
+    Reader r(b,n);int op=static_cast<int>(b[0]);
+    if(op==300){
+        Owner o;o.ttl=r.next();o.shot_seconds=r.next();o.proximity=r.next();o.maximum=r.next();o.memory=r.next();o.designated=r.next();o.budget=r.integer();r.end();
+        if(o.ttl<0||o.budget<0||o.proximity<0||o.maximum<o.proximity)throw std::invalid_argument("perception parameters");
+        int id=next_owner++;owners[id]=o;b[0]=id;return 0;
+    }
+    Owner &o=owner(r);
+    if(op==301){r.end();if(o.job.active)throw std::invalid_argument("unfinished perception operation");o.frame=Frame();o.frame.active=true;o.frame.budget=o.budget;return 0;}
+    if(op==302){
+        double now=r.next();int count=r.integer();if(count<0||count>30)throw std::invalid_argument("room size");
+        std::vector<Source> sources;
+        for(int i=0;i<count;++i){Source s;s.record=record(r,false);s.record.fire=r.integer();s.selected[0]=r.integer();s.selected[1]=r.integer();s.eligible=r.integer()!=0;sources.push_back(s);}
+        r.end();if(!o.frame.active||o.frame.prepared){b[0]=0;return 0;}
+        prepare(o,sources,now);b[0]=1;return 0;
+    }
+    if(op==303){r.end();b[0]=o.frame.active;if(o.frame.active)finish(o);return 0;}
+    if(op==305){
+        int count=r.integer();if(count<0||count>30||o.job.active)throw std::invalid_argument("roster size/state");
+        std::vector<Record> roster;
+        for(int i=0;i<count;++i){Record t=record(r,false);t.alive=r.integer()!=0;roster.push_back(t);}
+        r.end();o.roster.swap(roster);o.templates.clear();o.remembered.clear();return 0;
+    }
+    if(op==304||op==307){
+        if(n!=PACKET||o.job.active)throw std::invalid_argument("perception operation state/width");
+        o.job=Job();Job &j=o.job;j.active=true;j.single=op==307;j.source=record(r,true);j.now=r.next();
+        if(j.single)j.target=record(r,true);
+        else for(size_t i=0;i<o.roster.size();++i){
+            j.processed.push_back(r.integer()!=0);j.shared.push_back(r.integer()!=0);
+            o.roster[i].alive=r.integer()!=0;o.roster[i].team=r.integer();
+        }
+        advance(o,b);return 0;
+    }
+    if(op==306){
+        if(n!=PACKET||!o.job.active)throw std::invalid_argument("perception resume state/width");
+        Job &j=o.job;int stage=r.integer();if(stage!=j.stage)throw std::invalid_argument("perception resume tag");
+        if(stage==1){
+            Record t=record(r,true),expected=o.roster[j.cursor];
+            if(t.kind!=expected.kind||t.id!=expected.id)throw std::invalid_argument("template identity");
+            o.templates[std::make_pair(j.cursor,j.phase)]=t;j.stage=0;
+        }else if(stage==2){
+            Projection p;p.view=r.next();p.base0=r.next();p.base1=r.next();p.shot=r.next();p.moving=r.integer()!=0;p.add=r.next();p.multiply=r.next();j.projection=p;
+            if(!detected(o,j.distance,p.view,camouflage(p,j.fired,0,true),true)){store(o,false);result(o,false);}
+            else if(!admit(o,j.key))result(o,false);
+            else j.stage=3;
+        }else if(stage==3){
+            bool los=r.integer()!=0;double foliage=r.next();
+            bool value=detected(o,j.distance,j.projection.view,camouflage(j.projection,j.fired,foliage,false),los);
+            store(o,value);result(o,value);
+        }else throw std::invalid_argument("perception query tag");
+        advance(o,b);return 0;
+    }
+    if(op==308||op==309){
+        TeamKey key;key[0]=r.integer();key[1]=r.integer();key[2]=r.integer();double now=r.next();
+        if(op==308){double duration=r.next();r.end();renew(o,key,now,duration);b[0]=1;}
+        else {r.end();b[0]=remaining(o,key,now);}
+        return 0;
+    }
+    if(op==310){
+        if(n!=20)throw std::invalid_argument("perception stats width");
+        double age=0;for(auto item:o.deferred)age=std::max(age,std::max(0.0,o.diagnostic_now-item.second));
+        b[0]=o.waiting.size();b[1]=o.max_depth;b[2]=age;b[3]=o.max_age;
+        b[4]=o.admitted;b[5]=o.completed;b[6]=o.deferred_count;
+        for(int i=0;i<4;++i)b[7+i]=o.services[i];
+        return 0;
+    }
+    if(op==311){r.end();o.job=Job();return 0;}
+    if(op==312){r.end();int id=static_cast<int>(b[1]);owners.erase(id);return 0;}
+    throw std::invalid_argument("perception opcode");
+}

--- a/tools/ffi_experiment/perception_core.h
+++ b/tools/ffi_experiment/perception_core.h
@@ -1,0 +1,5 @@
+#ifndef OFFLINE_PERCEPTION_CORE_H
+#define OFFLINE_PERCEPTION_CORE_H
+int offline_perception_dispatch(double *buffer, int count);
+void offline_perception_reset();
+#endif

--- a/tools/ffi_experiment/portable_workload.py
+++ b/tools/ffi_experiment/portable_workload.py
@@ -124,7 +124,11 @@ def main():
                         help='attribute host CPU using a --profile build; separate from primary timing')
     parser.add_argument('--components', default='', help='Additional native components: aiming,driver,driver-flow,contacts,world,world-sync,navigation-flow,motion-flow,kernel,world-resolver')
     parser.add_argument('--world-trace-output', help='record ordered collision leaves for a separate computation estimate')
+    parser.add_argument('--codec-fixture-output',
+                        help='export final Python-owned rows for the isolated C++ thread experiment')
     args = parser.parse_args()
+    if args.codec_fixture_output and args.backend != 'python':
+        parser.error('--codec-fixture-output requires --backend python')
     if args.seconds <= 0 or args.fps <= 0 or (args.backend != 'python' and not args.module):
         parser.error('positive duration/cadence and a native module are required')
     if args.world_trace_output and args.backend != 'python':
@@ -221,6 +225,20 @@ def main():
                         'paths': sorted((repr(key), path) for key, path in nav.paths.items()),
                     })
                 cpu_seconds = CLOCK() - started
+                if args.codec_fixture_output:
+                    from kernel_adapter import codec_config
+                    codec = fixture['fixtures']._load().bot_state_codec
+                    identities = sorted(runtime.states)
+                    rows = [codec.encode_row(runtime.states[key]) for key in identities]
+                    # Reconstruct only the published contract. Runtime state also
+                    # contains engine fixture objects that have no JSON ABI.
+                    states = [codec.decode_row(row, dict(equipment_contracts=[
+                        e.contract for e in runtime._equipment_states.get(key, ())]))
+                        for key, row in zip(identities, rows)]
+                    with open(args.codec_fixture_output, 'w') as stream:
+                        json.dump(dict(codec=codec_config(codec), states=states,
+                                       rows=rows), stream,
+                                  sort_keys=True, allow_nan=False)
                 if args.boundary_profile:
                     boundary_profile = backend.module.profile_stop()
                     profiling = False

--- a/tools/ffi_experiment/portable_workload.py
+++ b/tools/ffi_experiment/portable_workload.py
@@ -120,7 +120,7 @@ def main():
     parser.add_argument('--fps', type=float, default=15.0)
     parser.add_argument('--output', required=True)
     parser.add_argument('--stage-timing', action='store_true')
-    parser.add_argument('--components', default='', help='Additional native components: aiming,driver,contacts,world')
+    parser.add_argument('--components', default='', help='Additional native components: aiming,driver,driver-flow,contacts,world,world-sync,navigation-flow,motion-flow')
     parser.add_argument('--world-trace-output', help='record ordered collision leaves for a separate computation estimate')
     args = parser.parse_args()
     if args.seconds <= 0 or args.fps <= 0 or (args.backend != 'python' and not args.module):
@@ -130,6 +130,7 @@ def main():
     backend = None
     stage_recorder = None
     components = []
+    motion_component = None
     world_recorder = None
     messages, progress = [], []
     random.seed(17)
@@ -148,15 +149,25 @@ def main():
             if 'aiming' in args.components.split(','):
                 from combat_adapter import CombatBackend
                 components.append(CombatBackend(backend, fixture['fixtures']._load()).install())
-            if 'driver' in args.components.split(','):
+            if 'driver' in args.components.split(',') or 'driver-flow' in args.components.split(','):
                 from driver_adapter import DriverBackend
-                components.append(DriverBackend(backend, runtime))
+                components.append(DriverBackend(backend, runtime, 'driver-flow' in args.components.split(',')))
             if 'contacts' in args.components.split(','):
                 from perception_adapter import PerceptionBackend
                 components.append(PerceptionBackend(backend, runtime, fixture['fixtures']._load()))
             if 'world' in args.components.split(','):
                 from world_adapter import WorldBackend
                 components.append(WorldBackend(backend))
+            if 'world-sync' in args.components.split(','):
+                from world_adapter import SyncWorldBackend
+                components.append(SyncWorldBackend(backend))
+            if 'navigation-flow' in args.components.split(','):
+                from navigation_flow_adapter import NavigationFlowBackend
+                components.append(NavigationFlowBackend(backend, runtime, navigation))
+            if 'motion-flow' in args.components.split(','):
+                from motion_adapter import MotionFlowBackend
+                motion_component = MotionFlowBackend(backend, runtime, fixture['fixtures']._load())
+                components.append(motion_component)
         init_seconds = CLOCK() - init_started
         @contextlib.contextmanager
         def no_queries():
@@ -204,6 +215,8 @@ def main():
                   seconds=args.seconds, fps=args.fps,
                   real_native_timing=False, projectile_terminals_simulated=False,
                   snapshot=snapshot)
+    if motion_component is not None:
+        report['motion_vertical_coverage'] = motion_component.vertical_counts
     if stage_recorder is not None:
         report['stage_timings'] = stage_recorder.rows
     if world_recorder is not None:

--- a/tools/ffi_experiment/portable_workload.py
+++ b/tools/ffi_experiment/portable_workload.py
@@ -120,7 +120,7 @@ def main():
     parser.add_argument('--fps', type=float, default=15.0)
     parser.add_argument('--output', required=True)
     parser.add_argument('--stage-timing', action='store_true')
-    parser.add_argument('--components', default='', help='Additional native components: aiming,driver,driver-flow,contacts,world,world-sync,navigation-flow,motion-flow')
+    parser.add_argument('--components', default='', help='Additional native components: aiming,driver,driver-flow,contacts,world,world-sync,navigation-flow,motion-flow,kernel')
     parser.add_argument('--world-trace-output', help='record ordered collision leaves for a separate computation estimate')
     args = parser.parse_args()
     if args.seconds <= 0 or args.fps <= 0 or (args.backend != 'python' and not args.module):
@@ -131,6 +131,7 @@ def main():
     stage_recorder = None
     components = []
     motion_component = None
+    kernel_component = None
     world_recorder = None
     messages, progress = [], []
     random.seed(17)
@@ -144,8 +145,10 @@ def main():
             components.append(world_recorder)
         init_started = CLOCK()
         if args.backend != 'python':
-            backend = Backend(args.module).install(navigation, batch=args.backend == 'native')
-            backend.graph(runtime.navigator.grid, navigation)
+            backend = Backend(args.module)
+            if 'kernel' not in args.components.split(','):
+                backend.install(navigation, batch=args.backend == 'native')
+                backend.graph(runtime.navigator.grid, navigation)
             if 'aiming' in args.components.split(','):
                 from combat_adapter import CombatBackend
                 components.append(CombatBackend(backend, fixture['fixtures']._load()).install())
@@ -176,6 +179,12 @@ def main():
                    if args.scenario == 'combat' else no_queries())
         try:
             with context as queries:
+                if 'kernel' in args.components.split(','):
+                    from kernel_adapter import KernelBackend
+                    kernel_started = CLOCK()
+                    kernel_component = KernelBackend(backend, runtime, fixture['fixtures']._load()).install()
+                    components.append(kernel_component)
+                    init_seconds += CLOCK() - kernel_started
                 if args.stage_timing:
                     from stage_timing import Recorder
                     stage_recorder = Recorder(backend, runtime)
@@ -197,6 +206,8 @@ def main():
                         'paths': sorted((repr(key), path) for key, path in nav.paths.items()),
                     })
                 cpu_seconds = CLOCK() - started
+            if kernel_component is not None:
+                runtime._decision_counts = kernel_component.counters()['decisions']
             counts = ({'calls': backend.calls, 'expansions': backend.expansions,
                        'completed': backend.completed} if backend else {})
             snapshot = {'messages': messages, 'native_queries': queries,

--- a/tools/ffi_experiment/portable_workload.py
+++ b/tools/ffi_experiment/portable_workload.py
@@ -228,6 +228,12 @@ def main():
                   snapshot=snapshot)
     if motion_component is not None:
         report['motion_vertical_coverage'] = motion_component.vertical_counts
+    if kernel_component is not None:
+        leaves = kernel_component.engine
+        report['kernel_callback_counts'] = dict(
+            engine_leaves_cpp_to_python=sum(count for kind, count in leaves.calls.items() if kind >= 750),
+            actor_reads=leaves.actor_calls, actor_decodes=leaves.actor_decodes,
+            leaves=leaves.calls)
     if stage_recorder is not None:
         report['stage_timings'] = stage_recorder.rows
     if world_recorder is not None:

--- a/tools/ffi_experiment/portable_workload.py
+++ b/tools/ffi_experiment/portable_workload.py
@@ -120,11 +120,13 @@ def main():
     parser.add_argument('--fps', type=float, default=15.0)
     parser.add_argument('--output', required=True)
     parser.add_argument('--stage-timing', action='store_true')
+    parser.add_argument('--components', default='', help='Additional native components: aiming,driver,contacts')
     args = parser.parse_args()
     if args.seconds <= 0 or args.fps <= 0 or (args.backend != 'python' and not args.module):
         parser.error('positive duration/cadence and a native module are required')
     backend = None
     stage_recorder = None
+    components = []
     messages, progress = [], []
     random.seed(17)
     with redirected():
@@ -135,6 +137,15 @@ def main():
         if args.backend != 'python':
             backend = Backend(args.module).install(navigation, batch=args.backend == 'native')
             backend.graph(runtime.navigator.grid, navigation)
+            if 'aiming' in args.components.split(','):
+                from combat_adapter import CombatBackend
+                components.append(CombatBackend(backend, fixture['fixtures']._load()).install())
+            if 'driver' in args.components.split(','):
+                from driver_adapter import DriverBackend
+                components.append(DriverBackend(backend, runtime))
+            if 'contacts' in args.components.split(','):
+                from perception_adapter import PerceptionBackend
+                components.append(PerceptionBackend(backend, runtime, fixture['fixtures']._load()))
         init_seconds = CLOCK() - init_started
         @contextlib.contextmanager
         def no_queries():
@@ -145,7 +156,7 @@ def main():
             with context as queries:
                 if args.stage_timing:
                     from stage_timing import Recorder
-                    stage_recorder = Recorder(backend)
+                    stage_recorder = Recorder(backend, runtime)
                 started = CLOCK()
                 for frame in range(int(round(args.seconds * args.fps))):
                     outgoing = runtime.update(1.0 / args.fps, 100.0 + (frame + 1) / args.fps)
@@ -168,13 +179,15 @@ def main():
                        'completed': backend.completed} if backend else {})
             snapshot = {'messages': messages, 'native_queries': queries,
                         'probes': runtime.probe_totals(), 'decisions': runtime._decision_counts,
-                        'navigation': progress}
+                        'navigation': progress, 'diagnostics': runtime.diagnostic_totals()}
         finally:
             if stage_recorder is not None:
                 stage_recorder.close()
+            for component in reversed(components):
+                component.close()
             if backend is not None:
                 backend.close()
-    report = dict(backend=args.backend, cpu_seconds=cpu_seconds,
+    report = dict(backend=args.backend, components=args.components, cpu_seconds=cpu_seconds,
                   initialization_cpu_seconds=init_seconds, native_counts=counts,
                   python=sys.version, scenario=args.scenario, map=args.map,
                   seconds=args.seconds, fps=args.fps,

--- a/tools/ffi_experiment/portable_workload.py
+++ b/tools/ffi_experiment/portable_workload.py
@@ -120,6 +120,8 @@ def main():
     parser.add_argument('--fps', type=float, default=15.0)
     parser.add_argument('--output', required=True)
     parser.add_argument('--stage-timing', action='store_true')
+    parser.add_argument('--boundary-profile', action='store_true',
+                        help='attribute host CPU using a --profile build; separate from primary timing')
     parser.add_argument('--components', default='', help='Additional native components: aiming,driver,driver-flow,contacts,world,world-sync,navigation-flow,motion-flow,kernel,world-resolver')
     parser.add_argument('--world-trace-output', help='record ordered collision leaves for a separate computation estimate')
     args = parser.parse_args()
@@ -127,6 +129,8 @@ def main():
         parser.error('positive duration/cadence and a native module are required')
     if args.world_trace_output and args.backend != 'python':
         parser.error('--world-trace-output requires the unmodified Python backend')
+    if args.boundary_profile and args.backend == 'python':
+        parser.error('--boundary-profile requires the native host bridge')
     if 'world-resolver' in args.components.split(',') and (
             'kernel' not in args.components.split(',') or args.scenario != 'combat'):
         parser.error('world-resolver requires the kernel and combat owner fixture')
@@ -136,6 +140,8 @@ def main():
     motion_component = None
     kernel_component = None
     world_recorder = None
+    boundary_profile = None
+    profiling = False
     messages, progress = [], []
     random.seed(17)
     with redirected():
@@ -194,6 +200,9 @@ def main():
                 if args.stage_timing:
                     from stage_timing import Recorder
                     stage_recorder = Recorder(backend, runtime)
+                if args.boundary_profile:
+                    backend.module.profile_start()
+                    profiling = True
                 started = CLOCK()
                 for frame in range(int(round(args.seconds * args.fps))):
                     outgoing = runtime.update(1.0 / args.fps, 100.0 + (frame + 1) / args.fps)
@@ -212,6 +221,9 @@ def main():
                         'paths': sorted((repr(key), path) for key, path in nav.paths.items()),
                     })
                 cpu_seconds = CLOCK() - started
+                if args.boundary_profile:
+                    boundary_profile = backend.module.profile_stop()
+                    profiling = False
             if kernel_component is not None:
                 runtime._decision_counts = kernel_component.counters()['decisions']
             counts = ({'calls': backend.calls, 'expansions': backend.expansions,
@@ -220,6 +232,8 @@ def main():
                         'probes': runtime.probe_totals(), 'decisions': runtime._decision_counts,
                         'navigation': progress, 'diagnostics': runtime.diagnostic_totals()}
         finally:
+            if profiling:
+                backend.module.profile_stop()
             if stage_recorder is not None:
                 stage_recorder.close()
             for component in reversed(components):
@@ -245,6 +259,8 @@ def main():
             leaves=leaves.calls)
     if stage_recorder is not None:
         report['stage_timings'] = stage_recorder.rows
+    if boundary_profile is not None:
+        report['boundary_profile'] = boundary_profile
     if world_recorder is not None:
         with open(args.world_trace_output, 'w') as stream:
             json.dump(world_recorder.traces, stream)

--- a/tools/ffi_experiment/portable_workload.py
+++ b/tools/ffi_experiment/portable_workload.py
@@ -120,19 +120,27 @@ def main():
     parser.add_argument('--fps', type=float, default=15.0)
     parser.add_argument('--output', required=True)
     parser.add_argument('--stage-timing', action='store_true')
-    parser.add_argument('--components', default='', help='Additional native components: aiming,driver,contacts')
+    parser.add_argument('--components', default='', help='Additional native components: aiming,driver,contacts,world')
+    parser.add_argument('--world-trace-output', help='record ordered collision leaves for a separate computation estimate')
     args = parser.parse_args()
     if args.seconds <= 0 or args.fps <= 0 or (args.backend != 'python' and not args.module):
         parser.error('positive duration/cadence and a native module are required')
+    if args.world_trace_output and args.backend != 'python':
+        parser.error('--world-trace-output requires the unmodified Python backend')
     backend = None
     stage_recorder = None
     components = []
+    world_recorder = None
     messages, progress = [], []
     random.seed(17)
     with redirected():
         fixture = load_fixture(args.fixture)
         runtime, ground = fixture['make_runtime'](Path(ROOT), args.map, args.scenario)
         from gui.mods.offline_lan_0922.ai import navigation
+        if args.world_trace_output:
+            from world_trace import Recorder as WorldRecorder
+            world_recorder = WorldRecorder()
+            components.append(world_recorder)
         init_started = CLOCK()
         if args.backend != 'python':
             backend = Backend(args.module).install(navigation, batch=args.backend == 'native')
@@ -146,6 +154,9 @@ def main():
             if 'contacts' in args.components.split(','):
                 from perception_adapter import PerceptionBackend
                 components.append(PerceptionBackend(backend, runtime, fixture['fixtures']._load()))
+            if 'world' in args.components.split(','):
+                from world_adapter import WorldBackend
+                components.append(WorldBackend(backend))
         init_seconds = CLOCK() - init_started
         @contextlib.contextmanager
         def no_queries():
@@ -195,6 +206,9 @@ def main():
                   snapshot=snapshot)
     if stage_recorder is not None:
         report['stage_timings'] = stage_recorder.rows
+    if world_recorder is not None:
+        with open(args.world_trace_output, 'w') as stream:
+            json.dump(world_recorder.traces, stream)
     with open(args.output, 'w') as stream:
         json.dump(report, stream, sort_keys=True)
     print(json.dumps(dict((key, value) for key, value in report.items() if key != 'snapshot'), sort_keys=True))

--- a/tools/ffi_experiment/portable_workload.py
+++ b/tools/ffi_experiment/portable_workload.py
@@ -94,7 +94,7 @@ def load_fixture(path):
     scope = dict(math=math, types=types, sys=sys, json=json, mock=mock,
                  contextlib=contextlib)
     order = ('_Strict1513Component', '_HitTester1513', '_combat_descriptor',
-             '_bot_equipment_contracts', '_Vector', '_Manager', '_catalog',
+             '_bot_equipment_contracts', '_Vector', '_Manager', '_ItemMatrix', '_catalog',
              '_empty_catalog_scan_fixture', 'crew_factors_module', 'make_runtime',
              'combat_native_queries')
     for name in order:
@@ -120,13 +120,16 @@ def main():
     parser.add_argument('--fps', type=float, default=15.0)
     parser.add_argument('--output', required=True)
     parser.add_argument('--stage-timing', action='store_true')
-    parser.add_argument('--components', default='', help='Additional native components: aiming,driver,driver-flow,contacts,world,world-sync,navigation-flow,motion-flow,kernel')
+    parser.add_argument('--components', default='', help='Additional native components: aiming,driver,driver-flow,contacts,world,world-sync,navigation-flow,motion-flow,kernel,world-resolver')
     parser.add_argument('--world-trace-output', help='record ordered collision leaves for a separate computation estimate')
     args = parser.parse_args()
     if args.seconds <= 0 or args.fps <= 0 or (args.backend != 'python' and not args.module):
         parser.error('positive duration/cadence and a native module are required')
     if args.world_trace_output and args.backend != 'python':
         parser.error('--world-trace-output requires the unmodified Python backend')
+    if 'world-resolver' in args.components.split(',') and (
+            'kernel' not in args.components.split(',') or args.scenario != 'combat'):
+        parser.error('world-resolver requires the kernel and combat owner fixture')
     backend = None
     stage_recorder = None
     components = []
@@ -182,7 +185,10 @@ def main():
                 if 'kernel' in args.components.split(','):
                     from kernel_adapter import KernelBackend
                     kernel_started = CLOCK()
-                    kernel_component = KernelBackend(backend, runtime, fixture['fixtures']._load()).install()
+                    world_owner = (runtime._ffi_world_owner
+                                   if 'world-resolver' in args.components.split(',') else None)
+                    kernel_component = KernelBackend(backend, runtime, fixture['fixtures']._load(),
+                                                     world_owner=world_owner).install()
                     components.append(kernel_component)
                     init_seconds += CLOCK() - kernel_started
                 if args.stage_timing:
@@ -230,6 +236,9 @@ def main():
         report['motion_vertical_coverage'] = motion_component.vertical_counts
     if kernel_component is not None:
         leaves = kernel_component.engine
+        if leaves.world is not None:
+            report['world_resolver_callbacks'] = dict(zip(
+                ('begin', 'query', 'finish', 'query_pair'), leaves.world.calls))
         report['kernel_callback_counts'] = dict(
             engine_leaves_cpp_to_python=sum(count for kind, count in leaves.calls.items() if kind >= 750),
             actor_reads=leaves.actor_calls, actor_decodes=leaves.actor_decodes,

--- a/tools/ffi_experiment/portable_workload.py
+++ b/tools/ffi_experiment/portable_workload.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python
+"""Run the same existing Bot fixture on CPython 2.7 or 3.
+
+Export the selected fixture bodies first with export_fixture.py. This runner
+supplies only import/path/mock compatibility for that test scaffolding. It
+executes the repository's client modules directly, without translating them.
+"""
+from __future__ import print_function
+import argparse
+import contextlib
+import importlib
+import io
+import json
+import math
+import os
+import random
+import sys
+import time
+import types
+from navigation_adapter import Backend
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+CLOCK = time.process_time if hasattr(time, 'process_time') else time.clock
+
+
+class Namespace(object):
+    def __init__(self, **values):
+        self.__dict__.update(values)
+
+
+class Path(object):
+    def __init__(self, value):
+        self.value = str(value)
+    def __str__(self):
+        return self.value
+    def __truediv__(self, value):
+        return Path(os.path.join(self.value, str(value)))
+    __div__ = __truediv__
+    def read_text(self):
+        with open(self.value) as stream:
+            return stream.read()
+
+
+@contextlib.contextmanager
+def patch_dict(target, values):
+    previous = dict(target)
+    target.update(values)
+    try:
+        yield
+    finally:
+        for key in values:
+            if key in previous:
+                target[key] = previous[key]
+            else:
+                target.pop(key, None)
+
+
+@contextlib.contextmanager
+def patch_object(target, name, return_value):
+    previous = getattr(target, name)
+    setattr(target, name, lambda *args, **kwargs: return_value)
+    try:
+        yield
+    finally:
+        setattr(target, name, previous)
+
+
+@contextlib.contextmanager
+def redirected():
+    previous = sys.stdout
+    # Client logging uses text writes in both interpreters.
+    stream = io.BytesIO() if sys.version_info[0] == 2 else io.StringIO()
+    sys.stdout = stream
+    try:
+        yield
+    finally:
+        sys.stdout = previous
+
+
+def load_fixture(path):
+    client = os.path.join(ROOT, 'src', 'res', 'scripts', 'client', 'gui', 'mods', 'offline_lan_0922')
+    for name, directory in [('gui', client), ('gui.mods', client),
+                            ('gui.mods.offline_lan_0922', client),
+                            ('gui.mods.offline_lan_0922.ai', os.path.join(client, 'ai'))]:
+        module = types.ModuleType(name)
+        module.__path__ = [directory]
+        sys.modules[name] = module
+    if not hasattr(types, 'SimpleNamespace'):
+        types.SimpleNamespace = Namespace
+    with open(path) as stream:
+        bodies = json.load(stream)
+    mock = Namespace(Mock=lambda return_value: lambda *args, **kwargs: return_value,
+                     patch=Namespace(dict=patch_dict, object=patch_object))
+    scope = dict(math=math, types=types, sys=sys, json=json, mock=mock,
+                 contextlib=contextlib)
+    order = ('_Strict1513Component', '_HitTester1513', '_combat_descriptor',
+             '_bot_equipment_contracts', '_Vector', '_Manager', '_catalog',
+             '_empty_catalog_scan_fixture', 'crew_factors_module', 'make_runtime',
+             'combat_native_queries')
+    for name in order:
+        code = compile(('# -*- coding: utf-8 -*-\n' + bodies[name]).encode('utf-8'), name, 'exec')
+        eval(code, scope)
+    fixtures = Namespace(**scope)
+    fixtures._load = lambda: importlib.import_module('gui.mods.offline_lan_0922.bot_runtime')
+    fixtures.DestructiblesCompatibilityTests = type('EmptyFixture', (object,), {
+        '_empty_catalog_scan_fixture': scope['_empty_catalog_scan_fixture']})
+    scope['fixtures'] = fixtures
+    scope['destructibles_sensor'] = importlib.import_module('gui.mods.offline_lan_0922.destructibles_sensor')
+    return scope
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--fixture', required=True)
+    parser.add_argument('--backend', choices=('python', 'native', 'native-step'), required=True)
+    parser.add_argument('--module')
+    parser.add_argument('--map', default='59_asia_great_wall')
+    parser.add_argument('--scenario', choices=('navigation', 'combat'), default='combat')
+    parser.add_argument('--seconds', type=float, default=30.0)
+    parser.add_argument('--fps', type=float, default=15.0)
+    parser.add_argument('--output', required=True)
+    parser.add_argument('--stage-timing', action='store_true')
+    args = parser.parse_args()
+    if args.seconds <= 0 or args.fps <= 0 or (args.backend != 'python' and not args.module):
+        parser.error('positive duration/cadence and a native module are required')
+    backend = None
+    stage_recorder = None
+    messages, progress = [], []
+    random.seed(17)
+    with redirected():
+        fixture = load_fixture(args.fixture)
+        runtime, ground = fixture['make_runtime'](Path(ROOT), args.map, args.scenario)
+        from gui.mods.offline_lan_0922.ai import navigation
+        init_started = CLOCK()
+        if args.backend != 'python':
+            backend = Backend(args.module).install(navigation, batch=args.backend == 'native')
+            backend.graph(runtime.navigator.grid, navigation)
+        init_seconds = CLOCK() - init_started
+        @contextlib.contextmanager
+        def no_queries():
+            yield []
+        context = (fixture['combat_native_queries'](runtime, ground)
+                   if args.scenario == 'combat' else no_queries())
+        try:
+            with context as queries:
+                if args.stage_timing:
+                    from stage_timing import Recorder
+                    stage_recorder = Recorder(backend)
+                started = CLOCK()
+                for frame in range(int(round(args.seconds * args.fps))):
+                    outgoing = runtime.update(1.0 / args.fps, 100.0 + (frame + 1) / args.fps)
+                    messages.extend(outgoing)
+                    for message in outgoing:
+                        for launch in message.get('launches', ()):
+                            runtime.ack_projectile_launch(launch['id'], launch['fire_seq'])
+                    nav = runtime.navigator
+                    progress.append({
+                        'pending': sorted(repr(key) for key in nav.searches),
+                        'next': repr(nav.search_next_key),
+                        'credit': nav.search_credit, 'budget': nav.search_frame_budget,
+                        'completed': nav.search_completed, 'failed': nav.search_failed,
+                        'last_frames': sorted((repr(key), search.last_frame)
+                                              for key, search in nav.searches.items()),
+                        'paths': sorted((repr(key), path) for key, path in nav.paths.items()),
+                    })
+                cpu_seconds = CLOCK() - started
+            counts = ({'calls': backend.calls, 'expansions': backend.expansions,
+                       'completed': backend.completed} if backend else {})
+            snapshot = {'messages': messages, 'native_queries': queries,
+                        'probes': runtime.probe_totals(), 'decisions': runtime._decision_counts,
+                        'navigation': progress}
+        finally:
+            if stage_recorder is not None:
+                stage_recorder.close()
+            if backend is not None:
+                backend.close()
+    report = dict(backend=args.backend, cpu_seconds=cpu_seconds,
+                  initialization_cpu_seconds=init_seconds, native_counts=counts,
+                  python=sys.version, scenario=args.scenario, map=args.map,
+                  seconds=args.seconds, fps=args.fps,
+                  real_native_timing=False, projectile_terminals_simulated=False,
+                  snapshot=snapshot)
+    if stage_recorder is not None:
+        report['stage_timings'] = stage_recorder.rows
+    with open(args.output, 'w') as stream:
+        json.dump(report, stream, sort_keys=True)
+    print(json.dumps(dict((key, value) for key, value in report.items() if key != 'snapshot'), sort_keys=True))
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/ffi_experiment/query_bridge.cpp
+++ b/tools/ffi_experiment/query_bridge.cpp
@@ -42,6 +42,9 @@ extern "C" int offline_query_can_enter(const double *buffer,int count) {
 extern "C" int offline_query(double *packet, int count) {
     return active_callback ? active_callback(active_owner, packet, count) : 18;
 }
+OfflineQueryRoute::OfflineQueryRoute(OfflineQueryCallback callback,void *owner):previous(active_callback),previous_owner(active_owner){active_callback=callback;active_owner=owner;}
+OfflineQueryRoute::~OfflineQueryRoute(){active_callback=previous;active_owner=previous_owner;}
+int OfflineQueryRoute::forward(double *packet,int count)const{return previous?previous(previous_owner,packet,count):18;}
 extern "C" int offline_query_dispatch(double *buffer, int count,
                                      double *query_buffer,int query_count,
                                      OfflineQueryCallback callback, void *owner) {

--- a/tools/ffi_experiment/query_bridge.cpp
+++ b/tools/ffi_experiment/query_bridge.cpp
@@ -1,0 +1,62 @@
+#include "query_bridge.h"
+#include "astar_core.h"
+#include <cstdint>
+#include <cstddef>
+using std::size_t;
+
+namespace {
+// The bridge keeps the GIL and runs only on its caller's thread. Only reviewed
+// synchronous query operations may nest; no callback can reset an active owner.
+OfflineQueryCallback active_callback = 0;
+void *active_owner = 0;
+struct Borrowed {
+    uintptr_t command,query;size_t command_bytes,query_bytes;Borrowed *previous;
+};
+Borrowed *borrowed=0;
+bool overlaps(uintptr_t a,size_t an,uintptr_t b,size_t bn){
+    return a<=b?b-a<an:a-b<bn;
+}
+bool available(const double *buffer,int count){
+    if(!buffer||count<1||count>12000012)return false;
+    uintptr_t at=reinterpret_cast<uintptr_t>(buffer);size_t size=static_cast<size_t>(count)*sizeof(double);
+    if(at>UINTPTR_MAX-size)return false;
+    for(Borrowed *p=borrowed;p;p=p->previous)
+        if(overlaps(at,size,p->command,p->command_bytes)||overlaps(at,size,p->query,p->query_bytes))return false;
+    return true;
+}
+}
+extern "C" int offline_query_buffers_available(const double *buffer,int count,const double *query,int query_count){
+    return available(buffer,count)&&available(query,query_count)&&
+        !overlaps(reinterpret_cast<uintptr_t>(buffer),static_cast<size_t>(count)*sizeof(double),
+                  reinterpret_cast<uintptr_t>(query),static_cast<size_t>(query_count)*sizeof(double));
+}
+extern "C" int offline_query_active(void) { return active_callback != 0; }
+extern "C" int offline_query_can_enter(const double *buffer,int count) {
+    if(!active_callback)return 1;
+    if(!available(buffer,count))return 0;
+    if(buffer[0]==405)return 1; // Stack-owned horizontal sweep; no persistent job.
+    if(buffer[0]==501)return 1; // Geometry query on immutable map data.
+    if(buffer[0]==512&&count>=4)return buffer[2]==6||buffer[2]==7||buffer[2]==8||buffer[2]==9;
+    return 0;
+}
+extern "C" int offline_query(double *packet, int count) {
+    return active_callback ? active_callback(active_owner, packet, count) : 18;
+}
+extern "C" int offline_query_dispatch(double *buffer, int count,
+                                     double *query_buffer,int query_count,
+                                     OfflineQueryCallback callback, void *owner) {
+    if (!callback || !offline_query_can_enter(buffer,count)||
+            !offline_query_buffers_available(buffer,count,query_buffer,query_count)) return 18;
+    Borrowed local{reinterpret_cast<uintptr_t>(buffer),reinterpret_cast<uintptr_t>(query_buffer),
+        static_cast<size_t>(count)*sizeof(double),static_cast<size_t>(query_count)*sizeof(double),borrowed};
+    borrowed=&local;
+    OfflineQueryCallback previous_callback=active_callback;
+    void *previous_owner=active_owner;
+    active_callback = callback;
+    active_owner = owner;
+    int status = offline_astar_dispatch(buffer, count);
+    active_callback = previous_callback;
+    active_owner = previous_owner;
+    borrowed=local.previous;
+    return status;
+}

--- a/tools/ffi_experiment/query_bridge.h
+++ b/tools/ffi_experiment/query_bridge.h
@@ -16,5 +16,18 @@ int offline_query_can_enter(const double *buffer, int count);
 int offline_query(double *packet, int count);
 #ifdef __cplusplus
 }
+// Native owners may compose already-reviewed cores on one stack without
+// crossing Python for internal state-publication events. Engine leaves are
+// forwarded to the borrowed outer callback; nesting restores it on unwind.
+class OfflineQueryRoute {
+    OfflineQueryCallback previous;
+    void *previous_owner;
+public:
+    OfflineQueryRoute(OfflineQueryCallback callback,void *owner);
+    ~OfflineQueryRoute();
+    int forward(double *packet,int count)const;
+    OfflineQueryRoute(const OfflineQueryRoute &)=delete;
+    OfflineQueryRoute &operator=(const OfflineQueryRoute &)=delete;
+};
 #endif
 #endif

--- a/tools/ffi_experiment/query_bridge.h
+++ b/tools/ffi_experiment/query_bridge.h
@@ -1,0 +1,20 @@
+#ifndef OFFLINE_QUERY_BRIDGE_H
+#define OFFLINE_QUERY_BRIDGE_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+/* The callback is borrowed for this synchronous call only. It replaces the
+ * request packet with its answer; neither side may resize its owned buffer. */
+typedef int (*OfflineQueryCallback)(void *owner, double *packet, int count);
+int offline_query_dispatch(double *buffer, int count,
+                           double *query_buffer, int query_count,
+                           OfflineQueryCallback callback, void *owner);
+int offline_query_buffers_available(const double *buffer,int count,
+                                    const double *query_buffer,int query_count);
+int offline_query_active(void);
+int offline_query_can_enter(const double *buffer, int count);
+int offline_query(double *packet, int count);
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/tools/ffi_experiment/stage_timing.py
+++ b/tools/ffi_experiment/stage_timing.py
@@ -19,6 +19,7 @@ class Recorder(object):
         nav = importlib.import_module(prefix + 'ai.navigation')
         driver = importlib.import_module(prefix + 'ai.adapter')
         battle = importlib.import_module(prefix + 'battle_runtime')
+        world = importlib.import_module(prefix + 'world_collision')
         specs = [
             (bot.BotRuntime, '_update_once', 'bot.slice'),
             (bot.BotRuntime, '_contacts_for', 'contacts'),
@@ -28,6 +29,7 @@ class Recorder(object):
             # its containing driver call, including route work outside A*.
             (driver.BotAdapter, 'decide_with_order', 'driving.and.route'),
             (battle.BattleRuntime, '_resolve_bot_motion', 'motion.collision'),
+            (world, '_check_horizontal_collision', 'motion.world'),
             (bot.BotRuntime, '_cadenced_ballistic_solution', 'ballistics'),
             (bot.BotRuntime, '_update_gun_aim', 'gun.aim'),
             (bot.BotRuntime, '_service_shot_lane_work', 'shot.lanes'),

--- a/tools/ffi_experiment/stage_timing.py
+++ b/tools/ffi_experiment/stage_timing.py
@@ -1,0 +1,71 @@
+"""Optional coarse CPU attribution for the isolated workload, Python 2/3.
+
+Exclusive time subtracts only other selected scopes, not every called
+function. This observer is separate from the uninstrumented primary timing.
+"""
+import importlib
+import time
+
+CLOCK = time.process_time if hasattr(time, 'process_time') else time.clock
+
+
+class Recorder(object):
+    def __init__(self, backend=None):
+        self.rows = {}
+        self.stack = []
+        self.patches = []
+        prefix = 'gui.mods.offline_lan_0922.'
+        bot = importlib.import_module(prefix + 'bot_runtime')
+        nav = importlib.import_module(prefix + 'ai.navigation')
+        driver = importlib.import_module(prefix + 'ai.adapter')
+        battle = importlib.import_module(prefix + 'battle_runtime')
+        specs = [
+            (bot.BotRuntime, '_update_once', 'bot.slice'),
+            (bot.BotRuntime, '_contacts_for', 'contacts'),
+            (nav.TerrainNavigator, '_advance_searches', 'astar.batch'),
+            (nav.TerrainGrid, 'begin_plan', 'astar.request'),
+            # The adapter already holds a bound navigation callback. Measure
+            # its containing driver call, including route work outside A*.
+            (driver.BotAdapter, 'decide_with_order', 'driving.and.route'),
+            (battle.BattleRuntime, '_resolve_bot_motion', 'motion.collision'),
+            (bot.BotRuntime, '_cadenced_ballistic_solution', 'ballistics'),
+            (bot.BotRuntime, '_update_gun_aim', 'gun.aim'),
+            (bot.BotRuntime, '_service_shot_lane_work', 'shot.lanes'),
+            (bot.bot_state_codec, 'encode_row', 'publication.encoding'),
+            (bot.vehicle_physics, 'longitudinal_step', 'motion.longitudinal'),
+            (bot.vehicle_physics, 'traverse_step', 'motion.traverse'),
+        ]
+        if backend is not None:
+            specs.append((backend.module, 'dispatch', 'native.dispatch'))
+        for owner, name, label in specs:
+            self.wrap(owner, name, label)
+
+    def wrap(self, owner, name, label):
+        original = owner.__dict__[name]
+        row = self.rows.setdefault(label, {
+            'calls': 0, 'inclusive_cpu_seconds': 0.0,
+            'exclusive_cpu_seconds': 0.0})
+        recorder = self
+
+        def measured(*args, **kwargs):
+            item = [CLOCK(), 0.0]
+            recorder.stack.append(item)
+            try:
+                return original(*args, **kwargs)
+            finally:
+                elapsed = CLOCK() - item[0]
+                recorder.stack.pop()
+                row['calls'] += 1
+                row['inclusive_cpu_seconds'] += elapsed
+                row['exclusive_cpu_seconds'] += elapsed - item[1]
+                if recorder.stack:
+                    recorder.stack[-1][1] += elapsed
+
+        setattr(owner, name, measured)
+        self.patches.append((owner, name, original, measured))
+
+    def close(self):
+        for owner, name, original, measured in reversed(self.patches):
+            if owner.__dict__[name] is measured:
+                setattr(owner, name, original)
+        self.patches = []

--- a/tools/ffi_experiment/stage_timing.py
+++ b/tools/ffi_experiment/stage_timing.py
@@ -10,7 +10,7 @@ CLOCK = time.process_time if hasattr(time, 'process_time') else time.clock
 
 
 class Recorder(object):
-    def __init__(self, backend=None):
+    def __init__(self, backend=None, runtime=None):
         self.rows = {}
         self.stack = []
         self.patches = []
@@ -38,6 +38,9 @@ class Recorder(object):
         if backend is not None:
             specs.append((backend.module, 'dispatch', 'native.dispatch'))
         for owner, name, label in specs:
+            if (owner is bot.BotRuntime and runtime is not None and
+                    name in runtime.__dict__):
+                owner = runtime
             self.wrap(owner, name, label)
 
     def wrap(self, owner, name, label):

--- a/tools/ffi_experiment/vehicle_motion.h
+++ b/tools/ffi_experiment/vehicle_motion.h
@@ -1,0 +1,143 @@
+#ifndef OFFLINE_EXPERIMENT_VEHICLE_MOTION_H
+#define OFFLINE_EXPERIMENT_VEHICLE_MOTION_H
+#include <algorithm>
+#include <array>
+#include <cmath>
+
+namespace offline_motion {
+// Values are read from the current Python vehicle_physics owner at install.
+// Configured tuning and descriptor-derived parameters cross once, not per ray.
+#define OFFLINE_MOTION_CONSTANTS(X) \
+    X(GRAVITY) X(GRAVITY_FACTOR) X(COHESION) X(DRIVE_TRACTION) \
+    X(SLOPE_GRIP_LNG_FULL_Y) X(SLOPE_GRIP_LNG_FULL) X(SLOPE_GRIP_LNG_MIN_Y) X(SLOPE_GRIP_LNG_MIN) \
+    X(POWER_FACTOR) X(BKWD_POWER_FRACTION) X(ENGINE_MIN_V) X(STEER_RESIST_MULT) \
+    X(COH_DECAY_Y) X(COH_DECAY_FACTOR) X(COH_DECAY_POW) X(SLOPE_COH_DECAY_Y) X(SLOPE_COH_DECAY) X(COH_DECAY_BOUND) \
+    X(COAST_BRAKE_SHARE) X(SLIDE_KINETIC) X(SLIDE_HOLD_TAN) X(SLIP_THRESHOLD_TAN) X(SLIP_DRAG) \
+    X(OVERSPEED_MAX_FACTOR) X(OVERSPEED_BUILD) X(OVERSPEED_DAMP) \
+    X(SPEED_AFFECT_ROT_DECREASE) X(ANG_ACCELERATION_TIME) \
+    X(HARD_CONTACT_ENTRY_FACTOR) X(HARD_CONTACT_SLIDE_DECAY) X(HARD_CONTACT_BRAKE_DECAY) X(HARD_CONTACT_STOP_SPEED) \
+    X(GROUND_PITCH_LIMIT) X(GROUND_FOLLOW_BASE) X(GROUND_FOLLOW_MIN) X(GROUND_FOLLOW_MAX) \
+    X(SLIDE_DRAG) X(SLIDE_MAX) X(FALL_SAFE_SPEED) X(FALL_DMG_PER_MS)
+struct Tuning {
+#define DECLARE(name) double name;
+    OFFLINE_MOTION_CONSTANTS(DECLARE)
+#undef DECLARE
+};
+struct Params {
+    double mass,powerW,nativePowerRatio,specificFriction,brakeDecel,speedFwd,speedBwd,rotSpd;
+    std::array<double,3> terrainResist;
+};
+inline double clamp(double v,double low,double high){return std::max(low,std::min(high,v));}
+inline double cohesion(const Tuning &c,double ny){
+    double value=c.COHESION;
+    if(ny<c.COH_DECAY_Y)value-=c.COH_DECAY_FACTOR*std::pow(c.COH_DECAY_Y-ny,c.COH_DECAY_POW);
+    if(ny<c.SLOPE_COH_DECAY_Y)value-=c.SLOPE_COH_DECAY;
+    return value>c.COH_DECAY_BOUND?value:c.COH_DECAY_BOUND;
+}
+inline double longitudinal_grip(const Tuning &c,double pitch){
+    double ny=std::cos(pitch),grip;
+    if(ny>=c.SLOPE_GRIP_LNG_FULL_Y)grip=c.SLOPE_GRIP_LNG_FULL;
+    else if(ny<=c.SLOPE_GRIP_LNG_MIN_Y)grip=c.SLOPE_GRIP_LNG_MIN;
+    else{
+        double span=c.SLOPE_GRIP_LNG_FULL_Y-c.SLOPE_GRIP_LNG_MIN_Y;
+        double progress=(ny-c.SLOPE_GRIP_LNG_MIN_Y)/span;
+        grip=c.SLOPE_GRIP_LNG_MIN+progress*(c.SLOPE_GRIP_LNG_FULL-c.SLOPE_GRIP_LNG_MIN);
+    }
+    return grip*c.DRIVE_TRACTION;
+}
+inline double grip_decel(const Tuning &c,double pitch){double ny=std::cos(pitch);return cohesion(c,ny)*c.GRAVITY*(ny>0.1?ny:0.1);}
+inline double rolling(const Tuning &c,const Params &p,int terrain,bool steering){
+    double f=p.mass*p.specificFriction*c.GRAVITY_FACTOR*p.terrainResist[terrain];
+    if(steering)f*=c.STEER_RESIST_MULT;
+    return f;
+}
+inline double engine(const Tuning &c,const Params &p,double v,double throttle,double pitch){
+    if(throttle==0)return 0;
+    double power=p.powerW*c.POWER_FACTOR*p.nativePowerRatio;
+    if(throttle<0)power*=c.BKWD_POWER_FRACTION;
+    double f=power/std::max(std::abs(v),c.ENGINE_MIN_V),ny=std::cos(pitch);
+    double cap=longitudinal_grip(c,pitch)*p.mass*c.GRAVITY*(ny>0.1?ny:0.1);
+    if(f>cap)f=cap;
+    return f*throttle;
+}
+inline double longitudinal(const Tuning &c,const Params &p,double v,double throttle,bool steering,
+                           double pitch,double dt,bool airborne=false,int terrain=0,bool handbrake=false){
+    if(airborne)return v;
+    double grav=c.GRAVITY*std::sin(pitch);
+    if(handbrake){
+        double grip=grip_decel(c,pitch);
+        if(std::abs(v)<0.05)return std::abs(grav)<=grip?0.0:v+(grav-(grav>0?grip:-grip))*dt;
+        double accel=grav-(v>0?grip:-grip),next=v+accel*dt;
+        return (v>0)!=(next>0)?0.0:next;
+    }
+    double grip=grip_decel(c,pitch),rr=rolling(c,p,terrain,steering)/p.mass,accel;
+    if(throttle!=0){
+        double ef=engine(c,p,v,throttle,pitch)/p.mass,ny=std::cos(pitch);
+        double climb=longitudinal_grip(c,pitch)*c.GRAVITY*(ny>0.1?ny:0.1);
+        bool cannot=throttle*grav<0&&climb<std::abs(grav)+rr;
+        if(cannot)ef=0;
+        accel=ef+grav;double drag=clamp(v/0.08,-1,1);accel-=rr*drag;
+        if(cannot){
+            if(std::abs(v)>0.05){double kinetic=c.SLIDE_KINETIC*c.GRAVITY*(ny>0.1?ny:0.1);accel+=v<0?kinetic:-kinetic;}
+        }else if((throttle>0&&v<-0.1)||(throttle<0&&v>0.1)){
+            double need=-v/dt-accel;accel+=std::abs(need)<grip?need:(need>0?grip:-grip);
+        }
+    }else{
+        if(std::abs(v)<0.02){
+            double ny=std::cos(pitch),hold=c.SLIDE_HOLD_TAN*c.GRAVITY*(ny>0.1?ny:0.1);
+            if(std::abs(grav)<=hold)return 0;
+            accel=grav-(grav>0?hold:-hold);
+        }else{
+            double sign=v>0?1:-1,downhill=std::max(0.0,std::tan(pitch)*sign),start=0.8*c.SLIDE_HOLD_TAN;
+            double fade=std::min(1.0,std::max(0.0,(downhill-start)/(c.SLIDE_HOLD_TAN-start)));
+            double resist=rr+c.COAST_BRAKE_SHARE*(1.0-fade)*grip;accel=grav-(v>0?resist:-resist);
+        }
+    }
+    double grade=v>0?-pitch:pitch;
+    if(std::abs(v)>0.5&&grade>0){
+        double tangent=std::tan(grade);
+        if(tangent>c.SLIP_THRESHOLD_TAN){double slip=c.SLIP_DRAG*(tangent-c.SLIP_THRESHOLD_TAN)*c.GRAVITY;accel-=v>0?slip:-slip;}
+    }
+    double next=v+accel*dt;
+    if(throttle==0&&std::abs(grav)<=grip&&v!=0&&(v>0)!=(next>0))next=0;
+    double sign=next>=0?1:-1,limit=next>=0?p.speedFwd:p.speedBwd;
+    if(std::abs(next)>limit){
+        double cap=limit*(c.OVERSPEED_MAX_FACTOR-1.0),previous=std::abs(v)-limit;
+        if(previous<0)previous=0;
+        double excess=(throttle*sign>0&&grav*sign>0.05)?
+            previous+c.OVERSPEED_BUILD*std::sin(std::abs(pitch))*dt:previous-(rr+c.OVERSPEED_DAMP)*dt;
+        if(excess<0)excess=0;
+        if(excess>cap)excess=cap;
+        next=sign*(limit+excess);
+    }
+    return next;
+}
+inline double traverse(const Tuning &c,const Params &p,double omega,double steer,double v,double dt,int terrain=0,double intent=0){
+    double ratio=std::abs(v)/std::max(p.speedFwd,0.1),modifier=1.0/(1.0+ratio*c.SPEED_AFFECT_ROT_DECREASE);
+    double ground=p.terrainResist[0]/p.terrainResist[terrain],maximum=p.rotSpd*modifier*ground;
+    double target=steer*(intent<0?-1.0:1.0)*maximum,diff=target-omega,ramp=maximum/c.ANG_ACCELERATION_TIME;
+    if(std::abs(diff)<ramp*dt)omega=target;else omega+=ramp*dt*(diff>0?1:-1);
+    if(steer==0&&std::abs(omega)<0.01)omega=0;
+    return omega;
+}
+inline std::array<double,3> hard_contact(const Tuning &c,double speed,double dt,bool grinding,bool slide,double yaw){
+    dt=std::max(0.0,dt);
+    if(!slide){speed*=std::pow(c.HARD_CONTACT_BRAKE_DECAY,dt*60.0);if(std::abs(speed)<c.HARD_CONTACT_STOP_SPEED)speed=0;return {{speed,0,0}};}
+    if(!grinding)speed*=c.HARD_CONTACT_ENTRY_FACTOR;
+    speed*=std::pow(c.HARD_CONTACT_SLIDE_DECAY,dt*60.0);
+    return {{speed,std::sin(yaw)*speed*dt,std::cos(yaw)*speed*dt}};
+}
+inline double ground_gap(const Tuning &c,double speed,double pitch,double dt){
+    dt=std::max(0.0,dt);pitch=clamp(pitch,-c.GROUND_PITCH_LIMIT,c.GROUND_PITCH_LIMIT);
+    double tangent=std::max(0.0,speed*std::tan(pitch)*dt),gap=c.GROUND_FOLLOW_BASE+tangent+c.GRAVITY*dt*dt;
+    return clamp(gap,c.GROUND_FOLLOW_MIN,c.GROUND_FOLLOW_MAX);
+}
+inline double launch_speed(double speed,double pitch){double vertical=speed*std::sin(-pitch);return vertical>0?vertical:0.0;}
+inline double slope_slide(const Tuning &c,double current,double tangent,double dt){
+    double theta=std::atan(tangent);
+    if(tangent<=c.SLIDE_HOLD_TAN){current-=c.COHESION*c.GRAVITY*dt;return current>0?current:0.0;}
+    current+=(c.GRAVITY*(std::sin(theta)-c.SLIDE_HOLD_TAN*std::cos(theta))-c.SLIDE_DRAG*current)*dt;
+    return clamp(current,0,c.SLIDE_MAX);
+}
+}
+#endif

--- a/tools/ffi_experiment/world_adapter.py
+++ b/tools/ffi_experiment/world_adapter.py
@@ -1,0 +1,92 @@
+"""Opt-in horizontal collision core; Python retains exact engine leaves."""
+from __future__ import print_function
+from array import array
+import importlib
+
+
+def point(value):
+    return [value.x, value.y, value.z]
+
+
+def inputs(world, pos, yaw, vel, descriptor, airborne, dt, motion_yaw, pitch, roll):
+    extents = world._vehicle_motion_extents(descriptor)
+    if extents is None:
+        extents = (1.5, 3.5, 3.5)
+    return point(pos) + [yaw, vel] + list(extents) + [
+        int(bool(airborne)), dt, int(motion_yaw is not None),
+        motion_yaw if motion_yaw is not None else 0.0, pitch, roll]
+
+
+def reply(kind, hit, identity=0):
+    if hit is None:
+        return [0] * 8
+    if kind == 2:
+        return [1, 0, float(hit[0].y), 0, 0, 0, 0, 0]
+    try:
+        normal = point(hit[1])
+    except (AttributeError, IndexError, TypeError):
+        normal = [0, 0, 0]
+    return [1] + point(hit[0]) + normal + [identity]
+
+
+class WorldBackend(object):
+    def __init__(self, backend):
+        self.backend = backend
+        self.world = importlib.import_module('gui.mods.offline_lan_0922.world_collision')
+        self.original = self.world._check_horizontal_collision
+        self.replacement = self.check
+        self.world._check_horizontal_collision = self.replacement
+
+    def close(self):
+        if self.world._check_horizontal_collision is self.replacement:
+            self.world._check_horizontal_collision = self.original
+
+    def check(self, spaceID, pos, yaw, vel, td=None, airborne=False, dt=0.04,
+              return_status=False, allow_kinetic=False, kinetic_speed=None,
+              commit_enabled=True, motion_yaw=None, pitch=0.0, roll=0.0):
+        import BigWorld
+        import Math
+        world = self.world
+        header = inputs(world, pos, yaw, vel, td, airborne, dt, motion_yaw, pitch, roll)
+        values = self.backend.call([400] + header + [0] * 16)[-16:]
+        handle = int(values[15])
+        collision_filter, crush_state, hits = None, [False], {}
+        packet = array('d', [401, handle] + [0] * 24)
+        sequence = 0
+        try:
+            while values[0]:
+                kind = int(values[0])
+                start, end = Math.Vector3(*values[1:4]), Math.Vector3(*values[4:7])
+                sequence += 1
+                if kind == 1:
+                    collision_filter = world.prepare_horizontal_collision_filter(start, end)
+                    answer = [0] * 8
+                elif kind == 2:
+                    try:
+                        args = (spaceID, start, end, 128)
+                        if collision_filter is not None:
+                            args += (collision_filter,)
+                        hit = world.observed_ray('native.motion.ground', BigWorld.wg_collideSegment, *args)
+                        answer = reply(kind, hit)
+                    except (AttributeError, IndexError, TypeError, ValueError):
+                        answer = [0] * 8
+                elif kind == 3:
+                    hit = world._collide_horizontal(spaceID, start, end, collision_filter)
+                    answer = reply(kind, hit, sequence)
+                    if hit is not None:
+                        hits[sequence] = hit
+                elif kind == 4:
+                    result = world._destroy_and_recast(
+                        spaceID, start, end, hits[int(values[7])], yaw, vel, td,
+                        crush_state, allow_kinetic, kinetic_speed, commit_enabled,
+                        collision_filter)
+                    answer = [2 if result == 'kinetic' else 1 if result is True else 0] + [0] * 7
+                else:
+                    raise RuntimeError('unknown native world request')
+                packet[2:10] = array('d', answer)
+                self.backend.call(packet)
+                values = packet[-16:]
+            status = int(values[1])
+            return ('hard', 'clear', 'kinetic')[status] if return_status else status != 1
+        finally:
+            self.backend.call([402, handle])

--- a/tools/ffi_experiment/world_adapter.py
+++ b/tools/ffi_experiment/world_adapter.py
@@ -90,3 +90,54 @@ class WorldBackend(object):
             return ('hard', 'clear', 'kinetic')[status] if return_status else status != 1
         finally:
             self.backend.call([402, handle])
+
+
+class SyncWorldBackend(WorldBackend):
+    """Keep the entire sweep on the C++ stack across borrowed engine calls."""
+    def check(self, spaceID, pos, yaw, vel, td=None, airborne=False, dt=0.04,
+              return_status=False, allow_kinetic=False, kinetic_speed=None,
+              commit_enabled=True, motion_yaw=None, pitch=0.0, roll=0.0):
+        import BigWorld
+        import Math
+        world = self.world
+        header = inputs(world, pos, yaw, vel, td, airborne, dt, motion_yaw, pitch, roll)
+        packet = array('d', [0] * 16)
+        collision_filter, crush_state, hits = [None], [False], {}
+        sequence = [0]
+
+        def query():
+            kind = int(packet[0])
+            start = Math.Vector3(packet[1], packet[2], packet[3])
+            end = Math.Vector3(packet[4], packet[5], packet[6])
+            sequence[0] += 1
+            if kind == 1:
+                collision_filter[0] = world.prepare_horizontal_collision_filter(start, end)
+                answer = [0] * 8
+            elif kind == 2:
+                try:
+                    args = (spaceID, start, end, 128)
+                    if collision_filter[0] is not None:
+                        args += (collision_filter[0],)
+                    hit = world.observed_ray('native.motion.ground', BigWorld.wg_collideSegment, *args)
+                    answer = reply(kind, hit)
+                except (AttributeError, IndexError, TypeError, ValueError):
+                    answer = [0] * 8
+            elif kind == 3:
+                hit = world._collide_horizontal(spaceID, start, end, collision_filter[0])
+                answer = reply(kind, hit, sequence[0])
+                if hit is not None:
+                    hits[sequence[0]] = hit
+            elif kind == 4:
+                result = world._destroy_and_recast(
+                    spaceID, start, end, hits[int(packet[7])], yaw, vel, td,
+                    crush_state, allow_kinetic, kinetic_speed, commit_enabled,
+                    collision_filter[0])
+                answer = [2 if result == 'kinetic' else 1 if result is True else 0] + [0] * 7
+            else:
+                raise RuntimeError('unknown synchronous world request')
+            # Equal-length replacement keeps the borrowed buffer address stable.
+            packet[:8] = array('d', answer)
+
+        values = self.backend.call_sync([405] + header, packet, query)
+        status = int(values[0])
+        return ('hard', 'clear', 'kinetic')[status] if return_status else status != 1

--- a/tools/ffi_experiment/world_core.cpp
+++ b/tools/ffi_experiment/world_core.cpp
@@ -18,30 +18,40 @@ struct Reader {
     int integer(){double v=next();if(v!=std::floor(v)||std::abs(v)>1000000000)throw std::invalid_argument("world integer");return static_cast<int>(v);}
     void end(){if(i!=n)throw std::invalid_argument("world width");}
 };
-struct V {double x,y,z;V(double a=0,double b=0,double c=0):x(a),y(b),z(c){}};
+using V = offline_world::Point;
+double source_power(double base, double exponent) {
+    // CPython 2 BINARY_POWER calls libm even for exponent 2. GCC otherwise
+    // folds pow(x, 2) to multiplication, which changes some ray heights by
+    // one ULP. Preserve the source operation at every world power expression.
+    double (*volatile power)(double, double) = std::pow;
+    return power(base, exponent);
+}
 V vec(Reader &r){double x=r.next(),y=r.next(),z=r.next();return V(x,y,z);}
 double distance(V a,V b){double x=a.x-b.x,y=a.y-b.y,z=a.z-b.z;return std::sqrt(x*x+y*y+z*z);}
 struct Optional {bool has;double value;Optional():has(false),value(0){} Optional(double v):has(true),value(v){}};
 struct Plane {double x,y,z,gx,gz;};
 struct Answer {int status,id;V point,normal;};
 struct Query {int kind,id;V a,b;};
-struct Input {V pos;double yaw,speed,hw,back,front,dt,motion,pitch,roll;bool airborne,has_motion;};
+using Input = offline_world::Input;
 struct Lane {double x1,z1,x2,z2,length,px,pz,ps,pc,direction,look;};
 struct Hit {double length;V a,b;Answer hit;};
+Answer checked_answer(const double *packet) {
+    for(int i=0;i<8;++i)if(!std::isfinite(packet[i]))throw std::invalid_argument("world engine answer");
+    if(packet[0]!=std::floor(packet[0])||packet[0]<0||packet[0]>2||packet[7]!=std::floor(packet[7])||std::abs(packet[7])>1000000000)
+        throw std::invalid_argument("world engine answer type");
+    return Answer{static_cast<int>(packet[0]),static_cast<int>(packet[7]),V(packet[1],packet[2],packet[3]),V(packet[4],packet[5],packet[6])};
+}
 struct Job {
     Input in;std::vector<Answer> answers;std::vector<Query> expected;
-    size_t cursor;bool validate,synchronous;
-    Job():cursor(0),validate(false),synchronous(false){}
+    size_t cursor;bool validate,synchronous,batch_independent;
+    Job():cursor(0),validate(false),synchronous(false),batch_independent(false){}
     Answer query(int kind,V a,V b,int id=0){
         Query q={kind,id,a,b};
         if(synchronous){
             double packet[16]={static_cast<double>(kind),a.x,a.y,a.z,b.x,b.y,b.z,static_cast<double>(id)};
             if(offline_query(packet,16))throw std::runtime_error("world engine query failed");
-            for(int i=0;i<8;++i)if(!std::isfinite(packet[i]))throw std::invalid_argument("world engine answer");
-            if(packet[0]!=std::floor(packet[0])||packet[0]<0||packet[0]>2||packet[7]!=std::floor(packet[7])||std::abs(packet[7])>1000000000)
-                throw std::invalid_argument("world engine answer type");
             ++cursor;
-            return Answer{static_cast<int>(packet[0]),static_cast<int>(packet[7]),V(packet[1],packet[2],packet[3]),V(packet[4],packet[5],packet[6])};
+            return checked_answer(packet);
         }
         if(cursor==answers.size())throw q;
         if(validate){
@@ -50,6 +60,25 @@ struct Job {
                 throw std::invalid_argument("world query geometry/order differs");
         }
         return answers[cursor++];
+    }
+    std::array<Answer, 2> pair(int kind, const std::pair<V,V> &first, const std::pair<V,V> &second) {
+        if (!synchronous || !batch_independent) {
+            Answer a = query(kind, first.first, first.second);
+            Answer b = query(kind, second.first, second.second);
+            return {{a, b}};
+        }
+        double packet[33] = {5};
+        size_t at = 1;
+        for (const auto &ray : {first, second}) {
+            packet[at] = kind;
+            packet[at+1] = ray.first.x; packet[at+2] = ray.first.y; packet[at+3] = ray.first.z;
+            packet[at+4] = ray.second.x; packet[at+5] = ray.second.y; packet[at+6] = ray.second.z;
+            at += 16;
+        }
+        if (offline_query(packet,33)) throw std::runtime_error("world engine pair failed");
+        Answer a = checked_answer(packet), b = checked_answer(packet+8);
+        cursor += 2;
+        return {{a, b}};
     }
 };
 std::map<int,Job> jobs,traces;int next_job=1,next_trace=1;
@@ -65,14 +94,28 @@ V endpoint(V a,V b,const Input &in){
     if(df>0)fraction=std::min(fraction,(in.front-a.z)/df);else if(df<0)fraction=std::min(fraction,(-in.back-a.z)/df);
     fraction=std::max(0.0,std::min(1.0,fraction));return V(a.x+dr*fraction,0,a.z+df*fraction);
 }
+bool ground_request(const Input &in,double x,double z,double look,Plane p,std::pair<V,V> &ray){
+    double down=std::max(5.0,look*1.75+1.0),sy=std::min(in.pos.y+12.0,p.y+(x-p.x)*p.gx+(z-p.z)*p.gz);
+    if(sy<=in.pos.y-down)return false;
+    ray=std::make_pair(V(x,sy,z),V(x,in.pos.y-down,z));return true;
+}
 Optional ground(Job &j,double x,double z,double look,Plane p){
-    double down=std::max(5.0,look*1.75+1.0),sy=std::min(j.in.pos.y+12.0,p.y+(x-p.x)*p.gx+(z-p.z)*p.gz);
-    if(sy<=j.in.pos.y-down)return Optional();
-    Answer a=j.query(2,V(x,sy,z),V(x,j.in.pos.y-down,z));return a.status?Optional(a.point.y):Optional();
+    std::pair<V,V> ray;
+    if(!ground_request(j.in,x,z,look,p,ray))return Optional();
+    Answer a=j.query(2,ray.first,ray.second);return a.status?Optional(a.point.y):Optional();
 }
 Optional ahead(Job &j,const Lane &l,V local_start,V local_end,V py,double c,double s,Plane p){
     double fx=j.in.pos.x+c*local_end.x+s*local_end.z,fz=j.in.pos.z-s*local_end.x+c*local_end.z;
-    Optional a=ground(j,l.x1,l.z1,l.length,p),b=ground(j,fx,fz,l.length,p);
+    std::pair<V,V> left,right;Optional a,b;
+    bool has_left=ground_request(j.in,l.x1,l.z1,l.length,p,left),has_right=ground_request(j.in,fx,fz,l.length,p,right);
+    if(has_left&&has_right){
+        auto hits=j.pair(2,left,right);
+        if(hits[0].status)a=Optional(hits[0].point.y);
+        if(hits[1].status)b=Optional(hits[1].point.y);
+    }else{
+        if(has_left){Answer hit=j.query(2,left.first,left.second);if(hit.status)a=Optional(hit.point.y);}
+        if(has_right){Answer hit=j.query(2,right.first,right.second);if(hit.status)b=Optional(hit.point.y);}
+    }
     bool descending=(local_end.x-local_start.x)*py.x+(local_end.z-local_start.z)*py.z<-1e-9;
     if(descending&&a.has&&b.has){
         double support=j.in.pos.y+local_start.x*py.x+local_start.z*py.z;
@@ -81,7 +124,7 @@ Optional ahead(Job &j,const Lane &l,V local_start,V local_end,V py,double c,doub
         if(!middle.has||middle.value>(a.value+b.value)*0.5+1e-3)return Optional();
     }
     double ix=fx-l.x1,iz=fz-l.z1,dx=l.x2-l.x1,dz=l.z2-l.z1;
-    double inside=std::sqrt(std::pow(ix,2)+std::pow(iz,2)),full=std::sqrt(std::pow(dx,2)+std::pow(dz,2));
+    double inside=std::sqrt(source_power(ix,2)+source_power(iz,2)),full=std::sqrt(source_power(dx,2)+source_power(dz,2));
     if(a.has&&b.has&&inside>1e-6)return Optional(a.value+(b.value-a.value)*full/inside);
     if(a.has&&b.has)return Optional(std::min(a.value,b.value));
     return a.has?a:b;
@@ -92,8 +135,8 @@ std::pair<V,V> ray(const Input &in,const Lane &l,V a,V b,V py,double height,Opti
     return std::make_pair(V(l.x1,sy,l.z1),V(l.x2,ey,l.z2));
 }
 bool surface(const Answer &a,double gradient){
-    double length=std::pow(a.normal.x*a.normal.x+a.normal.y*a.normal.y+a.normal.z*a.normal.z,0.5);
-    return length>0&&a.normal.y/length>=1.0/std::pow(1.0+std::pow(gradient,2),0.5);
+    double length=source_power(a.normal.x*a.normal.x+a.normal.y*a.normal.y+a.normal.z*a.normal.z,0.5);
+    return length>0&&a.normal.y/length>=1.0/source_power(1.0+source_power(gradient,2),0.5);
 }
 bool drivable(const std::vector<double> &h,double segment){
     if(h.size()<2||std::abs(h.back()-h.front())<=0.15)return false;
@@ -178,8 +221,12 @@ int sweep(Job &j){
             }
             hits.push_back(Hit{d,lower.first,lower.second,hit});
         }
-        for(double h:std::array<double,2>{{1.1,1.6}}){
-            auto r=ray(in,l,a,b,py,h,top);Answer upper=j.query(3,r.first,r.second);
+        // Both ordinary upper rays are issued before any hit is resolved.
+        // The slope branch above can stop after its first ray and stays scalar.
+        std::array<std::pair<V,V>,2> upper_rays{{ray(in,l,a,b,py,1.1,top),ray(in,l,a,b,py,1.6,top)}};
+        auto upper_hits=j.pair(3,upper_rays[0],upper_rays[1]);
+        for(size_t i=0;i<2;++i){
+            const auto &r=upper_rays[i];const Answer &upper=upper_hits[i];
             if(!upper.status)continue;
             double length=distance(upper.point,r.first);if(length<target)hits.push_back(Hit{length,r.first,r.second,upper});
         }
@@ -195,6 +242,13 @@ void run(Job &j,double *b,int out){
 }
 }
 void offline_world_reset(){jobs.clear();traces.clear();}
+int offline_world::sweep(const offline_world::Input &input, bool batch_independent) {
+    Job job;
+    job.in = input;
+    job.synchronous = true;
+    job.batch_independent = batch_independent;
+    return ::sweep(job);
+}
 int offline_world_dispatch(double *b,int n){
     Reader r(b,n);int op=static_cast<int>(b[0]);
     if(op==405){Job j;j.in=input(r);r.end();j.synchronous=true;b[0]=sweep(j);b[1]=j.cursor;return 0;}

--- a/tools/ffi_experiment/world_core.cpp
+++ b/tools/ffi_experiment/world_core.cpp
@@ -1,0 +1,206 @@
+// Complete horizontal sweep calculations. Engine/destruction leaves yield
+// ordered numeric requests; recorded answers also support a bulk CPU estimate.
+#include "world_core.h"
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <map>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+const int WIDTH=16;
+struct Reader {
+    double *b; int n,i;
+    Reader(double *p,int size):b(p),n(size),i(1){}
+    double next(){if(i>=n||!std::isfinite(b[i]))throw std::invalid_argument("world buffer");return b[i++];}
+    int integer(){double v=next();if(v!=std::floor(v)||std::abs(v)>1000000000)throw std::invalid_argument("world integer");return static_cast<int>(v);}
+    void end(){if(i!=n)throw std::invalid_argument("world width");}
+};
+struct V {double x,y,z;V(double a=0,double b=0,double c=0):x(a),y(b),z(c){}};
+V vec(Reader &r){double x=r.next(),y=r.next(),z=r.next();return V(x,y,z);}
+double distance(V a,V b){double x=a.x-b.x,y=a.y-b.y,z=a.z-b.z;return std::sqrt(x*x+y*y+z*z);}
+struct Optional {bool has;double value;Optional():has(false),value(0){} Optional(double v):has(true),value(v){}};
+struct Plane {double x,y,z,gx,gz;};
+struct Answer {int status,id;V point,normal;};
+struct Query {int kind,id;V a,b;};
+struct Input {V pos;double yaw,speed,hw,back,front,dt,motion,pitch,roll;bool airborne,has_motion;};
+struct Lane {double x1,z1,x2,z2,length,px,pz,ps,pc,direction,look;};
+struct Hit {double length;V a,b;Answer hit;};
+struct Job {
+    Input in;std::vector<Answer> answers;std::vector<Query> expected;
+    size_t cursor;bool validate;
+    Job():cursor(0),validate(false){}
+    Answer query(int kind,V a,V b,int id=0){
+        Query q={kind,id,a,b};
+        if(cursor==answers.size())throw q;
+        if(validate){
+            const Query &e=expected[cursor];
+            if(e.kind!=kind||e.id!=id||e.a.x!=a.x||e.a.y!=a.y||e.a.z!=a.z||e.b.x!=b.x||e.b.y!=b.y||e.b.z!=b.z)
+                throw std::invalid_argument("world query geometry/order differs");
+        }
+        return answers[cursor++];
+    }
+};
+std::map<int,Job> jobs,traces;int next_job=1,next_trace=1;
+Input input(Reader &r){
+    Input v;v.pos=vec(r);v.yaw=r.next();v.speed=r.next();v.hw=r.next();v.back=r.next();v.front=r.next();
+    v.airborne=r.integer()!=0;v.dt=r.next();v.has_motion=r.integer()!=0;v.motion=r.next();v.pitch=r.next();v.roll=r.next();return v;
+}
+Answer answer(Reader &r){Answer a;a.status=r.integer();a.point=vec(r);a.normal=vec(r);a.id=r.integer();return a;}
+V pose_y(const Input &v){if(v.pitch==0&&v.roll==0)return V(0,1,0);double c=std::cos(v.pitch);return V(c*std::sin(v.roll),c*std::cos(v.roll),-std::sin(v.pitch));}
+V endpoint(V a,V b,const Input &in){
+    double fraction=1,dr=b.x-a.x,df=b.z-a.z;
+    if(dr>0)fraction=std::min(fraction,(in.hw-a.x)/dr);else if(dr<0)fraction=std::min(fraction,(-in.hw-a.x)/dr);
+    if(df>0)fraction=std::min(fraction,(in.front-a.z)/df);else if(df<0)fraction=std::min(fraction,(-in.back-a.z)/df);
+    fraction=std::max(0.0,std::min(1.0,fraction));return V(a.x+dr*fraction,0,a.z+df*fraction);
+}
+Optional ground(Job &j,double x,double z,double look,Plane p){
+    double down=std::max(5.0,look*1.75+1.0),sy=std::min(j.in.pos.y+12.0,p.y+(x-p.x)*p.gx+(z-p.z)*p.gz);
+    if(sy<=j.in.pos.y-down)return Optional();
+    Answer a=j.query(2,V(x,sy,z),V(x,j.in.pos.y-down,z));return a.status?Optional(a.point.y):Optional();
+}
+Optional ahead(Job &j,const Lane &l,V local_start,V local_end,V py,double c,double s,Plane p){
+    double fx=j.in.pos.x+c*local_end.x+s*local_end.z,fz=j.in.pos.z-s*local_end.x+c*local_end.z;
+    Optional a=ground(j,l.x1,l.z1,l.length,p),b=ground(j,fx,fz,l.length,p);
+    bool descending=(local_end.x-local_start.x)*py.x+(local_end.z-local_start.z)*py.z<-1e-9;
+    if(descending&&a.has&&b.has){
+        double support=j.in.pos.y+local_start.x*py.x+local_start.z*py.z;
+        if(a.value<support-1e-3)return Optional();
+        Optional middle=ground(j,(l.x1+fx)*0.5,(l.z1+fz)*0.5,l.length,p);
+        if(!middle.has||middle.value>(a.value+b.value)*0.5+1e-3)return Optional();
+    }
+    double ix=fx-l.x1,iz=fz-l.z1,dx=l.x2-l.x1,dz=l.z2-l.z1;
+    double inside=std::sqrt(std::pow(ix,2)+std::pow(iz,2)),full=std::sqrt(std::pow(dx,2)+std::pow(dz,2));
+    if(a.has&&b.has&&inside>1e-6)return Optional(a.value+(b.value-a.value)*full/inside);
+    if(a.has&&b.has)return Optional(std::min(a.value,b.value));
+    return a.has?a:b;
+}
+std::pair<V,V> ray(const Input &in,const Lane &l,V a,V b,V py,double height,Optional top){
+    double sy=in.pos.y+a.x*py.x+height*py.y+a.z*py.z,ey=in.pos.y+b.x*py.x+height*py.y+b.z*py.z;
+    if(top.has)ey=std::min(ey,top.value+height);
+    return std::make_pair(V(l.x1,sy,l.z1),V(l.x2,ey,l.z2));
+}
+bool surface(const Answer &a,double gradient){
+    double length=std::pow(a.normal.x*a.normal.x+a.normal.y*a.normal.y+a.normal.z*a.normal.z,0.5);
+    return length>0&&a.normal.y/length>=1.0/std::pow(1.0+std::pow(gradient,2),0.5);
+}
+bool drivable(const std::vector<double> &h,double segment){
+    if(h.size()<2||std::abs(h.back()-h.front())<=0.15)return false;
+    segment=std::max(0.001,segment);
+    for(size_t i=1;i<h.size();++i){double delta=h[i]-h[i-1];if(std::abs(delta)>segment*(delta<0?1.75:1.28))return false;}
+    return true;
+}
+bool matches(const Answer &a,const std::vector<double> &h,double segment,const Lane &l){
+    if(h.size()<2||segment<=0)return false;
+    double d=l.direction*((a.point.x-l.px)*l.ps+(a.point.z-l.pz)*l.pc);
+    if(d<0||d>segment*(h.size()-1))return false;
+    size_t index=std::min(h.size()-2,static_cast<size_t>(d/segment));double f=(d-index*segment)/segment;
+    return std::abs(a.point.y-(h[index]+(h[index+1]-h[index])*f))<=0.15;
+}
+bool exact(Job &j,const Answer &a,const Lane &l,Plane p){Optional top=ground(j,a.point.x,a.point.z,l.look,p);return top.has&&std::abs(top.value-a.point.y)<=1e-3;}
+std::vector<Lane> lanes(const Input &in,double c,double s){
+    std::vector<Lane> out;double ahead=std::abs(in.speed)*in.dt+0.2;if(!in.airborne)ahead=std::max(0.4,ahead);
+    if(!in.has_motion){
+        double back=in.speed>0?-0.5:0.5,front=in.speed>0?in.front+ahead:-(in.back+ahead);
+        double direction=in.speed>=0?1.0:-1.0,look=(in.speed>0?in.front:in.back)+ahead;
+        for(double offset:std::array<double,3>{{-in.hw,0,in.hw}}){
+            double sx=in.pos.x+c*offset,sz=in.pos.z-s*offset;
+            out.push_back(Lane{sx+s*back,sz+c*back,sx+s*front,sz+c*front,std::abs(back)+look,sx,sz,s,c,direction,look});
+        }
+    }else{
+        double ms=std::sin(in.motion),mc=std::cos(in.motion),px=mc,pz=-ms;
+        double ru=ms*c-mc*s,fu=ms*s+mc*c,rv=px*c-pz*s,fv=px*s+pz*c;
+        std::vector<std::array<double,3> > projected,merged;
+        for(auto corner:std::array<std::pair<double,double>,4>{{{-in.hw,-in.back},{in.hw,-in.back},{in.hw,in.front},{-in.hw,in.front}}}){
+            double u=ru*corner.first+fu*corner.second,v=rv*corner.first+fv*corner.second;projected.push_back({{v,u,u+ahead}});
+        }
+        std::vector<double> limits;
+        if(ru>1e-9)limits.push_back(in.hw/ru);else if(ru<-1e-9)limits.push_back(-in.hw/ru);
+        if(fu>1e-9)limits.push_back(in.front/fu);else if(fu<-1e-9)limits.push_back(-in.back/fu);
+        double front=limits.empty()?0:*std::min_element(limits.begin(),limits.end());projected.push_back({{0,-0.5,front+ahead}});
+        std::sort(projected.begin(),projected.end());
+        for(auto item:projected){
+            if(!merged.empty()&&std::abs(item[0]-merged.back()[0])<=1e-7){merged.back()[1]=std::min(merged.back()[1],item[1]);merged.back()[2]=std::max(merged.back()[2],item[2]);}
+            else merged.push_back(item);
+        }
+        for(auto p:merged){
+            double x1=in.pos.x+px*p[0]+ms*p[1],z1=in.pos.z+pz*p[0]+mc*p[1];
+            double x2=in.pos.x+px*p[0]+ms*p[2],z2=in.pos.z+pz*p[0]+mc*p[2],length=p[2]-p[1];
+            out.push_back(Lane{x1,z1,x2,z2,length,x1,z1,ms,mc,1,length});
+        }
+    }
+    return out;
+}
+int sweep(Job &j){
+    const Input &in=j.in;double c=std::cos(in.yaw),s=std::sin(in.yaw);V py=pose_y(in);
+    Plane plane={in.pos.x,in.pos.y+1.6*py.y,in.pos.z,c*py.x+s*py.z,-s*py.x+c*py.z};
+    std::vector<Lane> all=lanes(in,c,s);double minx=all[0].x1,maxx=minx,minz=all[0].z1,maxz=minz;
+    for(const Lane &l:all){minx=std::min(minx,std::min(l.x1,l.x2));maxx=std::max(maxx,std::max(l.x1,l.x2));minz=std::min(minz,std::min(l.z1,l.z2));maxz=std::max(maxz,std::max(l.z1,l.z2));}
+    j.query(1,V(minx,in.pos.y+0.6,minz),V(maxx,in.pos.y+1.6,maxz));bool kinetic=false;
+    for(Lane l:all){
+        double dx=l.x1-in.pos.x,dz=l.z1-in.pos.z,ex=l.x2-in.pos.x,ez=l.z2-in.pos.z;
+        V a(dx*c-dz*s,0,dx*s+dz*c),raw(ex*c-ez*s,0,ex*s+ez*c),b=endpoint(a,raw,in);
+        bool clamped=(py.x!=0||py.y!=1||py.z!=0)&&(std::abs(b.x-raw.x)>1e-9||std::abs(b.z-raw.z)>1e-9);
+        Optional top=py.z!=0?ahead(j,l,a,b,py,c,s,plane):Optional();
+        auto lower=ray(in,l,a,b,py,0.6,top);Answer hit=j.query(3,lower.first,lower.second);
+        double target=distance(lower.second,lower.first),d=hit.status?distance(hit.point,lower.first):0;
+        std::vector<Hit> hits;
+        if(hit.status&&d<target){
+            std::vector<double> heights;double segment=0,gradient=1.75;Plane p=plane;
+            if(surface(hit,gradient))p=Plane{hit.point.x,hit.point.y+1.6,hit.point.z,-hit.normal.x/hit.normal.y,-hit.normal.z/hit.normal.y};
+            if(surface(hit,gradient)||clamped){
+                segment=l.look/6.0;
+                for(int i=0;i<=6;++i){double offset=segment*i;Optional g=ground(j,l.px+l.ps*offset*l.direction,l.pz+l.pc*offset*l.direction,l.look,p);if(!g.has){heights.clear();break;}heights.push_back(g.value);}
+                gradient=!heights.empty()&&heights.back()<heights.front()?1.75:1.28;
+                if(!heights.empty()&&std::abs(heights.back()-heights.front())>0.15&&!drivable(heights,segment))return 0;
+            }
+            bool is_ground=surface(hit,gradient);
+            if(!is_ground&&clamped&&matches(hit,heights,segment,l))is_ground=exact(j,hit,l,p);
+            if(!heights.empty()&&drivable(heights,segment)&&is_ground){
+                for(double h:std::array<double,2>{{1.1,1.6}}){
+                    auto r=ray(in,l,a,b,py,h,top);Answer upper=j.query(3,r.first,r.second);
+                    if(!upper.status||distance(upper.point,r.first)>=target||surface(upper,gradient))continue;
+                    if(matches(upper,heights,segment,l)&&exact(j,upper,l,p))continue;
+                    return 0;
+                }
+                continue;
+            }
+            hits.push_back(Hit{d,lower.first,lower.second,hit});
+        }
+        for(double h:std::array<double,2>{{1.1,1.6}}){
+            auto r=ray(in,l,a,b,py,h,top);Answer upper=j.query(3,r.first,r.second);
+            if(!upper.status)continue;
+            double length=distance(upper.point,r.first);if(length<target)hits.push_back(Hit{length,r.first,r.second,upper});
+        }
+        std::stable_sort(hits.begin(),hits.end(),[](const Hit &a,const Hit &b){return a.length<b.length;});
+        for(const Hit &h:hits){Answer resolved=j.query(4,h.a,h.b,h.hit.id);if(resolved.status==2)kinetic=true;else if(resolved.status!=1)return 0;}
+    }
+    return kinetic?2:1;
+}
+void run(Job &j,double *b,int out){
+    j.cursor=0;
+    try{int status=sweep(j);if(j.cursor!=j.answers.size())throw std::invalid_argument("unused world answers");b[out]=0;b[out+1]=status;b[out+2]=j.cursor;}
+    catch(const Query &q){b[out]=q.kind;b[out+1]=q.a.x;b[out+2]=q.a.y;b[out+3]=q.a.z;b[out+4]=q.b.x;b[out+5]=q.b.y;b[out+6]=q.b.z;b[out+7]=q.id;}
+}
+}
+void offline_world_reset(){jobs.clear();traces.clear();}
+int offline_world_dispatch(double *b,int n){
+    Reader r(b,n);int op=static_cast<int>(b[0]);
+    if(op==400){Job j;j.in=input(r);int out=r.i;if(n!=out+WIDTH)throw std::invalid_argument("world start width");int id=next_job++;jobs[id]=j;run(jobs[id],b,out);b[out+15]=id;return 0;}
+    if(op==401){int id=r.integer();auto it=jobs.find(id);if(it==jobs.end())throw std::invalid_argument("world owner");Answer a=answer(r);int out=r.i;if(n!=out+WIDTH)throw std::invalid_argument("world resume width");it->second.answers.push_back(a);run(it->second,b,out);return 0;}
+    if(op==402){int id=r.integer();r.end();jobs.erase(id);return 0;}
+    if(op==403){
+        Job j;j.in=input(r);int count=r.integer();if(count<0||count>10000)throw std::invalid_argument("world tape length");
+        for(int i=0;i<count;++i){Query q;q.kind=r.integer();q.a=vec(r);q.b=vec(r);q.id=r.integer();j.expected.push_back(q);j.answers.push_back(answer(r));}
+        int expected=r.integer();r.end();j.validate=true;j.cursor=0;int actual=sweep(j);
+        if(actual!=expected||j.cursor!=j.answers.size())throw std::invalid_argument("world trace result");
+        int id=next_trace++;traces[id]=j;b[0]=id;return 0;
+    }
+    if(op==404){
+        int loops=r.integer();r.end();if(loops<1||loops>10000)throw std::invalid_argument("world loops");
+        long long total=0;for(int i=0;i<loops;++i)for(auto &entry:traces){Job &j=entry.second;j.cursor=0;total+=sweep(j);if(j.cursor!=j.answers.size())throw std::invalid_argument("world trace completion");}
+        b[0]=total;b[1]=traces.size();return 0;
+    }
+    throw std::invalid_argument("world opcode");
+}

--- a/tools/ffi_experiment/world_core.cpp
+++ b/tools/ffi_experiment/world_core.cpp
@@ -1,6 +1,7 @@
 // Complete horizontal sweep calculations. Engine/destruction leaves yield
 // ordered numeric requests; recorded answers also support a bulk CPU estimate.
 #include "world_core.h"
+#include "query_bridge.h"
 #include <algorithm>
 #include <array>
 #include <cmath>
@@ -29,10 +30,19 @@ struct Lane {double x1,z1,x2,z2,length,px,pz,ps,pc,direction,look;};
 struct Hit {double length;V a,b;Answer hit;};
 struct Job {
     Input in;std::vector<Answer> answers;std::vector<Query> expected;
-    size_t cursor;bool validate;
-    Job():cursor(0),validate(false){}
+    size_t cursor;bool validate,synchronous;
+    Job():cursor(0),validate(false),synchronous(false){}
     Answer query(int kind,V a,V b,int id=0){
         Query q={kind,id,a,b};
+        if(synchronous){
+            double packet[16]={static_cast<double>(kind),a.x,a.y,a.z,b.x,b.y,b.z,static_cast<double>(id)};
+            if(offline_query(packet,16))throw std::runtime_error("world engine query failed");
+            for(int i=0;i<8;++i)if(!std::isfinite(packet[i]))throw std::invalid_argument("world engine answer");
+            if(packet[0]!=std::floor(packet[0])||packet[0]<0||packet[0]>2||packet[7]!=std::floor(packet[7])||std::abs(packet[7])>1000000000)
+                throw std::invalid_argument("world engine answer type");
+            ++cursor;
+            return Answer{static_cast<int>(packet[0]),static_cast<int>(packet[7]),V(packet[1],packet[2],packet[3]),V(packet[4],packet[5],packet[6])};
+        }
         if(cursor==answers.size())throw q;
         if(validate){
             const Query &e=expected[cursor];
@@ -187,6 +197,7 @@ void run(Job &j,double *b,int out){
 void offline_world_reset(){jobs.clear();traces.clear();}
 int offline_world_dispatch(double *b,int n){
     Reader r(b,n);int op=static_cast<int>(b[0]);
+    if(op==405){Job j;j.in=input(r);r.end();j.synchronous=true;b[0]=sweep(j);b[1]=j.cursor;return 0;}
     if(op==400){Job j;j.in=input(r);int out=r.i;if(n!=out+WIDTH)throw std::invalid_argument("world start width");int id=next_job++;jobs[id]=j;run(jobs[id],b,out);b[out+15]=id;return 0;}
     if(op==401){int id=r.integer();auto it=jobs.find(id);if(it==jobs.end())throw std::invalid_argument("world owner");Answer a=answer(r);int out=r.i;if(n!=out+WIDTH)throw std::invalid_argument("world resume width");it->second.answers.push_back(a);run(it->second,b,out);return 0;}
     if(op==402){int id=r.integer();r.end();jobs.erase(id);return 0;}

--- a/tools/ffi_experiment/world_core.h
+++ b/tools/ffi_experiment/world_core.h
@@ -1,5 +1,18 @@
 #ifndef OFFLINE_WORLD_CORE_H
 #define OFFLINE_WORLD_CORE_H
+namespace offline_world {
+struct Point {
+    double x, y, z;
+    Point(double a = 0, double b = 0, double c = 0) : x(a), y(b), z(c) {}
+};
+struct Input {
+    Point pos;
+    double yaw, speed, hw, back, front, dt, motion, pitch, roll;
+    bool airborne, has_motion;
+};
+// Compose the reviewed sweep on the current borrowed callback stack.
+int sweep(const Input &input, bool batch_independent = false);
+} // namespace offline_world
 int offline_world_dispatch(double *buffer, int count);
 void offline_world_reset();
 #endif

--- a/tools/ffi_experiment/world_core.h
+++ b/tools/ffi_experiment/world_core.h
@@ -1,0 +1,5 @@
+#ifndef OFFLINE_WORLD_CORE_H
+#define OFFLINE_WORLD_CORE_H
+int offline_world_dispatch(double *buffer, int count);
+void offline_world_reset();
+#endif

--- a/tools/ffi_experiment/world_trace.py
+++ b/tools/ffi_experiment/world_trace.py
@@ -1,0 +1,203 @@
+"""Record exact collision leaves, then replay the full numeric controller.
+
+Replay is a computation experiment. It never supplies cached physics to a
+live battle, and does not measure native engine cost or a shippable boundary.
+"""
+from __future__ import print_function
+import importlib
+import math
+import sys
+
+from world_adapter import inputs, point, reply
+
+
+def request(kind, start, end, identity=0):
+    return [kind] + point(start) + point(end) + [identity]
+
+
+class Recorder(object):
+    def __init__(self, backend=None):
+        self.world = importlib.import_module('gui.mods.offline_lan_0922.world_collision')
+        self.original = self.world._check_horizontal_collision
+        self.backend = backend
+        self.traces = []
+        self.replacement = self.check
+        self.world._check_horizontal_collision = self.replacement
+
+    def close(self):
+        if self.world._check_horizontal_collision is self.replacement:
+            self.world._check_horizontal_collision = self.original
+
+    def check(self, spaceID, pos, yaw, vel, td=None, airborne=False, dt=0.04,
+              return_status=False, allow_kinetic=False, kinetic_speed=None,
+              commit_enabled=True, motion_yaw=None, pitch=0.0, roll=0.0):
+        import BigWorld
+        world = self.world
+        header = inputs(world, pos, yaw, vel, td, airborne, dt, motion_yaw, pitch, roll)
+        old_prepare, old_horizontal, old_destroy = (
+            world.prepare_horizontal_collision_filter, world._collide_horizontal,
+            world._destroy_and_recast)
+        old_ray = BigWorld.wg_collideSegment
+        rows, hit_ids = [], {}
+        context = [2, False]
+
+        def prepare(start, end):
+            value = old_prepare(start, end)
+            if not context[1]:
+                rows.append(request(1, start, end) + [int(value is not None)] + [0] * 7)
+            return value
+
+        def ray(space, start, end, *args):
+            value = old_ray(space, start, end, *args)
+            if not context[1]:
+                identity = len(rows) + 1
+                data = reply(context[0], value, identity)
+                rows.append(request(context[0], start, end) + data)
+                if value is not None and context[0] == 3:
+                    hit_ids[(tuple(point(start) + point(end)), id(value))] = identity
+            return value
+
+        def horizontal(*args, **kwargs):
+            prior = context[0]
+            context[0] = 3
+            try:
+                return old_horizontal(*args, **kwargs)
+            finally:
+                context[0] = prior
+
+        def destroy(*args, **kwargs):
+            context[1] = True
+            try:
+                value = old_destroy(*args, **kwargs)
+            finally:
+                context[1] = False
+            start, end, hit = args[1:4]
+            identity = hit_ids[(tuple(point(start) + point(end)), id(hit))]
+            status = 2 if value == 'kinetic' else 1 if value is True else 0
+            rows.append(request(4, start, end, identity) +
+                        [status] + [0] * 6 + [int(bool(args[7][0]))])
+            return value
+
+        world.prepare_horizontal_collision_filter = prepare
+        world._collide_horizontal = horizontal
+        world._destroy_and_recast = destroy
+        BigWorld.wg_collideSegment = ray
+        try:
+            value = self.original(
+                spaceID, pos, yaw, vel, td, airborne, dt, True, allow_kinetic,
+                kinetic_speed, commit_enabled, motion_yaw, pitch, roll)
+        finally:
+            world.prepare_horizontal_collision_filter = old_prepare
+            world._collide_horizontal = old_horizontal
+            world._destroy_and_recast = old_destroy
+            BigWorld.wg_collideSegment = old_ray
+        status = ('hard', 'clear', 'kinetic').index(value)
+        trace = dict(inputs=header, queries=rows, status=status)
+        if self.backend is not None:
+            try:
+                register(self.backend, trace)
+            except RuntimeError:
+                # A complete numeric record makes a mismatch reproducible.
+                import json
+                with open('/tmp/wot-world-mismatch.json', 'w') as stream:
+                    json.dump(trace, stream)
+                raise
+        self.traces.append(trace)
+        return value if return_status else status != 1
+
+
+def register(backend, trace):
+    packet = [403] + trace['inputs'] + [len(trace['queries'])]
+    for row in trace['queries']:
+        packet.extend(row)
+    packet.append(trace['status'])
+    return int(backend.call(packet)[0])
+
+
+class Vector(object):
+    def __init__(self, x=0.0, y=0.0, z=0.0):
+        self.x, self.y, self.z = float(x), float(y), float(z)
+
+    def __sub__(self, other):
+        return Vector(self.x-other.x, self.y-other.y, self.z-other.z)
+
+    @property
+    def length(self):
+        return math.sqrt(self.x*self.x + self.y*self.y + self.z*self.z)
+
+
+class Namespace(object):
+    def __init__(self, **values):
+        self.__dict__.update(values)
+
+
+class Replay(object):
+    def __init__(self):
+        self.world = importlib.import_module('gui.mods.offline_lan_0922.world_collision')
+        self.missing = object()
+        self.old_modules = dict((key, sys.modules.get(key, self.missing)) for key in ('BigWorld', 'Math'))
+        sys.modules['BigWorld'] = Namespace(wg_collideSegment=self.ray)
+        sys.modules['Math'] = Namespace(Vector3=Vector)
+        names = ('prepare_horizontal_collision_filter', '_collide_horizontal',
+                 '_destroy_and_recast', '_vehicle_motion_extents')
+        self.originals = dict((name, getattr(self.world, name)) for name in names)
+        self.world.prepare_horizontal_collision_filter = self.prepare
+        self.world._collide_horizontal = self.horizontal
+        self.world._destroy_and_recast = self.destroy
+        self.world._vehicle_motion_extents = lambda unused: tuple(self.trace['inputs'][5:8])
+        self.filter_token = object()
+        self.kind = 2
+        self.verify = True
+
+    def close(self):
+        for name, value in self.originals.items():
+            setattr(self.world, name, value)
+        for key, value in self.old_modules.items():
+            if value is self.missing:
+                sys.modules.pop(key, None)
+            else:
+                sys.modules[key] = value
+
+    def consume(self, kind, start, end, identity=0):
+        row = self.trace['queries'][self.cursor]
+        if self.verify and row[:8] != request(kind, start, end, identity):
+            raise AssertionError('Python trace query %d differs: %r != %r' %
+                                 (self.cursor, request(kind, start, end, identity), row[:8]))
+        self.cursor += 1
+        return row[8:]
+
+    def prepare(self, start, end):
+        value = self.consume(1, start, end)
+        return self.filter_token if value[0] else None
+
+    def ray(self, space, start, end, *unused):
+        value = self.consume(self.kind, start, end)
+        if not value[0]:
+            return None
+        hit = (Vector(*value[1:4]), Vector(*value[4:7]), 0)
+        self.hits[(tuple(point(start) + point(end)), id(hit))] = int(value[7])
+        return hit
+
+    def horizontal(self, *args, **kwargs):
+        self.kind = 3
+        try:
+            return self.originals['_collide_horizontal'](*args, **kwargs)
+        finally:
+            self.kind = 2
+
+    def destroy(self, *args, **unused):
+        start, end, hit = args[1:4]
+        identity = self.hits[(tuple(point(start) + point(end)), id(hit))]
+        value = self.consume(4, start, end, identity)
+        args[7][0] = bool(value[7])
+        return 'kinetic' if value[0] == 2 else value[0] == 1
+
+    def run(self, trace):
+        self.trace, self.cursor, self.hits = trace, 0, {}
+        v = trace['inputs']
+        value = self.world._check_horizontal_collision(
+            1, Vector(*v[:3]), v[3], v[4], None, bool(v[8]), v[9], True,
+            motion_yaw=v[11] if v[10] else None, pitch=v[12], roll=v[13])
+        if ('hard', 'clear', 'kinetic').index(value) != trace['status'] or self.cursor != len(trace['queries']):
+            raise AssertionError('Python trace result/consumption differs')
+        return trace['status']


### PR DESCRIPTION
Superseded by #161, which rebases all nine experiment commits onto main `c6b2d373847254b140531213fcd3b7bab91c1195`, reconciles the changed runtime contracts and supplies fresh current-source measurements. Review the entire experiment there. This original branch and its historical evidence are retained without force-pushing.

---

The complete Bot CPU experiment reduces median host loop CPU from **10.881820 s to 5.547883 s (49.02%)** with exact compared results. The latest native publication change saves another **3.31%** against the previous kernel measured in the same rounds. An independent C++ thread experiment confirms that two-thread encoding finishes **33.93% sooner**, while quantifying its small absolute contribution and higher aggregate CPU use.

This draft targets `main` and includes **all nine previously unreviewed experiment commits**, from `4e16d6f0` through `47b444561aecfb821b727a55fdebb32aa1521ee7`. Review the combined final tree: no earlier commit is assumed reviewed. The complete diff contains only `tools/ffi_experiment/` and `COMPATIBILITY_REVIEW.md`; production modules, launcher and packages do not import the experiment. This is a prototype and evidence review, not production integration or Windows acceptance.

## Complete scope and review map

1. `4e16d6f0`: batched A*, host and #1513 x86 bridges, fixtures, parity and workload tools.
2. `c700fb2b`: perception, driving, aiming and combat calculations.
3. `2994dd9c`: world collision computation and explicit query boundaries.
4. `fec5af49`: persistent navigation/motion state and synchronous borrowed-query flow.
5. `fabc7e6e`: native-owned Bot state and update orchestration: decisions/perception, orders/routes/traffic, fair motion receipts, movement/contact, weapons/ammunition, health/equipment, Siege modes, launch acknowledgements, wire output and diagnostics.
6. `fb2ba3cf`: 139 fixed state slots, prebound fields, narrower callback projections and ownership checks. Irregular keys retain maps, and slot values retain the tagged `Value` representation.
7. `49c03342`: compose collision arbitration directly with the native sweep; compile descriptor extents and unmodified speed caps per mode; pair only unconditional ground/upper queries; retain catalog ownership and failure/teardown barriers. Preserve libm power calls after reproducing a one-ULP collision-ray mismatch.
8. `3c9bc7d7f7fe5569d07f5664642edc828f0b7662`: bound aim argument copies to the 17-value native request; add optional host CPU boundary attribution, disabled/enabled observer controls and a borrowed-packet regression. Audit nested callbacks, exceptions and observer cleanup.
9. `47b444561aecfb821b727a55fdebb32aa1521ee7`: reuse ordered native publication records, prebind optional codec groups and reserve row storage; preserve durable event semantics. Add an independent one/two-thread encoding probe, Python wire fixtures and publication-edge parity checks.

Python retains real engine calls, native hit/filter references, destructible spatial indexes, destruction and canonical publication. Native collision code reads current Bot state directly. Per-operation Python references clear on completion, failure and teardown; partial startup restores installed adapters. Runtime, round, space and catalog identities are checked around terminal leaves and between paired queries. Independent pairs preserve sequential engine calls and stop after the first exception, invalid numeric answer or owner retirement. Dependent probes, slope early exits, destruction/recast and catalog commits remain barriers.

## Latest controlled measurements

Three rotating rounds, fifteen fresh processes; Linux aarch64, CPython 2.7.18, Great Wall combat, 29 Bots, 30 simulated seconds at 15 callbacks/second:

| Variant | Median loop CPU | Observed range | Reduction vs Python |
| --- | ---: | ---: | ---: |
| Unmodified Python | 10.881820 s | 10.798626–10.969403 s | 0.00% |
| Frozen previous kernel and adapters (`3c9bc7d7`) | 5.737643 s | 5.694688–5.755725 s | 47.27% |
| Reusable C++ publication records | 5.547883 s | 5.479581–5.568934 s | 49.02% |

All fifteen complete snapshots match: messages, ordered fake engine queries, probes, decisions, navigation progress and diagnostics. The 225 state publications, 77,172 fake collision rays, 111,533 reverse callbacks, 2,562 forward dispatches and actor counts are unchanged. Median native initialization is 0.167041 s. The new publication signature retains ordered scalar/presence, ammunition, equipment, shot, launch and ram records in two reusable buffers. Missing/null distinctions, cooldown readiness, shallow ownership and event revisions retain their previous behavior. Optional codec groups bind once, and output rows reserve their fixed/optional payload widths.

The preceding Python change bounds 8,914 aim argument slices from 2,329,691,728 bytes to 1,212,304 bytes without changing native requests. That earlier stage's normal native binary was byte-identical to its control; the latest stage changes the C++ publication core. Earlier stage savings must not be added to this fresh comparison.

The distinct profiling binary takes 5.520867 s with observation off and 5.875001 s with observation on. Observed deltas are -0.49% against the normal binary and +6.41% for enabling the observer. These controls are excluded from the primary comparison.

| CPU owner | Mean observed CPU | Share |
| --- | ---: | ---: |
| Native dispatch body, excluding callbacks | 2.209018 s | 37.02% |
| Python callbacks, including call entry and ordinary callees | 3.172138 s | 53.16% |
| Python outer loop, conversion and snapshot capture | 0.468830 s | 7.86% |
| C callback-buffer copies and result release | 0.116917 s | 1.96% |

These zones include clock overhead and describe ownership, not irreducible costs. The C bridge row is not all FFI overhead: Python decoding, actor dictionaries, vector construction and call entry are included in callbacks. Those callbacks include builtins and native-query fakes, so their entire share is not removable production Python. Inclusive callback rows can overlap; only the four zones partition time. Earlier native sampling identified allocation, container destruction and hash lookups as remaining costs; its detailed counts and sampling limits remain in `COMPATIBILITY_REVIEW.md`.

Loop CPU includes ordinary callbacks and per-frame output/navigation capture. It excludes process/fixture startup and final report-file serialization. The Python source oracle remains `900744ce`, while current `main` has advanced; these measurements do not establish parity with current `main`.

## Parallel encoding experiment and tradeoff

`benchmark_codec_threads.cpp` is a separate host executable using immutable states reconstructed from the Python publication contract. Seven alternating rounds launch 14 fresh processes, each encoding the same 29 rows for 10,000 batches after 20 warmups. Two workers means the caller plus one persistent helper; timings include dispatch/completion barriers and row allocation/release, excluding thread startup.

| Workers | Median wall time per batch | Median aggregate CPU per batch |
| --- | ---: | ---: |
| Caller only | 66.954 us | 66.934 us |
| Caller plus helper | 44.238 us | 77.897 us |

Two threads reduce batch latency by **33.93%** while increasing aggregate CPU by **16.38%**. All rows match the Python oracle; both modes recover after first/last-row failures. No Python object, engine call or borrowed query bridge reaches the helper. Separate processes avoid contamination from the standard library's single-thread/reference-count mode.

The absolute difference is 22.716 us per batch. Extrapolating to 225 publications gives about 5.1 ms of encoding wall time, before integration effects; this is not an end-to-end measurement. The thread helper remains a benchmark and is not linked into the kernel or x86 bridge. The current Bot loop shares perception caches, budgets and ledgers, and later actors consume earlier committed poses. Its query route is caller-thread/GIL owned with process-global borrowed buffers. Larger immutable computation stages with ordered commits need separate evidence before parallelizing that loop.

## Validation

The latest stage passes:

- 884 publication-signature oracle comparisons under normal and ASan/UBSan builds: isolated scalar, ammunition, shot, equipment and cooldown transitions, missing/null values, empty/shrinking/reordered rosters, launches and ram events.
- Normal and ASan/UBSan state suites: 13,632 weapon transitions, 311 wire/invalid rows, 900 equipment transitions, 4,256 decimal cases, 2,015 health/publication transitions and 13 packed-output/lifecycle checks.
- An 80-frame combined native-world Siege/human/cover/order comparison in both builds; normal 80-frame Himmelsdorf navigation and the original Python world-callback path.
- Bridge ownership/nesting/exception checks and host profiling guards with 230 observed callbacks.
- Host and x86 builds with warnings as errors; x86 imports remain only KERNEL32.dll/msvcrt.dll. CPython 2.7 source compilation passes for 132 client/runtime-compatible experiment modules.
- Fifteen complete workload snapshots and 14 fresh-process thread comparisons with Python row parity and failure recovery.

Sanitizers halt on error with leak checking disabled. Earlier stages also passed the kernel subsystem differential suites, 480 focused collision cases, populated fragile/structure catalog ordering and physical/query traces. Those are preceding-stage evidence rather than checks rerun for unrelated code in this step.

`COMPATIBILITY_REVIEW.md` contains contracts, ranges, limitations and reproduction commands. Production CI does not build or execute this opt-in experiment; local checks supply its native evidence. For head `47b444561aecfb821b727a55fdebb32aa1521ee7`, the [push workflow](https://github.com/pengw0048/wot-offline-battles/actions/runs/34572949224) and [PR merge workflow](https://github.com/pengw0048/wot-offline-battles/actions/runs/34572953246) are running; their results will be verified for this exact head.

## Remaining boundaries

The kernel requires complete server Bot orders and the copied vertical controller; it rejects native motion and the optional ten-spring trial. Local tactical fallback, BattleRuntime damage/reconciliation ingress, authority takeover and projectile terminal processing remain outside the adapter. It starts and ends with the fixture, rather than being installed into an active battle. The timed registry is empty and launches are acknowledged without simulating terminals; populated catalog checks are correctness evidence, not a representative performance workload.

Remaining candidates include Python callback construction/catalog work, native container allocation/lookups and larger independent computation batches. No share has been proved an optimization floor or promised removable. Python 3.12 is not the whole-update numerical oracle. Windows #1513 loading, x86 numerical parity, native memory/callback behavior and real gameplay frame pacing remain unproved. Host CPU reduction is not an FPS result or evidence that 90% is achievable.
