### PR TITLE
Draw the spotting ribbon from the detection the server credited

### DIFF
--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -1328,7 +1328,25 @@ already revealed adds nothing, while an enemy that goes dark and reappears
 credits whoever finds it that time. This replaces a count of every enemy the
 vehicle had ever directly seen, which had no team fence and could never drop.
 Patrol Duty (`scout`) reads the same number, and earned experience moves with
-it.
+it. `scripts/common/battle_results_shared.py` fixes the per-enemy half of that
+rule exactly: `VEH_INTERACTION_DETAILS` declares `('spotted', 'B', 1, 0)`, so a
+detail row cannot carry a second detection of the same vehicle, and the
+in-battle ribbon agrees because `_MultiVehicleRibbon.getCount` is
+`len(self._hits)` keyed by vehicle id.
+
+The same decision owns the in-battle ribbon. The visible client used to raise
+it from a local presentation edge — the enemy's model appearing while this
+client's own line of sight was clear — but that edge is the 565 m entity AOI,
+which an enemy a teammate revealed across the map crosses long after the team
+detected it. The ribbon therefore appeared for detections the results column
+never counted. A client cannot close that gap alone: it knows its own line of
+sight and the team's merged spot lease, never whether its own sighting is what
+revealed the enemy. `_commit_detections` now publishes a `detection` event to
+the human observer it credited, and the client draws the stock `SPOTTED` and
+`TARGET_VISIBILITY` pair from that event alone. `TARGET_VISIBILITY` reaches
+only `TriggersManager.PLAYER_DETECT_ENEMY` in #1513 — `feedback_adaptor` does
+not forward it to `onPlayerFeedbackReceived` — so no damage-log or ribbon
+consumer loses anything by moving with it.
 
 Ammunition belongs to whoever owns the gun, so Fadin's medal takes the shell
 total from the producer rather than inferring it. The visible client puts

--- a/server/lan_battle_server.py
+++ b/server/lan_battle_server.py
@@ -12047,7 +12047,8 @@ class BattleState:
         observer already revealed adds nothing, while an enemy whose lease
         expired and is found again credits whoever finds it that time.  This
         is the ``spotted`` column the results screen shows and the count
-        Scout (``scout``) reads.
+        Scout (``scout``) reads, and ``_publish_detection`` gives a human
+        observer's client the in-battle ribbon for the same decision.
         """
         observers = [(("bot", int(bot_id)), spotted)
                      for bot_id, spotted in self.bot_spotted.items()]
@@ -12075,8 +12076,28 @@ class BattleState:
                     interaction["spotted"] = 1
                     row = self._statistics_row(*reporter)
                     row["spotted"] = int(row.get("spotted", 0)) + 1
+                    self._publish_detection(reporter, target)
             self.team_visible_targets[team] = set(visible) | set(
                 self.team_lit_targets.get(team, ()))
+
+    def _publish_detection(self, observer, target):
+        """Tell a human observer's client about the detection it just earned.
+
+        #1513 draws the in-battle spotting ribbon from the same detection the
+        results column counts, so the authority that owns the statistic owns
+        the ribbon.  A visible client cannot decide this for itself: it knows
+        only its own line of sight and the team's merged spot lease, never
+        whether its own sighting is what revealed the enemy.  A Bot has no
+        ribbon to draw, so only a human observer is published.
+        """
+        if observer[0] != "player":
+            return False
+        self.pending_events.append({
+            "kind": "detection",
+            "observer_kind": "player", "observer_id": int(observer[1]),
+            "target_kind": str(target[0]), "target_id": int(target[1]),
+        })
+        return True
 
     def _direct_spotters(self, target):
         """Return every enemy observer that directly sees ``target``.

--- a/server/lan_battle_server.py
+++ b/server/lan_battle_server.py
@@ -13504,11 +13504,21 @@ class BattleState:
             # loss, or epoch change cannot invalidate this batch between
             # extraction and delivery; the reliable outbox fences its snapshot.
             if events_message is not None:
