### PR TITLE
Make wrecks pushable bodies with the client's own track physics

### DIFF
--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -18940,6 +18940,11 @@ class BattleRuntime(object):
                 # only keeps the player at full speed after a ram, so it
                 # immediately catches and damages the same Bot again.
                 'impulse': True,
+                # A Bot wreck is shoved by the authority worker, so it keeps a
+                # real inverse mass here and the local hull only takes its own
+                # share of the separation.  A dead human hull has no
+                # integrator in any process and stays world geometry.
+                'immovable': not alive and record.get('kind') != 'bot',
                 'x': x, 'y': y, 'z': z,
                 'yaw': yaw,
                 'mass': _number(mass, 25000.0),
@@ -19018,13 +19023,33 @@ class BattleRuntime(object):
                 push_z = 0.0
             else:
                 position = candidate
-        # Preserve the existing 0.90-per-60-Hz-tick damping in real time.
-        # Applying 0.90 once per rendered frame made a lateral shove last
-        # several times longer at the 20-30 FPS rates this client commonly
-        # reaches, which is why a teammate could slide the player so far.
-        push_decay = 0.90 ** (max(0.0, float(dt)) * 60.0)
-        self._local_push_x = push_x * push_decay
-        self._local_push_z = push_z * push_decay
+        # The hull resists an outside shove with the tracks it is standing
+        # on, not with a fixed exponential: rolling drag along the hull while
+        # the drivetrain turns, the parked perch hold when it does not, and
+        # the fall-line hold across the tracks either way.  The old 0.90 per
+        # 60 Hz tick removed about 6.3 m/s2 at 1 m/s in every direction, seven
+        # times a tank's own rolling drag, and never actually reached zero.
+        #
+        # Both halves of a human/Bot contact still share one impulse; only the
+        # residual decay differs, because a live Bot keeps the reviewed
+        # exponential for now (see bot_runtime: the residual push is currently
+        # the only escape from a terrain wedge in the spawn departure guards).
+        # A shoved wreck already uses this law on the authority side.
+        if self._local_physics is None:
+            # Every drive step installs the descriptor's physics before this
+            # runs; a bare harness without one keeps the push unchanged
+            # rather than inventing a resistance for an unknown hull.
+            self._local_push_x, self._local_push_z = push_x, push_z
+        else:
+            rolling = bool(
+                abs(self._local_speed) > 0.05 or
+                abs(_number(getattr(self._sender, 'forward', 0.0))) > 0.0)
+            self._local_push_x, self._local_push_z = (
+                vehicle_physics.contact_push_step(
+                    self._local_physics, push_x, push_z, yaw, dt,
+                    rolling=rolling,
+                    normal_y=(math.cos(self._local_pitch) *
+                              math.cos(self._local_roll))))
         return position
 
     def local_ram_contact(self):

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -8159,10 +8159,10 @@ class BotRuntime(object):
             state['push_x'] = 0.0
             state['push_z'] = 0.0
             return False
