### PR TITLE
perf: reuse suspension geometry within solver poses

### DIFF
--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -431,6 +431,8 @@ _FRAME_STAGE_NAMES = (
     'house', 'sync', 'critical', 'drown', 'prewarm', 'transition', 'local',
     'outline', 'bots_update', 'bot_present', 'bot_events', 'spot', 'lock',
     'schedule', 'diag_emit')
+# These durations are contained in ``local`` and must not be added to it.
+_FRAME_DETAIL_NAMES = ('local_ground', 'local_solver')
 _PROJECTILE_METRIC_NAMES = (
     'active', 'chords', 'debt', 'advance', 'terminals', 'scans',
     'candidates')
@@ -500,10 +502,10 @@ class _FrameDiagnostics(object):
         self._load_busiest = ()
         self._collections = {}
         self._worker_runtime = {}
-        self._stage_sums = dict((name, 0.0)
-                                for name in _FRAME_STAGE_NAMES)
-        self._stage_maxima = dict((name, 0.0)
-                                  for name in _FRAME_STAGE_NAMES)
+        self._stage_sums = dict(
+            (name, 0.0) for name in _FRAME_STAGE_NAMES + _FRAME_DETAIL_NAMES)
+        self._stage_maxima = dict(
+            (name, 0.0) for name in _FRAME_STAGE_NAMES + _FRAME_DETAIL_NAMES)
         self._probe_sums = dict((name, 0) for name in PROBE_KINDS)
         self._probe_maxima = dict((name, 0) for name in PROBE_KINDS)
         self._probe_duration_sums = dict(
@@ -607,7 +609,7 @@ class _FrameDiagnostics(object):
             self._sim_caps += 1
         if row.get('context', {}).get('role') == 'authority':
             self._authority_frames += 1
-        for name in _FRAME_STAGE_NAMES:
+        for name in _FRAME_STAGE_NAMES + _FRAME_DETAIL_NAMES:
             value = max(0.0, float(row['stages'].get(name, 0.0)))
             self._stage_sums[name] += value
             self._stage_maxima[name] = max(
@@ -684,7 +686,11 @@ class _FrameDiagnostics(object):
             'outside_ms': round(row['outside'] * 1000.0, 3),
             'offframe_ms': round(row.get('offframe', 0.0) * 1000.0, 3),
             'stages_ms': dict((name, round(value * 1000.0, 3))
-                              for name, value in row['stages'].items()),
+                              for name, value in row['stages'].items()
+                              if name in _FRAME_STAGE_NAMES),
+            'details_ms': dict((name, round(value * 1000.0, 3))
+                               for name, value in row['stages'].items()
+                               if name in _FRAME_DETAIL_NAMES),
             'projectile': dict(row.get('projectile') or {}),
             'detail': row.get('combat'),
         }
@@ -734,12 +740,14 @@ class _FrameDiagnostics(object):
         outside_distribution = self._distribution(
             self._outside_samples, self._outside_max)
         stage_snapshot = {}
-        for name in _FRAME_STAGE_NAMES:
+        for name in _FRAME_STAGE_NAMES + _FRAME_DETAIL_NAMES:
             stage_snapshot[name] = {
                 'avg_ms': self._milliseconds(
                     self._stage_sums[name] / samples),
                 'max_ms': self._milliseconds(self._stage_maxima[name]),
             }
+        detail_snapshot = dict(
+            (name, stage_snapshot.pop(name)) for name in _FRAME_DETAIL_NAMES)
         probe_snapshot = {}
         for name in PROBE_KINDS:
             probe_snapshot[name] = {
@@ -775,6 +783,7 @@ class _FrameDiagnostics(object):
             'python_callback_ms': exec_distribution,
             'outside_callback_ms': outside_distribution,
             'python_stages_ms': stage_snapshot,
+            'python_details_ms': detail_snapshot,
             # One logical probe can contain several native calls. The current
             # Python boundary cannot truthfully derive raw call/primitives.
             'raw_native_calls_measured': False,
@@ -887,6 +896,12 @@ class _FrameDiagnostics(object):
                 self._milliseconds(self._stage_maxima[name])))
         lines.append(prefix + 'stages_ms_avg_max ' +
                      ' '.join(stage_values) + '\n')
