### PR TITLE
diagnostic: sample visible-client sync and local update costs

### DIFF
--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -706,6 +706,32 @@ return values, freshness windows, deadlines and 110-pair safety budget are
 unchanged. Straight-line Windows driving remains the frame-pacing acceptance
 test; this source review cannot claim that the visible hitch is eliminated.
 
+Visible clients additionally emit `PERF visible_costs` for the existing frame
+windows. `visible_diagnostics.py` selects one frame per eight-frame block,
+rotating the position within each block to avoid always observing the same
+phase of periodic track feeds. Only synchronous sync playback and local
+driving bind the observer. Fixed stages cover sync event application, pose and
+aim setters, track updates, motion checks, world-probe helpers, tank contacts,
+support, ground samples, suspension solving, and local presentation. Counts
+refer to these Python boundaries, including early returns and failed calls;
+they are not raw native-call counts. Timings include Python and native work
+within each boundary, plus observer overhead. They do not measure rendering
+outside the callback or distinguish CPU work from waiting.
+
+`total_ms_per_sample` includes measured children; `self_ms_per_sample` removes
+them. Inclusive totals must not be added across nested stages. Averages use
+the reported valid `sampled_frames`, including zero calls to a stage, rather
+than all `window_frames`; `failed_frames` are discarded separately. The
+existing all-frame stage and ground/solver averages keep their denominators.
+`PERF visible_slow` attaches numeric rows to a sampled slow interval's causal
+frame; an unsampled slow interval has no inferred detail. Both records use the
+same bounded line splitting as combat records below. Storage is bounded by
+fixed stage names, nesting depth, and the existing slow-frame limit; it holds
+no actors or call arguments. Clock/scope failures discard only the sample.
+Sampling does not depend on player input or change gameplay cadence, collision
+queries, interpolation, or native writes. Exact Windows reports are required
+to locate a remaining hotspot and assess both sampler overhead and FPS.
+
 The current hidden worker also supports bounded combat timing beyond its
 five-second startup probe sample. `worker_diagnostics.py` captures up to three
 30-second windows per round, with a 30-second cooldown. A live battle frame

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -62,7 +62,7 @@ from gui.mods.offline_lan_0922 import (
     prebaked_foliage,
     prebaked_navigation, native_mapping_mask, shot_geometry, spotting,
     tank_collision, track_damage,
-    vehicle_blacklist, vehicle_configuration, vehicle_physics,
+    vehicle_blacklist, vehicle_configuration, vehicle_physics, visible_diagnostics,
     world_collision)
 
 
@@ -506,6 +506,9 @@ class _FrameDiagnostics(object):
             (name, 0.0) for name in _FRAME_STAGE_NAMES + _FRAME_DETAIL_NAMES)
         self._stage_maxima = dict(
             (name, 0.0) for name in _FRAME_STAGE_NAMES + _FRAME_DETAIL_NAMES)
