### PR TITLE
Turn a limited-traverse hull with the mouse only while parked

### DIFF
--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -1940,23 +1940,52 @@ which is exactly what this January 2018 build does. Reproducing the 1.12.1
 convenience would be a deliberate product deviation from #1513, not a parity
 fix.
 
+Wargaming's own newcomer guide states the mode rule and no other condition:
+a turretless vehicle's gun "can only move horizontally up to a limit, after
+which the hull has to be turned to move it further", SPGs auto-turn the hull in
+every aiming mode, and tank destroyers do not auto-turn it in Sniper mode. It
+is silent on the throttle, so it neither supports nor refutes a drive-input
+condition.
+
 Only the cell behaviour is ours. The copied local physics reads the stock
 `getAutorotation()` and, when the unclamped mouse target leaves the installed
 `gun.turretYawLimits`, feeds one binary rotation direction into the single pose
 integrator; the descriptor, native gun rotator and copied traverse physics keep
-owning the arc, gun speed and dispersion. A live A/D command and
-`CMD_BLOCK_TRACKS` both suppress it, but the throttle does not: the pinned
-executable computes the direction in `WGGunRotatorImpl` from elapsed time, the
-desired yaw, the current turret yaw, the yaw limits and the turret and vehicle
-rotation speeds, with no drive input reaching that routine, and the movement
-flags it publishes carry `_MOVEMENT_FLAGS.FORWARD` beside the rotation bit.
-The copied cell composes that desired hull direction with forward or reverse
-driving. Its traverse integrator reverses A/D steering under reverse drive, so
-the autorotation adapter converts the desired hull direction to that input
-convention first; otherwise reversing makes the hull turn away from the aim.
+owning the arc, gun speed and dispersion. A live A/D command,
+`CMD_BLOCK_TRACKS` and any live throttle — including the native R/F cruise
+presets — all suppress it, so the mouse turns the hull only while the player
+issues no movement command at all.
+
+The pinned executable's own flags are what place the composition there.
+`WGGunRotatorImpl` computes the direction in `0x00f5ad40` from elapsed time,
+the desired yaw, the current turret yaw (`+0xcc`), the installed yaw limits
+(`+0x28`/`+0x2c`, valid per `+0x30`) and the turret and vehicle rotation speeds
+(`+0x60`/`+0x68`), clears `autorotationFlags` (`+0xd8`) whenever the clamped
+rotation reaches the desired yaw, and otherwise publishes `5` or `9` —
+`_MOVEMENT_FLAGS.FORWARD` beside one rotation bit, through
+`lea eax, [eax*4 + 5]`, and never a bare rotation bit. Those flags are shaped
+like a whole movement command rather than a rotation contribution: ORing `5`
+into a player's `BACKWARD` yields `FORWARD | BACKWARD`, which the stock
+`PlayerAvatar.moveVehicle` decode resolves as forward. That reading is
+consistent with a cell that applies them while the player issues none, but it
+does not exclude a cell that masks the rotation bits out of them under a live
+drive command, and the `FORWARD` bit alone therefore proves neither rule. What
+it does rule out is the inference this section previously drew: that the
+direction routine reading no drive input means a driving hull follows the
+mouse. It only says where the composition lives.
+
 How the retail cell merges those flags is server Python that no client build
-ships, so the exact composition remains an inference and the resulting feel
-still needs Windows play.
+ships, so the composition remains an inference. Windows play is the evidence
+that selected this one, and it is the rule this port shipped before the
+throttle-independent reading replaced it: a limited-traverse hull that kept
+following the mouse under throttle was reported as wrong, because it steered
+the vehicle off the driver's heading whenever the camera moved. Two gaps stay
+open against a retail cell. The port applies only the rotation half of the
+command, never its `FORWARD` bit, so a parked retail hull may creep forward
+while it aligns where this port pivots, and native track animation sees that
+same bare rotation. A coasting hull under no drive command also autorotates
+here, because the cell can only see flags and not a measured speed. Neither
+difference has been measured on Windows.
 
 LAN pose samples retain the fractional remainder of the nominal 30 Hz
 publication interval. Clearing the entire accumulator quantised a 40 FPS

--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -1984,8 +1984,8 @@ open against a retail cell. The port applies only the rotation half of the
 command, never its `FORWARD` bit, so a parked retail hull may creep forward
 while it aligns where this port pivots, and native track animation sees that
 same bare rotation. A coasting hull under no drive command also autorotates
-here, because the cell can only see flags and not a measured speed. Neither
-difference has been measured on Windows.
+here, because this port gates on input intent rather than measured speed.
+Neither difference has been measured on Windows.
 
 LAN pose samples retain the fractional remainder of the nominal 30 Hz
 publication interval. Clearing the entire accumulator quantised a 40 FPS

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -20471,18 +20471,28 @@ class BattleRuntime(object):
         integrator.  The descriptor, native gun rotator and copied traverse
         physics continue to own the arc, gun speed and resulting dispersion.
 
