### PR TITLE
Give each offline career its own #1513 vehicle dossier cache

### DIFF
--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -2941,7 +2941,22 @@ operation is forbidden, not unlimited.
   stock averages and best-vehicle labels. Dossier cache schema changes request
   a full refresh even when the old cache's battle watermark is unchanged.
   Previously discarded results cannot reconstruct an unknown historical
-  maximum. The current receipt does not measure mileage, each vehicle's time
+  maximum.
+- `DossierCache` persists those vehicle rows between sessions. It names its
+  `.dat` file `b32encode('%s;%s;%s' % (BigWorld.server(), accountName,
+  accountClassName))` and uses `accountName` for nothing else; `__readCache`
+  restores `__maxChangeTime` as the highest `changeTime` in that file, and
+  `__sendSyncRequest` then asks `CMD_SYNC_DOSSIERS` only for rows newer than
+  it. Nothing else ever lowers that watermark: a version mismatch in
+  `__onSyncComplete` clears the cached rows but leaves it standing. All three
+  key parts are constant offline, so every save slot and both processes would
+  share one file, and a career whose battle ordinal sits below another's
+  watermark would receive no vehicle row at all while its battles kept
+  settling. `compat.pin_dossier_cache` therefore scopes `accountName` by save
+  slot, process role and the post-battle store's account key before any
+  `PlayerAccount` exists, which is the one-file-per-account isolation retail
+  relies on. The account dossier is unaffected: `account_rpc/server.py`
+  pushes it in the post-battle diff rather than through this cache. The current receipt does not measure mileage, each vehicle's time
   alive or stunning-vehicle eligibility; these values are not inferred.
 - Selling and rebuying a vehicle preserves its XP, including across restart.
   Elite vehicles with stored XP remain conversion candidates after sale.

--- a/COMPATIBILITY_REVIEW.md
+++ b/COMPATIBILITY_REVIEW.md
@@ -2952,11 +2952,14 @@ operation is forbidden, not unlimited.
   key parts are constant offline, so every save slot and both processes would
   share one file, and a career whose battle ordinal sits below another's
   watermark would receive no vehicle row at all while its battles kept
-  settling. `compat.pin_dossier_cache` therefore scopes `accountName` by save
-  slot, process role and the post-battle store's account key before any
-  `PlayerAccount` exists, which is the one-file-per-account isolation retail
-  relies on. The account dossier is unaffected: `account_rpc/server.py`
-  pushes it in the post-battle diff rather than through this cache. The current receipt does not measure mileage, each vehicle's time
+  settling. `compat.pin_dossier_cache` therefore scopes `accountName` by a
+  fixed-width digest of the save slot, process role and complete post-battle
+  account key before any `PlayerAccount` exists. Hashing the complete identity
+  preserves separate career namespaces without letting a valid 64-character
+  slot push the stock base32 cache path beyond Windows `MAX_PATH` under the
+  normal preferences directory. The account dossier is unaffected:
+  `account_rpc/server.py` pushes it in the post-battle diff rather than through
+  this cache. The current receipt does not measure mileage, each vehicle's time
   alive or stunning-vehicle eligibility; these values are not inferred.
 - Selling and rebuying a vehicle preserves its XP, including across restart.
   Elite vehicles with stored XP remain conversion candidates after sale.

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bootstrap.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bootstrap.py
@@ -1167,7 +1167,7 @@ def _dossier_cache_career():
     account_key = ''
     if _postbattle_store is not None:
         account_key = str(
-            getattr(_postbattle_store, 'account_key', '') or '')[:16]
+            getattr(_postbattle_store, 'account_key', '') or '')
     return '%s.%s.%s' % (port_config.active_save_slot(), role, account_key)
 
 

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/bootstrap.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/bootstrap.py
@@ -1111,6 +1111,16 @@ def _wait_for_login_space():
             _schedule(0.0, _wait_for_login_space)
             return
         _login_space_seen = False