+        self._visible_samples = 0
+        self._visible_failures = 0
+        self._visible_costs = {}
         self._probe_sums = dict((name, 0) for name in PROBE_KINDS)
         self._probe_maxima = dict((name, 0) for name in PROBE_KINDS)
         self._probe_duration_sums = dict(
@@ -614,6 +617,21 @@ class _FrameDiagnostics(object):
             self._stage_sums[name] += value
             self._stage_maxima[name] = max(
                 self._stage_maxima[name], value)
+        visible = row.get('visible')
+        if visible is not None:
+            if visible.get('failed'):
+                self._visible_failures += 1
+            else:
+                self._visible_samples += 1
+                for name, values in visible['stages'].items():
+                    calls, total, own, maximum_call = values
+                    cost = self._visible_costs.setdefault(
+                        name, [0, 0.0, 0.0, 0.0, 0.0])
+                    cost[0] += calls
+                    cost[1] += total
+                    cost[2] += own
+                    cost[3] = max(cost[3], maximum_call)
+                    cost[4] = max(cost[4], total)
         for name in PROBE_KINDS:
             value = max(0, int(row['probes'].get(name, 0)))
             self._probe_sums[name] += value
@@ -728,6 +746,37 @@ class _FrameDiagnostics(object):
         """Return the most recently completed bounded performance window."""
         return dict(self._last_snapshot)
 
+    def _visible_summary(self):
+        if not self._visible_samples and not self._visible_failures:
+            return None
+        samples = max(1, self._visible_samples)
+        stages = {}
+        for name in visible_diagnostics.STAGES:
+            values = self._visible_costs.get(name)
+            if values is None:
+                continue
+            calls, total, own, maximum_call, maximum_frame = values
+            stages[name] = {
+                'calls': calls,
+                'calls_per_sample': round(float(calls) / samples, 3),
+                'total_ms_per_sample': self._milliseconds(total / samples),
+                'self_ms_per_sample': self._milliseconds(own / samples),
+                'max_call_ms': self._milliseconds(maximum_call),
+                'max_frame_ms': self._milliseconds(maximum_frame),
+            }
+        return {
+            'schema': 1, 'stride': visible_diagnostics.FRAME_STRIDE,
+            'selection': 'rotating_phase',
+            'window': self._window_id,
+            'round': self._last_context.get('round', '-'),
+            'map': self._last_context.get('map', '-'),
+            'phase': self._last_context.get('phase', '-'),
+            'sampled_frames': self._visible_samples,
+            'failed_frames': self._visible_failures,
+            'window_frames': self._samples,
+            'stages': stages,
+        }
+
     def _format(self):
         samples = max(1, self._samples)
         elapsed = max(1e-9, self._window_elapsed)
@@ -784,6 +833,7 @@ class _FrameDiagnostics(object):
             'outside_callback_ms': outside_distribution,
             'python_stages_ms': stage_snapshot,
             'python_details_ms': detail_snapshot,
+            'visible_costs': self._visible_summary(),
             # One logical probe can contain several native calls. The current
             # Python boundary cannot truthfully derive raw call/primitives.
             'raw_native_calls_measured': False,
@@ -902,6 +952,10 @@ class _FrameDiagnostics(object):
                          self._milliseconds(self._stage_sums[name] / samples),
                          self._milliseconds(self._stage_maxima[name]))
                          for name in _FRAME_DETAIL_NAMES) + '\n')
+        visible_summary = self._last_snapshot['visible_costs']
+        if visible_summary is not None:
+            lines.append(_combat_log_lines(
+                prefix, 'visible_costs', visible_summary))
         probe_values = []
         for name in PROBE_KINDS:
             probe_values.append('%s=%.2f/%d' % (
@@ -1014,6 +1068,14 @@ class _FrameDiagnostics(object):
                          name, self._milliseconds(
                              probe_durations.get(name, 0.0)))
                               for name in PROBE_KINDS)))
+            if row.get('visible') is not None:
+                lines.append(_combat_log_lines(prefix, 'visible_slow', {
+                    'schema': 1, 'cause': row['cause'],
+                    'window': self._window_id,
+                    'costs': row['visible'],
+                    'units': 'seconds',
+                    'row_fields': ['calls', 'total', 'self', 'max_call'],
+                }))
             if context.get('role') == 'worker':
                 frames = [('focus', 0, self._compact_frame(row))]
                 if rank == 1:
@@ -1037,7 +1099,7 @@ class _FrameDiagnostics(object):
 
     def finish(self, frame_id, entry_wall, tick_dt, motion_dt, stages,
                probes, context, probe_durations=None, projectile=None,
-               combat=None):
+               combat=None, visible=None):
         if not self.enabled:
             return
         try:
@@ -1064,6 +1126,7 @@ class _FrameDiagnostics(object):
                 'probe_durations': dict(probe_durations or {}),
                 'projectile': dict(projectile or {}),
                 'combat': combat,
+                'visible': visible,
                 'context': dict(context or {}), 'emitted': emitted,
             }
         except Exception:
@@ -1729,6 +1792,7 @@ class BattleRuntime(object):
         self._local_spring_ground_memory = None
         self._local_pseudo_ground_memory = None
         self._local_frame_stages = None
+        self._visible_frame_costs = None
         self._local_pitch = 0.0
         self._local_roll = 0.0
         self._local_suspension_pitch_velocity = 0.0
@@ -6793,6 +6857,7 @@ class BattleRuntime(object):
             (velocity[axis] - previous[axis]) / window for axis in range(3))
         return velocity, acceleration
 
+    @visible_diagnostics.measured('local.present')
     def _update_local_presentation(self, entity, dt=0.0):
         if self._local_matrix is None or self._local_model is None:
             raise RuntimeError('player presentation is not attached')
@@ -6898,6 +6963,7 @@ class BattleRuntime(object):
             return (ENGINE_MODE_RUNNING, flags)
         return (ENGINE_MODE_IDLE, flags)
 
