### PR TITLE
Stop a bot firing whole reloads into a wreck it cannot see

### DIFF
--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -1775,6 +1775,7 @@ class BattleRuntime(object):
         self._bot_motion_kinds = {}
         self._crush_reports = 0
         self._next_crush_report = {}
+        self._bot_lane_wreck_rows_cache = None
         self._destructible_verdict_reports = 0
         self._soft_static_recast_budget = [BOT_SOFT_RECAST_BUDGET]
         self._local_vertical_speed = 0.0
@@ -2097,6 +2098,7 @@ class BattleRuntime(object):
         self._bot_motion_kinds = {}
         self._crush_reports = 0
         self._next_crush_report = {}
+        self._bot_lane_wreck_rows_cache = None
         self._destructible_verdict_reports = 0
         self._soft_static_recast_budget = [BOT_SOFT_RECAST_BUDGET]
         self._local_vertical_speed = 0.0
@@ -21484,6 +21486,11 @@ class BattleRuntime(object):
             # the plumbing that scores it went missing.
             ranks = (self._bots is None or
                      self._bots.bot_aim_selection_allowed(source, target))
+            # Neither end of this lane is its own blocker. Both are alive,
+            # so neither is in the wreck view either; keep the exclusion
+            # structural so a later predicate cannot strand every gunner.
+            wreck_rows = self._bot_lane_wreck_rows()
+            lane_ends = (record, entry['record'])
             best = None
             best_score = None
             exposed = None
@@ -21493,6 +21500,9 @@ class BattleRuntime(object):
                     self._avatar.spaceID, self._vector(origin),
                     self._vector(point), 128)
                 if hit is not None:
+                    continue
+                if self._wreck_blocks_bot_lane(
+                        wreck_rows, origin, point, lane_ends):
                     continue
                 score = self._bot_aim_damage_score(
                     descriptor, entry, source, target, origin, point)
@@ -21518,6 +21528,99 @@ class BattleRuntime(object):
             return False
         return False
 
+    def _bot_lane_rows(self, source_id, accept, prefilter=None):
+        """Return the hulls one bot's shell could meet, with their poses.
+
+        Every bot lane question - an ally on the parabola, a wreck across
+        the aim ray - needs the same record skips, so one builder owns them.
+        ``accept(record, state, vehicle)`` selects which hulls the question
+        is about, and an optional ``prefilter(record, state)`` rejects one
+        before its entity is resolved at all.  A ``source_id`` of ``None``
+        keeps every bot, for a view whose consumers apply their own
+        identity exclusions.
+        """
+        rows = []
+        for record in self._records.values():
+            if record.get('tombstone') or not record.get('ready'):
+                continue
+            if self._worker_mode and record.get('local'):
+                continue
+            if source_id is not None and record.get('kind') == 'bot':
+                try:
+                    if int(record.get('network_id')) == source_id:
+                        continue
+                except (TypeError, ValueError):
+                    continue
+            state = record.get('state') or {}
+            if prefilter is not None and not prefilter(record, state):
+                continue
+            vehicle = self._server_entity(record.get('engine_id'))
+            if vehicle is None or not getattr(vehicle, 'isStarted', False):
+                continue
+            if not accept(record, state, vehicle):
+                continue
+            position = (tuple(self._local_position)
+                        if record.get('local') else
+                        _xyz(getattr(vehicle, 'position', state)))
+            rows.append((record, vehicle, position))
+        return tuple(rows)
+
+    def _bot_lane_row_contact(self, rows, points, splash_radius=0.0,
+                              exclude=()):
+        """Return the first supplied hull one bot shell path contacts.
+
+        One broad phase and one body/ground pose dispatch, matching the
+        projectile resolver, so a pose contract cannot be corrected for
+        allies and missed for wrecks.  A native collision failure
+        propagates to the caller, which decides what an unproved lane means.
+        """
+        terminal = points[-1]
+        broadphase_sq = PROJECTILE_BROADPHASE_RADIUS ** 2
+        for record, vehicle, position in rows:
+            # Identity, never equality: two records with the same fields are
+            # two vehicles, and a dict compare would walk both of them.
+            if any(record is excluded for excluded in exclude):
+                continue
+            blocked = bool(
+                splash_radius > 0.0 and
+                sum((position[index] - terminal[index]) ** 2
+                    for index in range(3)) <= splash_radius ** 2)
+            if not blocked:
+                for first, second in zip(points, points[1:]):
+                    if (not point_in_expanded_segment_bounds(
+                            position, first, second,
+                            PROJECTILE_BROADPHASE_RADIUS) or
+                            point_segment_distance_sq(
+                                position, first, second) > broadphase_sq):
+                        continue
+                    start = self._vector(first)
+                    end = self._vector(second)
+                    if (record.get('local') and
+                            self._local_matrix is not None):
+                        collisions = collide_vehicle_at_matrix(
+                            vehicle, self._local_body_pose(), start, end,
+                            self._runtime.math,
+                            chassis_matrix=self._local_matrix)
+                    elif record.get('native_remote'):
+                        body_matrix, chassis_matrix = \
+                            self._projectile_vehicle_matrices(
+                                record, vehicle)
+                        collisions = collide_vehicle_at_matrix(
+                            vehicle, body_matrix, start, end,
+                            self._runtime.math,
+                            chassis_matrix=chassis_matrix)
+                    else:
+                        collide = getattr(
+                            vehicle, 'collideSegmentExt', None)
+                        collisions = (collide(start, end)
+                                      if callable(collide) else ())
+                    if collisions:
+                        blocked = True
+                        break
+            if blocked:
+                return record, vehicle, position
+        return None
+
     def _bot_friendly_path_verdict(
             self, source, path, splash_radius=0.0):
         """Test live allied hulls against one frozen physical shell path."""
