### PR TITLE
Suppress outlines behind retained wreck and landed turret bounds

### DIFF
--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -40,7 +40,8 @@ from gui.mods.offline_lan_0922.entities.remote_vehicle import (
     _collide_vehicle_evidence_at_matrix,
     _component_aim_angles, _pose_components, collide_vehicle_at_matrix,
     encode_damage_sticker, pose_animation_writes,
-    reset_pose_animation_writes, vehicle_blast_probe_points_at_matrix)
+    reset_pose_animation_writes,
+    vehicle_blast_probe_points_at_matrix, vehicle_target_bounds_at_matrix)
 from gui.mods.offline_lan_0922.entities.runtime import EntityPropertyBuilder
 from gui.mods.offline_lan_0922.projectile_manager import InFlightProjectiles
 from gui.mods.offline_lan_0922.projectile_runtime import (
@@ -214,6 +215,10 @@ _SIMPLE_EVENT_KINDS = (
 _COMBAT_EVENT_KINDS = (
     'health', 'hit', 'bot_hit', 'bot_human_hit', 'bot_bot_hit')
 _SHOT_OCCLUSION_EPSILON = 1.0e-3
+# A vehicle whose origin is further than this from the cursor ray cannot
+# overlap it. Shared with the projectile broad phase so one conservative
+# bound covers every hull this port supports.
+_TARGET_PICK_BROADPHASE_SQ = PROJECTILE_BROADPHASE_RADIUS ** 2
 # physics_shared.TRACK_SCROLL_LIMITS: the exact #1513 belt-speed wire range.
 TRACK_SCROLL_LIMITS = (-15.0, 30.0)
 # Metres of view-range change worth another syncVehicleAttrs push.
@@ -1776,6 +1781,7 @@ class BattleRuntime(object):
         self._crush_reports = 0
         self._next_crush_report = {}
         self._destructible_verdict_reports = 0
+        self._wreck_impact_reports = 0
         self._soft_static_recast_budget = [BOT_SOFT_RECAST_BUDGET]
         self._local_vertical_speed = 0.0
         self._local_airborne = False
@@ -2098,6 +2104,7 @@ class BattleRuntime(object):
         self._crush_reports = 0
         self._next_crush_report = {}
         self._destructible_verdict_reports = 0
+        self._wreck_impact_reports = 0
         self._soft_static_recast_budget = [BOT_SOFT_RECAST_BUDGET]
         self._local_vertical_speed = 0.0
         self._local_airborne = False
@@ -14131,6 +14138,47 @@ class BattleRuntime(object):
             return {'reason': 'impact', 'fraction': nearest_fraction}
         return None
 
+    _WRECK_IMPACT_REPORT_LIMIT = 12
+
+    def _report_wreck_impact(self, target_kind, target_record, data, impact):
+        """Name the wreck part that ended one shell, a few times per round.
+
+        A player only reports that a wreck ate the shell somewhere that
+        looked clear.  The part, the pose that part was tested at and the
+        contact point are the whole diagnosis: a hull contact is retail's
+        own ``getCollidableEntities`` contract, while a gun contact metres
+        off the hull says the drawn wreck and the tested one disagree.
+        Bounded, and written only by the process that owns the resolution.
+        """
+        if not self._worker_mode:
+            return False
+        if (self._wreck_impact_reports >=
+                self._WRECK_IMPACT_REPORT_LIMIT):
+            return False
+        self._wreck_impact_reports += 1
+        data = data if isinstance(data, dict) else {}
+        collisions = data.get('collisions') or ()
+        nearest = (min(collisions, key=lambda item: float(item.dist))
+                   if collisions else None)
+        pose = data.get('collision_pose')
+        if not isinstance(pose, dict):
+            pose = target_record.get('projectile_collision_pose')
+        pose = pose if isinstance(pose, dict) else {}
+        sys.stdout.write(
+            '[Offline LAN 0.9.22] WRECK IMPACT %s=%s part=%s '
+            'pose=(%.2f, %.2f, %.2f) yaw=%.3f pitch=%.3f roll=%.3f '
+            'turret=%.3f gun=%.3f at=(%.2f, %.2f, %.2f)\n' % (
+                target_kind, target_record.get('network_id'),
+                'unknown' if nearest is None else
+                getattr(nearest, 'compName', 'unknown'),
+                _number(pose.get('x')), _number(pose.get('y')),
+                _number(pose.get('z')), _number(pose.get('yaw')),
+                _number(pose.get('pitch')), _number(pose.get('roll')),
+                _number(pose.get('turret_yaw')),
+                _number(pose.get('gun_pitch')),
+                _number(impact[0]), _number(impact[1]), _number(impact[2])))
+        return True
+
     def _report_shot_scene_stop(self, reason, impact):
         """Name the scenery contract that ended a shot, once per round.
 
@@ -15113,6 +15161,8 @@ class BattleRuntime(object):
                         'target_kind': target_kind,
                         'target_id': int(target_record.get('network_id')),
                     }
+                    self._report_wreck_impact(
+                        target_kind, target_record, data, impact)
         if hit_vehicle and direct is None and wreck_hit is None:
             # A live vehicle impact must carry the exact armour proposal,
             # including legal zero-damage ricochets and non-penetrations. If
@@ -16611,7 +16661,22 @@ class BattleRuntime(object):
         return start, direction
 
     def _wreck_blocks_target_outline(self, start, end, target_depth):
-        """Return whether a retained wreck owns the nearer cursor hit."""
+        """Return whether a nearer dead body owns #1513's cursor pick.
+
+        Stock never occludes targeting with a vehicle: ``pickFirst`` scores
+        every candidate as ``angleTo + 0.001 * zDistance`` and the line of
+        sight ``isEntitySelectable`` runs is ``ChunkSpace::collide``, the
+        static scene alone.  A wreck keeps the ``targetCaps``
+        ``vehicle_onEnterWorld`` gave it and the ``targetFullBounds``
+        ``Vehicle.__init__`` set, so a dead hull under the cursor wins that
+        score purely by being nearer, and ``PlayerAvatar.targetFocus`` then
+        draws no edge at all because the entity it picked is not alive.
+        Reproduce that on the same full bounds rather than on the exact
+        hit-test geometry a shell uses: a pin-point ray slips over a hull
+        roof or between hull and gun where stock has already taken the pick,
+        and the outline then promises a line the shell does not have.
+        """
+        ray = (_xyz(start), _xyz(end))
         for record in self._records.values():
             if (record.get('local') or record.get('tombstone') or
                     not record.get('ready')):
@@ -16621,17 +16686,45 @@ class BattleRuntime(object):
                     not getattr(vehicle, 'isStarted', False) or
                     self._record_alive(record, vehicle)):
                 continue
-            if record.get('native_remote'):
-                collisions = collide_vehicle_at_matrix(
-                    vehicle, vehicle.matrix, start, end,
-                    self._runtime.math)
-            else:
-                collide = getattr(vehicle, 'collideSegmentExt', None)
-                collisions = collide(start, end) if callable(collide) else ()
-            if (collisions and min(float(item.dist) for item in collisions) +
-                    _SHOT_OCCLUSION_EPSILON < target_depth):
+            # Composing full bounds costs four component transforms, so
+            # reject the wrecks this cursor ray cannot reach first. The
+            # radius is the same conservative vehicle bound the projectile
+            # broad phase uses, and it never rejects a real overlap.
+            position = _xyz(getattr(
+                vehicle, 'position', record.get('state', {})))
+            if point_segment_distance_sq(
+                    position, ray[0],
+                    ray[1]) > _TARGET_PICK_BROADPHASE_SQ:
+                continue
+            matrix = getattr(vehicle, 'matrix', None)
+            if matrix is None:
+                continue
+            distance = shot_geometry.segment_box_entry_distance(
+                start, end, vehicle_target_bounds_at_matrix(
+                    vehicle, matrix, self._runtime.math))
+            if (distance is not None and
+                    distance + _SHOT_OCCLUSION_EPSILON < target_depth):
                 return True
         return False
+
+    def _thrown_turret_blocks_target_outline(self, start, end, target_depth):
+        """Return whether a landed turret owns the nearer cursor pick.
+
+        ``DetachedTurret.__init__`` sets ``targetFullBounds`` and
+        ``targetCaps = [1]``, so a thrown turret is an ordinary picker
+        candidate that carries no ``isAlive`` edge.  The same landed pose
+        already stops a shell here, so the outline must not keep promising
+        a line through it.
+        """
+        obstacles = self._detached_turret_obstacles
+        if obstacles is None:
+            return False
+        entry = getattr(obstacles, 'target_entry_distance', None)
+        if not callable(entry):
+            return False
+        distance = entry(start, end, self._turret_server_time_ms())
+        return (distance is not None and
+                distance + _SHOT_OCCLUSION_EPSILON < target_depth)
 
     def _update_target_outline(self, now):
         """Outline the vehicle the cursor ray actually strikes.
@@ -16662,6 +16755,7 @@ class BattleRuntime(object):
         chosen_depth = None
         miss = None
         decline = None
+        blocked = None
         for record in self._records.values():
             if record.get('local'):
                 continue
@@ -16741,18 +16835,26 @@ class BattleRuntime(object):
                 reason = 'is behind scenery'
                 if held_id == blocked_id:
                     held_reason = reason
-                decline = (blocked_id, reason)
+                blocked = (blocked_id, reason)
+                decline = blocked
                 chosen = None
                 chosen_depth = None
-            elif self._wreck_blocks_target_outline(
-                    start, target_end, chosen_depth):
-                blocked_id = chosen
-                reason = 'is behind a wreck'
-                if held_id == blocked_id:
-                    held_reason = reason
-                decline = (blocked_id, reason)
-                chosen = None
-                chosen_depth = None
+            else:
+                reason = None
+                if self._wreck_blocks_target_outline(
+                        start, target_end, chosen_depth):
+                    reason = 'is behind a wreck'
+                elif self._thrown_turret_blocks_target_outline(
+                        start, target_end, chosen_depth):
+                    reason = 'is behind a thrown turret'
+                if reason is not None:
+                    blocked_id = chosen
+                    if held_id == blocked_id:
+                        held_reason = reason
+                    blocked = (blocked_id, reason)
+                    decline = blocked
+                    chosen = None
+                    chosen_depth = None
         # Retail drops the target when it stops being eligible, and a vehicle
         # the round no longer records at all can never be kept.
         if held_id is not None and chosen != held_id and held_reason is None:
@@ -16761,7 +16863,8 @@ class BattleRuntime(object):
         dropped = None
         if held_id is not None and chosen != held_id:
             dropped = (held_id, held_reason)
-        self._report_target_outline(now, chosen, miss, decline, dropped)
+        self._report_target_outline(
+            now, chosen, miss, decline, dropped, blocked)
         if chosen == held_id:
             if chosen is not None:
                 self._refresh_native_target_outline()
@@ -17082,12 +17185,21 @@ class BattleRuntime(object):
                         None) is not None))
         return True
 