+    @visible_diagnostics.measured('local.tracks')
     def _update_local_tracks(self, entity):
         """Feed the native track, wheel, spline and trace animation.
 
@@ -16049,6 +16115,8 @@ class BattleRuntime(object):
         self._spotted_signature = None
         frame_id = (diagnostics.begin(entry_wall, raw_dt, offframe)
                     if profiling else 0)
+        visible_costs = (visible_diagnostics.new_frame(frame_id, _PROFILE_CLOCK)
+                         if profiling and not self._worker_mode else None)
         combat_diagnostic = self._combat_diagnostics
         if combat_diagnostic is not None and self._battle_live and profiling:
             trigger = None
@@ -16092,7 +16160,11 @@ class BattleRuntime(object):
                 stages['house'] = max(0.0, next_boundary - boundary)
                 boundary = next_boundary
             if self._sync is not None:
-                self._sync.advance(now)
+                self._visible_frame_costs = visible_costs
+                try:
+                    visible_diagnostics.call(self, 'sync', self._sync.advance, now)
+                finally:
+                    self._visible_frame_costs = None
             if self._battle_live and self._worker_mode:
                 self._advance_player_fire_authority(rule_dt, now)
                 self._publish_player_environment(rule_dt, now)
@@ -16227,10 +16299,12 @@ class BattleRuntime(object):
                 boundary = next_boundary
             if self._battle_live and not self._worker_mode:
                 self._local_frame_stages = stages if profiling else None
+                self._visible_frame_costs = visible_costs
                 try:
-                    self._drive_local(dt)
+                    visible_diagnostics.call(self, 'local', self._drive_local, dt)
                 finally:
                     self._local_frame_stages = None
+                    self._visible_frame_costs = None
             if profiling:
                 next_boundary = _PROFILE_CLOCK()
                 stages['local'] = max(0.0, next_boundary - boundary)
@@ -16484,7 +16558,9 @@ class BattleRuntime(object):
                 }, probe_durations=probe_durations,
                 projectile=projectile_perf,
                 combat=(combat_diagnostic.finish_frame()
-                        if combat_diagnostic is not None else None))
+                        if combat_diagnostic is not None else None),
+                visible=(visible_costs.snapshot()
+                         if visible_costs is not None else None))
 
     def _mutable_shot_ray(self):
         """Copy #1513's native gun ray before normalising or scattering it."""
@@ -17918,6 +17994,7 @@ class BattleRuntime(object):
         after = self._local_turret_pose(end, end_yaw, pitch, roll)
         return self._turret_motion_is_clear(before, after, descriptor)
 
+    @visible_diagnostics.measured('local.motion')
     def _pose_sweep_is_clear(
             self, entity, start_position, start_yaw, end_position, end_yaw,
             speed, dt):
@@ -17993,6 +18070,7 @@ class BattleRuntime(object):
             start_position, start_yaw)
         return status in ('clear', 'crushed', 'approach')
 
+    @visible_diagnostics.measured('local.motion')
     def _motion_is_clear(self, entity, position, yaw, speed, dt,
                          allow_crush_drive=False, hull_yaw=None):
         """Thin tuple-to-Vector adapter around the copied 0.8.2 probe."""
@@ -18104,7 +18182,8 @@ class BattleRuntime(object):
                         self._send_pending_local_destructible_contacts()
                     return False
                 self._send_pending_local_destructible_contacts()