+        try:
+            # #1513 keys its vehicle dossier cache file on the account name,
+            # and PlayerAccount.__init__ builds that cache before any account
+            # hook of ours runs.  Scope it here, once, for both processes.
+            from gui.mods.offline_lan_0922 import compat as _compat
+            _compat.pin_dossier_cache(_dossier_cache_career)
+        except Exception as error:
+            sys.stdout.write(
+                '[Offline LAN 0.9.22] the vehicle dossier cache was not '
+                'scoped to this career: %s\n' % error)
         if _client_mode == port_config.SIMULATION_WORKER_MODE:
             # The worker needs a native lobby only as a safe map-lifecycle
             # bridge. It owns no Battle button, announcement or preference
@@ -1137,6 +1147,28 @@ def _wait_for_login_space():
         _schedule(0.10, _wait_for_lobby)
     except Exception as error:
         _fail_startup(error)
+
+
+def _dossier_cache_career():
+    """Return the identity that owns this process's vehicle dossier cache.
+
+    #1513 caches vehicle dossiers per account and asks the server only for
+    rows newer than the highest ``changeTime`` it already holds.  Offline
+    every save slot logs in under the same account name, and the hidden
+    worker logs in beside the visible client, so all of them would share one
+    file and one watermark.  The save slot names the career, the role
+    separates the two processes, and the post-battle store's account key
+    separates a career that was recreated in the same slot from the one whose
+    rows the cache still holds.  ``PostBattleStore`` mints a fresh key until a
+    battle persists one, which is correct: there is no record to cache yet.
+    """
+    role = ('worker' if _client_mode == port_config.SIMULATION_WORKER_MODE
+            else 'player')
+    account_key = ''
+    if _postbattle_store is not None:
+        account_key = str(
+            getattr(_postbattle_store, 'account_key', '') or '')[:16]
+    return '%s.%s.%s' % (port_config.active_save_slot(), role, account_key)
 
 
 def _wait_for_lobby():

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/compat.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/compat.py
@@ -19,6 +19,7 @@ _OFFLINE_INIT_COMPLETE = '_offlineLANInitComplete'
 _OFFLINE_PLAYER_READY = '_offlineLANPlayerReady'
 _OFFLINE_RETIRE_PENDING = '_offlineLANRetirePending'
 _account_settings_pinned = False
+_dossier_cache_pinned = False
 # AccountSettings.DEFAULT_VALUES keys whose sections this port adopts once.
 _SETTINGS_KEYS = ('settings', 'filters', 'counters', 'notifications')
 
@@ -91,6 +92,76 @@ def _account_settings_module():
     # so resolve the module the way the interpreter recorded it.
     import account_helpers.AccountSettings  # noqa: F401
     return sys.modules['account_helpers.AccountSettings']