-    def _report_target_outline(self, now, chosen, miss, decline, dropped):
-        """Keep a bounded sample of changing outline decisions."""
+    def _report_target_outline(self, now, chosen, miss, decline, dropped,
+                               blocked=None):
+        """Keep a bounded sample of changing outline decisions.
+
+        A vehicle the cursor really struck and something nearer then took
+        outranks a cone miss: it is a decision about the target the player
+        is pointing at, while ``miss`` only names the closest candidate
+        that was never chosen.
+        """
         if chosen is not None:
             message = 'outlined id=%s' % chosen
         elif dropped is not None:
             message = 'none: dropped id=%s, it %s' % dropped
+        elif blocked is not None:
+            message = 'none: id=%s %s' % blocked
         elif miss is not None:
             message = (
                 'none: id=%s is %.1f deg off the cursor at %.0f m'

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -215,9 +215,8 @@ _SIMPLE_EVENT_KINDS = (
 _COMBAT_EVENT_KINDS = (
     'health', 'hit', 'bot_hit', 'bot_human_hit', 'bot_bot_hit')
 _SHOT_OCCLUSION_EPSILON = 1.0e-3
-# A vehicle whose origin is further than this from the cursor ray cannot
-# overlap it. Shared with the projectile broad phase so one conservative
-# bound covers every hull this port supports.
+# Reuse the projectile broad phase's conservative vehicle radius before
+# composing descriptor bounds for an outline candidate.
 _TARGET_PICK_BROADPHASE_SQ = PROJECTILE_BROADPHASE_RADIUS ** 2
 # physics_shared.TRACK_SCROLL_LIMITS: the exact #1513 belt-speed wire range.
 TRACK_SCROLL_LIMITS = (-15.0, 30.0)
@@ -14143,11 +14142,9 @@ class BattleRuntime(object):
     def _report_wreck_impact(self, target_kind, target_record, data, impact):
         """Name the wreck part that ended one shell, a few times per round.
 
-        A player only reports that a wreck ate the shell somewhere that
-        looked clear.  The part, the pose that part was tested at and the
-        contact point are the whole diagnosis: a hull contact is retail's
-        own ``getCollidableEntities`` contract, while a gun contact metres
-        off the hull says the drawn wreck and the tested one disagree.
+        The tested part, pose and contact point help correlate a player's
+        report with the authoritative query. They do not establish where
+        Windows drew that part or prove that its collision was correct.
         Bounded, and written only by the process that owns the resolution.
         """
         if not self._worker_mode:
@@ -14156,27 +14153,32 @@ class BattleRuntime(object):
                 self._WRECK_IMPACT_REPORT_LIMIT):
             return False
         self._wreck_impact_reports += 1
-        data = data if isinstance(data, dict) else {}
-        collisions = data.get('collisions') or ()
-        nearest = (min(collisions, key=lambda item: float(item.dist))
-                   if collisions else None)
-        pose = data.get('collision_pose')
-        if not isinstance(pose, dict):
-            pose = target_record.get('projectile_collision_pose')
-        pose = pose if isinstance(pose, dict) else {}
-        sys.stdout.write(
-            '[Offline LAN 0.9.22] WRECK IMPACT %s=%s part=%s '
-            'pose=(%.2f, %.2f, %.2f) yaw=%.3f pitch=%.3f roll=%.3f '
-            'turret=%.3f gun=%.3f at=(%.2f, %.2f, %.2f)\n' % (
-                target_kind, target_record.get('network_id'),
-                'unknown' if nearest is None else
-                getattr(nearest, 'compName', 'unknown'),
-                _number(pose.get('x')), _number(pose.get('y')),
-                _number(pose.get('z')), _number(pose.get('yaw')),
-                _number(pose.get('pitch')), _number(pose.get('roll')),
-                _number(pose.get('turret_yaw')),
-                _number(pose.get('gun_pitch')),
-                _number(impact[0]), _number(impact[1]), _number(impact[2])))
+        try:
+            data = data if isinstance(data, dict) else {}
+            collisions = data.get('collisions') or ()
+            nearest = (min(collisions, key=lambda item: float(item.dist))
+                       if collisions else None)
+            pose = data.get('collision_pose')
+            if not isinstance(pose, dict):
+                pose = target_record.get('projectile_collision_pose')
+            pose = pose if isinstance(pose, dict) else {}
+            sys.stdout.write(
+                '[Offline LAN 0.9.22] WRECK IMPACT %s=%s part=%s '
+                'pose=(%.2f, %.2f, %.2f) yaw=%.3f pitch=%.3f roll=%.3f '
+                'turret=%.3f gun=%.3f at=(%.2f, %.2f, %.2f)\n' % (
+                    target_kind, target_record.get('network_id'),
+                    'unknown' if nearest is None else
+                    getattr(nearest, 'compName', 'unknown'),
+                    _number(pose.get('x')), _number(pose.get('y')),
+                    _number(pose.get('z')), _number(pose.get('yaw')),
+                    _number(pose.get('pitch')), _number(pose.get('roll')),
+                    _number(pose.get('turret_yaw')),
+                    _number(pose.get('gun_pitch')),
+                    _number(impact[0]), _number(impact[1]), _number(impact[2])))
+        except Exception:
+            # Optional diagnostics must not replace a resolved wreck impact
+            # with a no-effect terminal when its fields or log stream fail.
+            return False
         return True
 
     def _report_shot_scene_stop(self, reason, impact):
@@ -16661,20 +16663,14 @@ class BattleRuntime(object):
         return start, direction
 
     def _wreck_blocks_target_outline(self, start, end, target_depth):
-        """Return whether a nearer dead body owns #1513's cursor pick.
+        """Suppress an outline behind a nearer retained wreck's full bounds.
 
-        Stock never occludes targeting with a vehicle: ``pickFirst`` scores
-        every candidate as ``angleTo + 0.001 * zDistance`` and the line of
-        sight ``isEntitySelectable`` runs is ``ChunkSpace::collide``, the
-        static scene alone.  A wreck keeps the ``targetCaps``
-        ``vehicle_onEnterWorld`` gave it and the ``targetFullBounds``
-        ``Vehicle.__init__`` set, so a dead hull under the cursor wins that
-        score purely by being nearer, and ``PlayerAvatar.targetFocus`` then
-        draws no edge at all because the entity it picked is not alive.
-        Reproduce that on the same full bounds rather than on the exact
-        hit-test geometry a shell uses: a pin-point ray slips over a hull
-        roof or between hull and gun where stock has already taken the pick,
-        and the outline then promises a line the shell does not have.
+        #1513 Vehicle.onEnterWorld sets targetFullBounds. Public BigWorld
+        2.0.1 picker source motivates checking the whole compound envelope,
+        but it is not evidence for the shipped #1513 native implementation.
+        This local selection rule uses descriptor bounds and segment-entry
+        order; it is not the public engine's entity-origin zDistance score.
+        Exact Windows picker parity remains unverified.
         """
         ray = (_xyz(start), _xyz(end))
         for record in self._records.values():
@@ -16686,10 +16682,8 @@ class BattleRuntime(object):
                     not getattr(vehicle, 'isStarted', False) or
                     self._record_alive(record, vehicle)):
                 continue
-            # Composing full bounds costs four component transforms, so
-            # reject the wrecks this cursor ray cannot reach first. The
-            # radius is the same conservative vehicle bound the projectile
-            # broad phase uses, and it never rejects a real overlap.
+            # Avoid component transforms for distant wrecks using the same
+            # conservative radius as the projectile broad phase.
             position = _xyz(getattr(
                 vehicle, 'position', record.get('state', {})))
             if point_segment_distance_sq(
@@ -16708,13 +16702,12 @@ class BattleRuntime(object):
         return False
 
     def _thrown_turret_blocks_target_outline(self, start, end, target_depth):
-        """Return whether a landed turret owns the nearer cursor pick.
+        """Return whether a landed turret's full bounds precede the target.
 
         ``DetachedTurret.__init__`` sets ``targetFullBounds`` and
-        ``targetCaps = [1]``, so a thrown turret is an ordinary picker
-        candidate that carries no ``isAlive`` edge.  The same landed pose
-        already stops a shell here, so the outline must not keep promising
-        a line through it.
+        ``targetCaps = [1]``. Use the server-accepted landed geometry for this
+        local selection rule, just as the projectile obstacle query does.
+        Native picker behaviour while the turret is in flight is unverified.
         """
         obstacles = self._detached_turret_obstacles
         if obstacles is None:

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/entities/remote_vehicle.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/entities/remote_vehicle.py
@@ -1873,6 +1873,73 @@ def collide_vehicle_at_matrix(vehicle, vehicle_matrix, start_point,
         chassis_matrix=chassis_matrix)
 
 
+def _point_xyz(value):
+    """Read one native or test point without assuming a single accessor."""
+    if hasattr(value, 'x'):
+        return (float(value.x), float(value.y), float(value.z))
+    return (float(value[0]), float(value[1]), float(value[2]))
+
+
+def vehicle_target_bounds_at_matrix(vehicle, vehicle_matrix, math_module,
+                                    chassis_matrix=None):
+    """Return the world box #1513's entity picker targets for one vehicle.
+
+    ``EntityPicker::getBoundingBox`` reads the primary embodiment's local
+    bounding box and transforms it into world space, so targeting works on
+    the whole compound -- gun included -- and never on the exact hit-test
+    geometry a shell uses.  ``Vehicle.__init__`` sets ``targetFullBounds``,
+    which keeps that box unshrunk.  This runtime owns no BigWorld compound
+    for a replica, so compose the same extent from the attached descriptor
+    hit-test boxes at the supplied body and chassis poses.  Accumulating in
+    world space keeps the result inside the box stock would transform, and
+    it never invents an extent a missing descriptor box cannot supply.
+    """
+    try:
+        components = _pose_components(vehicle, math_module)
+    except AttributeError:
+        # Stock ``CompoundAppearance.__onModelsRefresh`` detaches before it
+        # relinks, so a wreck can be between compounds for one frame. The
+        # picker simply has no candidate then; the next pass reads the
+        # rebound turret and gun matrices.
+        return None
+    lower = None
+    upper = None
+    for component_index, entry in enumerate(components):
+        component, component_matrix, is_attached = entry
+        if not is_attached:
+            # A detached turret is a separate picker candidate with its own
+            # landed pose.  This hull must not target the part it threw.
+            continue
+        tester = _component_value(component, 'hitTester')
+        bounds = _blast_bbox_bounds(_component_value(tester, 'bbox'))
+        if bounds is None:
+            continue
+        root_matrix = (chassis_matrix if component_index == 0 and
+                       chassis_matrix is not None else vehicle_matrix)
+        component_to_root = math_module.Matrix(component_matrix)
+        component_to_root.invert()
+        to_world = math_module.Matrix(root_matrix)
+        to_world.preMultiply(component_to_root)
+        for index in range(8):
+            corner = to_world.applyPoint(math_module.Vector3(
+                bounds[index & 1][0],
+                bounds[(index >> 1) & 1][1],
+                bounds[(index >> 2) & 1][2]))
+            point = _point_xyz(corner)
+            if lower is None:
+                lower = list(point)
+                upper = list(point)
+                continue
+            for axis in range(3):
+                if point[axis] < lower[axis]:
+                    lower[axis] = point[axis]
+                elif point[axis] > upper[axis]:
+                    upper[axis] = point[axis]
+    if lower is None:
+        return None
+    return tuple(lower), tuple(upper)
+
+
 class RemoteVehicle(object):
     """Python gameplay identity separated from its OfflineEntity visual."""
 

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/entities/remote_vehicle.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/entities/remote_vehicle.py
@@ -1882,62 +1882,60 @@ def _point_xyz(value):
 
 def vehicle_target_bounds_at_matrix(vehicle, vehicle_matrix, math_module,
                                     chassis_matrix=None):
-    """Return the world box #1513's entity picker targets for one vehicle.
+    """Compose a world AABB over the attached descriptor hit-test boxes.
 
-    ``EntityPicker::getBoundingBox`` reads the primary embodiment's local
-    bounding box and transforms it into world space, so targeting works on
-    the whole compound -- gun included -- and never on the exact hit-test
-    geometry a shell uses.  ``Vehicle.__init__`` sets ``targetFullBounds``,
-    which keeps that box unshrunk.  This runtime owns no BigWorld compound
-    for a replica, so compose the same extent from the attached descriptor
-    hit-test boxes at the supplied body and chassis poses.  Accumulating in
-    world space keeps the result inside the box stock would transform, and
-    it never invents an extent a missing descriptor box cannot supply.
+    #1513 Vehicle.onEnterWorld enables targetFullBounds. The public BigWorld
+    2.0.1 picker uses an embodiment bounding box, which motivates this local
+    full-envelope rule. Descriptor boxes are an approximation of the visual
+    compound's bounds; neither their equality nor the shipped native picker
+    rule has been established on #1513. Missing geometry contributes no box.
     """
     try:
         components = _pose_components(vehicle, math_module)
-    except AttributeError:
+        lower = None
+        upper = None
+        for component_index, entry in enumerate(components):
+            component, component_matrix, is_attached = entry
+            if not is_attached:
+                # A detached turret is a separate picker candidate with its own
+                # landed pose.  This hull must not target the part it threw.
+                continue
+            tester = _component_value(component, 'hitTester')
+            bounds = _blast_bbox_bounds(_component_value(tester, 'bbox'))
+            if bounds is None:
+                continue
+            root_matrix = (chassis_matrix if component_index == 0 and
+                           chassis_matrix is not None else vehicle_matrix)
+            component_to_root = math_module.Matrix(component_matrix)
+            component_to_root.invert()
+            to_world = math_module.Matrix(root_matrix)
+            to_world.preMultiply(component_to_root)
+            for index in range(8):
+                corner = to_world.applyPoint(math_module.Vector3(
+                    bounds[index & 1][0],
+                    bounds[(index >> 1) & 1][1],
+                    bounds[(index >> 2) & 1][2]))
+                point = _point_xyz(corner)
+                if lower is None:
+                    lower = list(point)
+                    upper = list(point)
+                    continue
+                for axis in range(3):
+                    if point[axis] < lower[axis]:
+                        lower[axis] = point[axis]
+                    elif point[axis] > upper[axis]:
+                        upper[axis] = point[axis]
+        if lower is None:
+            return None
+        return tuple(lower), tuple(upper)
+    except (AttributeError, IndexError, KeyError, TypeError, ValueError,
+            OverflowError):
         # Stock ``CompoundAppearance.__onModelsRefresh`` detaches before it
         # relinks, so a wreck can be between compounds for one frame. The
-        # picker simply has no candidate then; the next pass reads the
-        # rebound turret and gun matrices.
+        # local query skips this candidate; the next pass reads the rebound
+        # turret and gun matrices. A temporarily unavailable native provider
+        # must not disable all outline presentation for the rest of the round.
         return None
-    lower = None
-    upper = None
-    for component_index, entry in enumerate(components):
-        component, component_matrix, is_attached = entry
-        if not is_attached:
-            # A detached turret is a separate picker candidate with its own
-            # landed pose.  This hull must not target the part it threw.
-            continue
-        tester = _component_value(component, 'hitTester')
-        bounds = _blast_bbox_bounds(_component_value(tester, 'bbox'))
-        if bounds is None:
-            continue
-        root_matrix = (chassis_matrix if component_index == 0 and
-                       chassis_matrix is not None else vehicle_matrix)
-        component_to_root = math_module.Matrix(component_matrix)
-        component_to_root.invert()
-        to_world = math_module.Matrix(root_matrix)
-        to_world.preMultiply(component_to_root)
-        for index in range(8):
-            corner = to_world.applyPoint(math_module.Vector3(
-                bounds[index & 1][0],
-                bounds[(index >> 1) & 1][1],
-                bounds[(index >> 2) & 1][2]))
-            point = _point_xyz(corner)
-            if lower is None:
-                lower = list(point)
-                upper = list(point)
-                continue
-            for axis in range(3):
-                if point[axis] < lower[axis]:
-                    lower[axis] = point[axis]
-                elif point[axis] > upper[axis]:
-                    upper[axis] = point[axis]
-    if lower is None:
-        return None
-    return tuple(lower), tuple(upper)
 
 
 class RemoteVehicle(object):

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/entities/turret_obstacles.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/entities/turret_obstacles.py
@@ -122,7 +122,7 @@ def _world_box(bounds, offset, position, attitude):
 
 
 def _boxes_world_bounds(boxes):
-    """Return the world AABB stock's ``getBoundingBox`` would transform."""
+    """Enclose the supplied component boxes in one world AABB."""
     lower = None
     upper = None
     for center, half_axes in boxes:
@@ -345,10 +345,10 @@ class DetachedTurretObstacles(object):
     def target_entry_distance(self, start, end, server_time_ms):
         """Return where a cursor ray first enters a landed turret's bounds.
 
-        ``DetachedTurret.__init__`` sets ``targetFullBounds`` and
-        ``targetCaps = [1]``, so stock's picker scores a thrown turret on
-        its whole box exactly like a vehicle.  Only a settled turret is a
-        candidate, matching the pose every other query here uses.
+        #1513 DetachedTurret.__init__ enables targetFullBounds and sets
+        targetCaps = [1]. This local bounds approximation uses only settled
+        turrets, matching the accepted pose used by the obstacle queries;
+        it does not establish the shipped native picker's selection rule.
         """
         nearest = None
         for turret in self._ready(server_time_ms):

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/entities/turret_obstacles.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/entities/turret_obstacles.py
@@ -121,6 +121,30 @@ def _world_box(bounds, offset, position, attitude):
     return center, tuple(half_axes)
 
 
+def _boxes_world_bounds(boxes):
+    """Return the world AABB stock's ``getBoundingBox`` would transform."""
+    lower = None
+    upper = None
+    for center, half_axes in boxes:
+        for index in range(1 << len(half_axes)):
+            point = center
+            for axis, half in enumerate(half_axes):
+                point = (_add(point, half) if (index >> axis) & 1
+                         else _subtract(point, half))
+            if lower is None:
+                lower = list(point)
+                upper = list(point)
+                continue
+            for axis in range(3):
+                if point[axis] < lower[axis]:
+                    lower[axis] = point[axis]
+                elif point[axis] > upper[axis]:
+                    upper[axis] = point[axis]
+    if lower is None:
+        return None
+    return tuple(lower), tuple(upper)
+
+
 def _segment_distance_squared(point, start, end):
     direction = _subtract(end, start)
     delta = _subtract(point, start)
@@ -270,6 +294,7 @@ class DetachedTurretObstacles(object):
         self._turrets[key] = {
             'row': copy.deepcopy(row), 'components': components, 'rest': rest,
             'attitude': attitude, 'radius': radius, 'boxes': boxes,
+            'target_bounds': _boxes_world_bounds(boxes),
             'hulls': tuple(hulls),
             'settles_at_ms': (_finite(row['created_time_ms']) +
                               1000.0 * _finite(flight['duration'])),
@@ -315,6 +340,23 @@ class DetachedTurretObstacles(object):
                 except Exception as error:
                     if callable(self._log):
                         self._log('detached turret hit test failed', error)
+        return nearest
+
+    def target_entry_distance(self, start, end, server_time_ms):
+        """Return where a cursor ray first enters a landed turret's bounds.
+
+        ``DetachedTurret.__init__`` sets ``targetFullBounds`` and
+        ``targetCaps = [1]``, so stock's picker scores a thrown turret on
+        its whole box exactly like a vehicle.  Only a settled turret is a
+        candidate, matching the pose every other query here uses.
+        """
+        nearest = None
+        for turret in self._ready(server_time_ms):
+            distance = shot_geometry.segment_box_entry_distance(
+                start, end, turret['target_bounds'])
+            if distance is not None and (nearest is None or
+                                         distance < nearest):
+                nearest = distance
         return nearest
 
     def sweep_blocks(self, start_pose, end_pose, descriptor, server_time_ms):

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/shot_geometry.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/shot_geometry.py
@@ -101,8 +101,8 @@ def segment_box_entry_distance(start_point, end_point, bounds):
     """Return how far along one segment it first enters an axis-aligned box.
 
     Zero is returned for a segment that starts inside the box, and ``None``
-    when it never reaches it.  The picker compares whole candidates, so an
-    entry distance is the analogue of its ``zDistance`` ordering.
+    when it never reaches it. This is geometric entry distance, not an
+    entity-origin distance or a native targeting score.
     """
     if bounds is None:
         return None

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/shot_geometry.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/shot_geometry.py
@@ -90,6 +90,50 @@ def _rotate_z(vector, angle):
             vector[2])
 
 
+def _box_point(value):
+    """Read one native or test point without assuming a single accessor."""
+    if hasattr(value, 'x'):
+        return (float(value.x), float(value.y), float(value.z))
+    return (float(value[0]), float(value[1]), float(value[2]))
+
+
+def segment_box_entry_distance(start_point, end_point, bounds):
+    """Return how far along one segment it first enters an axis-aligned box.
+
+    Zero is returned for a segment that starts inside the box, and ``None``
+    when it never reaches it.  The picker compares whole candidates, so an
+    entry distance is the analogue of its ``zDistance`` ordering.
+    """
+    if bounds is None:
+        return None
+    lower, upper = bounds
+    start = _box_point(start_point)
+    end = _box_point(end_point)
+    delta = tuple(end[axis] - start[axis] for axis in range(3))
+    length = math.sqrt(sum(value * value for value in delta))
+    if length <= 1.0e-9:
+        return None
+    near = 0.0
+    far = length
+    for axis in range(3):
+        direction = delta[axis] / length
+        if abs(direction) <= 1.0e-9:
+            if (start[axis] < lower[axis] or start[axis] > upper[axis]):
+                return None
+            continue
+        first = (lower[axis] - start[axis]) / direction
+        second = (upper[axis] - start[axis]) / direction
+        if first > second:
+            first, second = second, first
+        if first > near:
+            near = first
+        if second < far:
+            far = second
+        if near > far:
+            return None
+    return near
+
+
 def transform_vehicle_vector(vector, yaw, pitch=0.0, roll=0.0):
     """Apply BigWorld's stabilised yaw/pitch/roll rotation to a vector."""
     vector = _vector3(vector, 'vehicle-local vector')

--- a/tests/test_port_0922_battle_projectiles.py
+++ b/tests/test_port_0922_battle_projectiles.py
@@ -3216,6 +3216,42 @@ class BattleProjectileTests(unittest.TestCase):
         self.assertIn(
             'stage=effects reason=missing_live_direct', output.getvalue())
 
+    def test_wreck_diagnostic_failure_preserves_the_impact_terminal(self):
+        for failure in ('stdout', 'collision_detail'):
+            with self.subTest(failure=failure):
+                battle, unused_bigworld = _battle()
+                self.assertTrue(battle._accept_projectile_event(_event()))
+                battle._worker_mode = True
+                battle._records['bot:8'] = {
+                    'engine_id': 42, 'network_id': 8, 'kind': 'bot',
+                    'local': False, 'ready': True,
+                    'state': {'health': 0, 'alive': False}}
+                battle._projectile_direct_effect = mock.Mock(return_value=None)
+                collision = types.SimpleNamespace(dist=5.0, compName='gun')
+                if failure == 'collision_detail':
+                    collision.dist = None
+                battle._projectile_terminal_data['player:7:1'] = {
+                    'target_key': 'bot:8',
+                    'impact': (5.0, 1.0, 0.0),
+                    'collisions': (collision,),
+                }
+                state = battle._projectiles.get('player:7:1')
+                output = io.StringIO()
+                if failure == 'stdout':
+                    output = mock.Mock()
+                    output.write.side_effect = IOError('log stream closed')
+                with mock.patch('sys.stdout', output):
+                    self.assertTrue(battle._projectile_terminal(
+                        state, {'reason': 'impact'}))
+
+                args, kwargs = battle.client.resolutions[-1]
+                self.assertEqual('impact', args[3])
+                self.assertEqual([5.0, 1.0, 0.0], args[5])
+                self.assertTrue(kwargs['hit_vehicle'])
+                self.assertEqual(
+                    {'target_kind': 'bot', 'target_id': 8},
+                    kwargs['wreck_hit'])
+
     def test_stock_max_29_projectile_debt_bounds_frame_and_reduces_scans(self):
         for warm_history in (False, True):
             with self.subTest(warm_history=warm_history):

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -5499,7 +5499,7 @@ class RemoteVehicleFactoryTests(unittest.TestCase):
             vehicle, body, math_module)
 
     def test_picker_bounds_compose_every_attached_component(self):