-        before = (state['x'], state['z'])
+        before = _position(state)
         self._apply_tank_contact_response(state, result, step)
         if (abs(state['x'] - before[0]) <= 1.0e-6 and
-                abs(state['z'] - before[1]) <= 1.0e-6):
+                abs(state['z'] - before[2]) <= 1.0e-6):
             return False
         try:
             ground = self._ground_probe_at(
@@ -8173,7 +8173,7 @@ class BotRuntime(object):
             # Undo this hull's slide rather than leave a dead tank hanging.
             ground = None
         if ground is None:
-            state['x'], state['z'] = before
+            state['x'], state['y'], state['z'] = before
             state['push_x'] = 0.0
             state['push_z'] = 0.0
             return False
@@ -8181,7 +8181,16 @@ class BotRuntime(object):
         if not -WRECK_SUPPORT_DROP <= rise <= WRECK_SUPPORT_RISE:
             # A cliff lip or a step the hull could not have climbed. Keep the
             # wreck where it already rested instead of dropping or lifting it.
-            state['x'], state['z'] = before
+            state['x'], state['y'], state['z'] = before
+            state['push_x'] = 0.0
+            state['push_z'] = 0.0
+            return False
+        candidate = (state['x'], float(ground), state['z'])
+        if not self._turret_pose_is_clear(
+                state, before, state['yaw'], candidate, state['yaw']):
+            # The horizontal probe used the old support height. Settling can
+            # enter a landed turret even when that first sweep was clear.
+            state['x'], state['y'], state['z'] = before
             state['push_x'] = 0.0
             state['push_z'] = 0.0
             return False

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bot_runtime.py
@@ -211,6 +211,12 @@ BOT_OVERTURN_WARNING_COSINE = vehicle_physics.OVERTURN_WARNING_COSINE
 BOT_OVERTURN_DANGER_COSINE = vehicle_physics.OVERTURN_DANGER_COSINE
 BOT_OVERTURN_DEATH_SECONDS = 30.0
 BOT_OVERTURN_DEATH_REASON = 7
+# A shoved wreck re-settles on the ground it slid onto. It has no engine, so
+# it may follow a drop of about one hull clearance and may not be lifted onto
+# anything it could not have rolled over. Outside that envelope the slide is
+# undone rather than left floating or sunk.
+WRECK_SUPPORT_DROP = 0.60
+WRECK_SUPPORT_RISE = 0.25
 
 # The ten-spring trial may follow a rise above the mature 0.6 m step gate only
 # when the last and current spring batches describe one continuous terrain
@@ -8012,10 +8018,115 @@ class BotRuntime(object):
                 push_z = 0.0
         state['x'] += move_x
         state['z'] += move_z
-        push_decay = (0.90 ** (max(0.0, float(step)) * 60.0)
-                      if advance_push else 1.0)
-        state['push_x'] = push_x * push_decay
-        state['push_z'] = push_z * push_decay
+        if not advance_push:
+            state['push_x'] = push_x
+            state['push_z'] = push_z
+            return
+        if state.get('alive', True):
+            # A live hull keeps the reviewed residual decay. Replacing it with
+            # the track budget below is the physically correct law, but a
+            # residual push is also today's only escape from a terrain wedge:
+            # with dry friction the Himmelsdorf and Airfield 24 FPS spawn
+            # guards each strand one Bot whose separation the world probe
+            # vetoes. That belongs to the wedge recovery, not to this change.
+            decay = 0.90 ** (max(0.0, float(step)) * 60.0)
+            state['push_x'] = push_x * decay
+            state['push_z'] = push_z * decay
+            return
+        state['push_x'], state['push_z'] = self._bleed_contact_push(
+            state, push_x, push_z, step)
+
+    def _bleed_contact_push(self, state, push_x, push_z, step):
+        """Spend one slice of this wreck's own track budget on its push.
+
+        A destroyed hull has no drivetrain, so both of its axes resist with
+        the held track laws: the parked perch limit along the hull and the
+        fall-line hold across it. Dry friction removes a fixed amount of
+        speed per second and stops the hull dead, which is what keeps a
+        shoved wreck from creeping for the rest of the round.
+        """
+        try:
+            params = self._physics_params_for(int(state['id']))
+        except (KeyError, TypeError, ValueError, OverflowError):
+            return push_x, push_z
+        if not params:
+            return push_x, push_z
+        return vehicle_physics.contact_push_step(
+            params, push_x, push_z, _number(state.get('yaw')), step,
+            rolling=False,
+            normal_y=(math.cos(_number(state.get('pitch'))) *
+                      math.cos(_number(state.get('roll')))))
+
+    def _wreck_tracks_absorb(self, state, result, step):
+        """Return whether this wreck's tracks hold against the whole impulse.
+
+        The applied impulse divided by the slice is the acceleration the
+        contact is asking of the hull. Comparing it against the same parked
+        perch hold that keeps a stopped tank on a slope is exactly the
+        Coulomb static test, so a light hull leaning on a heavy wreck moves
+        nothing while a heavy one breaks it loose.
+        """
+        try:
+            params = self._physics_params_for(int(state['id']))
+        except (KeyError, TypeError, ValueError, OverflowError):
+            return False
+        if not params:
+            return False
+        return vehicle_physics.contact_push_is_held(
+            params,
+            state.get('push_x', 0.0) + result['delta_velocity'][0],
+            state.get('push_z', 0.0) + result['delta_velocity'][1],
+            _number(state.get('yaw')), step, rolling=False,
+            normal_y=(math.cos(_number(state.get('pitch'))) *
+                      math.cos(_number(state.get('roll')))))
+
+    def _apply_wreck_contact_response(self, state, result, step):
+        """Shove one destroyed hull and keep it standing on the ground.
+
+        A wreck has no planner, no drive step and no suspension pass, so this
+        is its whole integrator. It reuses the live contact response for the
+        horizontal move - including the same world-collision veto, so a wreck
+        can never be shoved through a wall - and then re-settles the hull on
+        the terrain it slid onto. A move whose new column has no usable
+        support is undone rather than left hanging: the last pose a dead hull
+        was seen at is always a legal one.
+        """
+        if self._wreck_tracks_absorb(state, result, step):
+            # Static friction: the pusher could not break the tracks loose.
+            # Baumgarte separation is not a force and would otherwise walk
+            # any wreck along at the pusher's inverse-mass share whatever its
+            # mass, so the pusher owns the whole overlap this tick instead.
+            state['push_x'] = 0.0
+            state['push_z'] = 0.0
+            return False
+        before = (state['x'], state['z'])
+        self._apply_tank_contact_response(state, result, step)
+        if (abs(state['x'] - before[0]) <= 1.0e-6 and
+                abs(state['z'] - before[1]) <= 1.0e-6):
+            return False
+        try:
+            ground = self._ground_probe_at(
+                state['x'], state['z'], state['y'])
+        except (TypeError, ValueError, AttributeError, RuntimeError,
+                OverflowError):
+            # Without a ground authority the new column cannot be verified.
+            # Undo this hull's slide rather than leave a dead tank hanging.
+            ground = None
+        if ground is None:
+            state['x'], state['z'] = before
+            state['push_x'] = 0.0
+            state['push_z'] = 0.0
+            return False
+        rise = float(ground) - _number(state.get('y'))
+        if not -WRECK_SUPPORT_DROP <= rise <= WRECK_SUPPORT_RISE:
+            # A cliff lip or a step the hull could not have climbed. Keep the
+            # wreck where it already rested instead of dropping or lifting it.
+            state['x'], state['z'] = before
+            state['push_x'] = 0.0
+            state['push_z'] = 0.0
+            return False
+        state['y'] = float(ground)
+        return True
 
     def _resolve_human_ram_receipts(self, players, now, step=None,
                                     processed_pairs=None,
@@ -8395,6 +8506,11 @@ class BotRuntime(object):
                 # the exception: it owns the velocity response so the local
                 # player does not inherit the teammate's lateral momentum.
                 'impulse': False,
+                # A dead human hull has no integrator at all: the visible
+                # client stops its drive step on death and this worker never
+                # owned the player pose.  Keep it as world geometry instead of
+                # handing it a share of a correction nobody applies.
+                'immovable': not alive,
                 'x': raw.get('x', 0.0), 'y': raw.get('y', 0.0),
                 'z': raw.get('z', 0.0), 'yaw': yaw,
                 'mass': profile['mass'], 'shape': profile['shape'],
@@ -8447,8 +8563,10 @@ class BotRuntime(object):
             return tuple(reversed(canonical))
 
         for state in self._ordered_states():
-            if not state.get('alive', True):
-                continue
+            # A wreck resolves too.  It has no engine and never rams, but it
+            # is a hull on tracks and its inverse-mass share of a live hull's
+            # push has to actually move it.
+            state_alive = bool(state.get('alive', True))
             own = by_id.get(int(state['id']))
             if own is None:
                 continue
@@ -8478,29 +8596,62 @@ class BotRuntime(object):
                 # A separated tank still owns residual contact momentum and
                 # must advance/decay it through the same world collision gate.
                 if state.get('push_x', 0.0) or state.get('push_z', 0.0):
-                    self._apply_tank_contact_response(state, {
-                        'correction': (0.0, 0.0),
-                        'delta_velocity': (0.0, 0.0),
-                    }, step)
+                    idle = {'correction': (0.0, 0.0),
+                            'delta_velocity': (0.0, 0.0)}
+                    if state_alive:
+                        self._apply_tank_contact_response(state, idle, step)
+                    else:
+                        self._apply_wreck_contact_response(state, idle, step)
                 continue
-            resolve_kwargs = {
-                'now': now,
-                'ram_cooldowns': self._ram_cooldowns,
-                'active_ram_contacts': frozenset(
-                    set(previous_ram_contacts) | current_ram_contacts),
-            }
-            if self.ram_contact_probe is not None:
-                resolve_kwargs['contact_armor_probe'] = \
-                    contact_armor_probe
+            if not state_alive:
+                # ``impulse`` false says the visible client owns the player's
+                # half of the pair and the Bot's half arrives as a ram
+                # receipt.  No receipt is ever produced for a wreck, so this
+                # solver is the only owner of the wreck's half; leaving the
+                # flag alone let a player's shove reach the hull as bare
+                # separation with its track resistance never consulted.
+                others = [dict(other, impulse=True)
+                          if (other.get('kind') == 'player' and
+                              not other.get('impulse', True)) else other
+                          for other in others]
+            if not state_alive and not (
+                    state.get('push_x', 0.0) or state.get('push_z', 0.0) or
+                    any(other.get('alive', True) or other['vx'] or
+                        other['vz'] for other in others)):
+                # Nothing in reach can move this wreck and it carries no
+                # momentum of its own. Two settled wrecks left overlapping by
+                # their death poses must not re-solve each other every tick
+                # for the rest of the round.
+                continue
+            if state_alive:
+                resolve_kwargs = {
+                    'now': now,
+                    'ram_cooldowns': self._ram_cooldowns,
+                    'active_ram_contacts': frozenset(
+                        set(previous_ram_contacts) | current_ram_contacts),
+                }
+                if self.ram_contact_probe is not None:
+                    resolve_kwargs['contact_armor_probe'] = \
+                        contact_armor_probe
+            else:
+                # ``now`` None keeps every separation and impulse while
+                # disabling ram admission, so a shoved wreck can never open a
+                # damage episode or consume an armour probe.
+                resolve_kwargs = {'now': None}
             result = tank_collision.resolve_tank(
                 own, others, **resolve_kwargs)
-            self._ram_cooldowns = result['cooldowns']
-            current_ram_contacts.update(result['contacts'])
+            if state_alive:
+                self._ram_cooldowns = result['cooldowns']
+                current_ram_contacts.update(result['contacts'])
+            if not state_alive:
+                self._apply_wreck_contact_response(state, result, step)
+                continue
             if (any(abs(value) > 0.0001
                     for value in result['delta_velocity']) or
                     any(abs(value) > 0.0001
                         for value in result['correction'])):
                 # Another hull owns this tank's lack of progress this tick.
+                # A wreck has no driver and no stuck timer to protect.
                 contacted_bot_ids.add(int(state['id']))
             self._apply_tank_contact_response(state, result, step)
             reports.extend(self._ram_reports(

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/snapshot_sync.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/snapshot_sync.py
@@ -40,6 +40,12 @@ TIMED_DELAY_GROW_STALL_US = 100000.0
 TIMED_WARMUP_INTERVALS = 3
 TIMED_WARMUP_HEADROOM_RATIO = 1.0 / 3.0
 TIMED_WARMUP_MAX_HEADROOM_US = 20000.0
+# A destroyed hull is still a body another tank can shove. It has no drive,
+# no jitter buffer and no timed sample history, so it simply chases the
+# authority pose and then stops emitting entirely: 29 settled wrecks must cost
+# nothing per rendered frame.
+WRECK_SETTLE_DISTANCE = 0.002
+WRECK_SETTLE_ANGLE = 0.001
 SNAP_DISTANCE = 25.0
 MAX_VELOCITY = 80.0
 MAX_MOTION_TIME_US = 10000000000000000
@@ -390,11 +396,21 @@ class SnapshotSync(object):
         if not alive:
             if not record['dead']:
                 record['dead'] = True
+                record['wreck_settled'] = True
                 if pose is not None:
                     record['current'] = dict(pose)
+                    record['target'] = dict(pose)
                 self._emit({'type': 'destroy', 'entity': key, 'kind': kind,
                             'id': state['id'], 'reason': 'dead',
                             'keep_corpse': True, 'state': _copy_state(state)}, output)
+                return
+            # A wreck keeps receiving poses: the authority shoves it when a
+            # live hull leans on it. Feed the frame chase directly; the live
+            # timed buffer belongs to entities that drive themselves.
+            if pose is not None and record['current'] is not None:
+                record['target'] = dict(pose)
+                record['target_time'] = now
+                record['timed_prediction'] = False
             return
         if record['dead']:
             return
@@ -596,6 +612,49 @@ class SnapshotSync(object):
                                 'revision': revision}, output)
         return output
 
+    def _advance_wreck(self, record, key, alpha, output):
+        """Chase one shoved wreck's authority pose, then go quiet.
+
+        ``wreck_settled`` is derived, never remembered from the producer: a
+        wreck that is not being pushed converges once, emits one final exact
+        pose, and then costs nothing until something moves it again.
+        """
+        target = record['target']
+        current = record['current']
+        delta_x = target['x'] - current['x']
+        delta_y = target['y'] - current['y']
+        delta_z = target['z'] - current['z']
+        delta_yaw = _angle_delta(current['yaw'], target['yaw'])
+        if (delta_x * delta_x + delta_y * delta_y + delta_z * delta_z <=
+                WRECK_SETTLE_DISTANCE * WRECK_SETTLE_DISTANCE and
+                abs(delta_yaw) <= WRECK_SETTLE_ANGLE):
+            if record.get('wreck_settled'):
+                return False
+            record['current'] = dict(target)
+            record['wreck_settled'] = True
+            snapped = True
+            presented = target
+        else:
+            current = dict(current)
+            for axis in ('x', 'y', 'z'):
+                current[axis] += (target[axis] - current[axis]) * alpha
+            for axis in ('yaw', 'aim_yaw'):
+                current[axis] += _angle_delta(
+                    current[axis], target[axis]) * alpha
+            for axis in ('pitch', 'roll'):
+                current[axis] += (target[axis] - current[axis]) * alpha
+            current['gun_pitch'] += (
+                target['gun_pitch'] - current['gun_pitch']) * alpha
+            record['current'] = current
+            record['wreck_settled'] = False
+            snapped = False
+            presented = current
+        self._emit({'type': 'update', 'entity': key, 'kind': record['kind'],
+                    'id': record['id'], 'pose': dict(presented),
+                    'remote': True, 'presentation_time_us': None,
+                    'interpolated': True, 'snap': snapped}, output)
+        return True
+
     def advance(self, now=None):
         """Return interpolated/predicted remote poses for one render frame."""
         now = self._now() if now is None else float(now)
@@ -606,7 +665,10 @@ class SnapshotSync(object):
         alpha = 1.0 - math.exp(-20.0 * delta)
         output = []
         for key, record in self._entities.items():
-            if record['dead'] or record['target'] is None or record['current'] is None:
+            if record['target'] is None or record['current'] is None:
+                continue
+            if record['dead']:
+                self._advance_wreck(record, key, alpha, output)
                 continue
             target = record['target']
             elapsed = max(0.0, now - record['target_time'])

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/snapshot_sync.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/snapshot_sync.py
@@ -621,15 +621,19 @@ class SnapshotSync(object):
         """
         target = record['target']
         current = record['current']
+        if record.get('wreck_settled') and current == target:
+            return False
         delta_x = target['x'] - current['x']
         delta_y = target['y'] - current['y']
         delta_z = target['z'] - current['z']
-        delta_yaw = _angle_delta(current['yaw'], target['yaw'])
+        angle_error = max(
+            [abs(_angle_delta(current[axis], target[axis]))
+             for axis in ('yaw', 'aim_yaw')] +
+            [abs(target[axis] - current[axis])
+             for axis in ('pitch', 'roll', 'gun_pitch')])
         if (delta_x * delta_x + delta_y * delta_y + delta_z * delta_z <=
                 WRECK_SETTLE_DISTANCE * WRECK_SETTLE_DISTANCE and
-                abs(delta_yaw) <= WRECK_SETTLE_ANGLE):
-            if record.get('wreck_settled'):
-                return False
+                angle_error <= WRECK_SETTLE_ANGLE):
             record['current'] = dict(target)
             record['wreck_settled'] = True
             snapped = True

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/tank_collision.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/tank_collision.py
@@ -544,8 +544,10 @@ def pair_response(contact, inverse_a, inverse_b, velocity_a, velocity_b,
     sliding across each other without along-face drag; that wedge has to be
     understood before the term can land.  ``USE_PSEUDO_CONTACTS`` True and
     ``CONTACT_PENETRATION`` 0.1 from the same function are the
-    positional-correction class implemented above, and ``RESTITUTION`` is
-    never loaded in this build, so the normal term stays e=0.
+    positional-correction class implemented above. That Python function does
+    not configure ``RESTITUTION``; this does not establish the native default
+    or retail restitution. The normal term preserves this project's existing
+    e=0 response.
     """
     zero = (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
     if contact is None:

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/tank_collision.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/tank_collision.py
@@ -533,7 +533,20 @@ def planar_closing_speed(velocity_a, velocity_b, normal):
 
 def pair_response(contact, inverse_a, inverse_b, velocity_a, velocity_b,
                   slop=POSITION_SLOP, percent=POSITION_PERCENT):
-    """Return inverse-mass corrections and e=0 impulses for both bodies."""
+    """Return inverse-mass corrections and e=0 impulses for both bodies.
+
+    Exact #1513 ``physics_shared.updateCommonConf`` publishes the retail
+    solver's hull-to-hull Coulomb coefficient as
+    ``wg_setupPhysicsParam('CONTACT_FRICTION_VEHICLES', 0.3)``, so a real
+    contact also carries a tangential impulse this pure normal response does
+    not.  Adding it strands one Bot in the Himmelsdorf and Airfield 24 FPS
+    spawn guards, whose local traffic solution currently depends on hulls
+    sliding across each other without along-face drag; that wedge has to be
+    understood before the term can land.  ``USE_PSEUDO_CONTACTS`` True and
+    ``CONTACT_PENETRATION`` 0.1 from the same function are the
+    positional-correction class implemented above, and ``RESTITUTION`` is
+    never loaded in this build, so the normal term stays e=0.
+    """
     zero = (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
     if contact is None:
         return zero
@@ -683,10 +696,12 @@ def resolve_tank(tank, others, now=None, ram_cooldowns=None,
                  active_ram_contacts=None, contact_armor_probe=None):
     """Resolve one hull against other hulls using only plain data.
 
-    A body with ``alive`` false is a wreck: it still blocks and separates, but
-    it never moves and never produces a ram event.  A body with ``impulse``
-    false separates without transferring velocity, which leaves one owner for
-    a contact that both sides resolve.
+    A body with ``alive`` false is a wreck: it blocks, separates and can be
+    shoved by its inverse-mass share, but it never produces a ram event and
+    never takes ram damage.  A body with ``immovable`` true keeps the old
+    infinite-mass behaviour for a hull no process integrates.  A body with
+    ``impulse`` false separates without transferring velocity, which leaves
+    one owner for a contact that both sides resolve.
 
     The return value is a mapping with:
 
@@ -743,6 +758,12 @@ def resolve_tank(tank, others, now=None, ram_cooldowns=None,
         if other is None or other_id == self_id:
             continue
         other_is_wreck = not _tank_value(other, 'alive', True)
+        # A wreck has no engine, but it is still a hull resting on tracks and
+        # a heavy enough neighbour shoves it.  ``immovable`` is for a body no
+        # process integrates - the local player's own wreck - which has to
+        # keep behaving as world geometry rather than absorb a share of the
+        # correction nobody will ever apply.
+        other_is_immovable = bool(_tank_value(other, 'immovable', False))
         other_x = float(_tank_value(other, 'x', 0.0) or 0.0)
         other_y = _tank_value(other, 'y')
         other_z = float(_tank_value(other, 'z', 0.0) or 0.0)
@@ -761,7 +782,7 @@ def resolve_tank(tank, others, now=None, ram_cooldowns=None,
 
         mass_other = max(
             float(_tank_value(other, 'mass', 1.0) or 1.0), 1.0)
-        inverse_other = 0.0 if other_is_wreck else 1.0 / mass_other
+        inverse_other = 0.0 if other_is_immovable else 1.0 / mass_other
         other_yaw = float(_tank_value(other, 'yaw', 0.0) or 0.0)
         contact = obb_contact(
             x, z, yaw, own_shape,
@@ -773,9 +794,12 @@ def resolve_tank(tank, others, now=None, ram_cooldowns=None,
         pair = (min(self_id, other_id), max(self_id, other_id))
         overlap_pairs.add(pair)
 
-        if other_is_wreck:
+        if other_is_immovable:
             other_velocity_x = other_velocity_y = other_velocity_z = 0.0
         else:
+            # A pushed wreck carries a real contact velocity.  Reading it as
+            # zero made the solver see a closing pair that was already moving
+            # together and re-cancel the same momentum every frame.
             other_velocity_x = float(_tank_value(other, 'vx', 0.0) or 0.0)
             other_velocity_y = float(_tank_value(other, 'vy', 0.0) or 0.0)
             other_velocity_z = float(_tank_value(other, 'vz', 0.0) or 0.0)

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/vehicle_physics.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/vehicle_physics.py
@@ -43,9 +43,11 @@ SLOPE_GRIP_LNG_FULL_Y = math.cos(math.radians(27.5))
 SLOPE_GRIP_LNG_FULL = 1.0
 SLOPE_GRIP_LNG_MIN_Y = math.cos(math.radians(32.0))
 SLOPE_GRIP_LNG_MIN = 0.1
-# The contrib suspension trial applies a separate side-slip projection. These
-# two points came from the contributed implementation; this repository has not
-# proved that they reproduce the #1513 native curve.
+# Side grip. Exact #1513 ``g_defaultTankXPhysicsCfg['chassis']`` stores
+# ``slopeGripSdwTerrain = (0.9099612708765432, 1.0, 0.8746197071393957, 0.1)``,
+# which is (cos 24.5 deg, 1.0, cos 29 deg, 0.1): the same clamped two-point
+# form as the longitudinal curve above. The contrib suspension trial guessed
+# these two angles; this build's own configuration confirms them.
 SLOPE_GRIP_SDW_FULL_Y = math.cos(math.radians(24.5))
 SLOPE_GRIP_SDW_FULL = 1.0
 SLOPE_GRIP_SDW_MIN_Y = math.cos(math.radians(29.0))
@@ -1812,6 +1814,78 @@ def brake_force(p, active, terrainIdx=0, slope_pitch=0.0):
 		return p['mass'] * brake
 	return (rolling_resist_force(p, terrainIdx, False) +
 		p['mass'] * COAST_BRAKE_SHARE * brake)
+
+
+def contact_push_decel(p, rolling, terrainIdx=0, normal_y=1.0):
+	'''Return the (longitudinal, lateral) m/s^2 the tracks oppose an EXTERNAL
+	push with. This is the ground reaction to another hull shoving this one, so
+	it is deliberately anisotropic: a track rolls along the hull and scrubs
+	across it.
+
+	rolling=True means this hull's own drivetrain is already turning (it has
+	throttle or road speed), so a shove along the hull only fights
+	rolling_resist_force. rolling=False is the parked/wrecked hull whose tracks
+	are held; it resists with the same static perch limit longitudinal_step uses
+	for a parked hull on a slope. Sideways there is no rolling case at all - the
+	tracks always scrub - so the lateral axis keeps the fall-line hold
+	slope_slide_speed already applies, scaled by the #1513 side-grip curve.
+
+	No constant here is new: the whole point is that being pushed uses the same
+	track laws as driving, braking and sliding.'''
+	ny = normal_y if normal_y > 0.1 else 0.1
+	roll = rolling_resist_force(p, terrainIdx, False) / (
+		p['mass'] if p['mass'] > 1.0 else 1.0)
+	hold = SLIDE_HOLD_TAN * GRAVITY * ny
+	longitudinal = roll if rolling else (hold if hold > roll else roll)
+	lateral = SLIDE_HOLD_TAN * lateral_slope_grip(normal_y) * GRAVITY * ny
+	if lateral < roll:
+		lateral = roll
+	return longitudinal, lateral
+
+
+def _bleed(value, budget):
+	'''Coulomb bleed: remove up to budget, never crossing zero.'''
+	if budget <= 0.0:
+		return value
+	if value > budget:
+		return value - budget
+	if value < -budget:
+		return value + budget
+	return 0.0
+
+
+def contact_push_step(p, push_x, push_z, yaw, dt, rolling=False,
+                      terrainIdx=0, normal_y=1.0):
+	'''Advance one hull's external contact-push velocity by dt.
+
+	The push is a world-frame velocity a contact impulse gave this hull. Resolve
+	it into the hull frame, spend the matching track budget on each axis, and
+	rotate back. Dry friction removes a fixed amount of speed per second and
+	stops the hull dead, which is why a shove no longer creeps forever the way
+	an exponential decay did.'''
+	dt = float(dt)
+	if dt <= 0.0:
+		return float(push_x), float(push_z)
+	longitudinal, lateral = contact_push_decel(
+		p, rolling, terrainIdx, normal_y)
+	sine = math.sin(yaw)
+	cosine = math.cos(yaw)
+	forward = push_x * sine + push_z * cosine
+	right = push_x * cosine - push_z * sine
+	forward = _bleed(forward, longitudinal * dt)
+	right = _bleed(right, lateral * dt)
+	return (forward * sine + right * cosine,
+		forward * cosine - right * sine)
+
+
+def contact_push_is_held(p, push_x, push_z, yaw, dt, rolling=False,
+                         terrainIdx=0, normal_y=1.0):
+	'''Return whether the tracks absorb this whole push within one slice.
+
+	The static Coulomb test, expressed through the same budget contact_push_step
+	spends, so the predicate and the integration can never disagree.'''
+	return contact_push_step(
+		p, push_x, push_z, yaw, dt, rolling, terrainIdx, normal_y) == (0.0, 0.0)
 
 
 def _grip_decel(p, slope_pitch):

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -6906,6 +6906,10 @@ class BattleRuntimeContractTests(unittest.TestCase):
                 'spot_visible': False}
             bodies.append({
                 'id': 1000000 + engine_id, 'team': team, 'alive': alive,
+                # A Bot wreck is shoved by the authority worker and keeps a
+                # real inverse mass; a dead human hull nobody integrates
+                # stays world geometry.
+                'immovable': not alive and kind != 'bot',
                 'x': state['x'], 'y': state['y'], 'z': state['z'],
                 'yaw': state['yaw'], 'mass': mass, 'shape': shape,
                 'vx': math.sin(state['yaw']) * state['speed'],
@@ -6943,7 +6947,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
             'state': {'x': 0.0, 'y': 0.0, 'z': 6.5, 'yaw': 0.0,
                       'speed': 0.0, 'alive': True,
                       'effective_params': _effective_params_snapshot()}}}
-        battle._local_physics = {'mass': 25000.0}
+        battle._local_physics = _effective_params_snapshot()['physics']
         battle._local_speed = 5.0
         battle._motion_is_clear = mock.Mock(return_value=True)
         battle._baked_pose_safe = mock.Mock(return_value=True)
@@ -6967,7 +6971,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
         battle.client = _Client()
         battle._avatar = runtime.bigworld.avatar
         battle._arena_bounds = (-300.0, -300.0, 300.0, 300.0)
-        battle._local_physics = {'mass': 25000.0}
+        battle._local_physics = _effective_params_snapshot()['physics']
         battle._local_pitch = 0.23
         battle._local_roll = -0.17
         battle._contact_tanks = mock.Mock(return_value=[])
@@ -7034,7 +7038,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
                           'yaw': math.pi, 'alive': True}],
             }))
         battle._last_snapshot = {'bot_state_revision': 38}
-        battle._local_physics = {'mass': 25000.0}
+        battle._local_physics = _effective_params_snapshot()['physics']
         battle._local_speed = 10.0
         battle._server = types.SimpleNamespace(vehicle_id=10)
         battle._local_position = (0.0, 0.0, 0.0)
@@ -7115,7 +7119,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
                           'yaw': math.pi, 'alive': True}],
             }))
         battle._last_snapshot = {'bot_state_revision': 38}
-        battle._local_physics = {'mass': 25000.0}
+        battle._local_physics = _effective_params_snapshot()['physics']
         battle._local_speed = 10.0
         battle._server = types.SimpleNamespace(vehicle_id=10)
         battle._local_position = (99.0, 0.0, 99.0)
@@ -8056,7 +8060,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
             'state': state,
         }}
         battle._bots = types.SimpleNamespace(states={11: state})
-        battle._local_physics = {'mass': 25000.0}
+        battle._local_physics = _effective_params_snapshot()['physics']
         battle._local_speed = 0.0
         battle._local_push_x = 0.0
         battle._local_push_z = 0.0
@@ -8096,14 +8100,21 @@ class BattleRuntimeContractTests(unittest.TestCase):
                 battle._local_push_x, battle._local_push_z))
         self.assertEqual(dead_results[0], dead_results[1])
 
-    def test_local_push_decay_is_equal_across_render_rates(self):
+    def test_local_push_bleeds_at_the_track_budget_at_every_render_rate(self):
+        """An outside shove is spent against this hull's own track laws.
+
+        The old 0.90-per-60-Hz exponential took about 6.3 m/s2 at 1 m/s in
+        every direction and never quite reached zero. Dry friction removes a
+        fixed budget per second on each hull axis and stops the hull dead, and
+        it stays identical at 20, 30 and 60 FPS.
+        """
         def run_for_one_second(frame_rate):
             runtime = _runtime()
             battle = BattleRuntime(runtime)
             battle._local_effective_params = _effective_params_snapshot()
             battle._avatar = runtime.bigworld.avatar
             battle._records = {}
-            battle._local_physics = {'mass': 25000.0}
+            battle._local_physics = _effective_params_snapshot()['physics']
             battle._local_speed = 0.0
             battle._local_push_x = 10.0
             battle._local_push_z = -4.0
@@ -8123,13 +8134,20 @@ class BattleRuntimeContractTests(unittest.TestCase):
 
         results = dict((frame_rate, run_for_one_second(frame_rate))
                        for frame_rate in (20, 30, 60))
-        expected = 10.0 * 0.90 ** 60
+        # yaw 0 puts the hull's forward axis on +z and its right axis on +x,
+        # and a stopped hull with no throttle is held on both.
+        longitudinal, lateral = vehicle_physics.contact_push_decel(
+            _effective_params_snapshot()['physics'], False)
 
-        self.assertAlmostEqual(9.0, results[60][0], places=12)
+        self.assertAlmostEqual(
+            10.0 - lateral / 60.0, results[60][0], places=12)
         for unused_frame_rate, (unused_first, final_push) in results.items():
-            self.assertAlmostEqual(expected, final_push, places=12)
+            # 4 m/s along the tracks is fully absorbed inside the second;
+            # 10 m/s across them keeps exactly what the budget could not take.
+            self.assertAlmostEqual(10.0 - lateral, final_push, places=12)
         self.assertAlmostEqual(results[20][1], results[30][1], places=12)
         self.assertAlmostEqual(results[30][1], results[60][1], places=12)
+        self.assertGreater(longitudinal, 4.0)
 
     def test_local_tank_contact_cannot_push_hull_through_world_geometry(self):
         runtime = _runtime()
@@ -8147,7 +8165,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
             'state': {'x': 0.0, 'y': 0.0, 'z': 6.5, 'yaw': 0.0,
                       'speed': 0.0, 'alive': True,
                       'effective_params': _effective_params_snapshot()}}}
-        battle._local_physics = {'mass': 25000.0}
+        battle._local_physics = _effective_params_snapshot()['physics']
         battle._local_speed = 5.0
         battle._motion_is_clear = mock.Mock(return_value=False)
         battle._baked_pose_safe = mock.Mock(return_value=True)

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -28053,6 +28053,57 @@ class BattleRuntimeContractTests(unittest.TestCase):
         battle._binding.arena_vehicle_killed.assert_called_once_with(
             11, 0, 0)
 
+    def test_shoved_wreck_snapshot_updates_retained_native_pose_and_collision(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle.state = 'running'
+        battle._avatar = runtime.bigworld.avatar
+        battle._server = types.SimpleNamespace()
+        battle._binding = mock.Mock()
+        initial = {'id': 2, 'health': 500, 'alive': True,
+                   'x': 0.0, 'y': 0.0, 'z': 0.0, 'yaw': 0.0}
+        record = {'engine_id': 11, 'state': dict(initial),
+                  'kind': 'bot', 'network_id': 2, 'local': False,
+                  'ready': True}
+        battle._records = {'bot:2': record}
+        entity = _Vehicle(11, _Descriptor(), _Vector(), (0, 0, 0),
+                          {'health': 500})
+        runtime.bigworld.entities[11] = entity
+        sync = battle_runtime_module.SnapshotSync(
+            1, on_event=battle._apply_sync_event,
+            clock=lambda: runtime.bigworld.now)
+        sync.manifest({'round_id': 1, 'bots': [initial]})
+        sync.snapshot({'round_id': 1, 'server_tick': 1, 'bots': [initial]})
+        dead = dict(initial, health=0, alive=False)
+        sync.snapshot({'round_id': 1, 'server_tick': 2, 'bots': [dead]})
+        self.assertEqual(0, entity.health)
+        self.assertIs(record, battle._records['bot:2'])
+        self.assertFalse(record.get('tombstone'))
+        self.assertEqual([], sync.advance(runtime.bigworld.now))
+        battle._binding.reset_mock()
+
+        moved = dict(dead, x=0.0005, pitch=0.0002, roll=0.0003,
+                     aim_yaw=0.0004, gun_pitch=0.0005)
+        sync.snapshot({'round_id': 1, 'server_tick': 3, 'bots': [moved]})
+        runtime.bigworld.now += 0.05
+        events = sync.advance(runtime.bigworld.now)
+
+        self.assertEqual(['update'], [event['type'] for event in events])
+        args = battle._binding.set_vehicle_pose.call_args.args
+        self.assertEqual((0.0005, 0.0, 0.0), tuple(args[1]))
+        self.assertEqual(_engine_rotation(0.0, 0.0002, 0.0003), args[2])
+        battle._binding.update_vehicle_aim.assert_called_once_with(
+            11, 0.0, 0.0004, 0.0005)
+        collision_pose = record['projectile_collision_pose']
+        self.assertEqual((0.0005, 0.0, 0.0), tuple(
+            collision_pose[axis] for axis in ('x', 'y', 'z')))
+        self.assertEqual((0.0002, 0.0003),
+                         (collision_pose['pitch'], collision_pose['roll']))
+        self.assertIs(record, battle._records['bot:2'])
+        self.assertEqual(0, entity.health)
+        self.assertEqual([], sync.advance(runtime.bigworld.now + 0.05))
+        battle._binding.destroy_entity.assert_not_called()
+
     def test_pending_remote_presentation_destroy_cancels_late_load(self):
         runtime = _runtime()
         battle = BattleRuntime(runtime)

--- a/tests/test_port_0922_bot_runtime.py
+++ b/tests/test_port_0922_bot_runtime.py
@@ -20104,6 +20104,28 @@ class ShovedWreckTests(unittest.TestCase):
         self.assertEqual(0.0, state['z'])
         self.assertEqual(0.0, state['push_z'])
 
+    def test_a_wreck_settle_cannot_move_down_into_a_landed_turret(self):
+        runtime = self._runtime(ground=-0.3)
+        state = self._wreck(runtime)
+        state.update(pitch=0.2, terrain_pitch=0.15,
+                     suspension_pitch=0.05, roll=0.1)
+        probes = []
+
+        def clear(before, after, descriptor):
+            probes.append((before, after))
+            return after['y'] >= before['y']
+
+        runtime._turret_motion_probe = clear
+        moved = runtime._apply_wreck_contact_response(
+            state, {'delta_velocity': (0.0, 2.0),
+                    'correction': (0.0, 0.05)}, 0.1)
+
+        self.assertFalse(moved)
+        self.assertEqual((0.0, 0.0, 0.0), (state['x'], state['y'], state['z']))
+        self.assertEqual((0.0, 0.0), (state['push_x'], state['push_z']))
+        self.assertTrue(any(after['y'] < before['y'] for before, after in probes))
+        self.assertEqual(0.15, probes[-1][1]['chassis']['pitch'])
+
     def test_a_slide_off_a_cliff_lip_is_undone_instead_of_dropping(self):
         runtime = self._runtime(ground=-40.0)
         state = self._wreck(runtime)

--- a/tests/test_port_0922_bot_runtime.py
+++ b/tests/test_port_0922_bot_runtime.py
@@ -59,6 +59,48 @@ def _graph(map_name='01_karelia', waypoint_count=2):
     }
 
 
+def _flat_open_graph():
+    """A flat, fully linked 31x31 graph for pure contact-physics fixtures."""
+    graph = _graph()
+    width = 31
+    directions = ((-1, -1), (0, -1), (1, -1), (-1, 0),
+                  (1, 0), (-1, 1), (0, 1), (1, 1))
+    links = []
+    for z in range(width):
+        for x in range(width):
+            links.append(sum(
+                1 << index for index, (dx, dz) in enumerate(directions)
+                if 0 <= x + dx < width and 0 <= z + dz < width))
+    graph.update({
+        'origin': (-60.0, -60.0), 'bounds': (-62.0, -62.0, 62.0, 62.0),
+        'width': width, 'height': width,
+        'heights_mm': [0] * (width * width),
+        'links': links, 'hazards': [0] * (width * width),
+    })
+    return graph
+
+
+def _plain_attribute_factors(unused_descriptor, crew=None, crew_level=None):
+    """The #1513 default-crew factor set every Bot fixture needs."""
+    level = (100.0 if crew_level is None else
+             max(50.0, min(100.0, float(crew_level))))
+    factor = 0.57 + 0.0043 * level
+    return {
+        'turret/rotationSpeed': factor,
+        'gun/rotationSpeed': factor,
+        'gun/reloadTime': 1.0 / factor,
+        'gun/aimingTime': 1.0 / factor,
+        'shotDispersion': (1.0 / factor,),
+        'repairSpeed': 0.57,
+        'vehicle/rotationSpeed': 1.0,
+        'engine/power': 1.0,
+        'chassis/terrainResistance': (1.0, 1.0, 1.0),
+        'radio/distance': 1.0,
+        'circularVisionRadius': 1.0,
+        'camouflage': 0.57,
+    }
+
+
 def _spawn_resolver(team, slot):
     point = _graph()['spawn_formations'][str(int(team))][int(slot)]
     return ((point[0], point[1], point[2]), point[3])
@@ -14095,9 +14137,10 @@ class BotRuntimeTests(unittest.TestCase):
             self.assertFalse(runtime._ram_contacts)
             # Broad phase uses each mounted hull's size, including a wreck;
             # it must never assume that all tanks fit a default-size circle.
+            # The wreck resolves too: a live neighbour in reach can shove it.
             peer.update(alive=False, collision_shape=(20.0, 3.5, -0.8, 2.0))
             runtime._resolve_tank_contacts([], 1.1, 0.1)
-            self.assertEqual([(11, (12,))], calls)
+            self.assertEqual([(11, (12,)), (12, (11,))], calls)
         finally:
             self.module.tank_collision.resolve_tank = original
 
@@ -19821,6 +19864,291 @@ class BotRuntimeTests(unittest.TestCase):
         self.assertGreaterEqual(busiest[0][1], 1)
         # Reading the report clears the window's counters.
         self.assertEqual((), runtime.load_report()['busiest'])
+
+
+class ShovedWreckTests(unittest.TestCase):
+    """A destroyed hull is a body on tracks, not a piece of world geometry."""
+
+    def setUp(self):
+        self._modules = dict((key, value) for key, value in sys.modules.items()
+                             if key == 'gui' or key.startswith('gui.'))
+        self.module = _load()
+        self._native_attribute_factors = self.module.loadout.attribute_factors
+        self.module.loadout.attribute_factors = _plain_attribute_factors
+        self.start = {
+            'round_id': 5, 'map': '01_karelia', 'bot_authority_id': 1,
+            'bot_skill_mode': 'brutal',
+            'bots': [{'id': 11, 'team': 2, 'slot': 0, 'name': 'Wreck'},
+                     {'id': 12, 'team': 1, 'slot': 0, 'name': 'Driver'}]}
+
+    def tearDown(self):
+        self.module.loadout.attribute_factors = self._native_attribute_factors
+        for key in list(sys.modules):
+            if key == 'gui' or key.startswith('gui.'):
+                sys.modules.pop(key, None)
+        sys.modules.update(self._modules)
+
+    def _runtime(self, ground=0.0, clear=True):
+        probe = (lambda *unused, **kwargs: {
+            'clear': clear, 'collision': not clear,
+            'water': False, 'slope': 0.0})
+        runtime = self.module.BotRuntime(
+            1, descriptor_resolver=lambda unused: _combat_descriptor(),
+            adapter_factory=lambda *unused, **kwargs: _FixedAdapter(
+                {'throttle': 0.0, 'turn': 0.0, 'fire_allowed': False}),
+            direction_probe=probe,
+            ground_probe=lambda *unused: ground,
+            physics_ground_probe=lambda *unused: ground,
+            spawn_resolver=_spawn_resolver, baked_graph=_graph())
+        runtime.battle_start(self.start)
+        return runtime
+
+    def _wreck(self, runtime):
+        state = runtime.states[11]
+        state.update(x=0.0, y=0.0, z=0.0, yaw=0.0, speed=0.0, alive=False,
+                     health=0, half_length=3.5, half_width=1.7,
+                     grounded_once=True, push_x=0.0, push_z=0.0)
+        return state
+
+    def test_a_shove_moves_the_wreck_and_re_settles_it_on_the_ground(self):
+        runtime = self._runtime(ground=0.0)
+        state = self._wreck(runtime)
+
+        moved = runtime._apply_wreck_contact_response(
+            state, {'delta_velocity': (0.0, 2.0),
+                    'correction': (0.0, 0.05)}, 0.1)
+
+        self.assertTrue(moved)
+        self.assertGreater(state['z'], 0.0)
+        self.assertEqual(0.0, state['y'])
+
+    def test_a_wreck_is_never_shoved_through_static_geometry(self):
+        runtime = self._runtime(ground=0.0, clear=False)
+        state = self._wreck(runtime)
+
+        moved = runtime._apply_wreck_contact_response(
+            state, {'delta_velocity': (0.0, 2.0),
+                    'correction': (0.0, 0.05)}, 0.1)
+
+        self.assertFalse(moved)
+        self.assertEqual(0.0, state['z'])
+        self.assertEqual(0.0, state['push_z'])
+
+    def test_a_slide_off_a_cliff_lip_is_undone_instead_of_dropping(self):
+        runtime = self._runtime(ground=-40.0)
+        state = self._wreck(runtime)
+
+        moved = runtime._apply_wreck_contact_response(
+            state, {'delta_velocity': (0.0, 2.0),
+                    'correction': (0.0, 0.05)}, 0.1)
+
+        self.assertFalse(moved)
+        self.assertEqual(0.0, state['z'])
+        self.assertEqual(0.0, state['y'])
+        self.assertEqual(0.0, state['push_z'])
+
+    def test_a_wreck_keeps_no_engine_and_bleeds_at_the_parked_hold(self):
+        runtime = self._runtime(ground=0.0)
+        state = self._wreck(runtime)
+        state['push_z'] = 2.0
+
+        runtime._apply_wreck_contact_response(
+            state, {'delta_velocity': (0.0, 0.0),
+                    'correction': (0.0, 0.0)}, 0.1)
+
+        params = runtime._physics_params_for(11)
+        expected = 2.0 - self.module.vehicle_physics.contact_push_decel(
+            params, False)[0] * 0.1
+        self.assertAlmostEqual(expected, state['push_z'])
+        self.assertEqual(0.0, state['speed'])
+
+    def test_a_settled_wreck_stops_moving_entirely(self):
+        runtime = self._runtime(ground=0.0)
+        state = self._wreck(runtime)
+        state['push_z'] = 0.4
+
+        for unused_tick in range(60):
+            runtime._apply_wreck_contact_response(
+                state, {'delta_velocity': (0.0, 0.0),
+                        'correction': (0.0, 0.0)}, 1.0 / 30.0)
+
+        self.assertEqual(0.0, state['push_z'])
+        settled = state['z']
+        runtime._apply_wreck_contact_response(
+            state, {'delta_velocity': (0.0, 0.0),
+                    'correction': (0.0, 0.0)}, 1.0 / 30.0)
+        self.assertEqual(settled, state['z'])
+
+    def test_a_wreck_never_publishes_a_ram_report(self):
+        runtime = self._runtime(ground=0.0)
+        wreck = self._wreck(runtime)
+        wreck.update(x=0.0, z=0.0, team=1)
+        driver = runtime.states[12]
+        driver.update(x=0.0, y=0.0, z=5.0, yaw=math.pi, speed=12.0,
+                      alive=True, half_length=3.5, half_width=1.7,
+                      grounded_once=True, push_x=0.0, push_z=0.0, team=2)
+
+        reports = runtime._resolve_tank_contacts((), 100.0, 1.0 / 30.0)
+
+        self.assertEqual(
+            [], [report for report in reports
+                 if int(report.get('bot_id', -1)) == 11])
+        # The wreck is genuinely shoved out of the overlap it started in.
+        self.assertLess(wreck['z'], -0.1)
+        self.assertLess(wreck['push_z'], 0.0)
+        self.assertGreater(driver['z'], 5.0)
+
+
+class WreckPushMassTests(unittest.TestCase):
+    """Who can shove a wreck, measured through the real contact loop.
+
+    ``_drive_into`` in the physics tests is the one-dimensional version of
+    this. It cannot see the Baumgarte separation, which is not a force and
+    would otherwise walk any wreck along at the pusher's inverse-mass share
+    whatever the hulls weigh. These cases run the whole worker tick.
+    """
+
+    def setUp(self):
+        self._modules = dict((key, value) for key, value in sys.modules.items()
+                             if key == 'gui' or key.startswith('gui.'))
+        self.module = _load()
+        self._native_attribute_factors = self.module.loadout.attribute_factors
+        self.module.loadout.attribute_factors = _plain_attribute_factors
+
+    def tearDown(self):
+        self.module.loadout.attribute_factors = self._native_attribute_factors
+        for key in list(sys.modules):
+            if key == 'gui' or key.startswith('gui.'):
+                sys.modules.pop(key, None)
+        sys.modules.update(self._modules)
+
+    def _travel(self, pusher_mass, pusher_hp, wreck_mass, ticks=180):
+        module = self.module
+        runtime = module.BotRuntime(
+            1, descriptor_resolver=lambda unused: _combat_descriptor(),
+            adapter_factory=lambda *unused, **kwargs: _FixedAdapter({
+                'throttle': 1.0, 'turn': 0.0, 'fire_allowed': False,
+                'movement_intent': True, 'combat_mode': 'route',
+                'recovery_mode': 'drive', 'target_yaw': 0.0,
+                'move_position': (0.0, 0.0, 60.0)}),
+            direction_probe=lambda *unused, **kwargs: {
+                'clear': True, 'collision': False,
+                'water': False, 'slope': 0.0},
+            ground_probe=lambda *unused: 0.0,
+            physics_ground_probe=lambda *unused: 0.0,
+            spawn_resolver=lambda team, slot: (
+                (0.0, 0.0, 0.0 if slot == 0 else 12.0), 0.0),
+            baked_graph=_flat_open_graph())
+        runtime.battle_start({
+            'round_id': 1, 'map': '01_karelia', 'bot_authority_id': 1,
+            'bots': [{'id': 1, 'team': 1, 'slot': 0, 'name': 'Push',
+                      'vehicle': 'fake'},
+                     {'id': 2, 'team': 1, 'slot': 1, 'name': 'Dead',
+                      'vehicle': 'fake'}]})
+        pusher, wreck = runtime.states[1], runtime.states[2]
+        pusher.update(x=0.0, y=0.0, z=0.0, yaw=0.0, speed=0.0, alive=True,
+                      grounded_once=True, push_x=0.0, push_z=0.0)
+        wreck.update(x=0.0, y=0.0, z=8.0, yaw=0.0, speed=0.0, alive=False,
+                     health=0, grounded_once=True, push_x=0.0, push_z=0.0)
+
+        def pin():
+            runtime._physics_params[1]['mass'] = float(pusher_mass)
+            runtime._physics_params[1]['powerW'] = (
+                float(pusher_hp) * 735.49875)
+            runtime._physics_params[2]['mass'] = float(wreck_mass)
+            pusher['mass'] = float(pusher_mass)
+            wreck['mass'] = float(wreck_mass)
+            wreck['alive'] = False
+            wreck['health'] = 0
+            wreck['speed'] = 0.0
+
+        pin()
+        start = wreck['z']
+        for tick in range(ticks):
+            runtime.update(1.0 / 30.0, tick / 30.0)
+            pin()
+        return wreck['z'] - start
+
+    def test_a_heavy_hull_shoves_a_light_wreck_down_the_road(self):
+        self.assertGreater(self._travel(68000.0, 1050.0, 32000.0), 10.0)
+
+    def test_a_heavy_hull_still_shoves_an_equally_heavy_wreck(self):
+        self.assertGreater(self._travel(68000.0, 1050.0, 68000.0), 5.0)
+
+    def test_a_medium_cannot_walk_a_heavy_wreck_along(self):
+        # Only the first contact's separation, then the tracks hold.
+        self.assertLess(self._travel(32000.0, 500.0, 68000.0), 1.0)
+
+    def test_a_light_cannot_walk_a_heavy_wreck_along(self):
+        self.assertLess(self._travel(21000.0, 430.0, 68000.0), 1.0)
+
+
+class HumanShovedWreckTests(unittest.TestCase):
+    """The player's own hull must be able to move a wreck too."""
+
+    def setUp(self):
+        self._modules = dict((key, value) for key, value in sys.modules.items()
+                             if key == 'gui' or key.startswith('gui.'))
+        self.module = _load()
+        self._native_attribute_factors = self.module.loadout.attribute_factors
+        self.module.loadout.attribute_factors = _plain_attribute_factors
+
+    def tearDown(self):
+        self.module.loadout.attribute_factors = self._native_attribute_factors
+        for key in list(sys.modules):
+            if key == 'gui' or key.startswith('gui.'):
+                sys.modules.pop(key, None)
+        sys.modules.update(self._modules)
+
+    def _runtime(self):
+        runtime = self.module.BotRuntime(
+            1, descriptor_resolver=lambda unused: _combat_descriptor(),
+            adapter_factory=lambda *unused, **kwargs: _FixedAdapter(
+                {'throttle': 0.0, 'turn': 0.0, 'fire_allowed': False}),
+            direction_probe=lambda *unused, **kwargs: {
+                'clear': True, 'collision': False,
+                'water': False, 'slope': 0.0},
+            ground_probe=lambda *unused: 0.0,
+            physics_ground_probe=lambda *unused: 0.0,
+            spawn_resolver=_spawn_resolver, baked_graph=_graph())
+        runtime.battle_start({
+            'round_id': 5, 'map': '01_karelia', 'bot_authority_id': 1,
+            'bots': [{'id': 11, 'team': 2, 'slot': 0, 'name': 'Dead'}]})
+        return runtime
+
+    def _player(self, speed):
+        return {'id': 1, 'team': 1, 'vehicle': 'fake', 'alive': True,
+                'x': 0.0, 'y': 0.0, 'z': -5.0, 'yaw': 0.0, 'speed': speed,
+                'effective_params': _effective_params_snapshot(mass=68000.0)}
+
+    def test_a_player_driving_into_a_wreck_transfers_real_momentum(self):
+        runtime = self._runtime()
+        wreck = runtime.states[11]
+        wreck.update(x=0.0, y=0.0, z=0.0, yaw=0.0, speed=0.0, alive=False,
+                     health=0, mass=25000.0, grounded_once=True,
+                     push_x=0.0, push_z=0.0)
+
+        runtime._resolve_tank_contacts(
+            [self._player(9.0)], 100.0, 1.0 / 30.0)
+
+        # A shove the tracks cannot hold becomes real velocity, not just the
+        # separation the solver would have applied to any mass at all.
+        self.assertGreater(wreck['push_z'], 0.0)
+        self.assertGreater(wreck['z'], 0.0)
+
+    def test_a_creeping_player_cannot_break_the_tracks_loose(self):
+        runtime = self._runtime()
+        wreck = runtime.states[11]
+        wreck.update(x=0.0, y=0.0, z=-1.4, yaw=0.0, speed=0.0, alive=False,
+                     health=0, mass=68000.0, grounded_once=True,
+                     push_x=0.0, push_z=0.0)
+        before = wreck['z']
+
+        runtime._resolve_tank_contacts(
+            [self._player(0.05)], 100.0, 1.0 / 30.0)
+
+        self.assertEqual(0.0, wreck['push_z'])
+        self.assertEqual(before, wreck['z'])
 
 
 class BotOwnStationaryVisionTests(unittest.TestCase):

--- a/tests/test_port_0922_snapshot_sync.py
+++ b/tests/test_port_0922_snapshot_sync.py
@@ -1264,3 +1264,33 @@ class SnapshotSyncTests(unittest.TestCase):
             3.0, self.sync._entities['bot:7']['current']['x'])
         self.now[0] = moment + 1.0
         self.assertEqual([], self.sync.advance(self.now[0]))
+
+    def test_a_settled_wreck_presents_each_changed_pose_angle(self):
+        for angle in ('yaw', 'pitch', 'roll', 'aim_yaw', 'gun_pitch'):
+            with self.subTest(angle=angle):
+                sync = self.module.SnapshotSync(1, clock=lambda: self.now[0])
+                initial = player(7, 0.0, alive=False)
+                sync.manifest({'round_id': 1, 'bots': [initial]})
+                sync.snapshot({'round_id': 1, 'server_tick': 1, 'bots': [initial]})
+                self.assertEqual([], sync.advance(0.0))
+                moved = dict(initial)
+                moved[angle] = 0.25
+                sync.snapshot({'round_id': 1, 'server_tick': 2, 'bots': [moved]})
+                events = sync.advance(0.05)
+                self.assertEqual(['update'], [event['type'] for event in events])
+                self.assertGreater(events[0]['pose'][angle], 0.0)
+                self.assertLess(events[0]['pose'][angle], 0.25)
+
+    def test_a_settled_wreck_applies_a_final_subthreshold_pose_once(self):
+        initial = player(7, 0.0, alive=False)
+        self.sync.manifest({'round_id': 1, 'bots': [initial]})
+        self.sync.snapshot({'round_id': 1, 'server_tick': 1, 'bots': [initial]})
+        self.assertEqual([], self.sync.advance(0.0))
+        moved = dict(initial, x=0.0005, pitch=0.0002)
+        self.sync.snapshot({'round_id': 1, 'server_tick': 2, 'bots': [moved]})
+        events = self.sync.advance(0.05)
+        self.assertEqual(['update'], [event['type'] for event in events])
+        self.assertEqual((0.0005, 0.0002),
+                         (events[0]['pose']['x'], events[0]['pose']['pitch']))
+        self.assertTrue(events[0]['snap'])
+        self.assertEqual([], self.sync.advance(0.1))

--- a/tests/test_port_0922_snapshot_sync.py
+++ b/tests/test_port_0922_snapshot_sync.py
@@ -1215,3 +1215,52 @@ class SnapshotSyncTests(unittest.TestCase):
                                                  'players': [player(2, alive=False)]}))
         self.assertEqual([], self.sync.snapshot({'round_id': 1, 'server_tick': 3,
                                                  'players': []}))
