### PR TITLE
Decal the earned Marks of Excellence onto the gun barrel in battle

### DIFF
--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -1421,6 +1421,23 @@ also reads `damageRating` for the badge tooltip.
 hundredths — the same split retail produces, since its dossier updater applies
 `int(results['damageRating'] * 100)` to the unpacked float.
 
+The marks are also drawn in the world, and that path is separate from both
+results and the garage. `vehicle_systems/CompoundAppearance.__createStickers`
+reads `self.__vehicle.publicInfo['marksOnGun']` and passes it to
+`VehicleStickers(typeDescriptor, insigniaRank, outfit)`; the hangar's
+`ClientHangarSpace._VehicleAppearance.__setupEmblems` builds the same object
+from `itemsCache.items.getVehicleDossier(...).getRandomStats().getAchievement(
+MARK_ON_GUN_RECORD).getValue()`, and the carousel card reads the same record
+through `getTotalStats`. Retail fills `publicInfo` from the account's dossier,
+so this port's account server owns that field: `PostBattleStore.marks_on_gun`
+returns the row `account_rpc.data.dossiers` already publishes as the garage
+badge, the LAN client carries it in `hello` and `select_vehicle`, and
+`_public_player` republishes it on every roster row — including the lean rows
+that omit the much larger outfit and effective-parameter blocks — so a remote
+human's replica decals the same count. Bots have no account and publish zero.
+The selection is republished immediately before every start request, so a mark
+earned in the previous round is on the barrel in the next one.
+
 The rules are the client's own text in `res/text/LC_MESSAGES/achievements.mo`.
 `markOfMasteryContent` gives the mastery classes as more battle XP than 50, 80,
 95 and 99 percent of the players who drove that vehicle in the previous seven

--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -1428,15 +1428,17 @@ reads `self.__vehicle.publicInfo['marksOnGun']` and passes it to
 `ClientHangarSpace._VehicleAppearance.__setupEmblems` builds the same object
 from `itemsCache.items.getVehicleDossier(...).getRandomStats().getAchievement(
 MARK_ON_GUN_RECORD).getValue()`, and the carousel card reads the same record
-through `getTotalStats`. Retail fills `publicInfo` from the account's dossier,
-so this port's account server owns that field: `PostBattleStore.marks_on_gun`
+through `getTotalStats`. This port supplies that field from its account store:
+`PostBattleStore.marks_on_gun`
 returns the row `account_rpc.data.dossiers` already publishes as the garage
 badge, the LAN client carries it in `hello` and `select_vehicle`, and
 `_public_player` republishes it on every roster row — including the lean rows
 that omit the much larger outfit and effective-parameter blocks — so a remote
 human's replica decals the same count. Bots have no account and publish zero.
 The selection is republished immediately before every start request, so a mark
-earned in the previous round is on the barrel in the next one.
+earned in the previous round reaches the next round's vehicle properties.
+These checks establish the value supplied to the stock sticker constructor;
+the exact Windows client must still verify that the gun decal actually draws.
 
 The rules are the client's own text in `res/text/LC_MESSAGES/achievements.mo`.
 `markOfMasteryContent` gives the mastery classes as more battle XP than 50, 80,