+
+
+def _dossier_cache_module():
+    # account_helpers/__init__ shadows the submodule name with the class,
+    # so resolve the module the way the interpreter recorded it.
+    import account_helpers.DossierCache  # noqa: F401
+    return sys.modules['account_helpers.DossierCache']
+
+
+def _dossier_cache_career(career_provider):
+    """Return this process's career id, or ``''`` when it cannot be read.
+
+    An exception here would reach ``PlayerAccount.__init__`` and leave the
+    player with no account at all, which is far worse than a shared cache
+    file, so an unreadable career falls back to the stock name.
+    """
+    try:
+        return str(career_provider() or '')
+    except Exception as error:
+        print('[Offline LAN 0.9.22] the dossier cache career is unavailable: '
+              '%s' % error)
+        return ''
+
+
+def _career_scoped_account(account_name, career):
+    """Return ``account_name`` narrowed to one offline career."""
+    return '%s#%s' % (account_name, career) if career else account_name
+
+
+def pin_dossier_cache(career_provider, dossier_cache=None):
+    """Give each offline career its own #1513 vehicle dossier cache file.
+
+    ``DossierCache.__init__`` names its ``.dat`` file
+    ``b32encode('%s;%s;%s' % (BigWorld.server(), accountName,
+    accountClassName))`` and uses ``accountName`` for nothing else.  All three
+    are constant offline, so every save slot -- and the hidden worker running
+    beside the visible client -- share one file.  ``__readCache`` restores
+    ``__maxChangeTime`` as the highest ``changeTime`` in that file and
+    ``__sendSyncRequest`` then asks only for rows newer than it, so a career
+    whose battle count sits below another career's watermark receives no
+    vehicle dossier row at all: its garage mastery badges, Marks of Excellence
+    and per-vehicle records freeze while battles keep settling normally.
+    Nothing resets that watermark except building the cache from a file.
+
+    Scoping the name restores the one thing retail relies on, one cache file
+    per account, and stops two processes writing the same pickle.  Like the
+    interface-settings pin this must outlive every connect and disconnect:
+    ``Account.PlayerAccount.__init__`` builds the cache itself, before any
+    account hook of ours can run.
+    """
+    global _dossier_cache_pinned
+    if _dossier_cache_pinned:
+        return False
+    if dossier_cache is None:
+        dossier_cache = _dossier_cache_module()
+    cache_type = dossier_cache.DossierCache
+    original_init = cache_type.__init__
+
+    def scoped_init(self, accountName, accountClassName):
+        original_init(
+            self,
+            _career_scoped_account(
+                accountName, _dossier_cache_career(career_provider)),
+            accountClassName)
+
+    cache_type.__init__ = scoped_init
+    _dossier_cache_pinned = True
+    print('[Offline LAN 0.9.22] vehicle dossier cache scoped to career %r'
+          % _dossier_cache_career(career_provider))
+    return True
 
 
 def _account_sections(settings_type):

--- a/src/res/scripts/client/gui/mods/offline_lan_0922/compat.py
+++ b/src/res/scripts/client/gui/mods/offline_lan_0922/compat.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import hashlib
 import sys
 import traceback
 
@@ -117,8 +118,14 @@ def _dossier_cache_career(career_provider):
 
 
 def _career_scoped_account(account_name, career):
-    """Return ``account_name`` narrowed to one offline career."""
-    return '%s#%s' % (account_name, career) if career else account_name
+    """Return a bounded cache namespace for the complete offline career."""
+    if not career:
+        return account_name
+    # #1513 base32-expands the name beneath the preferences directory. A
+    # valid 64-character slot already exceeds Windows MAX_PATH when copied
+    # into the account name, so hash the complete identity into 128 bits.
+    suffix = hashlib.sha256(career.encode('utf-8')).hexdigest()[:32]
+    return '%s#%s' % (account_name, suffix)
 
 
 def pin_dossier_cache(career_provider, dossier_cache=None):

--- a/tests/test_port_0922.py
+++ b/tests/test_port_0922.py
@@ -1,8 +1,10 @@
+import base64
 import importlib.util
 import contextlib
 import hashlib
 import io
 import json
+import ntpath
 import os
 from pathlib import Path
 import gc
@@ -5609,9 +5611,48 @@ class OfflineCompatibilityTests(unittest.TestCase):
         career[0] = career[1]
         module.DossierCache('offline_account', 'PlayerAccount')
 
