### PR TITLE
Fix manual fire extinguisher activation from the stock HUD

### DIFF
--- a/server/lan_battle_server.py
+++ b/server/lan_battle_server.py
@@ -11624,6 +11624,12 @@ class BattleState:
                     return self._finish_equipment_intent(
                         player, intent_seq, False,
                         "invalid_activation_code")
+            elif kind == "extinguisher":
+                # #1513 _ExtinguisherItem uses 65536 + equipment ID.
+                if extra_index != 1:
+                    return self._finish_equipment_intent(
+                        player, intent_seq, False,
+                        "invalid_activation_code")
             elif not repair_all and extra_index != 0:
                 return self._finish_equipment_intent(
                     player, intent_seq, False, "invalid_activation_code")

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -28718,15 +28718,14 @@ class BattleRuntimeContractTests(unittest.TestCase):
                           selected='engineHealth',
                           requested_active=None), call)
 
-    def test_manual_extinguisher_does_not_send_extra_zero_as_a_target(self):
+    def test_stock_manual_extinguisher_activation_reaches_server_without_target(self):
+        import test_port_0922_effective_params as fixtures
+
         runtime = _runtime()
         battle = BattleRuntime(runtime)
         battle._avatar = runtime.bigworld.avatar
-        send_intent = mock.Mock(return_value=1)
-        battle.client = types.SimpleNamespace(
-            player_id=1, send_equipment_intent=send_intent)
         descriptor = _Descriptor()
-        descriptor.extras = {0: types.SimpleNamespace(name='fire')}
+        descriptor.extras = {1: types.SimpleNamespace(name='engineHealth')}
         entity = _Vehicle(10, descriptor, _Vector(), (0, 0, 0),
                           {'health': 500})
         runtime.bigworld.entities[10] = entity
@@ -28735,16 +28734,52 @@ class BattleRuntimeContractTests(unittest.TestCase):
             'engine_id': 10, 'state': {'health': 500, 'alive': True},
             'kind': 'player', 'network_id': 1, 'local': True}}
         extinguisher = types.SimpleNamespace(
-            id=(11, 42), compactDescr=402, name='handExtinguishers',
-            tags=(), reuseCount=0, cooldownSeconds=0.0,
+            id=(15, 0), compactDescr=251, name='handExtinguishers',
+            tags=(), reuseCount=1, cooldownSeconds=90.0,
             autoactivate=False)
         battle._equipment_state = [equipment_mechanics.EquipmentState(
             equipment_mechanics.project_equipment(extinguisher))]
 
-        self.assertTrue(battle._activate_equipment(42))
-        send_intent.assert_called_once_with(
-            42, activation_code=42, selected=None,
-            requested_active=None)
+        params = fixtures.effective_params()
+        params['equipment'] = [battle._equipment_state[0].contract]
+        state = fixtures.BattleState()
+        player, error = state.add_player(
+            fixtures._Connection(), ('127.0.0.1', 2000),
+            fixtures._hello(params))
+        self.assertIsNone(error)
+        self.assertTrue(state._install_player_equipments(player))
+        state.phase = 'battle'
+        state.tick = 10000
+        player.participating = True
+        player.critical['fire'] = True
+        client = fixtures.LANClient(
+            '127.0.0.1', 28782, 'Player', 'ussr:R11_MS-1',
+            max_health=90, effective_params=params,
+            vehicle_compact_descr='dGVzdA==')
+        client.player_id = player.player_id
+        client.ready = True
+        client.phase = 'battle'
+        client.round_id = state.round_id
+        messages = []
+        client._send = lambda message: messages.append(
+            json.loads(json.dumps(message))) or True
+        battle.client = client
+
+        # #1513 _ExtinguisherItem.getActivationCode returns 65536 + id[1].
+        # The high word means "activate", not the vehicle's extra index 1.
+        self.assertTrue(battle.change_vehicle_setting(
+            runtime.constants.VEHICLE_SETTING.ACTIVATE_EQUIPMENT, 65536))
+        self.assertEqual(1, len(messages))
+        self.assertEqual(0, messages[0]['equipment_id'])
+        self.assertEqual(65536, messages[0]['activation_code'])
+        self.assertIsNone(messages[0]['selected'])
+        self.assertIsNone(messages[0]['requested_active'])
+        self.assertTrue(state.submit_equipment_intent(
+            player.player_id, messages[0]))
+        self.assertTrue(player.equipment_intent_result['accepted'])
+        self.assertFalse(player.critical['fire'])
+        self.assertEqual({'251': 1}, state._statistics_row(
+            'player', player.player_id)['equipment_used'])
 
     def test_multiple_ap_destructibles_accumulate_before_vehicle(self):
         runtime = _runtime()