@@ -21535,89 +21638,88 @@ class BattleRuntime(object):
                 any(math.isnan(value) or math.isinf(value)
                     for point in points for value in point)):
             return {'clear': False}
-        terminal = points[-1]
-        broadphase_sq = PROJECTILE_BROADPHASE_RADIUS ** 2
-        for record in self._records.values():
-            if record.get('tombstone') or not record.get('ready'):
-                continue
-            if self._worker_mode and record.get('local'):
-                continue
-            if record.get('kind') == 'bot':
-                try:
-                    if int(record.get('network_id')) == source_id:
-                        continue
-                except (TypeError, ValueError):
-                    continue
-            state = record.get('state') or {}
+
+        def is_ally(unused_record, state):
             try:
-                if int(state.get('team')) != source_team:
-                    continue
+                return int(state.get('team')) == source_team
             except (TypeError, ValueError):
-                continue
-            vehicle = self._server_entity(record.get('engine_id'))
-            if (vehicle is None or not getattr(vehicle, 'isStarted', False) or
-                    not self._record_alive(record, vehicle)):
-                continue
-            position = (tuple(self._local_position)
-                        if record.get('local') else
-                        _xyz(getattr(vehicle, 'position', state)))
-            blocked = bool(
-                splash_radius > 0.0 and
-                sum((position[index] - terminal[index]) ** 2
-                    for index in range(3)) <= splash_radius ** 2)
-            if not blocked:
-                for first, second in zip(points, points[1:]):
-                    if (not point_in_expanded_segment_bounds(
-                            position, first, second,
-                            PROJECTILE_BROADPHASE_RADIUS) or
-                            point_segment_distance_sq(
-                                position, first, second) > broadphase_sq):
-                        continue
-                    start = self._vector(first)
-                    end = self._vector(second)
-                    try:
-                        if (record.get('local') and
-                                self._local_matrix is not None):
-                            collisions = collide_vehicle_at_matrix(
-                                vehicle, self._local_body_pose(), start, end,
-                                self._runtime.math,
-                                chassis_matrix=self._local_matrix)
-                        elif record.get('native_remote'):
-                            body_matrix, chassis_matrix = \
-                                self._projectile_vehicle_matrices(
-                                    record, vehicle)
-                            collisions = collide_vehicle_at_matrix(
-                                vehicle, body_matrix, start, end,
-                                self._runtime.math,
-                                chassis_matrix=chassis_matrix)
-                        else:
-                            collide = getattr(
-                                vehicle, 'collideSegmentExt', None)
-                            collisions = (collide(start, end)
-                                          if callable(collide) else ())
-                    except Exception:
-                        return {'clear': False}
-                    if collisions:
-                        blocked = True
-                        break
-            if not blocked:
-                continue
-            try:
-                shape = tank_collision.chassis_shape(
-                    vehicle.typeDescriptor)
-                blocker_radius = math.hypot(shape[0], shape[1])
-            except Exception:
-                fallback = tank_collision.DEFAULT_SHAPE
-                blocker_radius = math.hypot(fallback[0], fallback[1])
-            return {
-                'clear': False,
-                'blocker_kind': record.get('kind'),
-                'blocker_id': record.get('network_id'),
-                'blocker_team': source_team,
-                'blocker_position': position,
-                'blocker_radius': blocker_radius,
-            }
-        return {'clear': True}
+                return False
+
+        def is_live(record, unused_state, vehicle):
+            return self._record_alive(record, vehicle)
+
+        try:
+            contact = self._bot_lane_row_contact(
+                self._bot_lane_rows(source_id, is_live, prefilter=is_ally),
+                points, splash_radius=splash_radius)
+        except Exception:
+            return {'clear': False}
+        if contact is None:
+            return {'clear': True}
+        record, vehicle, position = contact
+        try:
+            shape = tank_collision.chassis_shape(
+                vehicle.typeDescriptor)
+            blocker_radius = math.hypot(shape[0], shape[1])
+        except Exception:
+            fallback = tank_collision.DEFAULT_SHAPE
+            blocker_radius = math.hypot(fallback[0], fallback[1])
+        return {
+            'clear': False,
+            'blocker_kind': record.get('kind'),
+            'blocker_id': record.get('network_id'),
+            'blocker_team': source_team,
+            'blocker_position': position,
+            'blocker_radius': blocker_radius,
+        }
+
+    def _bot_lane_wreck_rows(self):
+        """Materialise this frame's dead hulls once for every lane probe.
+
+        Up to ``MAX_WORKER_SHOT_LANE_PAIRS_PER_FRAME`` pairs probe in one
+        frame and every one of them meets the same wrecks, so rebuilding the
+        record view per probe was the whole added cost. ``bot_lane_origin``
+        beside this already reuses one frame the same way. Retiring on the
+        record revision as well keeps a roster edit from being missed, and a
+        death that lands mid-frame is admitted on the next one - far inside
+        the ``SHOT_LANE_SECONDS`` window the verdict itself is cached for.
+        """
+        key = (self._last_frame_time, self._records_revision)
+        cached = self._bot_lane_wreck_rows_cache
+        if cached is not None and cached[0] == key:
+            return cached[1]
+
+        def is_wreck(record, unused_state, vehicle):
+            return not self._record_alive(record, vehicle)
+
+        rows = self._bot_lane_rows(None, is_wreck)
+        self._bot_lane_wreck_rows_cache = (key, rows)
+        return rows
+
+    def _wreck_blocks_bot_lane(self, rows, origin, point, lane_ends=()):
+        """Return whether a dead hull or landed turret owns this aim ray.
+
+        Nothing on the map stops a shell that the shooter cannot see coming:
+        ``getCollidableEntities`` hands the resolver every ``isStarted``
+        vehicle with no alive filter, so a retained wreck ends a bot's shell
+        exactly as a wall does.  The static mask-128 ray beside this one
+        never sees a wreck, so without this a bot keeps firing whole reloads
+        into a dead hull it has no way to notice.  The geometry is the
+        shell's own, not the picker's bounds: the question here is only
+        whether the round arrives.
+        """
+        points = (tuple(origin), tuple(point))
+        if rows and self._bot_lane_row_contact(
+                rows, points, exclude=lane_ends) is not None:
+            return True
+        obstacles = self._detached_turret_obstacles
+        if obstacles is None:
+            return False
+        # The same accepted rest pose the projectile resolver already stops
+        # a shell on, queried on the same server clock.
+        return obstacles.block_distance(
+            self._vector(points[0]), self._vector(points[1]),
+            self._turret_server_time_ms()) is not None
 
     def _bot_friendly_firing_lane(
             self, source, unused_target, descriptor, shell_index, launch):

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/battle_runtime.py
@@ -21501,8 +21501,8 @@ class BattleRuntime(object):
                     self._vector(point), 128)
                 if hit is not None:
                     continue