-        self.assertEqual(
-            [('offline_account#alpha.player.1111', 'PlayerAccount'),
-             ('offline_account#beta.player.2222', 'PlayerAccount')], built)
+        self.assertNotEqual(built[0][0], built[1][0])
+        self.assertTrue(all(account.startswith('offline_account#')
+                            and class_name == 'PlayerAccount'
+                            for account, class_name in built))
+
+    def test_longest_save_slot_fits_the_native_windows_dossier_path(self):
+        compatibility_module = _load_port_source('compat')
+        config_module = _load_port_source('config')
+        slot = 's' * 64
+        self.assertTrue(config_module.valid_save_slot(slot))
+        module, built = self._fake_dossier_cache()
+        self.assertTrue(compatibility_module.pin_dossier_cache(
+            lambda: '%s.player.%s' % (slot, 'a' * 16), module))
+
+        module.DossierCache('offline_account', 'PlayerAccount')
+
+        # Exact #1513 DossierCache.__init__ base32-encodes this tuple below
+        # the preferences directory. Raw slot names exceed MAX_PATH even
+        # with the ordinary profile path and an empty server name.
+        account_name, class_name = built[0]
+        for server in ('', compatibility_module.OFFLINE_SERVER_ADDRESS):
+            with self.subTest(server=server):
+                filename = base64.b32encode(('%s;%s;%s' % (
+                    server, account_name, class_name)).encode('ascii'))
+                cache_path = ntpath.join(
+                    r'C:\Users\peng\AppData\Roaming\Wargaming.net\WorldOfTanks',
+                    'dossier_cache', filename.decode('ascii') + '.dat')
+                self.assertLess(len(cache_path), 260)
+
+    def test_dossier_scope_is_stable_and_uses_the_entire_career(self):
+        compatibility_module = _load_port_source('compat')
+        career = '%s.player.%s' % ('s' * 64, 'a' * 64)
+        first = compatibility_module._career_scoped_account(
+            'offline_account', career)
+        restarted_module = _load_port_source('compat')
+
+        self.assertEqual(first, restarted_module._career_scoped_account(
+            'offline_account', career))
+        self.assertNotEqual(first, restarted_module._career_scoped_account(
+            'offline_account', career[:-1] + 'b'))
+        self.assertNotEqual(first, restarted_module._career_scoped_account(
+            'offline_account', career.replace('.player.', '.worker.')))
 
     def test_the_dossier_cache_scope_is_installed_exactly_once(self):
         compatibility_module = _load_port_source('compat')
@@ -5625,8 +5666,10 @@ class OfflineCompatibilityTests(unittest.TestCase):
         module.DossierCache('offline_account', 'PlayerAccount')
 
         # A second wrapper would scope the already scoped name again.
-        self.assertEqual(
-            [('offline_account#alpha.player.1111', 'PlayerAccount')], built)
+        self.assertEqual(1, len(built))
+        self.assertEqual('PlayerAccount', built[0][1])
+        self.assertEqual(compatibility_module._career_scoped_account(
+            'offline_account', 'alpha.player.1111'), built[0][0])
 
     def test_an_unreadable_career_keeps_the_stock_dossier_cache_name(self):
         # This runs inside PlayerAccount.__init__: raising here would leave

--- a/tests/test_port_0922.py
+++ b/tests/test_port_0922.py
@@ -5582,6 +5582,68 @@ class OfflineCompatibilityTests(unittest.TestCase):
             original,
             settings_type.__dict__['_AccountSettings__readUserSection'])
 