--- a/tests/test_port_0922_effective_params.py
+++ b/tests/test_port_0922_effective_params.py
@@ -95,7 +95,7 @@ class EffectiveParamsContractTests(unittest.TestCase):
             dict(member, instance='commander', roles=['commander']),
             dict(member, instance='driver', roles=['driver'])])
         params['critical']['activation_targets'] = [
-            {'index': 1, 'name': 'commander'}, {'index': 2, 'name': 'driver'}]
+            {'index': 7, 'name': 'commander'}, {'index': 2, 'name': 'driver'}]
         params['equipment'] = [equipment_mechanics.project_equipment(
             types.SimpleNamespace(
                 name='medkit', id=(15, 2), compactDescr=763,
@@ -115,7 +115,7 @@ class EffectiveParamsContractTests(unittest.TestCase):
         intent = {
             'type': 'equipment_intent', 'round_id': state.round_id,
             'intent_seq': 1, 'equipment_id': 2,
-            'activation_code': (1 << 16) | 2,
+            'activation_code': (7 << 16) | 2,
             'selected': 'commander', 'requested_active': None,
         }
 
@@ -150,7 +150,7 @@ class EffectiveParamsContractTests(unittest.TestCase):
         player.critical['fire'] = True
         intent = {
             'type': 'equipment_intent', 'round_id': state.round_id,
-            'intent_seq': 1, 'equipment_id': 0, 'activation_code': 0,
+            'intent_seq': 1, 'equipment_id': 0, 'activation_code': 65536,
             'selected': None, 'requested_active': None,
         }
         before_critical = copy.deepcopy(player.critical)
@@ -184,7 +184,7 @@ class EffectiveParamsContractTests(unittest.TestCase):
 
     def test_zero_id_manual_extinguisher_joins_and_extinguishes_once(self):
         from gui.mods.offline_lan_0922 import equipment_mechanics
-        # Exact #1513 handExtinguishers: local ID 0, packed equipment ID 251.
+        # #1513 handExtinguishers: ID 0, compact 251, HUD activation 65536.
         equipment = equipment_mechanics.project_equipment(types.SimpleNamespace(
             name='handExtinguishers', id=(15, 0), compactDescr=251,
             cooldownSeconds=90.0, reuseCount=1))
@@ -215,18 +215,89 @@ class EffectiveParamsContractTests(unittest.TestCase):
         client.round_id = state.round_id
         messages = []
         client._send = lambda message: messages.append(message) or True
-        self.assertEqual(1, client.send_equipment_intent(0, activation_code=0))
+        self.assertEqual(1, client.send_equipment_intent(
+            0, activation_code=65536))
         self.assertTrue(state.submit_equipment_intent(player.player_id, messages[0]))
         self.assertTrue(player.equipment_intent_result['accepted'])
         self.assertFalse(player.critical['fire'])
+        mounted = player.equipment_states[0]
+        after_use = mounted.snapshot(player.equipment_clock)
+        self.assertEqual(1, after_use['usesLeft'])
+        self.assertEqual(90.0, after_use['cooldownTimeLeft'])
+        self.assertEqual({'251': 1}, state._statistics_row(
+            'player', player.player_id)['equipment_used'])
         revision = player.equipment_revision
         self.assertTrue(state.submit_equipment_intent(player.player_id, messages[0]))
         self.assertEqual(revision, player.equipment_revision)
+        self.assertEqual(after_use, mounted.snapshot(player.equipment_clock))
+        player.critical['fire'] = True
+        self.assertEqual(2, client.send_equipment_intent(
+            0, activation_code=65536))
+        self.assertTrue(state.submit_equipment_intent(player.player_id, messages[1]))
+        self.assertEqual({
+            'intent_seq': 2, 'accepted': False,
+            'reason': 'equipment_ineligible'}, player.equipment_intent_result)
+        self.assertTrue(player.critical['fire'])
+        self.assertEqual(revision, player.equipment_revision)
+        self.assertEqual(after_use, mounted.snapshot(player.equipment_clock))
         for invalid in (-1, False, 65536):
             self.assertIsNone(client.send_equipment_intent(
-                invalid, activation_code=0))
-            forged = dict(messages[0], equipment_id=invalid, intent_seq=2)
+                invalid, activation_code=65536))
+            forged = dict(messages[0], equipment_id=invalid, intent_seq=3)
             self.assertFalse(state.submit_equipment_intent(player.player_id, forged))
+
+    def test_extinguisher_activation_rejects_invalid_codes_targets_and_modes(self):
+        from gui.mods.offline_lan_0922 import equipment_mechanics
+        for automatic, equipment_id, compact_descr, name in (
+                (False, 0, 251, 'handExtinguishers'),
+                (True, 1, 507, 'autoExtinguishers')):
+            params = effective_params()
+            params['equipment'] = [equipment_mechanics.project_equipment(
+                types.SimpleNamespace(
+                    name=name, id=(15, equipment_id),
+                    compactDescr=compact_descr, autoactivate=automatic,
+                    cooldownSeconds=90.0, reuseCount=1))]
+            state = BattleState()
+            player, error = state.add_player(
+                _Connection(), ('127.0.0.1', 2000), _hello(params))
+            self.assertIsNone(error)
+            self.assertTrue(state._install_player_equipments(player))
+            state.phase = 'battle'
+            state.tick = 10000
+            player.participating = True
+            player.critical['fire'] = True
+            mounted = player.equipment_states[0]
+            before = mounted.snapshot(0.0)
+            revision = player.equipment_revision
+            cases = [
+                (0, None, None, 'invalid_activation_code'),
+                (2, None, None, 'invalid_activation_code'),
+                (32767, None, None, 'invalid_activation_code'),
+                (1, 'engineHealth', None, 'invalid_equipment_target'),
+                (1, None, True, 'invalid_activation_mode'),
+            ]
+            if automatic:
+                cases.append((1, None, None, 'automatic_only'))
+            for sequence, (high_word, selected, active, reason) in enumerate(
+                    cases, 1):
+                with self.subTest(automatic=automatic, sequence=sequence):
+                    intent = {
+                        'type': 'equipment_intent', 'round_id': state.round_id,
+                        'intent_seq': sequence, 'equipment_id': equipment_id,
+                        'activation_code': (high_word << 16) | equipment_id,
+                        'selected': selected, 'requested_active': active,
+                    }
+                    self.assertTrue(state.submit_equipment_intent(
+                        player.player_id, intent))
+                    self.assertEqual({
+                        'intent_seq': sequence, 'accepted': False,
+                        'reason': reason}, player.equipment_intent_result)
+                    self.assertTrue(player.critical['fire'])
+                    self.assertEqual(revision, player.equipment_revision)
+                    self.assertEqual(
+                        before, mounted.snapshot(player.equipment_clock))
+                    self.assertEqual({}, state._statistics_row(
+                        'player', player.player_id)['equipment_used'])
 
     def test_dynamic_spotting_ratios_use_native_factor_pairs(self):
         healthy = {


### PR DESCRIPTION
Manual fire extinguishers could not be used from the stock battle HUD: #1513 emits activation code `65536 + equipment ID`, but the server rejected the high word `1` as `invalid_activation_code`. Accept that exact encoding for extinguishers while retaining the existing target, mode, automatic-use, and other equipment checks.

Replace the synthetic zero-code tests with the real ID 0 / activation code 65536 contract, including a client setting call through LANClient and JSON transport to server consumption. Cover cooldown, duplicate requests, resolver rollback, invalid encodings, and automatic extinguisher restrictions.

Validation: executed the pinned #1513 HUD bytecode to verify its emitted code; the real-code regressions failed before the fix and pass afterward. All 1,064 tests in `test_port_0922_effective_params`, `test_port_0922_equipment_mechanics`, `test_port_0922_battle_runtime`, and `test_port_0922_server_projectiles` passed. Windows gameplay has not been re-run with this patch.