+
+    def test_a_shoved_wreck_keeps_receiving_and_presenting_poses(self):
+        """A destroyed hull another tank pushes must not freeze in place."""
+        self.sync.manifest({'round_id': 1, 'bots': [player(7)]})
+        self.sync.snapshot({'round_id': 1, 'server_tick': 1,
+                            'bots': [player(7, 0.0)]})
+        self.now[0] = 0.1
+        self.sync.advance(self.now[0])
+        self.assertEqual(
+            ['destroy'],
+            [event['type'] for event in self.sync.snapshot({
+                'round_id': 1, 'server_tick': 2,
+                'bots': [player(7, 0.0, alive=False)]})])
+
+        self.now[0] = 0.2
+        self.assertEqual([], self.sync.advance(self.now[0]))
+        self.sync.snapshot({'round_id': 1, 'server_tick': 3,
+                            'bots': [player(7, 3.0, alive=False)]})
+
+        self.now[0] = 0.25
+        events = self.sync.advance(self.now[0])
+        self.assertEqual(['update'], [event['type'] for event in events])
+        self.assertEqual('bot:7', events[0]['entity'])
+        self.assertGreater(events[0]['pose']['x'], 0.0)
+        self.assertLess(events[0]['pose']['x'], 3.0)
+
+    def test_a_settled_wreck_costs_nothing_per_rendered_frame(self):
+        self.sync.manifest({'round_id': 1, 'bots': [player(7)]})
+        self.sync.snapshot({'round_id': 1, 'server_tick': 1,
+                            'bots': [player(7, 0.0)]})
+        self.sync.snapshot({'round_id': 1, 'server_tick': 2,
+                            'bots': [player(7, 0.0, alive=False)]})
+        self.sync.snapshot({'round_id': 1, 'server_tick': 3,
+                            'bots': [player(7, 3.0, alive=False)]})
+
+        moment = 0.2
+        settled = None
+        for unused_frame in range(400):
+            moment += 1.0 / 60.0
+            self.now[0] = moment
+            events = self.sync.advance(moment)
+            if not events:
+                settled = moment
+                break
+        self.assertIsNotNone(settled)
+        self.assertEqual(
+            3.0, self.sync._entities['bot:7']['current']['x'])
+        self.now[0] = moment + 1.0
+        self.assertEqual([], self.sync.advance(self.now[0]))

