### PR TITLE
Reduce remote matrix and aim writes during active gameplay

### DIFF
--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -22666,6 +22666,10 @@ class BattleRuntime(object):
                 # The matrix owner deduplicates unchanged hull components,
                 # including an aim-only sample, without dropping velocity or
                 # acceleration settlement from the original pose stream.
+                # Clear the old signature before a setter can partially
+                # mutate its provider. A later sample may return to that old
+                # pose instead of retrying the failed target.
+                record.pop('_remote_pose_signature', None)
                 self._binding.set_vehicle_pose(
                     record['engine_id'], self._vector((x, y, z)),
                     _engine_rotation(yaw, pitch, roll), now=now)
@@ -22696,6 +22700,9 @@ class BattleRuntime(object):
                 record.get('presented_siege_state'))
             aim_changed = aim_signature != record.get('_remote_aim_signature')
             if aim_changed:
+                # Turret yaw can succeed before gun pitch fails. The old
+                # signature no longer describes that partially written aim.
+                record.pop('_remote_aim_signature', None)
                 self._binding.update_vehicle_aim(
                     record['engine_id'], yaw, aim_yaw, gun_pitch)
                 record['_remote_aim_signature'] = aim_signature

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -22657,7 +22657,22 @@ class BattleRuntime(object):
             alive = bool(state.get('alive', True)) and int(
                 state.get('health', 1) or 0) > 0
             signature = (x, y, z, yaw, pitch, roll, aim_yaw, gun_pitch)
-            if signature == record.get('_remote_pose_signature'):
+            lifecycle = (self._generation, record['engine_id'], id(record))
+            pose_changed = (
+                signature != record.get('_remote_pose_signature') or
+                lifecycle != record.get('_remote_pose_lifecycle'))
+            if pose_changed:
+                # Keep each changed presentation sample's motion timestamp.
+                # The matrix owner deduplicates unchanged hull components,
+                # including an aim-only sample, without dropping velocity or
+                # acceleration settlement from the original pose stream.
+                self._binding.set_vehicle_pose(
+                    record['engine_id'], self._vector((x, y, z)),
+                    _engine_rotation(yaw, pitch, roll), now=now)
+                record['_remote_pose_signature'] = signature
+                record['_remote_pose_lifecycle'] = lifecycle
+                record.pop('_remote_motion_settled_signature', None)
+            else:
                 motion_intended = bool(
                     abs(_number(state.get('speed'))) > BOT_MOVING_SPEED or
                     abs(_number(state.get('movement_dir'))) > 0.5 or
@@ -22673,43 +22688,32 @@ class BattleRuntime(object):
                         if settled:
                             record['_remote_motion_settled_signature'] = \
                                 signature
-                if record.get('kind') in ('bot', 'player'):
-                    # Keep the zero-turn sample fresh so the first real pivot
-                    # after a long stop is measured over one render interval,
-                    # not diluted across the whole stationary period.
-                    turn = self._remember_remote_track_turn(record, yaw, now)
-                    track_signature = (
-                        _number(state.get('speed')), alive, turn)
-                    if (record.get('_remote_track_pending') or
-                            track_signature != record.get(
-                                '_remote_track_state_signature')):
-                        updated = self._run_optional_feature(
-                            'remote track animation', self._update_bot_tracks,
-                            (record, state, now, turn))
-                        record['_remote_track_pending'] = not updated
-                        if updated:
-                            record['_remote_track_state_signature'] = \
-                                track_signature
-                return False
-            self._binding.set_vehicle_pose(
-                record['engine_id'], self._vector((x, y, z)),
-                _engine_rotation(yaw, pitch, roll),
-                now=now)
-            self._binding.update_vehicle_aim(
-                record['engine_id'], yaw, aim_yaw, gun_pitch)
-            record['_remote_pose_signature'] = signature
-            record.pop('_remote_motion_settled_signature', None)
+            # XYZ/roll do not change the aim input. Pitch remains an input
+            # for a worker's hydraulic geometry, and an applied Siege edge
+            # can replace the installed gun's static component angles.
+            aim_signature = (
+                lifecycle, yaw, pitch, aim_yaw, gun_pitch,
+                record.get('presented_siege_state'))
+            aim_changed = aim_signature != record.get('_remote_aim_signature')
+            if aim_changed:
+                self._binding.update_vehicle_aim(
+                    record['engine_id'], yaw, aim_yaw, gun_pitch)
+                record['_remote_aim_signature'] = aim_signature
             if record.get('kind') in ('bot', 'player'):
+                # Keep the zero-turn sample fresh through playback holds.
                 turn = self._remember_remote_track_turn(record, yaw, now)
                 track_signature = (
                     _number(state.get('speed')), alive, turn)
-                updated = self._run_optional_feature(
-                    'remote track animation', self._update_bot_tracks,
-                    (record, state, now, turn))
-                record['_remote_track_pending'] = not updated
-                if updated:
-                    record['_remote_track_state_signature'] = track_signature
-            return True
+                if (pose_changed or record.get('_remote_track_pending') or
+                        track_signature != record.get(
+                            '_remote_track_state_signature')):
+                    updated = self._run_optional_feature(
+                        'remote track animation', self._update_bot_tracks,
+                        (record, state, now, turn))
+                    record['_remote_track_pending'] = not updated
+                    if updated:
+                        record['_remote_track_state_signature'] = track_signature
+            return bool(pose_changed or aim_changed)
 
     def _flush_pending_entities(self, now):
         for unused_key, record in list(self._records.items()):

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/entities/native_remote_vehicle.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/entities/native_remote_vehicle.py
@@ -172,9 +172,13 @@ class _NativeRemoteState(object):
         self._capabilities_changed = False
 
     def _write_matrix(self, matrix):
+        previous = getattr(self, '_matrix_pose', None)
+        # A failed rotation/translation pair may have changed the provider.
+        # The next sample must repair it even if it returns to the old pose.
+        self._matrix_pose = None
         self._matrix_pose = _write_changed_pose(
             matrix, self.position, (self.yaw, self.pitch, self.roll),
-            getattr(self, '_matrix_pose', None))
+            previous)
 
     def _matrix_product(self, first, second=None):
         product_type = getattr(self._math, 'MatrixProduct', None)

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/entities/native_remote_vehicle.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/entities/native_remote_vehicle.py
@@ -15,6 +15,7 @@ import sys
 
 from gui.mods.offline_lan_0922.entities.remote_vehicle import (
     _RemoteShotPresenter, _blend_angle, _component_aim_angles,
+    _write_changed_pose,
     clear_ground_decal_visibility_state, close_stock_presentation_extras,
     set_model_attachment_visibility)
 