--- a/server/lan_battle_server.py
+++ b/server/lan_battle_server.py
@@ -455,6 +455,8 @@ CRITICAL_CAUSES = frozenset((
 TRACK_DEVICE_NAMES = frozenset(("leftTrackHealth", "rightTrackHealth"))
 OUTFIT_SEASONS = frozenset((1, 2, 4))
 MAX_OUTFIT_BYTES = 64 * 1024
+# dossiers2.custom.records caps the vehicle marksOnGun record at three.
+MAX_MARKS_ON_GUN = 3
 MAX_VEHICLE_COMPACT_BYTES = 64 * 1024
 
 
@@ -484,6 +486,23 @@ def _validated_outfits(value):
             raise ValueError("outfit catalogue is too large")
         result[str(season)] = base64.b64encode(raw).decode("ascii")
     return result
+
+
+def _validated_marks_on_gun(value):
+    """Return one gun-mark count, or raise ValueError.
+
+    ``dossiers2.custom.records`` stores ``marksOnGun`` as a 'B' capped at
+    three, and the client publishes only its own account's value.  This is
+    presentation bookkeeping on a trusted LAN, not an authority input: a
+    missing field is no marks rather than a refused join.
+    """
+    if value is None:
+        return 0
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError("invalid gun mark count")
+    if not 0 <= value <= MAX_MARKS_ON_GUN:
+        raise ValueError("invalid gun mark count")
+    return int(value)
 
 
 def _validated_vehicle_compact_descr(value):
@@ -2127,6 +2146,7 @@ class Player(_EndpointSendMixin):
     capabilities: Tuple[str, ...] = field(default_factory=tuple)
     account_key: str = ""
     outfits: dict = field(default_factory=dict)
+    marks_on_gun: int = 0
     vehicle_compact_descr: str = ""
     effective_params: dict = field(default_factory=dict)
     delivered_receipt_id: str = ""
@@ -2829,6 +2849,11 @@ class BattleState:
             except ValueError:
                 return None, "invalid_outfits"
             try:
+                marks_on_gun = _validated_marks_on_gun(
+                    hello.get("marks_on_gun"))
+            except ValueError:
+                return None, "invalid_marks_on_gun"
+            try:
                 vehicle_compact_descr = _validated_vehicle_compact_descr(
                     hello.get("vehicle_compact_descr"))
             except ValueError:
@@ -2902,6 +2927,7 @@ class BattleState:
                 capabilities=capabilities,
                 account_key=account_key,
                 outfits=outfits,
+                marks_on_gun=marks_on_gun,
                 vehicle_compact_descr=vehicle_compact_descr,
                 effective_params=effective_params,
             )
@@ -3151,6 +3177,10 @@ class BattleState:
             vehicle = _safe_vehicle(message.get("vehicle"), player.vehicle)
             try:
                 outfits = _validated_outfits(message.get("outfits"))
+                marks_on_gun = (
+                    player.marks_on_gun
+                    if message.get("marks_on_gun") is None
+                    else _validated_marks_on_gun(message.get("marks_on_gun")))
                 vehicle_compact_descr = \
                     _validated_vehicle_compact_descr(
                         message.get("vehicle_compact_descr"))
@@ -3160,6 +3190,7 @@ class BattleState:
                 return False
             if (vehicle == player.vehicle and max_health == player.max_health
                     and outfits == player.outfits and
+                    marks_on_gun == player.marks_on_gun and
                     vehicle_compact_descr ==
                     player.vehicle_compact_descr and
                     effective_params == player.effective_params):
@@ -3170,6 +3201,7 @@ class BattleState:
             player.siege_state = SIEGE_DISABLED
             player.siege_transition_ticks = 0
             player.outfits = outfits
+            player.marks_on_gun = marks_on_gun
             player.vehicle_compact_descr = vehicle_compact_descr
             player.effective_params = effective_params
             self.state_revision += 1
@@ -13643,6 +13675,10 @@ class BattleState:
             "team": player.team,
             "slot": player.slot,
             "requested_team": BattleState._requested_team_for_player(player),
+            # #1513 decals the gun barrel from publicInfo['marksOnGun'] on
+            # every roster row, so this rides even the lean rows that drop
+            # the much larger outfit and effective-parameter blocks.
+            "marks_on_gun": int(player.marks_on_gun),
             "participating": bool(player.participating),
             "world_pose": player.client_position,
             "spawn_x": (BattleState._spawn_x_for(player.slot)
@@ -14413,6 +14449,7 @@ class ClientHandler(socketserver.BaseRequestHandler):
                     "invalid_account_key": "invalid offline account identity",
                     "duplicate_account_key": "offline account identity is already connected",
                     "invalid_outfits": "invalid vehicle customization data",
+                    "invalid_marks_on_gun": "invalid gun mark count",
                     "invalid_max_health": "invalid vehicle maximum health",
                     "invalid_effective_params":
                         "invalid effective vehicle parameters",

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/postbattle_store.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/account_rpc/postbattle_store.py
@@ -939,6 +939,21 @@ class PostBattleStore(object):
     def progress(self):
         return json.loads(json.dumps(self._progress))
 
+    def marks_on_gun(self, type_name):
+        """Return the gun marks this account has earned on one vehicle.
+
+        #1513 puts the count in ``Vehicle.publicInfo['marksOnGun']`` so that
+        ``CompoundAppearance.__createStickers`` can decal the barrel, and the
+        account server is the only producer.  This store holds that number:
+        ``_award_badges`` advances it and ``account_rpc.data.dossiers``
+        publishes the same value to the garage.
+        """
+        row = self._progress.get('vehicles', {}).get(type_name)
+        if not isinstance(row, dict):
+            return 0
+        return max(0, min(_int(row.get('marksOnGun')),
+                          battle_mastery.MAX_MARKS_ON_GUN))
+
     def pending_arenas(self):
         return sorted(int(key) for key in self._pending)
 

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -1094,6 +1094,21 @@ def _angle_delta(current, target):
     return (target - current + math.pi) % (2.0 * math.pi) - math.pi
 
 
+def _marks_on_gun(value):
+    """Return a Marks of Excellence count #1513 can decal onto a barrel.
+
+    ``CompoundAppearance.__createStickers`` hands ``publicInfo['marksOnGun']``
+    straight to ``VehicleStickers``, and ``dossiers2.custom.records`` caps the
+    record at three.  A roster row from a client that does not publish the
+    count carries no marks rather than failing the entity properties.
+    """
+    try:
+        marks = int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+    return max(0, min(marks, lan_protocol.MAX_MARKS_ON_GUN))
+
+
 class _DestructibleSweepHitTester(object):
     """Expose one conservative interval bbox through the pinned sensor ABI."""
 
@@ -3182,6 +3197,8 @@ class BattleRuntime(object):
             properties = self._binding.properties_from_compact_descr(
                 descriptor.makeCompactDescr(), int(local.get('team', 1)),
                 local.get('name', self._config.get('name', 'Player')))
+            properties['publicInfo']['marksOnGun'] = _marks_on_gun(
+                local.get('marks_on_gun'))
             properties['health'] = max(1, min(
                 int(local.get('health', descriptor.maxHealth)),
                 int(descriptor.maxHealth)))
@@ -3534,7 +3551,8 @@ class BattleRuntime(object):
             'id': self.client.player_id, 'name': self.client.name,
             'vehicle': self.client.vehicle, 'team': self.client.team,
             'slot': self.client.slot, 'health': self.client.max_health,
-            'max_health': self.client.max_health, 'alive': True}
+            'max_health': self.client.max_health, 'alive': True,
+            'marks_on_gun': getattr(self.client, 'marks_on_gun', 0)}
         return result
 
     def _prebattle_seconds(self):