+                # The client accepts at most 256 events per envelope. A full
+                # human roster can earn 450 detections in one observation,
+                # so preserve every cause across ordered same-tick batches.
+                event_batches = [events_message]
+                if len(events) > 256:
+                    event_batches = [
+                        dict(events_message, events=events[offset:offset + 256])
+                        for offset in range(0, len(events), 256)]
                 for endpoint in recipients:
                     if id(endpoint) in failed_receipt_recipient_ids:
                         continue
-                    if not endpoint.offer_reliable(events_message):
-                        failed_event_recipients.append(endpoint)
+                    for event_batch in event_batches:
+                        if not endpoint.offer_reliable(event_batch):
+                            failed_event_recipients.append(endpoint)
+                            break
             snapshot_round_id = self.round_id
             snapshot_tick = self.tick
             snapshot_state_revision = self.state_revision

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -210,7 +210,7 @@ _PROJECTILE_POSE_CACHE_MISS = object()
 _SIMPLE_EVENT_KINDS = (
     'authority', 'bot_manifest', 'vehicle_statistics', 'destructible',
     'projectile_ricochet', 'projectile_impact', 'battle_result', 'assist',
-    'stun')
+    'stun', 'detection')
 _COMBAT_EVENT_KINDS = (
     'health', 'hit', 'bot_hit', 'bot_human_hit', 'bot_bot_hit')
 _SHOT_OCCLUSION_EPSILON = 1.0e-3
