### PR TITLE
Fix WPR native command execution and preserve diagnostic output

### DIFF
--- a/launcher/capture_performance.ps1
+++ b/launcher/capture_performance.ps1
@@ -32,6 +32,34 @@ function Same-Session {
     $current = Get-Content -LiteralPath $SessionState -Raw | ConvertFrom-Json
     return ($current.id -eq $SessionId -and -not $current.endedAt)
 }
+function Invoke-Wpr([string[]]$WprArguments) {
+    $process = [Diagnostics.Process]::new()
+    try {
+        $process.StartInfo.FileName = $wpr
+        # Arguments are fixed switches, the validated instance ID, or an ETL
+        # filename. Quote each one so a session directory may contain spaces.
+        $process.StartInfo.Arguments = ($WprArguments | ForEach-Object { '"' + $_ + '"' }) -join ' '
+        $process.StartInfo.UseShellExecute = $false
+        $process.StartInfo.CreateNoWindow = $true
+        $process.StartInfo.RedirectStandardOutput = $true
+        $process.StartInfo.RedirectStandardError = $true
+        Write-Status ('wpr: {0} {1}' -f $wpr, $process.StartInfo.Arguments)
+        [void]$process.Start()
+        # Windows PowerShell 5.1 can turn native stderr into a terminating
+        # error under ErrorActionPreference=Stop. Read both pipes directly
+        # and concurrently, preserving output even when WPR exits nonzero.
+        $stdout = $process.StandardOutput.ReadToEndAsync()
+        $stderr = $process.StandardError.ReadToEndAsync()
+        $process.WaitForExit()
+        $exitCode = $process.ExitCode
+        Write-Status "wpr_exit_code=$exitCode"
+        Write-Status ("wpr_stdout:`n" + $stdout.Result)
+        Write-Status ("wpr_stderr:`n" + $stderr.Result)
+        return $exitCode
+    } finally {
+        $process.Dispose()
+    }
+}
 try {
     Write-Status "session=$SessionId requested_seconds=$Seconds"
     Write-Status 'Scope: system-wide CPU scheduling/stacks and GPU events; no heap or network payload capture.'
@@ -77,10 +105,11 @@ try {
         Write-Status 'not_started: no live battle before deadline or session ended.'
         exit 0
     }
-    $output = & $wpr -start CPU -start GPU -filemode -instancename $instance 2>&1
-    Write-Status ($output -join "`n")
-    if ($LASTEXITCODE -ne 0) {
+    $exitCode = Invoke-Wpr @('-start', 'CPU', '-start', 'GPU', '-filemode', '-instancename', $instance)
+    if ($exitCode -ne 0) {
         Write-Status 'unavailable: WPR CPU/GPU start failed; no global recording was stopped.'
+        [void](Invoke-Wpr @('-profiles'))
+        [void](Invoke-Wpr @('-status', '-instancename', $instance))
         exit 0
     }
     $started = $true
@@ -89,9 +118,8 @@ try {
     while ([DateTime]::UtcNow -lt $deadline -and (Same-Session)) {
         Start-Sleep -Milliseconds 500
     }
-    $output = & $wpr -stop $pending -instancename $instance 2>&1
-    Write-Status ($output -join "`n")
-    if ($LASTEXITCODE -ne 0) { throw 'WPR stop failed.' }
+    $exitCode = Invoke-Wpr @('-stop', $pending, '-instancename', $instance)
+    if ($exitCode -ne 0) { throw 'WPR stop failed.' }
     $started = $false
     $current = Get-Content -LiteralPath $SessionState -Raw | ConvertFrom-Json
     if ($current.id -ne $SessionId) {
@@ -106,12 +134,18 @@ try {
     Move-Item -LiteralPath $pending -Destination $final
     Write-Status "complete: $final"
 } catch {
-    Write-Status ('unavailable: line={0} {1}' -f
-        $_.InvocationInfo.ScriptLineNumber, $_.Exception.Message)
+    Write-Status ('unavailable: line={0} type={1} error_id={2} {3}' -f
+        $_.InvocationInfo.ScriptLineNumber, $_.Exception.GetType().FullName,
+        $_.FullyQualifiedErrorId, $_.Exception.Message)
 } finally {
-    if ($started) {
-        # This instance was successfully started by this invocation only.
-        & $wpr -cancel -instancename $instance 2>&1 | ForEach-Object { Write-Status "$_" }
+    try {
+        if ($started) {
+            # This instance was successfully started by this invocation only.
+            [void](Invoke-Wpr @('-cancel', '-instancename', $instance))
+        }
+    } catch {
+        Write-Status ('cleanup_failed: {0}' -f $_.Exception.ToString())
+    } finally {
+        $log.Dispose()
     }
-    $log.Dispose()
 }


### PR DESCRIPTION
The elevated session in `wot-error-report-20260911-212347-6b569b970c90.zip` reaches the live-battle trigger, then exits at the WPR start invocation with only `unavailable: line=80` and no ETL, exit code, or useful command output.

Run WPR through `System.Diagnostics.Process`, draining stdout and stderr concurrently and recording both streams plus the exit code. This avoids Windows PowerShell 5.1's native stderr/error-stream interaction under `ErrorActionPreference=Stop`. Apply the same invocation to start, stop, and instance-owned cleanup; retain exception identity if the helper itself fails. A failed start also records available WPR profiles and the named instance status.

The report establishes the failing invocation, but cannot establish whether WPR itself succeeded or why it failed, because its output was lost. Microsoft's [PowerShell explanation](https://devblogs.microsoft.com/powershell/powershell-7-1-preview-6/) documents the pre-7.1 stderr behavior this change bypasses. No capture profiles, duration, game code, tests, or CI configuration change.

Validation: `git diff --cached --check`; one temporary PowerShell 7.4.6 smoke check parsed the complete script and exercised the exact helper with native stdout, blank/nonblank stderr (including output larger than a pipe buffer), exit codes 0 and 7, and paths containing spaces. Both cases preserved output and exit status with `ErrorActionPreference=Stop`. Windows PowerShell 5.1 and real WPR recording remain unverified here.

Stacked on #158 (`fix/0922-wpr-log-path`). Only `launcher/capture_performance.ps1` changes; this repairs diagnostic execution/output capture and does not claim an FPS improvement.