@@ -171,8 +172,9 @@ class _NativeRemoteState(object):
         self._capabilities_changed = False
 
     def _write_matrix(self, matrix):
-        matrix.setRotateYPR((self.yaw, self.pitch, self.roll))
-        matrix.translation = self.position
+        self._matrix_pose = _write_changed_pose(
+            matrix, self.position, (self.yaw, self.pitch, self.roll),
+            getattr(self, '_matrix_pose', None))
 
     def _matrix_product(self, first, second=None):
         product_type = getattr(self._math, 'MatrixProduct', None)
@@ -381,7 +383,7 @@ class _NativeRemoteState(object):
         relax_time = float(relax_time or 0.0)
         if self.animation is None:
             self._render_pose = target
-            self._write_pose(self._key_to, target)
+            # set_interpolate_motion seeds both keys on the enable edge.
             return False
         current = self._mirror_pose(now)
         if relax_time <= 0.0 or current is None:

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/entities/remote_vehicle.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/entities/remote_vehicle.py
@@ -1928,9 +1928,12 @@ class RemoteVehicle(object):
         self._update_matrix()
 
     def _update_matrix(self):
+        previous = getattr(self, '_matrix_pose', None)
+        # Native setters can fail after changing part of the transform.
+        self._matrix_pose = None
         self._matrix_pose = _write_changed_pose(
             self.matrix, self.position, (self.yaw, self.pitch, self.roll),
-            getattr(self, '_matrix_pose', None))
+            previous)
 
     def attach_visual(self, entity, entity_id, model):
         self.bw_entity = entity

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/entities/remote_vehicle.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/entities/remote_vehicle.py
@@ -1416,6 +1416,24 @@ def _component_aim_angles(descriptor, turret_yaw, gun_pitch):
     return float(turret_yaw), float(gun_pitch)
 
 