-        """The box must be the compound's, not the chassis' translated box.
+        """The local envelope includes every attached component's extent.
 
         ``_Matrix`` above models translation only, so the composition is
         checked here against a transform that actually rotates: a wrong
@@ -5521,7 +5521,7 @@ class RemoteVehicleFactoryTests(unittest.TestCase):
             self.assertAlmostEqual(value, expected, places=6)
 
     def test_a_turned_barrel_widens_the_picker_box_until_it_is_thrown(self):
-        """The gun is inside stock's target box and sweeps it with the turret."""
+        """The attached gun widens the local target box as its turret turns."""
         unused_lower, upper = self._picker_bounds(0.0, math.pi / 2.0)
         # The 2.0 m barrel now points along +x, past the 1.7 m hull.
         self.assertAlmostEqual(upper[0], 2.0, places=6)
@@ -5532,13 +5532,22 @@ class RemoteVehicleFactoryTests(unittest.TestCase):
         # its gun, and the landed turret becomes its own candidate instead.
         self.assertAlmostEqual(detached[0], 1.7, places=6)
 
-    def test_full_bounds_wreck_blocks_an_outline_an_exact_ray_misses(self):
-        """Stock picks on the compound box, not on hit-test geometry.
+    def test_picker_bounds_skip_an_unavailable_matrix_then_recover(self):
+        for owner, method in ((remote_vehicle_module, '_pose_components'),
+                              (_RigidMatrix, 'applyPoint')):
+            with self.subTest(stage=method):
+                with mock.patch.object(
+                        owner, method,
+                        side_effect=TypeError('matrix provider unavailable')):
+                    self.assertIsNone(self._picker_bounds(0.0, 0.0))
+                self.assertIsNotNone(self._picker_bounds(0.0, 0.0))
 
-        ``EntityPicker::angleTo`` is zero for every candidate whose
-        projected bounding box covers the cursor, so a nearer wreck takes
-        the pick even where a pin-point ray would slip past its hull. The
-        outline must not promise a line the shell does not have.
+    def test_full_bounds_wreck_blocks_an_outline_an_exact_ray_misses(self):
+        """The local outline rule uses the wreck's full descriptor envelope.
+
+        This deliberately suppresses an outline even where a shell's exact
+        hit test passes through a gap. Native picker parity is not established
+        by this pure-data test.
         """
         runtime = _runtime()
         factory = RemoteVehicleFactory(
@@ -5633,7 +5642,7 @@ class RemoteVehicleFactoryTests(unittest.TestCase):
         factory.destroy_all()
 
     def test_a_wreck_beyond_the_target_leaves_the_outline_alone(self):
-        """Only a nearer candidate wins ``pickFirst``'s distance tiebreak."""
+        """A bounds entry beyond the live hit cannot suppress its outline."""
         runtime = _runtime()
         factory = RemoteVehicleFactory(
             runtime.bigworld, runtime.math, runtime.model_assembler, 7)

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -1971,6 +1971,102 @@ class _BigWorld(object):
         self.edge_removes.append(entity)
 
 