-                if self._wreck_blocks_bot_lane(
-                        wreck_rows, origin, point, lane_ends):
+                if self._wreck_blocks_bot_path(
+                        wreck_rows, (origin, point), lane_ends):
                     continue
                 score = self._bot_aim_damage_score(
                     descriptor, entry, source, target, origin, point)
@@ -21623,7 +21623,7 @@ class BattleRuntime(object):
 
     def _bot_friendly_path_verdict(
             self, source, path, splash_radius=0.0):
-        """Test live allied hulls against one frozen physical shell path."""
+        """Reject shell obstructions, with escape metadata only for allies."""
         try:
             source_id = int(source.get('id'))
             source_team = int(source.get('team'))
@@ -21649,6 +21649,13 @@ class BattleRuntime(object):
             return self._record_alive(record, vehicle)
 
         try:
+            # Candidate lanes may predate a wreck or its final shoved pose.
+            # Recheck the frozen dispersed path for both direct guns and
+            # SPGs. Dead hulls need no splash clearance or ally escape order.
+            source_record = self._records.get('bot:%d' % source_id)
+            if self._wreck_blocks_bot_path(
+                    self._bot_lane_wreck_rows(), points, (source_record,)):
+                return {'clear': False}
             contact = self._bot_lane_row_contact(
                 self._bot_lane_rows(source_id, is_live, prefilter=is_ally),
                 points, splash_radius=splash_radius)