+def _write_changed_pose(matrix, position, rotation, previous):
+    """Write changed components of one persistent presentation matrix.
+
+    A rotation setter can reset translation, so every rotation write restores
+    XYZ as well. Publish the cache only after both native writes succeed, and
+    fence it by matrix identity so a replacement provider starts uncached.
+    Motion timestamps and velocity samples remain owned by the caller.
+    """
+    xyz = (float(position.x), float(position.y), float(position.z))
+    same_matrix = previous is not None and previous[0] is matrix
+    rotated = not same_matrix or previous[2] != rotation
+    if rotated:
+        matrix.setRotateYPR(rotation)
+    if rotated or previous[1] != xyz:
+        matrix.translation = position
+    return matrix, xyz, rotation
+
+
 def _pose_components(vehicle, math_module):
     """Build descriptor-local hit-test transforms below the body pose."""
     descriptor = vehicle.typeDescriptor
@@ -1910,8 +1928,9 @@ class RemoteVehicle(object):
         self._update_matrix()
 
     def _update_matrix(self):
-        self.matrix.setRotateYPR((self.yaw, self.pitch, self.roll))
-        self.matrix.translation = self.position
+        self._matrix_pose = _write_changed_pose(
+            self.matrix, self.position, (self.yaw, self.pitch, self.roll),
+            getattr(self, '_matrix_pose', None))
 
     def attach_visual(self, entity, entity_id, model):
         self.bw_entity = entity
@@ -2189,7 +2208,7 @@ class RemoteVehicle(object):
         animation = self._animation
         if animation is None:
             self._render_pose = target
-            self._write_pose(self._key_to, target)
+            # _new_animation seeds both keys when they acquire a consumer.
             return False
         current = self._mirror_pose(now)
         if relax_time <= 0.0 or current is None:

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -2640,6 +2640,60 @@ class RemotePresentationWriteTests(unittest.TestCase):
                                  (vehicle.matrix.yaw, vehicle.matrix.pitch,
                                   vehicle.matrix.roll))
 
+    def test_failed_matrix_write_can_return_to_the_previous_pose(self):
+        for vehicle in self._vehicles():
+            with self.subTest(adapter=type(vehicle).__name__):
+                original = _Vector(4.0, 2.0, 8.0)
+                vehicle.set_pose(original, (0.1, 0.2, 0.3))
+                vehicle.matrix.fail_translation = True
+                with self.assertRaisesRegex(RuntimeError, 'translation failed'):
+                    vehicle.set_pose(_Vector(1.0, 2.0, 3.0), (0.4, 0.5, 0.6))
+                vehicle.set_pose(original, (0.1, 0.2, 0.3))
+                self.assertEqual(tuple(original), tuple(vehicle.matrix.translation))
+                self.assertEqual((0.3, 0.2, 0.1),
+                                 (vehicle.matrix.yaw, vehicle.matrix.pitch,
+                                  vehicle.matrix.roll))
+
+    def test_failed_record_pose_can_return_to_the_previous_sample(self):
+        native, unused_fallback = self._vehicles()
+        battle = BattleRuntime(_runtime())
+        battle._binding = mock.Mock()
+        battle._binding.set_vehicle_pose.side_effect = (
+            lambda unused_id, position, rotation, **kwargs:
+            native.set_pose(position, rotation, **kwargs))
+        battle._update_bot_tracks = mock.Mock(return_value=True)
+        record = {'engine_id': 11, 'kind': 'bot', 'state': {'speed': 8.0}}
+        original = dict(x=4.0, y=2.0, z=8.0, yaw=0.3, pitch=0.2, roll=0.1)
+        battle._apply_record_pose(record, original)
+        native.matrix.fail_translation = True
+        with self.assertRaisesRegex(RuntimeError, 'translation failed'):
+            battle._apply_record_pose(record, dict(original, x=9.0, yaw=0.6))
+        battle._apply_record_pose(record, original)
+        self.assertEqual(3, battle._binding.set_vehicle_pose.call_count)
+        self.assertEqual((4.0, 2.0, 8.0), tuple(native.matrix.translation))
+        self.assertEqual(0.3, native.matrix.yaw)
+
+    def test_failed_record_aim_can_return_to_the_previous_sample(self):
+        native, unused_fallback = self._vehicles()
+        battle = BattleRuntime(_runtime())
+        battle._binding = mock.Mock()
+        battle._binding.update_vehicle_aim.side_effect = (
+            lambda unused_id, *angles: native.set_aim(*angles))
+        battle._update_bot_tracks = mock.Mock(return_value=True)
+        record = {'engine_id': 11, 'kind': 'bot', 'state': {'speed': 8.0}}
+        original = dict(x=4.0, y=2.0, z=8.0, yaw=0.0,
+                        aim_yaw=0.3, gun_pitch=0.1)
+        battle._apply_record_pose(record, original)
+        with mock.patch.object(native.aim.gunMatrix, 'setRotateYPR',
+                               side_effect=RuntimeError('gun aim failed')):
+            with self.assertRaisesRegex(RuntimeError, 'gun aim failed'):
+                battle._apply_record_pose(
+                    record, dict(original, aim_yaw=0.6, gun_pitch=0.2))
+        battle._apply_record_pose(record, original)
+        self.assertEqual(3, battle._binding.update_vehicle_aim.call_count)
+        self.assertAlmostEqual(0.3, native.aim.turretMatrix.yaw)
+        self.assertEqual(0.1, native.aim.gunMatrix.pitch)
+
     def test_aim_writes_follow_component_inputs_and_record_lifecycle(self):
         original = dict(x=4.0, y=2.0, z=8.0, yaw=0.3, pitch=0.1, roll=0.2,
                         aim_yaw=0.7, gun_pitch=-0.1)

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -2523,6 +2523,209 @@ def _runtime():
                 }})))
 
 