--- a/tests/test_port_0922_tank_collision.py
+++ b/tests/test_port_0922_tank_collision.py
@@ -629,7 +629,7 @@ class TankCollisionTests(unittest.TestCase):
         self.assertNotIn('message["damage_to_bot"])), 500)', server_source)
         self.assertNotIn('message["damage_to_target"])), 500)', server_source)
 
-    def test_wreck_blocks_the_mover_without_moving_or_dealing_ram_damage(self):
+    def test_wreck_separates_like_a_hull_and_never_deals_ram_damage(self):
         mover = _tank(1, 0.0, 0.0, mass=25000.0, vx=10.0)
         wreck = _tank(2, 0.8, 0.0, mass=10000.0)
         wreck['alive'] = False
@@ -643,10 +643,48 @@ class TankCollisionTests(unittest.TestCase):
         self.assertLess(against_wreck['correction'][0], 0.0)
         self.assertLess(against_wreck['delta_velocity'][0], 0.0)
         self.assertEqual((), against_wreck['ram_events'])
-        # An immovable wreck takes the whole separation, so the mover is
-        # pushed out farther than the lighter living hull pushes it.
-        self.assertLess(
+        # A wreck is a hull on tracks, not world geometry: the mover takes
+        # exactly the inverse-mass share it takes against the same live hull,
+        # and the wreck's own pass owns the rest.
+        self.assertAlmostEqual(
             against_wreck['correction'][0], against_live['correction'][0])
+        self.assertAlmostEqual(
+            against_wreck['delta_velocity'][0],
+            against_live['delta_velocity'][0])
+
+    def test_immovable_hull_still_takes_the_whole_separation(self):
+        """A body no process integrates has to stay world geometry."""
+        mover = _tank(1, 0.0, 0.0, mass=25000.0, vx=10.0)
+        wall = _tank(2, 0.8, 0.0, mass=10000.0)
+        wall['alive'] = False
+        wall['immovable'] = True
+        wreck = _tank(2, 0.8, 0.0, mass=10000.0)
+        wreck['alive'] = False
+
+        against_wall = tank_collision.resolve_tank(
+            mover, (wall,), now=10.0)
+        against_wreck = tank_collision.resolve_tank(
+            mover, (wreck,), now=10.0)
+
+        self.assertLess(
+            against_wall['correction'][0], against_wreck['correction'][0])
+        self.assertEqual((), against_wall['ram_events'])
+
+    def test_a_shoved_wreck_carries_its_contact_velocity(self):
+        """A wreck already sliding away is not still being closed on."""
+        mover = _tank(1, 0.0, 0.0, mass=25000.0, vx=10.0)
+        settled = _tank(2, 0.8, 0.0, mass=10000.0, vx=10.0)
+        settled['alive'] = False
+        stopped = _tank(2, 0.8, 0.0, mass=10000.0)
+        stopped['alive'] = False
+
+        moving_together = tank_collision.resolve_tank(
+            mover, (settled,), now=10.0)
+        closing = tank_collision.resolve_tank(
+            mover, (stopped,), now=10.0)
+
+        self.assertEqual(0.0, moving_together['delta_velocity'][0])
+        self.assertLess(closing['delta_velocity'][0], 0.0)
 
 
 class StraddledSupportTests(unittest.TestCase):

--- a/tests/test_port_0922_vehicle_physics.py
+++ b/tests/test_port_0922_vehicle_physics.py
@@ -1180,5 +1180,156 @@ class VehiclePhysicsAirborneTests(unittest.TestCase):
             0.0, vehicle_physics.launch_vertical_speed(12.0, pitch))
 
 