+class _RigidMatrix(object):
+    """A composing rigid transform, unlike the translation-only ``_Matrix``.
+
+    ``applyPoint`` follows BigWorld's row-vector convention, matching
+    ``_YawMatrix``: ``x' = cos*x + sin*z``, ``z' = -sin*x + cos*z``.  Only the
+    geometry ``vehicle_target_bounds_at_matrix`` actually composes is
+    modelled, so a wrong ``preMultiply`` direction cannot pass unnoticed.
+    """
+
+    def __init__(self, other=None):
+        self.rows = ((1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0))
+        self.offset = (0.0, 0.0, 0.0)
+        if other is not None:
+            self.rows = tuple(other.rows)
+            self.offset = tuple(other.offset)
+
+    @staticmethod
+    def _rotate_y(angle):
+        cosine, sine = math.cos(angle), math.sin(angle)
+        return ((cosine, 0.0, -sine), (0.0, 1.0, 0.0), (sine, 0.0, cosine))
+
+    @staticmethod
+    def _rotate_x(angle):
+        cosine, sine = math.cos(angle), math.sin(angle)
+        return ((1.0, 0.0, 0.0), (0.0, cosine, sine), (0.0, -sine, cosine))
+
+    @staticmethod
+    def _apply(rows, offset, point):
+        return tuple(
+            point[0] * rows[0][axis] + point[1] * rows[1][axis] +
+            point[2] * rows[2][axis] + offset[axis] for axis in range(3))
+
+    def setIdentity(self):
+        self.rows = ((1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0))
+        self.offset = (0.0, 0.0, 0.0)
+
+    def setRotateY(self, angle):
+        self.rows = self._rotate_y(float(angle))
+        self.offset = (0.0, 0.0, 0.0)
+
+    def setRotateX(self, angle):
+        self.rows = self._rotate_x(float(angle))
+        self.offset = (0.0, 0.0, 0.0)
+
+    def setRotateYPR(self, value):
+        yaw, pitch, unused_roll = (float(item) for item in value)
+        self.rows = self._rotate_y(yaw)
+        self.offset = (0.0, 0.0, 0.0)
+        pitch_rows = self._rotate_x(pitch)
+        self.rows = tuple(
+            self._apply(self.rows, (0.0, 0.0, 0.0), row)
+            for row in pitch_rows)
+
+    def setTranslate(self, value):
+        self.rows = ((1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0))
+        self.offset = tuple(float(item) for item in _xyz_of(value))
+
+    def applyPoint(self, value):
+        return _Vector(*self._apply(self.rows, self.offset, _xyz_of(value)))
+
+    def preMultiply(self, other):
+        """``other`` applies first, then this transform."""
+        rows = tuple(self._apply(self.rows, (0.0, 0.0, 0.0), row)
+                     for row in other.rows)
+        self.offset = self._apply(self.rows, self.offset, other.offset)
+        self.rows = rows
+
+    def postMultiply(self, other):
+        """This transform applies first, then ``other``."""
+        rows = tuple(other._apply(other.rows, (0.0, 0.0, 0.0), row)
+                     for row in self.rows)
+        self.offset = other._apply(other.rows, other.offset, self.offset)
+        self.rows = rows
+
+    def invert(self):
+        rows = tuple(tuple(self.rows[column][row] for column in range(3))
+                     for row in range(3))
+        offset = self._apply(rows, (0.0, 0.0, 0.0), self.offset)
+        self.rows = rows
+        self.offset = tuple(-value for value in offset)
+
+    @property
+    def yaw(self):
+        return math.atan2(self.rows[2][0], self.rows[2][2])
+
+    @property
+    def pitch(self):
+        return math.asin(max(-1.0, min(1.0, self.rows[2][1])))
+
+
+def _xyz_of(value):
+    if hasattr(value, 'x'):
+        return (float(value.x), float(value.y), float(value.z))
+    return (float(value[0]), float(value[1]), float(value[2]))
+
+
 class _Client(object):
     def __init__(self):
         self.player_id = 1