+    @staticmethod
+    def _fake_dossier_cache():
+        built = []
+
+        class DossierCache(object):
+            def __init__(self, accountName, accountClassName):
+                built.append((accountName, accountClassName))
+
+        module = types.ModuleType('account_helpers.DossierCache')
+        module.DossierCache = DossierCache
+        return module, built
+
+    def test_each_career_owns_its_vehicle_dossier_cache_file(self):
+        # #1513 names the cache file after (server, accountName, class) and
+        # restores its maxChangeTime watermark from it, so a shared name lets
+        # one save slot's battle count hide every row of another's.
+        compatibility_module = _load_port_source('compat')
+        module, built = self._fake_dossier_cache()
+        career = ['alpha.player.1111', 'beta.player.2222']
+
+        self.assertTrue(compatibility_module.pin_dossier_cache(
+            lambda: career[0], module))
+
+        module.DossierCache('offline_account', 'PlayerAccount')
+        career[0] = career[1]
+        module.DossierCache('offline_account', 'PlayerAccount')
+
+        self.assertEqual(
+            [('offline_account#alpha.player.1111', 'PlayerAccount'),
+             ('offline_account#beta.player.2222', 'PlayerAccount')], built)
+
+    def test_the_dossier_cache_scope_is_installed_exactly_once(self):
+        compatibility_module = _load_port_source('compat')
+        module, built = self._fake_dossier_cache()
+
+        self.assertTrue(compatibility_module.pin_dossier_cache(
+            lambda: 'alpha.player.1111', module))
+        self.assertFalse(compatibility_module.pin_dossier_cache(
+            lambda: 'beta.player.2222', module))
+
+        module.DossierCache('offline_account', 'PlayerAccount')
+
+        # A second wrapper would scope the already scoped name again.
+        self.assertEqual(
+            [('offline_account#alpha.player.1111', 'PlayerAccount')], built)
+
+    def test_an_unreadable_career_keeps_the_stock_dossier_cache_name(self):
+        # This runs inside PlayerAccount.__init__: raising here would leave
+        # the player with no account at all.
+        compatibility_module = _load_port_source('compat')
+        module, built = self._fake_dossier_cache()
+
+        def unavailable():
+            raise RuntimeError('the save slot is unreadable')
+
+        self.assertTrue(
+            compatibility_module.pin_dossier_cache(unavailable, module))
+
+        module.DossierCache('offline_account', 'PlayerAccount')
+
+        self.assertEqual([('offline_account', 'PlayerAccount')], built)
+
     def test_fini_does_not_overwrite_later_third_party_wrappers(self):
         compatibility_module = _load_port_source('compat')
         runtime, _ = self._runtime()

--- a/tests/test_port_0922_bootstrap_lifecycle.py
+++ b/tests/test_port_0922_bootstrap_lifecycle.py
@@ -694,10 +694,23 @@ class BootstrapLifecycleTests(unittest.TestCase):
 
         # The hidden worker keeps no career, so it publishes none.
         self.assertEqual('default.worker.', worker)
-        self.assertEqual('default.player.' + 'a' * 16, player)
-        self.assertEqual('default.player.' + 'b' * 16, rebuilt)
-        self.assertEqual('second.player.' + 'b' * 16, other_slot)
+        self.assertEqual('default.player.' + 'a' * 32, player)
+        self.assertEqual('default.player.' + 'b' * 32, rebuilt)
+        self.assertEqual('second.player.' + 'b' * 32, other_slot)
         self.assertEqual(4, len({player, worker, rebuilt, other_slot}))
+
+    def test_career_identity_preserves_the_complete_account_key(self):
+        bootstrap = self._load()[0]
+        bootstrap._client_mode = bootstrap.port_config.PLAYER_MODE
+        bootstrap.port_config.active_save_slot = lambda: 's' * 64
+        bootstrap._postbattle_store = types.SimpleNamespace(
+            account_key='a' * 64)
+        original = bootstrap._dossier_cache_career()
+
+        bootstrap._postbattle_store.account_key = 'a' * 63 + 'b'
+        recreated = bootstrap._dossier_cache_career()
+
+        self.assertNotEqual(original, recreated)
 
     def test_a_store_without_an_account_key_still_names_a_career(self):
         bootstrap = self._load()[0]

--- a/tests/test_port_0922_bootstrap_lifecycle.py
+++ b/tests/test_port_0922_bootstrap_lifecycle.py
@@ -268,6 +268,19 @@ class BootstrapLifecycleTests(unittest.TestCase):
         compat_module = types.ModuleType(
             'gui.mods.offline_lan_0922.compat')
         compat_module.g_compatibility = compatibility