+class RemotePresentationWriteTests(unittest.TestCase):
+
+    class CountingMatrix(_Matrix):
+        def __init__(self, other=None):
+            self.rotation_writes = 0
+            self.translation_writes = 0
+            super().__init__(other)
+
+        def setRotateYPR(self, value):
+            self.rotation_writes += 1
+            super().setRotateYPR(value)
+            # A rotation setter may replace the complete transform. The
+            # adapter must restore translation whenever it writes rotation.
+            object.__setattr__(self, 'translation', _Vector())
+
+        def __setattr__(self, name, value):
+            if name == 'translation':
+                if getattr(self, 'fail_translation', False):
+                    self.fail_translation = False
+                    raise RuntimeError('translation failed')
+                self.translation_writes += 1
+            object.__setattr__(self, name, value)
+
+        def reset_counts(self):
+            self.rotation_writes = self.translation_writes = 0
+
+    def _vehicles(self):
+        runtime = _runtime()
+        runtime.math.Matrix = self.CountingMatrix
+        native = _NativeRemoteState(
+            runtime.bigworld, runtime.math, runtime.compatibility, None,
+            _Vector(), (0.0, 0.0, 0.0), interpolate_motion=False)
+        fallback = RemoteVehicle(
+            1000, _Descriptor(), {'publicInfo': {'team': 2}, 'health': 500},
+            _Vector(), (0.0, 0.0, 0.0), runtime.math)
+        return native, fallback
+
+    def test_direct_moving_poses_write_only_changed_matrix_components(self):
+        for vehicle in self._vehicles():
+            with self.subTest(adapter=type(vehicle).__name__):
+                for matrix in (vehicle.matrix, vehicle._key_from,
+                               vehicle._key_to):
+                    matrix.reset_counts()
+                for frame in range(60):
+                    vehicle.set_pose(
+                        _Vector(0.0, 0.0, (frame + 1) / 6.0),
+                        (0.0, 0.0, 0.0), now=1.0 + frame / 60.0)
+                self.assertEqual(0, vehicle.matrix.rotation_writes)
+                self.assertEqual(60, vehicle.matrix.translation_writes)
+                for key in (vehicle._key_from, vehicle._key_to):
+                    self.assertEqual(
+                        (0, 0), (key.rotation_writes, key.translation_writes))
+                speed = (vehicle.speed if isinstance(vehicle, _NativeRemoteState)
+                         else vehicle.filter.speed)
+                self.assertAlmostEqual(10.0, speed)
+
+                # Turning at the same world position must restore translation
+                # after setRotateYPR, even though XYZ itself did not change.
+                vehicle.set_pose(
+                    _Vector(0.0, 0.0, 10.0), (0.1, 0.2, 0.3), now=2.0)
+                self.assertEqual(
+                    (0.0, 0.0, 10.0), tuple(vehicle.matrix.translation))
+                self.assertEqual((0.3, 0.2, 0.1),
+                                 (vehicle.matrix.yaw, vehicle.matrix.pitch,
+                                  vehicle.matrix.roll))
+                self.assertEqual((1, 61), (vehicle.matrix.rotation_writes,
+                                          vehicle.matrix.translation_writes))
+                vehicle.set_pose(
+                    _Vector(0.0, 0.0, 10.0), (0.1, 0.2, 0.3), now=2.1)
+                self.assertEqual((1, 61), (vehicle.matrix.rotation_writes,
+                                          vehicle.matrix.translation_writes))
+
+                # A replaced provider cannot inherit another matrix's cache.
+                vehicle.matrix = self.CountingMatrix()
+                vehicle.set_pose(
+                    _Vector(0.0, 0.0, 10.0), (0.1, 0.2, 0.3), now=2.2)
+                self.assertEqual(
+                    (0.0, 0.0, 10.0), tuple(vehicle.matrix.translation))
+                self.assertEqual(0.3, vehicle.matrix.yaw)
+
+    def test_interpolation_seeds_keys_from_the_latest_direct_pose(self):
+        for vehicle in self._vehicles():
+            with self.subTest(adapter=type(vehicle).__name__):
+                vehicle.set_pose(
+                    _Vector(10.0, 2.0, 3.0), (0.1, 0.2, 0.3), now=1.0)
+                if isinstance(vehicle, _NativeRemoteState):
+                    self.assertTrue(vehicle.set_interpolate_motion(True))
+                    animation = vehicle.animation
+                else:
+                    vehicle.attach_visual(
+                        types.SimpleNamespace(model=None), 7, _Model())
+                    animation = vehicle._animation
+                for key in (vehicle._key_from, vehicle._key_to):
+                    self.assertEqual((10.0, 2.0, 3.0), tuple(key.translation))
+                    self.assertEqual(
+                        (0.3, 0.2, 0.1), (key.yaw, key.pitch, key.roll))
+                vehicle.set_pose(_Vector(20.0, 2.0, 3.0), (0.1, 0.2, 0.3),
+                                 relax_time=0.1, now=2.0)
+                vehicle.set_pose(_Vector(30.0, 2.0, 3.0), (0.1, 0.2, 0.3),
+                                 relax_time=0.1, now=2.05)
+                self.assertAlmostEqual(15.0, vehicle._key_from.translation[0])
+                self.assertAlmostEqual(30.0, vehicle._key_to.translation[0])
+                self.assertIs(vehicle._key_to, animation.keyframes[1][1])
+
+    def test_failed_matrix_write_does_not_cache_a_partial_transform(self):
+        for vehicle in self._vehicles():
+            with self.subTest(adapter=type(vehicle).__name__):
+                vehicle.matrix.fail_translation = True
+                with self.assertRaisesRegex(RuntimeError, 'translation failed'):
+                    vehicle.set_pose(_Vector(1.0, 2.0, 3.0), (0.1, 0.2, 0.3))
+                vehicle.set_pose(_Vector(1.0, 2.0, 3.0), (0.1, 0.2, 0.3))
+                self.assertEqual(
+                    (1.0, 2.0, 3.0), tuple(vehicle.matrix.translation))
+                self.assertEqual((0.3, 0.2, 0.1),
+                                 (vehicle.matrix.yaw, vehicle.matrix.pitch,
+                                  vehicle.matrix.roll))
+
+    def test_aim_writes_follow_component_inputs_and_record_lifecycle(self):
+        original = dict(x=4.0, y=2.0, z=8.0, yaw=0.3, pitch=0.1, roll=0.2,
+                        aim_yaw=0.7, gun_pitch=-0.1)
+        for kind in ('bot', 'player'):
+            for field, aim_changed in (
+                    ('x', False), ('y', False), ('z', False), ('roll', False),
+                    ('yaw', True), ('pitch', True), ('aim_yaw', True),
+                    ('gun_pitch', True), ('siege', True), ('generation', True),
+                    ('engine_id', True), ('record', True)):
+                with self.subTest(kind=kind, field=field):
+                    battle = BattleRuntime(_runtime())
+                    battle._binding = mock.Mock()
+                    battle._update_bot_tracks = mock.Mock(return_value=True)
+                    record = {'engine_id': 11, 'kind': kind,
+                              'state': {'speed': 8.0}}
+                    battle._apply_record_pose(record, original)
+                    battle._binding.reset_mock()
+                    pose = dict(original)
+                    if field == 'siege':
+                        record['presented_siege_state'] = 2
+                    elif field == 'generation':
+                        battle._generation += 1
+                    elif field == 'engine_id':
+                        record['engine_id'] = 12
+                    elif field == 'record':
+                        record = dict(record)
+                    else:
+                        pose[field] += 1.0e-12
+                    battle._apply_record_pose(record, pose)
+                    self.assertEqual(
+                        int(aim_changed),
+                        battle._binding.update_vehicle_aim.call_count)
+                    self.assertEqual(
+                        pose['x'], record['projectile_collision_pose']['x'])
+
+    def test_failed_aim_retries_without_replaying_a_successful_pose(self):
+        battle = BattleRuntime(_runtime())
+        battle._binding = mock.Mock()
+        battle._update_bot_tracks = mock.Mock(return_value=True)
+        record = {'engine_id': 11, 'kind': 'bot', 'state': {'speed': 8.0}}
+        pose = dict(x=0.0, y=0.0, z=1.0, yaw=0.0, aim_yaw=0.2, gun_pitch=0.1)
+        battle._binding.update_vehicle_aim.side_effect = (
+            RuntimeError('aim failed'), None)
+        with self.assertRaisesRegex(RuntimeError, 'aim failed'):
+            battle._apply_record_pose(record, pose)
+        self.assertNotIn('_remote_aim_signature', record)
+        battle._apply_record_pose(record, pose)
+        self.assertEqual(1, battle._binding.set_vehicle_pose.call_count)
+        self.assertEqual(2, battle._binding.update_vehicle_aim.call_count)
+
+    def test_aim_only_samples_keep_motion_clock_without_hull_matrix_writes(self):
+        native, unused_fallback = self._vehicles()
+        battle = BattleRuntime(_runtime())
+        now = [1.0]
+        battle._clock = lambda: now[0]
+        battle._binding = mock.Mock()
+        battle._binding.set_vehicle_pose.side_effect = (
+            lambda unused_id, position, rotation, **kwargs:
+            native.set_pose(position, rotation, **kwargs))
+        battle._binding.update_vehicle_aim.side_effect = (
+            lambda unused_id, *angles: native.set_aim(*angles))
+        battle._update_bot_tracks = mock.Mock(return_value=True)
+        record = {'engine_id': 11, 'kind': 'bot', 'state': {'speed': 10.0}}
+        pose = dict(x=0.0, y=0.0, z=0.0, yaw=0.0, pitch=0.0, roll=0.0,
+                    aim_yaw=0.0, gun_pitch=0.0)
+        battle._apply_record_pose(record, pose)
+        now[0] = 1.1
+        pose['z'] = 1.0
+        battle._apply_record_pose(record, pose)
+        self.assertAlmostEqual(10.0, native.speed)
+        native.matrix.reset_counts()
+        for frame in range(60):
+            now[0] = 1.1 + (frame + 1) / 60.0
+            pose['aim_yaw'] = (frame + 1) / 60.0
+            battle._apply_record_pose(record, pose)
+        self.assertEqual((0, 0), (native.matrix.rotation_writes,
+                                  native.matrix.translation_writes))
+        self.assertEqual(0.0, native.speed)
+        self.assertEqual(now[0], native._last_pose_time)
+        self.assertEqual(1.0, record['projectile_collision_pose']['turret_yaw'])
+        now[0] += 0.1
+        pose['z'] = 2.0
+        battle._apply_record_pose(record, pose)
+        self.assertAlmostEqual(10.0, native.speed)
+
+
 class NativeRemoteVehicleFactoryTests(unittest.TestCase):
     def _failing_registration_factory(self, arena_side_effect):
         runtime = _runtime()