@@ -22566,6 +22584,11 @@ class BattleRuntime(object):
         # garage owner and always receive the stock empty descriptor.
         properties['publicInfo']['outfit'] = self._remote_outfit(
             state, event.get('kind'))
+        # A Bot has no account and therefore no marks; only a human's own
+        # server-published count decals a replica's gun barrel.
+        properties['publicInfo']['marksOnGun'] = (
+            _marks_on_gun(state.get('marks_on_gun'))
+            if event.get('kind') == 'player' else 0)
         properties['health'] = max(0, min(
             int(initial_state.get('health', descriptor.maxHealth)),
             int(descriptor.maxHealth)))

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/entities/bigworld_binding.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/entities/bigworld_binding.py
@@ -166,6 +166,11 @@ class BigWorldVehicleBinding(object):
                 'name': _entity_string(name),
                 'team': team,
                 'prebattleID': 0,
+                # #1513 decals the gun barrel from this field
+                # (``CompoundAppearance.__createStickers``, and the stock
+                # ``DetachedTurret``).  Only an account owns marks, so the
+                # caller that knows the owner sets it; a vehicle with no
+                # account keeps none.
                 'marksOnGun': 0,
                 'index': 0,
                 'outfit': _entity_string(self._outfit_provider(descriptor))},

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/lan_client.py
@@ -67,6 +67,8 @@ MAX_OUTBOUND_DEPTH = 16
 MAX_PROJECTILE_BATCH = 30
 MAX_HUMAN_RAM_PROBES = 64
 MAX_PROJECTILE_DESTRUCTIBLES = 64
+# ``dossiers2.custom.records`` stores marksOnGun as a 'B' capped at three.
+MAX_MARKS_ON_GUN = 3
 MAX_PROJECTILE_ID = 2147483647
 MAX_PROJECTILE_DAMAGE_STICKER = (1 << 64) - 1
 PLAYER_LANDING_MAX_IMPACT_SPEED = 200.0
@@ -1467,6 +1469,20 @@ def _canonical_effective_params(value):
     return effective_params_wire.canonical(value)
 
 
+def _canonical_marks_on_gun(value):
+    """Return a gun-mark count inside the #1513 dossier record's range.
+
+    ``dossiers2.custom.records`` caps ``marksOnGun`` at three, and the value
+    only ever describes this client's own account.  A missing or unreadable
+    count is no marks, never a refused selection.
+    """
+    try:
+        marks = int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+    return max(0, min(marks, MAX_MARKS_ON_GUN))
+
+
 def _same_canonical_source(left, right):
     """Compare JSON values without equating bools, integers and floats."""
     if isinstance(left, bool) or isinstance(right, bool):
@@ -1514,7 +1530,8 @@ class LANClient(object):
     def __init__(self, host, port, name, vehicle, max_health=100,
                  on_event=None, bigworld=None, account_key=None,
                  outfits=None, requested_team=0,
-                 vehicle_compact_descr=None, effective_params=None):
+                 vehicle_compact_descr=None, effective_params=None,
+                 marks_on_gun=0):
         self.host = _safe_text(host, '127.0.0.1', 255)
         self.port = int(port or 28782)
         self.name = _safe_text(name, 'Player')
@@ -1526,6 +1543,7 @@ class LANClient(object):
         self.vehicle_compact_descr = (
             _canonical_vehicle_compact_descr(vehicle_compact_descr) or '')
         self.effective_params = _canonical_effective_params(effective_params)
+        self.marks_on_gun = _canonical_marks_on_gun(marks_on_gun)
         self.requested_team = _team_choice(requested_team)
         self._published_player_outfits = {}
         self._published_player_outfit_sources = {}
@@ -1680,6 +1698,7 @@ class LANClient(object):
             'outfits': dict(self.outfits),
             'vehicle_compact_descr': self.vehicle_compact_descr,
             'effective_params': effective_params,
+            'marks_on_gun': _canonical_marks_on_gun(self.marks_on_gun),
         }
         if self.requested_team in (1, 2):
             payload['requested_team'] = self.requested_team
@@ -1788,8 +1807,14 @@ class LANClient(object):
         return self._send(message)
 
     def select_vehicle(self, vehicle, max_health, outfits=None,
-                       vehicle_compact_descr=None, effective_params=None):
-        """Accept the current loadout, sending only a changed selection."""
+                       vehicle_compact_descr=None, effective_params=None,
+                       marks_on_gun=None):
+        """Accept the current loadout, sending only a changed selection.
+
+        The gun-mark count travels with the selection because a battle can
+        earn a mark on the vehicle the player keeps: the count changes while
+        the vehicle, its outfits and its effective parameters do not.
+        """
         if not self.ready or self.phase != 'waiting':
             return False
         vehicle = _safe_text(vehicle, '', 64)
@@ -1805,23 +1830,28 @@ class LANClient(object):
         params = _canonical_effective_params(
             self.effective_params if effective_params is None
             else effective_params)