-                world_status = world_collision.check_horizontal_collision(
+                world_status = visible_diagnostics.call(
+                    self, 'local.world', world_collision.check_horizontal_collision,
                     self._runtime.bigworld, self._runtime.math,
                     self._avatar.spaceID, self._vector(position),
                     world_hull_yaw, speed,
@@ -18122,7 +18201,8 @@ class BattleRuntime(object):
                     'clear', 'crushed', 'approach')
             if tree_contact is not None:
                 self._send_pending_local_destructible_contacts()
-        world_status = world_collision.check_horizontal_collision(
+        world_status = visible_diagnostics.call(
+            self, 'local.world', world_collision.check_horizontal_collision,
             self._runtime.bigworld, self._runtime.math,
             self._avatar.spaceID, self._vector(position),
             world_hull_yaw, speed,
@@ -19126,6 +19206,7 @@ class BattleRuntime(object):
             })
         return result
 
+    @visible_diagnostics.measured('local.contacts')
     def _resolve_local_tank_contacts(self, entity, position, yaw, dt):
         """Apply chassis OBB separation without pushing a tank into walls."""
         self._retry_native_ram_contact_proofs()
@@ -19661,6 +19742,7 @@ class BattleRuntime(object):
         self._report_local_suspension_trial('retired: %s' % (error,))
         self._warn_optional_failure('ten-spring suspension trial', error)
 
+    @visible_diagnostics.measured('local.ground')
     def _local_suspension_ground_samples(
             self, position, yaw, probe_height=None,
             support_gradient=None, sweep_drop=0.0):
@@ -19705,6 +19787,7 @@ class BattleRuntime(object):
         self._local_spring_ground_memory = memory
         return tuple(result)
 
+    @visible_diagnostics.measured('local.ground')
     def _local_suspension_pseudo_ground_samples(
             self, position, yaw, probe_height=None,
             support_gradient=None, sweep_drop=0.0):
@@ -20028,6 +20111,7 @@ class BattleRuntime(object):
             self._local_airborne = False
         return position
 
+    @visible_diagnostics.measured('local.support')
     def _update_vertical_motion(
             self, entity, position, yaw, dt,
             support_height_delta=0.0, support_speed_delta=0.0):
@@ -20188,7 +20272,8 @@ class BattleRuntime(object):
             'roll_velocity': self._local_suspension_roll_velocity,
         }
         solver_started = _PROFILE_CLOCK() if timings is not None else 0.0