@@ -3153,6 +3356,7 @@ class NativeRemoteVehicleFactoryTests(unittest.TestCase):
         binding.set_vehicle_pose(
             vehicle_id, _Vector(2.0, 0.0, 4.0), (0.0, 0.0, 0.4),
             now=10.1)
+        binding.update_vehicle_aim(vehicle_id, 0.4, 0.9, -0.1)
         self.assertIs(provider, vehicle.model.matrix)
 
         vehicle._offlineNativeDrawVisible = False
@@ -3176,6 +3380,8 @@ class NativeRemoteVehicleFactoryTests(unittest.TestCase):
         for handler in tuple(vehicle.appearance.onModelChanged.handlers):
             handler()
         self.assertIs(provider, vehicle.model.matrix)
+        self.assertAlmostEqual(0.5, state.aim.turretMatrix.yaw)
+        self.assertAlmostEqual(-0.1, state.aim.gunMatrix.pitch)
         self.assertFalse(vehicle.model.visible)
         self.assertEqual([], vehicle.targetCaps)
         self.assertEqual(old_attach_count, len(old_hull.attach_calls))
@@ -27277,11 +27483,11 @@ class BattleRuntimeContractTests(unittest.TestCase):
                     'yaw': 0.0, 'pitch': 0.0, 'roll': 0.0,
                     'aim_yaw': 0.0, 'gun_pitch': 0.0}})
 