+        marks = _canonical_marks_on_gun(
+            self.marks_on_gun if marks_on_gun is None else marks_on_gun)
         if outfits is None or compact is None or params is None:
             return False
         if (vehicle == self.vehicle and max_health == self.max_health and
                 outfits == self.outfits and
                 compact == self.vehicle_compact_descr and
-                params == self.effective_params):
+                params == self.effective_params and
+                marks == self.marks_on_gun):
             return True
         message = {'type': 'select_vehicle', 'vehicle': vehicle,
                    'max_health': max_health,
                    'vehicle_compact_descr': compact,
-                   'effective_params': params}
+                   'effective_params': params,
+                   'marks_on_gun': marks}
         if publishes_outfits:
             message['outfits'] = outfits
         if not self._send(message):
             return False
         self.vehicle_compact_descr = compact
         self.effective_params = params
+        self.marks_on_gun = marks
         return True
 
     def select_team(self, team):
@@ -1891,6 +1921,9 @@ class LANClient(object):
             params = entry.get('effective_params')
             if params is not None:
                 self.effective_params = params
+            if 'marks_on_gun' in entry:
+                self.marks_on_gun = _canonical_marks_on_gun(
+                    entry.get('marks_on_gun'))
             return
 
     def _prepare_player_static_inputs(

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/lan_session.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/lan_session.py
@@ -21,6 +21,9 @@ POSTBATTLE_RETRY_DELAY = 0.10
 # The server returns an abandoned round to its waiting room five seconds after
 # the last participant leaves.  Rejoin if that roster never arrives.
 ROUND_END_TIMEOUT = 12.0
+# ``dossiers2.custom.records`` stores the vehicle marksOnGun record as a 'B'
+# capped at three.  Kept here so this module still loads its LAN client lazily.
+MAX_MARKS_ON_GUN = 3
 VEHICLE_SELECTION_WARNING = (
     'Select a valid vehicle in the garage, then click Battle! again.')
 
@@ -553,6 +556,7 @@ class LANSession(object):
                                  port_config.preferred_team(self._config))
         if self._postbattle_store is not None:
             client.account_key = self._postbattle_store.account_key
+        client.marks_on_gun = self._selected_vehicle_marks(vehicle)
         client.outfits = self._outfit_provider()
         try:
             client.vehicle_compact_descr = self._vehicle_compact_provider()
@@ -567,6 +571,27 @@ class LANSession(object):
                     'failed: %s\n' % error)
                 raise _VehicleSelectionError()
         return client
+
+    def _selected_vehicle_marks(self, vehicle):
+        """Return the gun marks this account holds on the selected vehicle.
+
+        The post-battle store is the account's own producer of the number
+        ``account_rpc.data.dossiers`` publishes to the garage, so the barrel
+        decal in battle and the badge in the garage read one value.  A session
+        without a store (a test seam, an embedder) carries no marks rather
+        than inventing them.
+        """
+        store = self._postbattle_store
+        reader = None if store is None else getattr(store, 'marks_on_gun', None)
+        if not callable(reader):
+            return 0
+        try:
+            return max(0, min(int(reader(vehicle)), MAX_MARKS_ON_GUN))
+        except Exception as error:
+            sys.stdout.write(
+                '[Offline LAN 0.9.22] the gun mark count is unavailable: '
+                '%s\n' % error)
+            return 0
 
     def _publish_postbattle_results(self):
         """Let the stock service request and cache each durable pending row."""
@@ -843,13 +868,14 @@ class LANSession(object):
             return False
         if not vehicle or max_health < 1:
             return False
+        marks_on_gun = self._selected_vehicle_marks(vehicle)
         try:
             if effective_params is None:
                 return bool(select(
                     vehicle, max_health, outfits, vehicle_compact_descr))
             return bool(select(
                 vehicle, max_health, outfits, vehicle_compact_descr,
-                effective_params))
+                effective_params, marks_on_gun))
         except Exception as error:
             # A failed modern projection/send must never fall back to a
             # vehicle-only request that reuses the previous loadout.

--- a/tests/test_port_0922_authority_worker_client.py
+++ b/tests/test_port_0922_authority_worker_client.py
@@ -351,6 +351,7 @@ class AuthorityWorkerClientTests(unittest.TestCase):
             'outfits': {},
             'vehicle_compact_descr': 'dGVzdA==',
             'effective_params': effective_params(),
+            'marks_on_gun': 0,
         }, client._hello_payload())
         self.assertNotIn('role', client._hello_payload())
 

--- a/tests/test_port_0922_battle_mastery.py
+++ b/tests/test_port_0922_battle_mastery.py
@@ -393,6 +393,47 @@ class MasteryResultTests(unittest.TestCase):
             restarted = postbattle_store.PostBattleStore(path=path)
             self.assertEqual(result, self._result(restarted, crossing))
 