+        lines.append(prefix + 'details_ms_avg_max parent=local ' +
+                     ' '.join('%s=%.3f/%.3f' % (
+                         name,
+                         self._milliseconds(self._stage_sums[name] / samples),
+                         self._milliseconds(self._stage_maxima[name]))
+                         for name in _FRAME_DETAIL_NAMES) + '\n')
         probe_values = []
         for name in PROBE_KINDS:
             probe_values.append('%s=%.2f/%d' % (
@@ -956,7 +971,7 @@ class _FrameDiagnostics(object):
                  'pose_step_m=%.4f speed_mps=%.3f camera_mps=%.3f '
                  'airborne=%d grind=%d bots=%d outgoing=%d '
                  'transition=%d prev_emit=%d '
-                 'projectile=%s stages_ms=%s logical_probes=%s '
+                 'projectile=%s stages_ms=%s details_ms=%s logical_probes=%s '
                  'logical_probe_ms=%s\n') % (
                      rank, row['cause'], row['next'],
                      self._milliseconds(row['wall_gap']),
@@ -989,6 +1004,9 @@ class _FrameDiagnostics(object):
                      ','.join('%s:%.3f' % (
                          name, self._milliseconds(stages.get(name, 0.0)))
                               for name in _FRAME_STAGE_NAMES),
+                     ','.join('%s:%.3f' % (
+                         name, self._milliseconds(stages.get(name, 0.0)))
+                              for name in _FRAME_DETAIL_NAMES),
                      ','.join('%s:%d' % (
                          name, int(probes.get(name, 0)))
                               for name in PROBE_KINDS),
@@ -1710,6 +1728,7 @@ class BattleRuntime(object):
         self._local_suspension_failed_this_tick = False
         self._local_spring_ground_memory = None
         self._local_pseudo_ground_memory = None
+        self._local_frame_stages = None
         self._local_pitch = 0.0
         self._local_roll = 0.0
         self._local_suspension_pitch_velocity = 0.0
@@ -16207,7 +16226,11 @@ class BattleRuntime(object):
                 stages['transition'] = max(0.0, next_boundary - boundary)
                 boundary = next_boundary
             if self._battle_live and not self._worker_mode:
-                self._drive_local(dt)
+                self._local_frame_stages = stages if profiling else None
+                try:
+                    self._drive_local(dt)
+                finally:
+                    self._local_frame_stages = None
             if profiling:
                 next_boundary = _PROFILE_CLOCK()
                 stages['local'] = max(0.0, next_boundary - boundary)
@@ -20065,12 +20088,17 @@ class BattleRuntime(object):
             position, motion_pose, previous_plane)
         sweep_drop = vehicle_physics.suspension_vertical_sweep_drop(
             self._local_vertical_speed + support_speed_delta, dt)
+        timings = self._local_frame_stages
+        ground_started = _PROFILE_CLOCK() if timings is not None else 0.0
         ground = self._local_suspension_ground_samples(
             position, yaw, probe_height=probe_height,
             support_gradient=support_gradient, sweep_drop=sweep_drop)
         pseudo_ground = self._local_suspension_pseudo_ground_samples(
             position, yaw, probe_height=probe_height,
             support_gradient=support_gradient, sweep_drop=sweep_drop)
+        if timings is not None:
+            timings['local_ground'] = timings.get('local_ground', 0.0) + max(
+                0.0, _PROFILE_CLOCK() - ground_started)
         if (not armed_before and
                 (not ground or all(value is None for value in ground)) and
                 (not pseudo_ground or
@@ -20134,9 +20162,13 @@ class BattleRuntime(object):
             'roll': previous_roll,
             'roll_velocity': self._local_suspension_roll_velocity,
         }
+        solver_started = _PROFILE_CLOCK() if timings is not None else 0.0
         solved = vehicle_physics.damper_suspension_step(
             params, physics_state, ground, dt, pseudo_ground,
             support_vertical_speed)
+        if timings is not None:
+            timings['local_solver'] = timings.get('local_solver', 0.0) + max(
+                0.0, _PROFILE_CLOCK() - solver_started)
         values = (
             solved['height'], solved['vertical_velocity'],
             solved['pitch'], solved['pitch_velocity'],

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/vehicle_physics.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/vehicle_physics.py
@@ -872,22 +872,33 @@ def derive_suspension_params(descriptor):
 	}
 
 
-def suspension_point_offset(point, pitch=0.0, roll=0.0):
-	'''Rotate one local suspension point by the same YPR law as the hull.'''
-	x, y, z = float(point['x']), float(point.get('y', 0.0)), float(point['z'])
+def _suspension_rotation(pitch, roll):
+	'''Prepare one immutable pose; rebuild after each solver pose change.'''
 	sp, cp = math.sin(float(pitch)), math.cos(float(pitch))
 	sr, cr = math.sin(float(roll)), math.cos(float(roll))
+	return sp, cp, sr, cr
+
+
+def _suspension_point_offset(point, rotation):
+	x, y, z = float(point['x']), float(point.get('y', 0.0)), float(point['z'])
+	sp, cp, sr, cr = rotation
 	rolled_y = sr * x + cr * y
 	return (cr * x - sr * y, cp * rolled_y - sp * z,
 		sp * rolled_y + cp * z)
 
 
+def suspension_point_offset(point, pitch=0.0, roll=0.0):
+	'''Rotate one local suspension point by the same YPR law as the hull.'''
+	return _suspension_point_offset(point, _suspension_rotation(pitch, roll))
+
+
 def _suspension_world_points(points, position, yaw, pitch, roll):
 	x, unused_y, z = map(float, position)
 	sine, cosine = math.sin(float(yaw)), math.cos(float(yaw))
+	rotation = _suspension_rotation(pitch, roll)
 	result = []
 	for point in points:
-		local_x, unused_y, local_z = suspension_point_offset(point, pitch, roll)
+		local_x, unused_y, local_z = _suspension_point_offset(point, rotation)
 		result.append((x + cosine * local_x + sine * local_z,
 			z - sine * local_x + cosine * local_z))
 	return tuple(result)
@@ -1075,7 +1086,8 @@ def suspension_ground_plane(params, ground_heights,
 def suspension_world_ground_plane(params, ground_heights, position, yaw,
 		maximum_residual=None, pitch=0.0, roll=0.0):
 	'''Fit one suspension plane in stable world-space coordinates.'''
-	points = tuple(suspension_point_offset(spring, pitch, roll)
+	rotation = _suspension_rotation(pitch, roll)
+	points = tuple(_suspension_point_offset(spring, rotation)
 		for spring in params['springs'])
 	local_plane = suspension_ground_plane(
 		params, ground_heights, maximum_residual,
@@ -1360,16 +1372,21 @@ def suspension_vertical_sweep_drop(vertical_speed, dt):
 	return max(0.0, -float(vertical_speed) * step + GRAVITY * step * step)
 
 
-def _rigid_point_height(state, point):
-	return float(state['height']) + suspension_point_offset(
-		point, state.get('pitch', 0.0), state.get('roll', 0.0))[1]
-
-
-def _rigid_point_height_gradients(state, point):
-	pitch, roll = float(state.get('pitch', 0.0)), float(state.get('roll', 0.0))
+def _rigid_point_height(state, point, rotation=None):
+	if rotation is None:
+		rotation = _suspension_rotation(
+			state.get('pitch', 0.0), state.get('roll', 0.0))
+	sp, cp, sr, cr = rotation
 	x, y, z = float(point['x']), float(point.get('y', 0.0)), float(point['z'])
-	sp, cp = math.sin(pitch), math.cos(pitch)
-	sr, cr = math.sin(roll), math.cos(roll)
+	return float(state['height']) + (cp * (sr * x + cr * y) - sp * z)
+
+
+def _rigid_point_height_gradients(state, point, rotation=None):
+	if rotation is None:
+		rotation = _suspension_rotation(
+			state.get('pitch', 0.0), state.get('roll', 0.0))
+	x, y, z = float(point['x']), float(point.get('y', 0.0)), float(point['z'])
+	sp, cp, sr, cr = rotation
 	return (-sp * (sr * x + cr * y) - cp * z, cp * (cr * x - sr * y))
 
 
@@ -1391,6 +1408,7 @@ def _spring_point_velocity(state, spring):
 def _suspension_contact_keys(params, state, ground_heights,
 		pseudo_ground_heights):
 	'''Return final geometric contacts, separated from within-step impacts.'''
+	rotation = None
 	contacts = set()
 	left = set()
 	right = set()
@@ -1398,9 +1416,12 @@ def _suspension_contact_keys(params, state, ground_heights,
 		ground = ground_heights[index]
 		if ground is None:
 			continue
+		if rotation is None:
+			rotation = _suspension_rotation(
+				state.get('pitch', 0.0), state.get('roll', 0.0))
 		compression = (
 			spring['static_compression'] + float(ground) -
-			_spring_height(state, spring))
+			_rigid_point_height(state, spring, rotation))
 		if compression <= 0.0:
 			continue
 		key = ('spring', index)
@@ -1413,7 +1434,10 @@ def _suspension_contact_keys(params, state, ground_heights,
 		ground = pseudo_ground_heights[index]
 		if ground is None:
 			continue
-		gap = float(ground) - _rigid_point_height(state, contact)
+		if rotation is None:
+			rotation = _suspension_rotation(
+				state.get('pitch', 0.0), state.get('roll', 0.0))
+		gap = float(ground) - _rigid_point_height(state, contact, rotation)
 		if gap < -CONTACT_PENETRATION:
 			continue
 		key = ('pseudo', index)
@@ -1427,32 +1451,31 @@ def _suspension_contact_keys(params, state, ground_heights,
 
 def suspension_limit_excess(params, state, ground_heights):
 	'''Return the largest compression beyond a projected hard limit.'''
+	rotation = None
 	maximum = 0.0
 	for index, spring in enumerate(params['springs']):
 		ground = ground_heights[index]
 		if ground is None:
 			continue
+		if rotation is None:
+			rotation = _suspension_rotation(
+				state.get('pitch', 0.0), state.get('roll', 0.0))
 		compression = (
 			spring['static_compression'] + float(ground) -
-			_spring_height(state, spring))
+			_rigid_point_height(state, spring, rotation))
 		maximum = max(maximum, compression - spring['max_compression'])
 	return maximum
 
 
-def _project_suspension_limits(params, state, ground_heights,
-		pseudo_ground_heights=None, support_vertical_velocity=0.0,
-		support_height_offset=0.0):
-	'''Resolve hard limits with an order-independent worst-contact projection.'''
-	inv_mass = 1.0 / params['mass']
-	inv_pitch = 1.0 / params['pitch_inertia']
-	inv_roll = 1.0 / params['roll_inertia']
+def _suspension_constraints(params, ground_heights, pseudo_ground_heights):
+	'''Prepare the fixed contacts of one immutable ground sample set.'''
 	constraints = []
 	for index, spring in enumerate(params['springs']):
 		ground = ground_heights[index]
 		if ground is not None:
 			constraints.append((
 				('spring', index), spring,
-				float(ground) + support_height_offset,
+				float(ground),
 				float(spring['max_compression']) -
 				float(spring['static_compression'])))
 	pseudo_ground_heights = pseudo_ground_heights or ()
@@ -1462,19 +1485,40 @@ def _project_suspension_limits(params, state, ground_heights,
 		if ground is not None:
 			constraints.append((
 				('pseudo', index), contact,
-				float(ground) + support_height_offset,
+				float(ground),
 				float(contact.get('penetration', ALLOWED_PENETRATION))))
+	return constraints
+
+
+def _project_suspension_limits(params, state, ground_heights,
+		pseudo_ground_heights=None, support_vertical_velocity=0.0,
+		support_height_offset=0.0, constraints=None):
+	'''Resolve hard limits with an order-independent worst-contact projection.'''
+	inv_mass = 1.0 / params['mass']
+	inv_pitch = 1.0 / params['pitch_inertia']
+	inv_roll = 1.0 / params['roll_inertia']
+	if constraints is None:
+		constraints = _suspension_constraints(
+			params, ground_heights, pseudo_ground_heights)
+	if not constraints:
+		return set()
+	if support_height_offset:
+		constraints = [(key, point, ground + support_height_offset, penetration)
+			for key, point, ground, penetration in constraints]
 	touched = set()
 	for unused_iteration in range(params['constraint_iterations']):
+		rotation = _suspension_rotation(
+			state.get('pitch', 0.0), state.get('roll', 0.0))
 		rows = []
 		maximum_excess = 0.0
 		for key, point, ground, penetration in constraints:
 			excess = (
-				ground - _rigid_point_height(state, point) - penetration)
+				ground - _rigid_point_height(state, point, rotation) - penetration)
 			if excess <= 1.0e-5:
 				continue
 			touched.add(key)
-			pitch_height, roll_height = _rigid_point_height_gradients(state, point)
+			pitch_height, roll_height = _rigid_point_height_gradients(
+				state, point, rotation)
 			pitch_grad, roll_grad = -pitch_height, -roll_height
 			denominator = (inv_mass + pitch_grad * pitch_grad * inv_pitch +
 				roll_grad * roll_grad * inv_roll)
@@ -1501,7 +1545,9 @@ def _project_suspension_limits(params, state, ground_heights,
 		velocity_roll = []
 		for point, excess, pitch_grad, roll_grad, denominator in selected:
 			point_velocity = (
-				_rigid_point_velocity(state, point) -
+				(float(state.get('vertical_velocity', 0.0)) +
+				-pitch_grad * float(state.get('pitch_velocity', 0.0)) +
+				-roll_grad * float(state.get('roll_velocity', 0.0))) -
 				support_vertical_velocity)
 			if point_velocity < 0.0:
 				velocity_impulse = -point_velocity / denominator
@@ -1530,8 +1576,10 @@ def _project_suspension_limits(params, state, ground_heights,
 	# projection (not a reported-value clamp) and satisfies every half-space at
 	# once without adding pitch/roll bias or another iterative sweep.
 	remaining_excess = 0.0
+	rotation = _suspension_rotation(
+		state.get('pitch', 0.0), state.get('roll', 0.0))
 	for key, point, ground, penetration in constraints:
-		excess = ground - _rigid_point_height(state, point) - penetration
+		excess = ground - _rigid_point_height(state, point, rotation) - penetration
 		if excess > 0.0:
 			remaining_excess = max(remaining_excess, excess)
 			touched.add(key)
@@ -1552,6 +1600,8 @@ def damper_suspension_step(params, state, ground_heights, dt,
 		pseudo_ground_heights = (None,) * len(pseudo_contacts)
 	if len(pseudo_ground_heights) != len(pseudo_contacts):
 		raise ValueError('pseudo-contact ground sample count mismatch')
+	constraints = _suspension_constraints(
+		params, ground_heights, pseudo_ground_heights)
 	try:
 		support_vertical_velocity = float(support_vertical_velocity)
 	except (TypeError, ValueError, OverflowError):
@@ -1579,6 +1629,8 @@ def damper_suspension_step(params, state, ground_heights, dt,
 	pitch_acceleration = 0.0
 	roll_acceleration = 0.0
 	for substep_index in range(steps):
+		rotation = (_suspension_rotation(result['pitch'], result['roll'])
+			if constraints else None)
 		# Horizontal travel moves the reduced heave constraint from the
 		# previous sample position to the current one.  Forces are evaluated at
 		# the start of this semi-implicit substep; its hard projection is
@@ -1602,7 +1654,7 @@ def damper_suspension_step(params, state, ground_heights, dt,
 			ground = float(ground) + support_force_offset
 			compression = (
 				spring['static_compression'] + ground -
-				_spring_height(result, spring))
+				_rigid_point_height(result, spring, rotation))
 			if compression <= 0.0:
 				continue
 			maximum_compression = max(maximum_compression, compression)
@@ -1614,8 +1666,12 @@ def damper_suspension_step(params, state, ground_heights, dt,
 				impact_speed = (substep_vertical_speed
 					if impact_speed is None else
 					min(impact_speed, substep_vertical_speed))
+			pitch_gradient, roll_gradient = _rigid_point_height_gradients(
+				result, spring, rotation)
 			relative_point_velocity = (
-				_spring_point_velocity(result, spring) -
+				(float(result['vertical_velocity']) +
+				pitch_gradient * float(result['pitch_velocity']) +
+				roll_gradient * float(result['roll_velocity'])) -
 				support_vertical_velocity)
 			force = (spring['stiffness'] * compression -
 				spring['damping'] * relative_point_velocity)
@@ -1625,8 +1681,6 @@ def damper_suspension_step(params, state, ground_heights, dt,
 					1.0 + excess / max(spring['max_compression'], 0.01))
 			force = max(0.0, min(spring['max_force'], force))
 			total_force += force
-			pitch_gradient, roll_gradient = _rigid_point_height_gradients(
-				result, spring)
 			pitch_torque += pitch_gradient * force
 			roll_torque += roll_gradient * force
 		for index, contact in enumerate(pseudo_contacts):
@@ -1634,7 +1688,7 @@ def damper_suspension_step(params, state, ground_heights, dt,
 			if ground is None:
 				continue
 			ground = float(ground) + support_force_offset
-			gap = ground - _rigid_point_height(result, contact)
+			gap = ground - _rigid_point_height(result, contact, rotation)
 			if gap < -CONTACT_PENETRATION:
 				continue
 			key = ('pseudo', index)
@@ -1669,7 +1723,7 @@ def damper_suspension_step(params, state, ground_heights, dt,
 		pre_projection_speed = result['vertical_velocity']
 		projected = _project_suspension_limits(
 			params, result, ground_heights, pseudo_ground_heights,
-			support_vertical_velocity, support_projection_offset)
+			support_vertical_velocity, support_projection_offset, constraints)
 		if projected:
 			if (not contact_transition_seen and
 					pre_projection_speed -
@@ -1713,13 +1767,15 @@ def damper_suspension_step(params, state, ground_heights, dt,
 	result['max_compression'] = maximum_compression
 	result['max_limit_excess'] = max(
 		0.0, suspension_limit_excess(params, result, ground_heights))
+	rotation = (_suspension_rotation(result['pitch'], result['roll'])
+		if constraints else None)
 	for index, contact in enumerate(pseudo_contacts):
 		ground = pseudo_ground_heights[index]
 		if ground is None:
 			continue
 		result['max_limit_excess'] = max(
 			result['max_limit_excess'], float(ground) -
-			_rigid_point_height(result, contact) -
+			_rigid_point_height(result, contact, rotation) -
 			float(contact.get('penetration', ALLOWED_PENETRATION)))
 	return result
 

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -6862,7 +6862,8 @@ class BattleRuntimeContractTests(unittest.TestCase):
         first = diagnostics.begin(0.0, 0.02)
         wall[0] = 0.006
         diagnostics.finish(
-            first, 0.0, 0.02, 0.02, {'local': 0.004},
+            first, 0.0, 0.02, 0.02,
+            {'local': 0.004, 'local_ground': 0.001, 'local_solver': 0.002},
             {'lane': 7}, {'role': 'authority', 'speed': 14.0},
             probe_durations={'lane': 0.005}, projectile={
                 'active': 29, 'chords': 58, 'debt': 0.05,
@@ -6914,6 +6915,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertIn('gap_ms=120.000', first_row)
         self.assertIn('raw_dt_ms=120.000', first_row)
         self.assertIn('local:4.000', first_row)
+        self.assertIn('details_ms=local_ground:1.000,local_solver:2.000', first_row)
         self.assertIn('lane:7', first_row)
         self.assertIn('probe_ms=', first_row)
         self.assertIn('lane:5.000', first_row)
@@ -6937,6 +6939,14 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertIn('scans=870.00/1740', payloads[0])
         snapshot = diagnostics.snapshot()
         self.assertEqual(2, snapshot['samples'])
+        self.assertEqual({'avg_ms': 0.5, 'max_ms': 1.0},
+                         snapshot['python_details_ms']['local_ground'])
+        self.assertEqual({'avg_ms': 1.0, 'max_ms': 2.0},
+                         snapshot['python_details_ms']['local_solver'])
+        self.assertNotIn('local_solver', snapshot['python_stages_ms'])
+        self.assertEqual(2.0, snapshot['python_stages_ms']['local']['avg_ms'])
+        self.assertIn('details_ms_avg_max parent=local local_ground=0.500/1.000 '
+                      'local_solver=1.000/2.000', payloads[0])
         self.assertAlmostEqual(
             150.0, snapshot['frame_interval_ms']['p50'])
         self.assertAlmostEqual(
@@ -16895,6 +16905,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
 
         battle._fail.assert_called_once_with(error)
         battle._schedule.assert_not_called()
+        self.assertIsNone(battle._local_frame_stages)
 
     def test_optional_frame_failures_disable_features_not_the_round(self):
         runtime = _runtime()
@@ -21514,6 +21525,36 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertFalse(battle._local_airborne)
         self.assertFalse(battle._local_left_flying)
         self.assertFalse(battle._local_right_flying)
+
+    def test_local_suspension_timing_accumulates_ground_and_solver_passes(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        battle._local_fall_armed = True
+        entity = _Vehicle(
+            10, _suspension_descriptor(), _Vector(), (0, 0, 0),
+            {'health': 500})
+        battle._suspension_ground_y = mock.Mock(return_value=0.0)
+        battle._local_frame_stages = {}
+        # Two support passes in one render callback: a real elapsed-time
+        # solve and a zero-time endpoint correction must both be accounted.
+        with mock.patch(
+                'gui.mods.offline_lan_0922.battle_runtime._PROFILE_CLOCK',
+                side_effect=(1.0, 1.002, 1.003, 1.007,
+                             2.0, 2.003, 2.005, 2.006)):
+            for dt in (0.025, 0.0):
+                battle._update_vertical_motion(
+                    entity, (0.0, 0.0, 0.0), 0.0, dt)
+
+        self.assertEqual(44, battle._suspension_ground_y.call_count)
+        self.assertAlmostEqual(0.005, battle._local_frame_stages['local_ground'])
+        self.assertAlmostEqual(0.005, battle._local_frame_stages['local_solver'])
+        battle._local_frame_stages = None
+        with mock.patch(
+                'gui.mods.offline_lan_0922.battle_runtime._PROFILE_CLOCK',
+                side_effect=AssertionError('disabled timing must not read the clock')):
+            battle._update_vertical_motion(entity, (0.0, 0.0, 0.0), 0.0, 0.025)
+        self.assertEqual(66, battle._suspension_ground_y.call_count)
 
     def test_local_suspension_tick_prepares_one_broken_skin_filter(self):
         """The 22 columns of one pose share the prepared envelope filter."""

--- a/tests/test_port_0922_vehicle_physics.py
+++ b/tests/test_port_0922_vehicle_physics.py
@@ -3,6 +3,7 @@ import math
 import sys
 import types
 import unittest
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -342,6 +343,48 @@ class VehiclePhysicsSuspensionTrialTests(unittest.TestCase):
         self.assertAlmostEqual(0.0, solved['roll'], places=12)
         self.assertFalse(solved['airborne'])
         self.assertEqual(18, solved['contact_count'])
+
+    def test_full_contact_solver_does_not_recompute_rotation_per_point(self):
+        """The moving-frame solver keeps all contacts within a trig budget."""
+        ground, pseudo_ground = self._plane_samples(self.params, 0.0, 0.15)
+        state = self._state(pitch=-0.1, roll=0.05, vertical_velocity=-0.3,
+                            pitch_velocity=0.03, roll_velocity=-0.01)
+        with mock.patch.object(vehicle_physics.math, 'sin',
+                               wraps=math.sin) as sine, \
+                mock.patch.object(vehicle_physics.math, 'cos',
+                                  wraps=math.cos) as cosine:
+            solved = vehicle_physics.damper_suspension_step(
+                self.params, state, ground, 0.025, pseudo_ground)
+
+        # The previous per-point height/gradient path needed over 500 of
+        # each for this same two-substep slope contact. This budget allows
+        # every solver iteration while preventing that repetition.
+        self.assertLess(sine.call_count, 100)
+        self.assertLess(cosine.call_count, 100)
+        self.assertFalse(solved['airborne'])
+        self.assertLessEqual(solved['max_limit_excess'], 1.0e-6)
+        self.assertNotEqual(state['pitch'], solved['pitch'])
+        self.assertNotEqual(state['roll'], solved['roll'])
+
+    def test_airborne_step_integrates_without_unused_contact_rotations(self):
+        state = self._state(height=2.0, vertical_velocity=-3.0,
+                            pitch=0.2, roll=-0.3, pitch_velocity=0.1)
+        dt = self.params['fixed_step'] * 0.5
+        with mock.patch.object(vehicle_physics.math, 'sin',
+                               wraps=math.sin) as sine, \
+                mock.patch.object(vehicle_physics.math, 'cos',
+                                  wraps=math.cos) as cosine:
+            solved = vehicle_physics.damper_suspension_step(
+                self.params, state, (None,) * 10, dt, (None,) * 12)
+
+        self.assertTrue(solved['airborne'])
+        self.assertEqual(0, solved['contact_count'])
+        velocity = -3.0 - vehicle_physics.GRAVITY * dt
+        self.assertAlmostEqual(velocity, solved['vertical_velocity'])
+        self.assertAlmostEqual(2.0 + velocity * dt, solved['height'])
+        self.assertNotEqual(state['pitch'], solved['pitch'])
+        sine.assert_not_called()
+        cosine.assert_not_called()
 
     def test_support_velocity_comes_only_from_plane_and_horizontal_motion(
             self):


### PR DESCRIPTION
The latest `3e97008b3473` Windows report (0.7.6, build `local-076-pr145-146-148-20260911`, Prokhorovka, 29 Bots) still records 45.53–48.79 visible-client FPS in complete live windows. Local vehicle updates consume 4.18–4.69 ms per frame, and the report confirms that the suspension solver is active. Remote sync/presentation also costs 2.91–3.66 ms; 11.37–12.39 ms remains outside the measured callback. This change addresses the repeated suspension work within `local`.

Reuse pitch/roll trigonometry across contacts while a solver pose is unchanged, rebuild it after integration/projection changes that pose, and reuse height gradients for both damping and torque. Prepare the fixed ground constraints once per outer solver call. Height-only checks no longer calculate unused X/Z coordinates. The same rotation preparation also serves spring/pseudo-contact world points and ground-plane fitting. Keep all contact columns, physics substeps, projection iterations, support motion, and impact bookkeeping. Airborne integration continues normally without preparing geometry for absent contacts.

Add `local_ground` (sample preparation plus native ground queries) and `local_solver` timings to the existing PERF summaries and slow-frame rows. They are explicitly nested within `local`, and separated from the main stage totals in structured snapshots. Accumulate endpoint correction passes within the same frame; release the timing collector even if local driving fails.

Validation:

- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=tests python3 -m unittest test_port_0922_vehicle_physics test_port_0922_battle_runtime test_port_0922_bot_runtime test_port_0922_tank_collision test_port_0922_snapshot_sync test_port_0922_turret_detachment` — 1,543 tests passed (181.069 s).
- CPython 2.7.18 in-memory compilation of all 112 client Python sources passed; `git diff --check` passed.
- Differential replay against the unchanged base solver on CPython 2.7.18: 1,920 steps across 24 trajectories with changing slopes, missing/one-sided support, landings, large attitudes, support velocities, and 0–200 ms time steps. Every output field matched exactly (maximum absolute difference 0).
- A two-substep slope solve drops sine/cosine calls from 522 each to 22 each, preserving 17 final contacts. Regression coverage also checks airborne gravity/attitude integration and diagnostic accumulation without changing the 22 ground queries per support pass.

Linux CPython 2.7.18 microbenchmark, same descriptor-derived 10-spring/12-contact fixture, medians of seven alternating before/after trials with 200 solves each:

| Scenario | Before (ms/solve) | After (ms/solve) | Reduction |
| --- | ---: | ---: | ---: |
| Flat ground, 25 ms step | 0.791 | 0.442 | 44% |
| Slope, 25 ms step | 0.756 | 0.418 | 45% |
| Moving support, 25 ms step | 0.733 | 0.409 | 44% |
| Landing, 25 ms step | 1.095 | 0.613 | 44% |
| Airborne, 25 ms step | 0.0284 | 0.0247 | 13% |
| Slope, 16 ms step | 0.514 | 0.301 | 42% |
| Slope, 50 ms step | 1.003 | 0.538 | 46% |

These are pure solver timings, not Windows FPS results. Exact #1513 Windows frame pacing and the actual fraction spent in native ground queries still require another runtime report. The new nested timings expose that boundary. Hidden-worker stalls and the remaining sync/outside-callback costs are not resolved by this PR.

CI for `be2c5567e5d628201744e806423926eea108b9e2`: [all workflow jobs passed](https://github.com/pengw0048/wot-offline-battles/actions/runs/34574652103), including the full client/launcher test suites, CPython 2.7 client build and wotmod validation, Windows server, native exception trail probe, and Windows launcher build.