-        The direction is independent of the throttle.  The pinned executable
-        computes it in ``WGGunRotatorImpl`` from the elapsed time, the desired
-        yaw, the current turret yaw, the installed yaw limits and the turret
-        and vehicle rotation speeds; no drive input reaches that routine, and
-        the movement flags it publishes carry ``_MOVEMENT_FLAGS.FORWARD``
-        beside the rotation bit.  The copied cell preserves that desired hull
-        direction when composing it with either forward or reverse driving.
+        Retail autorotation is the movement command a cell applies while the
+        player issues none.  ``WGGunRotatorImpl`` computes the direction in
+        ``0x00f5ad40`` from the elapsed time, the desired yaw, the current
+        turret yaw, the installed yaw limits and the turret and vehicle
+        rotation speeds, then publishes ``_MOVEMENT_FLAGS.FORWARD`` beside one
+        rotation bit and never a bare rotation bit: those flags are shaped like
+        a whole movement command, not a rotation contribution a reverse or
+        braking command could absorb.  Windows play selected that reading, and
+        it is the rule this port shipped before a throttle-independent reading
+        replaced it.  That the direction itself reads no drive input only says
+        where the composition lives; it is not a licence to steer a driving
+        hull with the mouse.
         """
         turn = float(turn)
         if turn != 0.0:
-            # A live A/D command owns the hull.  Only the rotation half of the
-            # retail command is in question here; the throttle keeps driving.
+            # A live A/D command owns the hull.
+            return turn
+        # ``forward`` also carries the native R/F cruise presets, so this
+        # covers keyboard drive and cruise without inferring motion from a
+        # measured speed that reads zero while a physically blocked hull is
+        # still under power.
+        if float(drive_intent) != 0.0:
             return turn
         # CMD_BLOCK_TRACKS is independent from the persistent autorotation
         # setting.  Holding Space does not clear that setting, but the retail
@@ -20520,11 +20530,7 @@ class BattleRuntime(object):
         elif relative_yaw > maximum + GUN_TRAVERSE_LIMIT_EPSILON:
             autorotation_turn = 1.0
         if autorotation_turn:
-            # traverse_step interprets steering as an A/D key and reverses it
-            # under reverse drive. Convert the desired hull yaw direction to
-            # that input convention so autorotation still approaches the aim.
-            return (-autorotation_turn if float(drive_intent) < 0.0 else
-                    autorotation_turn)
+            return autorotation_turn
         return turn
 
     def _local_siege_drive_locked(self, entity):

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -20471,18 +20471,17 @@ class BattleRuntime(object):
         integrator.  The descriptor, native gun rotator and copied traverse
         physics continue to own the arc, gun speed and resulting dispersion.
 
-        Retail autorotation is the movement command a cell applies while the
-        player issues none.  ``WGGunRotatorImpl`` computes the direction in
+        This port applies autorotation while the player issues no movement
+        command, following the Windows gameplay report.  ``WGGunRotatorImpl``
+        computes the direction in
         ``0x00f5ad40`` from the elapsed time, the desired yaw, the current
         turret yaw, the installed yaw limits and the turret and vehicle
         rotation speeds, then publishes ``_MOVEMENT_FLAGS.FORWARD`` beside one
-        rotation bit and never a bare rotation bit: those flags are shaped like
-        a whole movement command, not a rotation contribution a reverse or
-        braking command could absorb.  Windows play selected that reading, and
-        it is the rule this port shipped before a throttle-independent reading
-        replaced it.  That the direction itself reads no drive input only says
-        where the composition lives; it is not a licence to steer a driving
-        hull with the mouse.
+        rotation bit and never a bare rotation bit.  That shape permits an
+        idle-only cell policy, but does not prove it: the retail server could
+        mask out the forward bit when composing commands.  The client does
+        not ship that server code.  Restore the policy this port used before
+        a throttle-independent reading replaced it.
         """
         turn = float(turn)
         if turn != 0.0:

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -16611,9 +16611,9 @@ class BattleRuntimeContractTests(unittest.TestCase):
         battle._local_yaw = 0.0
         battle._avatar.inputHandler.getAutorotation = lambda: True
 