+    def test_store_publishes_the_earned_marks_to_the_battle_barrel(self):
+        """The account server owns publicInfo['marksOnGun'].
+
+        ``account_rpc.data.dossiers`` publishes this same row value as the
+        garage badge, so the barrel decal in battle and the garage badge read
+        one number rather than two independently derived ones.
+        """
+        curve = mastery_catalog.MARKS_DAMAGE[TYPE_59]
+        one_mark = curve[mastery_catalog.MARKS_PERCENTILES.index(65)]
+        with tempfile.TemporaryDirectory() as folder:
+            path = str(Path(folder) / 'postbattle_state.json')
+            store = postbattle_store.PostBattleStore(path=path)
+            self.assertEqual(0, store.marks_on_gun('china:Ch01_Type59'))
+            self.assertTrue(store.accept(_receipt(
+                store.account_key, damage=one_mark)))
+            self.assertEqual(0, store.marks_on_gun('china:Ch01_Type59'))
+
+            store._progress['vehicles']['china:Ch01_Type59'][
+                'movingAvgDamage'] = one_mark - 1
+            self.assertTrue(store.accept(_receipt(
+                store.account_key, index=2, damage=one_mark * 3)))
+
+            self.assertEqual(1, store.marks_on_gun('china:Ch01_Type59'))
+            self.assertEqual(
+                1, postbattle_store.PostBattleStore(
+                    path=path).marks_on_gun('china:Ch01_Type59'))
+
+    def test_store_reports_no_marks_for_an_unknown_or_damaged_row(self):
+        with tempfile.TemporaryDirectory() as folder:
+            store = postbattle_store.PostBattleStore(
+                path=str(Path(folder) / 'postbattle_state.json'))
+
+            self.assertEqual(0, store.marks_on_gun('ussr:R11_MS-1'))
+            store._progress['vehicles']['ussr:R11_MS-1'] = 'not a row'
+            self.assertEqual(0, store.marks_on_gun('ussr:R11_MS-1'))
+            store._progress['vehicles']['ussr:R11_MS-1'] = {
+                'marksOnGun': 'three'}
+            self.assertEqual(0, store.marks_on_gun('ussr:R11_MS-1'))
+            store._progress['vehicles']['ussr:R11_MS-1'] = {'marksOnGun': 40}
+            self.assertEqual(3, store.marks_on_gun('ussr:R11_MS-1'))
+
     def test_results_carry_the_badge_fields_and_the_new_mark_popup(self):
         curve = mastery_catalog.MARKS_DAMAGE[TYPE_59]
         one_mark = curve[mastery_catalog.MARKS_PERCENTILES.index(65)]

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -6846,7 +6846,7 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertEqual({
             'id': 1, 'name': 'Player', 'vehicle': 'ussr:R11_MS-1',
             'team': 1, 'slot': 0, 'health': 500, 'max_health': 500,
-            'alive': True,
+            'alive': True, 'marks_on_gun': 0,
         }, battle._local_state())
 
     def test_frame_diagnostics_attributes_work_to_the_next_interval(self):
@@ -11194,6 +11194,53 @@ class BattleRuntimeContractTests(unittest.TestCase):
             newer_show_battle_page,
             type(runtime.app_loader).__dict__['showBattlePage'])
         self.assertEqual('newer', runtime.app_loader.showBattlePage())
+
+    def test_player_vehicle_carries_the_account_gun_marks(self):
+        """#1513 decals the barrel from publicInfo['marksOnGun'].
+
+        ``CompoundAppearance.__createStickers`` reads that field and hands it
+        to ``VehicleStickers``, so a Marks of Excellence count that never
+        reaches the entity properties can never be drawn in battle.
+        """
+        runtime = _runtime()
+        runtime.bigworld.defer_vehicle_entry = True
+        battle = BattleRuntime(runtime)
+        client = _Client()
+        start = {
+            'round_id': 1, 'map': '01_karelia', 'bot_authority_id': 1,
+            'players': [{
+                'id': 1, 'team': 1, 'slot': 0, 'name': 'Player',
+                'vehicle': 'ussr:R11_MS-1', 'health': 500,
+                'marks_on_gun': 3}],
+            'bots': []}
+
+        self.assertTrue(battle.start({
+            'map': '01_karelia', 'vehicle': 'ussr:R11_MS-1',
+            'name': 'Player'}, start, client))
+
+        entity = runtime.bigworld.pending_entities[battle._server.vehicle_id]
+        self.assertEqual(3, entity.publicInfo['marksOnGun'])
+
+    def test_player_vehicle_clamps_an_out_of_range_gun_mark_count(self):
+        """``dossiers2.custom.records`` caps the marksOnGun record at three."""
+        runtime = _runtime()
+        runtime.bigworld.defer_vehicle_entry = True
+        battle = BattleRuntime(runtime)
+        client = _Client()
+        start = {
+            'round_id': 1, 'map': '01_karelia', 'bot_authority_id': 1,
+            'players': [{
+                'id': 1, 'team': 1, 'slot': 0, 'name': 'Player',
+                'vehicle': 'ussr:R11_MS-1', 'health': 500,
+                'marks_on_gun': 900}],
+            'bots': []}
+
+        self.assertTrue(battle.start({
+            'map': '01_karelia', 'vehicle': 'ussr:R11_MS-1',
+            'name': 'Player'}, start, client))
+
+        entity = runtime.bigworld.pending_entities[battle._server.vehicle_id]
+        self.assertEqual(3, entity.publicInfo['marksOnGun'])
 
     def test_map_to_native_vehicle_to_ready_lifecycle(self):
         runtime = _runtime()
@@ -28197,6 +28244,77 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertNotIn('bot:2', battle._records)
         battle._remote_factory.destroy.assert_called_once_with(1000)
         battle._binding.destroy_entity.assert_not_called()