+        # Both pins must be installed before any Account exists, and both
+        # outlive every connect and disconnect, so record them in the same
+        # ordered event list the connection uses.
+        self.dossier_cache_pins = []
+
+        def pin_dossier_cache(career_provider):
+            events.append('pin_dossier_cache')
+            self.dossier_cache_pins.append(career_provider)
+            return True
+
+        compat_module.pin_dossier_cache = pin_dossier_cache
+        compat_module.pin_account_settings = (
+            lambda: events.append('pin_account_settings') or True)
         config_module = types.ModuleType(
             'gui.mods.offline_lan_0922.config')
         config_module.PLAYER_MODE = 'player'
@@ -288,6 +301,7 @@ class BootstrapLifecycleTests(unittest.TestCase):
             100 if earnings_percent is None else earnings_percent)
         config_module.save_slot_initial_wallet = lambda: dict(initial_wallet or {})
         config_module.ACTIVE_SAVE_SLOT = object()
+        config_module.active_save_slot = lambda: 'default'
         # No inbox file exists unless a test writes one, so the launcher
         # delivery path is a no-op for every other test.
         inbox_root = tempfile.mkdtemp()
@@ -652,6 +666,45 @@ class BootstrapLifecycleTests(unittest.TestCase):
                         bootstrap, '_restore_garage', lambda snapshot: False):
                     return bootstrap._selected_vehicle(
                         {'vehicle': 'ussr:R11_MS-1'})