@@ -21696,34 +21703,24 @@ class BattleRuntime(object):
         self._bot_lane_wreck_rows_cache = (key, rows)
         return rows
 
-    def _wreck_blocks_bot_lane(self, rows, origin, point, lane_ends=()):
-        """Return whether a dead hull or landed turret owns this aim ray.
-
-        Nothing on the map stops a shell that the shooter cannot see coming:
-        ``getCollidableEntities`` hands the resolver every ``isStarted``
-        vehicle with no alive filter, so a retained wreck ends a bot's shell
-        exactly as a wall does.  The static mask-128 ray beside this one
-        never sees a wreck, so without this a bot keeps firing whole reloads
-        into a dead hull it has no way to notice.  The geometry is the
-        shell's own, not the picker's bounds: the question here is only
-        whether the round arrives.
-        """
-        points = (tuple(origin), tuple(point))
+    def _wreck_blocks_bot_path(self, rows, points, lane_ends=()):
+        """Test dead hulls and landed turrets on supplied shell segments."""
         if rows and self._bot_lane_row_contact(
                 rows, points, exclude=lane_ends) is not None:
             return True
         obstacles = self._detached_turret_obstacles
         if obstacles is None:
             return False
-        # The same accepted rest pose the projectile resolver already stops
-        # a shell on, queried on the same server clock.
-        return obstacles.block_distance(
-            self._vector(points[0]), self._vector(points[1]),
-            self._turret_server_time_ms()) is not None
+        # Reuse the resolver's accepted rest poses on the current server
+        # clock. A future landing cannot obstruct a present lane proof.
+        server_time_ms = self._turret_server_time_ms()
+        return any(obstacles.block_distance(
+            self._vector(first), self._vector(second), server_time_ms)
+            is not None for first, second in zip(points, points[1:]))
 
     def _bot_friendly_firing_lane(
             self, source, unused_target, descriptor, shell_index, launch):
-        """Reject allies on the exact frozen direct-shell parabola."""
+        """Check hulls and debris on the frozen direct-shell parabola."""
         try:
             source_id = int(source.get('id'))
             fire_seq = int(launch.get('fire_seq'))