+
+    def test_remote_human_replica_carries_published_gun_marks(self):
+        """A remote human's barrel shows the marks that player's account has.
+
+        ``remote_vehicle._attach_vehicle_stickers`` reads the same
+        ``publicInfo['marksOnGun']`` the stock CompoundAppearance reads, so a
+        replica needs the count the server published for its owner.
+        """
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        battle._config = {
+            'map': '01_karelia',
+            'vehicle': 'ussr:R11_MS-1',
+            'startupTimeoutSeconds': 30.0}
+        battle._server = types.SimpleNamespace()
+        battle._binding = mock.Mock()
+        battle._binding.properties_from_compact_descr.side_effect = (
+            lambda *unused_args: {
+                'publicInfo': {'compDescr': 'ussr:R11_MS-1',
+                               'marksOnGun': 0, 'outfit': ''},
+                'health': 500})
+        battle._remote_factory = mock.Mock()
+        battle._remote_factory.prepare_descriptor.side_effect = (
+            lambda descriptor: descriptor)
+        battle._remote_factory.create.return_value = 1000
+        battle._remote_factory.error.return_value = None
+        battle._remote_factory.is_ready.return_value = False
+
+        battle._create_remote({
+            'type': 'create', 'entity': 'player:7', 'kind': 'player', 'id': 7,
+            'state': {
+                'team': 2, 'slot': 1, 'x': 5.0, 'y': 0.0, 'z': 5.0,
+                'world_pose': True, 'marks_on_gun': 2,
+                'vehicle': 'ussr:R11_MS-1', 'health': 500}})
+
+        properties = battle._records['player:7']['properties']
+        self.assertEqual(2, properties['publicInfo']['marksOnGun'])
+
+    def test_bot_replica_never_carries_gun_marks(self):
+        """A Bot has no account and therefore no Marks of Excellence."""
+        runtime = _runtime()
+        battle = BattleRuntime(runtime)
+        battle._avatar = runtime.bigworld.avatar
+        battle._config = {
+            'map': '01_karelia',
+            'vehicle': 'ussr:R11_MS-1',
+            'startupTimeoutSeconds': 30.0}
+        battle._server = types.SimpleNamespace()
+        battle._binding = mock.Mock()
+        battle._binding.properties_from_compact_descr.side_effect = (
+            lambda *unused_args: {
+                'publicInfo': {'compDescr': 'ussr:R11_MS-1',
+                               'marksOnGun': 0, 'outfit': ''},
+                'health': 500})
+        battle._remote_factory = mock.Mock()
+        battle._remote_factory.prepare_descriptor.side_effect = (
+            lambda descriptor: descriptor)
+        battle._remote_factory.create.return_value = 1001
+        battle._remote_factory.error.return_value = None
+        battle._remote_factory.is_ready.return_value = False
+
+        battle._create_remote({
+            'type': 'create', 'entity': 'bot:3', 'kind': 'bot', 'id': 3,
+            'state': {
+                'team': 2, 'slot': 2, 'x': 5.0, 'y': 0.0, 'z': 5.0,
+                'world_pose': True, 'marks_on_gun': 3,
+                'vehicle': 'ussr:R11_MS-1', 'health': 500}})
+
+        properties = battle._records['bot:3']['properties']
+        self.assertEqual(0, properties['publicInfo']['marksOnGun'])
 
     def test_terminal_result_notifies_native_hud_once_with_finish_reason(self):
         runtime = _runtime()

--- a/tests/test_port_0922_lan_protocol.py
+++ b/tests/test_port_0922_lan_protocol.py
@@ -16,7 +16,7 @@ sys.path.insert(0, str(ROOT / 'src' / 'res' / 'scripts' / 'client'))
 sys.path.insert(0, str(ROOT / 'server'))
 
 from gui.mods.offline_lan_0922.lan_client import (
-    HUMAN_RAM_TIMELINE_CAPABILITY, LANClient,
+    CLIENT_CAPABILITIES, HUMAN_RAM_TIMELINE_CAPABILITY, LANClient,
     LEAN_SNAPSHOT_MANIFEST_CAPABILITY, MAX_PROJECTILE_ID,
     _canonical_runtime_vehicle_row,
     _project_human_ram_armors, _projectile_wire_round,
@@ -265,7 +265,8 @@ class LanProtocolTests(unittest.TestCase):
                           'vehicle': 'germany:G01_PzI',
                           'max_health': 150,
                           'vehicle_compact_descr': 'cHpp',
-                          'effective_params': effective_params()},
+                          'effective_params': effective_params(),
+                          'marks_on_gun': 0},
                          self.sent[-1])
         # Only the server-published roster may retire the pending selection,
         # so a rejected update is resent on the next waiting roster.
@@ -286,6 +287,97 @@ class LanProtocolTests(unittest.TestCase):
         self.assertEqual('germany:G01_PzI', self.client.vehicle)
         self.assertEqual(150, self.client.max_health)
         self.assertTrue(self.client.select_vehicle('germany:G01_PzI', 150))