-        solved = vehicle_physics.damper_suspension_step(
+        solved = visible_diagnostics.call(
+            self, 'local.solver', vehicle_physics.damper_suspension_step,
             params, physics_state, ground, dt, pseudo_ground,
             support_vertical_speed)
         if timings is not None:
@@ -21118,6 +21203,7 @@ class BattleRuntime(object):
             return (ENGINE_MODE_RUNNING, flags)
         return (ENGINE_MODE_IDLE, 0)
 
+    @visible_diagnostics.measured('sync.tracks')
     def _update_bot_tracks(self, record, state, now, turn_override=None):
         """Drive one bot's belts from its authority speed and turn rate."""
         # The hidden authority needs native hull and gun poses for collision
@@ -22397,6 +22483,7 @@ class BattleRuntime(object):
         accepted = sender(*args, **kwargs)
         return accepted == shot_seq
 
+    @visible_diagnostics.measured('sync.apply')
     def _apply_sync_event(self, event):
         if self.state in ('failed', 'stopped', 'leaving'):
             return
@@ -22944,7 +23031,8 @@ class BattleRuntime(object):
                 # mutate its provider. A later sample may return to that old
                 # pose instead of retrying the failed target.
                 record.pop('_remote_pose_signature', None)
-                self._binding.set_vehicle_pose(
+                visible_diagnostics.call(
+                    self, 'sync.pose', self._binding.set_vehicle_pose,
                     record['engine_id'], self._vector((x, y, z)),
                     _engine_rotation(yaw, pitch, roll), now=now)
                 record['_remote_pose_signature'] = signature
@@ -22977,7 +23065,8 @@ class BattleRuntime(object):
                 # Turret yaw can succeed before gun pitch fails. The old
                 # signature no longer describes that partially written aim.
                 record.pop('_remote_aim_signature', None)
-                self._binding.update_vehicle_aim(
+                visible_diagnostics.call(
+                    self, 'sync.aim', self._binding.update_vehicle_aim,
                     record['engine_id'], yaw, aim_yaw, gun_pitch)
                 record['_remote_aim_signature'] = aim_signature
             if record.get('kind') in ('bot', 'player'):

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/visible_diagnostics.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/visible_diagnostics.py
@@ -1,0 +1,118 @@
+"""Sample the visible client's extra sync and local-update work.
+
+Only synchronous calls inside those two frame phases bind this observer.
+Rows contain numbers and fixed stage names, never vehicles or call arguments.
+Inclusive time contains children; self time removes instrumented children.
+Neither the sampler nor a diagnostic failure may change gameplay work.
+"""
+
+import functools
+import math
+
+
+FRAME_STRIDE = 8
+STAGES = (
+    'sync', 'sync.apply', 'sync.pose', 'sync.aim', 'sync.tracks',
+    'local', 'local.motion', 'local.world', 'local.contacts',
+    'local.support', 'local.ground', 'local.solver',
+    'local.present', 'local.tracks',
+)
+MAX_DEPTH = 16
+
+
+def new_frame(frame_id, clock):
+    """Sample one frame per block, rotating across periodic track feeds."""
+    try:
+        index = int(frame_id) - 1
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if index < 0 or index % FRAME_STRIDE != (index // FRAME_STRIDE) % FRAME_STRIDE:
+        return None
+    return FrameCosts(clock)
+
+
+class FrameCosts(object):
+
+    def __init__(self, clock):
+        self.clock = clock
+        self.rows = {}
+        self.stack = []
+        self.failed = False
+
+    def _fail(self):
+        self.failed = True
+        self.rows.clear()
+        self.stack[:] = []
+
+    def start(self, name):
+        if self.failed:
+            return None
+        try:
+            if name not in STAGES or len(self.stack) >= MAX_DEPTH:
+                raise ValueError('invalid visible timing scope')
+            started = float(self.clock())
+            if math.isnan(started) or math.isinf(started):
+                raise ValueError('invalid visible timing clock')
+            token = [name, started, 0.0]
+            self.stack.append(token)
+            return token
+        except Exception:
+            self._fail()
+            return None
+
+    def stop(self, token):
+        if token is None or self.failed:
+            return
+        try:
+            if not self.stack or self.stack[-1] is not token:
+                raise ValueError('unbalanced visible timing scope')
+            elapsed = float(self.clock()) - token[1]
+            if math.isnan(elapsed) or math.isinf(elapsed) or elapsed < 0.0:
+                raise ValueError('invalid visible timing interval')
+            self.stack.pop()
+            own = max(0.0, elapsed - token[2])
+            row = self.rows.setdefault(token[0], [0, 0.0, 0.0, 0.0])
+            row[0] += 1
+            row[1] += elapsed
+            row[2] += own
+            row[3] = max(row[3], elapsed)
+            if self.stack:
+                self.stack[-1][2] += elapsed
+        except Exception:
+            self._fail()
+
+    def snapshot(self):
+        if self.stack:
+            self._fail()
+        return {
+            'failed': self.failed,
+            'stages': dict((name, tuple(row)) for name, row in self.rows.items()),
+        }
+
+
+def call(owner, name, function, *args, **kwargs):
+    costs = owner._visible_frame_costs
+    if costs is None:
+        return function(*args, **kwargs)
+    token = costs.start(name)
+    try:
+        return function(*args, **kwargs)
+    finally:
+        costs.stop(token)
+
+
+def measured(name):
+    """Observe a runtime method only while its frame phase owns a sample."""
+    def decorate(method):
+        @functools.wraps(method)
+        def measured_call(self, *args, **kwargs):
+            costs = self._visible_frame_costs
+            if costs is None:
+                return method(self, *args, **kwargs)
+            token = costs.start(name)
+            try:
+                return method(self, *args, **kwargs)
+            finally:
+                costs.stop(token)
+        return measured_call
+    return decorate

--- a/tests/test_port_0922_visible_diagnostics.py
+++ b/tests/test_port_0922_visible_diagnostics.py
@@ -1,0 +1,276 @@
+import contextlib
+import io
+import json
+from pathlib import Path
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / 'src/res/scripts/client'))
+
+from gui.mods.offline_lan_0922 import visible_diagnostics as diagnostics
+from gui.mods.offline_lan_0922.battle_runtime import _FrameDiagnostics
+import test_port_0922_battle_runtime as fixtures
+
+
+class VisibleTimingTests(unittest.TestCase):
+
+    def test_nested_calls_remove_children_and_accumulate_repeated_work(self):
+        clock = mock.Mock(side_effect=[0, 1, 3, 4, 7, 10])
+        costs = diagnostics.FrameCosts(clock)
+        parent = costs.start('local')
+        first = costs.start('local.ground')
+        costs.stop(first)
+        second = costs.start('local.ground')
+        costs.stop(second)
+        costs.stop(parent)
+
+        snapshot = costs.snapshot()
+        self.assertFalse(snapshot['failed'])
+        self.assertEqual((1, 10, 5, 10), snapshot['stages']['local'])
+        self.assertEqual((2, 5, 5, 3), snapshot['stages']['local.ground'])
+        costs.rows['local'][0] += 1
+        self.assertEqual(1, snapshot['stages']['local'][0])
+        json.dumps(snapshot)
+
+    def test_sampler_rotates_through_periodic_feed_phases(self):
+        clock = mock.Mock()
+        selected = [frame for frame in range(1, 65)
+                    if diagnostics.new_frame(frame, clock) is not None]
+        self.assertEqual(8, len(selected))
+        self.assertEqual(list(range(8)), [(frame - 1) // 8 for frame in selected])
+        self.assertEqual(list(range(8)), [(frame - 1) % 8 for frame in selected])
+        for invalid in (0, -1, None, 'invalid', float('inf')):
+            self.assertIsNone(diagnostics.new_frame(invalid, clock))
+        clock.assert_not_called()
+
+    def test_observation_never_changes_arguments_return_or_exception(self):
+        value = object()
+        error = RuntimeError('operation failed')
+        for clock_values in ([0, 1], [RuntimeError('clock failed')],
+                             [1, 0], [0, float('nan')], [float('inf')]):
+            for outcome in (value, error):
+                with self.subTest(clock=clock_values, outcome=outcome):
+                    costs = diagnostics.FrameCosts(mock.Mock(side_effect=clock_values))
+                    owner = types.SimpleNamespace(_visible_frame_costs=costs)
+                    operation = mock.Mock(return_value=outcome)
+                    if outcome is error:
+                        operation.side_effect = error
+                        with self.assertRaises(RuntimeError) as caught:
+                            diagnostics.call(owner, 'sync.pose', operation,
+                                             value, now=1.25)
+                        self.assertIs(error, caught.exception)
+                    else:
+                        self.assertIs(value, diagnostics.call(
+                            owner, 'sync.pose', operation, value, now=1.25))
+                    operation.assert_called_once_with(value, now=1.25)
+                    self.assertEqual([], costs.stack)
+                    self.assertEqual(clock_values != [0, 1], costs.snapshot()['failed'])
+
+    def test_decorator_is_inert_without_a_sample_and_unwinds_on_failure(self):
+        class Owner:
+            _visible_frame_costs = None
+
+            @diagnostics.measured('local.motion')
+            def operation(self, callback, **kwargs):
+                return callback(**kwargs)
+
+        owner = Owner()
+        callback = mock.Mock(return_value=object())
+        self.assertIs(callback.return_value, owner.operation(callback, speed=8.0))
+        callback.assert_called_once_with(speed=8.0)
+        owner._visible_frame_costs = diagnostics.FrameCosts(lambda: 0.0)
+        callback.side_effect = ValueError('motion failed')
+        with self.assertRaisesRegex(ValueError, 'motion failed'):
+            owner.operation(callback, speed=8.0)
+        self.assertEqual([], owner._visible_frame_costs.stack)
+        self.assertEqual((1, 0, 0, 0),
+                         owner._visible_frame_costs.snapshot()['stages']['local.motion'])
+
+    def test_invalid_scope_or_excess_nesting_discards_only_the_sample(self):
+        for invalid in ('unknown', 'depth', 'order', 'open'):
+            with self.subTest(invalid=invalid):
+                costs = diagnostics.FrameCosts(lambda: 0.0)
+                first = costs.start('local')
+                if invalid == 'unknown':
+                    costs.start('unbounded actor identifier')
+                elif invalid == 'depth':
+                    for unused in range(diagnostics.MAX_DEPTH):
+                        costs.start('local.motion')
+                elif invalid == 'order':
+                    costs.start('local.motion')
+                    costs.stop(first)
+                self.assertEqual({'failed': True, 'stages': {}}, costs.snapshot())
+                costs.stop(first)
+                self.assertEqual([], costs.stack)
+
+    def test_many_calls_retain_only_fixed_numeric_rows(self):
+        costs = diagnostics.FrameCosts(lambda: 0.0)
+        for unused in range(1000):
+            for name in diagnostics.STAGES:
+                costs.stop(costs.start(name))
+        self.assertEqual(len(diagnostics.STAGES), len(costs.rows))
+        self.assertTrue(all(row == (1000, 0, 0, 0)
+                            for row in costs.snapshot()['stages'].values()))
+
+
+class VisibleWindowTests(unittest.TestCase):
+
+    def test_sample_denominator_slow_frame_correlation_and_window_reset(self):
+        wall = [0.0]
+        payloads = []
+        window = _FrameDiagnostics(clock=lambda: wall[0], writer=payloads.append,
+                                   window_seconds=100.0)
+        first = {'failed': False, 'stages': {
+            'sync': (1, .008, .004, .008),
+            'sync.pose': (2, .004, .004, .003)}}
+        second = {'failed': False, 'stages': {'sync': (1, .004, .004, .004)}}
+        snapshots = [first, None, {'failed': True, 'stages': {}}, None, second]
+        for snapshot in snapshots:
+            frame = window.begin(wall[0], .1)
+            wall[0] += .01
+            window.finish(frame, wall[0] - .01, .1, .1,
+                          {'sync': .006, 'local_ground': .001}, {},
+                          {'role': 'guest'}, visible=snapshot)
+            wall[0] += .09
+        window.begin(wall[0], .1)
+        window.flush()
+        summary = window.snapshot()['visible_costs']
+        self.assertEqual((5, 2, 1), (summary['window_frames'],
+                                     summary['sampled_frames'], summary['failed_frames']))
+        self.assertEqual(6.0, summary['stages']['sync']['total_ms_per_sample'])
+        self.assertEqual(4.0, summary['stages']['sync']['self_ms_per_sample'])
+        self.assertEqual(1.0, summary['stages']['sync.pose']['calls_per_sample'])
+        self.assertEqual(2.0, summary['stages']['sync.pose']['total_ms_per_sample'])
+        self.assertEqual(3.0, summary['stages']['sync.pose']['max_call_ms'])
+        self.assertEqual(4.0, summary['stages']['sync.pose']['max_frame_ms'])
+        self.assertEqual(1.0, window.snapshot()['python_details_ms']['local_ground']['avg_ms'])
+        slow = [json.loads(line.split('visible_slow ', 1)[1])
+                for line in payloads[0].splitlines() if 'visible_slow ' in line]
+        self.assertTrue(any(row['cause'] == 1 and row['costs'] ==
+                            json.loads(json.dumps(first)) for row in slow))
+        self.assertTrue(all(len(line) < 7168 for line in payloads[0].splitlines()))
+        self.assertIsNone(window._visible_summary())
+
+
+class VisibleRuntimeTests(unittest.TestCase):
+
+    def test_moving_and_aiming_pose_stream_keeps_native_writes_and_motion_state(self):
+        def replay(sampled, kind):
+            native, unused = fixtures.RemotePresentationWriteTests()._vehicles()
+            runtime = fixtures._runtime()
+            battle = fixtures.BattleRuntime(runtime)
+            calls = []
+
+            def pose(engine_id, position, rotation, **kwargs):
+                calls.append(('pose', engine_id, tuple(position), rotation, kwargs['now']))
+                return native.set_pose(position, rotation, **kwargs)
+
+            def aim(engine_id, *angles):
+                calls.append(('aim', engine_id, angles))
+                return native.set_aim(*angles)
+
+            battle._binding = types.SimpleNamespace(set_vehicle_pose=pose,
+                                                     update_vehicle_aim=aim)
+            battle._update_bot_tracks = mock.Mock(return_value=True)
+            record = {'engine_id': 11, 'kind': kind, 'state': {'speed': 8.0}}
+            positions = []
+            for frame in range(128):
+                runtime.bigworld.now = 1.0 + frame / 60.0
+                costs = diagnostics.new_frame(frame + 1, lambda: 0.0) if sampled else None
+                battle._visible_frame_costs = costs
+                # Translation, turning, aim-only movement and exact repeats
+                # all retain their original timestamps and cache behavior.
+                tick = min(frame, 64)
+                battle._apply_record_pose(record, dict(
+                    x=0.0, y=0.0, z=tick / 10.0, yaw=tick / 100.0,
+                    pitch=0.1, roll=0.2,
+                    aim_yaw=min(frame, 96) / 50.0, gun_pitch=0.1))
+                positions.append((tuple(native.matrix.translation),
+                                  native.matrix.yaw, native.speed,
+                                  native._last_pose_time,
+                                  native.aim.turretMatrix.yaw))
+                if costs is not None:
+                    self.assertFalse(costs.snapshot()['failed'])
+            return (calls, positions, battle._update_bot_tracks.call_count,
+                    native.matrix.rotation_writes, native.matrix.translation_writes)
+
+        for kind in ('bot', 'player'):
+            with self.subTest(kind=kind):
+                self.assertEqual(replay(False, kind), replay(True, kind))
+
+    def test_frame_observer_is_bound_only_to_selected_visible_phases(self):
+        for frame_id, worker, enabled in ((1, False, True), (2, False, True),
+                                           (1, True, True), (1, False, False)):
+            with self.subTest(frame=frame_id, worker=worker, enabled=enabled):
+                runtime = fixtures._runtime()
+                runtime.bigworld.now = 1.0
+                battle = fixtures.BattleRuntimeContractTests()._live_frame_battle(runtime)
+                battle._worker_mode = worker
+                window = types.SimpleNamespace(enabled=enabled,
+                    begin=mock.Mock(return_value=frame_id), finish=mock.Mock())
+                battle._frame_diagnostics = window
+                events = []
+
+                def observe(name, argument):
+                    events.append((name, argument, battle._visible_frame_costs))
+
+                battle._sync = types.SimpleNamespace(
+                    advance=lambda now: observe('sync', now))
+                battle._drive_local = lambda dt: observe('local', dt)
+                battle._tick_critical_states = lambda dt: observe('critical', dt)
+                battle._advance_player_fire_authority = mock.Mock()
+                battle._publish_player_environment = mock.Mock()
+                with contextlib.redirect_stdout(io.StringIO()):
+                    battle._frame()
+                battle._fail.assert_not_called()
+                self.assertIsNone(battle._visible_frame_costs)
+                self.assertEqual(1.0, events[0][1])
+                sampled = frame_id == 1 and enabled and not worker
+                for name, argument, observer in events:
+                    self.assertEqual(sampled and name in ('sync', 'local'),
+                                     observer is not None)
+                    if name == 'local':
+                        self.assertAlmostEqual(.02, argument)
+                if enabled:
+                    snapshot = window.finish.call_args.kwargs['visible']
+                    self.assertEqual(sampled, snapshot is not None)
+                    if sampled:
+                        self.assertFalse(snapshot['failed'])
+                        self.assertEqual({'sync', 'local'}, set(snapshot['stages']))
+
+    def test_real_phase_failures_keep_round_failure_and_clear_observer(self):
+        for phase in ('sync', 'local'):
+            with self.subTest(phase=phase):
+                runtime = fixtures._runtime()
+                runtime.bigworld.now = 1.0
+                battle = fixtures.BattleRuntimeContractTests()._live_frame_battle(runtime)
+                battle._frame_diagnostics = _FrameDiagnostics(
+                    clock=lambda: 0.0, writer=lambda payload: None)
+                error = RuntimeError('phase failed')
+                observers = []
+
+                def fail(unused):
+                    observers.append(battle._visible_frame_costs)
+                    raise error
+
+                if phase == 'sync':
+                    battle._sync = types.SimpleNamespace(advance=fail)
+                else:
+                    battle._drive_local = fail
+                with contextlib.redirect_stdout(io.StringIO()):
+                    battle._frame()
+                battle._fail.assert_called_once_with(error)
+                battle._schedule.assert_not_called()
+                self.assertEqual(1, len(observers))
+                self.assertIsNotNone(observers[0])
+                self.assertEqual([], observers[0].stack)
+                self.assertIsNone(battle._visible_frame_costs)
+                self.assertIsNone(battle._local_frame_stages)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The latest Windows report still groups about 3.39 ms/frame under sync and another 2.52 ms/frame under local driving after excluding ground sampling and suspension solving. Those totals cannot identify the next safe optimization. This PR adds diagnostic detail; it does not implement or claim an FPS improvement.

Sample one visible frame per eight-frame block, rotating the selected position independently of player input. During sync playback and local driving, record calls, inclusive/self time, and per-call/per-frame maxima for pose, aim, tracks, motion/world probes, contacts, support, ground sampling, suspension solving, and presentation. Emit bounded `PERF visible_costs` summaries and attach detail to sampled slow intervals. Keep existing all-frame averages and report the separate sample denominator and diagnostic failures explicitly.

The observer retains only fixed stage names and numbers. Clock/scope failures discard the sample while preserving operation returns and exceptions. Workers do not bind it. Gameplay cadence, input processing, collision checks, interpolation, and native writes are unchanged. These timings measure Python boundaries containing native calls, not a census of native calls or rendering outside the callback.

Validation:

- `PYTHONPATH=tests PYTHONDONTWRITEBYTECODE=1 python3 -m unittest test_port_0922_battle_runtime test_port_0922_visible_diagnostics test_port_0922_snapshot_sync test_port_0922_vehicle_physics test_port_0922_tank_collision`: 1,050 passed.
- Re-ran 134 existing motion, suspension, contact, ground, track, and remote-presentation tests with an active observer: passed.
- CPython 2.7.18 in-memory compilation: all 113 client source files passed.
- Linux CPython 2.7.18 synthetic overhead check, five runs of 8,192 frames with 29 remote actors and one local update: sampling added 0.084–0.088 ms/frame over direct stub calls. This excludes actual native work and is not Windows performance evidence.

Exact #1513 Windows reports remain necessary to identify the remaining hotspot and measure sampler overhead and frame pacing. No gameplay performance gain has been established by this PR.