-        # Hull and aim remain render-rate smooth; only the native 20 Hz belt
-        # controller is rate limited, and no pose-only sample walks the full
-        # state/materialization path.
+        # Every changing hull sample reaches presentation; constant aim needs
+        # one feed. The native belt controller retains its existing 20 Hz
+        # cadence and pose-only samples bypass state/materialization work.
         self.assertEqual(fps, battle._binding.set_vehicle_pose.call_count)
-        self.assertEqual(fps, battle._binding.update_vehicle_aim.call_count)
+        self.assertEqual(1, battle._binding.update_vehicle_aim.call_count)
         self.assertEqual(20, vehicle.update_tracks.call_count)
         battle._materialize_record.assert_not_called()
         self.assertIs(state, record['state'])
@@ -27302,7 +27508,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
                 'yaw': 0.0, 'pitch': 0.0, 'roll': 0.0,
                 'aim_yaw': 0.0, 'gun_pitch': 0.0}})
         self.assertEqual(fps, battle._binding.set_vehicle_pose.call_count)
-        self.assertEqual(fps, battle._binding.update_vehicle_aim.call_count)
+        self.assertEqual(1, battle._binding.update_vehicle_aim.call_count)
         self.assertEqual(previous_track_calls + 1,
                          vehicle.update_tracks.call_count)
         vehicle.settle_motion.assert_not_called()