@@ -5382,6 +5478,230 @@ class RemoteVehicleFactoryTests(unittest.TestCase):
         self.assertEqual([], runtime.bigworld.edge_adds)
         self.assertIsNone(battle._outlined_engine_id)
         self.assertIn('is behind a wreck', battle._outline_report)
+        factory.destroy_all()
+
+    @staticmethod
+    def _picker_bounds(vehicle_yaw, turret_yaw, detached=False):
+        math_module = types.SimpleNamespace(
+            Matrix=_RigidMatrix, Vector3=_Vector)
+        body = _RigidMatrix()
+        body.setRotateYPR((vehicle_yaw, 0.0, 0.0))
+        turret = _RigidMatrix()
+        turret.setRotateY(turret_yaw)
+        gun = _RigidMatrix()
+        gun.setRotateX(0.0)
+        vehicle = types.SimpleNamespace(
+            typeDescriptor=_Descriptor(),
+            appearance=types.SimpleNamespace(
+                turretMatrix=turret, gunMatrix=gun),
+            isTurretDetached=detached)
+        return remote_vehicle_module.vehicle_target_bounds_at_matrix(
+            vehicle, body, math_module)
+
+    def test_picker_bounds_compose_every_attached_component(self):
+        """The box must be the compound's, not the chassis' translated box.
+
+        ``_Matrix`` above models translation only, so the composition is
+        checked here against a transform that actually rotates: a wrong
+        ``preMultiply`` direction or a dropped ``hullPosition`` would leave
+        the descriptor boxes stacked at the origin and still pass.
+        """
+        lower, upper = self._picker_bounds(0.0, 0.0)
+        # chassis y -0.8, hull 1.4 lifted by hullPosition 0.6, hull x 1.7.
+        for value, expected in zip(lower, (-1.7, -0.8, -3.5)):
+            self.assertAlmostEqual(value, expected, places=6)
+        for value, expected in zip(upper, (1.7, 2.0, 3.5)):
+            self.assertAlmostEqual(value, expected, places=6)
+
+        # A hull rotated 90 degrees swaps its own extents.
+        lower, upper = self._picker_bounds(math.pi / 2.0, 0.0)
+        for value, expected in zip(lower, (-3.5, -0.8, -1.7)):
+            self.assertAlmostEqual(value, expected, places=6)
+        for value, expected in zip(upper, (3.5, 2.0, 1.7)):
+            self.assertAlmostEqual(value, expected, places=6)
+
+    def test_a_turned_barrel_widens_the_picker_box_until_it_is_thrown(self):
+        """The gun is inside stock's target box and sweeps it with the turret."""
+        unused_lower, upper = self._picker_bounds(0.0, math.pi / 2.0)
+        # The 2.0 m barrel now points along +x, past the 1.7 m hull.
+        self.assertAlmostEqual(upper[0], 2.0, places=6)
+
+        unused_lower, detached = self._picker_bounds(
+            0.0, math.pi / 2.0, detached=True)
+        # getComponents publishes isAttached False for a thrown turret and
+        # its gun, and the landed turret becomes its own candidate instead.
+        self.assertAlmostEqual(detached[0], 1.7, places=6)
+
+    def test_full_bounds_wreck_blocks_an_outline_an_exact_ray_misses(self):
+        """Stock picks on the compound box, not on hit-test geometry.
+
+        ``EntityPicker::angleTo`` is zero for every candidate whose
+        projected bounding box covers the cursor, so a nearer wreck takes
+        the pick even where a pin-point ray would slip past its hull. The
+        outline must not promise a line the shell does not have.
+        """
+        runtime = _runtime()
+        factory = RemoteVehicleFactory(
+            runtime.bigworld, runtime.math, runtime.model_assembler, 7)
+        wreck_id = factory.create(_Descriptor(), {
+            'publicInfo': {'team': 2, 'name': 'Wreck'},
+            'health': 0, 'isCrewActive': False,
+            'gunAnglesPacked': 0}, _Vector(0.0, 0.0, 100.0),
+            (0.0, 0.0, 0.0))
+        target_id = factory.create(_Descriptor(), {
+            'publicInfo': {'team': 2, 'name': 'Target'},
+            'health': 500, 'isCrewActive': True,
+            'gunAnglesPacked': 0}, _Vector(0.0, 0.0, 300.0),
+            (0.0, 0.0, 0.0))
+        wreck = factory.get(wreck_id)
+        target = factory.get(target_id)
+        # The exact descriptor ray misses this wreck entirely; only its
+        # full bounds cover the cursor.
+        wreck.collideSegmentExt = lambda start, end: ()
+        target.collideSegmentExt = lambda start, end: (
+            types.SimpleNamespace(dist=300.0),)
+        battle = BattleRuntime(runtime)
+        battle.client = _Client()
+        battle._avatar = runtime.bigworld.avatar
+        battle._remote_factory = factory
+        battle._records = {
+            'bot:10': {
+                'engine_id': wreck_id, 'local': False, 'ready': True,
+                'state': {'health': 0, 'alive': False}},
+            'bot:11': {
+                'engine_id': target_id, 'local': False, 'ready': True,
+                'spot_visible': True,
+                'state': {'health': 500, 'alive': True}},
+        }
+
+        battle._update_target_outline(1.0)
+
+        self.assertEqual([], runtime.bigworld.edge_adds)
+        self.assertIsNone(battle._outlined_engine_id)
+        self.assertIn('is behind a wreck', battle._outline_report)
+        factory.destroy_all()
+
+    def test_a_block_is_logged_even_when_another_vehicle_missed(self):
+        """A decision about the pointed-at target outranks a cone miss.
+
+        The wreck reason was invisible in field reports whenever any other
+        vehicle happened to be the closest unchosen candidate.
+        """
+        runtime = _runtime()
+        factory = RemoteVehicleFactory(
+            runtime.bigworld, runtime.math, runtime.model_assembler, 7)
+        wreck_id = factory.create(_Descriptor(), {
+            'publicInfo': {'team': 2, 'name': 'Wreck'},
+            'health': 0, 'isCrewActive': False,
+            'gunAnglesPacked': 0}, _Vector(0.0, 0.0, 100.0),
+            (0.0, 0.0, 0.0))
+        target_id = factory.create(_Descriptor(), {
+            'publicInfo': {'team': 2, 'name': 'Target'},
+            'health': 500, 'isCrewActive': True,
+            'gunAnglesPacked': 0}, _Vector(0.0, 0.0, 300.0),
+            (0.0, 0.0, 0.0))
+        aside_id = factory.create(_Descriptor(), {
+            'publicInfo': {'team': 2, 'name': 'Aside'},
+            'health': 500, 'isCrewActive': True,
+            'gunAnglesPacked': 0}, _Vector(60.0, 0.0, 200.0),
+            (0.0, 0.0, 0.0))
+        factory.get(target_id).collideSegmentExt = lambda start, end: (
+            types.SimpleNamespace(dist=300.0),)
+        factory.get(aside_id).collideSegmentExt = lambda start, end: ()
+        battle = BattleRuntime(runtime)
+        battle.client = _Client()
+        battle._avatar = runtime.bigworld.avatar
+        battle._remote_factory = factory
+        battle._records = {
+            'bot:10': {
+                'engine_id': wreck_id, 'local': False, 'ready': True,
+                'state': {'health': 0, 'alive': False}},
+            'bot:11': {
+                'engine_id': target_id, 'local': False, 'ready': True,
+                'spot_visible': True,
+                'state': {'health': 500, 'alive': True}},
+            'bot:12': {
+                'engine_id': aside_id, 'local': False, 'ready': True,
+                'spot_visible': True,
+                'state': {'health': 500, 'alive': True}},
+        }
+
+        battle._update_target_outline(1.0)
+
+        self.assertIsNone(battle._outlined_engine_id)
+        self.assertIn('is behind a wreck', battle._outline_report)
+        factory.destroy_all()
+
+    def test_a_wreck_beyond_the_target_leaves_the_outline_alone(self):
+        """Only a nearer candidate wins ``pickFirst``'s distance tiebreak."""
+        runtime = _runtime()
+        factory = RemoteVehicleFactory(
+            runtime.bigworld, runtime.math, runtime.model_assembler, 7)
+        target_id = factory.create(_Descriptor(), {
+            'publicInfo': {'team': 2, 'name': 'Target'},
+            'health': 500, 'isCrewActive': True,
+            'gunAnglesPacked': 0}, _Vector(0.0, 0.0, 100.0),
+            (0.0, 0.0, 0.0))
+        wreck_id = factory.create(_Descriptor(), {
+            'publicInfo': {'team': 2, 'name': 'Wreck'},
+            'health': 0, 'isCrewActive': False,
+            'gunAnglesPacked': 0}, _Vector(0.0, 0.0, 300.0),
+            (0.0, 0.0, 0.0))
+        target = factory.get(target_id)
+        target.collideSegmentExt = lambda start, end: (
+            types.SimpleNamespace(dist=100.0),)
+        battle = BattleRuntime(runtime)
+        battle.client = _Client()
+        battle._avatar = runtime.bigworld.avatar
+        battle._remote_factory = factory
+        battle._records = {
+            'bot:10': {
+                'engine_id': wreck_id, 'local': False, 'ready': True,
+                'state': {'health': 0, 'alive': False}},
+            'bot:11': {
+                'engine_id': target_id, 'local': False, 'ready': True,
+                'spot_visible': True,
+                'state': {'health': 500, 'alive': True}},
+        }
+
+        battle._update_target_outline(1.0)
+
+        self.assertEqual(
+            [(target.bw_entity, 1, 0, False)], runtime.bigworld.edge_adds)
+        self.assertEqual(target_id, battle._outlined_engine_id)
+        factory.destroy_all()
+
+    def test_a_landed_turret_blocks_an_enemy_outline(self):
+        """A thrown turret is a full-bounds picker candidate of its own."""
+        runtime = _runtime()
+        factory = RemoteVehicleFactory(
+            runtime.bigworld, runtime.math, runtime.model_assembler, 7)
+        target_id = factory.create(_Descriptor(), {
+            'publicInfo': {'team': 2, 'name': 'Target'},
+            'health': 500, 'isCrewActive': True,
+            'gunAnglesPacked': 0}, _Vector(0.0, 0.0, 300.0),
+            (0.0, 0.0, 0.0))
+        target = factory.get(target_id)
+        target.collideSegmentExt = lambda start, end: (
+            types.SimpleNamespace(dist=300.0),)
+        battle = BattleRuntime(runtime)
+        battle.client = _Client()
+        battle._avatar = runtime.bigworld.avatar
+        battle._remote_factory = factory
+        battle._detached_turret_obstacles = types.SimpleNamespace(
+            target_entry_distance=lambda start, end, time_ms: 120.0)
+        battle._records = {
+            'bot:11': {
+                'engine_id': target_id, 'local': False, 'ready': True,
+                'spot_visible': True,
+                'state': {'health': 500, 'alive': True}},
+        }
+
+        battle._update_target_outline(1.0)
+
+        self.assertEqual([], runtime.bigworld.edge_adds)
+        self.assertIsNone(battle._outlined_engine_id)
+        self.assertIn('is behind a thrown turret', battle._outline_report)
         factory.destroy_all()
 
     def test_a_new_target_removes_the_previous_outline_before_adding(self):