+def _params(mass, horsepower):
+    """One vehicle's physics with everything but mass and power at default."""
+    params = vehicle_physics.derive_params({})
+    params['mass'] = float(mass)
+    params['powerW'] = float(horsepower) * 735.49875
+    params['speedFwd'] = 55.0 / 3.6
+    params['speedBwd'] = 15.0 / 3.6
+    return params
+
+
+class ContactPushLawTests(unittest.TestCase):
+    """The ground reaction that decides how far an outside shove carries."""
+
+    def test_a_rolling_hull_resists_a_shove_along_it_with_rolling_drag_only(self):
+        params = _params(30000.0, 500.0)
+
+        rolling = vehicle_physics.contact_push_decel(params, True)
+        parked = vehicle_physics.contact_push_decel(params, False)
+
+        expected = (vehicle_physics.rolling_resist_force(params, 0, False) /
+                    params['mass'])
+        self.assertAlmostEqual(expected, rolling[0])
+        self.assertGreater(parked[0], rolling[0] * 4.0)
+
+    def test_a_parked_hull_resists_with_the_static_perch_hold(self):
+        params = _params(30000.0, 500.0)
+
+        longitudinal, unused_lateral = vehicle_physics.contact_push_decel(
+            params, False)
+
+        self.assertAlmostEqual(
+            vehicle_physics.SLIDE_HOLD_TAN * vehicle_physics.GRAVITY,
+            longitudinal)
+
+    def test_tracks_always_scrub_sideways_even_while_the_hull_rolls(self):
+        params = _params(30000.0, 500.0)
+
+        rolling = vehicle_physics.contact_push_decel(params, True)
+        parked = vehicle_physics.contact_push_decel(params, False)
+
+        self.assertAlmostEqual(rolling[1], parked[1])
+        self.assertGreater(rolling[1], rolling[0] * 4.0)
+
+    def test_side_grip_releases_the_lateral_hold_on_a_steep_bank(self):
+        params = _params(30000.0, 500.0)
+
+        flat = vehicle_physics.contact_push_decel(params, False, 0, 1.0)
+        bank = vehicle_physics.contact_push_decel(
+            params, False, 0, math.cos(math.radians(29.0)))
+
+        self.assertLess(bank[1], flat[1] * 0.2)
+
+    def test_a_shove_stops_dead_instead_of_creeping(self):
+        params = _params(30000.0, 500.0)
+        push_x, push_z = 0.0, 0.4
+
+        for unused_step in range(200):
+            push_x, push_z = vehicle_physics.contact_push_step(
+                params, push_x, push_z, 0.0, 1.0 / 60.0)
+
+        self.assertEqual(0.0, push_x)
+        self.assertEqual(0.0, push_z)
+
+    def test_a_shove_bleeds_in_the_hull_frame_not_the_world_frame(self):
+        """A hull facing east resists an east-west shove along its tracks."""
+        params = _params(30000.0, 500.0)
+        yaw = math.pi / 2.0
+
+        along, unused = vehicle_physics.contact_push_step(
+            params, 2.0, 0.0, yaw, 0.1, rolling=True)
+        unused_x, across = vehicle_physics.contact_push_step(
+            params, 0.0, 2.0, yaw, 0.1, rolling=True)
+
+        # 2 m/s along the tracks keeps almost all of itself; the same speed
+        # across them loses six times as much in the same tenth of a second.
+        self.assertGreater(along, 1.9)
+        self.assertLess(across, 1.45)
+
+    def test_a_push_never_reverses_through_zero(self):
+        params = _params(30000.0, 500.0)
+
+        push_x, push_z = vehicle_physics.contact_push_step(
+            params, 0.0, 0.05, 0.0, 1.0)
+
+        self.assertEqual(0.0, push_x)
+        self.assertEqual(0.0, push_z)
+
+
+class PushedPairTests(unittest.TestCase):
+    """End-to-end: who moves whom, from engine power and track laws alone."""
+
+    @staticmethod
+    def _drive_into(pusher, target, target_rolling, seconds=6.0,
+                    step=1.0 / 30.0):
+        """Return the target's travel after one hull drives into it.
+
+        Both hulls are axis-aligned and nose to tail, so this is the pure
+        one-dimensional version of what ``resolve_tank`` plus the contact
+        push law do per tick: cancel the closing speed at the contact, then
+        let each hull spend its own track budget.
+        """
+        speed = 0.0
+        push = 0.0
+        travel = 0.0
+        elapsed = 0.0
+        while elapsed < seconds:
+            speed = vehicle_physics.longitudinal_step(
+                pusher, speed, 1.0, False, 0.0, step)
+            if speed > push:
+                shared = ((pusher['mass'] * speed + target['mass'] * push) /
+                          (pusher['mass'] + target['mass']))
+                speed, push = shared, shared
+            unused_x, push = vehicle_physics.contact_push_step(
+                target, 0.0, push, 0.0, step, rolling=target_rolling)
+            travel += push * step
+            elapsed += step
+        return travel
+
+    def test_a_heavy_hull_shoves_a_parked_medium(self):
+        travel = self._drive_into(
+            _params(68000.0, 1050.0), _params(32000.0, 500.0), False)
+
+        self.assertGreater(travel, 5.0)
+
+    def test_a_medium_cannot_shove_a_parked_heavy(self):
+        travel = self._drive_into(
+            _params(32000.0, 500.0), _params(68000.0, 1050.0), False)
+
+        self.assertLess(travel, 0.25)
+
+    def test_a_light_cannot_shove_a_parked_heavy(self):
+        travel = self._drive_into(
+            _params(21000.0, 430.0), _params(68000.0, 1050.0), False)
+
+        self.assertLess(travel, 0.25)
+
+    def test_the_same_medium_shoves_its_own_twin(self):
+        travel = self._drive_into(
+            _params(32000.0, 500.0), _params(32000.0, 500.0), False)
+
+        self.assertGreater(travel, 2.0)
+
+    def test_a_rolling_target_gives_way_much_further_than_a_parked_one(self):
+        pusher = _params(32000.0, 500.0)
+
+        parked = self._drive_into(pusher, _params(32000.0, 500.0), False)
+        rolling = self._drive_into(pusher, _params(32000.0, 500.0), True)
+
+        self.assertGreater(rolling, parked * 1.5)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
A live tank can now push a Bot wreck when its contact impulse overcomes the hull's existing track resistance. The hidden worker integrates that wreck, the server relays its position, and replicas continue updating the destroyed hull until it settles. Dead player hulls remain fixed because this change does not add an authority to integrate them.