@@ -9245,10 +9245,12 @@ class BattleRuntime(object):
         """
         if self._worker_mode:
             return False
-        assister = self._records.get(self._assist_entity_key(event, 'assister'))
+        assister = self._records.get(
+            self._feedback_entity_key(event, 'assister', 'assist'))
         if assister is None or not assister.get('local'):
             return False
-        target = self._records.get(self._assist_entity_key(event, 'target'))
+        target = self._records.get(
+            self._feedback_entity_key(event, 'target', 'assist'))
         if target is None:
             raise RuntimeError('assist event has no known target')
         name = self._ASSIST_EVENT_TYPES.get(event.get('category'))
@@ -9272,14 +9274,43 @@ class BattleRuntime(object):
                 damage, self._attack_reason('SHOT', 0)))}])
         return True
 
+    def _apply_detection_event(self, event):
+        """Draw the stock spotting ribbon the server just credited.
+
+        ``PlayerAvatar.onBattleEvents`` forwards only the controlled vehicle's
+        own events, so publish nothing unless this client is the observer.
+        The server credits one detection per enemy, at the moment the enemy
+        became visible to a team that could not see it, which is the same
+        number the results column shows.  Seeing an enemy a teammate had
+        already revealed earns neither.
+
+        Like the assist above, this needs the enemy's record only for its
+        engine id: the stock detection ribbon merges by vehicle id and the
+        visibility trigger carries one, so neither waits for the entity to
+        finish entering the world.
+        """
+        if self._worker_mode:
+            return False
+        observer = self._records.get(
+            self._feedback_entity_key(event, 'observer', 'detection'))
+        if observer is None or not observer.get('local'):
+            return False
+        target = self._records.get(
+            self._feedback_entity_key(event, 'target', 'detection'))
+        if target is None:
+            raise RuntimeError('detection event has no known target')
+        self._run_optional_feature(
+            'spotting feedback', self._present_direct_spot, (target,))
+        return True
+
     @staticmethod
-    def _assist_entity_key(event, role):
+    def _feedback_entity_key(event, role, label):
         """Resolve one ``<role>_kind``/``<role>_id`` pair to a record key."""
         kind = event.get(role + '_kind')
         actor = event.get(role + '_id')
         if kind not in ('player', 'bot') or actor is None:
             raise RuntimeError(
-                'assist event has an invalid %s identity' % role)
+                '%s event has an invalid %s identity' % (label, role))
         return '%s:%s' % (kind, actor)
 
     def _apply_ordered_event(self, event):
@@ -9301,6 +9332,8 @@ class BattleRuntime(object):
             self._apply_vehicle_statistics_event(event)
         elif kind == 'assist':
             self._apply_assist_event(event)
+        elif kind == 'detection':
+            self._apply_detection_event(event)
         elif kind == 'stun':
             target = self._records.get(self._stun_entity_key(event))
             if target is None:
@@ -23280,7 +23313,12 @@ class BattleRuntime(object):
         return model_visible, marker_visible
 
     def _present_direct_spot(self, record):
-        """Publish the one stock ribbon and sound for a first direct spot."""
+        """Publish the one stock ribbon and sound for a credited detection.
+
+        The server owns the decision and sends it once per enemy; the latch
+        below keeps a repeated delivery to the single ribbon #1513 draws,
+        which merges its own detections by vehicle id anyway.
+        """
         if record.get('spot_feedback_sent'):
             return False
         feedback_common = getattr(
@@ -23911,10 +23949,11 @@ class BattleRuntime(object):
                 record, entity, remembered)
             if (visible, marker_visible) != previous:
                 changed = True
-            if visible and not previous[0] and direct_seen:
-                self._run_optional_feature(
-                    'spotting feedback', self._present_direct_spot,
-                    (record,))
+            # The spotting ribbon is not a local presentation edge.  This
+            # transition is the enemy's model appearing inside the 565 m
+            # entity AOI, which happens for an enemy a teammate revealed long
+            # before, so it drew a ribbon the results column never counted.
+            # The server publishes the detection it actually credited.
             if visible and bool(record.get('direct_spot_visible', False)):
                 spotted_records.append(record)
         self._publish_spotted_targets(spotted_records)

--- a/tests/test_port_0922_battle_achievements.py
+++ b/tests/test_port_0922_battle_achievements.py
@@ -1236,6 +1236,53 @@ class DetectionTests(unittest.TestCase):
         state._commit_detections()
         self.assertEqual(0, state._statistics_row('player', 1)['spotted'])
 
+    @staticmethod
+    def _detections(state):
+        return [event for event in state.pending_events
+                if event.get('kind') == 'detection']
+
+    def test_a_credited_detection_reaches_its_human_observer(self):
+        state, unused_player = self._battle()
+        state.player_spotted = {1: frozenset({('bot', 1)})}
+        state._commit_detections()
+
+        # #1513 draws the in-battle ribbon from the detection the results
+        # column counts, so the server publishes the one it credited.
+        self.assertEqual([{
+            'kind': 'detection',
+            'observer_kind': 'player', 'observer_id': 1,
+            'target_kind': 'bot', 'target_id': 1,
+        }], self._detections(state))
+
+        # The same enemy is counted once, so it is published once.
+        state._commit_detections()
+        self.assertEqual(1, len(self._detections(state)))
+
+    def test_a_detection_by_a_bot_publishes_nothing(self):
+        state, unused_player = self._battle()
+        state.bot_states[2]['team'] = 1
+        state.bot_spotted = {2: frozenset({('bot', 1)})}
+        state._commit_detections()
+
+        self.assertEqual(1, state._statistics_row('bot', 2)['spotted'])
+        self.assertEqual([], self._detections(state))
+
+    def test_seeing_an_enemy_the_team_already_lit_publishes_nothing(self):
+        state, unused_player = self._battle()
+        state.bot_states[2]['team'] = 1
+        state.bot_spotted = {2: frozenset({('bot', 1)})}
+        state._replace_team_lit({1: {('bot', 1): float('inf')}})
+        state._commit_detections()
+
+        # The human now sees the enemy its teammate revealed.  Retail counts
+        # no detection for it, so no ribbon may be drawn either.
+        state.player_spotted = {1: frozenset({('bot', 1)})}
+        state._replace_team_lit({1: {('bot', 1): float('inf')}})
+        state._commit_detections()
+
+        self.assertEqual(0, state._statistics_row('player', 1)['spotted'])
+        self.assertEqual([], self._detections(state))
+
 
 class SpottingAssistTests(unittest.TestCase):
     """A spotting assist needs a blind shooter, and is shared by spotters."""

--- a/tests/test_port_0922_battle_achievements.py
+++ b/tests/test_port_0922_battle_achievements.py
@@ -1267,6 +1267,64 @@ class DetectionTests(unittest.TestCase):
         self.assertEqual(1, state._statistics_row('bot', 2)['spotted'])
         self.assertEqual([], self._detections(state))
 
+    def test_full_roster_detections_preserve_the_whole_tick_on_the_wire(self):
+        state, unused_player = self._battle()
+        state.bot_states = {}
+        state.bot_manifest = []
+        state.players = {
+            index: Player(index, _NullSocket(), ('127.0.0.1', index),
+                          team=1 if index <= 15 else 2)
+            for index in range(1, 31)}
+        state.player_spotted = {
+            index: {('player', target_id)
+                    for target_id, target in state.players.items()
+                    if target.team != observer.team}
+            for index, observer in state.players.items()}
+        state._commit_detections()
+        self.assertEqual(450, len(self._detections(state)))
+        # A co-occurring existing event must survive the detection burst too.
+        state.pending_events.append({
+            'kind': 'assist', 'category': 'radio', 'damage': 75,
+            'assister_kind': 'player', 'assister_id': 1,
+            'target_kind': 'player', 'target_id': 16})
+        expected = list(state.pending_events)
+        delivered = {index: [] for index in state.players}
+        for index, endpoint in state.players.items():
+            endpoint.offer_reliable = (
+                lambda message, index=index:
+                delivered[index].append(message) or True)
+            endpoint.offer_snapshot = endpoint.offer_reliable
+
+        state.tick_once(1.0 / 30.0)
+
+        for messages in delivered.values():
+            event_messages = [message for message in messages
+                              if message['type'] == 'events']
+            # Exercise the actual consumer limit instead of restating it.
+            received = []
+            client = lan_client_module.LANClient(
+                '127.0.0.1', 28782, 'Observer', 'ussr:R11_MS-1',
+                on_event=lambda kind, message: received.extend(
+                    message['events']) if kind == 'events' else None)
+            client.round_id = state.round_id
+            client.phase = 'battle'
+            for message in event_messages:
+                client._handle_message(message)
+            self.assertEqual(
+                ['%d:%d:%d' % (state.round_id, state.tick, index)
+                 for index in range(len(expected))],
+                [event['event_id'] for event in received])
+            self.assertEqual(expected, [
+                {key: value for key, value in event.items()
+                 if key != 'event_id'} for event in received])
+            snapshot_index = next(
+                index for index, message in enumerate(messages)
+                if message['type'] == 'snapshot')
+            self.assertTrue(all(
+                message['type'] == 'events'
+                for message in messages[:snapshot_index]))
+            self.assertEqual(len(event_messages), snapshot_index)
+
     def test_seeing_an_enemy_the_team_already_lit_publishes_nothing(self):
         state, unused_player = self._battle()
         state.bot_states[2]['team'] = 1

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -24218,12 +24218,10 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertTrue(enemy.model.visible)
         battle._binding.start_vehicle_visual.assert_called_once_with(
             1000, True)
-        self.assertEqual(1, len(battle._avatar.battle_events))
-        events = battle._avatar.battle_events[0]
-        self.assertEqual([0, 12], [event['eventType'] for event in events])
-        self.assertEqual([1000, 1000],
-                         [event['targetID'] for event in events])
-        self.assertEqual(3, events[1]['details'])
+        # Presentation only.  The ribbon and its sound follow the server's
+        # ``detection`` event, which knows whether this sighting is what
+        # revealed the enemy to the team.
+        self.assertEqual([], battle._avatar.battle_events)
 
         runtime.bigworld.wg_collideSegment = lambda *unused: (_Vector(),)
         self.assertFalse(battle._update_spotting(10.9))
@@ -24239,7 +24237,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
         # first-spot ribbon or detection sound.
         runtime.bigworld.wg_collideSegment = lambda *unused: None
         self.assertTrue(battle._update_spotting(20.9))
-        self.assertEqual(1, len(battle._avatar.battle_events))
+        self.assertEqual([], battle._avatar.battle_events)
 
     def test_destroyed_enemy_wreck_does_not_require_spot_history(self):
         runtime = _runtime()
@@ -24628,7 +24626,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
         battle._binding.start_vehicle_visual.assert_not_called()
         battle._binding.start_vehicle_minimap.assert_not_called()
 
-    def test_team_relay_visibility_does_not_claim_a_direct_spot(self):
+    def test_a_local_sighting_of_a_team_lit_enemy_draws_no_ribbon(self):
         runtime = _runtime()
         battle = BattleRuntime(runtime)
         battle.client = _Client()
@@ -24654,20 +24652,22 @@ class BattleRuntimeContractTests(unittest.TestCase):
             'engine_id': 12, 'network_id': 17, 'kind': 'bot',
             'ready': True, 'local': False, 'presentation': True,
             'tombstone': False, 'spot_visible': False,
-            'spot_until': 0.0, 'radio_spot_until': 0.0,
+            'spot_until': 0.0, 'radio_spot_until': 20.0,
             'spot_next': 10.0,
             'state': {'team': 2, 'health': 500, 'alive': True}}
         battle._records = {'bot:17': record}
-        sightings = iter((False, True))
-        battle._spot_line_of_sight = (
-            lambda *unused, **unused_kwargs: next(sightings))
+        battle._spot_line_of_sight = mock.Mock(return_value=True)
 
         self.assertTrue(battle._update_spotting(10.0))
+        # Seeing an enemy the team had already revealed is not a detection,
+        # and the model appearing inside the entity AOI is not one either.
+        # Only the server knows which sighting revealed the enemy, so the
+        # ribbon waits for its ``detection`` event.
         self.assertTrue(record['spot_visible'])
         self.assertNotIn('spot_feedback_sent', record)
         self.assertEqual([], battle._avatar.battle_events)
 
-    def test_direct_spot_feedback_failure_keeps_spotting_report_alive(self):
+    def test_a_first_local_sighting_reports_without_drawing_a_ribbon(self):
         runtime = _runtime()
         battle = BattleRuntime(runtime)
         battle.client = _Client()
@@ -24687,8 +24687,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
         battle._spot_line_of_sight = mock.Mock(return_value=True)
         battle._set_record_spot_visibility = lambda record, visible: \
             record.update(spot_visible=bool(visible)) or bool(visible)
-        battle._present_direct_spot = mock.Mock(
-            side_effect=RuntimeError('battle ribbon callback failed'))
+        battle._present_direct_spot = mock.Mock()
         battle._publish_spotted_targets = mock.Mock()
         record = {
             'engine_id': 12, 'network_id': 17, 'kind': 'bot',
@@ -24698,14 +24697,11 @@ class BattleRuntimeContractTests(unittest.TestCase):
             'state': {'team': 2, 'health': 500, 'alive': True}}
         battle._records = {'bot:17': record}
 
-        with contextlib.redirect_stdout(io.StringIO()) as log:
-            self.assertTrue(battle._update_spotting(10.0))
+        self.assertTrue(battle._update_spotting(10.0))
 
         self.assertTrue(record['spot_visible'])
         battle._publish_spotted_targets.assert_called_once_with([record])
-        self.assertEqual(
-            1, log.getvalue().count(
-                'optional spotting feedback disabled for this round'))
+        battle._present_direct_spot.assert_not_called()
 
     def test_direct_spotting_observer_is_only_the_local_human(self):
         runtime = _runtime()
@@ -30974,6 +30970,105 @@ class AssistFeedTests(unittest.TestCase):
 
         with self.assertRaises(RuntimeError):
             battle._apply_assist_event(self._event(category='ramming'))
+
+
+class DetectionFeedTests(unittest.TestCase):
+    """The spotting ribbon follows the detection the server credited."""
+
+    def _battle(self):
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        battle._records = {
+            'player:1': {'engine_id': 10, 'local': True,
+                         'state': {'team': 1, 'alive': True}},
+            'player:2': {'engine_id': 11, 'local': False,
+                         'state': {'team': 1, 'alive': True}},
+            'bot:7': {'engine_id': 17, 'local': False,
+                      'state': {'team': 2, 'alive': True}},
+        }
+        return battle, runtime
+
+    @staticmethod
+    def _event(**overrides):
+        event = {
+            'kind': 'detection',
+            'observer_kind': 'player', 'observer_id': 1,
+            'target_kind': 'bot', 'target_id': 7,
+        }
+        event.update(overrides)
+        return event
+
+    def test_a_credited_detection_draws_the_stock_ribbon(self):
+        battle, runtime = self._battle()
+        types_ = runtime.battle_feedback_common.BATTLE_EVENT_TYPE
+
+        self.assertTrue(battle._apply_detection_event(self._event()))
+
+        events = runtime.bigworld.avatar.battle_events[-1]
+        self.assertEqual(
+            [int(types_.SPOTTED), int(types_.TARGET_VISIBILITY)],
+            [entry['eventType'] for entry in events])
+        self.assertEqual([17, 17], [entry['targetID'] for entry in events])
+        self.assertTrue(battle._records['bot:7']['spot_feedback_sent'])
+
+    def test_the_same_enemy_never_draws_a_second_ribbon(self):
+        battle, runtime = self._battle()
+
+        self.assertTrue(battle._apply_detection_event(self._event()))
+        published = len(runtime.bigworld.avatar.battle_events)
+        self.assertTrue(battle._apply_detection_event(self._event()))
+
+        self.assertEqual(
+            published, len(runtime.bigworld.avatar.battle_events))
+
+    def test_a_detection_credited_to_somebody_else_is_not_published(self):
+        battle, runtime = self._battle()
+        before = len(runtime.bigworld.avatar.battle_events)
+
+        self.assertFalse(
+            battle._apply_detection_event(self._event(observer_id=2)))
+
+        self.assertEqual(before, len(runtime.bigworld.avatar.battle_events))
+
+    def test_the_hidden_worker_draws_no_ribbon(self):
+        battle, runtime = self._battle()
+        battle._worker_mode = True
+        before = len(runtime.bigworld.avatar.battle_events)
+
+        self.assertFalse(battle._apply_detection_event(self._event()))
+
+        self.assertEqual(before, len(runtime.bigworld.avatar.battle_events))
+
+    def test_an_unknown_target_is_refused(self):
+        battle, unused_runtime = self._battle()
+
+        with self.assertRaises(RuntimeError):
+            battle._apply_detection_event(self._event(target_id=9))
+
+    def test_a_ribbon_failure_retires_only_the_optional_feature(self):
+        battle, unused_runtime = self._battle()
+        battle._present_direct_spot = mock.Mock(
+            side_effect=RuntimeError('battle ribbon callback failed'))
+
+        with contextlib.redirect_stdout(io.StringIO()) as log:
+            self.assertTrue(battle._apply_detection_event(self._event()))
+
+        self.assertEqual(
+            1, log.getvalue().count(
+                'optional spotting feedback disabled for this round'))
+
+    def test_the_ribbon_does_not_wait_for_the_enemy_to_enter_the_world(self):
+        battle, runtime = self._battle()
+        # The ribbon merges by vehicle id and never touches the entity, so an
+        # enemy still entering the world must not park the event journal.
+        battle._records['bot:7']['ready'] = False
+
+        self.assertTrue(battle._event_is_ready(self._event()))
+        self.assertTrue(battle._apply_detection_event(self._event()))
+
+        self.assertEqual(
+            17, runtime.bigworld.avatar.battle_events[-1][0]['targetID'])
 
 
 class LocalSpottedStateTests(unittest.TestCase):

--- a/tests/test_port_0922_bot_runtime.py
+++ b/tests/test_port_0922_bot_runtime.py
@@ -1426,6 +1426,15 @@ class ServerBotObservationRelayTests(unittest.TestCase):
         self.assertEqual(frozenset((('bot', 11),)),
                          server.player_spotted[1])
         self.assertEqual(1, server._statistics_row('player', 1)['spotted'])
+        # The observer's own client draws the #1513 spotting ribbon from this
+        # event, so one detection is published exactly once, to the observer
+        # the ledger credited.
+        self.assertEqual([{
+            'kind': 'detection',
+            'observer_kind': 'player', 'observer_id': 1,
+            'target_kind': 'bot', 'target_id': 11,
+        }], [event for event in server.pending_events
+             if event.get('kind') == 'detection'])
 
         server._record_damage(('player', 2), ('bot', 11), 75, {})
         self.assertEqual(


### PR DESCRIPTION
## What Peng saw

An enemy a teammate had already lit still drew the in-battle 点亮 banner the
first time he saw it himself — but the results screen's 点亮 column never
counted that sighting. Two layers, two different rules for one statistic.

## Why

`battle_runtime._update_spotting` raised the ribbon on
`visible and not previous[0] and direct_seen`. `previous[0]` is `spot_visible`,
the **AOI-gated model visibility**, not the team's spotting state: an enemy
revealed by a teammate across the map is outside this client's 565 m entity
AOI, so its model is not drawn, and the moment the player closes in and sees
it himself the transition fires. The server, meanwhile, credits a detection
only when the enemy becomes visible to a team that could not see it
(`_commit_detections`), which is the retail rule the results column and Scout
already use.

The client cannot decide this alone: it knows its own line of sight and the
team's merged spot lease, never whether its own sighting is what lit the
enemy — and the worker publishes the lease earned by the player's own sighting
before the client's next staggered 2 Hz probe. So the decision moves to the
authority that already makes it.

## Change

- `_commit_detections` publishes one `detection` event to the human observer
  it credits. A Bot publishes nothing: a Bot has no ribbon to draw.
- The client draws the stock `SPOTTED` + `TARGET_VISIBILITY` pair from that
  event alone; the local trigger is gone.
- `_assist_entity_key` becomes `_feedback_entity_key(event, role, label)`, now
  shared by both server-attributed feedback events.

The event is not gated on entity readiness, so it can never park the event
journal behind an enemy still entering the world — the ribbon needs the
record's engine id only.

## Exact-client evidence

- `scripts/common/battle_results_shared.pyc`: `VEH_INTERACTION_DETAILS`
  contains `('spotted', 'B', 1, 0)` — the per-enemy detail is a 0/1 flag with
  max 1, so #1513's own wire format cannot carry a second detection of the
  same vehicle. `RESULT_INTERACTION_LIMITS["spotted"] = (0, 1)` is exact.
- `ribbons_aggregator._MultiVehicleRibbon.getCount` is `len(self._hits)` keyed
  by `vehID`, and `_EnemyDetectionRibbon` extends it, so the ribbon counts
  distinct vehicles too.
- `feedback_adaptor` consumes `TARGET_VISIBILITY` only to fire
  `TriggersManager.TRIGGER_TYPE.PLAYER_DETECT_ENEMY`; it is never forwarded to
  `onPlayerFeedbackReceived`, so no damage-log or ribbon consumer loses
  anything by moving with the ribbon.

What remains inference, not proof: that retail credits the detection to the
team's first observer at all. The judgement lives in the cell app, not in the
client; the tooltip "第一次点亮敌方坦克个数被计数" is ambiguous, and the
supporting evidence is the WG wiki's flat "Spotting an enemy tank for the
first time" bonus plus the medal structure (Scout's ≥9 and team maximum, Evil
Eye's "单独点亮"). This PR does not change that rule — Peng confirmed keeping
it — it makes the ribbon obey it.

## Tests

- `tests/test_port_0922_battle_runtime.py`: new `DetectionFeedTests` (7) —
  ribbon published for a credited local detection, once per enemy, nothing for
  another player's credit, nothing in the hidden worker, unknown target
  refused, a ribbon failure retires only the optional feature, and no wait for
  the entity. Two existing tests repointed: a local sighting of a team-lit
  enemy now draws no ribbon, and the spotting contract test keeps its
  presentation assertions without the ribbon.
- `tests/test_port_0922_battle_achievements.py`: the credited detection is
  published to its human observer exactly once, a Bot's is not published, and
  seeing an enemy the team already lit publishes nothing.
- `tests/test_port_0922_bot_runtime.py`: the end-to-end worker→server path
  with a non-empty `visible_by_player_ids` now also asserts the published
  event.

Ran: `test_port_0922_battle_runtime` (894 OK) and
`test_port_0922_battle_achievements test_port_0922_bot_runtime
test_port_0922_lan_protocol test_port_0922_server_projectiles` (808 OK), plus
the CPython 2.7.18 client compile (112 files).

Unproved without Windows: that the stock ribbon and its sound render on the
real client from this path. The event and its feedback payload are the same
ones the local trigger used, so only the trigger source changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)