@@ -21853,7 +21850,7 @@ class BattleRuntime(object):
 
     def _bot_artillery_friendly_lane(
             self, source, unused_target, descriptor, shell_index, receipt):
-        """Reject allies intersecting the proved SPG path or HE terminal."""
+        """Check SPG shell obstructions and live allies near the HE terminal."""
         try:
             raw_path = receipt.get('path')
             if not isinstance(raw_path, (list, tuple)) or len(raw_path) < 2:
@@ -21887,15 +21884,19 @@ class BattleRuntime(object):
         return bool(self._artillery.cancel_launch(source))
 
     def _artillery_arc_probe(self, start, end):
-        """Return the native world hit point, or None for one clear chord."""
+        """Check one budgeted SPG chord against scenery and retained wrecks."""
         hit = self._runtime.bigworld.wg_collideSegment(
             self._avatar.spaceID, self._vector(start), self._vector(end), 128)
-        if hit is None:
-            return None
         try:
-            return _xyz(hit[0])
+            finish = _xyz(hit[0]) if hit is not None else _xyz(end)
         except Exception:
             return False
+        # A ground hit near the target may be accepted by the arc queue;
+        # a wreck before it must reject this candidate even near the target.
+        if self._wreck_blocks_bot_path(
+                self._bot_lane_wreck_rows(), (_xyz(start), finish)):
+            return False
+        return finish if hit is not None else None
 
     def _advance_artillery_arcs(self, now):
         if self._artillery is None:

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -12491,6 +12491,126 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertFalse(battle._bot_firing_lane(source, target))
         runtime.bigworld.wg_collideSegment.assert_not_called()
 