The change uses descriptor mass and the existing longitudinal rolling/parking and lateral grip laws. World collision, missing support and excessive ground steps veto movement; the final settled pose also passes the canonical landed-turret volume sweep. Wrecks neither open ram episodes nor receive ram damage. Live Bot residual-push behavior and tangential hull friction remain unchanged because changing them regresses the existing crowded-spawn departure tests.

Review fixes ensure that already-settled wrecks still receive pitch, roll, turret/gun-angle and small final position corrections, and that changing ground height cannot bypass a landed turret. Focused regressions cover both failures and the SnapshotSync-to-native-pose/projectile-pose path. The exact-client Python configuration does not establish native restitution; this retains the project's existing e=0 normal response without claiming retail calibration.

Validation on the final tree containing #151:

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests`: 5,183 tests, OK (2 skipped).
- Launcher suite: 700 tests, OK (2 skipped).
- All 112 client Python sources compile under CPython 2.7.18; `git diff --check` passes.
- A worker publication through the real positional-row encoder, server admission and tick snapshot preserves the terminal combat ledger while relaying the wreck's new XYZ, pitch and roll.
- Independent #151 differential replay covered 9,832 cases on CPython 2.7 without changing solver results.

 Exact #1513 Windows acceptance remains necessary for the destroyed compound's native movement and collision feel. Off-centre angular response and movable player wrecks are outside this change.