+
+    def _marks_hello(self, **changes):
+        hello = {
+            'client_build': CLIENT_BUILD_0922,
+            'capabilities': list(CLIENT_CAPABILITIES),
+            'account_key': 'b' * 32,
+            'name': 'Marks', 'vehicle': 'ussr:R11_MS-1',
+            'max_health': 100, 'outfits': {},
+            'vehicle_compact_descr': 'dGVzdA==',
+            'effective_params': effective_params(),
+        }
+        hello.update(changes)
+        return hello
+
+    def test_join_publishes_the_owner_gun_marks_on_every_roster_row(self):
+        """#1513 decals a barrel from the roster's marksOnGun, never a guess.
+
+        The lean roster rows drop the large outfit and effective-parameter
+        blocks, but a replica still needs its owner's mark count, so the
+        single integer rides every row.
+        """
+        state = BattleState(map_name='01_karelia')
+        state.client_build = CLIENT_BUILD_0922
+        player, error = state.add_player(
+            _Socket(), ('127.0.0.1', 1),
+            self._marks_hello(marks_on_gun=2))
+
+        self.assertIsNone(error)
+        self.assertEqual(2, player.marks_on_gun)
+        self.assertEqual(2, state._public_player(player)['marks_on_gun'])
+        self.assertEqual(
+            2, state._public_player(player, include_outfits=False)[
+                'marks_on_gun'])
+
+    def test_join_without_a_gun_mark_count_earns_no_marks(self):
+        """An older client that never publishes the count still joins."""
+        state = BattleState(map_name='01_karelia')
+        state.client_build = CLIENT_BUILD_0922
+        player, error = state.add_player(
+            _Socket(), ('127.0.0.1', 1), self._marks_hello())
+
+        self.assertIsNone(error)
+        self.assertEqual(0, player.marks_on_gun)
+
+    def test_join_rejects_a_gun_mark_count_outside_the_dossier_record(self):
+        """``dossiers2.custom.records`` stores marksOnGun as a 'B' max 3."""
+        for name, value in (('float', 2.0), ('bool', True), ('string', '2'),
+                            ('negative', -1), ('overflow', 4)):
+            with self.subTest(name=name):
+                state = BattleState(map_name='01_karelia')
+                state.client_build = CLIENT_BUILD_0922
+                player, error = state.add_player(
+                    _Socket(), ('127.0.0.1', 1),
+                    self._marks_hello(marks_on_gun=value))
+
+                self.assertIsNone(player)
+                self.assertEqual('invalid_marks_on_gun', error)
+
+    def test_a_new_gun_mark_alone_republishes_the_same_vehicle(self):
+        """A battle can earn a mark on the tank the player keeps driving."""
+        state = self._room_with_one_player()
+        player = state.players[1]
+        message = {
+            'vehicle': 'ussr:R11_MS-1',
+            'max_health': 90,
+            'outfits': {},
+            'vehicle_compact_descr': 'dGVzdA==',
+            'effective_params': effective_params(),
+        }
+
+        self.assertFalse(state.select_vehicle(1, message))
+        self.assertTrue(state.select_vehicle(
+            1, dict(message, marks_on_gun=1)))
+        self.assertEqual(1, player.marks_on_gun)
+
+        # An omitted count keeps the marks the server already holds rather
+        # than silently stripping the barrel.
+        self.assertFalse(state.select_vehicle(1, message))
+        self.assertEqual(1, player.marks_on_gun)
+
+    def test_client_publishes_its_own_gun_marks_in_hello(self):
+        client = LANClient('127.0.0.1', 28782, 'Marks', 'ussr:R11_MS-1',
+                           effective_params=effective_params(),
+                           marks_on_gun=3)
+        self.assertEqual(3, client._hello_payload()['marks_on_gun'])
+
+    def test_client_gun_mark_count_is_clamped_to_the_dossier_record(self):
+        client = LANClient('127.0.0.1', 28782, 'Marks', 'ussr:R11_MS-1',
+                           effective_params=effective_params(),
+                           marks_on_gun=99)
+        self.assertEqual(3, client.marks_on_gun)
 
     def test_modern_vehicle_change_rejects_non_exact_health_atomically(self):
         invalid_values = (

--- a/tests/test_port_0922_lan_session.py
+++ b/tests/test_port_0922_lan_session.py
@@ -99,7 +99,8 @@ class _Client(object):
         return True
 
     def select_vehicle(self, vehicle, max_health, outfits=None,
-                       vehicle_compact_descr=None, effective_params=None):
+                       vehicle_compact_descr=None, effective_params=None,
+                       marks_on_gun=None):
         if not self.ready or self.phase != 'waiting':
             return False
         if vehicle == self.vehicle and max_health == self.max_health:
@@ -336,11 +337,46 @@ class LANSessionTests(unittest.TestCase):
         calls = []
         self.session._effective_params_provider = lambda: {'equipment': [441]}
         self.client.select_vehicle = lambda *args: calls.append(
-            ('select', args[-1])) or True
+            ('select', args[4])) or True
         self.client.request_start = lambda *args: calls.append(('start', args)) or True
         self.assertTrue(self.session.request_start('01_karelia'))
         self.assertEqual(['select', 'start'], [call[0] for call in calls])
         self.assertEqual({'equipment': [441]}, calls[0][1])
+
+    def test_selection_publishes_the_stored_gun_marks_for_the_barrel(self):
+        """The account's own store is the producer of the barrel decal count.
+
+        ``account_rpc.data.dossiers`` publishes the same row value as the
+        garage badge, so one number reaches both surfaces.
+        """
+        self.emit('welcome', {'phase': 'waiting', 'map_pool': ['01_karelia']})
+        self.session._postbattle_store = types.SimpleNamespace(
+            marks_on_gun=lambda vehicle: 2 if vehicle == 'ussr:R11_MS-1'
+            else 0)
+        self.session._effective_params_provider = lambda: {'equipment': []}
+        calls = []
+        self.client.select_vehicle = lambda *args: calls.append(args) or True
+
+        self.assertTrue(self.session._publish_selected_vehicle())
+
+        self.assertEqual(2, calls[0][5])
+
+    def test_an_unreadable_store_publishes_no_gun_marks(self):
+        """A failing read must never block the selection that starts a round."""
+        self.emit('welcome', {'phase': 'waiting', 'map_pool': ['01_karelia']})
+
+        def explode(unused_vehicle):
+            raise RuntimeError('save slot is unreadable')
+
+        self.session._postbattle_store = types.SimpleNamespace(
+            marks_on_gun=explode)
+        self.session._effective_params_provider = lambda: {'equipment': []}
+        calls = []
+        self.client.select_vehicle = lambda *args: calls.append(args) or True
+
+        self.assertTrue(self.session._publish_selected_vehicle())
+
+        self.assertEqual(0, calls[0][5])
 
     def test_inventory_refresh_blocks_start_then_publishes_completed_loadout(self):
         self.emit('welcome', {'phase': 'waiting', 'map_pool': ['01_karelia']})