### PR DESCRIPTION
Visible remote vehicles already receive an interpolated pose each render frame, with their second animation layer disabled. Nevertheless, every update rewrites the unused destination key matrix, resets the hull rotation during plain translation, and resubmits unchanged aim. Turning only the turret also rewrites the hull matrix.

Write only changed components of the persistent hull matrix, stop feeding animation keys while they have no consumer, and deduplicate aim independently from position. Apply the matrix fix to both existing remote presentation adapters. Changed pose samples still advance motion timestamps, velocity, acceleration and collision poses; interpolation, track cadence and gameplay authority retain their existing owners.

The matrix cache is tied to its provider. Pose, aim and matrix caches are invalidated before writes and restored only after success, so a partially written transform is repaired even when the next sample returns to the old pose. Every rotation write restores translation, and enabling interpolation seeds both keys from the latest pose. Aim caching includes round/entity/record identity, hull pitch and the applied Siege state. Tests cover partial-write retries and rollback, movement followed by aim-only samples and resumed motion, model relinks, interpolation transitions, exact component changes, Bot/player parity, and existing track/playback-hold behavior.

Validation:

- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=tests python3 -m unittest test_port_0922 test_port_0922_battle_runtime test_port_0922_battle_projectiles test_port_0922_projectile_visual_presenter test_port_0922_remote_aim test_port_0922_solid_collision_oracle test_port_0922_turret_detachment test_port_0922_critical_damage test_port_0922_he_blast_runtime test_internal_mesh_consumers`: 1,373 tests passed on the final tree, including current main's turret-detachment and live critical-geometry changes.
- CPython 2.7.18 in-memory compilation of all 110 client source files passed.
- `git diff --check` passed.

An instrumented test-fixture replay compared the unchanged presentation code in `1ff832cef2ef6265b0631c2bc482f2a28e22985c` (also present in base `12cff570ad9245222244a2087ba77195838624d3`) with this change. Counts below cover 29 vehicles over 60 frames after initial setup. Matrix writes count rotation setters and translation assignments on the hull and inactive animation keys; aim updates are counted separately.

| Continuous activity | Matrix writes before → after | Aim calls before → after |
| --- | ---: | ---: |
| Straight driving, constant aim | 6,960 → 1,740 | 1,740 → 0 |
| Driving, turning and aiming | 6,960 → 3,480 | 1,740 → 1,740 |
| Turret movement at a fixed hull pose | 6,960 → 0 | 1,740 → 1,740 |

These are Python-adapter call counts with engine fakes, not Windows frame timings. Exact Chinese HD #1513 Windows acceptance remains necessary to establish FPS/frame-pacing improvement and native presentation behavior. This PR follows the already merged contact optimization in #146; suspension/native-query timing remains a separate investigation.