+    def _bot_lane_wreck(self, runtime, battle, position, collisions):
+        """Put one dead hull into the scene at ``position``.
+
+        The roster view is reused for the whole frame, exactly as
+        ``bot_lane_origin`` beside it is, so advance the frame the way
+        ``_frame`` does before the new wreck is expected to count.
+        """
+        runtime.bigworld.entities[30] = types.SimpleNamespace(
+            isStarted=True, typeDescriptor=_Descriptor(),
+            position=position,
+            collideSegmentExt=lambda start, end: collisions)
+        battle._records['bot:13'] = {
+            'engine_id': 30, 'ready': True, 'kind': 'bot',
+            'network_id': 13,
+            'state': {'alive': False, 'health': 0, 'team': 1},
+        }
+        battle._last_frame_time = (
+            0.0 if battle._last_frame_time is None
+            else battle._last_frame_time) + 0.05
+        return battle._records['bot:13']
+
+    def test_one_frame_reuses_a_single_bot_lane_wreck_view(self):
+        """Sixteen pairs a frame meet the same wrecks; walk them once.
+
+        Rebuilding the record view per probe was the entire added cost of
+        seeing wrecks at all, and a death is admitted on the next frame -
+        far inside the window the lane verdict itself is cached for.
+        """
+        runtime, battle, source, target, unused = self._bot_lane_scene()
+        runtime.bigworld.wg_collideSegment = (
+            lambda *unused_args: None)
+        battle._last_frame_time = 10.0
+
+        first = battle._bot_lane_wreck_rows()
+        self.assertIs(first, battle._bot_lane_wreck_rows())
+
+        battle._last_frame_time = 10.05
+        self.assertIsNot(first, battle._bot_lane_wreck_rows())
+
+        battle._last_frame_time = 10.05
+        battle._records_revision += 1
+        self.assertIsNot(first, battle._bot_lane_wreck_rows())
+
+    def test_a_wreck_across_the_aim_ray_closes_the_bot_firing_lane(self):
+        """A retained wreck stops a bot's shell exactly as a wall does.
+
+        ``getCollidableEntities`` hands the resolver every ``isStarted``
+        vehicle with no alive filter, but the static mask-128 ray beside
+        this check never sees one, so a bot kept firing whole reloads into
+        a dead hull it had no way to notice.
+        """
+        runtime, battle, source, target, unused = self._bot_lane_scene()
+        runtime.bigworld.wg_collideSegment = (
+            lambda *unused_args: None)
+        self.assertTrue(battle._bot_firing_lane(source, target))
+
+        self._bot_lane_wreck(
+            runtime, battle, _Vector(0.0, 0.0, 50.0),
+            (types.SimpleNamespace(dist=50.0),))
+
+        self.assertFalse(battle._bot_firing_lane(source, target))
+        self.assertIsNone(battle._bot_aim_point(source, target))
+
+    def test_a_wreck_the_exact_ray_clears_keeps_the_lane_open(self):
+        """The broad phase narrows the scan; it never decides the verdict."""
+        runtime, battle, source, target, unused = self._bot_lane_scene()
+        runtime.bigworld.wg_collideSegment = (
+            lambda *unused_args: None)
+        # Inside the broad-phase radius of the lane, but the exact hit test
+        # the shell itself would run reports no contact.
+        self._bot_lane_wreck(runtime, battle, _Vector(0.0, 0.0, 50.0), ())
+
+        self.assertTrue(battle._bot_firing_lane(source, target))
+
+    def test_a_wreck_beyond_the_target_never_closes_the_lane(self):
+        """Only the hulls the shell reaches before its target can stop it."""
+        runtime, battle, source, target, unused = self._bot_lane_scene()
+        runtime.bigworld.wg_collideSegment = (
+            lambda *unused_args: None)
+        self._bot_lane_wreck(
+            runtime, battle, _Vector(0.0, 0.0, 150.0),
+            (types.SimpleNamespace(dist=50.0),))
+
+        self.assertTrue(battle._bot_firing_lane(source, target))
+
+    def test_the_targets_own_hull_never_closes_the_lane_to_itself(self):
+        """The aim ray ends on the target, so it is not its own blocker."""
+        runtime, battle, source, target, unused = self._bot_lane_scene()
+        runtime.bigworld.wg_collideSegment = (
+            lambda *unused_args: None)
+        entity = runtime.bigworld.entities[20]
+        entity.position = _Vector(0.0, 0.0, 100.0)
+        entity.collideSegmentExt = lambda start, end: (
+            types.SimpleNamespace(dist=100.0),)
+        # Nothing in this port marks a live target dead, but the exclusion
+        # is structural so a later predicate cannot strand every gunner.
+        battle._records['bot:12']['state'] = {
+            'alive': False, 'health': 0, 'team': 1}
+
+        self.assertTrue(battle._bot_firing_lane(source, target))
+
+    def test_a_landed_turret_closes_the_bot_firing_lane(self):
+        """The accepted rest pose already ends a shell in the resolver."""
+        runtime, battle, source, target, unused = self._bot_lane_scene()
+        runtime.bigworld.wg_collideSegment = (
+            lambda *unused_args: None)
+        self.assertTrue(battle._bot_firing_lane(source, target))
+
+        queries = []
+
+        def block(start, end, server_time_ms):
+            queries.append(server_time_ms)
+            return 40.0
+
+        battle._detached_turret_obstacles = types.SimpleNamespace(
+            block_distance=block)
+
+        self.assertFalse(battle._bot_firing_lane(source, target))
+        self.assertTrue(queries)
+
     def test_bot_friendly_lane_uses_the_frozen_dispersed_parabola(self):
         runtime = _runtime()
         battle = BattleRuntime(runtime)

--- a/tests/test_port_0922_battle_runtime.py
+++ b/tests/test_port_0922_battle_runtime.py
@@ -12528,11 +12528,12 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self.assertIs(first, battle._bot_lane_wreck_rows())
 
         battle._last_frame_time = 10.05
-        self.assertIsNot(first, battle._bot_lane_wreck_rows())
+        second = battle._bot_lane_wreck_rows()
+        self.assertIsNot(first, second)
 
         battle._last_frame_time = 10.05
         battle._records_revision += 1