-        # #1513's rotator publishes FORWARD beside the rotation bit, so its
-        # flags are the whole movement command a cell applies while the player
-        # issues none.  Any live drive command owns the hull instead.
+        # The Windows gameplay report selects this port's idle-only policy;
+        # the native rotator flags alone do not prove retail cell composition.
+        # Any live drive command owns the hull instead.
         self.assertEqual(1.0, battle._local_autorotation_turn(entity, 0.0))
         for throttle in (-1.0, -0.5, 0.25, 1.0):
             self.assertEqual(0.0, battle._local_autorotation_turn(

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -16599,7 +16599,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
         handler.switchAutorotation()
         self.assertFalse(handler.getAutorotation())
 
-    def test_limited_traverse_autorotation_composes_with_a_live_throttle(self):
+    def test_limited_traverse_autorotation_yields_to_a_drive_command(self):
         runtime = _runtime()
         battle = BattleRuntime(runtime)
         battle._avatar = runtime.bigworld.avatar
@@ -16611,11 +16611,15 @@ class BattleRuntimeContractTests(unittest.TestCase):
         battle._local_yaw = 0.0
         battle._avatar.inputHandler.getAutorotation = lambda: True
 
-        # #1513's WGGunRotatorImpl publishes the rotation direction without
-        # reading any drive input, so driving does not suppress the hull turn.
+        # #1513's rotator publishes FORWARD beside the rotation bit, so its
+        # flags are the whole movement command a cell applies while the player
+        # issues none.  Any live drive command owns the hull instead.
         self.assertEqual(1.0, battle._local_autorotation_turn(entity, 0.0))
-        # Explicit A/D still owns steering, including its reverse convention.
-        for throttle in (-1.0, 1.0):
+        for throttle in (-1.0, -0.5, 0.25, 1.0):
+            self.assertEqual(0.0, battle._local_autorotation_turn(
+                entity, 0.0, drive_intent=throttle))
+        # Explicit A/D still owns steering at every throttle.
+        for throttle in (-1.0, 0.0, 1.0):
             for turn in (-1.0, 1.0):
                 self.assertEqual(turn, battle._local_autorotation_turn(
                     entity, turn, drive_intent=throttle))
@@ -16651,7 +16655,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
         runtime.bigworld.entities[10] = entity
         battle._server = types.SimpleNamespace(vehicle_id=10)
         battle._sender = types.SimpleNamespace(
-            forward=1.0, turn=0.0, aim_yaw=0.75, handbrake=False,
+            forward=0.0, turn=0.0, aim_yaw=0.75, handbrake=False,
             send_current=lambda: client.send_input('current'))
         battle._local_descriptor = descriptor
         battle._attach_local_presentation()
@@ -16664,12 +16668,24 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertEqual(1.0, step.call_args.args[2])
         self.assertAlmostEqual(0.05, battle._local_yaw)
         self.assertEqual(0.5, battle._local_turn_speed)
-        # The hull turns while the throttle keeps driving, exactly like the
-        # ``FORWARD | ROTATE_RIGHT`` command #1513's rotator publishes.
-        self.assertEqual((2, 9), entity.engineMode)
+        # A parked hull turns, and native track animation sees the rotation
+        # that copied physics actually consumed rather than keyboard state.
+        self.assertEqual((2, 8), entity.engineMode)
         self.assertEqual(0.5, runtime.bigworld.avatar.positions[-1][3])
 
-    def test_autorotation_tracks_target_while_driving_in_either_direction(self):
+        # The same scene under a live throttle steers nothing.
+        battle._sender.forward = 1.0
+        battle._local_yaw = 0.0
+        battle._local_turn_speed = 0.0
+        with mock.patch(
+                'gui.mods.offline_lan_0922.battle_runtime.'
+                'vehicle_physics.traverse_step', return_value=0.0) as step:
+            battle._drive_local(0.1)
+
+        self.assertEqual(0.0, step.call_args.args[2])
+        self.assertEqual(0.0, battle._local_yaw)
+
+    def test_autorotation_closes_yaw_error_only_without_a_drive_command(self):
         for throttle in (-1.0, -0.25, 0.0, 0.25, 1.0):
             for aim_yaw in (-0.75, 0.75):
                 with self.subTest(throttle=throttle, aim_yaw=aim_yaw):
@@ -16690,15 +16706,20 @@ class BattleRuntimeContractTests(unittest.TestCase):
                     battle._local_descriptor = descriptor
                     battle._attach_local_presentation()
 
-                    # Exercise the real integrator: reverse steering changes
-                    # the input sign, but aiming must still close the yaw error.
+                    # Exercise the real integrator rather than a mocked
+                    # traverse step.
                     battle._drive_local(0.1)
 
-                    self.assertGreater(battle._local_yaw * aim_yaw, 0.0)
-                    self.assertLess(abs(aim_yaw - battle._local_yaw),
-                                    abs(aim_yaw))
                     if throttle:
-                        self.assertGreater(battle._local_speed * throttle, 0.0)
+                        # The driver's heading is preserved and only the
+                        # throttle acts.
+                        self.assertEqual(0.0, battle._local_yaw)
+                        self.assertGreater(
+                            battle._local_speed * throttle, 0.0)
+                    else:
+                        self.assertGreater(battle._local_yaw * aim_yaw, 0.0)
+                        self.assertLess(abs(aim_yaw - battle._local_yaw),
+                                        abs(aim_yaw))
 
     def test_drowning_countdown_keeps_movement_until_the_vehicle_drowns(self):
         runtime = _runtime()


### PR DESCRIPTION
## The report

Windows play: on a turretless (limited gun traverse) vehicle, moving the mouse
past the gun arc **while driving** drags the hull around, steering the vehicle
off the driver's heading. The expected rule is that the mouse turns the hull
only while the vehicle is not being driven, and never in sniper mode.

This is a regression report against PR #126, merged one day earlier, which
deleted the drive-command gate this port had shipped with. The behaviour
described as correct is the behaviour before #126, so this restores it.

## What the exact client proves

- `SniperControlMode.getPreferredAutorotationMode` (`control_modes.pyc`
  1427-1437) returns `False` for a limited-traverse gun, `onControlModeChanged`
  forces it, and `enableSwitchAutorotationMode` then makes both `X` and
  `PlayerAvatar.moveVehicle`'s re-enable no-ops. Independently,
  `SniperAimingSystem.focusOnPos` installs `gun.turretYawLimits` as
  `__yawLimits` and `__clampToLimits` clamps the mouse-driven aim to that arc,
  so in sniper the aim cannot leave the arc in the first place. **The sniper
  half of the rule is stock code this port already runs; nothing changes here.**
- `PlayerAvatar.enableOwnVehicleAutorotation` only invalidates
  `VEHICLE_VIEW_STATE.AUTO_ROTATION` and sends
  `VEHICLE_SETTING.AUTOROTATION_ENABLED` to the cell, and no client script
  references `WGGunRotatorImpl` at all, so the hull turn is cell behaviour that
  no client build ships. Only this port's copied local physics reproduces it.
- The pinned `WGGunRotatorImpl` autorotation routine at `0x00f5ad40` reads
  `dt`, the desired yaw, `curTurretYaw` (`+0xcc`), the yaw limits
  (`+0x28`/`+0x2c`, valid per `+0x30`) and the turret/vehicle rotation speeds
  (`+0x60`/`+0x68`). PR #126 read this correctly: **no drive input reaches it**,
  so the *direction* is throttle-independent.

## Why that is not the composition rule

The direction being throttle-independent says where the composition lives, not
what it is. The same routine clears `autorotationFlags` (`+0xd8`) when the
clamped rotation reaches the desired yaw and otherwise publishes `5` or `9` via
`lea eax, [eax*4 + 5]` — `_MOVEMENT_FLAGS.FORWARD` beside one rotation bit, and
never a bare rotation bit.

Those flags are therefore shaped like a whole movement command rather than a
rotation contribution: ORing `5` into a player's `BACKWARD` yields
`FORWARD | BACKWARD`, which the stock `PlayerAvatar.moveVehicle` decode
resolves as forward. That is consistent with a cell applying them while the
player issues no movement command, which is the rule Windows play reports, but
it does not exclude a cell that masks their rotation bits out under a live
drive command. The composition is an inference either way, and gameplay is
what selects between them.

## Change

- `BattleRuntime._local_autorotation_turn` gates on the drive command again,
  which also covers the native R/F cruise presets, rather than on a measured
  speed that reads zero while a blocked hull is still under power. A live A/D
  command and `CMD_BLOCK_TRACKS` keep suppressing it as before.
- Drop the reverse-steering conversion, which only existed to compose
  autorotation with reverse driving and is unreachable once the gate is back.
- `COMPATIBILITY_REVIEW.md`: record the flag encoding and what it does and does
  not prove, Wargaming's newcomer-guide wording (SPGs auto-turn the hull in
  every aiming mode, tank destroyers do not in sniper mode — silent on the
  throttle, so it neither supports nor refutes a drive-input condition), and the
  two remaining gaps against a retail cell: this port applies only the rotation
  half of the command, so a parked retail hull may creep forward while it
  aligns where this port pivots and native track animation sees a bare
  rotation, and a coasting hull under no drive command autorotates here.
- Tests: the three cases PR #126 wrote for the driving hull now assert the
  opposite, including one through the real traverse integrator at every
  throttle sign.

## Validation

- `python3 -m unittest discover -s tests -p test_port_0922_battle_runtime.py` —
  886 tests, OK.
- `tools/audit_client_abi.py` against the exact `#1513` `scripts.pkg` with
  CPython 2.7.18 — exit 0 (the stock pins PR #126 added are unchanged and still
  hold).
- CPython 2.7 source compile of `src/res/scripts/client` — 112 files.

Still unproved: the retail cell composition, and the feel of the restored rule
on the exact Windows client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