+
+    def test_each_career_and_process_names_its_own_dossier_cache(self):
+        """#1513 caches vehicle dossiers per account name and syncs only rows
+        newer than the highest changeTime that file holds.  Offline the save
+        slot, the two processes and a recreated career all log in under the
+        same name, so the identity has to carry all three.
+        """
+        bootstrap = self._load()[0]
+        bootstrap._client_mode = bootstrap.port_config.PLAYER_MODE
+        bootstrap._postbattle_store = types.SimpleNamespace(
+            account_key='a' * 32)
+
+        player = bootstrap._dossier_cache_career()
+
+        bootstrap._client_mode = bootstrap.port_config.SIMULATION_WORKER_MODE
+        bootstrap._postbattle_store = None
+        worker = bootstrap._dossier_cache_career()
+
+        bootstrap._client_mode = bootstrap.port_config.PLAYER_MODE
+        bootstrap._postbattle_store = types.SimpleNamespace(
+            account_key='b' * 32)
+        rebuilt = bootstrap._dossier_cache_career()
+
+        bootstrap.port_config.active_save_slot = lambda: 'second'
+        other_slot = bootstrap._dossier_cache_career()
+
+        # The hidden worker keeps no career, so it publishes none.
+        self.assertEqual('default.worker.', worker)
+        self.assertEqual('default.player.' + 'a' * 16, player)
+        self.assertEqual('default.player.' + 'b' * 16, rebuilt)
+        self.assertEqual('second.player.' + 'b' * 16, other_slot)
+        self.assertEqual(4, len({player, worker, rebuilt, other_slot}))
+
+    def test_a_store_without_an_account_key_still_names_a_career(self):
+        bootstrap = self._load()[0]
+        bootstrap._client_mode = bootstrap.port_config.PLAYER_MODE
+        bootstrap._postbattle_store = types.SimpleNamespace(account_key=None)
+
+        self.assertEqual('default.player.', bootstrap._dossier_cache_career())
 
     def test_every_crew_price_the_garage_charges_reaches_the_snapshot(self):
         """One missing key would make a paid crew command free and silent.
@@ -1558,8 +1611,9 @@ class BootstrapLifecycleTests(unittest.TestCase):
             callbacks.run_next()
 
         self.assertEqual(
-            ['clear_entities_and_spaces', 'install_announcement_router',
-             'install_battle_router', 'connect'],
+            ['clear_entities_and_spaces', 'pin_dossier_cache',
+             'install_announcement_router', 'install_battle_router',
+             'pin_account_settings', 'connect'],
             events)
         self.assertEqual(1, len(compatibility.connect_calls))
         self.assertTrue(compatibility.connect_calls[0][0])
@@ -1567,6 +1621,56 @@ class BootstrapLifecycleTests(unittest.TestCase):
         with mock.patch.dict(sys.modules, modules):
             self.assertIsNone(bootstrap._cleanup_runtime())
         self.assertEqual('uninstall_announcement_router', events[-1])
+
+    def test_the_dossier_cache_is_scoped_before_any_account_exists(self):
+        """``PlayerAccount.__init__`` builds the cache itself, so the scope
+        has to be installed before the connection that creates the account,
+        and it has to reach the hidden worker too -- both processes otherwise
+        write one pickle.
+        """
+        (bootstrap, callbacks, compatibility, app_loader,
+         spaces, events, modules) = self._load()
+
+        with mock.patch.dict(sys.modules, modules):
+            bootstrap._run_once()
+            app_loader.space_id = spaces.LOGIN
+            callbacks.run_next()
+            callbacks.run_next()
+
+        self.assertEqual(1, len(self.dossier_cache_pins))
+        self.assertEqual(1, len(compatibility.connect_calls))
+        self.assertLess(events.index('pin_dossier_cache'),
+                        events.index('connect'))
+        self.assertTrue(self.dossier_cache_pins[0]())
+
+        with mock.patch.dict(sys.modules, modules):
+            self.assertIsNone(bootstrap._cleanup_runtime())
+
+    def test_the_hidden_worker_scopes_its_dossier_cache_too(self):
+        """The pin sits before the process-mode branch: the worker logs in
+        beside the visible client and would otherwise write the same pickle.
+        """
+        (bootstrap, callbacks, compatibility, app_loader,
+         spaces, events, modules) = self._load()
+        app_loader.space_id = spaces.LOGIN
+        bootstrap._client_mode = bootstrap.port_config.SIMULATION_WORKER_MODE
+        installed = []
+        bootstrap._install_worker_session = (
+            lambda: installed.append('worker_session'))
+
+        with mock.patch.dict(sys.modules, modules):
+            bootstrap._wait_for_login_space()
+            bootstrap._wait_for_login_space()
+
+        self.assertEqual(['worker_session'], installed)
+        self.assertEqual(1, len(self.dossier_cache_pins))
+        self.assertEqual('default.worker.', self.dossier_cache_pins[0]())
+        self.assertLess(events.index('pin_dossier_cache'),
+                        events.index('connect'))
+        self.assertNotIn('pin_account_settings', events)
+
+        with mock.patch.dict(sys.modules, modules):
+            self.assertIsNone(bootstrap._cleanup_runtime())
 
     def test_inventory_refresh_notifies_only_the_current_lan_session(self):
         (bootstrap, unused_callbacks, unused_compatibility,


### PR DESCRIPTION
Different offline save slots and the hidden worker shared #1513's vehicle dossier cache file because they logged in under the same account name. The cache restores its highest change-time watermark from disk, so a career with fewer settled battles could receive no new vehicle rows and stop refreshing garage marks, mastery badges, and per-vehicle records.

Pin the dossier cache constructor before either process creates an Account, and give the cache a stable namespace derived from the complete save-slot, process-role, and post-battle account identity. Use a bounded 128-bit naming digest: copying a legal 64-character slot into the stock base32-expanded filename exceeded the embedded runtime's Windows path limit. Preserve the complete account key so valid keys sharing their first 16 characters remain separate. The old shared file is left untouched, and an unavailable identity retains the stock fallback rather than preventing Account construction.

The exact #1513 constructor was executed with Windows path semantics to verify the filename contract. With the standard preferences directory and offline server identity, the long-slot example falls from 299 to 211 characters; the repaired naming also handles a maximum-length stored account key. This change does not alter dossier versions, watermark rules, or manual save rollback behavior.

Validation: 162 focused compatibility/bootstrap tests passed; new regressions first reproduced the path-length and account-key-prefix defects. All 112 client source files compile with CPython 2.7.18. Actual Windows cache writes and cross-slot garage refresh remain to be exercised.