-        self.assertIsNot(first, battle._bot_lane_wreck_rows())
+        self.assertIsNot(second, battle._bot_lane_wreck_rows())
 
     def test_a_wreck_across_the_aim_ray_closes_the_bot_firing_lane(self):
         """A retained wreck stops a bot's shell exactly as a wall does.
@@ -12564,6 +12565,59 @@ class BattleRuntimeContractTests(unittest.TestCase):
         self._bot_lane_wreck(runtime, battle, _Vector(0.0, 0.0, 50.0), ())
 
         self.assertTrue(battle._bot_firing_lane(source, target))
+
+    def test_bot_lane_wreck_view_tracks_death_motion_and_entity_retirement(self):
+        runtime, battle, source, target, unused = self._bot_lane_scene()
+        runtime.bigworld.wg_collideSegment = lambda *unused_args: None
+        record = self._bot_lane_wreck(
+            runtime, battle, _Vector(0.0, 0.0, 50.0),
+            (types.SimpleNamespace(dist=50.0),))
+        record['state'].update(alive=True, health=100)
+        self.assertTrue(battle._bot_firing_lane(source, target))
+
+        record['state'].update(alive=False, health=0)
+        battle._last_frame_time += 0.05
+        self.assertFalse(battle._bot_firing_lane(source, target))
+
+        entity = runtime.bigworld.entities[30]
+        entity.position = _Vector(100.0, 0.0, 50.0)
+        battle._last_frame_time += 0.05
+        self.assertTrue(battle._bot_firing_lane(source, target))
+
+        entity.position = _Vector(0.0, 0.0, 50.0)
+        entity.isStarted = False
+        battle._last_frame_time += 0.05
+        self.assertTrue(battle._bot_firing_lane(source, target))
+
+        del runtime.bigworld.entities[30]
+        battle._last_frame_time += 0.05
+        self.assertTrue(battle._bot_firing_lane(source, target))
+
+    def test_bot_wreck_lane_uses_canonical_body_and_chassis_matrices(self):
+        runtime, battle, source, target, unused = self._bot_lane_scene()
+        runtime.bigworld.wg_collideSegment = lambda *unused_args: None
+        record = self._bot_lane_wreck(
+            runtime, battle, _Vector(0.0, 0.0, 50.0), ())
+        record['native_remote'] = True
+        battle._worker_mode = True
+        entity = runtime.bigworld.entities[30]
+        entity.matrix = _Matrix()
+        body, chassis = _Matrix(), _Matrix()
+        factory = types.SimpleNamespace(projectile_collision_matrices=(
+            mock.Mock(return_value=(body, chassis))))
+        # Resolve the test roster normally, while the factory owns only the
+        # unblended physical matrices rather than a stock filter at spawn.
+        battle._remote_factory = factory
+        battle._server_entity = runtime.bigworld.entities.get
+        with mock.patch.object(
+                battle_runtime_module, 'collide_vehicle_at_matrix',
+                return_value=(types.SimpleNamespace(dist=50.0),)) as collide:
+            self.assertFalse(battle._bot_firing_lane(source, target))
+        self.assertTrue(factory.projectile_collision_matrices.called)
+        for call in collide.call_args_list:
+            self.assertIs(entity, call.args[0])
+            self.assertIs(body, call.args[1])
+            self.assertIs(chassis, call.kwargs['chassis_matrix'])
 
     def test_a_wreck_beyond_the_target_never_closes_the_lane(self):
         """Only the hulls the shell reaches before its target can stop it."""
@@ -12610,6 +12664,66 @@ class BattleRuntimeContractTests(unittest.TestCase):
 
         self.assertFalse(battle._bot_firing_lane(source, target))
         self.assertTrue(queries)
+
+    def test_spg_planning_rejects_a_wreck_on_an_arc_chord(self):
+        runtime, battle, unused_source, unused_target, unused = (
+            self._bot_lane_scene())
+        runtime.bigworld.wg_collideSegment = lambda *unused_args: None
+        self._bot_lane_wreck(
+            runtime, battle, _Vector(0.0, 0.0, 50.0),
+            (types.SimpleNamespace(dist=5.0),))
+
+        self.assertIs(False, battle._artillery_arc_probe(
+            (0.0, 3.0, 45.0), (0.0, 1.0, 55.0)))
+        # A high arc over the same hull remains eligible.
+        self.assertIsNone(battle._artillery_arc_probe(
+            (0.0, 100.0, 45.0), (0.0, 100.0, 55.0)))
+
+        # A nearby terrain arrival is allowed by the queue, but it cannot
+        # hide a wreck which the same chord reaches first.
+        runtime.bigworld.wg_collideSegment = (
+            lambda *unused_args: (_Vector(0.0, 0.0, 55.0),))
+        self.assertIs(False, battle._artillery_arc_probe(
+            (0.0, 3.0, 45.0), (0.0, 0.0, 60.0)))
+
+        runtime.bigworld.entities[30].collideSegmentExt = (
+            lambda *unused_args: ())
+        self.assertEqual((0.0, 0.0, 55.0), battle._artillery_arc_probe(
+            (0.0, 3.0, 45.0), (0.0, 0.0, 60.0)))
+
+    def test_frozen_direct_and_spg_paths_reject_a_wreck_without_ally_metadata(self):
+        runtime, battle, source, target, descriptor = self._bot_lane_scene()
+        source.update(team=1, fire_seq=0)
+        self._bot_lane_wreck(
+            runtime, battle, _Vector(0.0, 0.0, 50.0),
+            (types.SimpleNamespace(dist=1.0),))
+        launch = {
+            'fire_seq': 1, 'shell_index': 0,
+            'shot_yaw': 0.0, 'shot_pitch': 0.0,
+            'flight_time': 0.125, 'origin': (0.0, 2.5, 0.0),
+        }
+        receipt = {'path': (
+            (0.0, 20.0, 0.0), (0.0, 2.5, 50.0), (0.0, 0.0, 100.0))}
+
+        for verdict in (
+                battle._bot_friendly_firing_lane(
+                    source, target, descriptor, 0, launch),
+                battle._bot_artillery_friendly_lane(
+                    source, target, descriptor, 0, receipt)):
+            self.assertEqual({'clear': False}, verdict)
+
+    def test_frozen_path_rejects_landed_turret_and_ignores_wreck_splash(self):
+        runtime, battle, source, unused_target, unused = self._bot_lane_scene()
+        source['team'] = 1
+        self._bot_lane_wreck(runtime, battle, _Vector(1.0, 0.0, 100.0), ())
+        path = ((0.0, 2.5, 0.0), (0.0, 0.0, 100.0))
+        self.assertEqual({'clear': True}, battle._bot_friendly_path_verdict(
+            source, path, splash_radius=10.0))
+
+        battle._detached_turret_obstacles = types.SimpleNamespace(
+            block_distance=lambda *unused_args: 40.0)
+        self.assertEqual({'clear': False}, battle._bot_friendly_path_verdict(
+            source, path, splash_radius=10.0))
 
     def test_bot_friendly_lane_uses_the_frozen_dispersed_parabola(self):
         runtime = _runtime()


### PR DESCRIPTION
Bots could repeatedly choose a firing lane through a retained wreck because their static scene probes did not query vehicle collision geometry. Test those paths against dead hulls with the same descriptor hit testers and canonical body/chassis poses used by projectile resolution, and against landed turrets with the existing obstacle query.

The final implementation covers direct-fire aim samples, each SPG arc chord admitted by the existing query budget, and the final frozen/dispersed paths of both direct guns and SPGs. A blocked SPG chord rejects that candidate through the existing arc queue. A dead obstruction never produces friendly-splash clearance or teammate escape instructions. Shared record traversal retains the ally prefilter, excludes lane endpoints by identity, and reuses the wreck roster within a frame while querying current poses.

Review exposed and fixed the original patch's missing SPG and final-path checks. Regression coverage includes blocked SPG candidates, direct/SPG frozen paths, landed turrets, current canonical matrices, and roster invalidation across death, movement, and retirement. Existing candidate and arc budgets remain unchanged; the original direct-lane-only benchmark does not establish the cost of the completed change.

Validation: 904 battle-runtime, 498 bot-runtime, and 34 artillery tests passed; all 112 client source files compile with CPython 2.7.18. Windows gameplay still needs to establish retargeting behavior and frame pacing.
