### PR TITLE
perf: reuse tree sweep polygons within each motion query

### DIFF
--- a/src/res/scripts/client/gui/mods/offline_lan_0922/destructibles_sensor.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/destructibles_sensor.py
@@ -2859,10 +2859,9 @@ def _tree_xz_zonotope_hull_1513(sweep_box):
 	return tuple(lower[:-1] + upper[:-1])
 
 
-def _point_near_tree_sweep_1513(x, z, sweep_box,
+def _point_near_tree_hull_1513(x, z, hull,
 		contact_radius=_SOLID_CONTACT_RADIUS_1513):
-	"""Test a tree origin against a swept zonotope plus its circular skin."""
-	hull = _tree_xz_zonotope_hull_1513(sweep_box)
+	"""Test a tree origin against a prepared sweep polygon and circular skin."""
 	if not hull:
 		return False
 	point = (float(x), float(z))
@@ -2902,13 +2901,13 @@ def _point_near_tree_sweep_1513(x, z, sweep_box,
 
 @observed('destructible.tree_candidates')
 def _tree_candidates_for_sweeps_1513(
-		chunk_id, registry, sweep_boxes, tree_type,
+		chunk_id, registry, sweep_boxes, tree_type, sweep_hulls,
 		contact_radius=_SOLID_CONTACT_RADIUS_1513):
-	"""Return exact named tree records and known isolated contacts."""
+	"""Find exact tree contacts, sharing polygons within this motion query."""
 	candidates = {}
 	isolated_hits = set()
 	seen = set()
-	for sweep_box in sweep_boxes:
+	for sweep_index, sweep_box in enumerate(sweep_boxes):
 		minimum_x, maximum_x, minimum_z, maximum_z = (
 			_box_xz_bounds(sweep_box))
 		minimum_x -= contact_radius
@@ -2925,8 +2924,15 @@ def _tree_candidates_for_sweeps_1513(
 				if (item[4] != tree_type or
 						not _normalized_filename(item[5])):
 					continue
-				if not _point_near_tree_sweep_1513(
-						item[1], item[3], sweep_box, contact_radius):
+				# The polygon depends only on this immutable sweep slice, not
+				# the tree or chunk. Build it only when a candidate needs it;
+				# empty bins must not pay for an unused convex hull.
+				hull = sweep_hulls.get(sweep_index)
+				if hull is None:
+					hull = _tree_xz_zonotope_hull_1513(sweep_box)
+					sweep_hulls[sweep_index] = hull
+				if not _point_near_tree_hull_1513(
+						item[1], item[3], hull, contact_radius):
 					continue
 				seen.add(identity)
 				if _destructible_isolated_1513(chunk_id, item_index):
@@ -4824,12 +4830,16 @@ def _tree_motion_resolution_1513(
 		return 'hard', {}, set(), chunk_status, set()
 	candidates = {}
 	isolated_hits = set()
+	# Geometry reuse ends with this query. A later proposal/commit, vehicle,
+	# pose or round always builds its own polygons and checks live tree state.
+	sweep_hulls = {}
 	for chunk_id in sorted(scan_chunks):
 		if chunk_status.get(chunk_id) != 'ready':
 			continue
 		chunk_candidates, chunk_isolated_hits = (
 			_tree_candidates_for_sweeps_1513(
-				chunk_id, state['chunks'][chunk_id], sweep_boxes, tree_type))
+				chunk_id, state['chunks'][chunk_id], sweep_boxes, tree_type,
+				sweep_hulls))
 		candidates.update(chunk_candidates)
 		isolated_hits.update(chunk_isolated_hits)
 	if len(candidates) > _TREE_CONTACT_TOKEN_LIMIT_1513:
@@ -5355,6 +5365,8 @@ def _fell_trees_near(
 				1 if cid == _current_cid else 2,
 				-_prewarm_priority.get(cid, (0.0, 0.0))[0],
 				-_prewarm_priority.get(cid, (0.0, 0.0))[1], cid))
+		_tree_vehicle_box = None
+		_tree_sweep_hulls = {}
 		for cid in _cid_order:
 			combat_count('destructible_body_chunks')
 			if _destructible_isolated_1513(cid):
@@ -5782,16 +5794,17 @@ def _fell_trees_near(
 				continue
 			if not registry['count']:
 				continue
-			_tree_vehicle_box = vehicle_box
-			if vel < 0.0:
-				# Preserve the legacy scanner's fixed 0.8 m reverse reach.  Its
-				# velocity-scaled look-ahead historically applied only forwards.
-				_tree_vehicle_box = _vehicle_swept_box(
-					pos, yaw, vel, bbox, travel_reach=0.8)
+			if _tree_vehicle_box is None:
+				_tree_vehicle_box = vehicle_box
+				if vel < 0.0:
+					# Preserve the legacy scanner's fixed 0.8 m reverse reach.
+					# Prepare this query's geometry once across all chunks.
+					_tree_vehicle_box = _vehicle_swept_box(
+						pos, yaw, vel, bbox, travel_reach=0.8)
 			_tree_candidates, unused_tree_isolated_hits = (
 				_tree_candidates_for_sweeps_1513(
 					cid, registry, (_tree_vehicle_box,),
-					AreaDestructibles.DESTR_TYPE_TREE, 0.0))
+					AreaDestructibles.DESTR_TYPE_TREE, _tree_sweep_hulls, 0.0))
 			_tree_candidate_keys = set(_tree_candidates)
 			for (_ti, _tx, _ty, _tz, _ttyp, _tfn, _thp, _tmass,
 					_world_boxes, _contact_radius) in _nearby_destructibles(

--- a/tests/test_port_0922_destructibles.py
+++ b/tests/test_port_0922_destructibles.py
@@ -1266,6 +1266,8 @@ class DestructiblesCompatibilityTests(unittest.TestCase):
 
         sweeps = destructibles_sensor._tree_pose_sweep_boxes_1513(
             start, start_yaw, end, end_yaw, bbox)
+        hulls = tuple(destructibles_sensor._tree_xz_zonotope_hull_1513(sweep)
+                      for sweep in sweeps)
 
         for sample in range(101):
             fraction = sample / 100.0
@@ -1283,9 +1285,105 @@ class DestructiblesCompatibilityTests(unittest.TestCase):
                     world_z = (position.z - sine * local_x +
                                cosine * local_z)
                     self.assertTrue(any(
-                        destructibles_sensor._point_near_tree_sweep_1513(
-                            world_x, world_z, sweep, 0.0)
-                        for sweep in sweeps))
+                        destructibles_sensor._point_near_tree_hull_1513(
+                            world_x, world_z, hull, 0.0)
+                        for hull in hulls))
+
+    def test_tree_sweep_polygon_is_shared_across_trees_and_chunks_only_per_query(self):
+        positions = tuple(_Vector(-0.5, 0.0, 2.0 + index * 0.05)
+                          for index in range(12))
+        bbox = ((-1.0, -1.0, -3.0), (1.0, 1.0, 3.0), None)
+        (manager, area, bigworld, math_module, descriptor,
+         authority, destroyed, destroy_calls) = self._tree_motion_fixture(
+             positions, bbox=bbox)
+        manager.set_chunk_count(23, len(positions))
+        area.chunkIDFromPosition = lambda point: 22 if point.x < 0.0 else 23
+        bigworld.wg_getDestructibleMatrix.side_effect = (
+            lambda space, chunk, index: _ItemMatrix(_Vector(
+                -0.5 if chunk == 22 else 0.5, 0.0, positions[index].z)))
+        expected = {(chunk, index, None)
+                    for chunk in (22, 23) for index in range(12)}
+
+        with mock.patch.dict(sys.modules, {
+                'AreaDestructibles': area, 'BigWorld': bigworld,
+                'Math': math_module}), mock.patch.object(
+                    destructibles_sensor, '_get_destr_authority',
+                    return_value=authority), mock.patch.object(
+                    destructibles_sensor, '_tree_xz_zonotope_hull_1513',
+                    wraps=destructibles_sensor._tree_xz_zonotope_hull_1513
+                    ) as build_hull:
+            # Registration has a per-render-tick name budget. Observe both
+            # chunks becoming ready before measuring the shared query.
+            bigworld.time = lambda: float(tick)
+            for tick in range(8):
+                warmed = destructibles_sensor.prewarm_tree_registry(
+                    1, _Vector(), 0.0, descriptor, 1.0,
+                    priority_chunks=(22, 23))
+                if set(warmed['ready_chunks']) == {22, 23}:
+                    break
+            self.assertEqual({22, 23}, set(warmed['ready_chunks']))
+            build_hull.assert_not_called()
+            first = destructibles_sensor._tree_motion_proposal(
+                1, _Vector(), 0.0, _Vector(0.0, 0.0, 0.2), 0.0,
+                6.0, descriptor, 1.0)
+            self.assertEqual(expected, set(first['token']))
+            self.assertTrue(first['requires_commit'])
+            self.assertEqual(1, build_hull.call_count)
+
+            # The next proposal checks current destruction state even at the
+            # same pose. Geometry and physical verdicts never survive a query.
+            destroyed.update(expected)
+            second = destructibles_sensor._tree_motion_proposal(
+                1, _Vector(), 0.0, _Vector(0.0, 0.0, 0.2), 0.0,
+                6.0, descriptor, 1.1)
+            self.assertEqual(expected, set(second['token']))
+            self.assertFalse(second['requires_commit'])
+            self.assertEqual(2, build_hull.call_count)
+
+            # Turning the long hull away removes those contacts, although
+            # the same trees and sweep index are examined again.
+            turned = destructibles_sensor._tree_motion_proposal(
+                1, _Vector(), math.pi / 2.0,
+                _Vector(0.0, 0.0, 0.2), math.pi / 2.0,
+                6.0, descriptor, 1.2)
+            self.assertEqual('clear', turned['status'])
+            self.assertIsNone(turned['token'])
+            self.assertEqual(3, build_hull.call_count)
+        self.assertEqual([], destroy_calls)
+
+    def test_tree_sweep_without_eligible_candidates_does_not_build_polygon(self):
+        sweep = ((0.0, 0.0, 0.0),
+                 ((1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0)))
+        bin_key = destructibles_sensor._destructible_bin_key(0.0, 0.0)
+        ineligible = [(1, 0.0, 0.0, 0.0, 2, 'model'),
+                      (2, 0.0, 0.0, 0.0, 1, '')]
+        with mock.patch.object(
+                destructibles_sensor, '_tree_xz_zonotope_hull_1513',
+                side_effect=AssertionError('unused polygon built')):
+            for registry in ({'bins': {}}, {'bins': {bin_key: ineligible}}):
+                hulls = {}
+                self.assertEqual(({}, set()),
+                    destructibles_sensor._tree_candidates_for_sweeps_1513(
+                        22, registry, (sweep,), 1, hulls))
+                self.assertEqual({}, hulls)
+
+    def test_legacy_tree_scanner_reuses_polygon_without_skipping_destruction(self):
+        positions = tuple(_Vector(0.0, 0.0, index * 0.1) for index in range(8))
+        (unused_manager, area, bigworld, math_module, descriptor,
+         authority, unused_destroyed, destroy_calls) = self._tree_motion_fixture(
+             positions)
+        with mock.patch.dict(sys.modules, {
+                'AreaDestructibles': area, 'BigWorld': bigworld,
+                'Math': math_module}), mock.patch.object(
+                    destructibles_sensor, '_get_destr_authority',
+                    return_value=authority), mock.patch.object(
+                    destructibles_sensor, '_tree_xz_zonotope_hull_1513',
+                    wraps=destructibles_sensor._tree_xz_zonotope_hull_1513
+                    ) as build_hull:
+            destructibles_sensor._fell_trees_near(
+                1, _Vector(), 0.0, 1.0, descriptor)
+        self.assertEqual(1, build_hull.call_count)
+        self.assertEqual(list(range(8)), sorted(call[2] for call in destroy_calls))
 
     def test_tree_commit_applies_only_requested_subset_and_rejects_foreign(self):
         positions = (_Vector(0.0, 0.0, 4.0),


### PR DESCRIPTION
Tree contact scanning rebuilt the same swept-hull convex polygon for every nearby candidate tree, including candidates in adjacent chunks. Build each needed polygon once per motion query and reuse it across those candidates. For a query covering 24 trees in two chunks, polygon construction drops from 24 calls to one while returning the same contacts.

Both explicit motion proposals/commits and the existing proximity scanner use this path. Geometry is created lazily, so empty or ineligible bins do not build a polygon. Reuse ends at the query boundary; subsequent poses, vehicles, rounds and commits prepare fresh geometry and inspect current tree state. Candidate traversal, exact point/skin checks, isolation handling, destruction/publication, contact radius and reverse reach remain intact. No input-dependent skipping or cadence reduction is introduced.

The Windows report `wot-error-report-20260911-070554-74d41baca5fc.zip` confirms the PR #154 diagnostic build. Its seven complete live windows average 46.1 FPS over 210 seconds. Sampled local motion checks average 1.56 ms/frame, including 0.39 ms in the world-probe helper; this change removes a demonstrated repeated calculation within the remaining motion work. The report does not separately time polygon generation, so its share and the resulting Windows FPS gain remain unmeasured. This optimization is independent of the diagnostic PR.

Validation:

- `PYTHONPATH=tests PYTHONDONTWRITEBYTECODE=1 python3 -m unittest test_port_0922_destructibles test_port_0922_battle_runtime test_port_0922_world_collision`: 1,249 tests passed.
- CPython 2.7.18 in-memory compilation: all 112 client source files passed.
- Linux CPython 2.7.18 comparison against the parent source: 25 synthetic combinations of forward, reverse, lateral, turning and wrapped-yaw motion with 0–64 candidates returned identical contacts. Three runs of 256 queries per case; median query time for 32 candidates fell from 0.970 to 0.341 ms straight, and 1.114 to 0.487 ms turning. These are candidate-scan timings, not whole-frame or Windows FPS measurements.
- Regression coverage includes multi-chunk reuse, fresh queries after destruction or heading changes, zero polygon work for empty/ineligible bins, dense swept-corner coverage, and proximity destruction/reverse-reach behavior.

Exact #1513 Windows frame pacing and gameplay performance remain the runtime acceptance boundary.
