### PR TITLE
fix: resolve WPR client log from the session game root

### DIFF
--- a/launcher/capture_performance.ps1
+++ b/launcher/capture_performance.ps1
@@ -42,14 +42,21 @@ try {
     }
     $wpr = (Get-Command wpr.exe -ErrorAction Stop).Source
     $source = $session.sources.'visible-client'
+    if ($null -eq $source -or $source.kind -ne 'game' -or
+        [string]::IsNullOrWhiteSpace($session.gameRoot)) {
+        throw 'Session visible-client log checkpoint or gameRoot is missing.'
+    }
     if ($source.blocked) { throw 'Session client log is blocked.' }
+    # Checkpoints contain metadata only. Match error_reports._source_path.
+    $sourcePath = Join-Path $session.gameRoot 'offline-player-python.log'
     $position = [long]$source.offset
     $carry = ''
     $deadline = [DateTime]::UtcNow.AddSeconds($WaitSeconds)
     $live = $false
+    Write-Status "waiting_for_live: log=$sourcePath timeout_seconds=$WaitSeconds"
     while ([DateTime]::UtcNow -lt $deadline -and (Same-Session)) {
-        if (Test-Path -LiteralPath $source.path) {
-            $stream = [IO.File]::Open($source.path, [IO.FileMode]::Open,
+        if (Test-Path -LiteralPath $sourcePath) {
+            $stream = [IO.File]::Open($sourcePath, [IO.FileMode]::Open,
                 [IO.FileAccess]::Read, [IO.FileShare]::ReadWrite)
             try {
                 if ($stream.Length -lt $position) { $position = 0 }
@@ -99,7 +106,8 @@ try {
     Move-Item -LiteralPath $pending -Destination $final
     Write-Status "complete: $final"
 } catch {
-    Write-Status ('unavailable: ' + $_.Exception.Message)
+    Write-Status ('unavailable: line={0} {1}' -f
+        $_.InvocationInfo.ScriptLineNumber, $_.Exception.Message)
 } finally {
     if ($started) {
         # This instance was successfully started by this invocation only.


### PR DESCRIPTION
The elevated `02f278ea89b9` report failed before starting WPR with `Cannot bind argument to parameter 'LiteralPath' because it is null`. The helper read `$source.path`, but launcher source checkpoints store metadata (`kind`, `offset`, identity and status) and deliberately contain no path.

Resolve `offline-player-python.log` from the session's `gameRoot`, matching `error_reports._source_path`. Retain the recorded offset, check the source metadata, and log the waiting path plus the line number of any subsequent failure. Only the adjacent launcher capture script changes.

Stacked on #156. Checked the actual Python checkpoint producer/path resolver and `git diff --check`; no test suite or CI changes. PowerShell/WPR execution is not available in this Linux environment, so the next Windows capture must confirm recording and ETL finalization. The prior report already confirms that elevation passed and `wpr.exe` was found.