--- a/tests/test_port_0922_turret_obstacles.py
+++ b/tests/test_port_0922_turret_obstacles.py
@@ -101,11 +101,11 @@ class TurretObstacleTests(unittest.TestCase):
         self.assertAlmostEqual(obstacles.block_distance(start, end, 4000, start_time_ms=3000), 2)
 
     def test_target_bounds_cover_the_gap_an_exact_ray_slips_through(self):
-        """``DetachedTurret`` is a full-bounds picker candidate.
+        """The landed-turret outline rule uses one full descriptor envelope.
 
         The shell ray keeps the empty gap between turret and gun open; the
-        entity picker never sees that gap, because ``getBoundingBox`` hands
-        it one box over the whole compound.
+        local outline query deliberately includes that gap in its one box.
+        This does not establish the shipped native picker's bounds or score.
         """
         obstacles = self.obstacle()
         start, end = _Vector(-3, 1, 2.5), _Vector(3, 1, 2.5)

--- a/tests/test_port_0922_turret_obstacles.py
+++ b/tests/test_port_0922_turret_obstacles.py
@@ -100,6 +100,23 @@ class TurretObstacleTests(unittest.TestCase):
         self.assertIsNone(obstacles.block_distance(start, end, 4000, start_time_ms=2000))
         self.assertAlmostEqual(obstacles.block_distance(start, end, 4000, start_time_ms=3000), 2)
 
+    def test_target_bounds_cover_the_gap_an_exact_ray_slips_through(self):
+        """``DetachedTurret`` is a full-bounds picker candidate.
+
+        The shell ray keeps the empty gap between turret and gun open; the
+        entity picker never sees that gap, because ``getBoundingBox`` hands
+        it one box over the whole compound.
+        """
+        obstacles = self.obstacle()
+        start, end = _Vector(-3, 1, 2.5), _Vector(3, 1, 2.5)
+        self.assertIsNone(obstacles.block_distance(start, end, 4000))
+        self.assertAlmostEqual(
+            obstacles.target_entry_distance(start, end, 4000), 2)
+        # A turret still in the air is not a candidate, exactly as it is not
+        # an obstacle.
+        self.assertIsNone(
+            obstacles.target_entry_distance(start, end, 2999))
+
     def test_separate_components_leave_the_empty_gap_open(self):
         obstacles = self.obstacle()
         self.assertIsNone(obstacles.block_distance(_Vector(-3, 1, 2.5), _Vector(3, 1, 2.5), 4000))


### PR DESCRIPTION
An enemy outline could remain visible behind a retained wreck when the cursor ray passed through a gap in the wreck's exact shell collision geometry. Suppress that outline using the attached descriptor components' combined bounds, and include landed detached turrets at their accepted rest poses. Projectile collision continues to use the exact hit testers.

This is a local selection approximation. The #1513 bytecode establishes that `Vehicle.onEnterWorld` enables `targetFullBounds`, and that `DetachedTurret.__init__` enables full bounds and target capabilities. It does not establish that descriptor bounds and segment-entry ordering exactly reproduce the shipped native picker. A field-report impact inside a wreck's bounding envelope also cannot establish that its drawn and tested geometry agree.

Two review fixes preserve operation-local failure handling: unavailable component matrices skip the current outline candidate and can recover on the next query; failures in the bounded `WRECK IMPACT` diagnostic cannot replace an already resolved impact with an expired projectile. The diagnostic retains the tested component, pose, and impact point to support a matching Windows investigation.

Validation: 1075 focused battle-runtime, projectile, and turret-obstacle tests passed, including regressions first reproduced before the review fixes; all 112 client source files compile with CPython 2.7.18. Exact Windows outline behavior, drawn-versus-tested collision positions, and frame cost remain unverified.