@@ -356,7 +392,7 @@ class LANSessionTests(unittest.TestCase):
         self.assertEqual('waiting', self.session.state)
         self.session.on_inventory_refreshed()
         self.assertEqual({'equipment': [441, 442, 443]},
-                         self.client.select_vehicle.call_args[0][-1])
+                         self.client.select_vehicle.call_args[0][4])
         self.assertTrue(self.session.request_start('01_karelia'))
 
     def test_start_does_not_use_old_loadout_after_projection_failure(self):


### PR DESCRIPTION
## The bug

Marks of Excellence never appear on a gun barrel in battle — on any tank,
including the player's own.

`vehicle_systems/CompoundAppearance.__createStickers` (line 1183 in the pinned
`scripts.pkg`) reads `self.__vehicle.publicInfo['marksOnGun']` and passes it
straight to `VehicleStickers(typeDescriptor, insigniaRank, outfit)`. The stock
`DetachedTurret.__createAndAttachStickers` reads the same field off the owning
vehicle, and this port's `remote_vehicle._attach_vehicle_stickers` reads it for
a Python-built replica.

`BigWorldVehicleBinding._properties_from_descriptor` published a literal `0`
there for every vehicle it built, and neither the local-player call site
(`battle_runtime.py` `_create_entities`) nor `_create_remote` overwrote it
before `addVehicleToArena` / `RemoteVehicleFactory.create`. The marks
themselves were computed, banked and published to the garage correctly — only
the in-world decal was missing.

## The fix

One owner, mirroring how `outfits` already travels:

- `PostBattleStore.marks_on_gun(type_name)` returns the same row value
  `account_rpc.data.dossiers` publishes as the garage badge, so the barrel and
  the badge read one number.
- The LAN client carries it in `hello` and `select_vehicle`. It rides
  `select_vehicle` because a battle can earn a mark on the vehicle the player
  keeps: the count changes while the vehicle, its outfits and its effective
  parameters do not. `_send_start_request` republishes the selection
  immediately before every start, so a mark earned last round is on the barrel
  this round.
- The server validates `0..3` and `_public_player` republishes it on **every**
  roster row — including the lean rows that drop the much larger outfit and
  effective-parameter blocks — so a remote human's replica decals that
  player's own count.
- A Bot has no account and publishes none. The stock detached turret inherits
  the owner's count for free, since it reads the vehicle's `publicInfo`.

Bounded at three everywhere it crosses a boundary, which is the cap
`dossiers2.custom.records` puts on the vehicle `marksOnGun` record. A roster
row without the field is no marks, never a refused join or a failed set of
entity properties.

## What was already correct

The garage path is wired: `MARK_ON_GUN_RECORD` is `(_AB.TOTAL, 'marksOnGun')`
and `_AB.TOTAL == 'achievements'`, which is exactly the block
`account_rpc.data._write_badges` writes; the hangar's
`_VehicleAppearance.__setupEmblems` and the carousel's `_getVehicleStats` both
read that record. The results-window popup path (`dossierPopUps`, record 295)
was already published by `_add_badge_results`.

## Validation

- Full client suite: 5213 tests, `OK` (1 skipped), run in five module chunks
  (2402 / 1083 / 639 / 541 / 548) because the box's memory watchdog kept
  killing the single-process run.
- CPython 2.7 source compile gate: 112 files.
- The two new local-player tests fail on the unfixed tree with
  `AssertionError: 3 != 0`.
- New coverage: store accessor (earn, persist across restart, damaged row);
  server hello/roster publication including the lean row; rejection of a
  count outside the dossier record; a mark change alone republishing an
  unchanged vehicle; client hello shape and clamping; local player entity
  properties and their clamp; remote human replica; Bot replica staying at
  zero; the session provider and its failure path.
- Two pinned wire-shape expectations were updated for the new field
  (`_local_state` fallback, player `hello`). The hidden worker's `hello` still
  carries no player fields.

## Not proved here

Only the exact Windows client can prove the decal texture actually draws.
Worth checking on a Tier V+ tank with at least one stored mark, in battle,
third-person.

## Separate, still-live defect (not in this PR)

`compat.py` logs in under one constant `_OFFLINE_ACCOUNT_NAME`, so every save
slot shares one `DossierCache` file and its persisted `maxChangeTime`. Any
store whose battle count sits below that watermark publishes no vehicle
dossier row at all, which freezes the *garage* marks, mastery badge and
per-vehicle records while battles keep settling. Different root cause,
different class (all per-vehicle records, not just MoE) — happy to open a
second PR for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
